### PR TITLE
Add GitHub Actions PR gates for build+unit-test and dotnet-format

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -1,0 +1,50 @@
+name: Build and unit test
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-unit-test:
+    name: Build and unit test
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+      DOTNET_NOLOGO: '1'
+      NUGET_XMLDOC_MODE: skip
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Restore dependencies
+        run: dotnet restore MailMcp.slnx
+
+      - name: Build solution
+        run: dotnet build MailMcp.slnx --configuration Release --no-restore
+
+      - name: Run unit tests
+        run: dotnet test MailMcp.slnx --configuration Release --no-build --logger "trx;LogFilePrefix=unit-tests"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: '**/TestResults/*.trx'
+          if-no-files-found: ignore

--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -39,7 +39,7 @@ jobs:
         run: dotnet build MailMcp.slnx --configuration Release --no-restore
 
       - name: Run unit tests
-        run: dotnet test MailMcp.slnx --configuration Release --no-build --logger "trx;LogFilePrefix=unit-tests"
+        run: dotnet test --solution MailMcp.slnx --configuration Release --no-build -- --report-xunit-trx --report-xunit-trx-filename unit-tests.trx
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -1,0 +1,39 @@
+name: dotnet format
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dotnet-format:
+    name: dotnet format
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+      DOTNET_NOLOGO: '1'
+      NUGET_XMLDOC_MODE: skip
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Restore dependencies
+        run: dotnet restore MailMcp.slnx
+
+      - name: Verify formatting
+        run: dotnet format MailMcp.slnx --verify-no-changes --verbosity diagnostic

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -24,3 +24,13 @@ dotnet run --project src/AppHost/AppHost.csproj
 ```
 
 The AppHost PostgreSQL resource uses the `pgvector/pgvector:0.8.2-pg17` image so local development starts with a PostgreSQL server that can support the `vector` extension required by the RAG and embedding slices.
+
+## Pull request gates
+
+Pull requests targeting `main` run two GitHub Actions gates:
+
+- `Build and unit test` restores `MailMcp.slnx`, builds the solution in Release configuration, and runs the solution unit test projects without rebuilding.
+- `dotnet format` restores `MailMcp.slnx` and verifies repository formatting without applying changes.
+
+Both workflows use the SDK pinned in `global.json`, cancel superseded runs for the same pull request, request read-only repository permissions, and avoid credentials or service-specific secrets.
+

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -29,7 +29,7 @@ The AppHost PostgreSQL resource uses the `pgvector/pgvector:0.8.2-pg17` image so
 
 Pull requests targeting `main` run two GitHub Actions gates:
 
-- `Build and unit test` restores `MailMcp.slnx`, builds the solution in Release configuration, and runs the solution unit test projects without rebuilding.
+- `Build and unit test` restores `MailMcp.slnx`, builds the solution in Release configuration, and runs the solution unit test projects without rebuilding by using the .NET 10 Microsoft Testing Platform solution syntax and xUnit TRX reporting options.
 - `dotnet format` restores `MailMcp.slnx` and verifies repository formatting without applying changes.
 
 Both workflows use the SDK pinned in `global.json`, cancel superseded runs for the same pull request, request read-only repository permissions, and avoid credentials or service-specific secrets.


### PR DESCRIPTION
### Motivation
- Provide two lightweight GitHub Actions gates that run on every PR to `main` to ensure the solution builds, unit tests run, and repository formatting is enforced.
- Keep the workflows simple, free of any credentials or upstream project references, and use the SDK pinned in `global.json` for deterministic behavior.
- Implement fresh workflows inspired by common patterns (including Semantic Kernel ideas) but written from scratch to avoid copying credentials or cross-project references.

### Description
- Add `./github/workflows/build-and-unit-test.yml` which checks out the repository with read-only permissions, sets up the .NET SDK via `global.json`, runs `dotnet restore`, `dotnet build --no-restore`, and `dotnet test --no-build`, and uploads TRX test results as an artifact.
- Add `./github/workflows/dotnet-format.yml` which checks out the repository with read-only permissions, sets up the .NET SDK via `global.json`, runs `dotnet restore`, and verifies formatting with `dotnet format --verify-no-changes`.
- Both workflows cancel superseded runs for the same PR via `concurrency`, avoid persisting checkout credentials, and do not reference or include any credentials, secrets, or Semantic Kernel / Microsoft project identifiers.
- Document the new PR gates in `docs/operations/local-development.md` under a new `Pull request gates` section that explains the purpose and assumptions of both workflows.

### Testing
- `actionlint` style check was executed with `go run github.com/rhysd/actionlint/cmd/actionlint@latest` and completed successfully against the new workflow files.
- YAML parsing was validated by loading both workflow files with Ruby (`YAML.load_file`) and succeeded for both files.
- `dotnet` commands (`dotnet restore`, `dotnet build`, `dotnet test`, `dotnet format`) could not be executed in this environment because the `dotnet` CLI is not available, so local verification of .NET steps was not run here and must be validated in CI or a machine with the SDK installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a6349506c548324a0871a55337568c4)