### PR TITLE
Defer pull request CI until ready for review

### DIFF
--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -2,6 +2,11 @@ name: Build and unit test
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
     paths:
@@ -29,6 +34,7 @@ permissions:
 
 jobs:
   build-and-unit-test:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     name: Build and unit test
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build-and-unit-test.yml
+++ b/.github/workflows/build-and-unit-test.yml
@@ -7,6 +7,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - converted_to_draft
     branches:
       - main
     paths:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -7,6 +7,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - converted_to_draft
     branches:
       - main
     paths:

--- a/.github/workflows/dotnet-format.yml
+++ b/.github/workflows/dotnet-format.yml
@@ -2,6 +2,11 @@ name: dotnet format
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
     paths:
@@ -18,6 +23,7 @@ permissions:
 
 jobs:
   dotnet-format:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     name: dotnet format
     runs-on: ubuntu-latest
     env:

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -40,11 +40,11 @@ Raw Cobertura reports and TRX files are written under `artifacts/coverage/raw/`.
 
 ## Pull request checks
 
-Pull requests targeting `main` run two GitHub Actions checks:
+Pull requests targeting `main` run two GitHub Actions checks after they are marked ready for review. Draft pull requests skip both jobs without allocating a runner. Marking a draft ready for review starts the applicable checks immediately, and later commits continue to start them. Both workflows remain available through manual dispatch regardless of pull request state:
 
 - `Build and unit test` runs for pull requests to `main` that change production code, tests, the solution or SDK selection, shared build and package configuration, coverage tooling, or the workflow itself. It restores `MailMcp.slnx` and repository-local tools, builds the solution in Release configuration, runs all unit-test projects through Microsoft Testing Platform with unique coverage prefixes, merges their Cobertura reports, and fails below 85% aggregate line coverage for the complete configured production scope. It uploads raw and merged coverage artifacts and TRX results even when the threshold fails.
 - `dotnet format` restores `MailMcp.slnx` and verifies repository formatting without applying changes.
 
 The `main` branch protection rule requires a pull request and the `Build and unit test` check, requires the branch to be current with `main`, applies to administrators, and requires review conversations to be resolved. It does not require an approving review because the repository currently has one maintainer. Force-pushes and deletion of `main` are disabled. The GitHub repository coverage rule must remain disabled because GitHub Code Quality coverage uploads are unavailable for this user-owned repository; the required repository-owned check enforces the same 85% minimum against the complete configured code scope.
 
-Both workflows use the SDK pinned in `global.json`, cancel superseded runs for the same pull request, request read-only repository permissions, and avoid credentials or service-specific secrets. The formatting workflow remains limited to `src/**` and `tests/**` and is not a required status check.
+Both workflows use the SDK pinned in `global.json`, cancel superseded runs for the same pull request, request read-only repository permissions, and avoid credentials or service-specific secrets. A job-level draft guard skips both jobs unless a pull request is non-draft or the workflow was manually dispatched. The formatting workflow remains limited to `src/**` and `tests/**` and is not a required status check.

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -40,7 +40,7 @@ Raw Cobertura reports and TRX files are written under `artifacts/coverage/raw/`.
 
 ## Pull request checks
 
-Pull requests targeting `main` run two GitHub Actions checks after they are marked ready for review. Draft pull requests skip both jobs without allocating a runner. Marking a draft ready for review starts the applicable checks immediately, and later commits continue to start them. Both workflows remain available through manual dispatch regardless of pull request state:
+Pull requests targeting `main` run two GitHub Actions checks after they are marked ready for review. Draft pull requests skip both jobs without allocating a runner. Marking a draft ready for review starts the applicable checks immediately, and later commits continue to start them. Converting a ready pull request back to draft through the `converted_to_draft` activity cancels the superseded active run and skips the replacement job. Both workflows remain available through manual dispatch regardless of pull request state:
 
 - `Build and unit test` runs for pull requests to `main` that change production code, tests, the solution or SDK selection, shared build and package configuration, coverage tooling, or the workflow itself. It restores `MailMcp.slnx` and repository-local tools, builds the solution in Release configuration, runs all unit-test projects through Microsoft Testing Platform with unique coverage prefixes, merges their Cobertura reports, and fails below 85% aggregate line coverage for the complete configured production scope. It uploads raw and merged coverage artifacts and TRX results even when the threshold fails.
 - `dotnet format` restores `MailMcp.slnx` and verifies repository formatting without applying changes.

--- a/docs/superpowers/plans/2026-07-25-defer-draft-pr-ci.md
+++ b/docs/superpowers/plans/2026-07-25-defer-draft-pr-ci.md
@@ -1,0 +1,136 @@
+# Defer Draft Pull Request CI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent build, unit-test, coverage, and formatting jobs from running for draft pull requests while running them immediately when a pull request becomes ready for review.
+
+**Architecture:** Keep the existing workflows and filters, add explicit pull request activity types including `ready_for_review`, and gate each complete job on manual dispatch or a non-draft pull request. Update the operational documentation in the same change so it describes the implemented behavior.
+
+**Tech Stack:** GitHub Actions workflow YAML, Markdown, .NET 10 repository verification commands
+
+## Global Constraints
+
+- `workflow_dispatch` must remain available regardless of pull request state.
+- Draft pull requests may produce a skipped workflow result, but must not allocate a runner or execute build, test, coverage, or formatting steps.
+- Ready pull requests must run on `opened`, `reopened`, `synchronize`, and `ready_for_review`.
+- Existing target-branch filters, path filters, concurrency behavior, permissions, and job steps must remain unchanged.
+- Pull requests must be created as drafts.
+
+---
+
+### Task 1: Gate pull request checks until ready for review
+
+**Files:**
+- Modify: `.github/workflows/build-and-unit-test.yml`
+- Modify: `.github/workflows/dotnet-format.yml`
+- Modify: `docs/operations/local-development.md`
+- Create: `docs/superpowers/plans/2026-07-25-defer-draft-pr-ci.md`
+
+**Interfaces:**
+- Consumes: GitHub's `pull_request` activity types, `github.event_name`, and `github.event.pull_request.draft`.
+- Produces: Both existing CI jobs run only for manual dispatch or non-draft pull requests, including the transition to ready for review.
+
+- [ ] **Step 1: Demonstrate the missing ready-for-review trigger and job guards**
+
+Run:
+
+```bash
+rg -n "ready_for_review|github\.event_name == 'workflow_dispatch'|github\.event\.pull_request\.draft == false" \
+  .github/workflows/build-and-unit-test.yml \
+  .github/workflows/dotnet-format.yml
+```
+
+Expected: exit code `1` with no matches because neither workflow contains the trigger or guard.
+
+- [ ] **Step 2: Add the explicit pull request activity types**
+
+In both workflow files, change the start of the `pull_request` configuration to:
+
+```yaml
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+```
+
+Retain every existing `paths` entry.
+
+- [ ] **Step 3: Guard each complete job while preserving manual dispatch**
+
+Add this condition directly below each job identifier and before `name`:
+
+```yaml
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
+```
+
+Apply it to `build-and-unit-test` and `dotnet-format`. Do not add conditions to individual steps.
+
+- [ ] **Step 4: Document the pull request lifecycle behavior**
+
+Update the start of `docs/operations/local-development.md` section `Pull request checks` to say:
+
+```markdown
+Pull requests targeting `main` run two GitHub Actions checks after they are marked ready for review. Draft pull requests skip both jobs without allocating a runner. Marking a draft ready for review starts the applicable checks immediately, and later commits continue to start them. Both workflows remain available through manual dispatch regardless of pull request state:
+```
+
+Retain the existing descriptions of both checks and their path filters. Update the final shared-behavior paragraph to include the job-level draft guard.
+
+- [ ] **Step 5: Verify the trigger and guard are present in both workflows**
+
+Run:
+
+```bash
+rg -n "ready_for_review|github\.event_name == 'workflow_dispatch' \|\| github\.event\.pull_request\.draft == false" \
+  .github/workflows/build-and-unit-test.yml \
+  .github/workflows/dotnet-format.yml
+```
+
+Expected: two `ready_for_review` matches and two identical job-guard matches.
+
+- [ ] **Step 6: Run repository verification**
+
+Run:
+
+```bash
+dotnet restore
+dotnet build --no-restore
+dotnet test --no-build
+dotnet msbuild eng/CodeCoverage.proj -t:Collect
+dotnet format --verify-no-changes
+git diff --check
+```
+
+Expected: all commands exit with code `0`; all unit tests pass; aggregate configured line coverage is at least 85%; formatting has no changes; the diff contains no whitespace errors.
+
+- [ ] **Step 7: Review and commit the implementation**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+git status --short
+```
+
+Confirm that only the two workflows, operational documentation, design specification, and implementation plan are included and that no co-author trailer is present.
+
+Then run:
+
+```bash
+git add .github/workflows/build-and-unit-test.yml \
+  .github/workflows/dotnet-format.yml \
+  docs/operations/local-development.md \
+  docs/superpowers/plans/2026-07-25-defer-draft-pr-ci.md
+git commit -m "ci: defer pull request checks until ready"
+```
+
+Expected: one implementation commit containing the workflow behavior, matching documentation, and plan.
+
+- [ ] **Step 8: Publish a draft pull request**
+
+Push `agent/defer-draft-pr-ci` to `origin`, then create a draft pull request targeting `main` with a concise summary and the verification results. Confirm through GitHub that the pull request is a draft and return its URL.

--- a/docs/superpowers/plans/2026-07-25-defer-draft-pr-ci.md
+++ b/docs/superpowers/plans/2026-07-25-defer-draft-pr-ci.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent build, unit-test, coverage, and formatting jobs from running for draft pull requests while running them immediately when a pull request becomes ready for review.
 
-**Architecture:** Keep the existing workflows and filters, add explicit pull request activity types including `ready_for_review`, and gate each complete job on manual dispatch or a non-draft pull request. Update the operational documentation in the same change so it describes the implemented behavior.
+**Architecture:** Keep the existing workflows and filters, add explicit pull request activity types including `ready_for_review` and `converted_to_draft`, and gate each complete job on manual dispatch or a non-draft pull request. Update the operational documentation in the same change so it describes the implemented behavior.
 
 **Tech Stack:** GitHub Actions workflow YAML, Markdown, .NET 10 repository verification commands
 
@@ -12,7 +12,7 @@
 
 - `workflow_dispatch` must remain available regardless of pull request state.
 - Draft pull requests may produce a skipped workflow result, but must not allocate a runner or execute build, test, coverage, or formatting steps.
-- Ready pull requests must run on `opened`, `reopened`, `synchronize`, and `ready_for_review`.
+- Ready pull requests must run on `opened`, `reopened`, `synchronize`, and `ready_for_review`; `converted_to_draft` must cancel the superseded active run through a skipped replacement run.
 - Existing target-branch filters, path filters, concurrency behavior, permissions, and job steps must remain unchanged.
 - Pull requests must be created as drafts.
 
@@ -53,6 +53,7 @@ In both workflow files, change the start of the `pull_request` configuration to:
       - reopened
       - synchronize
       - ready_for_review
+      - converted_to_draft
     branches:
       - main
 ```
@@ -74,7 +75,7 @@ Apply it to `build-and-unit-test` and `dotnet-format`. Do not add conditions to 
 Update the start of `docs/operations/local-development.md` section `Pull request checks` to say:
 
 ```markdown
-Pull requests targeting `main` run two GitHub Actions checks after they are marked ready for review. Draft pull requests skip both jobs without allocating a runner. Marking a draft ready for review starts the applicable checks immediately, and later commits continue to start them. Both workflows remain available through manual dispatch regardless of pull request state:
+Pull requests targeting `main` run two GitHub Actions checks after they are marked ready for review. Draft pull requests skip both jobs without allocating a runner. Marking a draft ready for review starts the applicable checks immediately, and later commits continue to start them. Converting a ready pull request back to draft cancels the superseded active run and skips the replacement job. Both workflows remain available through manual dispatch regardless of pull request state:
 ```
 
 Retain the existing descriptions of both checks and their path filters. Update the final shared-behavior paragraph to include the job-level draft guard.
@@ -84,12 +85,12 @@ Retain the existing descriptions of both checks and their path filters. Update t
 Run:
 
 ```bash
-rg -n "ready_for_review|github\.event_name == 'workflow_dispatch' \|\| github\.event\.pull_request\.draft == false" \
+rg -n "ready_for_review|converted_to_draft|github\.event_name == 'workflow_dispatch' \|\| github\.event\.pull_request\.draft == false" \
   .github/workflows/build-and-unit-test.yml \
   .github/workflows/dotnet-format.yml
 ```
 
-Expected: two `ready_for_review` matches and two identical job-guard matches.
+Expected: two `ready_for_review` matches, two `converted_to_draft` matches, and two identical job-guard matches.
 
 - [ ] **Step 6: Run repository verification**
 

--- a/docs/superpowers/specs/2026-07-25-defer-draft-pr-ci-design.md
+++ b/docs/superpowers/specs/2026-07-25-defer-draft-pr-ci-design.md
@@ -6,12 +6,12 @@ Avoid consuming GitHub Actions runners for draft pull requests while preserving 
 
 ## Workflow behavior
 
-Both pull request workflows will explicitly listen for `opened`, `reopened`, `synchronize`, and `ready_for_review` activity. Each job will run when either:
+Both pull request workflows will explicitly listen for `opened`, `reopened`, `synchronize`, `ready_for_review`, and `converted_to_draft` activity. Each job will run when either:
 
 - the workflow was started manually with `workflow_dispatch`; or
 - the pull request is not a draft.
 
-Opening or updating a draft pull request may create a skipped workflow result, but no runner or build, test, coverage, or formatting step will execute. Marking the pull request ready for review will trigger the workflows immediately. Later commits to a ready pull request will continue to trigger them through `synchronize`.
+Opening or updating a draft pull request may create a skipped workflow result, but no runner or build, test, coverage, or formatting step will execute. Marking the pull request ready for review will trigger the workflows immediately. Later commits to a ready pull request will continue to trigger them through `synchronize`. Converting a ready pull request back to draft creates a skipped replacement run that cancels the superseded active run through the existing concurrency group.
 
 The existing target-branch filters, path filters, concurrency behavior, permissions, and manual dispatch support remain unchanged.
 
@@ -28,7 +28,7 @@ Update `docs/operations/local-development.md` so the documented pull request beh
 
 Verify that both workflow files:
 
-- include `ready_for_review` alongside the standard pull request activity types;
+- include `ready_for_review` and `converted_to_draft` alongside the standard pull request activity types;
 - guard the complete job rather than individual steps;
 - allow `workflow_dispatch` regardless of pull request state;
 - retain the existing branch and path filters.

--- a/docs/superpowers/specs/2026-07-25-defer-draft-pr-ci-design.md
+++ b/docs/superpowers/specs/2026-07-25-defer-draft-pr-ci-design.md
@@ -1,0 +1,36 @@
+# Defer pull request CI until ready for review
+
+## Goal
+
+Avoid consuming GitHub Actions runners for draft pull requests while preserving the existing build, unit-test, coverage, and formatting checks once a pull request is ready for review.
+
+## Workflow behavior
+
+Both pull request workflows will explicitly listen for `opened`, `reopened`, `synchronize`, and `ready_for_review` activity. Each job will run when either:
+
+- the workflow was started manually with `workflow_dispatch`; or
+- the pull request is not a draft.
+
+Opening or updating a draft pull request may create a skipped workflow result, but no runner or build, test, coverage, or formatting step will execute. Marking the pull request ready for review will trigger the workflows immediately. Later commits to a ready pull request will continue to trigger them through `synchronize`.
+
+The existing target-branch filters, path filters, concurrency behavior, permissions, and manual dispatch support remain unchanged.
+
+## Implementation
+
+Add the activity types and the same job-level condition to:
+
+- `.github/workflows/build-and-unit-test.yml`
+- `.github/workflows/dotnet-format.yml`
+
+Update `docs/operations/local-development.md` so the documented pull request behavior matches the workflows.
+
+## Verification
+
+Verify that both workflow files:
+
+- include `ready_for_review` alongside the standard pull request activity types;
+- guard the complete job rather than individual steps;
+- allow `workflow_dispatch` regardless of pull request state;
+- retain the existing branch and path filters.
+
+Run the repository-required restore, build, unit-test, coverage, and formatting checks, then inspect the final diff before publishing a draft pull request.


### PR DESCRIPTION
## Summary

- skip the complete build/test/coverage and formatting jobs while a pull request is a draft
- trigger the checks when a pull request becomes ready for review and on later updates
- cancel an active run when a ready pull request is converted back to draft
- preserve unconditional manual `workflow_dispatch` support
- document the pull request check lifecycle and implementation design

## Why

Draft pull requests are work in progress and should not consume GitHub Actions runners. The checks should start only once the pull request is published for review, while retaining the existing branch filters, path filters, concurrency groups, permissions, and job steps.

## Validation

- `dotnet restore`
- `dotnet build --no-restore` — 0 warnings, 0 errors
- `dotnet test --no-build` — 34 passed, 0 failed
- `dotnet build --configuration Release --no-restore` — 0 warnings, 0 errors
- `dotnet msbuild eng/CodeCoverage.proj -t:Collect` — 97.71% aggregate line coverage (minimum 85%)
- `dotnet format --verify-no-changes`
- focused workflow trigger and job-guard checks
- `git diff --check`
- task-scoped and whole-branch reviews completed with no remaining findings