### PR TITLE
Require stable explicit enum values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ The product and solution name is `MailMcp`. The solution file is `MailMcp.slnx`;
 - Enable nullable reference types, implicit usings, deterministic builds, .NET analyzers, and code-style enforcement during builds.
 - Treat compiler and analyzer warnings as errors in repository code. Suppress a diagnostic only at the narrowest scope and document the concrete reason.
 - Maintain one repository `.editorconfig` and let automated formatting define whitespace and layout. Do not hand-format against configured rules.
+- Give every enum member an explicit, unique integral value starting at `0` and increasing contiguously in declaration order. Never reorder, renumber, or reuse an existing value; append new members with the next value. Apply this to every enum, including private and currently non-persisted types, so a future numeric persistence representation cannot silently change meaning after refactoring.
 - Prefer immutable records or value objects for data that represents values; use entities only when identity and lifecycle matter.
 - Use domain-correct, descriptive names for types, methods, parameters, variables, fields, and files. Avoid abbreviations except established terms such as IMAP, SMTP, MIME, MCP, UID, TLS, and RAG.
 - Prefer a longer name that communicates intent, constraints, or result over a short ambiguous name. Long method names are acceptable when every word adds useful domain meaning.
@@ -187,6 +188,7 @@ The product and solution name is `MailMcp`. The solution file is `MailMcp.slnx`;
 - Test observable behavior and domain invariants, not private implementation details. One test should describe one behavior even if several assertions are needed to prove it.
 - Tests must be fast, isolated, repeatable, order-independent, and safe to run in parallel. Do not use real clocks, random nondeterministic values, shared mutable fixtures, sleeps, network calls, databases, containers, or the filesystem in unit tests.
 - Prefer real domain values and simple in-memory fakes for state. Use NSubstitute at external or architectural boundaries where interaction is part of the contract.
+- Never use the EF Core InMemory provider, SQLite in-memory, any other in-memory SQL database, or mocked `DbSet` query behavior as a substitute for PostgreSQL persistence semantics. Unit-test application behavior through application-owned ports and hand-written state fakes; verify provider-specific persistence behavior only against real PostgreSQL integration tests when that phase is enabled.
 - Do not substitute concrete MailKit clients. Define narrow application-facing session or transport ports and use NSubstitute to model IMAP/SMTP server capabilities, responses, disconnects, and failures.
 - Use `Received()` and `DidNotReceive()` only when the interaction itself is a required side effect or safety invariant. Prefer state or result assertions otherwise.
 - Use argument matchers only while configuring substitutes or verifying received calls.

--- a/docs/superpowers/plans/2026-07-25-explicit-enum-values.md
+++ b/docs/superpowers/plans/2026-07-25-explicit-enum-values.md
@@ -1,0 +1,152 @@
+# Explicit Enum Values Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every enum member an explicit contiguous numeric value starting at zero and make the convention and persistence-test restrictions unambiguous in repository guidance.
+
+**Architecture:** Keep the change source-level and dependency-free. Update repository guidance, then make the only noncompliant private enum explicit without changing persistence mappings or runtime behavior.
+
+**Tech Stack:** C# 14, .NET 10, Markdown, Git.
+
+## Global Constraints
+
+- Every enum member declares an explicit integral value.
+- Values start at `0` and remain unique and contiguous in declaration order.
+- Existing numeric assignments are never reordered, renumbered, or reused.
+- New members are appended with the next available value.
+- The convention applies to all enums, including private and currently non-persisted types.
+- Do not change the existing EF Core string conversion or database schema.
+- Do not add dependencies.
+
+---
+
+### Task 1: Repository guidance
+
+**Files:**
+- Modify: `AGENTS.md`
+- Modify: `docs/superpowers/specs/2026-07-25-explicit-enum-values-design.md`
+
+**Interfaces:**
+- Consumes: the accepted enum convention and ADR 0001 persistence-test boundary
+- Produces: durable instructions for future contributors and agents
+
+- [x] **Step 1: Add the enum convention**
+
+Add this rule under `.NET and C# conventions`:
+
+```markdown
+- Give every enum member an explicit, unique integral value starting at `0` and increasing contiguously in declaration order. Never reorder, renumber, or reuse an existing value; append new members with the next value. Apply this to every enum, including private and currently non-persisted types, so a future numeric persistence representation cannot silently change meaning after refactoring.
+```
+
+- [x] **Step 2: Add the persistence-testing prohibition**
+
+Add this rule under `Unit testing policy`:
+
+```markdown
+- Never use the EF Core InMemory provider, SQLite in-memory, any other in-memory SQL database, or mocked `DbSet` query behavior as a substitute for PostgreSQL persistence semantics. Unit-test application behavior through application-owned ports and hand-written state fakes; verify provider-specific persistence behavior only against real PostgreSQL integration tests when that phase is enabled.
+```
+
+- [x] **Step 3: Verify the guidance is explicit**
+
+Run:
+
+```bash
+rg -n "every enum member|EF Core InMemory|SQLite in-memory|in-memory SQL|mocked `DbSet`|real PostgreSQL" AGENTS.md
+```
+
+Expected: both new rules are returned and all prohibited persistence-test substitutes are named.
+
+### Task 2: Explicit occurrence outcome values
+
+**Files:**
+- Modify: `src/Application/Synchronization/MailboxSynchronizer.cs`
+
+**Interfaces:**
+- Consumes: existing private `OccurrenceOutcome` enum
+- Produces: `Stored = 0` and `SkippedOversized = 1`
+
+- [x] **Step 1: Run the source-level regression check before implementation**
+
+Run:
+
+```bash
+if rg -n '^\s+(Stored|SkippedOversized),$' src/Application/Synchronization/MailboxSynchronizer.cs; then
+  exit 1
+fi
+```
+
+Expected: exit code `1` with both implicit members listed.
+
+- [x] **Step 2: Add the explicit values**
+
+Change the enum to:
+
+```csharp
+private enum OccurrenceOutcome
+{
+    Stored = 0,
+    SkippedOversized = 1,
+}
+```
+
+- [x] **Step 3: Re-run the source-level regression check**
+
+Run:
+
+```bash
+if rg -n '^\s+(Stored|SkippedOversized),$' src/Application/Synchronization/MailboxSynchronizer.cs; then
+  exit 1
+fi
+```
+
+Expected: exit code `0` with no matches.
+
+- [x] **Step 4: Inspect every production enum**
+
+Run:
+
+```bash
+rg -n --glob '*.cs' '^\s*(public|internal|private|protected)?\s*enum\s+|^\s+[A-Za-z][A-Za-z0-9_]*\s*(=\s*[0-9]+)?,\s*$' src
+```
+
+Expected: `StoredEmailContentAvailability` and `OccurrenceOutcome` are the only enum declarations, and every listed member has an explicit contiguous value starting at zero.
+
+### Task 3: Repository verification and publication
+
+**Files:**
+- Verify: all changed files
+
+**Interfaces:**
+- Consumes: completed guidance and enum changes
+- Produces: verified commit and draft pull request
+
+- [x] **Step 1: Run repository verification**
+
+Run:
+
+```bash
+dotnet restore
+dotnet build --no-restore
+dotnet test --no-build
+dotnet format --verify-no-changes
+dotnet build --configuration Release --no-restore
+dotnet msbuild .config/CodeCoverage.proj -t:Collect
+```
+
+Expected: every command exits `0`, all tests pass, formatting is unchanged, and aggregate line coverage is at least 85%.
+
+- [x] **Step 2: Inspect the final diff**
+
+Run:
+
+```bash
+git diff --check
+git diff origin/main...HEAD
+git status -sb
+```
+
+Expected: only the accepted enum convention, persistence-testing prohibition, design/plan documentation, and explicit enum assignments are present; no secrets or unrelated files appear.
+
+- [ ] **Step 3: Commit and publish**
+
+Stage only the four intended files, commit without co-author trailers, push `agent/explicit-enum-values`, and open a draft pull request targeting `main`.

--- a/docs/superpowers/specs/2026-07-25-explicit-enum-values-design.md
+++ b/docs/superpowers/specs/2026-07-25-explicit-enum-values-design.md
@@ -1,0 +1,23 @@
+# Explicit Enum Values Design
+
+## Goal
+
+Keep every C# enum safe for a future numeric persistence representation by assigning stable, explicit integral values.
+
+## Convention
+
+- Every enum member declares an explicit integral value.
+- Values start at `0` and remain unique and contiguous in declaration order.
+- Existing numeric assignments are never reordered, renumbered, or reused.
+- New members are appended with the next available value.
+- The convention applies to all enums, including private and currently non-persisted types.
+
+## Code Change
+
+`StoredEmailContentAvailability` already complies. `OccurrenceOutcome` will declare `Stored = 0` and `SkippedOversized = 1`.
+
+The existing EF Core string conversion for `StoredEmailContentAvailability` remains unchanged. This change does not modify the database schema or runtime behavior.
+
+## Verification
+
+Search all production C# sources for enum declarations and confirm each member has the expected explicit value. Run the repository restore, build, unit-test, formatting, and aggregate coverage checks.

--- a/docs/superpowers/specs/2026-07-25-explicit-enum-values-design.md
+++ b/docs/superpowers/specs/2026-07-25-explicit-enum-values-design.md
@@ -18,6 +18,10 @@ Keep every C# enum safe for a future numeric persistence representation by assig
 
 The existing EF Core string conversion for `StoredEmailContentAvailability` remains unchanged. This change does not modify the database schema or runtime behavior.
 
+## Persistence Testing Rule
+
+`AGENTS.md` will explicitly prohibit using the EF Core InMemory provider, SQLite in-memory, any other in-memory SQL database, or mocked `DbSet` query behavior as a substitute for PostgreSQL persistence semantics. Application behavior remains unit-tested through application-owned ports and hand-written state fakes. Provider-specific persistence behavior must be verified against real PostgreSQL when the integration-test phase is enabled.
+
 ## Verification
 
-Search all production C# sources for enum declarations and confirm each member has the expected explicit value. Run the repository restore, build, unit-test, formatting, and aggregate coverage checks.
+Search all production C# sources for enum declarations and confirm each member has the expected explicit value. Confirm that `AGENTS.md` names every prohibited in-memory persistence-testing mechanism. Run the repository restore, build, unit-test, formatting, and aggregate coverage checks.

--- a/src/Application/Synchronization/MailboxSynchronizer.cs
+++ b/src/Application/Synchronization/MailboxSynchronizer.cs
@@ -147,8 +147,8 @@ public sealed class MailboxSynchronizer
 
     private enum OccurrenceOutcome
     {
-        Stored,
-        SkippedOversized,
+        Stored = 0,
+        SkippedOversized = 1,
     }
 }
 


### PR DESCRIPTION
## Summary

- require every enum member to declare a unique, contiguous numeric value starting at `0`
- preserve existing enum values by forbidding reordering, renumbering, and reuse
- make the private `OccurrenceOutcome` assignments explicit
- prohibit EF Core InMemory, SQLite in-memory, other in-memory SQL databases, and mocked `DbSet` query behavior as substitutes for PostgreSQL persistence semantics

## Why

Explicit stable assignments prevent enum meaning from changing silently during refactoring if a type is later stored numerically. Persistence tests must exercise real PostgreSQL semantics instead of provider substitutes whose transactions, SQL dialect, query translation, and constraints differ.

## Impact

The existing EF Core string conversion remains unchanged. This PR does not change the database schema, runtime behavior, or dependencies.

## Validation

- `dotnet restore`
- `dotnet build --no-restore` — 0 warnings, 0 errors
- `dotnet test --no-build` — 34 passed, 0 failed
- `dotnet format --verify-no-changes`
- `dotnet build --configuration Release --no-restore` — 0 warnings, 0 errors
- `dotnet msbuild .config/CodeCoverage.proj -t:Collect` — 97.71% aggregate line coverage (213/218), required 85%
- source audit confirmed both production enums use explicit contiguous values from zero
- independent diff review completed with no findings