### PR TITLE
Remove redundant MessageOccurrenceId factory in favor of the primary constructor

### DIFF
--- a/src/Domain/Messages/MessageOccurrenceId.cs
+++ b/src/Domain/Messages/MessageOccurrenceId.cs
@@ -6,14 +6,12 @@ using MailMcp.Domain.Folders;
 namespace MailMcp.Domain.Messages;
 
 /// <summary>Identifies one stable remote IMAP message occurrence.</summary>
-/// <remarks>The identity deliberately uses account, folder, UIDVALIDITY, and UID because IMAP UIDs are stable only within one folder UIDVALIDITY scope.</remarks>
-public sealed record MessageOccurrenceId(MailAccountId AccountId, MailFolderName FolderName, ImapUidValidity UidValidity, ImapUid Uid)
-{
-    /// <summary>Creates a stable remote occurrence identity.</summary>
-    /// <param name="accountId">The owning local account.</param>
-    /// <param name="folderName">The remote folder name.</param>
-    /// <param name="uidValidity">The folder UIDVALIDITY value.</param>
-    /// <param name="uid">The message UID.</param>
-    /// <returns>A stable message occurrence identity.</returns>
-    public static MessageOccurrenceId Create(MailAccountId accountId, MailFolderName folderName, ImapUidValidity uidValidity, ImapUid uid) => new(accountId, folderName, uidValidity, uid);
-}
+/// <remarks>
+/// The identity deliberately uses account, folder, UIDVALIDITY, and UID because IMAP UIDs are stable only within one folder UIDVALIDITY scope.
+/// Every component is already a validated value object, so the primary constructor is the single construction path and no separate factory is offered.
+/// </remarks>
+/// <param name="AccountId">The owning local account.</param>
+/// <param name="FolderName">The remote folder name.</param>
+/// <param name="UidValidity">The folder UIDVALIDITY value.</param>
+/// <param name="Uid">The message UID.</param>
+public sealed record MessageOccurrenceId(MailAccountId AccountId, MailFolderName FolderName, ImapUidValidity UidValidity, ImapUid Uid);

--- a/src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs
+++ b/src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs
@@ -188,7 +188,7 @@ internal sealed class MailKitImapMailboxSession(
             : await folder.FetchAsync(batchedUids, MessageSummaryItems.Envelope | MessageSummaryItems.UniqueId | MessageSummaryItems.Size, cancellationToken);
         var uidValidity = ImapUidValidity.Create(folder.UidValidity);
         var messages = summaries.Select(summary => new RemoteMessageMetadata(
-            MessageOccurrenceId.Create(accountId, folderName, uidValidity, ImapUid.Create(summary.UniqueId.Id)),
+            new MessageOccurrenceId(accountId, folderName, uidValidity, ImapUid.Create(summary.UniqueId.Id)),
             summary.Envelope?.MessageId,
             summary.Envelope?.Subject,
             summary.Envelope?.Date?.ToUniversalTime(),

--- a/tests/Application.UnitTests/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/MailboxSynchronizerTests.cs
@@ -22,7 +22,7 @@ public sealed class MailboxSynchronizerTests
         var folderName = MailFolderName.Create("INBOX");
         var uidValidity = ImapUidValidity.Create(5);
         var uid = ImapUid.Create(10);
-        var occurrence = MessageOccurrenceId.Create(accountId, folderName, uidValidity, uid);
+        var occurrence = new MessageOccurrenceId(accountId, folderName, uidValidity, uid);
         var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
         var metadataRepository = Substitute.For<IMessageMetadataRepository>();
         var sessionScopeFactory = Substitute.For<ISessionFactory>();
@@ -75,7 +75,7 @@ public sealed class MailboxSynchronizerTests
         var folderName = MailFolderName.Create("INBOX");
         var uidValidity = ImapUidValidity.Create(5);
         var uid = ImapUid.Create(10);
-        var occurrence = MessageOccurrenceId.Create(accountId, folderName, uidValidity, uid);
+        var occurrence = new MessageOccurrenceId(accountId, folderName, uidValidity, uid);
         var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
         var metadataRepository = Substitute.For<IMessageMetadataRepository>();
         var sessionScopeFactory = Substitute.For<ISessionFactory>();
@@ -150,7 +150,7 @@ public sealed class MailboxSynchronizerTests
         var folderName = MailFolderName.Create("INBOX");
         var uidValidity = ImapUidValidity.Create(5);
         var uid = ImapUid.Create(10);
-        var occurrence = MessageOccurrenceId.Create(accountId, folderName, uidValidity, uid);
+        var occurrence = new MessageOccurrenceId(accountId, folderName, uidValidity, uid);
         var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
         var metadataRepository = Substitute.For<IMessageMetadataRepository>();
         var sessionScopeFactory = Substitute.For<ISessionFactory>();
@@ -187,7 +187,7 @@ public sealed class MailboxSynchronizerTests
         var folderName = MailFolderName.Create("INBOX");
         var uidValidity = ImapUidValidity.Create(5);
         var uid = ImapUid.Create(10);
-        var occurrence = MessageOccurrenceId.Create(accountId, folderName, uidValidity, uid);
+        var occurrence = new MessageOccurrenceId(accountId, folderName, uidValidity, uid);
         var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
         var metadataRepository = Substitute.For<IMessageMetadataRepository>();
         var sessionScopeFactory = Substitute.For<ISessionFactory>();
@@ -240,8 +240,8 @@ public sealed class MailboxSynchronizerTests
         var uidValidity = ImapUidValidity.Create(5);
         var firstUid = ImapUid.Create(10);
         var secondUid = ImapUid.Create(11);
-        var firstOccurrence = MessageOccurrenceId.Create(accountId, folderName, uidValidity, firstUid);
-        var secondOccurrence = MessageOccurrenceId.Create(accountId, folderName, uidValidity, secondUid);
+        var firstOccurrence = new MessageOccurrenceId(accountId, folderName, uidValidity, firstUid);
+        var secondOccurrence = new MessageOccurrenceId(accountId, folderName, uidValidity, secondUid);
         var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
         var metadataRepository = Substitute.For<IMessageMetadataRepository>();
         var sessionScopeFactory = Substitute.For<ISessionFactory>();
@@ -364,7 +364,7 @@ public sealed class MailboxSynchronizerTests
         // Arrange
         var accountId = MailAccountId.Create("primary");
         var folderName = MailFolderName.Create("INBOX");
-        var occurrence = MessageOccurrenceId.Create(accountId, folderName, ImapUidValidity.Create(5), ImapUid.Create(10));
+        var occurrence = new MessageOccurrenceId(accountId, folderName, ImapUidValidity.Create(5), ImapUid.Create(10));
         var inner = new InvalidOperationException("inner");
 
         // Act

--- a/tests/Domain.UnitTests/MailIdentityTests.cs
+++ b/tests/Domain.UnitTests/MailIdentityTests.cs
@@ -11,7 +11,7 @@ namespace MailMcp.Domain.UnitTests;
 public sealed class MailIdentityTests
 {
     [Fact]
-    public void Create_ValidOccurrence_ProducesStableIdentity()
+    public void Constructor_ValidOccurrence_ProducesStableIdentity()
     {
         // Arrange
         var accountId = MailAccountId.Create("primary");
@@ -20,7 +20,7 @@ public sealed class MailIdentityTests
         var uid = ImapUid.Create(100);
 
         // Act
-        var occurrence = MessageOccurrenceId.Create(accountId, folderName, uidValidity, uid);
+        var occurrence = new MessageOccurrenceId(accountId, folderName, uidValidity, uid);
 
         // Assert
         Assert.Equal("primary", occurrence.AccountId.Value);

--- a/tests/Infrastructure.UnitTests/MailKitImapMailboxSessionTests.cs
+++ b/tests/Infrastructure.UnitTests/MailKitImapMailboxSessionTests.cs
@@ -207,7 +207,7 @@ public sealed class MailKitImapMailboxSessionTests
             MailFolderName.Create("INBOX"),
             client,
             folder);
-        var foreignOccurrence = MessageOccurrenceId.Create(
+        var foreignOccurrence = new MessageOccurrenceId(
             MailAccountId.Create(occurrenceAccountId),
             MailFolderName.Create(occurrenceFolderName),
             ImapUidValidity.Create(occurrenceUidValidity),
@@ -260,7 +260,7 @@ public sealed class MailKitImapMailboxSessionTests
             MailFolderName.Create("INBOX"),
             client,
             folder);
-        var occurrenceId = MessageOccurrenceId.Create(
+        var occurrenceId = new MessageOccurrenceId(
             MailAccountId.Create("primary"),
             MailFolderName.Create("INBOX"),
             ImapUidValidity.Create(7),
@@ -293,7 +293,7 @@ public sealed class MailKitImapMailboxSessionTests
             MailFolderName.Create("INBOX"),
             client,
             folder);
-        var occurrenceId = MessageOccurrenceId.Create(
+        var occurrenceId = new MessageOccurrenceId(
             MailAccountId.Create("primary"),
             MailFolderName.Create("INBOX"),
             ImapUidValidity.Create(7),


### PR DESCRIPTION
## Why

`MessageOccurrenceId` is a positional record, so its primary constructor is already public. The static `Create` method was therefore a pure pass-through — it validated nothing, normalized nothing, and closed no construction path. That left two interchangeable ways to build the same type and made the repository's use of `Create` look inconsistent.

The distinction matters: the value-object structs (`MailAccountId`, `MailFolderName`, `ImapUid`, `ImapUidValidity`) keep `Create` for a real reason — their constructors are private, so the factory is the only entry point that enforces the invariant (non-blank text, non-zero UID, `Trim()` normalization). `MessageOccurrenceId` has no such invariant to enforce: every component is already a validated value object by the time it reaches the constructor.

## What changed

- Deleted `MessageOccurrenceId.Create`; the primary constructor is now the single construction path.
- Moved the factory's parameter documentation onto the record declaration and extended `<remarks>` to state why no factory exists, so the asymmetry with the value-object structs is intentional and readable.
- Updated all 12 call sites (1 in `Infrastructure`, 11 in tests) to use `new MessageOccurrenceId(...)`.
- Renamed `Create_ValidOccurrence_ProducesStableIdentity` to `Constructor_ValidOccurrence_ProducesStableIdentity` to keep the `Member_Scenario_ExpectedBehavior` convention accurate.

No behavior change — this is a construction-surface cleanup.

## Verification

- `dotnet build --no-restore` — succeeded, 0 warnings, 0 errors
- `dotnet test --no-build` — 32/32 passed
- `dotnet format --verify-no-changes` — clean
- `dotnet msbuild eng/CodeCoverage.proj -t:Collect` — aggregate line coverage 98.05% (201/205), threshold 85%

## Note

`SynchronizationCheckpoint` intentionally keeps its static `None(...)` and instance `AdvanceTo(...)`. Those are not constructor duplicates: `None` names a meaningful domain state and `AdvanceTo` enforces the invariant that a checkpoint never moves backwards within a UIDVALIDITY scope.