### PR TITLE
Ogranicz CI do zmian w `src/` i `tests/`

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'tests/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'tests/**'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
### Motivation
- Ograniczyć uruchamianie pipeline'ów build/test/format tylko do zmian kodu i testów, aby uniknąć niepotrzebnych przebiegów CI.

### Description
- Dodano filtr `paths` do `.github/workflows/build-and-unit-test.yml` oraz `.github/workflows/dotnet-format.yml`, ograniczając `pull_request` trigger do `src/**` i `tests/**` przy zachowaniu ręcznego uruchamiania przez `workflow_dispatch`.

### Testing
- Zweryfikowano, że pliki YAML parsują się poprawnie za pomocą `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "parsed #{f}" }' .github/workflows/build-and-unit-test.yml .github/workflows/dotnet-format.yml` oraz że nie ma problemów formatowych przez `git diff --check`; próba uruchomienia `dotnet restore && dotnet build && dotnet test && dotnet format` nie powiodła się, ponieważ `dotnet` nie jest zainstalowany w tym środowisku.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a63506ad0248324aab38faa9c013176)