### PR TITLE
Plan the secret reference resolution implementation

### DIFF
--- a/docs/superpowers/plans/2026-07-27-certificate-material-and-secret-rotation-02b.md
+++ b/docs/superpowers/plans/2026-07-27-certificate-material-and-secret-rotation-02b.md
@@ -32,7 +32,14 @@ This plan inherits the decisions recorded in the 02a plan and does not restate t
 Two decisions are new to this plan:
 
 - **28. Inline certificate material is PEM only, and says so.** A trust anchor is a public certificate, so writing one into configuration leaks nothing and the inline interpretation modes must accept it — that is what makes an Azure App Configuration deployment work end to end for the anchor as well as for passwords. But only PEM survives a configuration value: DER and PKCS#12 are binary and have no faithful representation there. An inline block carrying binary material therefore fails startup with a failure identity that names the encoding as the reason, rather than surfacing a generic parse error that sends the operator looking in the wrong place. PEM is multi-line, so a JSON document has to escape the newlines; that is the operator's problem to accept, and a store-backed provider does not have it because the value is transported rather than authored in JSON.
-- **29. The bundle password is a second secret block, resolved through the same contract.** A PKCS#12 bundle protected by a password needs two references, which is the concrete case 02a decision 25 shaped the block for. The password is a sibling `PasswordSecretReference` inside the same block, so it is discovered, validated, and erased by exactly the machinery 02a already built. Nothing about PKCS#12 gets its own resolution path.
+- **29. The bundle password is the nested block 02a already ships.** A PKCS#12 bundle protected by a password needs two references, which is the case 02a decision 25 shaped `ConfiguredSecret` for: the block carries an optional nested `Password` that is itself a `ConfiguredSecret`. An earlier draft made it a sibling *string* named `PasswordSecretReference`, which would have been invisible to the discovery walk — the walk looks for the block type, and a string is not one — so it could not have been bound, validated, resolved, or erased by the machinery this plan claims to reuse. Worse, fixing it here would have changed a contract 02a had already shipped, which this plan is barred from doing. The nested block is therefore defined in 02a, and this plan adds no property to `ConfiguredSecret` at all.
+
+```json
+"TrustedCertificateAuthority": {
+  "SecretReference": "file:/run/secrets/ca-bundle.pfx",
+  "Password": { "SecretReference": "systemd-credential:ca-bundle-password" }
+}
+```
 
 ## File structure
 
@@ -73,6 +80,7 @@ public enum CertificateMaterialFailure
     BinaryEncodingNotPermittedInline = 1,
     BundlePasswordMissing = 2,
     BundlePasswordIncorrect = 3,
+    PrivateKeyNotPermittedInTrustAnchor = 4,
 }
 
 internal static class X509CertificateMaterialLoader
@@ -80,6 +88,7 @@ internal static class X509CertificateMaterialLoader
     internal static bool TryLoad(
         ReadOnlySpan<byte> material,
         ResolvedSecret? bundlePassword,
+        SecretMaterialSource source,
         out X509Certificate2? certificate,
         out CertificateMaterialFailure failure);
 }
@@ -93,7 +102,8 @@ The fixture builds its certificates in memory with `CertificateRequest` and `Cre
 [Fact] TryLoad_PemCertificate_LoadsTheSubject
 [Fact] TryLoad_DerCertificate_LoadsTheSubject
 [Fact] TryLoad_Pkcs12BundleWithTheCorrectPassword_LoadsTheCertificate
-[Fact] TryLoad_Pkcs12BundleWithoutAPassword_ReportsBundlePasswordMissing
+[Fact] TryLoad_UnprotectedPkcs12Bundle_LoadsWithoutAPasswordBlock
+[Fact] TryLoad_ProtectedPkcs12BundleWithNoPasswordBlock_ReportsBundlePasswordMissing
 [Fact] TryLoad_Pkcs12BundleWithTheWrongPassword_ReportsBundlePasswordIncorrect
 [Fact] TryLoad_ArbitraryBytes_ReportsNotACertificate
 [Fact] TryLoad_EveryFailure_ProducesNoExceptionAndNoMaterialInTheResult
@@ -105,9 +115,15 @@ Expected: FAIL — the loader does not exist.
 
 - [ ] **Step 3: Implement**
 
-`X509Certificate2.CreateFromPem` and the PKCS#12 constructor both throw `CryptographicException` on bad material, so each is wrapped in a `try`/`catch (CryptographicException)` that becomes a named failure. A catch this broad is justified only because the alternative is an unhandled exception during startup validation with a message that may quote material; the caught exception is not rethrown and its message is not propagated.
+`X509Certificate2.CreateFromPem` and the PKCS#12 import both throw `CryptographicException` on bad material, so each is wrapped in a `try`/`catch (CryptographicException)` that becomes a named failure. A catch this broad is justified only because the alternative is an unhandled exception during startup validation with a message that may quote material; the caught exception is not rethrown and its message is not propagated.
 
 Encoding is detected by inspecting the material rather than by trusting a file extension, because `file:/run/secrets/ca.pem` may hold DER and the operator will not find that out from the name.
+
+**An unprotected PKCS#12 bundle is valid and loads.** The specification says a bundle *may* carry its own password, so a certificate-only or deliberately unprotected PFX is a legitimate form of a required encoding. The loader attempts a null password when no password block is configured, and reserves `BundlePasswordMissing` for a bundle that is actually protected. Requiring a password block unconditionally would reject files an operator is entitled to use.
+
+**A trust anchor must not carry a private key.** PKCS#12 bundles commonly do, and this feature needs only a public anchor — it presents no certificate of its own. An imported private key would sit outside the buffer this plan owns, so disposing the certificate would not satisfy the operation-scoped lifetime guarantee, and with default key-storage flags the import can persist key material to disk. Import therefore uses `X509KeyStorageFlags.EphemeralKeySet` so nothing is written to a key store, and a bundle whose certificate carries a private key is rejected as `PrivateKeyNotPermittedInTrustAnchor` rather than silently accepted. The rule is stated on the loader because a later caller that legitimately needs a key — a client certificate in stage 9 — must opt in explicitly rather than inherit an anchor's permissions.
+
+**Binary encodings are rejected only when the material came inline.** This is where 02a decision 28's `SecretMaterialSource` earns its place. `InlineValue` plus a detected binary encoding is `BinaryEncodingNotPermittedInline`; `SchemeAdapter` plus the same bytes is a perfectly ordinary DER or PFX anchor read from a file. Consulting the global interpretation mode instead would be wrong in both directions under `ReferenceOrInline` — it would reject a valid `file:` DER anchor, or accept an inline one, depending on which way the guess was written.
 
 - [ ] **Step 4: Resolve the anchor in the account options**
 
@@ -151,6 +167,7 @@ internal static class MailServerCertificateValidator
     internal static bool IsTrusted(
         X509Certificate2? trustedCertificateAuthority,
         X509Certificate? serverCertificate,
+        X509Chain? serverChain,
         SslPolicyErrors sslPolicyErrors);
 }
 ```
@@ -164,6 +181,8 @@ The fixture builds an in-memory CA and a leaf signed by it with `CertificateRequ
 ```csharp
 [Fact] IsTrusted_NoPolicyErrors_TrustsWithoutConsultingTheAnchor
 [Fact] IsTrusted_ChainErrorsAndLeafChainsToTheConfiguredAnchor_Trusts
+[Fact] IsTrusted_LeafSignedByAnIntermediateSuppliedByTheServer_Trusts
+[Fact] IsTrusted_IntermediateSuppliedByTheServerIsNotItselfTrusted_Rejects
 [Fact] IsTrusted_ChainErrorsAndLeafChainsToADifferentAuthority_Rejects
 [Fact] IsTrusted_ChainErrorsWithoutAConfiguredAnchor_Rejects
 [Fact] IsTrusted_NameMismatch_RejectsEvenWhenTheAnchorMatches
@@ -183,6 +202,7 @@ Expected: FAIL — the validator does not exist.
 internal static bool IsTrusted(
     X509Certificate2? trustedCertificateAuthority,
     X509Certificate? serverCertificate,
+    X509Chain? serverChain,
     SslPolicyErrors sslPolicyErrors)
 {
     if (sslPolicyErrors == SslPolicyErrors.None)
@@ -207,6 +227,18 @@ internal static bool IsTrusted(
     chain.ChainPolicy.CustomTrustStore.Add(trustedCertificateAuthority);
     chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
     chain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
+
+    // The server may have supplied intermediates that are in neither the machine store nor an AIA-reachable
+    // location. Discarding the callback's chain would reject a correctly provisioned root -> intermediate -> leaf
+    // deployment. Only non-leaf elements are carried over, and ExtraStore supplies candidates for path building
+    // without granting any of them trust: trust still comes solely from CustomTrustStore.
+    if (serverChain is not null)
+    {
+        foreach (var element in serverChain.ChainElements.Skip(1))
+        {
+            chain.ChainPolicy.ExtraStore.Add(element.Certificate);
+        }
+    }
 
     return chain.Build(presentedCertificate);
 }
@@ -254,6 +286,9 @@ Decision 18 makes this a blocking prerequisite: **do not start this task until A
 [Fact] ReloadAsync_ReferenceChangedToAResolvableTarget_PublishesTheNewSecrets
 [Fact] ReloadAsync_CandidateSnapshotHasAnUnresolvableReference_KeepsThePreviousSecrets
 [Fact] ReloadAsync_RejectedSnapshot_LogsThePathAndFailureWithoutMaterial
+[Fact] ReloadAsync_ResolutionThrows_KeepsThePreviousSnapshotAndDoesNotPropagate
+[Fact] ReloadAsync_TwoCandidatesInRapidSuccession_PublishesTheNewerOneLast
+[Fact] ReloadAsync_DatabasePasswordReferenceChanged_RebuildsTheDataSource
 [Fact] ResolveAsync_MaterialRotatedBehindAnUnchangedReference_ReturnsTheRotatedValue
 [Fact] ResolveAsync_MaterialRotatedMidOperation_DoesNotAffectTheOperationInFlight
 ```
@@ -266,15 +301,27 @@ The last two are the pair that distinguishes the two reload halves, and the last
 
 - [ ] **Step 3: Validate the candidate before publishing it**
 
-`MailSecretSnapshotPublisher` subscribes to `OnChange`, resolves every reference in the candidate snapshot, and publishes an immutable snapshot only when all of them resolve. On failure it retains the previous snapshot and logs the configuration path and the `SecretResolutionFailure` — never a path, a variable name, or material. This is the last-known-good behavior ADR 0002 requires of any reloadable group.
+`IOptionsMonitor.OnChange` takes a **synchronous** callback, and resolving a candidate snapshot is asynchronous by decision 4 and may later perform network I/O. Implementing this literally leaves only two shapes, and both are defects: blocking inside the callback stalls the configuration-provider thread, and `async void` lets an exception tear down the process and lets two rapid reloads race so that an older candidate publishes after a newer one.
 
-Reload validation must not crash the process: ADR 0002 is explicit that a rejected reload leaves the previous valid settings active, unlike a startup failure which is fatal.
+`MailSecretSnapshotPublisher` therefore does almost nothing in the callback. `OnChange` writes the candidate into a bounded channel and returns; a single `BackgroundService` reads it, resolves every reference, and publishes an immutable snapshot only when all of them resolve. One reader means candidates are validated in arrival order and the last one to publish is the last one to arrive. The channel drops the older candidate when a newer arrives while one is queued, since validating a superseded snapshot wastes a credential read for a result nobody will use.
+
+On failure it retains the previous snapshot and logs the configuration path and the `SecretResolutionFailure` — never the target, a variable name, or material. This is the last-known-good behavior ADR 0002 requires of any reloadable group.
+
+Reload validation must not crash the process: ADR 0002 is explicit that a rejected reload leaves the previous valid settings active, unlike a startup failure, which is fatal. The worker therefore catches every exception from resolution, logs it, and continues — the one place in this plan where a blanket catch is correct, because the alternative is a configuration edit killing a running host.
 
 - [ ] **Step 4: Resolve material per operation**
 
-No change is needed for the material half — decision 16 already resolves per use, which is what makes rotation behind an unchanged reference work. The test in Step 1 is what proves it, and it exists to catch a future "optimization" that caches the resolved value on the options instance.
+For mail secrets no change is needed: 02a decision 16 already resolves per use, which is what makes rotation behind an unchanged reference work. The test in Step 1 exists to catch a future "optimization" that caches the resolved value on the options instance.
 
-- [ ] **Step 5: Run the tests and commit**
+- [ ] **Step 5: Rotate the database credential too**
+
+The database password is the exception, and it would otherwise silently break the promise this specification makes for it. 02a composes it once into a singleton `NpgsqlDataSource`, so neither a changed `Persistence:Password` reference nor rotated material behind it reaches a connection opened afterwards — revoking the old credential would take MailMcp offline until restart, which is exactly the outcome rotation exists to prevent.
+
+`NpgsqlDataSource` is registered behind a provider that rebuilds it when the persistence snapshot changes, disposing the superseded data source only after its in-flight connections drain. Connections already open keep the credential they authenticated with, which is decision 17's operation boundary applied to the database rather than an exception to it.
+
+Rotation of material behind an *unchanged* database reference cannot be observed by a data source that was built once, so the provider re-resolves on a bounded interval and rebuilds when the resolved value differs. That is a deliberate departure from per-use resolution: opening a pooled connection is not the place to read a credential file, and the interval bounds how long a revoked credential stays usable. The interval is configuration, and its default is documented.
+
+- [ ] **Step 6: Run the tests and commit**
 
 ```bash
 dotnet test --project tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj
@@ -316,7 +363,12 @@ git commit -m "Document trust anchor behavior and the secret rotation procedure"
 | Specification requirement | Covered by |
 | --- | --- |
 | PEM, DER, and PKCS#12 all load from resolved bytes | Task 1 |
-| A PKCS#12 password comes from a second secret block | decision 29, Task 1 |
+| A PKCS#12 password comes from the nested secret block 02a ships | decision 29, Task 1 |
+| An unprotected PKCS#12 bundle loads without a password block | Task 1 |
+| A private-key-bearing anchor is rejected; import is ephemeral | Task 1 |
+| A server-supplied intermediate completes the chain without gaining trust | Task 2 |
+| The database credential rotates too | Task 3 Step 5 |
+| Reload never blocks, never crashes, never publishes out of order | Task 3 Step 3 |
 | Inline PEM works; inline binary fails naming the encoding | decision 28, Task 1 |
 | Malformed anchor material fails startup without disclosing material | Task 1 |
 | A private server connects with validation fully enabled | Task 2 |
@@ -330,5 +382,6 @@ git commit -m "Document trust anchor behavior and the secret rotation procedure"
 **Flagged for the owner**
 
 - **Blocking:** ADR 0002 must be amended before Task 3 begins (decision 18). Tasks 1 and 2 are unaffected and can proceed as soon as 02a merges.
+- The Codex review on PR #59 raised the intermediate-certificate, private-key, unprotected-bundle, reload-callback, and database-rotation points now folded into this plan. The one that changed the shape of the split is the bundle password: it had to become a nested block in 02a, because a sibling string would have been invisible to the discovery walk and fixing it here would have modified a contract 02a had already shipped. That is the escalation this plan's global constraint asks for, and it was resolved by moving the property rather than by bending the constraint.
 - Decision 28 rejects inline binary certificate material rather than accepting base64. Base64 would work and would let a DER anchor be configured inline, but it introduces a second encoding an operator has to know about and get right, for a case PEM already covers. If you would rather support it, it is a small addition to the loader and a line in the documentation.
 - `RevocationMode = NoCheck` on the custom-anchor path is a real trade-off, not an oversight: a private authority typically publishes no reachable CRL or OCSP responder, and a revocation lookup that cannot complete would reject a correctly provisioned server. It is confined to the custom-anchor path and the system trust path keeps the platform default. If revocation checking on private anchors matters more than that failure mode, this is the decision to revisit.

--- a/docs/superpowers/plans/2026-07-27-certificate-material-and-secret-rotation-02b.md
+++ b/docs/superpowers/plans/2026-07-27-certificate-material-and-secret-rotation-02b.md
@@ -129,10 +129,14 @@ Encoding is detected by inspecting the material rather than by trusting a file e
 
 `MailAccountSecretOptions.FindConfigurationErrorsAsync` and `ResolveAsync` regain the `ConfiguredSecret? trustedCertificateAuthority` parameter that 02a deliberately left out, resolve it when present, and load it through `TryLoad`. `MailAccountSecrets` becomes `(ResolvedSecret Password, X509Certificate2? TrustedCertificateAuthority)` and disposes both — `X509Certificate2` is itself disposable, and 02a decision 9's ownership rule already says the operation that resolved it disposes it.
 
-Inline material reaches `TryLoad` as bytes like any other, so decision 28's binary-inline rejection is a check on the interpretation mode plus the detected encoding, not a separate code path.
+Inline material reaches `TryLoad` as bytes like any other, so the binary-inline rejection is a check on 02a decision 28's `SecretMaterialSource` plus the detected encoding, not a separate code path.
+
+A protected bundle takes its password from the nested `Password` block 02a decision 25 defines, resolved through the same resolver as every other secret and disposed with the rest of `MailAccountSecrets`. Nothing here adds a property to `ConfiguredSecret`.
 
 ```csharp
 [Fact] FindConfigurationErrorsAsync_UnresolvableTrustAnchorReference_ReportsTheFailureAgainstTheTrustAnchorSetting
+[Fact] FindConfigurationErrorsAsync_UnresolvableBundlePasswordBlock_ReportsTheFailureAgainstTheNestedPasswordPath
+[Fact] ResolveAsync_ProtectedPkcs12AnchorWithANestedPasswordBlock_ResolvesBothAndLoadsTheAnchor
 [Fact] FindConfigurationErrorsAsync_TrustAnchorMaterialIsNotACertificate_ReportsNotACertificate
 [Fact] FindConfigurationErrorsAsync_InlineDerTrustAnchor_ReportsBinaryEncodingNotPermittedInline
 [Fact] FindConfigurationErrorsAsync_NoTrustAnchorConfigured_DoesNotConsultTheResolver

--- a/docs/superpowers/plans/2026-07-27-certificate-material-and-secret-rotation-02b.md
+++ b/docs/superpowers/plans/2026-07-27-certificate-material-and-secret-rotation-02b.md
@@ -1,0 +1,334 @@
+# Certificate Material and Secret Rotation Implementation Plan (02b)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Governing issue:** [#63 — Spec 02b — Certificate material and secret rotation](https://github.com/Krzysztof318/MailMcp/issues/63)
+**Governing specification:** [`specs/02b-certificate-material-and-secret-rotation.md`](../../../specs/02b-certificate-material-and-secret-rotation.md)
+**Architectural context:** `specs/2026-07-22-mail-mcp-architecture-draft.md` sections 7.3 and 19, ADR `docs/decisions/0002-configuration-reading-mapping-and-reload-boundary.md`
+**Depends on:** [#36 — Spec 02a](https://github.com/Krzysztof318/MailMcp/issues/36) and its plan, [`2026-07-27-secret-reference-resolution-02a.md`](2026-07-27-secret-reference-resolution-02a.md) — this plan consumes that contract and changes none of it
+
+**Goal:** Load deployment-provisioned certificate material through the resolution contract 02a delivers, install a trusted certificate authority into the mail transport's validation path so a private server is supported with validation fully enabled, and let a rotated secret take effect without restarting the process.
+
+**Architecture:** `Infrastructure` gains a certificate material loader above the resolver and the custom-root-trust validation callback the MailKit adapter installs. `Host` switches the mail options consumer to `IOptionsMonitor` and publishes a validated snapshot. `Application` and `Domain` gain nothing, exactly as in 02a.
+
+**Tech Stack:** .NET 10, C# preview, MailKit 4.17.0, xUnit.net v3 on Microsoft Testing Platform v2, NSubstitute 6.0.0.
+
+## Global Constraints
+
+- Certificate validation stays enabled unconditionally. Nothing introduced here may expose a "trust any certificate" flag, an `SslProtocols` override, or a callback that returns `true` on an unexamined chain. This is the constraint most at risk in this plan, because the trust anchor path is exactly where a shortcut would look reasonable.
+- No secret material reaches a log, an exception message, or a diagnostic dump. A trust anchor is public and may be logged by subject and thumbprint; a bundle password may not.
+- `Domain` and `Application` stay free of every type introduced here.
+- Nothing in this plan changes a contract 02a shipped. If a change looks necessary, it is a signal that the split was drawn in the wrong place and belongs back to the owner rather than being absorbed quietly.
+
+## Design decisions
+
+This plan inherits the decisions recorded in the 02a plan and does not restate them; they are one design record for one mechanism, and duplicating them would let two copies drift. Four of those decisions are this plan's own subject and keep their original numbers so a cross-reference from either plan resolves to the same thing:
+
+- **11. Typed material is loaded above the resolver, not inside it.** `X509CertificateMaterialLoader` in `Infrastructure` turns resolved bytes into an `X509Certificate2`, accepting PEM and DER and, for key material, PKCS#12 with an optional separately-referenced password. The resolver stays ignorant of X.509 so that adding a future material kind — an SSH key, a JWT signing key — adds a loader rather than touching every scheme adapter.
+- **17. Secrets are reloadable for new operations, not during running operations.** Both halves reload: a changed *reference* arrives through `IOptionsMonitor` and is validated by resolving the whole candidate snapshot before publishing it, with the last known good snapshot retained on failure; changed *material* is picked up by 02a decision 16's per-use resolution. Neither is applied mid-operation — a synchronization run that has authenticated finishes with the credential it authenticated with, because swapping a credential or trust anchor underneath an open IMAP session has no coherent meaning. This is ADR 0002's middle classification, chosen deliberately over the strictest one.
+- **18. ADR 0002 must be amended before this is implemented.** The ADR currently classifies credentials and certificate trust anchors as restart-required, and decision 17 departs from that. The departure is defensible — the reference indirection means rotation re-resolves a validated reference rather than mutating a bound secret in place — but `docs/AGENTS.md` forbids modifying an ADR without explicit owner approval, so no ADR is touched here. **This is a blocking prerequisite for Task 3, not a follow-up.** Tasks 1 and 2 are unaffected.
+- **21. A custom trust anchor is validated by rebuilding the chain, never by accepting errors.** `RemoteCertificateNotAvailable` and `RemoteCertificateNameMismatch` are rejected outright. Only `RemoteCertificateChainErrors` is re-examined, by building an `X509Chain` with `TrustMode = X509ChainTrustMode.CustomRootTrust` and the anchor in `CustomTrustStore` — which Microsoft documents as respected only under that trust mode — and requiring a clean rebuild. MailKit's own `SslCertificateValidation.cs` example stops at describing errors and does not implement custom-CA trust, so this logic is ours to write and ours to test.
+
+Two decisions are new to this plan:
+
+- **28. Inline certificate material is PEM only, and says so.** A trust anchor is a public certificate, so writing one into configuration leaks nothing and the inline interpretation modes must accept it — that is what makes an Azure App Configuration deployment work end to end for the anchor as well as for passwords. But only PEM survives a configuration value: DER and PKCS#12 are binary and have no faithful representation there. An inline block carrying binary material therefore fails startup with a failure identity that names the encoding as the reason, rather than surfacing a generic parse error that sends the operator looking in the wrong place. PEM is multi-line, so a JSON document has to escape the newlines; that is the operator's problem to accept, and a store-backed provider does not have it because the value is transported rather than authored in JSON.
+- **29. The bundle password is a second secret block, resolved through the same contract.** A PKCS#12 bundle protected by a password needs two references, which is the concrete case 02a decision 25 shaped the block for. The password is a sibling `PasswordSecretReference` inside the same block, so it is discovered, validated, and erased by exactly the machinery 02a already built. Nothing about PKCS#12 gets its own resolution path.
+
+## File structure
+
+**Create**
+
+- `src/Infrastructure/Secrets/X509CertificateMaterialLoader.cs` — PEM, DER, and PKCS#12 loading over resolved bytes.
+- `src/Infrastructure/Mail/MailServerCertificateValidator.cs` — the custom-root-trust validation callback.
+- `src/Host/Configuration/MailSecretSnapshotPublisher.cs` — validates a candidate snapshot before publishing it.
+- `tests/Infrastructure.UnitTests/X509CertificateMaterialLoaderTests.cs`
+- `tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs`
+- `tests/Infrastructure.UnitTests/MailAccountSecretReloadTests.cs`
+
+**Modify**
+
+- `src/Infrastructure/Mail/MailAccountSecretOptions.cs` — resolves and parses the trust anchor beside the password.
+- `src/Infrastructure/Mail/MailAccountSecrets.cs` — gains the resolved `X509Certificate2`, disposed on the same path as the password.
+- `src/Infrastructure/Mail/ImapAccountSettings.cs` — carries the optional trust anchor.
+- `src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs` — the client port carries the validation callback; the factory installs it before connecting.
+- `src/Host/Configuration/MailSynchronizationOptions.cs`, `src/Host/Program.cs` — `IOptionsMonitor` binding and snapshot publication.
+- `docs/features/imap-synchronization.md` — trust anchor behavior and the revocation trade-off; the pending item 02a left open is resolved here.
+- `docs/operations/secret-provisioning.md` — certificate encodings, the inline PEM limit, and the rotation procedure.
+
+---
+
+### Task 1: Certificate material loading above the resolver
+
+**Files:**
+- Create: `src/Infrastructure/Secrets/X509CertificateMaterialLoader.cs`
+- Modify: `src/Infrastructure/Mail/MailAccountSecretOptions.cs`, `src/Infrastructure/Mail/MailAccountSecrets.cs`, `src/Infrastructure/Mail/ImapAccountSettings.cs`
+- Test: `tests/Infrastructure.UnitTests/X509CertificateMaterialLoaderTests.cs`, `tests/Infrastructure.UnitTests/MailAccountSecretOptionsTests.cs`
+
+**Interfaces produced:**
+
+```csharp
+public enum CertificateMaterialFailure
+{
+    NotACertificate = 0,
+    BinaryEncodingNotPermittedInline = 1,
+    BundlePasswordMissing = 2,
+    BundlePasswordIncorrect = 3,
+}
+
+internal static class X509CertificateMaterialLoader
+{
+    internal static bool TryLoad(
+        ReadOnlySpan<byte> material,
+        ResolvedSecret? bundlePassword,
+        out X509Certificate2? certificate,
+        out CertificateMaterialFailure failure);
+}
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+The fixture builds its certificates in memory with `CertificateRequest` and `CreateSelfSigned`, exports PEM with `ExportCertificatePem()` and DER with `Export(X509ContentType.Cert)` — no file system, no network, no real trust store.
+
+```csharp
+[Fact] TryLoad_PemCertificate_LoadsTheSubject
+[Fact] TryLoad_DerCertificate_LoadsTheSubject
+[Fact] TryLoad_Pkcs12BundleWithTheCorrectPassword_LoadsTheCertificate
+[Fact] TryLoad_Pkcs12BundleWithoutAPassword_ReportsBundlePasswordMissing
+[Fact] TryLoad_Pkcs12BundleWithTheWrongPassword_ReportsBundlePasswordIncorrect
+[Fact] TryLoad_ArbitraryBytes_ReportsNotACertificate
+[Fact] TryLoad_EveryFailure_ProducesNoExceptionAndNoMaterialInTheResult
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Expected: FAIL — the loader does not exist.
+
+- [ ] **Step 3: Implement**
+
+`X509Certificate2.CreateFromPem` and the PKCS#12 constructor both throw `CryptographicException` on bad material, so each is wrapped in a `try`/`catch (CryptographicException)` that becomes a named failure. A catch this broad is justified only because the alternative is an unhandled exception during startup validation with a message that may quote material; the caught exception is not rethrown and its message is not propagated.
+
+Encoding is detected by inspecting the material rather than by trusting a file extension, because `file:/run/secrets/ca.pem` may hold DER and the operator will not find that out from the name.
+
+- [ ] **Step 4: Resolve the anchor in the account options**
+
+`MailAccountSecretOptions.FindConfigurationErrorsAsync` and `ResolveAsync` regain the `ConfiguredSecret? trustedCertificateAuthority` parameter that 02a deliberately left out, resolve it when present, and load it through `TryLoad`. `MailAccountSecrets` becomes `(ResolvedSecret Password, X509Certificate2? TrustedCertificateAuthority)` and disposes both — `X509Certificate2` is itself disposable, and 02a decision 9's ownership rule already says the operation that resolved it disposes it.
+
+Inline material reaches `TryLoad` as bytes like any other, so decision 28's binary-inline rejection is a check on the interpretation mode plus the detected encoding, not a separate code path.
+
+```csharp
+[Fact] FindConfigurationErrorsAsync_UnresolvableTrustAnchorReference_ReportsTheFailureAgainstTheTrustAnchorSetting
+[Fact] FindConfigurationErrorsAsync_TrustAnchorMaterialIsNotACertificate_ReportsNotACertificate
+[Fact] FindConfigurationErrorsAsync_InlineDerTrustAnchor_ReportsBinaryEncodingNotPermittedInline
+[Fact] FindConfigurationErrorsAsync_NoTrustAnchorConfigured_DoesNotConsultTheResolver
+[Fact] ResolveAsync_PemTrustAnchor_ReturnsThePasswordAndTheParsedAnchor
+[Fact] Dispose_ResolvedAccountSecrets_ErasesThePasswordAndDisposesTheAnchor
+```
+
+- [ ] **Step 5: Run the tests and commit**
+
+```bash
+dotnet test --project tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj
+git add src/Infrastructure tests/Infrastructure.UnitTests
+git commit -m "Load PEM, DER, and PKCS#12 certificate material from resolved secrets"
+```
+
+---
+
+### Task 2: Install the trust anchor in the certificate validation path
+
+**Files:**
+- Create: `src/Infrastructure/Mail/MailServerCertificateValidator.cs`
+- Modify: `src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs`
+- Test: `tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs`
+
+**Interfaces produced:**
+
+```csharp
+internal static class MailServerCertificateValidator
+{
+    internal static RemoteCertificateValidationCallback? CreateCallback(X509Certificate2? trustedCertificateAuthority);
+
+    internal static bool IsTrusted(
+        X509Certificate2? trustedCertificateAuthority,
+        X509Certificate? serverCertificate,
+        SslPolicyErrors sslPolicyErrors);
+}
+```
+
+`IMailKitImapClient` gains `RemoteCertificateValidationCallback? ServerCertificateValidationCallback { get; set; }`, forwarded by `MailKitImapClientAdapter` to `ImapClient.ServerCertificateValidationCallback`.
+
+- [ ] **Step 1: Write the failing tests**
+
+The fixture builds an in-memory CA and a leaf signed by it with `CertificateRequest`, so no file system, network, or real trust store is involved:
+
+```csharp
+[Fact] IsTrusted_NoPolicyErrors_TrustsWithoutConsultingTheAnchor
+[Fact] IsTrusted_ChainErrorsAndLeafChainsToTheConfiguredAnchor_Trusts
+[Fact] IsTrusted_ChainErrorsAndLeafChainsToADifferentAuthority_Rejects
+[Fact] IsTrusted_ChainErrorsWithoutAConfiguredAnchor_Rejects
+[Fact] IsTrusted_NameMismatch_RejectsEvenWhenTheAnchorMatches
+[Fact] IsTrusted_CertificateNotAvailable_Rejects
+[Fact] CreateCallback_NoAnchorConfigured_ReturnsNullSoTheDefaultValidationApplies
+```
+
+`IsTrusted_NameMismatch_RejectsEvenWhenTheAnchorMatches` is the test that stops this task from becoming a certificate-validation bypass.
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Expected: FAIL — the validator does not exist.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+internal static bool IsTrusted(
+    X509Certificate2? trustedCertificateAuthority,
+    X509Certificate? serverCertificate,
+    SslPolicyErrors sslPolicyErrors)
+{
+    if (sslPolicyErrors == SslPolicyErrors.None)
+    {
+        return true;
+    }
+
+    // Only an untrusted chain is reconsidered. A missing certificate proves nothing, and a name mismatch means the
+    // certificate belongs to a different host, which a private trust anchor does not and must not excuse.
+    if (trustedCertificateAuthority is null || sslPolicyErrors != SslPolicyErrors.RemoteCertificateChainErrors)
+    {
+        return false;
+    }
+
+    if (serverCertificate is not X509Certificate2 presentedCertificate)
+    {
+        return false;
+    }
+
+    using var chain = new X509Chain();
+    chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+    chain.ChainPolicy.CustomTrustStore.Add(trustedCertificateAuthority);
+    chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+    chain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
+
+    return chain.Build(presentedCertificate);
+}
+```
+
+`CustomTrustStore` is documented as respected only when `TrustMode` is `CustomRootTrust`, so both must be set together; setting the collection alone would silently keep the system trust store in effect. `VerificationFlags` is pinned to `NoFlag` so no future edit can relax expiry or basic-constraint checking. `RevocationMode` is `NoCheck` because a private authority typically publishes no reachable CRL or OCSP responder, and a revocation lookup that cannot complete would otherwise reject a correctly provisioned server — this is a deliberate, documented trade-off confined to the custom-anchor path, and the system trust path keeps whatever the platform default applies.
+
+The session factory installs the callback before connecting and reveals the password once:
+
+```csharp
+client.ServerCertificateValidationCallback =
+    MailServerCertificateValidator.CreateCallback(settings.TrustedCertificateAuthority);
+
+await client.ConnectAsync(...);
+...
+await client.AuthenticateAsync(settings.UserName, settings.Password.RevealAsString(), cancellationToken);
+```
+
+- [ ] **Step 4: Run the tests**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Infrastructure/Mail tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs
+git commit -m "Validate a private mail server against its configured trust anchor"
+```
+
+---
+
+
+### Task 3: Dynamic reload of references and material
+
+**Files:**
+- Modify: `src/Host/Configuration/MailSynchronizationOptions.cs`, `src/Host/Program.cs`, `src/Infrastructure/Mail/MailAccountSecretOptions.cs`
+- Create: `src/Host/Configuration/MailSecretSnapshotPublisher.cs`
+- Test: `tests/Infrastructure.UnitTests/MailAccountSecretReloadTests.cs`
+
+Decision 18 makes this a blocking prerequisite: **do not start this task until ADR 0002 has been amended with owner approval.** The ADR classifies credentials and trust anchors as restart-required, and this task deliberately reclassifies them as reloadable for new operations.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+[Fact] ReloadAsync_ReferenceChangedToAResolvableTarget_PublishesTheNewSecrets
+[Fact] ReloadAsync_CandidateSnapshotHasAnUnresolvableReference_KeepsThePreviousSecrets
+[Fact] ReloadAsync_RejectedSnapshot_LogsThePathAndFailureWithoutMaterial
+[Fact] ResolveAsync_MaterialRotatedBehindAnUnchangedReference_ReturnsTheRotatedValue
+[Fact] ResolveAsync_MaterialRotatedMidOperation_DoesNotAffectTheOperationInFlight
+```
+
+The last two are the pair that distinguishes the two reload halves, and the last one is what keeps decision 17's "not during running operations" honest.
+
+- [ ] **Step 2: Bind for reload**
+
+`Host` switches the mail options consumer from `IOptions<MailSynchronizationOptions>` to `IOptionsMonitor<MailSynchronizationOptions>`. Note that `IOptions<T>` is a singleton captured once, so leaving it in place would silently defeat the reference half of this task.
+
+- [ ] **Step 3: Validate the candidate before publishing it**
+
+`MailSecretSnapshotPublisher` subscribes to `OnChange`, resolves every reference in the candidate snapshot, and publishes an immutable snapshot only when all of them resolve. On failure it retains the previous snapshot and logs the configuration path and the `SecretResolutionFailure` — never a path, a variable name, or material. This is the last-known-good behavior ADR 0002 requires of any reloadable group.
+
+Reload validation must not crash the process: ADR 0002 is explicit that a rejected reload leaves the previous valid settings active, unlike a startup failure which is fatal.
+
+- [ ] **Step 4: Resolve material per operation**
+
+No change is needed for the material half — decision 16 already resolves per use, which is what makes rotation behind an unchanged reference work. The test in Step 1 is what proves it, and it exists to catch a future "optimization" that caches the resolved value on the options instance.
+
+- [ ] **Step 5: Run the tests and commit**
+
+```bash
+dotnet test --project tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj
+git add src/Host src/Infrastructure tests/Infrastructure.UnitTests/MailAccountSecretReloadTests.cs
+git commit -m "Reload secret references and material without restarting the host"
+```
+
+---
+
+
+### Task 4: Documentation and full verification
+
+**Files:**
+- Modify: `docs/features/imap-synchronization.md`, `docs/operations/secret-provisioning.md`
+
+- [ ] **Step 1: Document the implemented behavior**
+
+`docs/features/imap-synchronization.md` gains the trust anchor behavior: how an anchor is configured, that validation is never disabled, that a name mismatch is rejected regardless of the anchor, and the `RevocationMode = NoCheck` trade-off with the reason it is confined to the custom-anchor path. It removes the pending item that 02a left open.
+
+`docs/operations/secret-provisioning.md` gains the accepted certificate encodings, decision 28's inline PEM limit stated as a rule rather than as a discovery, the PKCS#12 bundle-password shape, and the rotation procedure for both deployment shapes — replacing a credential file, replacing a systemd credential, and what an operator should expect to see in the log when a reload is rejected.
+
+- [ ] **Step 2: Run the completion gates**
+
+```bash
+bash scripts/verify-full.sh
+```
+
+Run `$check-docs-licenses` and `$review-change`. Check specifically: no certificate-validation opt-out and no callback returning `true` on an unexamined chain; no bundle password in any message or log; no secret material outliving the operation that resolved it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs
+git commit -m "Document trust anchor behavior and the secret rotation procedure"
+```
+
+## Self-review
+
+| Specification requirement | Covered by |
+| --- | --- |
+| PEM, DER, and PKCS#12 all load from resolved bytes | Task 1 |
+| A PKCS#12 password comes from a second secret block | decision 29, Task 1 |
+| Inline PEM works; inline binary fails naming the encoding | decision 28, Task 1 |
+| Malformed anchor material fails startup without disclosing material | Task 1 |
+| A private server connects with validation fully enabled | Task 2 |
+| A name mismatch is rejected regardless of the anchor | decision 21, Task 2 |
+| No configuration path disables validation | Task 2, asserted by test |
+| Rotated material behind an unchanged reference is observed | decision 17, Task 3 |
+| A reload with an unresolvable reference keeps the previous secrets | Task 3 |
+| A rotation never affects an operation in flight | Task 3 |
+| ADR 0002 amended before implementation | decision 18, blocking |
+
+**Flagged for the owner**
+
+- **Blocking:** ADR 0002 must be amended before Task 3 begins (decision 18). Tasks 1 and 2 are unaffected and can proceed as soon as 02a merges.
+- Decision 28 rejects inline binary certificate material rather than accepting base64. Base64 would work and would let a DER anchor be configured inline, but it introduces a second encoding an operator has to know about and get right, for a case PEM already covers. If you would rather support it, it is a small addition to the loader and a line in the documentation.
+- `RevocationMode = NoCheck` on the custom-anchor path is a real trade-off, not an oversight: a private authority typically publishes no reachable CRL or OCSP responder, and a revocation lookup that cannot complete would reject a correctly provisioned server. It is confined to the custom-anchor path and the system trust path keeps the platform default. If revocation checking on private anchors matters more than that failure mode, this is the decision to revisit.

--- a/docs/superpowers/plans/2026-07-27-secret-reference-resolution-02a.md
+++ b/docs/superpowers/plans/2026-07-27-secret-reference-resolution-02a.md
@@ -69,9 +69,14 @@ Two integration shapes exist and must not be conflated. A provider that **pre-re
 22. **The database password becomes a reference too.** The specification's goal names it explicitly. `ConnectionStrings:mailmcp` keeps host, database, and user name; an optional `Persistence:Password` secret block is resolved at startup and applied through `NpgsqlConnectionStringBuilder.Password`, so the connection string in `appsettings.json` never carries the password and the composed string never reaches a log.
 23. **Two resolver names, two scopes.** `ISecretReferenceResolver` resolves one reference. `MailAccountSecretOptions` resolves one account's set of secrets and reports per-account configuration errors. Naming them both "secret resolver" would make the call sites ambiguous, which the root naming rules forbid.
 24. **`UserName` stays a plain configuration value.** The definition of done names raw *passwords*. A mailbox user name is an identifier the operator already writes next to the host, and turning it into a reference would double the provisioning burden for no confidentiality gain. It remains excluded from logs as personal data.
-25. **Every secret-bearing setting is a JSON object, never a bare string.** The object is `ConfiguredSecret`, and its `SecretReference` property carries the reference. The reason is forward compatibility: a PKCS#12 bundle needs a second reference for its own password, a certificate may need an explicit format hint, and a managed-store reference may need a version pin. Inside a block each of those is a sibling property. Had the setting shipped as a bare string, the first such addition would change the setting's JSON type from string to object and break every deployment that had configured it. Only the first setting to need it would be affected, but the fix would then have to be applied setting by setting against real deployments; the uniform block pays that cost once, now, while `TrustedCertificateAuthorityReference` has one consumer and no shipped release depends on it. Nothing beyond `SecretReference` is defined here — the property is the whole shape today, and the point is only that a second one costs nothing later.
+25. **Every secret-bearing setting is a JSON object, never a bare string.** The object is `ConfiguredSecret`, and its `SecretReference` property carries the reference. The reason is forward compatibility: a PKCS#12 bundle needs a second reference for its own password, a certificate may need an explicit format hint, and a managed-store reference may need a version pin. Inside a block each of those is a sibling property. Had the setting shipped as a bare string, the first such addition would change the setting's JSON type from string to object and break every deployment that had configured it. Only the first setting to need it would be affected, but the fix would then have to be applied setting by setting against real deployments; the uniform block pays that cost once, now, while `TrustedCertificateAuthorityReference` has one consumer and no shipped release depends on it. One sibling is defined now rather than later: an optional nested `Password` block, itself a `ConfiguredSecret`. Specification 02b needs it for a password-protected PKCS#12 bundle, and discovering that mid-02b would have forced a change to a contract 02a had already shipped — which is the case this plan says must go back to the owner rather than be absorbed. Defining it here costs one nullable property and keeps the recursion honest: the discovery walk of decision 26 descends into it like any other block, so a bundle password is bound, validated, resolved, and erased by exactly the machinery every other secret uses. The cycle guard the walk already needs covers the recursion.
 26. **The block's type is the marker, in place of an attribute.** A secret-bearing property is declared by binding to `ConfiguredSecret` rather than to `string`, so `MailSecretReferenceStartupValidator` discovers every one of them by walking the bound options graph for that type. An attribute would work the same way at the point of use, but it can be omitted on a property added six months from now and nothing would notice — the property would bind to `string`, hold a password, and skip every rule in this plan. A type cannot be omitted, because the property would not bind to the block shape at all. This is what makes decision 13's `ReferenceOnly` guarantee total rather than per-setting: under the default mode a block whose `SecretReference` is not a well-formed `<scheme>:<target>` fails startup naming its configuration path, so a plain-text password pasted where a reference belongs is a startup error and never a secret that resolved by accident. The Task 6 architecture test enforces the other direction, failing the build if a secret-looking property is bound as a raw `string`.
 27. **The block is verified against flat colon-separated keys, not only against JSON.** The block is one more path segment to any hierarchical configuration provider, so `MailSynchronization:Accounts:0:Secrets:Password:SecretReference` in Azure App Configuration and `MailSynchronization__Accounts__0__Secrets__Password__SecretReference` in an environment block address exactly the same setting. That has to be proved rather than assumed, because the whole Azure App Configuration path depends on it: the store holds that key, Key Vault holds the value, the provider maps one to the other, and `InlineOnly` tells MailMcp the bound value is already the secret. Binding tests therefore populate an in-memory provider with flat keys instead of parsing a JSON document, so a change that made the block depend on JSON document structure fails a test rather than a deployment.
+28. **A successful resolution carries where its material came from.** `SecretResolutionResult` exposes `SecretMaterialSource`: `SchemeAdapter` or `InlineValue`. Two commitments already made are unimplementable without it. Decision 14 promises to log *which settings* resolved inline, which cannot be known from the mode alone under `ReferenceOrInline`. And specification 02b must accept a DER or PKCS#12 anchor read through `file:` while rejecting the same bytes supplied inline — with only the global mode to consult it would either reject valid referenced binary certificates or accept forbidden inline ones. Since 02b is barred from changing this contract, the provenance has to exist before it ships. Both paths are tested here, not in 02b.
+29. **Material is bounded before it is allocated.** A mistaken `file:` target can name a log, a database file, or a device-backed pseudo-file, and reading it whole and then allocating an equally large pinned copy would exhaust memory or stall the host before validation finishes — during startup and again per operation, since decision 16 resolves per use. The reader therefore takes a maximum byte count and enforces it while reading, before the owned buffer is allocated, failing as `MaterialTooLarge`. The ceiling is generous enough for a certificate bundle and far below anything that threatens the process; the root rules require an explicit limit at every boundary that reads external input, and a secret path is one.
+30. **The source buffer is erased, and the read is asynchronous.** An earlier draft had the file port return `ReadOnlyMemory<byte>` from `File.ReadAllBytes`, which `ResolvedSecret.FromBytes` then copied into the pinned buffer. Only the copy would have been zeroed; the original movable array would have kept the credential until collection, defeating decision 7 for `file:` and `systemd-credential:` — the two schemes production actually uses. The port therefore returns the owned `ResolvedSecret` and erases its own intermediate buffer in a `finally`, so ownership transfers rather than duplicating. The same port is asynchronous and takes the caller's token, because a synchronous read blocks a thread on a stalled network-mounted secret path and would make decision 4's end-to-end cancellation claim false one layer below the contract that asserts it.
+31. **`env:` is a documented third exposure, not a clean scheme.** `Environment.GetEnvironmentVariable` returns a `string`, and decision 7 establishes that a `string` cannot be erased. Resolving an `env:` reference therefore leaves an un-erasable copy behind exactly as an inline value does, which the definition of done must say rather than imply otherwise. This is a further reason the documentation recommends against `env:` in production, and it is why the memory-hygiene guarantee is stated as covering material MailMcp allocates rather than material the platform hands it as a `string`.
+32. **The startup validator, not only the architecture test, enforces the marker.** The Task 6 reflection test scans `Infrastructure` and cannot reach `MailSynchronizationOptions` or `PersistenceOptions`, which live in coverage-excluded `Host` — so a future `Host` property named `ApiKey` or `Token` could bind a secret as a raw `string` while the test still reported green. The graph walk already runs over the real bound roots at startup, so it also fails the host when it finds a `string` property whose name matches the same secret-name rule. The architecture test keeps the failure at build time where it is cheapest; the runtime check is what makes the guarantee actually repository-wide instead of Infrastructure-wide.
 
 ## File structure
 
@@ -159,16 +164,23 @@ public sealed record SecretReference
     public string Target { get; }
 
     public static bool TryParse(string? reference, out SecretReference? parsed, out SecretResolutionFailure failure);
+
+    // Suppresses the synthesized record printing, which would otherwise write Target verbatim.
+    public override string ToString() => $"{this.Scheme.Name}:***";
+    private bool PrintMembers(StringBuilder builder) => throw new NotSupportedException();
 }
 
 /// <summary>The bindable shape of every secret-bearing configuration setting.</summary>
 public sealed class ConfiguredSecret
 {
     public string SecretReference { get; set; } = string.Empty;
+
+    /// <summary>Password protecting the referenced material, when the material is itself protected.</summary>
+    public ConfiguredSecret? Password { get; set; }
 }
 ```
 
-`ConfiguredSecret` is mutable with a settable property because the configuration binder requires it, and it is the only bindable type in `src/Infrastructure/Secrets/`. It carries no resolution logic: it is the JSON shape and the marker of decision 26, nothing more. A future bundle password or format hint is a second property here, which is the whole reason it is a class rather than the bare string it wraps today.
+`ConfiguredSecret` is mutable with a settable property because the configuration binder requires it, and it is the only bindable type in `src/Infrastructure/Secrets/`. It carries no resolution logic: it is the JSON shape and the marker of decision 26, nothing more. The nested `Password` is the reason it is a class rather than the bare string it wraps: a PKCS#12 bundle carries its own password, and 02b resolves it through this shape without touching this file.
 
 ```csharp
 public sealed record DiscoveredSecret(string ConfigurationPath, ConfiguredSecret Secret);
@@ -179,7 +191,7 @@ internal static class ConfiguredSecretDiscovery
 }
 ```
 
-`ConfiguredSecretDiscovery` is what makes the marker useful: it walks public readable properties of the bound options object, descends into nested options objects and into `IEnumerable` elements, and yields each `ConfiguredSecret` with the colon-separated path that reached it — `MailSynchronization:Accounts:0:Secrets:Password`. It must guard against a cycle in the object graph, since options types are ordinary classes and nothing forbids a back-reference. It never reads a `ConfiguredSecret`'s value; it returns the block and lets the caller resolve, so nothing in the walk can end up in a diagnostic.
+`ConfiguredSecretDiscovery` is what makes the marker useful: it walks public readable properties of the bound options object, descends into nested options objects, into `IEnumerable` elements, and into a block's own nested `Password` block, and yields each `ConfiguredSecret` with the colon-separated path that reached it — `MailSynchronization:Accounts:0:Secrets:Password`. It must guard against a cycle in the object graph, since options types are ordinary classes and nothing forbids a back-reference. It never reads a `ConfiguredSecret`'s value; it returns the block and lets the caller resolve, so nothing in the walk can end up in a diagnostic.
 
 Tests cover a block at the root, a nested one, one inside a list with its index in the path, a null block being skipped rather than reported as missing, and a cyclic graph terminating. A separate binding test builds the options graph from an in-memory provider populated with flat colon-separated keys and asserts the discovered paths match them exactly — decision 27, and what keeps the Azure App Configuration and environment-variable paths honest.
 
@@ -198,13 +210,20 @@ public sealed class ResolvedSecret : IDisposable
     public override string ToString();            // "***"
 }
 
+public enum SecretMaterialSource
+{
+    SchemeAdapter = 0,   // resolved by a registered adapter through a reference
+    InlineValue = 1,     // the configured value was itself the material
+}
+
 public sealed record SecretResolutionResult
 {
     public bool Succeeded { get; }
     public ResolvedSecret? Secret { get; }
+    public SecretMaterialSource? Source { get; }
     public SecretResolutionFailure? Failure { get; }
 
-    public static SecretResolutionResult Resolved(ResolvedSecret secret);
+    public static SecretResolutionResult Resolved(ResolvedSecret secret, SecretMaterialSource source);
     public static SecretResolutionResult Failed(SecretResolutionFailure failure);
 }
 ```
@@ -244,7 +263,7 @@ Expected: FAIL — `SecretReference` does not exist.
 
 - [ ] **Step 3: Implement**
 
-`TryParse` trims, rejects blank, splits on `IndexOf(':')`, normalizes the scheme name to lower case with `ToLowerInvariant`, and rejects an empty remainder. It does not check the name against a list: an unknown scheme is a well-formed reference to a provider that is not registered, and decision 3 puts that answer in the dispatch. `SecretReferenceScheme` compares by normalized name with `StringComparer.Ordinal`, and its well-known members are the four wire names. The member name `EnvironmentVariable` and the wire name `env` deliberately differ, because the configuration prefix should stay short while the member name stays explicit.
+`TryParse` rejects a blank input, splits on `IndexOf(':')`, and normalizes the scheme name to lower case with `ToLowerInvariant`. It trims **only the scheme**, never the target: `plaintext: secret ` must resolve to `" secret "`, because leading and trailing spaces are valid password characters and a parser that trims them silently changes the credential. A target that is empty after the separator is still a failure; a target that is entirely whitespace is not, because that too can be a password. Every byte after the first colon reaches the adapter untouched. It does not check the name against a list: an unknown scheme is a well-formed reference to a provider that is not registered, and decision 3 puts that answer in the dispatch. `SecretReferenceScheme` compares by normalized name with `StringComparer.Ordinal`, and its well-known members are the four wire names. The member name `EnvironmentVariable` and the wire name `env` deliberately differ, because the configuration prefix should stay short while the member name stays explicit.
 
 `ResolvedSecret` allocates its buffer with `GC.AllocateArray<byte>(length, pinned: true)` so the collector cannot relocate it and leave an un-erased copy, copies the material in, and erases it in `Dispose` with `CryptographicOperations.ZeroMemory`. `Dispose` is idempotent, and every accessor throws `ObjectDisposedException` afterwards rather than returning empty — a use-after-erase is a defect and must present as one. `ToString()` returns `"***"`.
 
@@ -300,7 +319,8 @@ public interface ISecretSchemeResolver
 
 internal interface ISecretFileReader
 {
-    bool TryReadAllBytes(string path, out ReadOnlyMemory<byte> material);
+    // Hands ownership of the pinned buffer to the caller; the reader retains no copy.
+    Task<ResolvedSecret?> ReadAsync(string path, int maxByteCount, CancellationToken cancellationToken);
 }
 
 internal interface IEnvironmentVariableReader
@@ -308,6 +328,8 @@ internal interface IEnvironmentVariableReader
     string? GetValue(string name);
 }
 ```
+
+The file reader is asynchronous, takes the caller's token, and takes a byte ceiling, all three for reasons decision 30 records: a synchronous port would block a thread on a stalled network-mounted secret path and would make decision 4's "cancellable end to end" claim false one layer below the contract that makes it. It returns the owned `ResolvedSecret` rather than a `ReadOnlyMemory<byte>` so that no un-erased intermediate array survives the read.
 
 `ISecretSchemeResolver` is `public` — unusually for this repository, which defaults to `internal` — because it is the extension point decision 2 promises. A provider adapter in another folder, another project, or a later change set implements it, and an `internal` contract would make that impossible without editing this file. The four adapters implementing it here stay `internal sealed`. The two reader ports stay `internal`: they exist for testability, not for extension, and `InternalsVisibleTo MailMcp.Infrastructure.UnitTests` already covers them.
 
@@ -354,7 +376,7 @@ Expected: FAIL — the resolvers do not exist.
 
 `CompositeSecretReferenceResolver` parses once and dispatches on the scheme through a dictionary built from the injected `ISecretSchemeResolver` set, so a scheme with no registered adapter fails as `SchemeNotSupported` rather than throwing. Its XML documentation states that no result and no diagnostic derived from it may carry the material.
 
-`FileSystemSecretFileReader` catches only `IOException` and `UnauthorizedAccessException` and maps them to `false`, so a permission error becomes `MaterialNotFound` rather than a startup crash with a path in the stack trace.
+`FileSystemSecretFileReader` validates the path before touching the file system and then catches the complete set of expected failures — `IOException`, `UnauthorizedAccessException`, `ArgumentException`, `NotSupportedException`, and `System.Security.SecurityException` — mapping each to `false`. Catching only the first two would let a malformed target such as a path containing a NUL character throw `ArgumentException` straight out of the resolver, past the result boundary, into an unhandled startup exception whose message quotes the path. That defeats both fail-fast aggregation and the guarantee that no diagnostic carries a target.
 
 - [ ] **Step 4: Run the tests**
 
@@ -401,7 +423,7 @@ public sealed record ImapAccountSettings(
     string Host,
     int Port,
     string UserName,
-    ResolvedSecret Password);
+    MailAccountSecrets Secrets) : IDisposable;
 ```
 
 `MailAccountSecrets` wraps a single secret today and looks like a type that could be collapsed into `ResolvedSecret`. It is not, because specification 02b adds the resolved trust anchor beside the password and the ownership rule below has to cover both; introducing it now keeps that a one-line addition instead of a signature change through the session factory.
@@ -476,19 +498,35 @@ git commit -m "Bind account secrets as reference blocks and resolve them in Infr
 
 When it is null the connection string is used unchanged, which keeps trust-authentication and Aspire-provided connection strings working untouched. A block present with an empty `SecretReference` is a startup failure rather than a silent fallback to the unchanged connection string, because an operator who wrote the block meant to supply a password.
 
-- [ ] **Step 2: Apply it when composing the connection string**
+- [ ] **Step 2: Compose the connection string after resolution, not during registration**
 
-`AddMailMcpInfrastructure` gains an optional resolved password parameter and applies it through `NpgsqlConnectionStringBuilder`:
+The obvious shape — `AddMailMcpInfrastructure` taking an already-resolved password — does not work, and the reason is an ordering trap worth stating so nobody reintroduces it. Service registration runs synchronously during composition, while resolution is asynchronous and decision 5 puts it in `StartingAsync`, which runs *after* every registration. A resolved password therefore does not exist yet at the moment the connection string would be composed. An optional parameter would simply stay omitted: the host would still build, the reference would still validate, and EF Core would quietly keep using the passwordless connection string.
+
+Composition is therefore deferred to first use. `AddMailMcpInfrastructure` registers a singleton `NpgsqlDataSource` built by a factory that resolves the reference when the data source is first requested:
 
 ```csharp
-var connectionStringBuilder = new NpgsqlConnectionStringBuilder(connectionString);
-if (databasePassword is { } password)
+services.AddSingleton(provider =>
 {
-    connectionStringBuilder.Password = password.RevealAsString();
-}
+    var persistence = provider.GetRequiredService<IOptions<PersistenceOptions>>().Value;
+    var resolver = provider.GetRequiredService<ISecretReferenceResolver>();
+    var builder = new NpgsqlDataSourceBuilder(connectionString);
+
+    if (persistence.Password is { } configuredPassword)
+    {
+        builder.ConnectionStringBuilder.Password = ResolveDatabasePassword(resolver, configuredPassword);
+    }
+
+    return builder.Build();
+});
 ```
 
-The composed string is never logged and never returned. An unresolvable reference fails startup through the same validator as the mail secrets.
+`ResolveDatabasePassword` is the one place this plan permits blocking on an asynchronous call, because the DI factory contract is synchronous. It is confined to a singleton factory that runs once, after `StartingAsync` has already proved the reference resolves, so it neither races startup validation nor repeats per request. It is called out here rather than left implicit, because the repository forbids blocking on tasks and a reader who finds it without this paragraph will reasonably assume it is a defect. If it turns out that first use can occur before `StartingAsync`, this becomes an `IHostedLifecycleService` that builds the data source eagerly instead.
+
+The composed string is never logged and never returned; `NpgsqlDataSource` owns it and no code path reads it back. The revealed password is the second documented `string` boundary from decision 8.
+
+A test asserts the resolved password actually reaches Npgsql — `NpgsqlDataSource.ConnectionString` redacts the password, so the assertion is made on the `NpgsqlConnectionStringBuilder` the factory composed, before the data source is built. Without that test the failure mode is silent: everything validates, nothing connects.
+
+Rotation of this reference is specification 02b's concern and is listed in its plan, because a singleton data source composed once cannot observe a rotated credential.
 
 - [ ] **Step 3: Commit**
 
@@ -618,7 +656,9 @@ public void InfrastructureOptionsTypes_PropertyNamedForASecret_BindsToConfigured
 
 It enumerates every type in the `Infrastructure` assembly whose name ends in `Options`, walks its property graph, and fails on any `string` property whose name contains `Password`, `Secret`, `Credential`, `PrivateKey`, or `Token`. Scanning the assembly rather than an `[InlineData]` list matters: an options type added later is covered without anyone remembering to register it, which is the same argument decision 26 makes about the marker itself. `ConfiguredSecret.SecretReference` is excluded, since it is the shape the rule steers toward.
 
-Two honest limits. The rule is name-based, so it cannot catch a secret called `Value`; it exists to make the *ordinary* mistake — adding `public string Password { get; set; }` to an options type — fail the build rather than ship, and its own documentation says so. And it reaches `Infrastructure` only: `MailSynchronizationOptions` and `PersistenceOptions` live in `Host`, which has no unit-test project and is excluded from coverage. What closes that gap is placement rather than reflection — secret-bearing options types belong in `Infrastructure` for the same reason Task 3 puts `MailAccountSecretOptions` there, leaving the `Host` types as sections that nest them. `PersistenceOptions.Password` is the one exception this plan leaves in `Host`, and it is small enough to read in review.
+One honest limit remains: the rule is name-based, so it cannot catch a secret called `Value`. It exists to make the *ordinary* mistake — adding `public string Password { get; set; }` to an options type — fail the build rather than ship, and its own documentation says so.
+
+The test reaches `Infrastructure` only, because `MailSynchronizationOptions` and `PersistenceOptions` live in coverage-excluded `Host`. Decision 32 closes that gap at runtime instead of leaving it documented: `ConfiguredSecretDiscovery` already walks the real bound roots during `StartingAsync`, so it applies the same secret-name rule to `string` properties it passes and fails the host on a match. Build-time coverage where it is cheap, startup coverage where reflection can actually see the roots.
 
 No architecture-test package is added for either test: introducing one would require a license review and owner approval for rules that a few lines of reflection already prove. Both live in `Infrastructure.UnitTests` because that is the only unit-test project referencing all three assemblies.
 
@@ -698,7 +738,12 @@ Run `$finish-change`: commit, push, and open a draft pull request whose body con
 | Bytes-first resolution; PKCS#12 and DER representable | 1, 2 |
 | Three interpretation modes; `ReferenceOnly` the default | decisions 13 and 14, Tasks 1 and 6 |
 | Pre-resolving provider works with no adapter and no code | decision 13 (`InlineOnly`) |
-| No `string`, pooled buffer, or `SecureString` holds material | decisions 7 and 8, Task 1 |
+| No `string`, pooled buffer, or `SecureString` holds allocated material | decisions 7, 8, 30, Task 1 |
+| Residual `string` exposures documented rather than implied away | decision 31 |
+| Material is bounded before allocation | decision 29, Task 2 |
+| A resolution records adapter or inline provenance | decision 28, Task 1 |
+| A parsed reference never prints its target | decision 12 applied to `SecretReference`, Task 1 |
+| The resolved database password actually reaches Npgsql | Task 4 Step 2 |
 | Pinned buffer zeroed with `CryptographicOperations.ZeroMemory` | 1 |
 | Material owned by its operation and disposed at its end | decision 9, Tasks 3 and 6 |
 | Core-dump and swap exposure documented for both shapes | 9 |
@@ -722,5 +767,6 @@ Managed secret stores — Kubernetes-native APIs, Azure Key Vault, HashiCorp Vau
 - The combined specification reached ~1700 lines against `specs/README.md`'s ~1000-line ceiling and has been split. This plan covers 02a at roughly 950 lines including tests and documentation; certificate material and rotation are ~750 lines in the 02b plan. Nothing is deferred outside the two specifications, and nothing depended on `02`, so the split cost no renumbering of specifications 03 onward. Issue #36's `Size` line should be updated when this plan is accepted.
 - Decision 25 renames `MailAccountTransportSecurityOptions.TrustedCertificateAuthorityReference` to `TrustedCertificateAuthority` and changes it from a string to a block. That is a breaking configuration change to a setting specification 01 already shipped, and it is proposed now precisely because it is cheap now — one consumer, no released deployment — and expensive later. An affected operator edits one line.
 - Decision 26's discovery walk uses reflection over the bound options graph, which the root rules restrict to measured need. The need argued here is that an explicit call list cannot cover a secret-bearing setting added after this ships, which is the entire value of the marker. It runs once at startup over a small object. If you would rather keep reflection out and accept that each new secret setting must be registered by hand, `ConfiguredSecretDiscovery` collapses into an explicit list and decision 26's guarantee weakens from structural to procedural.
+- The Codex review on PR #59 found the database-password ordering trap (registration runs before `StartingAsync`, so an "already-resolved password" parameter would have stayed omitted while everything still validated green), the un-erased intermediate read buffer, the missing provenance value, and `SecretReference.ToString()` printing a `plaintext:` secret verbatim. All four are folded in above. The provenance one is worth the owner's attention because it is a contract change made *for* 02b in 02a — the alternative was 02b modifying a shipped contract, which its plan forbids.
 - Decision 15 reads "permitted for non-production automation" as guidance rather than an enforced environment gate for `env:`. If it should be enforced, say so and it moves onto the same Development flag as `plaintext:`.
 - Decision 4 makes the contract asynchronous before any asynchronous provider exists. The cost is real and visible: `GetSettings` becomes `GetSettingsAsync`, and startup validation moves out of `IValidateOptions` into `IHostedLifecycleService`. It is proposed because retrofitting it alongside a first Key Vault adapter would touch the same files while also introducing SDK, identity, and licensing questions, and doing one of those at a time is cheaper. If managed stores are further off than this assumes, the synchronous contract is defensible and this is the decision to revisit.

--- a/docs/superpowers/plans/2026-07-27-secret-reference-resolution-02a.md
+++ b/docs/superpowers/plans/2026-07-27-secret-reference-resolution-02a.md
@@ -1,15 +1,16 @@
-# Secret Reference Resolution Implementation Plan
+# Secret Reference Resolution Implementation Plan (02a)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Governing issue:** [#36 — Spec 02 — Secret reference resolution](https://github.com/Krzysztof318/MailMcp/issues/36)
-**Governing specification:** [`specs/02-secret-reference-resolution.md`](../../../specs/02-secret-reference-resolution.md)
+**Governing issue:** [#36 — Spec 02a — Secret reference resolution](https://github.com/Krzysztof318/MailMcp/issues/36)
+**Governing specification:** [`specs/02a-secret-reference-resolution.md`](../../../specs/02a-secret-reference-resolution.md)
+**Followed by:** [`docs/superpowers/plans/2026-07-27-certificate-material-and-secret-rotation-02b.md`](2026-07-27-certificate-material-and-secret-rotation-02b.md), which consumes this contract for certificate material and rotation
 **Architectural context:** `specs/2026-07-22-mail-mcp-architecture-draft.md` sections 7.3 and 19, ADR `docs/decisions/0002-configuration-reading-mapping-and-reload-boundary.md`
 **Depends on:** [#35 — Spec 01](https://github.com/Krzysztof318/MailMcp/issues/35), merged as `a732e9a`
 
-**Goal:** Replace every raw secret bound from configuration with a scheme-qualified reference that `Infrastructure` resolves and `Host` fails fast on, and load the trust anchor material that specification 01 deliberately left as configuration shape only.
+**Goal:** Replace every raw secret bound from configuration with a scheme-qualified reference that `Infrastructure` resolves and `Host` fails fast on, and give every secret-bearing setting one uniform block shape so the guarantee holds for settings that do not exist yet.
 
-**Architecture:** `Infrastructure` owns the reference grammar, the per-scheme adapters, the composite dispatch, and the certificate-validation path that consumes a resolved trust anchor. `Host` binds reference strings, invokes resolution once before hosted services start, and turns failures into startup errors. `Application` and `Domain` gain nothing: they never see a resolver, a reference, or a scheme, which is the boundary ADR 0002 draws when it forbids normalizing broad secret access into application code.
+**Architecture:** `Infrastructure` owns the reference grammar, the secret block and its discovery, the per-scheme adapters, and the composite dispatch. `Host` binds secret blocks, invokes resolution once before hosted services start, and turns failures into startup errors. `Application` and `Domain` gain nothing: they never see a resolver, a reference, or a scheme, which is the boundary ADR 0002 draws when it forbids normalizing broad secret access into application code.
 
 The shape is chosen so that a future Kubernetes, Azure Key Vault, HashiCorp Vault, or AWS Secrets Manager adapter is a registration rather than a refactor: a scheme is declared by the adapter that serves it, dispatch is a lookup, and the contract is asynchronous and cancellable from the first commit. None of those providers is implemented here.
 
@@ -18,7 +19,7 @@ The shape is chosen so that a future Kubernetes, Azure Key Vault, HashiCorp Vaul
 ## Global Constraints
 
 - No new third-party packages. `LICENSES.md` therefore needs no dependency entry; `$check-docs-licenses` returns `n/a` for licensing and must still be run.
-- `Domain` and `Application` stay free of every type introduced here. The architecture test in Task 7 is the enforcement, not a review habit.
+- `Domain` and `Application` stay free of every type introduced here. The architecture test in Task 6 is the enforcement, not a review habit.
 - Certificate validation stays enabled unconditionally. Nothing introduced here may expose a "trust any certificate" flag, an `SslProtocols` override, or a callback that returns `true` on an unexamined chain.
 - No resolution failure message, log line, or exception may contain the resolved material, the file path, the environment variable's value, or the credential's contents. The account identifier, the logical secret name, and the scheme are the permitted vocabulary.
 - Unit tests never touch the real file system, environment block, network, or clock. Every scheme adapter reads through an injected in-memory port.
@@ -52,24 +53,25 @@ Two integration shapes exist and must not be conflated. A provider that **pre-re
 6. **The resolver returns bytes; text is a view over them.** A secret is not always a password: a trust anchor may be PEM or DER, and a private key arrives as a PKCS#12 bundle that is binary and may carry its own password reference. A `string`-returning resolver would make PKCS#12 unrepresentable and would corrupt DER through encoding round-trips. `ResolvedSecret` therefore stores a pinned `byte[]` (decision 7) and exposes it as `ReadOnlySpan<byte>`, which is what the root rules prescribe for byte payloads. `RevealBytes()` returns the material untouched; `RevealAsString()` returns the UTF-8 text view with one trailing newline stripped. The trim belongs to the text view only — trimming a PFX would corrupt it. `plaintext:` and `env:` UTF-8-encode on the way in, which costs nothing and keeps one result shape.
 7. **Secret material is a pinned byte buffer that is zeroed on dispose; it is never a `string` and never a `SecureString`.** Microsoft's guidance is explicit on all three points. `SecureString` is not recommended for new development on .NET, and it "does not encrypt the internal storage on non-Windows platform" — every MailMcp deployment target. A `string` is immutable, cannot be scheduled for deletion, and because its memory is not pinned "the garbage collector will make additional copies of `String` values when moving and compacting memory", so erasing one is not even well defined. The buffer is therefore allocated with `GC.AllocateArray<byte>(length, pinned: true)`, which the collector cannot relocate, and erased with `CryptographicOperations.ZeroMemory`, documented as existing "to future-proof against potential optimizations in the .NET runtime that could eliminate memory writes that aren't followed by memory reads" — a hand-written zeroing loop carries no such guarantee. `ArrayPool` is not used for secret material at all: a buffer returned uncleared hands the material to the next unrelated caller.
 8. **`RevealAsString()` exists, is the exception, and is named to look like one.** MailKit's `AuthenticateAsync(string, string)` and Npgsql's connection-string password are framework contracts that take a `string`, so a copy that cannot be erased is unavoidable at exactly those two call sites. `RevealBytes()` is the primary accessor and everything else uses it. `RevealAsString()` is called at the boundary itself, as late as possible, and its result is never stored, logged, or passed on. Its XML documentation states that the returned string cannot be erased and will persist until the collector reclaims it.
-9. **A resolved secret is owned by the operation that resolved it and disposed when that operation ends.** Combined with per-use resolution this bounds the exposure window to one synchronization run or one connection attempt rather than to process uptime. It also removes a lifetime hazard from dynamic reload: because every operation owns its own instance, publishing a new configuration snapshot never disposes material that an in-flight operation is still reading. `MailAccountSecrets` therefore implements `IDisposable` and disposes the secrets it owns, and `X509Certificate2` — itself disposable — is disposed on the same path.
+9. **A resolved secret is owned by the operation that resolved it and disposed when that operation ends.** Combined with per-use resolution this bounds the exposure window to one synchronization run or one connection attempt rather than to process uptime. It also removes a lifetime hazard from dynamic reload: because every operation owns its own instance, publishing a new configuration snapshot never disposes material that an in-flight operation is still reading. `MailAccountSecrets` therefore implements `IDisposable` and disposes the secrets it owns; specification 02b adds the resolved trust anchor to the same disposal path, since `X509Certificate2` is itself disposable.
 10. **The residual exposures are documented, not papered over.** Managed memory is still readable through a process dump, a debugger, or swap, and no code-level measure changes that. The mitigations are operational and belong in the operations documentation: `LimitCORE=0` on the systemd unit and `Storage=none` / `ProcessSizeMax=0` for `systemd-coredump`, plus keeping the service's memory out of swap in both the systemd and container shapes. `mlock` is deliberately rejected — it needs P/Invoke plus `CAP_IPC_LOCK` and a raised `RLIMIT_MEMLOCK` in every deployment shape, against the repository rule restricting unsafe and platform-invoke code to measured need, and it does not address dumps or debuggers anyway.
-11. **Typed material is loaded above the resolver, not inside it.** `X509CertificateMaterialLoader` in `Infrastructure` turns resolved bytes into an `X509Certificate2`, accepting PEM and DER and, for key material, PKCS#12 with an optional separately-referenced password. The resolver stays ignorant of X.509 so that adding a future material kind — an SSH key, a JWT signing key — adds a loader rather than touching every scheme adapter.
+11. **Typed material is loaded above the resolver, not inside it.** — *moved to specification 02b.* Recorded there, keeping this number so cross-references from either plan resolve to the same decision.
 12. **`ResolvedSecret` hides its material behind a method, not a property.** `System.Text.Json`, `record` synthesized `ToString()`, and most diagnostic dumps enumerate properties, so a property named `Value` would eventually be serialized by something. `ImapAccountSettings` is a `record`, which makes this concrete: its synthesized `ToString()` prints every member today. `RevealBytes()` and `RevealAsString()` are methods for that reason, and `ToString()` is overridden to return `***`.
 13. **Interpretation is an explicit three-valued mode, not an environment gate.** `SecretValueInterpretation` is `ReferenceOnly = 0` (default), `ReferenceOrInline = 1`, `InlineOnly = 2`. This replaces the earlier "`plaintext:` only in Development" rule, which turned out to be both too strict and too weak: too strict because an operator may knowingly put a secret in JSON and that is their call, and too weak because it does not address the real driver — a configuration provider that has already resolved the secret before MailMcp binds it. Azure App Configuration with Key Vault references is exactly that: the provider substitutes the vault value, so the bound setting is the raw secret with no prefix MailMcp could recognize. `InlineOnly` serves it by parsing nothing at all, which removes the ambiguity rather than guessing at it. The mode is passed to the composite resolver at registration, so `Infrastructure` still needs no reference to `Microsoft.Extensions.Hosting.Abstractions` and the rule stays trivially testable in all three directions.
 14. **Inline modes are logged, and their memory cost is stated.** Startup logs the active mode and, when it is not `ReferenceOnly`, the *names* of settings that resolved to an inline value — never the values — so an unintended inline secret is discoverable instead of silent. And an inline value arrives from `IConfiguration` as a `string`, which decision 7 establishes cannot be erased; the inline modes therefore forfeit part of the in-memory protection, which the operations documentation must say plainly. Both facts are why `ReferenceOnly` stays the default rather than the friendliest option winning.
 15. **`env:` resolves in every environment.** The specification gates exactly one scheme on the environment, and the definition of done names only the `plaintext:` rule. `env:` stays permitted with a documented recommendation against production use, rather than inventing a second environment gate the specification did not ask for. *Flagged for the owner: if `env:` should also fail outside Development, it is a one-line change to the same flag.*
 16. **Resolution runs at startup validation and again per use, which is what makes rotation work.** Startup validation resolves every reference and discards the material, so an unresolvable reference fails the host. Each actual use resolves again, so no long-lived copy exists and material rotated behind an unchanged reference — a replaced credential file, a re-issued vault entry — is observed by the next operation with no cache to invalidate and no restart. The material is a few hundred bytes from a tmpfs or an environment block; per-run re-reading is not a measured cost. A network-backed adapter for which per-use retrieval is too expensive caches inside itself under decision 19, without changing this.
-17. **Secrets are reloadable for new operations, not during running operations.** Both halves reload: a changed *reference* arrives through `IOptionsMonitor` and is validated by resolving the whole candidate snapshot before publishing it, with the last known good snapshot retained on failure; changed *material* is picked up by decision 10. Neither is applied mid-operation — a synchronization run that has authenticated finishes with the credential it authenticated with, because swapping a credential or trust anchor underneath an open IMAP session has no coherent meaning. This is ADR 0002's middle classification, chosen deliberately over the strictest one.
-18. **ADR 0002 must be amended before this is implemented.** The ADR currently classifies credentials and certificate trust anchors as restart-required, and decision 17 departs from that. The departure is defensible — the reference indirection means rotation re-resolves a validated reference rather than mutating a bound secret in place — but `docs/AGENTS.md` forbids modifying an ADR without explicit owner approval, so no ADR is touched here. **This is a blocking prerequisite, not a follow-up.**
+17. **Secrets are reloadable for new operations, not during running operations.** — *moved to specification 02b.* Recorded there, keeping this number so cross-references from either plan resolve to the same decision.
+18. **ADR 0002 must be amended before reload is implemented.** — *moved to specification 02b.* Recorded there, keeping this number so cross-references from either plan resolve to the same decision.
 19. **Provider-specific concerns stay inside the provider's adapter.** Timeouts, retry, backoff, endpoint and region configuration, SDK client lifetime, platform identity, and caching policy belong to the adapter that needs them, never to `ISecretReferenceResolver`. The contract carries a reference and a cancellation token and returns a result; that is the whole surface. This is what lets a store that must cache aggressively and a local file that must never cache coexist without the contract taking a position, and it keeps SDK types out of everything above the adapter exactly as the root dependency rules require.
 20. **A managed-store adapter authenticates through platform identity, not through a MailMcp secret.** An Azure managed identity, a Kubernetes ServiceAccount token, or a Vault role is issued by the platform the process already runs on. Requiring MailMcp to hold a credential in order to fetch its credentials would be circular and would put the most sensitive value back into the configuration this specification removes it from. Recorded now so a future adapter does not quietly reintroduce the problem; nothing implements it here.
-21. **A custom trust anchor is validated by rebuilding the chain, never by accepting errors.** `RemoteCertificateNotAvailable` and `RemoteCertificateNameMismatch` are rejected outright. Only `RemoteCertificateChainErrors` is re-examined, by building an `X509Chain` with `TrustMode = X509ChainTrustMode.CustomRootTrust` and the anchor in `CustomTrustStore` — which Microsoft documents as respected only under that trust mode — and requiring a clean rebuild. MailKit's own `SslCertificateValidation.cs` example stops at describing errors and does not implement custom-CA trust, so this logic is ours to write and ours to test.
+21. **A custom trust anchor is validated by rebuilding the chain, never by accepting errors.** — *moved to specification 02b.* Recorded there, keeping this number so cross-references from either plan resolve to the same decision.
 22. **The database password becomes a reference too.** The specification's goal names it explicitly. `ConnectionStrings:mailmcp` keeps host, database, and user name; an optional `Persistence:Password` secret block is resolved at startup and applied through `NpgsqlConnectionStringBuilder.Password`, so the connection string in `appsettings.json` never carries the password and the composed string never reaches a log.
 23. **Two resolver names, two scopes.** `ISecretReferenceResolver` resolves one reference. `MailAccountSecretOptions` resolves one account's set of secrets and reports per-account configuration errors. Naming them both "secret resolver" would make the call sites ambiguous, which the root naming rules forbid.
 24. **`UserName` stays a plain configuration value.** The definition of done names raw *passwords*. A mailbox user name is an identifier the operator already writes next to the host, and turning it into a reference would double the provisioning burden for no confidentiality gain. It remains excluded from logs as personal data.
 25. **Every secret-bearing setting is a JSON object, never a bare string.** The object is `ConfiguredSecret`, and its `SecretReference` property carries the reference. The reason is forward compatibility: a PKCS#12 bundle needs a second reference for its own password, a certificate may need an explicit format hint, and a managed-store reference may need a version pin. Inside a block each of those is a sibling property. Had the setting shipped as a bare string, the first such addition would change the setting's JSON type from string to object and break every deployment that had configured it. Only the first setting to need it would be affected, but the fix would then have to be applied setting by setting against real deployments; the uniform block pays that cost once, now, while `TrustedCertificateAuthorityReference` has one consumer and no shipped release depends on it. Nothing beyond `SecretReference` is defined here — the property is the whole shape today, and the point is only that a second one costs nothing later.
-26. **The block's type is the marker, in place of an attribute.** A secret-bearing property is declared by binding to `ConfiguredSecret` rather than to `string`, so `MailSecretReferenceStartupValidator` discovers every one of them by walking the bound options graph for that type. An attribute would work the same way at the point of use, but it can be omitted on a property added six months from now and nothing would notice — the property would bind to `string`, hold a password, and skip every rule in this plan. A type cannot be omitted, because the property would not bind to the block shape at all. This is what makes decision 13's `ReferenceOnly` guarantee total rather than per-setting: under the default mode a block whose `SecretReference` is not a well-formed `<scheme>:<target>` fails startup naming its configuration path, so a plain-text password pasted where a reference belongs is a startup error and never a secret that resolved by accident. The Task 7 architecture test enforces the other direction, failing the build if a secret-looking property is bound as a raw `string`.
+26. **The block's type is the marker, in place of an attribute.** A secret-bearing property is declared by binding to `ConfiguredSecret` rather than to `string`, so `MailSecretReferenceStartupValidator` discovers every one of them by walking the bound options graph for that type. An attribute would work the same way at the point of use, but it can be omitted on a property added six months from now and nothing would notice — the property would bind to `string`, hold a password, and skip every rule in this plan. A type cannot be omitted, because the property would not bind to the block shape at all. This is what makes decision 13's `ReferenceOnly` guarantee total rather than per-setting: under the default mode a block whose `SecretReference` is not a well-formed `<scheme>:<target>` fails startup naming its configuration path, so a plain-text password pasted where a reference belongs is a startup error and never a secret that resolved by accident. The Task 6 architecture test enforces the other direction, failing the build if a secret-looking property is bound as a raw `string`.
+27. **The block is verified against flat colon-separated keys, not only against JSON.** The block is one more path segment to any hierarchical configuration provider, so `MailSynchronization:Accounts:0:Secrets:Password:SecretReference` in Azure App Configuration and `MailSynchronization__Accounts__0__Secrets__Password__SecretReference` in an environment block address exactly the same setting. That has to be proved rather than assumed, because the whole Azure App Configuration path depends on it: the store holds that key, Key Vault holds the value, the provider maps one to the other, and `InlineOnly` tells MailMcp the bound value is already the secret. Binding tests therefore populate an in-memory provider with flat keys instead of parsing a JSON document, so a change that made the block depend on JSON document structure fails a test rather than a deployment.
 
 ## File structure
 
@@ -85,30 +87,27 @@ Two integration shapes exist and must not be conflated. A provider that **pre-re
 - `src/Infrastructure/Secrets/ISecretReferenceResolver.cs`, `ISecretSchemeResolver.cs` — the one-reference contract and the public per-scheme extension point.
 - `src/Infrastructure/Secrets/ISecretFileReader.cs`, `IEnvironmentVariableReader.cs` — the two in-memory-testable ports.
 - `src/Infrastructure/Secrets/FileSystemSecretFileReader.cs`, `ProcessEnvironmentVariableReader.cs` — the real adapters.
-- `src/Infrastructure/Secrets/X509CertificateMaterialLoader.cs` — PEM, DER, and PKCS#12 loading over resolved bytes.
 - `src/Infrastructure/Secrets/SystemdCredentialSecretReferenceResolver.cs`, `FileSecretReferenceResolver.cs`, `EnvironmentVariableSecretReferenceResolver.cs`, `PlaintextSecretReferenceResolver.cs`, `CompositeSecretReferenceResolver.cs`
 - `src/Infrastructure/Mail/MailAccountSecretOptions.cs` — the account's secret blocks and their resolution into `MailAccountSecrets`.
-- `src/Infrastructure/Mail/MailAccountSecrets.cs` — resolved password plus optional trust anchor.
-- `src/Infrastructure/Mail/MailServerCertificateValidator.cs` — the custom-root-trust validation callback.
+- `src/Infrastructure/Mail/MailAccountSecrets.cs` — the account's resolved secrets, owned and disposed by the operation that resolved them.
 - `tests/Infrastructure.UnitTests/SecretReferenceTests.cs`
 - `tests/Infrastructure.UnitTests/SecretReferenceResolverTests.cs`
 - `tests/Infrastructure.UnitTests/MailAccountSecretOptionsTests.cs`
-- `tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs`
 - `tests/Infrastructure.UnitTests/SecretBoundaryArchitectureTests.cs`
 - `src/Host/Hosting/MailSecretReferenceStartupValidator.cs` — `IHostedLifecycleService.StartingAsync` fail-fast resolution.
 - `docs/operations/secret-provisioning.md`
 
 **Modify**
 
-- `src/Infrastructure/Mail/ImapAccountSettings.cs` — `Password` becomes `ResolvedSecret`; the record gains the trust anchor; `IImapAccountSettingsProvider.GetSettings` becomes `GetSettingsAsync`.
-- `src/Infrastructure/Mail/MailAccountTransportSecurityOptions.cs` — `TrustedCertificateAuthorityReference` becomes a `ConfiguredSecret?` block; the key name and the domain contract are unchanged.
-- `src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs` — the client port carries the validation callback; the factory installs it before connecting and reveals the password at the single `AuthenticateAsync` call.
+- `src/Infrastructure/Mail/ImapAccountSettings.cs` — `Password` becomes `ResolvedSecret`; `IImapAccountSettingsProvider.GetSettings` becomes `GetSettingsAsync`.
+- `src/Infrastructure/Mail/MailAccountTransportSecurityOptions.cs` — `TrustedCertificateAuthorityReference` is renamed to `TrustedCertificateAuthority` and becomes a `ConfiguredSecret?` block; the domain contract is unchanged.
+- `src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs` — the factory awaits `GetSettingsAsync`, reveals the password at the single `AuthenticateAsync` call, and disposes the resolved secrets once the folder is open.
 - `src/Infrastructure/ServiceCollectionExtensions.cs` — `AddMailMcpSecretResolution`, and the resolved database password applied to the connection string.
 - `src/Host/Configuration/MailSynchronizationOptions.cs` — `Password` becomes a nested `Secrets` section; `GetSettings` becomes `GetSettingsAsync` and resolves.
 - `src/Host/Configuration/PersistenceOptions.cs` — optional `Password` secret block.
 - `src/Host/Program.cs` — register secret resolution with the configured interpretation mode, register the startup validator ahead of the worker, compose the connection string.
 - `src/Host/appsettings.json`, `src/Host/appsettings.Development.json` — reference-shaped examples.
-- `docs/features/imap-synchronization.md` — configuration, the two resolved pending items, transport-security trust anchor behavior.
+- `docs/features/imap-synchronization.md` — the new account configuration shape and the resolution and fail-fast behavior.
 - `docs/operations/local-development.md` — the Development secret workflow.
 
 ---
@@ -182,7 +181,7 @@ internal static class ConfiguredSecretDiscovery
 
 `ConfiguredSecretDiscovery` is what makes the marker useful: it walks public readable properties of the bound options object, descends into nested options objects and into `IEnumerable` elements, and yields each `ConfiguredSecret` with the colon-separated path that reached it — `MailSynchronization:Accounts:0:Secrets:Password`. It must guard against a cycle in the object graph, since options types are ordinary classes and nothing forbids a back-reference. It never reads a `ConfiguredSecret`'s value; it returns the block and lets the caller resolve, so nothing in the walk can end up in a diagnostic.
 
-Tests cover a block at the root, a nested one, one inside a list with its index in the path, a null block being skipped rather than reported as missing, and a cyclic graph terminating.
+Tests cover a block at the root, a nested one, one inside a list with its index in the path, a null block being skipped rather than reported as missing, and a cyclic graph terminating. A separate binding test builds the options graph from an in-memory provider populated with flat colon-separated keys and asserts the discovered paths match them exactly — decision 27, and what keeps the Azure App Configuration and environment-variable paths honest.
 
 `SecretReferenceScheme` is open by decision 2: a future Azure Key Vault adapter calls `Create("azure-key-vault")` in its own file and registers itself. `ProviderUnavailable` is appended now rather than later so a network-backed adapter has a failure identity to report that is distinguishable from a missing secret; nothing in this change set produces it. Enum values are append-only, so this costs nothing and avoids renumbering a persisted-looking value later.
 
@@ -388,32 +387,30 @@ public sealed class MailAccountSecretOptions
 
     public Task<IReadOnlyList<MailAccountSecretConfigurationError>> FindConfigurationErrorsAsync(
         ISecretReferenceResolver resolver,
-        ConfiguredSecret? trustedCertificateAuthority,
         CancellationToken cancellationToken);
 
     public Task<MailAccountSecrets> ResolveAsync(
         ISecretReferenceResolver resolver,
-        ConfiguredSecret? trustedCertificateAuthority,
         CancellationToken cancellationToken);
 }
 
-public sealed record MailAccountSecrets(ResolvedSecret Password, X509Certificate2? TrustedCertificateAuthority) : IDisposable;
+public sealed record MailAccountSecrets(ResolvedSecret Password) : IDisposable;
 
 public sealed record ImapAccountSettings(
     string AccountId,
     string Host,
     int Port,
     string UserName,
-    ResolvedSecret Password,
-    X509Certificate2? TrustedCertificateAuthority);
+    ResolvedSecret Password);
 ```
 
-The trust anchor block is passed in rather than duplicated onto this type, because specification 01 already placed it on `MailAccountTransportSecurityOptions` and moving it between sections would churn a shipped configuration key for no gain.
+`MailAccountSecrets` wraps a single secret today and looks like a type that could be collapsed into `ResolvedSecret`. It is not, because specification 02b adds the resolved trust anchor beside the password and the ownership rule below has to cover both; introducing it now keeps that a one-line addition instead of a signature change through the session factory.
 
-Its *shape* does change, though: `TrustedCertificateAuthorityReference` goes from `string?` to `ConfiguredSecret?` so that decision 25 holds for every secret-bearing setting rather than for the new ones only. The key name is unchanged, so an operator who configured it edits one line. Three consequences to handle in this task:
+**The trust anchor setting is reshaped here but not read here.** `MailAccountTransportSecurityOptions.TrustedCertificateAuthorityReference` is renamed to `TrustedCertificateAuthority` and goes from `string?` to `ConfiguredSecret?`, so decision 25 holds for every secret-bearing setting from the moment the block exists rather than for new settings only. The `Reference` suffix earned its place while the value *was* the reference string; now that a block holds it in `SecretReference`, the suffix repeats the word and the setting is better named after what it configures. Loading the material behind it is specification 02b. Four consequences to handle in this task:
 
-- `MailTransportSecurityPolicy.Create` and `FindViolations` in `Domain` keep taking a nullable `string`, and the options type now passes `this.TrustedCertificateAuthorityReference?.SecretReference`. The block is a configuration-adapter shape and must not cross into `Domain`, which is also why the domain rules for `TrustedCertificateAuthorityReferenceRequired` and `TrustedCertificateAuthorityReferenceNotApplicable` need no change.
-- A block that is present but carries an empty `SecretReference` must read as *absent* to those domain rules, not as a configured anchor. Otherwise `"TrustedCertificateAuthorityReference": {}` would satisfy `TrustedCertificateAuthorityReferenceRequired` and then fail later at resolution, reporting a confusing missing-material error instead of the missing-anchor error the operator needs.
+- `MailTransportSecurityPolicy.Create` and `FindViolations` in `Domain` keep taking a nullable `string`, and the options type now passes `this.TrustedCertificateAuthority?.SecretReference`. The block is a configuration-adapter shape and must not cross into `Domain`, which is also why the domain violation members `TrustedCertificateAuthorityReferenceRequired` and `TrustedCertificateAuthorityReferenceNotApplicable` keep their names: they describe a domain rule about a reference being present, not the configuration key that carries it.
+- A block that is present but carries an empty `SecretReference` must read as *absent* to those domain rules, not as a configured anchor. Otherwise `"TrustedCertificateAuthority": {}` would satisfy `TrustedCertificateAuthorityReferenceRequired` and then fail later at resolution, reporting a confusing missing-material error instead of the missing-anchor error the operator needs.
+- `SettingFor(MailTransportSecurityViolation)` maps those two violations onto a setting name for the operator message. It must report `TrustedCertificateAuthority`, the new key, not the violation member's own spelling — otherwise the startup error names a key that does not exist in the file the operator is editing.
 - The existing `MailAccountTransportSecurityOptionsTests` that set the reference as a string are updated to the block. They are assertions about domain rules, not about the JSON shape, so their expectations stay as they are.
 
 - [ ] **Step 1: Write the failing tests**
@@ -423,15 +420,19 @@ Its *shape* does change, though: `TrustedCertificateAuthorityReference` goes fro
 [Fact] FindConfigurationErrorsAsync_UnresolvablePasswordReference_ReportsTheFailureAgainstThePasswordBlock
 [Fact] FindConfigurationErrorsAsync_EmptyPasswordSecretReference_ReportsReferenceMissing
 [Fact] FindConfigurationErrorsAsync_PlainTextInThePasswordBlockUnderReferenceOnly_ReportsSchemeMissing
-[Fact] FindConfigurationErrorsAsync_UnresolvableTrustAnchorReference_ReportsTheFailureAgainstTheTrustAnchorSetting
-[Fact] FindConfigurationErrorsAsync_TrustAnchorMaterialIsNotACertificate_ReportsMaterialNotFound
-[Fact] FindConfigurationErrorsAsync_NoTrustAnchorConfigured_DoesNotConsultTheResolver
 [Fact] FindConfigurationErrorsAsync_EveryError_CarriesNoSecretMaterial
-[Fact] ResolveAsync_ResolvableReferences_ReturnsThePasswordAndTheParsedTrustAnchor
-[Fact] ResolveAsync_PemTrustAnchor_LoadsTheCertificateSubject
+[Fact] ResolveAsync_ResolvableReference_ReturnsTheResolvedPassword
+[Fact] Dispose_ResolvedAccountSecrets_ErasesThePasswordMaterial
 ```
 
-The PEM test builds its certificate in memory with `CertificateRequest` and `CreateSelfSigned`, then exports it with `ExportCertificatePem()` — no file system, no network.
+`MailAccountTransportSecurityOptionsTests` gains coverage of the reshaped setting, since the domain rules now read through the block:
+
+```csharp
+[Fact] FindConfigurationErrors_AdditionalTrustedAuthorityWithABlock_ReportsNoError
+[Fact] FindConfigurationErrors_AdditionalTrustedAuthorityWithAnEmptyBlock_ReportsTheAnchorAsMissing
+[Fact] FindConfigurationErrors_TrustAnchorBlockWithoutAdditionalTrustedAuthority_ReportsNotApplicable
+[Fact] FindConfigurationErrors_TrustAnchorViolation_NamesTheTrustedCertificateAuthoritySetting
+```
 
 - [ ] **Step 2: Run the tests and confirm they fail**
 
@@ -439,17 +440,17 @@ Expected: FAIL — `MailAccountSecretOptions` does not exist and `ImapAccountSet
 
 - [ ] **Step 3: Implement**
 
-`FindConfigurationErrorsAsync` resolves the password reference and, when a trust anchor reference is present, resolves and parses it, then discards both — decision 16's startup half. Trust anchor parsing uses `X509Certificate2.CreateFromPem` inside a `try`/`catch (CryptographicException)` that becomes a configuration error, so malformed material fails startup instead of failing the first TLS handshake hours later.
+`FindConfigurationErrorsAsync` resolves the password reference and discards the material — decision 16's startup half.
 
-`Resolve` performs the same work and returns the values, and throws `InvalidOperationException` if a reference that validated at startup no longer resolves — a fail-closed path, not an ordinary branch.
+`ResolveAsync` performs the same work and returns the value, and throws `InvalidOperationException` if a reference that validated at startup no longer resolves — a fail-closed path, not an ordinary branch.
 
-`ImapAccountSettings` carries `ResolvedSecret` and the optional anchor. Its XML documentation gains a remark that the record's synthesized `ToString()` is safe only because `ResolvedSecret` redacts itself.
+`ImapAccountSettings` carries `ResolvedSecret`. Its XML documentation gains a remark that the record's synthesized `ToString()` is safe only because `ResolvedSecret` redacts itself.
 
-`MailAccountSecrets` implements `IDisposable` and disposes both the password and the `X509Certificate2`, which is itself disposable. Per decision 9 the instance is owned by the operation that resolved it: `MailKitImapMailboxSessionFactory.OpenReadOnlyAsync` disposes it once the client is authenticated and the folder is open, and the startup validator disposes everything it resolved before returning. `ImapAccountSettings` does *not* own the secrets — it is a carrier — so the ownership rule is stated in its XML documentation to stop a future caller from disposing it twice or not at all.
+`MailAccountSecrets` implements `IDisposable` and disposes the password. Per decision 9 the instance is owned by the operation that resolved it: `MailKitImapMailboxSessionFactory.OpenReadOnlyAsync` disposes it once the client is authenticated and the folder is open, and the startup validator disposes everything it resolved before returning. `ImapAccountSettings` does *not* own the secrets — it is a carrier — so the ownership rule is stated in its XML documentation to stop a future caller from disposing it twice or not at all.
 
 - [ ] **Step 4: Run the tests**
 
-Expected: PASS for `Infrastructure.UnitTests`; the solution does not build until Task 6 updates `Host`.
+Expected: PASS for `Infrastructure.UnitTests`; the solution does not build until Task 5 updates `Host`.
 
 - [ ] **Step 5: Commit**
 
@@ -460,111 +461,7 @@ git commit -m "Bind account secrets as reference blocks and resolve them in Infr
 
 ---
 
-### Task 4: Custom trust anchor in the certificate validation path
-
-**Files:**
-- Create: `src/Infrastructure/Mail/MailServerCertificateValidator.cs`
-- Modify: `src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs`
-- Test: `tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs`
-
-**Interfaces produced:**
-
-```csharp
-internal static class MailServerCertificateValidator
-{
-    internal static RemoteCertificateValidationCallback? CreateCallback(X509Certificate2? trustedCertificateAuthority);
-
-    internal static bool IsTrusted(
-        X509Certificate2? trustedCertificateAuthority,
-        X509Certificate? serverCertificate,
-        SslPolicyErrors sslPolicyErrors);
-}
-```
-
-`IMailKitImapClient` gains `RemoteCertificateValidationCallback? ServerCertificateValidationCallback { get; set; }`, forwarded by `MailKitImapClientAdapter` to `ImapClient.ServerCertificateValidationCallback`.
-
-- [ ] **Step 1: Write the failing tests**
-
-The fixture builds an in-memory CA and a leaf signed by it with `CertificateRequest`, so no file system, network, or real trust store is involved:
-
-```csharp
-[Fact] IsTrusted_NoPolicyErrors_TrustsWithoutConsultingTheAnchor
-[Fact] IsTrusted_ChainErrorsAndLeafChainsToTheConfiguredAnchor_Trusts
-[Fact] IsTrusted_ChainErrorsAndLeafChainsToADifferentAuthority_Rejects
-[Fact] IsTrusted_ChainErrorsWithoutAConfiguredAnchor_Rejects
-[Fact] IsTrusted_NameMismatch_RejectsEvenWhenTheAnchorMatches
-[Fact] IsTrusted_CertificateNotAvailable_Rejects
-[Fact] CreateCallback_NoAnchorConfigured_ReturnsNullSoTheDefaultValidationApplies
-```
-
-`IsTrusted_NameMismatch_RejectsEvenWhenTheAnchorMatches` is the test that stops this task from becoming a certificate-validation bypass.
-
-- [ ] **Step 2: Run the tests and confirm they fail**
-
-Expected: FAIL — the validator does not exist.
-
-- [ ] **Step 3: Implement**
-
-```csharp
-internal static bool IsTrusted(
-    X509Certificate2? trustedCertificateAuthority,
-    X509Certificate? serverCertificate,
-    SslPolicyErrors sslPolicyErrors)
-{
-    if (sslPolicyErrors == SslPolicyErrors.None)
-    {
-        return true;
-    }
-
-    // Only an untrusted chain is reconsidered. A missing certificate proves nothing, and a name mismatch means the
-    // certificate belongs to a different host, which a private trust anchor does not and must not excuse.
-    if (trustedCertificateAuthority is null || sslPolicyErrors != SslPolicyErrors.RemoteCertificateChainErrors)
-    {
-        return false;
-    }
-
-    if (serverCertificate is not X509Certificate2 presentedCertificate)
-    {
-        return false;
-    }
-
-    using var chain = new X509Chain();
-    chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-    chain.ChainPolicy.CustomTrustStore.Add(trustedCertificateAuthority);
-    chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-    chain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
-
-    return chain.Build(presentedCertificate);
-}
-```
-
-`CustomTrustStore` is documented as respected only when `TrustMode` is `CustomRootTrust`, so both must be set together; setting the collection alone would silently keep the system trust store in effect. `VerificationFlags` is pinned to `NoFlag` so no future edit can relax expiry or basic-constraint checking. `RevocationMode` is `NoCheck` because a private authority typically publishes no reachable CRL or OCSP responder, and a revocation lookup that cannot complete would otherwise reject a correctly provisioned server — this is a deliberate, documented trade-off confined to the custom-anchor path, and the system trust path keeps whatever the platform default applies.
-
-The session factory installs the callback before connecting and reveals the password once:
-
-```csharp
-client.ServerCertificateValidationCallback =
-    MailServerCertificateValidator.CreateCallback(settings.TrustedCertificateAuthority);
-
-await client.ConnectAsync(...);
-...
-await client.AuthenticateAsync(settings.UserName, settings.Password.RevealAsString(), cancellationToken);
-```
-
-- [ ] **Step 4: Run the tests**
-
-Expected: PASS.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/Infrastructure/Mail tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs
-git commit -m "Validate a private mail server against its configured trust anchor"
-```
-
----
-
-### Task 5: Database password reference
+### Task 4: Database password reference
 
 **Files:**
 - Modify: `src/Host/Configuration/PersistenceOptions.cs`, `src/Infrastructure/ServiceCollectionExtensions.cs`
@@ -602,7 +499,7 @@ git commit -m "Resolve the database password from a secret reference"
 
 ---
 
-### Task 6: Host binding, wiring, and fail-fast validation
+### Task 5: Host binding, wiring, and fail-fast validation
 
 **Files:**
 - Modify: `src/Host/Configuration/MailSynchronizationOptions.cs`, `src/Host/Program.cs`, `src/Host/appsettings.json`, `src/Host/appsettings.Development.json`
@@ -644,7 +541,7 @@ The configuration path, the failure identity, and nothing else — no target pat
 
 The second line is decision 26 doing its work: the block was found by type, so a plain-text password sitting where a reference belongs fails here rather than authenticating successfully against the server. Reporting every failure together matters when an operator provisions five accounts and mistypes two names; one-at-a-time discovery costs five restarts.
 
-The graph walk is the one place this plan accepts reflection, and it earns it: enumerating `ConfiguredSecret` properties is what makes decision 26's guarantee automatic for settings that do not exist yet, which an explicit call list cannot be. It runs once, at startup, over a bound options object of a few dozen properties. The walk itself lives in `Infrastructure` as `ConfiguredSecretDiscovery` so it is unit-testable — `Host` is excluded from coverage, and the same rule that put `MailAccountSecretOptions` in `Infrastructure` applies here. `MailAccountSecretOptions.FindConfigurationErrorsAsync` stays as the account-scoped path used by Task 8's reload, which validates one candidate snapshot rather than the whole graph.
+The graph walk is the one place this plan accepts reflection, and it earns it: enumerating `ConfiguredSecret` properties is what makes decision 26's guarantee automatic for settings that do not exist yet, which an explicit call list cannot be. It runs once, at startup, over a bound options object of a few dozen properties. The walk itself lives in `Infrastructure` as `ConfiguredSecretDiscovery` so it is unit-testable — `Host` is excluded from coverage, and the same rule that put `MailAccountSecretOptions` in `Infrastructure` applies here. `MailAccountSecretOptions.FindConfigurationErrorsAsync` stays as the account-scoped path, which specification 02b's reload reuses to validate one candidate snapshot rather than the whole graph.
 
 `StartingAsync` is documented to run before any hosted service's `StartAsync`, so the synchronization worker never starts against an unresolvable secret. The remaining four lifecycle members are empty. The type stays a thin translation because `Host` is excluded from coverage; every rule it reports comes from Task 3 and from `ConfiguredSecretDiscovery`.
 
@@ -676,7 +573,7 @@ dotnet build MailMcp.slnx
 grep -rnE "string\??\s+(Password|Secret|Credential|PrivateKey|Token)\b" src/ --include=*.cs
 ```
 
-Expected: build succeeds; the grep matches only `ConfiguredSecret.SecretReference`. Searching for the *type* rather than for the JSON key `"Password"` is the point — after decision 25 the key is legitimate and appears in every secret block, so the old key-based grep would report the correct shape as a finding. This is the specification's first definition-of-done item, and Task 7's assembly-wide test is its permanent form; this grep also reaches `Host`, which that test cannot.
+Expected: build succeeds; the grep matches only `ConfiguredSecret.SecretReference`. Searching for the *type* rather than for the JSON key `"Password"` is the point — after decision 25 the key is legitimate and appears in every secret block, so the old key-based grep would report the correct shape as a finding. This is the specification's first definition-of-done item, and Task 6's assembly-wide test is its permanent form; this grep also reaches `Host`, which that test cannot.
 
 - [ ] **Step 7: Commit**
 
@@ -687,7 +584,7 @@ git commit -m "Bind mail and database secrets as references and fail startup whe
 
 ---
 
-### Task 7: Architecture test for the boundary
+### Task 6: Architecture tests for the boundary and the marker
 
 **Files:**
 - Create: `tests/Infrastructure.UnitTests/SecretBoundaryArchitectureTests.cs`
@@ -735,52 +632,7 @@ git commit -m "Assert secret resolution stays out of Domain and Application"
 
 ---
 
-### Task 8: Dynamic reload of references and material
-
-**Files:**
-- Modify: `src/Host/Configuration/MailSynchronizationOptions.cs`, `src/Host/Program.cs`, `src/Infrastructure/Mail/MailAccountSecretOptions.cs`
-- Create: `src/Host/Configuration/MailSecretSnapshotPublisher.cs`
-- Test: `tests/Infrastructure.UnitTests/MailAccountSecretReloadTests.cs`
-
-Decision 18 makes this a blocking prerequisite: **do not start this task until ADR 0002 has been amended with owner approval.** The ADR classifies credentials and trust anchors as restart-required, and this task deliberately reclassifies them as reloadable for new operations.
-
-- [ ] **Step 1: Write the failing tests**
-
-```csharp
-[Fact] ReloadAsync_ReferenceChangedToAResolvableTarget_PublishesTheNewSecrets
-[Fact] ReloadAsync_CandidateSnapshotHasAnUnresolvableReference_KeepsThePreviousSecrets
-[Fact] ReloadAsync_RejectedSnapshot_LogsTheAccountAndFailureWithoutMaterial
-[Fact] ResolveAsync_MaterialRotatedBehindAnUnchangedReference_ReturnsTheRotatedValue
-[Fact] ResolveAsync_MaterialRotatedMidOperation_DoesNotAffectTheOperationInFlight
-```
-
-The last two are the pair that distinguishes the two reload halves, and the last one is what keeps decision 17's "not during running operations" honest.
-
-- [ ] **Step 2: Bind for reload**
-
-`Host` switches the mail options consumer from `IOptions<MailSynchronizationOptions>` to `IOptionsMonitor<MailSynchronizationOptions>`. Note that `IOptions<T>` is a singleton captured once, so leaving it in place would silently defeat the reference half of this task.
-
-- [ ] **Step 3: Validate the candidate before publishing it**
-
-`MailSecretSnapshotPublisher` subscribes to `OnChange`, resolves every reference in the candidate snapshot, and publishes an immutable snapshot only when all of them resolve. On failure it retains the previous snapshot and logs the account, the setting, and the `SecretResolutionFailure` — never a path, a variable name, or material. This is the last-known-good behavior ADR 0002 requires of any reloadable group.
-
-Reload validation must not crash the process: ADR 0002 is explicit that a rejected reload leaves the previous valid settings active, unlike a startup failure which is fatal.
-
-- [ ] **Step 4: Resolve material per operation**
-
-No change is needed for the material half — decision 16 already resolves per use, which is what makes rotation behind an unchanged reference work. The test in Step 1 is what proves it, and it exists to catch a future "optimization" that caches the resolved value on the options instance.
-
-- [ ] **Step 5: Run the tests and commit**
-
-```bash
-dotnet test --project tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj
-git add src/Host src/Infrastructure tests/Infrastructure.UnitTests/MailAccountSecretReloadTests.cs
-git commit -m "Reload secret references and material without restarting the host"
-```
-
----
-
-### Task 9: Documentation and full verification
+### Task 7: Documentation and full verification
 
 **Files:**
 - Create: `docs/operations/secret-provisioning.md`
@@ -788,13 +640,13 @@ git commit -m "Reload secret references and material without restarting the host
 
 - [ ] **Step 1: Write the provisioning page**
 
-`docs/operations/secret-provisioning.md` documents the reference grammar, the four schemes, and — because MailMcp is deployed several ways — a section per deployment shape: the native systemd path with `LoadCredential=`, `LoadCredentialEncrypted=`, `systemd-creds`, and `$CREDENTIALS_DIRECTORY`; the container path with Compose `secrets:` mounted at `/run/secrets/<name>`; and the Kubernetes path with a Secret mounted as a read-only tmpfs volume — the last two both addressed as `file:`, with an explicit note that no container- or Kubernetes-specific scheme exists or is needed. It states the trailing-newline trimming and that it applies to text secrets only, the accepted certificate encodings, the operational hardening that bounds in-memory exposure — `LimitCORE=0` on the systemd unit, `Storage=none` and `ProcessSizeMax=0` for `systemd-coredump`, and keeping the service out of swap in both the systemd and container shapes, with the honest statement that a dump or debugger can still read managed memory and that no code-level measure changes that — the three interpretation modes with `ReferenceOnly` as the default and `InlineOnly` as the Azure App Configuration path, the fact that inline values cannot be erased from memory, the recommendation against `env:` in production, and the ADR 0002 classification from decision 17.
+`docs/operations/secret-provisioning.md` documents the reference grammar, the four schemes, and — because MailMcp is deployed several ways — a section per deployment shape: the native systemd path with `LoadCredential=`, `LoadCredentialEncrypted=`, `systemd-creds`, and `$CREDENTIALS_DIRECTORY`; the container path with Compose `secrets:` mounted at `/run/secrets/<name>`; and the Kubernetes path with a Secret mounted as a read-only tmpfs volume — the last two both addressed as `file:`, with an explicit note that no container- or Kubernetes-specific scheme exists or is needed. It states the trailing-newline trimming and that it applies to text secrets only, the operational hardening that bounds in-memory exposure — `LimitCORE=0` on the systemd unit, `Storage=none` and `ProcessSizeMax=0` for `systemd-coredump`, and keeping the service out of swap in both the systemd and container shapes, with the honest statement that a dump or debugger can still read managed memory and that no code-level measure changes that — the three interpretation modes with `ReferenceOnly` as the default and `InlineOnly` as the Azure App Configuration path, the fact that inline values cannot be erased from memory, and the recommendation against `env:` in production. It also states, for each of the three modes, how the same setting is addressed by a flattening provider — `MailSynchronization:Accounts:0:Secrets:Password:SecretReference` in Azure App Configuration and its double-underscore form in an environment block — because that is the path an operator on a managed store actually configures.
 
 A closing section states what a future managed-store provider would add — one `ISecretSchemeResolver`, one registration extension, its own timeouts and caching, platform identity rather than a MailMcp-held credential, and a `LICENSES.md` entry — so an operator reading the page can tell which schemes exist today from which are anticipated. It documents anticipated extension, not unimplemented behavior, and says so plainly; `docs/AGENTS.md` requires documentation to describe verified implemented behavior, and this section is explicitly labelled as the extension contract rather than as a feature.
 
 - [ ] **Step 2: Update the feature and development pages**
 
-`docs/features/imap-synchronization.md` gets the new account JSON, the resolution and fail-fast behavior, the trust-anchor behavior from Task 4 including the revocation trade-off, and loses the two now-resolved pending items — deployment-specific secret binding, and trust anchor loading. `docs/operations/local-development.md` gains the Development workflow: `plaintext:` in `appsettings.Development.json` or user secrets, and why neither is a production secret store.
+`docs/features/imap-synchronization.md` gets the new account JSON and the resolution and fail-fast behavior, and loses the now-resolved pending item on deployment-specific secret binding. Trust anchor loading stays listed as pending, because specification 02b delivers it. `docs/operations/local-development.md` gains the Development workflow: `plaintext:` in `appsettings.Development.json` or user secrets, and why neither is a production secret store.
 
 - [ ] **Step 3: Run the documentation and licensing gate**
 
@@ -836,7 +688,7 @@ Run `$finish-change`: commit, push, and open a draft pull request whose body con
 | Provider concerns confined to the provider's adapter | decisions 19 and 20 |
 | Resolver contract and adapters live in `Infrastructure` | 1–4 |
 | `Host` invokes resolution once before hosted services start | 6 |
-| No options type binds a raw password | 3, 5, 6 (verified by `grep` in Task 6 Step 6) |
+| No options type binds a raw password | 3, 4, 5 (verified by `grep` in Task 5 Step 6) |
 | Failure message names account, logical secret, and scheme only | 3, 6 |
 | Secrets exposed through an accessor, not an ordinary property | 1, 3 |
 | Rotated material observed without restart | decision 16, Tasks 3 and 8 |
@@ -852,9 +704,7 @@ Run `$finish-change`: commit, push, and open a draft pull request whose body con
 | Core-dump and swap exposure documented for both shapes | 9 |
 | Text view decodes UTF-8 and trims one trailing newline | 1 |
 | Rotated material observed by the next operation, no restart | 8 |
-| Reload with an unresolvable reference keeps previous secrets | 8 |
-| Trust anchor loaded, validated as usable, and installed in the validation path | 3, 4 |
-| Malformed trust anchor fails startup | 3 |
+| Trust anchor setting reshaped to a block without being read | 3 |
 | Private server connects with validation fully enabled | 4 |
 | No secret-resolution contract reachable from `Application` or `Domain` | 7 |
 | Scheme adapters tested against in-memory file/credential abstractions | 2 |
@@ -863,16 +713,14 @@ Run `$finish-change`: commit, push, and open a draft pull request whose body con
 | `docs/operations/` page for the systemd credential deployment path | 8 |
 | 85% coverage gate | 8 |
 
-**Deliberately out of scope:** Data Protection key-ring provisioning, encrypted secret storage in PostgreSQL, secret rotation without restart, and MCP client certificates (stage 9).
+**Deliberately out of scope:** certificate and private-key material loading, installing a trust anchor into the validation path, and secret rotation without restart — all three are specification 02b, which consumes this contract unchanged. Also out of scope: Data Protection key-ring provisioning, encrypted secret storage in PostgreSQL, and MCP client certificates (stage 9).
 
 Managed secret stores — Kubernetes-native APIs, Azure Key Vault, HashiCorp Vault, AWS Secrets Manager — are out of scope as implementations but not as constraints. Decisions 2, 4, 19, and 20 exist for them, and the Task 2 extensibility test is what keeps the promise honest. Note that Kubernetes and container deployments need nothing added at all: their secrets are files, so `file:` already serves them today.
 
 **Flagged for the owner**
 
-- **Blocking:** ADR 0002 must be amended before Task 8 begins (decision 18). The dynamic-reload requirement contradicts the ADR's current restart-required classification for credentials and trust anchors, and `docs/AGENTS.md` forbids amending an ADR without explicit owner approval. Tasks 1–7 and 9 are unaffected.
-- **Blocking:** the specification is now estimated at ~1700 lines against `specs/README.md`'s ~1000-line ceiling, and `specs/02` records a proposed 02a/02b split. Whether to split — and therefore whether this plan stays one plan — is the owner's call, because renumbering touches the roadmap board and the dependency chain from specification 03 onward.
-- The specification originally estimated ~500 lines. Loading and validating the trust anchor (Task 4), the database password reference (Task 5), the asynchronous contract that ripples through `IImapAccountSettingsProvider` and startup validation (decisions 4 and 5), memory hygiene, dynamic reload, and now the secret block with its discovery walk (decisions 25 and 26) bring this to roughly 1700 lines including tests and documentation. Nothing is proposed for deferral; the estimate is what is optimistic. Issue #36's `Size` line should be updated when this plan is accepted.
-- Decision 25 changes `MailAccountTransportSecurityOptions.TrustedCertificateAuthorityReference` from a string to a block, which is a breaking configuration change to a setting specification 01 already shipped. It is proposed now precisely because it is cheap now — one consumer, no released deployment — and expensive later. The key name is unchanged, so an affected operator edits one line.
+- The combined specification reached ~1700 lines against `specs/README.md`'s ~1000-line ceiling and has been split. This plan covers 02a at roughly 950 lines including tests and documentation; certificate material and rotation are ~750 lines in the 02b plan. Nothing is deferred outside the two specifications, and nothing depended on `02`, so the split cost no renumbering of specifications 03 onward. Issue #36's `Size` line should be updated when this plan is accepted.
+- Decision 25 renames `MailAccountTransportSecurityOptions.TrustedCertificateAuthorityReference` to `TrustedCertificateAuthority` and changes it from a string to a block. That is a breaking configuration change to a setting specification 01 already shipped, and it is proposed now precisely because it is cheap now — one consumer, no released deployment — and expensive later. An affected operator edits one line.
 - Decision 26's discovery walk uses reflection over the bound options graph, which the root rules restrict to measured need. The need argued here is that an explicit call list cannot cover a secret-bearing setting added after this ships, which is the entire value of the marker. It runs once at startup over a small object. If you would rather keep reflection out and accept that each new secret setting must be registered by hand, `ConfiguredSecretDiscovery` collapses into an explicit list and decision 26's guarantee weakens from structural to procedural.
 - Decision 15 reads "permitted for non-production automation" as guidance rather than an enforced environment gate for `env:`. If it should be enforced, say so and it moves onto the same Development flag as `plaintext:`.
 - Decision 4 makes the contract asynchronous before any asynchronous provider exists. The cost is real and visible: `GetSettings` becomes `GetSettingsAsync`, and startup validation moves out of `IValidateOptions` into `IHostedLifecycleService`. It is proposed because retrofitting it alongside a first Key Vault adapter would touch the same files while also introducing SDK, identity, and licensing questions, and doing one of those at a time is cheaper. If managed stores are further off than this assumes, the synchronous contract is defensible and this is the decision to revisit.

--- a/docs/superpowers/plans/2026-07-27-secret-reference-resolution-02a.md
+++ b/docs/superpowers/plans/2026-07-27-secret-reference-resolution-02a.md
@@ -156,6 +156,7 @@ public enum SecretResolutionFailure
     MaterialNotFound = 6,
     MaterialEmpty = 7,
     ProviderUnavailable = 8,
+    MaterialTooLarge = 9,
 }
 
 public sealed record SecretReference
@@ -193,7 +194,7 @@ internal static class ConfiguredSecretDiscovery
 
 `ConfiguredSecretDiscovery` is what makes the marker useful: it walks public readable properties of the bound options object, descends into nested options objects, into `IEnumerable` elements, and into a block's own nested `Password` block, and yields each `ConfiguredSecret` with the colon-separated path that reached it — `MailSynchronization:Accounts:0:Secrets:Password`. It must guard against a cycle in the object graph, since options types are ordinary classes and nothing forbids a back-reference. It never reads a `ConfiguredSecret`'s value; it returns the block and lets the caller resolve, so nothing in the walk can end up in a diagnostic.
 
-Tests cover a block at the root, a nested one, one inside a list with its index in the path, a null block being skipped rather than reported as missing, and a cyclic graph terminating. A separate binding test builds the options graph from an in-memory provider populated with flat colon-separated keys and asserts the discovered paths match them exactly — decision 27, and what keeps the Azure App Configuration and environment-variable paths honest.
+Tests cover a block at the root, a nested one, one inside a list with its index in the path, a block's own nested `Password` block reported at `…:TrustedCertificateAuthority:Password` so 02b's bundle password is discovered by the same walk, a null block being skipped rather than reported as missing, a `string` property named for a secret failing the walk under decision 32, and a cyclic graph terminating. A separate binding test builds the options graph from an in-memory provider populated with flat colon-separated keys and asserts the discovered paths match them exactly — decision 27, and what keeps the Azure App Configuration and environment-variable paths honest.
 
 `SecretReferenceScheme` is open by decision 2: a future Azure Key Vault adapter calls `Create("azure-key-vault")` in its own file and registers itself. `ProviderUnavailable` is appended now rather than later so a network-backed adapter has a failure identity to report that is distinguishable from a missing secret; nothing in this change set produces it. Enum values are append-only, so this costs nothing and avoids renumbering a persisted-looking value later.
 
@@ -237,7 +238,8 @@ public sealed record SecretResolutionResult
 TryParse_SupportedScheme_ParsesSchemeAndTarget
 [Fact]    TryParse_TargetContainsColon_KeepsEverythingAfterTheFirstColon        // "file:C:\\secrets\\imap" => "C:\\secrets\\imap"
 [Fact]    TryParse_MixedCaseScheme_ParsesScheme                                 // "File:/run/secrets/imap"
-[Fact]    TryParse_SurroundingWhitespace_TrimsBeforeParsing
+[Fact]    TryParse_WhitespaceAroundTheScheme_TrimsTheSchemeOnly                 // " file :/run/secrets/imap"
+[Fact]    TryParse_PlaintextTargetWithLeadingAndTrailingSpaces_KeepsEverySpace  // "plaintext: secret " => " secret "
 [Fact]    TryParse_NullOrWhitespace_FailsWithReferenceMissing
 [Fact]    TryParse_NoColon_FailsWithSchemeMissing                               // under ReferenceOnly a bare password must never parse
 [Fact]    TryParse_UnregisteredScheme_ParsesBecauseSupportIsADispatchQuestion   // "azure-key-vault:imap" parses
@@ -252,9 +254,10 @@ TryParse_SupportedScheme_ParsesSchemeAndTarget
 [Fact]    Dispose_CalledTwice_DoesNotThrow
 [Fact]    RevealBytes_AfterDispose_Throws                           // a use-after-erase is a bug, not a silent empty
 [Fact]    ToString_SecretResolutionResult_DoesNotContainTheMaterial             // the record's synthesized ToString
+[Fact]    ToString_SecretReference_ContainsNeitherTheTargetNorAPlaintextSecret  // the record's synthesized ToString
 ```
 
-The last two matter more than they look: they are the regression guard for decision 4.
+The last three matter more than they look: they are the regression guard for decision 12. `SecretReference` is a record with a public `Target`, so the synthesized printing would otherwise write a file path, a variable name, a vault identifier, or — for `plaintext:` — the complete secret into any log, exception message, or diagnostic dump the parsed object reaches.
 
 - [ ] **Step 2: Run the tests and confirm they fail to compile**
 
@@ -345,6 +348,8 @@ The file reader is asynchronous, takes the caller's token, and takes a byte ceil
 [Fact] ResolveAsync_File_ReadsTheProvisionedFile
 [Fact] ResolveAsync_FileMissing_FailsWithMaterialNotFound
 [Fact] ResolveAsync_FileEmpty_FailsWithMaterialEmpty
+[Fact] ResolveAsync_FileLargerThanTheCeiling_FailsWithMaterialTooLargeWithoutAllocatingTheMaterial
+[Fact] ResolveAsync_FileMalformedPath_FailsWithMaterialNotFoundInsteadOfThrowing   // a NUL character throws ArgumentException
 [Fact] ResolveAsync_EnvironmentVariable_ReadsTheVariable
 [Fact] ResolveAsync_EnvironmentVariableUnset_FailsWithMaterialNotFound
 [Fact] ResolveAsync_Plaintext_ReturnsTheLiteralInEveryModeThatParses
@@ -355,6 +360,8 @@ The file reader is asynchronous, takes the caller's token, and takes a byte ceil
 [Fact] ResolveAsync_UnregisteredScheme_FailsWithSchemeNotSupportedWithoutConsultingAnyReader
 [Fact] ResolveAsync_SchemeAdapterRegisteredOnlyByTheTest_ResolvesThroughTheSameDispatch
 [Fact] ResolveAsync_Cancelled_PropagatesTheCancellation
+[Fact] ResolveAsync_ResolvedThroughAnAdapter_ReportsSchemeAdapterAsTheSource
+[Fact] ResolveAsync_ValueAcceptedInline_ReportsInlineValueAsTheSource
 [Theory] ResolveAsync_EveryFailure_ReturnsNoSecretMaterial
 ```
 
@@ -487,6 +494,7 @@ git commit -m "Bind account secrets as reference blocks and resolve them in Infr
 
 **Files:**
 - Modify: `src/Host/Configuration/PersistenceOptions.cs`, `src/Infrastructure/ServiceCollectionExtensions.cs`
+- Test: `tests/Infrastructure.UnitTests/DatabasePasswordCompositionTests.cs`
 
 - [ ] **Step 1: Add the optional reference**
 
@@ -524,14 +532,21 @@ services.AddSingleton(provider =>
 
 The composed string is never logged and never returned; `NpgsqlDataSource` owns it and no code path reads it back. The revealed password is the second documented `string` boundary from decision 8.
 
-A test asserts the resolved password actually reaches Npgsql — `NpgsqlDataSource.ConnectionString` redacts the password, so the assertion is made on the `NpgsqlConnectionStringBuilder` the factory composed, before the data source is built. Without that test the failure mode is silent: everything validates, nothing connects.
+`DatabasePasswordCompositionTests` asserts the resolved password actually reaches Npgsql — `NpgsqlDataSource.ConnectionString` redacts the password, so the assertion is made on the `NpgsqlConnectionStringBuilder` the factory composed, before the data source is built:
+
+```csharp
+[Fact] BuildDataSource_ResolvablePasswordReference_ComposesTheResolvedPasswordIntoTheConnectionString
+[Fact] BuildDataSource_NoPasswordBlock_LeavesTheConnectionStringUnchanged
+```
+
+Without those the failure mode is silent: everything validates, nothing connects.
 
 Rotation of this reference is specification 02b's concern and is listed in its plan, because a singleton data source composed once cannot observe a rotated credential.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add src/Host/Configuration/PersistenceOptions.cs src/Infrastructure/ServiceCollectionExtensions.cs
+git add src/Host/Configuration/PersistenceOptions.cs src/Infrastructure/ServiceCollectionExtensions.cs tests/Infrastructure.UnitTests/DatabasePasswordCompositionTests.cs
 git commit -m "Resolve the database password from a secret reference"
 ```
 
@@ -576,6 +591,8 @@ MailSynchronization:Accounts:1:Secrets:Password — the value is not a secret re
 ```
 
 The configuration path, the failure identity, and nothing else — no target path, no variable name, no material. The path replaces the earlier account-plus-property phrasing because decision 25 nests the setting one level deeper and because an operator fixes the error by editing that exact path; `AccountId` is not usable as the anchor anyway, since a mistyped or duplicated account may not have one.
+
+The same walk applies decision 32's other half: a `string` property whose name contains `Password`, `Secret`, `Credential`, `PrivateKey`, or `Token` is reported as a configuration error against its path, because `MailSynchronizationOptions` and `PersistenceOptions` live in `Host` where Task 6's build-time test cannot reach them.
 
 The second line is decision 26 doing its work: the block was found by type, so a plain-text password sitting where a reference belongs fails here rather than authenticating successfully against the server. Reporting every failure together matters when an operator provisions five accounts and mistypes two names; one-at-a-time discovery costs five restarts.
 

--- a/docs/superpowers/plans/2026-07-27-secret-reference-resolution.md
+++ b/docs/superpowers/plans/2026-07-27-secret-reference-resolution.md
@@ -65,9 +65,11 @@ Two integration shapes exist and must not be conflated. A provider that **pre-re
 19. **Provider-specific concerns stay inside the provider's adapter.** Timeouts, retry, backoff, endpoint and region configuration, SDK client lifetime, platform identity, and caching policy belong to the adapter that needs them, never to `ISecretReferenceResolver`. The contract carries a reference and a cancellation token and returns a result; that is the whole surface. This is what lets a store that must cache aggressively and a local file that must never cache coexist without the contract taking a position, and it keeps SDK types out of everything above the adapter exactly as the root dependency rules require.
 20. **A managed-store adapter authenticates through platform identity, not through a MailMcp secret.** An Azure managed identity, a Kubernetes ServiceAccount token, or a Vault role is issued by the platform the process already runs on. Requiring MailMcp to hold a credential in order to fetch its credentials would be circular and would put the most sensitive value back into the configuration this specification removes it from. Recorded now so a future adapter does not quietly reintroduce the problem; nothing implements it here.
 21. **A custom trust anchor is validated by rebuilding the chain, never by accepting errors.** `RemoteCertificateNotAvailable` and `RemoteCertificateNameMismatch` are rejected outright. Only `RemoteCertificateChainErrors` is re-examined, by building an `X509Chain` with `TrustMode = X509ChainTrustMode.CustomRootTrust` and the anchor in `CustomTrustStore` — which Microsoft documents as respected only under that trust mode — and requiring a clean rebuild. MailKit's own `SslCertificateValidation.cs` example stops at describing errors and does not implement custom-CA trust, so this logic is ours to write and ours to test.
-22. **The database password becomes a reference too.** The specification's goal names it explicitly. `ConnectionStrings:mailmcp` keeps host, database, and user name; an optional `Persistence:PasswordReference` is resolved at startup and applied through `NpgsqlConnectionStringBuilder.Password`, so the connection string in `appsettings.json` never carries the password and the composed string never reaches a log.
+22. **The database password becomes a reference too.** The specification's goal names it explicitly. `ConnectionStrings:mailmcp` keeps host, database, and user name; an optional `Persistence:Password` secret block is resolved at startup and applied through `NpgsqlConnectionStringBuilder.Password`, so the connection string in `appsettings.json` never carries the password and the composed string never reaches a log.
 23. **Two resolver names, two scopes.** `ISecretReferenceResolver` resolves one reference. `MailAccountSecretOptions` resolves one account's set of secrets and reports per-account configuration errors. Naming them both "secret resolver" would make the call sites ambiguous, which the root naming rules forbid.
 24. **`UserName` stays a plain configuration value.** The definition of done names raw *passwords*. A mailbox user name is an identifier the operator already writes next to the host, and turning it into a reference would double the provisioning burden for no confidentiality gain. It remains excluded from logs as personal data.
+25. **Every secret-bearing setting is a JSON object, never a bare string.** The object is `ConfiguredSecret`, and its `SecretReference` property carries the reference. The reason is forward compatibility: a PKCS#12 bundle needs a second reference for its own password, a certificate may need an explicit format hint, and a managed-store reference may need a version pin. Inside a block each of those is a sibling property. Had the setting shipped as a bare string, the first such addition would change the setting's JSON type from string to object and break every deployment that had configured it. Only the first setting to need it would be affected, but the fix would then have to be applied setting by setting against real deployments; the uniform block pays that cost once, now, while `TrustedCertificateAuthorityReference` has one consumer and no shipped release depends on it. Nothing beyond `SecretReference` is defined here — the property is the whole shape today, and the point is only that a second one costs nothing later.
+26. **The block's type is the marker, in place of an attribute.** A secret-bearing property is declared by binding to `ConfiguredSecret` rather than to `string`, so `MailSecretReferenceStartupValidator` discovers every one of them by walking the bound options graph for that type. An attribute would work the same way at the point of use, but it can be omitted on a property added six months from now and nothing would notice — the property would bind to `string`, hold a password, and skip every rule in this plan. A type cannot be omitted, because the property would not bind to the block shape at all. This is what makes decision 13's `ReferenceOnly` guarantee total rather than per-setting: under the default mode a block whose `SecretReference` is not a well-formed `<scheme>:<target>` fails startup naming its configuration path, so a plain-text password pasted where a reference belongs is a startup error and never a secret that resolved by accident. The Task 7 architecture test enforces the other direction, failing the build if a secret-looking property is bound as a raw `string`.
 
 ## File structure
 
@@ -75,6 +77,8 @@ Two integration shapes exist and must not be conflated. A provider that **pre-re
 
 - `src/Infrastructure/Secrets/SecretReferenceScheme.cs` — the open scheme value and the four well-known members.
 - `src/Infrastructure/Secrets/SecretReference.cs` — parsed scheme and target, with the parse rules of decision 1.
+- `src/Infrastructure/Secrets/ConfiguredSecret.cs` — the bindable secret block, and the type that marks a setting as secret-bearing.
+- `src/Infrastructure/Secrets/ConfiguredSecretDiscovery.cs` — walks a bound options object and yields every secret block with the configuration path that reached it.
 - `src/Infrastructure/Secrets/SecretResolutionFailure.cs` — machine-readable failure identities.
 - `src/Infrastructure/Secrets/SecretResolutionResult.cs` — success carrying `ResolvedSecret`, or a failure identity.
 - `src/Infrastructure/Secrets/ResolvedSecret.cs` — pinned buffer, `RevealBytes()`/`RevealAsString()`, zeroing `Dispose`, redacted `ToString()`.
@@ -83,7 +87,7 @@ Two integration shapes exist and must not be conflated. A provider that **pre-re
 - `src/Infrastructure/Secrets/FileSystemSecretFileReader.cs`, `ProcessEnvironmentVariableReader.cs` — the real adapters.
 - `src/Infrastructure/Secrets/X509CertificateMaterialLoader.cs` — PEM, DER, and PKCS#12 loading over resolved bytes.
 - `src/Infrastructure/Secrets/SystemdCredentialSecretReferenceResolver.cs`, `FileSecretReferenceResolver.cs`, `EnvironmentVariableSecretReferenceResolver.cs`, `PlaintextSecretReferenceResolver.cs`, `CompositeSecretReferenceResolver.cs`
-- `src/Infrastructure/Mail/MailAccountSecretOptions.cs` — the account's reference strings and their resolution into `MailAccountSecrets`.
+- `src/Infrastructure/Mail/MailAccountSecretOptions.cs` — the account's secret blocks and their resolution into `MailAccountSecrets`.
 - `src/Infrastructure/Mail/MailAccountSecrets.cs` — resolved password plus optional trust anchor.
 - `src/Infrastructure/Mail/MailServerCertificateValidator.cs` — the custom-root-trust validation callback.
 - `tests/Infrastructure.UnitTests/SecretReferenceTests.cs`
@@ -97,10 +101,11 @@ Two integration shapes exist and must not be conflated. A provider that **pre-re
 **Modify**
 
 - `src/Infrastructure/Mail/ImapAccountSettings.cs` — `Password` becomes `ResolvedSecret`; the record gains the trust anchor; `IImapAccountSettingsProvider.GetSettings` becomes `GetSettingsAsync`.
+- `src/Infrastructure/Mail/MailAccountTransportSecurityOptions.cs` — `TrustedCertificateAuthorityReference` becomes a `ConfiguredSecret?` block; the key name and the domain contract are unchanged.
 - `src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs` — the client port carries the validation callback; the factory installs it before connecting and reveals the password at the single `AuthenticateAsync` call.
 - `src/Infrastructure/ServiceCollectionExtensions.cs` — `AddMailMcpSecretResolution`, and the resolved database password applied to the connection string.
 - `src/Host/Configuration/MailSynchronizationOptions.cs` — `Password` becomes a nested `Secrets` section; `GetSettings` becomes `GetSettingsAsync` and resolves.
-- `src/Host/Configuration/PersistenceOptions.cs` — optional `PasswordReference`.
+- `src/Host/Configuration/PersistenceOptions.cs` — optional `Password` secret block.
 - `src/Host/Program.cs` — register secret resolution with the configured interpretation mode, register the startup validator ahead of the worker, compose the connection string.
 - `src/Host/appsettings.json`, `src/Host/appsettings.Development.json` — reference-shaped examples.
 - `docs/features/imap-synchronization.md` — configuration, the two resolved pending items, transport-security trust anchor behavior.
@@ -111,8 +116,8 @@ Two integration shapes exist and must not be conflated. A provider that **pre-re
 ### Task 1: The reference grammar and the resolution result
 
 **Files:**
-- Create: `src/Infrastructure/Secrets/SecretReferenceScheme.cs`, `SecretReference.cs`, `SecretResolutionFailure.cs`, `SecretResolutionResult.cs`, `ResolvedSecret.cs`
-- Test: `tests/Infrastructure.UnitTests/SecretReferenceTests.cs`
+- Create: `src/Infrastructure/Secrets/SecretReferenceScheme.cs`, `SecretReference.cs`, `ConfiguredSecret.cs`, `ConfiguredSecretDiscovery.cs`, `SecretResolutionFailure.cs`, `SecretResolutionResult.cs`, `ResolvedSecret.cs`
+- Test: `tests/Infrastructure.UnitTests/SecretReferenceTests.cs`, `tests/Infrastructure.UnitTests/ConfiguredSecretDiscoveryTests.cs`
 
 **Interfaces produced:**
 
@@ -156,7 +161,28 @@ public sealed record SecretReference
 
     public static bool TryParse(string? reference, out SecretReference? parsed, out SecretResolutionFailure failure);
 }
+
+/// <summary>The bindable shape of every secret-bearing configuration setting.</summary>
+public sealed class ConfiguredSecret
+{
+    public string SecretReference { get; set; } = string.Empty;
+}
 ```
+
+`ConfiguredSecret` is mutable with a settable property because the configuration binder requires it, and it is the only bindable type in `src/Infrastructure/Secrets/`. It carries no resolution logic: it is the JSON shape and the marker of decision 26, nothing more. A future bundle password or format hint is a second property here, which is the whole reason it is a class rather than the bare string it wraps today.
+
+```csharp
+public sealed record DiscoveredSecret(string ConfigurationPath, ConfiguredSecret Secret);
+
+internal static class ConfiguredSecretDiscovery
+{
+    internal static IReadOnlyList<DiscoveredSecret> FindIn(object boundOptions, string rootSectionName);
+}
+```
+
+`ConfiguredSecretDiscovery` is what makes the marker useful: it walks public readable properties of the bound options object, descends into nested options objects and into `IEnumerable` elements, and yields each `ConfiguredSecret` with the colon-separated path that reached it — `MailSynchronization:Accounts:0:Secrets:Password`. It must guard against a cycle in the object graph, since options types are ordinary classes and nothing forbids a back-reference. It never reads a `ConfiguredSecret`'s value; it returns the block and lets the caller resolve, so nothing in the walk can end up in a diagnostic.
+
+Tests cover a block at the root, a nested one, one inside a list with its index in the path, a null block being skipped rather than reported as missing, and a cyclic graph terminating.
 
 `SecretReferenceScheme` is open by decision 2: a future Azure Key Vault adapter calls `Create("azure-key-vault")` in its own file and registers itself. `ProviderUnavailable` is appended now rather than later so a network-backed adapter has a failure identity to report that is distinguishable from a missing secret; nothing in this change set produces it. Enum values are append-only, so this costs nothing and avoids renumbering a persisted-looking value later.
 
@@ -348,8 +374,8 @@ git commit -m "Resolve secret references through per-scheme adapters"
 
 **Files:**
 - Create: `src/Infrastructure/Mail/MailAccountSecretOptions.cs`, `src/Infrastructure/Mail/MailAccountSecrets.cs`
-- Modify: `src/Infrastructure/Mail/ImapAccountSettings.cs`
-- Test: `tests/Infrastructure.UnitTests/MailAccountSecretOptionsTests.cs`
+- Modify: `src/Infrastructure/Mail/ImapAccountSettings.cs`, `src/Infrastructure/Mail/MailAccountTransportSecurityOptions.cs`
+- Test: `tests/Infrastructure.UnitTests/MailAccountSecretOptionsTests.cs`, `tests/Infrastructure.UnitTests/MailAccountTransportSecurityOptionsTests.cs`
 
 **Interfaces produced:**
 
@@ -358,16 +384,16 @@ public sealed record MailAccountSecretConfigurationError(string PropertyName, Se
 
 public sealed class MailAccountSecretOptions
 {
-    public string PasswordReference { get; set; } = string.Empty;
+    public ConfiguredSecret Password { get; set; } = new();
 
     public Task<IReadOnlyList<MailAccountSecretConfigurationError>> FindConfigurationErrorsAsync(
         ISecretReferenceResolver resolver,
-        string? trustedCertificateAuthorityReference,
+        ConfiguredSecret? trustedCertificateAuthority,
         CancellationToken cancellationToken);
 
     public Task<MailAccountSecrets> ResolveAsync(
         ISecretReferenceResolver resolver,
-        string? trustedCertificateAuthorityReference,
+        ConfiguredSecret? trustedCertificateAuthority,
         CancellationToken cancellationToken);
 }
 
@@ -382,14 +408,21 @@ public sealed record ImapAccountSettings(
     X509Certificate2? TrustedCertificateAuthority);
 ```
 
-The trust anchor reference is passed in rather than duplicated onto this type, because specification 01 already placed it on `MailAccountTransportSecurityOptions` and moving it now would churn a shipped configuration section for no gain.
+The trust anchor block is passed in rather than duplicated onto this type, because specification 01 already placed it on `MailAccountTransportSecurityOptions` and moving it between sections would churn a shipped configuration key for no gain.
+
+Its *shape* does change, though: `TrustedCertificateAuthorityReference` goes from `string?` to `ConfiguredSecret?` so that decision 25 holds for every secret-bearing setting rather than for the new ones only. The key name is unchanged, so an operator who configured it edits one line. Three consequences to handle in this task:
+
+- `MailTransportSecurityPolicy.Create` and `FindViolations` in `Domain` keep taking a nullable `string`, and the options type now passes `this.TrustedCertificateAuthorityReference?.SecretReference`. The block is a configuration-adapter shape and must not cross into `Domain`, which is also why the domain rules for `TrustedCertificateAuthorityReferenceRequired` and `TrustedCertificateAuthorityReferenceNotApplicable` need no change.
+- A block that is present but carries an empty `SecretReference` must read as *absent* to those domain rules, not as a configured anchor. Otherwise `"TrustedCertificateAuthorityReference": {}` would satisfy `TrustedCertificateAuthorityReferenceRequired` and then fail later at resolution, reporting a confusing missing-material error instead of the missing-anchor error the operator needs.
+- The existing `MailAccountTransportSecurityOptionsTests` that set the reference as a string are updated to the block. They are assertions about domain rules, not about the JSON shape, so their expectations stay as they are.
 
 - [ ] **Step 1: Write the failing tests**
 
 ```csharp
 [Fact] FindConfigurationErrorsAsync_ResolvableReferences_ReportsNoError
-[Fact] FindConfigurationErrorsAsync_UnresolvablePasswordReference_ReportsTheFailureAgainstPasswordReference
-[Fact] FindConfigurationErrorsAsync_MissingPasswordReference_ReportsReferenceMissing
+[Fact] FindConfigurationErrorsAsync_UnresolvablePasswordReference_ReportsTheFailureAgainstThePasswordBlock
+[Fact] FindConfigurationErrorsAsync_EmptyPasswordSecretReference_ReportsReferenceMissing
+[Fact] FindConfigurationErrorsAsync_PlainTextInThePasswordBlockUnderReferenceOnly_ReportsSchemeMissing
 [Fact] FindConfigurationErrorsAsync_UnresolvableTrustAnchorReference_ReportsTheFailureAgainstTheTrustAnchorSetting
 [Fact] FindConfigurationErrorsAsync_TrustAnchorMaterialIsNotACertificate_ReportsMaterialNotFound
 [Fact] FindConfigurationErrorsAsync_NoTrustAnchorConfigured_DoesNotConsultTheResolver
@@ -421,8 +454,8 @@ Expected: PASS for `Infrastructure.UnitTests`; the solution does not build until
 - [ ] **Step 5: Commit**
 
 ```bash
-git add src/Infrastructure/Mail tests/Infrastructure.UnitTests/MailAccountSecretOptionsTests.cs
-git commit -m "Bind account secrets as references and resolve them in Infrastructure"
+git add src/Infrastructure/Mail tests/Infrastructure.UnitTests/MailAccountSecretOptionsTests.cs tests/Infrastructure.UnitTests/MailAccountTransportSecurityOptionsTests.cs
+git commit -m "Bind account secrets as reference blocks and resolve them in Infrastructure"
 ```
 
 ---
@@ -538,7 +571,13 @@ git commit -m "Validate a private mail server against its configured trust ancho
 
 - [ ] **Step 1: Add the optional reference**
 
-`PersistenceOptions` gains `string? PasswordReference`. When it is null the connection string is used unchanged, which keeps trust-authentication and Aspire-provided connection strings working untouched.
+`PersistenceOptions` gains `ConfiguredSecret? Password`:
+
+```json
+"Persistence": { "Password": { "SecretReference": "file:/run/secrets/postgres-password" } }
+```
+
+When it is null the connection string is used unchanged, which keeps trust-authentication and Aspire-provided connection strings working untouched. A block present with an empty `SecretReference` is a startup failure rather than a silent fallback to the unchanged connection string, because an operator who wrote the block meant to supply a password.
 
 - [ ] **Step 2: Apply it when composing the connection string**
 
@@ -576,7 +615,9 @@ New account configuration shape:
   "Host": "imap.example.test",
   "Port": 993,
   "UserName": "mailmcp@example.test",
-  "Secrets": { "PasswordReference": "systemd-credential:imap-primary-password" },
+  "Secrets": {
+    "Password": { "SecretReference": "systemd-credential:imap-primary-password" }
+  },
   "TransportSecurity": { "ConnectionSecurity": "TlsOnConnect" },
   "Folders": [ "INBOX" ]
 }
@@ -592,15 +633,20 @@ New account configuration shape:
 
 - [ ] **Step 3: Fail fast on an unresolvable reference**
 
-Add `MailSecretReferenceStartupValidator : IHostedLifecycleService` in `src/Host/Hosting/`, injected with the options and the resolver. `StartingAsync` calls `MailAccountSecretOptions.FindConfigurationErrorsAsync` for every configured account plus the database reference, and throws `OptionsValidationException` listing every failure at once:
+Add `MailSecretReferenceStartupValidator : IHostedLifecycleService` in `src/Host/Hosting/`, injected with the options and the resolver. `StartingAsync` walks the bound options graph, collects every `ConfiguredSecret` it finds with the configuration path that reached it, resolves each one through the resolver, and throws `OptionsValidationException` listing every failure at once:
 
 ```
-Account 'primary': the PasswordReference could not be resolved [MaterialNotFound].
+MailSynchronization:Accounts:0:Secrets:Password — the secret reference could not be resolved [MaterialNotFound].
+MailSynchronization:Accounts:1:Secrets:Password — the value is not a secret reference and the interpretation mode is ReferenceOnly [SchemeMissing].
 ```
 
-The account, the setting, and the failure identity — no path, no variable name, no material. Reporting every failure together matters when an operator provisions five accounts and mistypes two names; one-at-a-time discovery costs five restarts.
+The configuration path, the failure identity, and nothing else — no target path, no variable name, no material. The path replaces the earlier account-plus-property phrasing because decision 25 nests the setting one level deeper and because an operator fixes the error by editing that exact path; `AccountId` is not usable as the anchor anyway, since a mistyped or duplicated account may not have one.
 
-`StartingAsync` is documented to run before any hosted service's `StartAsync`, so the synchronization worker never starts against an unresolvable secret. The remaining four lifecycle members are empty. The type stays a thin translation because `Host` is excluded from coverage; every rule it reports comes from Task 3.
+The second line is decision 26 doing its work: the block was found by type, so a plain-text password sitting where a reference belongs fails here rather than authenticating successfully against the server. Reporting every failure together matters when an operator provisions five accounts and mistypes two names; one-at-a-time discovery costs five restarts.
+
+The graph walk is the one place this plan accepts reflection, and it earns it: enumerating `ConfiguredSecret` properties is what makes decision 26's guarantee automatic for settings that do not exist yet, which an explicit call list cannot be. It runs once, at startup, over a bound options object of a few dozen properties. The walk itself lives in `Infrastructure` as `ConfiguredSecretDiscovery` so it is unit-testable — `Host` is excluded from coverage, and the same rule that put `MailAccountSecretOptions` in `Infrastructure` applies here. `MailAccountSecretOptions.FindConfigurationErrorsAsync` stays as the account-scoped path used by Task 8's reload, which validates one candidate snapshot rather than the whole graph.
+
+`StartingAsync` is documented to run before any hosted service's `StartAsync`, so the synchronization worker never starts against an unresolvable secret. The remaining four lifecycle members are empty. The type stays a thin translation because `Host` is excluded from coverage; every rule it reports comes from Task 3 and from `ConfiguredSecretDiscovery`.
 
 - [ ] **Step 4: Wire the resolver**
 
@@ -615,16 +661,22 @@ The validator is registered before the synchronization worker so hosted-service 
 
 - [ ] **Step 5: Update the shipped configuration examples**
 
-`appsettings.json` keeps an empty account list, documents the reference shape by example only, and leaves `Secrets:Interpretation` unset so the default `ReferenceOnly` applies. `appsettings.Development.json` sets `ReferenceOrInline` and shows a `plaintext:` example, which is what makes local development convenient without weakening the shipped default. No real credential appears in either file.
+`appsettings.json` keeps an empty account list, documents the block shape by example only, and leaves `Secrets:Interpretation` unset so the default `ReferenceOnly` applies. `appsettings.Development.json` sets `ReferenceOrInline` and shows the block carrying a `plaintext:` reference:
+
+```json
+"Secrets": { "Password": { "SecretReference": "plaintext:dev-password" } }
+```
+
+That is what makes local development convenient without weakening the shipped default — the shape is identical to production, only the reference differs, so moving a working development configuration to a real deployment is one string edit rather than a restructuring. No real credential appears in either file.
 
 - [ ] **Step 6: Verify the removal is complete**
 
 ```bash
 dotnet build MailMcp.slnx
-grep -rn "\"Password\"" src/ --include=*.cs --include=*.json
+grep -rnE "string\??\s+(Password|Secret|Credential|PrivateKey|Token)\b" src/ --include=*.cs
 ```
 
-Expected: build succeeds; no options type binds a raw password — the specification's first definition-of-done item.
+Expected: build succeeds; the grep matches only `ConfiguredSecret.SecretReference`. Searching for the *type* rather than for the JSON key `"Password"` is the point — after decision 25 the key is legitimate and appears in every secret block, so the old key-based grep would report the correct shape as a finding. This is the specification's first definition-of-done item, and Task 7's assembly-wide test is its permanent form; this grep also reaches `Host`, which that test cannot.
 
 - [ ] **Step 7: Commit**
 
@@ -660,7 +712,18 @@ public void SecretResolutionTypes_DomainAndApplicationAssemblies_AreNotReachable
 }
 ```
 
-No architecture-test package is added: introducing one would require a license review and owner approval for a rule that two lines of reflection already prove. The test lives in `Infrastructure.UnitTests` because that is the only unit-test project referencing all three assemblies.
+A second test enforces decision 26 from the other side, so the marker cannot be bypassed by declaring a secret as a plain string:
+
+```csharp
+[Fact]
+public void InfrastructureOptionsTypes_PropertyNamedForASecret_BindsToConfiguredSecret()
+```
+
+It enumerates every type in the `Infrastructure` assembly whose name ends in `Options`, walks its property graph, and fails on any `string` property whose name contains `Password`, `Secret`, `Credential`, `PrivateKey`, or `Token`. Scanning the assembly rather than an `[InlineData]` list matters: an options type added later is covered without anyone remembering to register it, which is the same argument decision 26 makes about the marker itself. `ConfiguredSecret.SecretReference` is excluded, since it is the shape the rule steers toward.
+
+Two honest limits. The rule is name-based, so it cannot catch a secret called `Value`; it exists to make the *ordinary* mistake — adding `public string Password { get; set; }` to an options type — fail the build rather than ship, and its own documentation says so. And it reaches `Infrastructure` only: `MailSynchronizationOptions` and `PersistenceOptions` live in `Host`, which has no unit-test project and is excluded from coverage. What closes that gap is placement rather than reflection — secret-bearing options types belong in `Infrastructure` for the same reason Task 3 puts `MailAccountSecretOptions` there, leaving the `Host` types as sections that nest them. `PersistenceOptions.Password` is the one exception this plan leaves in `Host`, and it is small enough to read in review.
+
+No architecture-test package is added for either test: introducing one would require a license review and owner approval for rules that a few lines of reflection already prove. Both live in `Infrastructure.UnitTests` because that is the only unit-test project referencing all three assemblies.
 
 - [ ] **Step 2: Run and commit**
 
@@ -777,7 +840,9 @@ Run `$finish-change`: commit, push, and open a draft pull request whose body con
 | Failure message names account, logical secret, and scheme only | 3, 6 |
 | Secrets exposed through an accessor, not an ordinary property | 1, 3 |
 | Rotated material observed without restart | decision 16, Tasks 3 and 8 |
-| Every secret-bearing setting is a `*Reference` string in JSON | 3, 5, 6 |
+| Every secret-bearing setting is a `SecretReference` block in JSON | 3, 5, 6 |
+| A plain-text value under `ReferenceOnly` fails startup naming its path | 6 |
+| No secret-bearing setting can be declared as a raw `string` | 7 |
 | Bytes-first resolution; PKCS#12 and DER representable | 1, 2 |
 | Three interpretation modes; `ReferenceOnly` the default | decisions 13 and 14, Tasks 1 and 6 |
 | Pre-resolving provider works with no adapter and no code | decision 13 (`InlineOnly`) |
@@ -805,7 +870,9 @@ Managed secret stores — Kubernetes-native APIs, Azure Key Vault, HashiCorp Vau
 **Flagged for the owner**
 
 - **Blocking:** ADR 0002 must be amended before Task 8 begins (decision 18). The dynamic-reload requirement contradicts the ADR's current restart-required classification for credentials and trust anchors, and `docs/AGENTS.md` forbids amending an ADR without explicit owner approval. Tasks 1–7 and 9 are unaffected.
-- **Blocking:** the specification is now estimated at ~1300 lines against `specs/README.md`'s ~1000-line ceiling, and `specs/02` records a proposed 02a/02b split. Whether to split — and therefore whether this plan stays one plan — is the owner's call, because renumbering touches the roadmap board and the dependency chain from specification 03 onward.
-- The specification originally estimated ~500 lines. Loading and validating the trust anchor (Task 4), the database password reference (Task 5), and the asynchronous contract that ripples through `IImapAccountSettingsProvider` and startup validation (decisions 4 and 5) realistically bring this to roughly 850 lines including tests and documentation. Nothing is proposed for deferral; the estimate is what is optimistic. Issue #36's `Size` line should be updated when this plan is accepted.
+- **Blocking:** the specification is now estimated at ~1700 lines against `specs/README.md`'s ~1000-line ceiling, and `specs/02` records a proposed 02a/02b split. Whether to split — and therefore whether this plan stays one plan — is the owner's call, because renumbering touches the roadmap board and the dependency chain from specification 03 onward.
+- The specification originally estimated ~500 lines. Loading and validating the trust anchor (Task 4), the database password reference (Task 5), the asynchronous contract that ripples through `IImapAccountSettingsProvider` and startup validation (decisions 4 and 5), memory hygiene, dynamic reload, and now the secret block with its discovery walk (decisions 25 and 26) bring this to roughly 1700 lines including tests and documentation. Nothing is proposed for deferral; the estimate is what is optimistic. Issue #36's `Size` line should be updated when this plan is accepted.
+- Decision 25 changes `MailAccountTransportSecurityOptions.TrustedCertificateAuthorityReference` from a string to a block, which is a breaking configuration change to a setting specification 01 already shipped. It is proposed now precisely because it is cheap now — one consumer, no released deployment — and expensive later. The key name is unchanged, so an affected operator edits one line.
+- Decision 26's discovery walk uses reflection over the bound options graph, which the root rules restrict to measured need. The need argued here is that an explicit call list cannot cover a secret-bearing setting added after this ships, which is the entire value of the marker. It runs once at startup over a small object. If you would rather keep reflection out and accept that each new secret setting must be registered by hand, `ConfiguredSecretDiscovery` collapses into an explicit list and decision 26's guarantee weakens from structural to procedural.
 - Decision 15 reads "permitted for non-production automation" as guidance rather than an enforced environment gate for `env:`. If it should be enforced, say so and it moves onto the same Development flag as `plaintext:`.
 - Decision 4 makes the contract asynchronous before any asynchronous provider exists. The cost is real and visible: `GetSettings` becomes `GetSettingsAsync`, and startup validation moves out of `IValidateOptions` into `IHostedLifecycleService`. It is proposed because retrofitting it alongside a first Key Vault adapter would touch the same files while also introducing SDK, identity, and licensing questions, and doing one of those at a time is cheaper. If managed stores are further off than this assumes, the synchronous contract is defensible and this is the decision to revisit.

--- a/docs/superpowers/plans/2026-07-27-secret-reference-resolution.md
+++ b/docs/superpowers/plans/2026-07-27-secret-reference-resolution.md
@@ -40,11 +40,11 @@ MailMcp runs both as a container (Docker Compose or rootless Podman Compose unde
 
 Adding `docker-secret:` or `kubernetes-secret:` schemes was rejected: each would resolve to exactly the file read that `file:` already performs, and a scheme whose only distinction is documentation is configuration surface with no behavior behind it. A Kubernetes Secret projected into the environment block is `env:` for the same reason.
 
-A managed store reached over the network — Azure Key Vault, HashiCorp Vault, AWS Secrets Manager — is the case that does earn a scheme, because retrieval behavior genuinely differs: authentication, endpoint, timeout, retry, and caching. Nothing here implements one, but decisions 1, 2, and 18 exist so that adding one later registers an adapter and edits nothing else.
+Two integration shapes exist and must not be conflated. A provider that **pre-resolves** — Azure App Configuration with Key Vault references — does its mapping below MailMcp in the configuration pipeline, so the bound value is already the secret and MailMcp needs no adapter at all, only the `InlineOnly` mode of decision 13. A store MailMcp **queries itself** — direct Key Vault, HashiCorp Vault, AWS Secrets Manager — is the case that earns a scheme, because retrieval behavior genuinely differs: authentication, endpoint, timeout, retry, and caching. Nothing here implements one, but decisions 1, 2, and 19 exist so that adding one later registers an adapter and edits nothing else.
 
 ## Design decisions locked before implementation
 
-1. **The reference grammar is `<scheme>:<target>`, split on the first colon only.** A Windows-style path or a URL in the target therefore survives untouched — the latter matters for a future `azure-key-vault:https://vault.example/secrets/imap` style target. An empty scheme or an empty target is a resolution failure, never a fallback to treating the whole string as a literal: silently accepting a malformed reference as plaintext is exactly the leak the specification exists to prevent. Parsing validates the *grammar* only; whether a scheme is supported is a dispatch question, answered by decision 2.
+1. **The reference grammar is `<scheme>:<target>`, split on the first colon only.** A Windows-style path or a URL in the target therefore survives untouched — the latter matters for a future `azure-key-vault:https://vault.example/secrets/imap` style target. Under the default `ReferenceOnly` interpretation mode an empty scheme or an empty target is a resolution failure, never a silent fallback to treating the whole string as a literal — that fallback is exactly the leak the specification exists to prevent, and it is reachable only by the explicit opt-in in decision 13. Parsing validates the *grammar* only; whether a scheme is supported is a dispatch question, answered by decision 2.
 2. **A scheme is a value an adapter declares, not a closed enum the core owns.** `SecretReferenceScheme` is a `sealed record` wrapping its normalized wire name, with well-known static members for the four schemes shipped here. Each adapter exposes the scheme it serves, and `CompositeSecretReferenceResolver` builds its dispatch from the registered adapter set, so adding Azure Key Vault or Vault later registers one adapter and edits no existing type. This mirrors specification 01's accepted reversal of `MailAuthenticationMechanism` from an enum plus mapping table to a value carrying its own registered name. It is a `record` rather than a `readonly record struct` because `default(T)` would otherwise produce a scheme with a null name, and unlike the SASL mechanism this value is parsed once per resolution and never sits on a hot path.
 3. **Resolution returns a result; it does not throw.** An unresolved reference is an expected configuration failure with a named cause, per the specification. The failure enum is justified here because `Host` acts on it by rendering a startup message; nothing above `Host` branches on it. `SchemeNotSupported` is reported by the dispatch, which is also how an operator learns a provider adapter was not registered.
 4. **The contract is asynchronous and cancellable from the first commit.** Every scheme implemented here reads a local file or an environment variable and would be happy synchronously. A managed-store adapter is a network call, and the root rules forbid blocking on it; retrofitting `ResolveAsync` later would break `IImapAccountSettingsProvider`, the session factory, and startup validation at once. Paying one `Task` allocation per resolution now is cheaper than that change, and resolutions happen once per synchronization run.
@@ -56,17 +56,18 @@ A managed store reached over the network — Azure Key Vault, HashiCorp Vault, A
 10. **The residual exposures are documented, not papered over.** Managed memory is still readable through a process dump, a debugger, or swap, and no code-level measure changes that. The mitigations are operational and belong in the operations documentation: `LimitCORE=0` on the systemd unit and `Storage=none` / `ProcessSizeMax=0` for `systemd-coredump`, plus keeping the service's memory out of swap in both the systemd and container shapes. `mlock` is deliberately rejected — it needs P/Invoke plus `CAP_IPC_LOCK` and a raised `RLIMIT_MEMLOCK` in every deployment shape, against the repository rule restricting unsafe and platform-invoke code to measured need, and it does not address dumps or debuggers anyway.
 11. **Typed material is loaded above the resolver, not inside it.** `X509CertificateMaterialLoader` in `Infrastructure` turns resolved bytes into an `X509Certificate2`, accepting PEM and DER and, for key material, PKCS#12 with an optional separately-referenced password. The resolver stays ignorant of X.509 so that adding a future material kind — an SSH key, a JWT signing key — adds a loader rather than touching every scheme adapter.
 12. **`ResolvedSecret` hides its material behind a method, not a property.** `System.Text.Json`, `record` synthesized `ToString()`, and most diagnostic dumps enumerate properties, so a property named `Value` would eventually be serialized by something. `ImapAccountSettings` is a `record`, which makes this concrete: its synthesized `ToString()` prints every member today. `RevealBytes()` and `RevealAsString()` are methods for that reason, and `ToString()` is overridden to return `***`.
-13. **`plaintext:` is gated by a constructor flag, not by `IHostEnvironment`.** `Infrastructure` does not reference `Microsoft.Extensions.Hosting.Abstractions` and gains nothing by starting to. `Host` passes `builder.Environment.IsDevelopment()` at registration, which also makes the rule trivially testable in both directions.
-14. **`env:` resolves in every environment.** The specification gates exactly one scheme on the environment, and the definition of done names only the `plaintext:` rule. `env:` stays permitted with a documented recommendation against production use, rather than inventing a second environment gate the specification did not ask for. *Flagged for the owner: if `env:` should also fail outside Development, it is a one-line change to the same flag.*
-15. **Resolution runs at startup validation and again per use, which is what makes rotation work.** Startup validation resolves every reference and discards the material, so an unresolvable reference fails the host. Each actual use resolves again, so no long-lived copy exists and material rotated behind an unchanged reference — a replaced credential file, a re-issued vault entry — is observed by the next operation with no cache to invalidate and no restart. The material is a few hundred bytes from a tmpfs or an environment block; per-run re-reading is not a measured cost. A network-backed adapter for which per-use retrieval is too expensive caches inside itself under decision 18, without changing this.
-16. **Secrets are reloadable for new operations, not during running operations.** Both halves reload: a changed *reference* arrives through `IOptionsMonitor` and is validated by resolving the whole candidate snapshot before publishing it, with the last known good snapshot retained on failure; changed *material* is picked up by decision 10. Neither is applied mid-operation — a synchronization run that has authenticated finishes with the credential it authenticated with, because swapping a credential or trust anchor underneath an open IMAP session has no coherent meaning. This is ADR 0002's middle classification, chosen deliberately over the strictest one.
-17. **ADR 0002 must be amended before this is implemented.** The ADR currently classifies credentials and certificate trust anchors as restart-required, and decision 16 departs from that. The departure is defensible — the reference indirection means rotation re-resolves a validated reference rather than mutating a bound secret in place — but `docs/AGENTS.md` forbids modifying an ADR without explicit owner approval, so no ADR is touched here. **This is a blocking prerequisite, not a follow-up.**
-18. **Provider-specific concerns stay inside the provider's adapter.** Timeouts, retry, backoff, endpoint and region configuration, SDK client lifetime, platform identity, and caching policy belong to the adapter that needs them, never to `ISecretReferenceResolver`. The contract carries a reference and a cancellation token and returns a result; that is the whole surface. This is what lets a store that must cache aggressively and a local file that must never cache coexist without the contract taking a position, and it keeps SDK types out of everything above the adapter exactly as the root dependency rules require.
-19. **A managed-store adapter authenticates through platform identity, not through a MailMcp secret.** An Azure managed identity, a Kubernetes ServiceAccount token, or a Vault role is issued by the platform the process already runs on. Requiring MailMcp to hold a credential in order to fetch its credentials would be circular and would put the most sensitive value back into the configuration this specification removes it from. Recorded now so a future adapter does not quietly reintroduce the problem; nothing implements it here.
-20. **A custom trust anchor is validated by rebuilding the chain, never by accepting errors.** `RemoteCertificateNotAvailable` and `RemoteCertificateNameMismatch` are rejected outright. Only `RemoteCertificateChainErrors` is re-examined, by building an `X509Chain` with `TrustMode = X509ChainTrustMode.CustomRootTrust` and the anchor in `CustomTrustStore` — which Microsoft documents as respected only under that trust mode — and requiring a clean rebuild. MailKit's own `SslCertificateValidation.cs` example stops at describing errors and does not implement custom-CA trust, so this logic is ours to write and ours to test.
-21. **The database password becomes a reference too.** The specification's goal names it explicitly. `ConnectionStrings:mailmcp` keeps host, database, and user name; an optional `Persistence:PasswordReference` is resolved at startup and applied through `NpgsqlConnectionStringBuilder.Password`, so the connection string in `appsettings.json` never carries the password and the composed string never reaches a log.
-22. **Two resolver names, two scopes.** `ISecretReferenceResolver` resolves one reference. `MailAccountSecretOptions` resolves one account's set of secrets and reports per-account configuration errors. Naming them both "secret resolver" would make the call sites ambiguous, which the root naming rules forbid.
-23. **`UserName` stays a plain configuration value.** The definition of done names raw *passwords*. A mailbox user name is an identifier the operator already writes next to the host, and turning it into a reference would double the provisioning burden for no confidentiality gain. It remains excluded from logs as personal data.
+13. **Interpretation is an explicit three-valued mode, not an environment gate.** `SecretValueInterpretation` is `ReferenceOnly = 0` (default), `ReferenceOrInline = 1`, `InlineOnly = 2`. This replaces the earlier "`plaintext:` only in Development" rule, which turned out to be both too strict and too weak: too strict because an operator may knowingly put a secret in JSON and that is their call, and too weak because it does not address the real driver — a configuration provider that has already resolved the secret before MailMcp binds it. Azure App Configuration with Key Vault references is exactly that: the provider substitutes the vault value, so the bound setting is the raw secret with no prefix MailMcp could recognize. `InlineOnly` serves it by parsing nothing at all, which removes the ambiguity rather than guessing at it. The mode is passed to the composite resolver at registration, so `Infrastructure` still needs no reference to `Microsoft.Extensions.Hosting.Abstractions` and the rule stays trivially testable in all three directions.
+14. **Inline modes are logged, and their memory cost is stated.** Startup logs the active mode and, when it is not `ReferenceOnly`, the *names* of settings that resolved to an inline value — never the values — so an unintended inline secret is discoverable instead of silent. And an inline value arrives from `IConfiguration` as a `string`, which decision 7 establishes cannot be erased; the inline modes therefore forfeit part of the in-memory protection, which the operations documentation must say plainly. Both facts are why `ReferenceOnly` stays the default rather than the friendliest option winning.
+15. **`env:` resolves in every environment.** The specification gates exactly one scheme on the environment, and the definition of done names only the `plaintext:` rule. `env:` stays permitted with a documented recommendation against production use, rather than inventing a second environment gate the specification did not ask for. *Flagged for the owner: if `env:` should also fail outside Development, it is a one-line change to the same flag.*
+16. **Resolution runs at startup validation and again per use, which is what makes rotation work.** Startup validation resolves every reference and discards the material, so an unresolvable reference fails the host. Each actual use resolves again, so no long-lived copy exists and material rotated behind an unchanged reference — a replaced credential file, a re-issued vault entry — is observed by the next operation with no cache to invalidate and no restart. The material is a few hundred bytes from a tmpfs or an environment block; per-run re-reading is not a measured cost. A network-backed adapter for which per-use retrieval is too expensive caches inside itself under decision 19, without changing this.
+17. **Secrets are reloadable for new operations, not during running operations.** Both halves reload: a changed *reference* arrives through `IOptionsMonitor` and is validated by resolving the whole candidate snapshot before publishing it, with the last known good snapshot retained on failure; changed *material* is picked up by decision 10. Neither is applied mid-operation — a synchronization run that has authenticated finishes with the credential it authenticated with, because swapping a credential or trust anchor underneath an open IMAP session has no coherent meaning. This is ADR 0002's middle classification, chosen deliberately over the strictest one.
+18. **ADR 0002 must be amended before this is implemented.** The ADR currently classifies credentials and certificate trust anchors as restart-required, and decision 17 departs from that. The departure is defensible — the reference indirection means rotation re-resolves a validated reference rather than mutating a bound secret in place — but `docs/AGENTS.md` forbids modifying an ADR without explicit owner approval, so no ADR is touched here. **This is a blocking prerequisite, not a follow-up.**
+19. **Provider-specific concerns stay inside the provider's adapter.** Timeouts, retry, backoff, endpoint and region configuration, SDK client lifetime, platform identity, and caching policy belong to the adapter that needs them, never to `ISecretReferenceResolver`. The contract carries a reference and a cancellation token and returns a result; that is the whole surface. This is what lets a store that must cache aggressively and a local file that must never cache coexist without the contract taking a position, and it keeps SDK types out of everything above the adapter exactly as the root dependency rules require.
+20. **A managed-store adapter authenticates through platform identity, not through a MailMcp secret.** An Azure managed identity, a Kubernetes ServiceAccount token, or a Vault role is issued by the platform the process already runs on. Requiring MailMcp to hold a credential in order to fetch its credentials would be circular and would put the most sensitive value back into the configuration this specification removes it from. Recorded now so a future adapter does not quietly reintroduce the problem; nothing implements it here.
+21. **A custom trust anchor is validated by rebuilding the chain, never by accepting errors.** `RemoteCertificateNotAvailable` and `RemoteCertificateNameMismatch` are rejected outright. Only `RemoteCertificateChainErrors` is re-examined, by building an `X509Chain` with `TrustMode = X509ChainTrustMode.CustomRootTrust` and the anchor in `CustomTrustStore` — which Microsoft documents as respected only under that trust mode — and requiring a clean rebuild. MailKit's own `SslCertificateValidation.cs` example stops at describing errors and does not implement custom-CA trust, so this logic is ours to write and ours to test.
+22. **The database password becomes a reference too.** The specification's goal names it explicitly. `ConnectionStrings:mailmcp` keeps host, database, and user name; an optional `Persistence:PasswordReference` is resolved at startup and applied through `NpgsqlConnectionStringBuilder.Password`, so the connection string in `appsettings.json` never carries the password and the composed string never reaches a log.
+23. **Two resolver names, two scopes.** `ISecretReferenceResolver` resolves one reference. `MailAccountSecretOptions` resolves one account's set of secrets and reports per-account configuration errors. Naming them both "secret resolver" would make the call sites ambiguous, which the root naming rules forbid.
+24. **`UserName` stays a plain configuration value.** The definition of done names raw *passwords*. A mailbox user name is an identifier the operator already writes next to the host, and turning it into a reference would double the provisioning burden for no confidentiality gain. It remains excluded from logs as personal data.
 
 ## File structure
 
@@ -81,7 +82,7 @@ A managed store reached over the network — Azure Key Vault, HashiCorp Vault, A
 - `src/Infrastructure/Secrets/ISecretFileReader.cs`, `IEnvironmentVariableReader.cs` — the two in-memory-testable ports.
 - `src/Infrastructure/Secrets/FileSystemSecretFileReader.cs`, `ProcessEnvironmentVariableReader.cs` — the real adapters.
 - `src/Infrastructure/Secrets/X509CertificateMaterialLoader.cs` — PEM, DER, and PKCS#12 loading over resolved bytes.
-- `src/Infrastructure/Secrets/SystemdCredentialSecretReferenceResolver.cs`, `FileSecretReferenceResolver.cs`, `EnvironmentVariableSecretReferenceResolver.cs`, `DevelopmentPlaintextSecretReferenceResolver.cs`, `CompositeSecretReferenceResolver.cs`
+- `src/Infrastructure/Secrets/SystemdCredentialSecretReferenceResolver.cs`, `FileSecretReferenceResolver.cs`, `EnvironmentVariableSecretReferenceResolver.cs`, `PlaintextSecretReferenceResolver.cs`, `CompositeSecretReferenceResolver.cs`
 - `src/Infrastructure/Mail/MailAccountSecretOptions.cs` — the account's reference strings and their resolution into `MailAccountSecrets`.
 - `src/Infrastructure/Mail/MailAccountSecrets.cs` — resolved password plus optional trust anchor.
 - `src/Infrastructure/Mail/MailServerCertificateValidator.cs` — the custom-root-trust validation callback.
@@ -100,7 +101,7 @@ A managed store reached over the network — Azure Key Vault, HashiCorp Vault, A
 - `src/Infrastructure/ServiceCollectionExtensions.cs` — `AddMailMcpSecretResolution`, and the resolved database password applied to the connection string.
 - `src/Host/Configuration/MailSynchronizationOptions.cs` — `Password` becomes a nested `Secrets` section; `GetSettings` becomes `GetSettingsAsync` and resolves.
 - `src/Host/Configuration/PersistenceOptions.cs` — optional `PasswordReference`.
-- `src/Host/Program.cs` — register secret resolution with the Development flag, register the startup validator ahead of the worker, compose the connection string.
+- `src/Host/Program.cs` — register secret resolution with the configured interpretation mode, register the startup validator ahead of the worker, compose the connection string.
 - `src/Host/appsettings.json`, `src/Host/appsettings.Development.json` — reference-shaped examples.
 - `docs/features/imap-synchronization.md` — configuration, the two resolved pending items, transport-security trust anchor behavior.
 - `docs/operations/local-development.md` — the Development secret workflow.
@@ -128,13 +129,20 @@ public sealed record SecretReferenceScheme
     public static SecretReferenceScheme Create(string name);          // for adapters declared elsewhere
 }
 
+public enum SecretValueInterpretation
+{
+    ReferenceOnly = 0,      // default: a bare value fails
+    ReferenceOrInline = 1,  // recognized scheme resolves; anything else is the secret
+    InlineOnly = 2,         // nothing is parsed; every value is already the secret
+}
+
 public enum SecretResolutionFailure
 {
     ReferenceMissing = 0,
     SchemeMissing = 1,
     SchemeNotSupported = 2,
     TargetMissing = 3,
-    PlaintextPermittedOnlyInDevelopment = 4,
+    InlineValueNotPermittedByInterpretationMode = 4,
     CredentialsDirectoryUnavailable = 5,
     MaterialNotFound = 6,
     MaterialEmpty = 7,
@@ -187,7 +195,7 @@ TryParse_SupportedScheme_ParsesSchemeAndTarget
 [Fact]    TryParse_MixedCaseScheme_ParsesScheme                                 // "File:/run/secrets/imap"
 [Fact]    TryParse_SurroundingWhitespace_TrimsBeforeParsing
 [Fact]    TryParse_NullOrWhitespace_FailsWithReferenceMissing
-[Fact]    TryParse_NoColon_FailsWithSchemeMissing                               // a bare password must never parse
+[Fact]    TryParse_NoColon_FailsWithSchemeMissing                               // under ReferenceOnly a bare password must never parse
 [Fact]    TryParse_UnregisteredScheme_ParsesBecauseSupportIsADispatchQuestion   // "azure-key-vault:imap" parses
 [Fact]    TryParse_EmptyTarget_FailsWithTargetMissing                           // "file:"
 [Fact]    TryParse_UrlTarget_KeepsTheWholeUrl                                   // "azure-key-vault:https://v.example/s/imap"
@@ -248,7 +256,7 @@ git commit -m "Add the secret reference grammar and resolution result"
 ### Task 2: Per-scheme resolvers and composite dispatch
 
 **Files:**
-- Create: `src/Infrastructure/Secrets/ISecretReferenceResolver.cs`, `ISecretFileReader.cs`, `IEnvironmentVariableReader.cs`, `FileSystemSecretFileReader.cs`, `ProcessEnvironmentVariableReader.cs`, `SystemdCredentialSecretReferenceResolver.cs`, `FileSecretReferenceResolver.cs`, `EnvironmentVariableSecretReferenceResolver.cs`, `DevelopmentPlaintextSecretReferenceResolver.cs`, `CompositeSecretReferenceResolver.cs`
+- Create: `src/Infrastructure/Secrets/ISecretReferenceResolver.cs`, `ISecretFileReader.cs`, `IEnvironmentVariableReader.cs`, `FileSystemSecretFileReader.cs`, `ProcessEnvironmentVariableReader.cs`, `SystemdCredentialSecretReferenceResolver.cs`, `FileSecretReferenceResolver.cs`, `EnvironmentVariableSecretReferenceResolver.cs`, `PlaintextSecretReferenceResolver.cs`, `CompositeSecretReferenceResolver.cs`
 - Test: `tests/Infrastructure.UnitTests/SecretReferenceResolverTests.cs`
 
 **Interfaces produced:**
@@ -292,8 +300,11 @@ internal interface IEnvironmentVariableReader
 [Fact] ResolveAsync_FileEmpty_FailsWithMaterialEmpty
 [Fact] ResolveAsync_EnvironmentVariable_ReadsTheVariable
 [Fact] ResolveAsync_EnvironmentVariableUnset_FailsWithMaterialNotFound
-[Fact] ResolveAsync_PlaintextInDevelopment_ReturnsTheLiteral
-[Fact] ResolveAsync_PlaintextOutsideDevelopment_FailsWithPlaintextPermittedOnlyInDevelopment
+[Fact] ResolveAsync_Plaintext_ReturnsTheLiteralInEveryModeThatParses
+[Fact] ResolveAsync_BareValueUnderReferenceOnly_FailsWithSchemeMissing
+[Fact] ResolveAsync_BareValueUnderReferenceOrInline_ReturnsItAsTheSecret
+[Fact] ResolveAsync_SchemeShapedValueUnderInlineOnly_ReturnsItVerbatimWithoutParsing   // "file:/x" is the password
+[Fact] ResolveAsync_RecognizedSchemeUnderReferenceOrInline_ResolvesThroughTheAdapter
 [Fact] ResolveAsync_UnregisteredScheme_FailsWithSchemeNotSupportedWithoutConsultingAnyReader
 [Fact] ResolveAsync_SchemeAdapterRegisteredOnlyByTheTest_ResolvesThroughTheSameDispatch
 [Fact] ResolveAsync_Cancelled_PropagatesTheCancellation
@@ -312,7 +323,9 @@ Expected: FAIL — the resolvers do not exist.
 
 `SystemdCredentialSecretReferenceResolver` reads `CREDENTIALS_DIRECTORY` through `IEnvironmentVariableReader` — systemd documents that "the path to access them is derived from the environment variable `$CREDENTIALS_DIRECTORY`" and that access is restricted to the service's user — rejects a target containing `/`, `\`, or `..`, joins, and reads. `FileSecretReferenceResolver` reads the target directly, which is also the container path: Compose mounts secrets at `/run/secrets/<secret_name>`. Both read bytes and neither modifies them; the newline trim lives in `ResolvedSecret.RevealAsString()` so binary material is never touched, and both report `MaterialEmpty` when the material has zero length.
 
-`DevelopmentPlaintextSecretReferenceResolver(bool developmentEnvironment)` returns the target verbatim in Development and `PlaintextPermittedOnlyInDevelopment` otherwise, per decision 5.
+`PlaintextSecretReferenceResolver` returns the target verbatim; it carries no environment gate of its own, because decision 13 moved that responsibility to the interpretation mode.
+
+`CompositeSecretReferenceResolver` takes the `SecretValueInterpretation` mode and branches before parsing. Under `InlineOnly` it never parses and wraps the whole value as material — the Azure App Configuration case, where `file:/x` may legitimately *be* the password. Under `ReferenceOnly` an unparseable value fails. Under `ReferenceOrInline` a recognized scheme dispatches and anything else becomes material. The `InlineOnly` branch must come first: parsing and then ignoring the result would leave a code path where a scheme-shaped password is silently treated as a reference.
 
 `CompositeSecretReferenceResolver` parses once and dispatches on the scheme through a dictionary built from the injected `ISecretSchemeResolver` set, so a scheme with no registered adapter fails as `SchemeNotSupported` rather than throwing. Its XML documentation states that no result and no diagnostic derived from it may carry the material.
 
@@ -393,7 +406,7 @@ Expected: FAIL — `MailAccountSecretOptions` does not exist and `ImapAccountSet
 
 - [ ] **Step 3: Implement**
 
-`FindConfigurationErrorsAsync` resolves the password reference and, when a trust anchor reference is present, resolves and parses it, then discards both — decision 15's startup half. Trust anchor parsing uses `X509Certificate2.CreateFromPem` inside a `try`/`catch (CryptographicException)` that becomes a configuration error, so malformed material fails startup instead of failing the first TLS handshake hours later.
+`FindConfigurationErrorsAsync` resolves the password reference and, when a trust anchor reference is present, resolves and parses it, then discards both — decision 16's startup half. Trust anchor parsing uses `X509Certificate2.CreateFromPem` inside a `try`/`catch (CryptographicException)` that becomes a configuration error, so malformed material fails startup instead of failing the first TLS handshake hours later.
 
 `Resolve` performs the same work and returns the values, and throws `InvalidOperationException` if a reference that validated at startup no longer resolves — a fail-closed path, not an ordinary branch.
 
@@ -592,17 +605,17 @@ The account, the setting, and the failure identity — no path, no variable name
 - [ ] **Step 4: Wire the resolver**
 
 ```csharp
-builder.Services.AddMailMcpSecretResolution(builder.Environment.IsDevelopment());
+builder.Services.AddMailMcpSecretResolution(builder.Configuration.GetValue("Secrets:Interpretation", SecretValueInterpretation.ReferenceOnly));
 builder.Services.AddHostedService<MailSecretReferenceStartupValidator>();
 ```
 
-`AddMailMcpSecretResolution` is a focused extension owned by `Infrastructure`, per the `src/AGENTS.md` rule that registration lives with the implementation. It registers the two reader ports, the four scheme adapters, and the composite. A future provider adapter adds its own `AddMailMcpAzureKeyVaultSecrets(...)` extension next to this call and needs no edit here — the composite resolves whatever `ISecretSchemeResolver` registrations it is handed, which is decision 2 made concrete in the container.
+`AddMailMcpSecretResolution` is a focused extension owned by `Infrastructure`, per the `src/AGENTS.md` rule that registration lives with the implementation. It registers the two reader ports, the four scheme adapters, and the composite with its interpretation mode. The default is `ReferenceOnly`, so a deployment that says nothing gets the safe behavior. A future provider adapter adds its own `AddMailMcpAzureKeyVaultSecrets(...)` extension next to this call and needs no edit here — the composite resolves whatever `ISecretSchemeResolver` registrations it is handed, which is decision 2 made concrete in the container.
 
 The validator is registered before the synchronization worker so hosted-service ordering reinforces `StartingAsync` ordering rather than depending on it alone.
 
 - [ ] **Step 5: Update the shipped configuration examples**
 
-`appsettings.json` keeps an empty account list and documents the reference shape by example only. `appsettings.Development.json` shows `plaintext:` with a comment that it is Development-only. No real credential appears in either file.
+`appsettings.json` keeps an empty account list, documents the reference shape by example only, and leaves `Secrets:Interpretation` unset so the default `ReferenceOnly` applies. `appsettings.Development.json` sets `ReferenceOrInline` and shows a `plaintext:` example, which is what makes local development convenient without weakening the shipped default. No real credential appears in either file.
 
 - [ ] **Step 6: Verify the removal is complete**
 
@@ -666,7 +679,7 @@ git commit -m "Assert secret resolution stays out of Domain and Application"
 - Create: `src/Host/Configuration/MailSecretSnapshotPublisher.cs`
 - Test: `tests/Infrastructure.UnitTests/MailAccountSecretReloadTests.cs`
 
-Decision 17 makes this a blocking prerequisite: **do not start this task until ADR 0002 has been amended with owner approval.** The ADR classifies credentials and trust anchors as restart-required, and this task deliberately reclassifies them as reloadable for new operations.
+Decision 18 makes this a blocking prerequisite: **do not start this task until ADR 0002 has been amended with owner approval.** The ADR classifies credentials and trust anchors as restart-required, and this task deliberately reclassifies them as reloadable for new operations.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -678,7 +691,7 @@ Decision 17 makes this a blocking prerequisite: **do not start this task until A
 [Fact] ResolveAsync_MaterialRotatedMidOperation_DoesNotAffectTheOperationInFlight
 ```
 
-The last two are the pair that distinguishes the two reload halves, and the last one is what keeps decision 16's "not during running operations" honest.
+The last two are the pair that distinguishes the two reload halves, and the last one is what keeps decision 17's "not during running operations" honest.
 
 - [ ] **Step 2: Bind for reload**
 
@@ -692,7 +705,7 @@ Reload validation must not crash the process: ADR 0002 is explicit that a reject
 
 - [ ] **Step 4: Resolve material per operation**
 
-No change is needed for the material half — decision 15 already resolves per use, which is what makes rotation behind an unchanged reference work. The test in Step 1 is what proves it, and it exists to catch a future "optimization" that caches the resolved value on the options instance.
+No change is needed for the material half — decision 16 already resolves per use, which is what makes rotation behind an unchanged reference work. The test in Step 1 is what proves it, and it exists to catch a future "optimization" that caches the resolved value on the options instance.
 
 - [ ] **Step 5: Run the tests and commit**
 
@@ -712,7 +725,7 @@ git commit -m "Reload secret references and material without restarting the host
 
 - [ ] **Step 1: Write the provisioning page**
 
-`docs/operations/secret-provisioning.md` documents the reference grammar, the four schemes, and — because MailMcp is deployed several ways — a section per deployment shape: the native systemd path with `LoadCredential=`, `LoadCredentialEncrypted=`, `systemd-creds`, and `$CREDENTIALS_DIRECTORY`; the container path with Compose `secrets:` mounted at `/run/secrets/<name>`; and the Kubernetes path with a Secret mounted as a read-only tmpfs volume — the last two both addressed as `file:`, with an explicit note that no container- or Kubernetes-specific scheme exists or is needed. It states the trailing-newline trimming and that it applies to text secrets only, the accepted certificate encodings, the operational hardening that bounds in-memory exposure — `LimitCORE=0` on the systemd unit, `Storage=none` and `ProcessSizeMax=0` for `systemd-coredump`, and keeping the service out of swap in both the systemd and container shapes, with the honest statement that a dump or debugger can still read managed memory and that no code-level measure changes that — the `plaintext:` Development gate, the recommendation against `env:` in production, and the ADR 0002 classification from decision 16.
+`docs/operations/secret-provisioning.md` documents the reference grammar, the four schemes, and — because MailMcp is deployed several ways — a section per deployment shape: the native systemd path with `LoadCredential=`, `LoadCredentialEncrypted=`, `systemd-creds`, and `$CREDENTIALS_DIRECTORY`; the container path with Compose `secrets:` mounted at `/run/secrets/<name>`; and the Kubernetes path with a Secret mounted as a read-only tmpfs volume — the last two both addressed as `file:`, with an explicit note that no container- or Kubernetes-specific scheme exists or is needed. It states the trailing-newline trimming and that it applies to text secrets only, the accepted certificate encodings, the operational hardening that bounds in-memory exposure — `LimitCORE=0` on the systemd unit, `Storage=none` and `ProcessSizeMax=0` for `systemd-coredump`, and keeping the service out of swap in both the systemd and container shapes, with the honest statement that a dump or debugger can still read managed memory and that no code-level measure changes that — the three interpretation modes with `ReferenceOnly` as the default and `InlineOnly` as the Azure App Configuration path, the fact that inline values cannot be erased from memory, the recommendation against `env:` in production, and the ADR 0002 classification from decision 17.
 
 A closing section states what a future managed-store provider would add — one `ISecretSchemeResolver`, one registration extension, its own timeouts and caching, platform identity rather than a MailMcp-held credential, and a `LICENSES.md` entry — so an operator reading the page can tell which schemes exist today from which are anticipated. It documents anticipated extension, not unimplemented behavior, and says so plainly; `docs/AGENTS.md` requires documentation to describe verified implemented behavior, and this section is explicitly labelled as the extension contract rather than as a feature.
 
@@ -755,17 +768,19 @@ Run `$finish-change`: commit, push, and open a draft pull request whose body con
 | Resolution returns a result rather than throwing | 1, 2 |
 | Composite dispatch over per-scheme adapters | 2 |
 | Unknown-scheme and missing-reference failures | 1, 2 |
-| A new scheme is one adapter registration, no core edit | decisions 2 and 18, proved by the Task 2 extensibility test |
+| A new scheme is one adapter registration, no core edit | decisions 2 and 19, proved by the Task 2 extensibility test |
 | Contract asynchronous and cancellable for a network provider | decision 4, Tasks 1–3, 6 |
-| Provider concerns confined to the provider's adapter | decisions 18 and 19 |
+| Provider concerns confined to the provider's adapter | decisions 19 and 20 |
 | Resolver contract and adapters live in `Infrastructure` | 1–4 |
 | `Host` invokes resolution once before hosted services start | 6 |
 | No options type binds a raw password | 3, 5, 6 (verified by `grep` in Task 6 Step 6) |
 | Failure message names account, logical secret, and scheme only | 3, 6 |
 | Secrets exposed through an accessor, not an ordinary property | 1, 3 |
-| Rotated material observed without restart | decision 15, Tasks 3 and 8 |
+| Rotated material observed without restart | decision 16, Tasks 3 and 8 |
 | Every secret-bearing setting is a `*Reference` string in JSON | 3, 5, 6 |
 | Bytes-first resolution; PKCS#12 and DER representable | 1, 2 |
+| Three interpretation modes; `ReferenceOnly` the default | decisions 13 and 14, Tasks 1 and 6 |
+| Pre-resolving provider works with no adapter and no code | decision 13 (`InlineOnly`) |
 | No `string`, pooled buffer, or `SecureString` holds material | decisions 7 and 8, Task 1 |
 | Pinned buffer zeroed with `CryptographicOperations.ZeroMemory` | 1 |
 | Material owned by its operation and disposed at its end | decision 9, Tasks 3 and 6 |
@@ -785,12 +800,12 @@ Run `$finish-change`: commit, push, and open a draft pull request whose body con
 
 **Deliberately out of scope:** Data Protection key-ring provisioning, encrypted secret storage in PostgreSQL, secret rotation without restart, and MCP client certificates (stage 9).
 
-Managed secret stores — Kubernetes-native APIs, Azure Key Vault, HashiCorp Vault, AWS Secrets Manager — are out of scope as implementations but not as constraints. Decisions 2, 4, 18, and 19 exist for them, and the Task 2 extensibility test is what keeps the promise honest. Note that Kubernetes and container deployments need nothing added at all: their secrets are files, so `file:` already serves them today.
+Managed secret stores — Kubernetes-native APIs, Azure Key Vault, HashiCorp Vault, AWS Secrets Manager — are out of scope as implementations but not as constraints. Decisions 2, 4, 19, and 20 exist for them, and the Task 2 extensibility test is what keeps the promise honest. Note that Kubernetes and container deployments need nothing added at all: their secrets are files, so `file:` already serves them today.
 
 **Flagged for the owner**
 
-- **Blocking:** ADR 0002 must be amended before Task 8 begins (decision 17). The dynamic-reload requirement contradicts the ADR's current restart-required classification for credentials and trust anchors, and `docs/AGENTS.md` forbids amending an ADR without explicit owner approval. Tasks 1–7 and 9 are unaffected.
+- **Blocking:** ADR 0002 must be amended before Task 8 begins (decision 18). The dynamic-reload requirement contradicts the ADR's current restart-required classification for credentials and trust anchors, and `docs/AGENTS.md` forbids amending an ADR without explicit owner approval. Tasks 1–7 and 9 are unaffected.
 - **Blocking:** the specification is now estimated at ~1300 lines against `specs/README.md`'s ~1000-line ceiling, and `specs/02` records a proposed 02a/02b split. Whether to split — and therefore whether this plan stays one plan — is the owner's call, because renumbering touches the roadmap board and the dependency chain from specification 03 onward.
 - The specification originally estimated ~500 lines. Loading and validating the trust anchor (Task 4), the database password reference (Task 5), and the asynchronous contract that ripples through `IImapAccountSettingsProvider` and startup validation (decisions 4 and 5) realistically bring this to roughly 850 lines including tests and documentation. Nothing is proposed for deferral; the estimate is what is optimistic. Issue #36's `Size` line should be updated when this plan is accepted.
-- Decision 14 reads "permitted for non-production automation" as guidance rather than an enforced environment gate for `env:`. If it should be enforced, say so and it moves onto the same Development flag as `plaintext:`.
+- Decision 15 reads "permitted for non-production automation" as guidance rather than an enforced environment gate for `env:`. If it should be enforced, say so and it moves onto the same Development flag as `plaintext:`.
 - Decision 4 makes the contract asynchronous before any asynchronous provider exists. The cost is real and visible: `GetSettings` becomes `GetSettingsAsync`, and startup validation moves out of `IValidateOptions` into `IHostedLifecycleService`. It is proposed because retrofitting it alongside a first Key Vault adapter would touch the same files while also introducing SDK, identity, and licensing questions, and doing one of those at a time is cheaper. If managed stores are further off than this assumes, the synchronous contract is defensible and this is the decision to revisit.

--- a/docs/superpowers/plans/2026-07-27-secret-reference-resolution.md
+++ b/docs/superpowers/plans/2026-07-27-secret-reference-resolution.md
@@ -40,7 +40,7 @@ MailMcp runs both as a container (Docker Compose or rootless Podman Compose unde
 
 Adding `docker-secret:` or `kubernetes-secret:` schemes was rejected: each would resolve to exactly the file read that `file:` already performs, and a scheme whose only distinction is documentation is configuration surface with no behavior behind it. A Kubernetes Secret projected into the environment block is `env:` for the same reason.
 
-A managed store reached over the network — Azure Key Vault, HashiCorp Vault, AWS Secrets Manager — is the case that does earn a scheme, because retrieval behavior genuinely differs: authentication, endpoint, timeout, retry, and caching. Nothing here implements one, but decisions 1, 2, and 14 exist so that adding one later registers an adapter and edits nothing else.
+A managed store reached over the network — Azure Key Vault, HashiCorp Vault, AWS Secrets Manager — is the case that does earn a scheme, because retrieval behavior genuinely differs: authentication, endpoint, timeout, retry, and caching. Nothing here implements one, but decisions 1, 2, and 18 exist so that adding one later registers an adapter and edits nothing else.
 
 ## Design decisions locked before implementation
 
@@ -49,20 +49,24 @@ A managed store reached over the network — Azure Key Vault, HashiCorp Vault, A
 3. **Resolution returns a result; it does not throw.** An unresolved reference is an expected configuration failure with a named cause, per the specification. The failure enum is justified here because `Host` acts on it by rendering a startup message; nothing above `Host` branches on it. `SchemeNotSupported` is reported by the dispatch, which is also how an operator learns a provider adapter was not registered.
 4. **The contract is asynchronous and cancellable from the first commit.** Every scheme implemented here reads a local file or an environment variable and would be happy synchronously. A managed-store adapter is a network call, and the root rules forbid blocking on it; retrofitting `ResolveAsync` later would break `IImapAccountSettingsProvider`, the session factory, and startup validation at once. Paying one `Task` allocation per resolution now is cheaper than that change, and resolutions happen once per synchronization run.
 5. **Startup validation runs in `IHostedLifecycleService.StartingAsync`, not in `IValidateOptions`.** Options validation is synchronous, so an async resolver cannot run inside it without blocking — which decision 4 exists to avoid. `StartingAsync` is documented to run before any hosted service's `StartAsync`, so a throw there fails the host before the synchronization worker or any endpoint starts, which is the fail-fast behavior the specification requires. Structural options validation stays in `ValidateOnStart` where it belongs; only secret resolution moves.
-6. **The resolver returns bytes; text is a view over them.** A secret is not always a password: a trust anchor may be PEM or DER, and a private key arrives as a PKCS#12 bundle that is binary and may carry its own password reference. A `string`-returning resolver would make PKCS#12 unrepresentable and would corrupt DER through encoding round-trips. `ResolvedSecret` therefore stores `ReadOnlyMemory<byte>`, which is also what the root rules prescribe for byte payloads crossing async and object boundaries. `Reveal()` returns the UTF-8 text view with one trailing newline stripped; `RevealBytes()` returns the material untouched. The trim belongs to the text view only — trimming a PFX would corrupt it. `plaintext:` and `env:` UTF-8-encode on the way in, which costs nothing and keeps one result shape.
-7. **Typed material is loaded above the resolver, not inside it.** `X509CertificateMaterialLoader` in `Infrastructure` turns resolved bytes into an `X509Certificate2`, accepting PEM and DER and, for key material, PKCS#12 with an optional separately-referenced password. The resolver stays ignorant of X.509 so that adding a future material kind — an SSH key, a JWT signing key — adds a loader rather than touching every scheme adapter.
-8. **`ResolvedSecret` hides its material behind a method, not a property.** `System.Text.Json`, `record` synthesized `ToString()`, and most diagnostic dumps enumerate properties, so a property named `Value` would eventually be serialized by something. `ImapAccountSettings` is a `record`, which makes this concrete: its synthesized `ToString()` prints every member today. `ResolvedSecret.Reveal()` is the single intentional disclosure point and `ToString()` is overridden to return `***`.
-9. **`plaintext:` is gated by a constructor flag, not by `IHostEnvironment`.** `Infrastructure` does not reference `Microsoft.Extensions.Hosting.Abstractions` and gains nothing by starting to. `Host` passes `builder.Environment.IsDevelopment()` at registration, which also makes the rule trivially testable in both directions.
-10. **`env:` resolves in every environment.** The specification gates exactly one scheme on the environment, and the definition of done names only the `plaintext:` rule. `env:` stays permitted with a documented recommendation against production use, rather than inventing a second environment gate the specification did not ask for. *Flagged for the owner: if `env:` should also fail outside Development, it is a one-line change to the same flag.*
-11. **Resolution runs at startup validation and again per use, which is what makes rotation work.** Startup validation resolves every reference and discards the material, so an unresolvable reference fails the host. Each actual use resolves again, so no long-lived copy exists and material rotated behind an unchanged reference — a replaced credential file, a re-issued vault entry — is observed by the next operation with no cache to invalidate and no restart. The material is a few hundred bytes from a tmpfs or an environment block; per-run re-reading is not a measured cost. A network-backed adapter for which per-use retrieval is too expensive caches inside itself under decision 14, without changing this.
-12. **Secrets are reloadable for new operations, not during running operations.** Both halves reload: a changed *reference* arrives through `IOptionsMonitor` and is validated by resolving the whole candidate snapshot before publishing it, with the last known good snapshot retained on failure; changed *material* is picked up by decision 10. Neither is applied mid-operation — a synchronization run that has authenticated finishes with the credential it authenticated with, because swapping a credential or trust anchor underneath an open IMAP session has no coherent meaning. This is ADR 0002's middle classification, chosen deliberately over the strictest one.
-13. **ADR 0002 must be amended before this is implemented.** The ADR currently classifies credentials and certificate trust anchors as restart-required, and decision 12 departs from that. The departure is defensible — the reference indirection means rotation re-resolves a validated reference rather than mutating a bound secret in place — but `docs/AGENTS.md` forbids modifying an ADR without explicit owner approval, so no ADR is touched here. **This is a blocking prerequisite, not a follow-up.**
-14. **Provider-specific concerns stay inside the provider's adapter.** Timeouts, retry, backoff, endpoint and region configuration, SDK client lifetime, platform identity, and caching policy belong to the adapter that needs them, never to `ISecretReferenceResolver`. The contract carries a reference and a cancellation token and returns a result; that is the whole surface. This is what lets a store that must cache aggressively and a local file that must never cache coexist without the contract taking a position, and it keeps SDK types out of everything above the adapter exactly as the root dependency rules require.
-15. **A managed-store adapter authenticates through platform identity, not through a MailMcp secret.** An Azure managed identity, a Kubernetes ServiceAccount token, or a Vault role is issued by the platform the process already runs on. Requiring MailMcp to hold a credential in order to fetch its credentials would be circular and would put the most sensitive value back into the configuration this specification removes it from. Recorded now so a future adapter does not quietly reintroduce the problem; nothing implements it here.
-16. **A custom trust anchor is validated by rebuilding the chain, never by accepting errors.** `RemoteCertificateNotAvailable` and `RemoteCertificateNameMismatch` are rejected outright. Only `RemoteCertificateChainErrors` is re-examined, by building an `X509Chain` with `TrustMode = X509ChainTrustMode.CustomRootTrust` and the anchor in `CustomTrustStore` — which Microsoft documents as respected only under that trust mode — and requiring a clean rebuild. MailKit's own `SslCertificateValidation.cs` example stops at describing errors and does not implement custom-CA trust, so this logic is ours to write and ours to test.
-17. **The database password becomes a reference too.** The specification's goal names it explicitly. `ConnectionStrings:mailmcp` keeps host, database, and user name; an optional `Persistence:PasswordReference` is resolved at startup and applied through `NpgsqlConnectionStringBuilder.Password`, so the connection string in `appsettings.json` never carries the password and the composed string never reaches a log.
-18. **Two resolver names, two scopes.** `ISecretReferenceResolver` resolves one reference. `MailAccountSecretOptions` resolves one account's set of secrets and reports per-account configuration errors. Naming them both "secret resolver" would make the call sites ambiguous, which the root naming rules forbid.
-19. **`UserName` stays a plain configuration value.** The definition of done names raw *passwords*. A mailbox user name is an identifier the operator already writes next to the host, and turning it into a reference would double the provisioning burden for no confidentiality gain. It remains excluded from logs as personal data.
+6. **The resolver returns bytes; text is a view over them.** A secret is not always a password: a trust anchor may be PEM or DER, and a private key arrives as a PKCS#12 bundle that is binary and may carry its own password reference. A `string`-returning resolver would make PKCS#12 unrepresentable and would corrupt DER through encoding round-trips. `ResolvedSecret` therefore stores a pinned `byte[]` (decision 7) and exposes it as `ReadOnlySpan<byte>`, which is what the root rules prescribe for byte payloads. `RevealBytes()` returns the material untouched; `RevealAsString()` returns the UTF-8 text view with one trailing newline stripped. The trim belongs to the text view only — trimming a PFX would corrupt it. `plaintext:` and `env:` UTF-8-encode on the way in, which costs nothing and keeps one result shape.
+7. **Secret material is a pinned byte buffer that is zeroed on dispose; it is never a `string` and never a `SecureString`.** Microsoft's guidance is explicit on all three points. `SecureString` is not recommended for new development on .NET, and it "does not encrypt the internal storage on non-Windows platform" — every MailMcp deployment target. A `string` is immutable, cannot be scheduled for deletion, and because its memory is not pinned "the garbage collector will make additional copies of `String` values when moving and compacting memory", so erasing one is not even well defined. The buffer is therefore allocated with `GC.AllocateArray<byte>(length, pinned: true)`, which the collector cannot relocate, and erased with `CryptographicOperations.ZeroMemory`, documented as existing "to future-proof against potential optimizations in the .NET runtime that could eliminate memory writes that aren't followed by memory reads" — a hand-written zeroing loop carries no such guarantee. `ArrayPool` is not used for secret material at all: a buffer returned uncleared hands the material to the next unrelated caller.
+8. **`RevealAsString()` exists, is the exception, and is named to look like one.** MailKit's `AuthenticateAsync(string, string)` and Npgsql's connection-string password are framework contracts that take a `string`, so a copy that cannot be erased is unavoidable at exactly those two call sites. `RevealBytes()` is the primary accessor and everything else uses it. `RevealAsString()` is called at the boundary itself, as late as possible, and its result is never stored, logged, or passed on. Its XML documentation states that the returned string cannot be erased and will persist until the collector reclaims it.
+9. **A resolved secret is owned by the operation that resolved it and disposed when that operation ends.** Combined with per-use resolution this bounds the exposure window to one synchronization run or one connection attempt rather than to process uptime. It also removes a lifetime hazard from dynamic reload: because every operation owns its own instance, publishing a new configuration snapshot never disposes material that an in-flight operation is still reading. `MailAccountSecrets` therefore implements `IDisposable` and disposes the secrets it owns, and `X509Certificate2` — itself disposable — is disposed on the same path.
+10. **The residual exposures are documented, not papered over.** Managed memory is still readable through a process dump, a debugger, or swap, and no code-level measure changes that. The mitigations are operational and belong in the operations documentation: `LimitCORE=0` on the systemd unit and `Storage=none` / `ProcessSizeMax=0` for `systemd-coredump`, plus keeping the service's memory out of swap in both the systemd and container shapes. `mlock` is deliberately rejected — it needs P/Invoke plus `CAP_IPC_LOCK` and a raised `RLIMIT_MEMLOCK` in every deployment shape, against the repository rule restricting unsafe and platform-invoke code to measured need, and it does not address dumps or debuggers anyway.
+11. **Typed material is loaded above the resolver, not inside it.** `X509CertificateMaterialLoader` in `Infrastructure` turns resolved bytes into an `X509Certificate2`, accepting PEM and DER and, for key material, PKCS#12 with an optional separately-referenced password. The resolver stays ignorant of X.509 so that adding a future material kind — an SSH key, a JWT signing key — adds a loader rather than touching every scheme adapter.
+12. **`ResolvedSecret` hides its material behind a method, not a property.** `System.Text.Json`, `record` synthesized `ToString()`, and most diagnostic dumps enumerate properties, so a property named `Value` would eventually be serialized by something. `ImapAccountSettings` is a `record`, which makes this concrete: its synthesized `ToString()` prints every member today. `RevealBytes()` and `RevealAsString()` are methods for that reason, and `ToString()` is overridden to return `***`.
+13. **`plaintext:` is gated by a constructor flag, not by `IHostEnvironment`.** `Infrastructure` does not reference `Microsoft.Extensions.Hosting.Abstractions` and gains nothing by starting to. `Host` passes `builder.Environment.IsDevelopment()` at registration, which also makes the rule trivially testable in both directions.
+14. **`env:` resolves in every environment.** The specification gates exactly one scheme on the environment, and the definition of done names only the `plaintext:` rule. `env:` stays permitted with a documented recommendation against production use, rather than inventing a second environment gate the specification did not ask for. *Flagged for the owner: if `env:` should also fail outside Development, it is a one-line change to the same flag.*
+15. **Resolution runs at startup validation and again per use, which is what makes rotation work.** Startup validation resolves every reference and discards the material, so an unresolvable reference fails the host. Each actual use resolves again, so no long-lived copy exists and material rotated behind an unchanged reference — a replaced credential file, a re-issued vault entry — is observed by the next operation with no cache to invalidate and no restart. The material is a few hundred bytes from a tmpfs or an environment block; per-run re-reading is not a measured cost. A network-backed adapter for which per-use retrieval is too expensive caches inside itself under decision 18, without changing this.
+16. **Secrets are reloadable for new operations, not during running operations.** Both halves reload: a changed *reference* arrives through `IOptionsMonitor` and is validated by resolving the whole candidate snapshot before publishing it, with the last known good snapshot retained on failure; changed *material* is picked up by decision 10. Neither is applied mid-operation — a synchronization run that has authenticated finishes with the credential it authenticated with, because swapping a credential or trust anchor underneath an open IMAP session has no coherent meaning. This is ADR 0002's middle classification, chosen deliberately over the strictest one.
+17. **ADR 0002 must be amended before this is implemented.** The ADR currently classifies credentials and certificate trust anchors as restart-required, and decision 16 departs from that. The departure is defensible — the reference indirection means rotation re-resolves a validated reference rather than mutating a bound secret in place — but `docs/AGENTS.md` forbids modifying an ADR without explicit owner approval, so no ADR is touched here. **This is a blocking prerequisite, not a follow-up.**
+18. **Provider-specific concerns stay inside the provider's adapter.** Timeouts, retry, backoff, endpoint and region configuration, SDK client lifetime, platform identity, and caching policy belong to the adapter that needs them, never to `ISecretReferenceResolver`. The contract carries a reference and a cancellation token and returns a result; that is the whole surface. This is what lets a store that must cache aggressively and a local file that must never cache coexist without the contract taking a position, and it keeps SDK types out of everything above the adapter exactly as the root dependency rules require.
+19. **A managed-store adapter authenticates through platform identity, not through a MailMcp secret.** An Azure managed identity, a Kubernetes ServiceAccount token, or a Vault role is issued by the platform the process already runs on. Requiring MailMcp to hold a credential in order to fetch its credentials would be circular and would put the most sensitive value back into the configuration this specification removes it from. Recorded now so a future adapter does not quietly reintroduce the problem; nothing implements it here.
+20. **A custom trust anchor is validated by rebuilding the chain, never by accepting errors.** `RemoteCertificateNotAvailable` and `RemoteCertificateNameMismatch` are rejected outright. Only `RemoteCertificateChainErrors` is re-examined, by building an `X509Chain` with `TrustMode = X509ChainTrustMode.CustomRootTrust` and the anchor in `CustomTrustStore` — which Microsoft documents as respected only under that trust mode — and requiring a clean rebuild. MailKit's own `SslCertificateValidation.cs` example stops at describing errors and does not implement custom-CA trust, so this logic is ours to write and ours to test.
+21. **The database password becomes a reference too.** The specification's goal names it explicitly. `ConnectionStrings:mailmcp` keeps host, database, and user name; an optional `Persistence:PasswordReference` is resolved at startup and applied through `NpgsqlConnectionStringBuilder.Password`, so the connection string in `appsettings.json` never carries the password and the composed string never reaches a log.
+22. **Two resolver names, two scopes.** `ISecretReferenceResolver` resolves one reference. `MailAccountSecretOptions` resolves one account's set of secrets and reports per-account configuration errors. Naming them both "secret resolver" would make the call sites ambiguous, which the root naming rules forbid.
+23. **`UserName` stays a plain configuration value.** The definition of done names raw *passwords*. A mailbox user name is an identifier the operator already writes next to the host, and turning it into a reference would double the provisioning burden for no confidentiality gain. It remains excluded from logs as personal data.
 
 ## File structure
 
@@ -72,7 +76,7 @@ A managed store reached over the network — Azure Key Vault, HashiCorp Vault, A
 - `src/Infrastructure/Secrets/SecretReference.cs` — parsed scheme and target, with the parse rules of decision 1.
 - `src/Infrastructure/Secrets/SecretResolutionFailure.cs` — machine-readable failure identities.
 - `src/Infrastructure/Secrets/SecretResolutionResult.cs` — success carrying `ResolvedSecret`, or a failure identity.
-- `src/Infrastructure/Secrets/ResolvedSecret.cs` — material behind `Reveal()`, redacted `ToString()`.
+- `src/Infrastructure/Secrets/ResolvedSecret.cs` — pinned buffer, `RevealBytes()`/`RevealAsString()`, zeroing `Dispose`, redacted `ToString()`.
 - `src/Infrastructure/Secrets/ISecretReferenceResolver.cs`, `ISecretSchemeResolver.cs` — the one-reference contract and the public per-scheme extension point.
 - `src/Infrastructure/Secrets/ISecretFileReader.cs`, `IEnvironmentVariableReader.cs` — the two in-memory-testable ports.
 - `src/Infrastructure/Secrets/FileSystemSecretFileReader.cs`, `ProcessEnvironmentVariableReader.cs` — the real adapters.
@@ -150,14 +154,14 @@ public sealed record SecretReference
 
 ```csharp
 
-public sealed class ResolvedSecret
+public sealed class ResolvedSecret : IDisposable
 {
-    public ResolvedSecret(ReadOnlyMemory<byte> material);
-
+    public static ResolvedSecret FromBytes(ReadOnlySpan<byte> material);
     public static ResolvedSecret FromText(string material);   // UTF-8 encodes; for plaintext: and env:
 
-    public string Reveal();                       // UTF-8 text view, one trailing newline stripped
-    public ReadOnlyMemory<byte> RevealBytes();    // untouched material, for PKCS#12 and DER
+    public ReadOnlySpan<byte> RevealBytes();      // primary accessor: material, untouched
+    public string RevealAsString();               // framework-contract escape hatch; see decision 8
+    public void Dispose();                        // CryptographicOperations.ZeroMemory over the pinned buffer
     public override string ToString();            // "***"
 }
 
@@ -188,10 +192,13 @@ TryParse_SupportedScheme_ParsesSchemeAndTarget
 [Fact]    TryParse_EmptyTarget_FailsWithTargetMissing                           // "file:"
 [Fact]    TryParse_UrlTarget_KeepsTheWholeUrl                                   // "azure-key-vault:https://v.example/s/imap"
 [Fact]    ToString_ResolvedSecret_DoesNotContainTheMaterial
-[Fact]    Reveal_ResolvedSecret_ReturnsTheUtf8TextView
-[Fact]    Reveal_MaterialEndsWithNewline_StripsOneTrailingNewline
+[Fact]    RevealAsString_ResolvedSecret_ReturnsTheUtf8TextView
+[Fact]    RevealAsString_MaterialEndsWithNewline_StripsOneTrailingNewline
 [Fact]    RevealBytes_BinaryMaterial_ReturnsEveryByteUnchanged      // a PKCS#12 bundle must survive
 [Fact]    RevealBytes_MaterialEndsWithNewline_DoesNotStripIt        // trimming a PFX would corrupt it
+[Fact]    Dispose_ResolvedSecret_ZeroesTheMaterial
+[Fact]    Dispose_CalledTwice_DoesNotThrow
+[Fact]    RevealBytes_AfterDispose_Throws                           // a use-after-erase is a bug, not a silent empty
 [Fact]    ToString_SecretResolutionResult_DoesNotContainTheMaterial             // the record's synthesized ToString
 ```
 
@@ -206,7 +213,24 @@ Expected: FAIL — `SecretReference` does not exist.
 
 `TryParse` trims, rejects blank, splits on `IndexOf(':')`, normalizes the scheme name to lower case with `ToLowerInvariant`, and rejects an empty remainder. It does not check the name against a list: an unknown scheme is a well-formed reference to a provider that is not registered, and decision 3 puts that answer in the dispatch. `SecretReferenceScheme` compares by normalized name with `StringComparer.Ordinal`, and its well-known members are the four wire names. The member name `EnvironmentVariable` and the wire name `env` deliberately differ, because the configuration prefix should stay short while the member name stays explicit.
 
-`ResolvedSecret` stores the material in a private field, exposes `Reveal()`, and overrides `ToString()` to return `"***"`. XML documentation states that `Reveal()` is the single intentional disclosure point and that callers must not store, log, or re-wrap the returned string.
+`ResolvedSecret` allocates its buffer with `GC.AllocateArray<byte>(length, pinned: true)` so the collector cannot relocate it and leave an un-erased copy, copies the material in, and erases it in `Dispose` with `CryptographicOperations.ZeroMemory`. `Dispose` is idempotent, and every accessor throws `ObjectDisposedException` afterwards rather than returning empty — a use-after-erase is a defect and must present as one. `ToString()` returns `"***"`.
+
+XML documentation states that `RevealBytes` is the primary accessor, that `RevealAsString` produces a copy which cannot be erased and exists only for framework contracts that take a `string`, and that the instance is owned by the operation that resolved it.
+
+```csharp
+public void Dispose()
+{
+    if (this.disposed)
+    {
+        return;
+    }
+
+    CryptographicOperations.ZeroMemory(this.material);
+    this.disposed = true;
+}
+```
+
+The zeroing must go through `CryptographicOperations.ZeroMemory` rather than `Array.Clear` or a loop: it is documented as existing "to future-proof against potential optimizations in the .NET runtime that could eliminate memory writes that aren't followed by memory reads", which is exactly this write.
 
 - [ ] **Step 4: Run the tests**
 
@@ -286,7 +310,7 @@ Expected: FAIL — the resolvers do not exist.
 
 - [ ] **Step 3: Implement**
 
-`SystemdCredentialSecretReferenceResolver` reads `CREDENTIALS_DIRECTORY` through `IEnvironmentVariableReader` — systemd documents that "the path to access them is derived from the environment variable `$CREDENTIALS_DIRECTORY`" and that access is restricted to the service's user — rejects a target containing `/`, `\`, or `..`, joins, and reads. `FileSecretReferenceResolver` reads the target directly, which is also the container path: Compose mounts secrets at `/run/secrets/<secret_name>`. Both read bytes and neither modifies them; the newline trim lives in `ResolvedSecret.Reveal()` so binary material is never touched, and both report `MaterialEmpty` when the material has zero length.
+`SystemdCredentialSecretReferenceResolver` reads `CREDENTIALS_DIRECTORY` through `IEnvironmentVariableReader` — systemd documents that "the path to access them is derived from the environment variable `$CREDENTIALS_DIRECTORY`" and that access is restricted to the service's user — rejects a target containing `/`, `\`, or `..`, joins, and reads. `FileSecretReferenceResolver` reads the target directly, which is also the container path: Compose mounts secrets at `/run/secrets/<secret_name>`. Both read bytes and neither modifies them; the newline trim lives in `ResolvedSecret.RevealAsString()` so binary material is never touched, and both report `MaterialEmpty` when the material has zero length.
 
 `DevelopmentPlaintextSecretReferenceResolver(bool developmentEnvironment)` returns the target verbatim in Development and `PlaintextPermittedOnlyInDevelopment` otherwise, per decision 5.
 
@@ -334,7 +358,7 @@ public sealed class MailAccountSecretOptions
         CancellationToken cancellationToken);
 }
 
-public sealed record MailAccountSecrets(ResolvedSecret Password, X509Certificate2? TrustedCertificateAuthority);
+public sealed record MailAccountSecrets(ResolvedSecret Password, X509Certificate2? TrustedCertificateAuthority) : IDisposable;
 
 public sealed record ImapAccountSettings(
     string AccountId,
@@ -369,11 +393,13 @@ Expected: FAIL — `MailAccountSecretOptions` does not exist and `ImapAccountSet
 
 - [ ] **Step 3: Implement**
 
-`FindConfigurationErrorsAsync` resolves the password reference and, when a trust anchor reference is present, resolves and parses it, then discards both — decision 11's startup half. Trust anchor parsing uses `X509Certificate2.CreateFromPem` inside a `try`/`catch (CryptographicException)` that becomes a configuration error, so malformed material fails startup instead of failing the first TLS handshake hours later.
+`FindConfigurationErrorsAsync` resolves the password reference and, when a trust anchor reference is present, resolves and parses it, then discards both — decision 15's startup half. Trust anchor parsing uses `X509Certificate2.CreateFromPem` inside a `try`/`catch (CryptographicException)` that becomes a configuration error, so malformed material fails startup instead of failing the first TLS handshake hours later.
 
 `Resolve` performs the same work and returns the values, and throws `InvalidOperationException` if a reference that validated at startup no longer resolves — a fail-closed path, not an ordinary branch.
 
 `ImapAccountSettings` carries `ResolvedSecret` and the optional anchor. Its XML documentation gains a remark that the record's synthesized `ToString()` is safe only because `ResolvedSecret` redacts itself.
+
+`MailAccountSecrets` implements `IDisposable` and disposes both the password and the `X509Certificate2`, which is itself disposable. Per decision 9 the instance is owned by the operation that resolved it: `MailKitImapMailboxSessionFactory.OpenReadOnlyAsync` disposes it once the client is authenticated and the folder is open, and the startup validator disposes everything it resolved before returning. `ImapAccountSettings` does *not* own the secrets — it is a carrier — so the ownership rule is stated in its XML documentation to stop a future caller from disposing it twice or not at all.
 
 - [ ] **Step 4: Run the tests**
 
@@ -476,7 +502,7 @@ client.ServerCertificateValidationCallback =
 
 await client.ConnectAsync(...);
 ...
-await client.AuthenticateAsync(settings.UserName, settings.Password.Reveal(), cancellationToken);
+await client.AuthenticateAsync(settings.UserName, settings.Password.RevealAsString(), cancellationToken);
 ```
 
 - [ ] **Step 4: Run the tests**
@@ -509,7 +535,7 @@ git commit -m "Validate a private mail server against its configured trust ancho
 var connectionStringBuilder = new NpgsqlConnectionStringBuilder(connectionString);
 if (databasePassword is { } password)
 {
-    connectionStringBuilder.Password = password.Reveal();
+    connectionStringBuilder.Password = password.RevealAsString();
 }
 ```
 
@@ -640,7 +666,7 @@ git commit -m "Assert secret resolution stays out of Domain and Application"
 - Create: `src/Host/Configuration/MailSecretSnapshotPublisher.cs`
 - Test: `tests/Infrastructure.UnitTests/MailAccountSecretReloadTests.cs`
 
-Decision 12 makes this a blocking prerequisite: **do not start this task until ADR 0002 has been amended with owner approval.** The ADR classifies credentials and trust anchors as restart-required, and this task deliberately reclassifies them as reloadable for new operations.
+Decision 17 makes this a blocking prerequisite: **do not start this task until ADR 0002 has been amended with owner approval.** The ADR classifies credentials and trust anchors as restart-required, and this task deliberately reclassifies them as reloadable for new operations.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -652,7 +678,7 @@ Decision 12 makes this a blocking prerequisite: **do not start this task until A
 [Fact] ResolveAsync_MaterialRotatedMidOperation_DoesNotAffectTheOperationInFlight
 ```
 
-The last two are the pair that distinguishes the two reload halves, and the last one is what keeps decision 11's "not during running operations" honest.
+The last two are the pair that distinguishes the two reload halves, and the last one is what keeps decision 16's "not during running operations" honest.
 
 - [ ] **Step 2: Bind for reload**
 
@@ -666,7 +692,7 @@ Reload validation must not crash the process: ADR 0002 is explicit that a reject
 
 - [ ] **Step 4: Resolve material per operation**
 
-No change is needed for the material half — decision 11 already resolves per use, which is what makes rotation behind an unchanged reference work. The test in Step 1 is what proves it, and it exists to catch a future "optimization" that caches the resolved value on the options instance.
+No change is needed for the material half — decision 15 already resolves per use, which is what makes rotation behind an unchanged reference work. The test in Step 1 is what proves it, and it exists to catch a future "optimization" that caches the resolved value on the options instance.
 
 - [ ] **Step 5: Run the tests and commit**
 
@@ -686,7 +712,7 @@ git commit -m "Reload secret references and material without restarting the host
 
 - [ ] **Step 1: Write the provisioning page**
 
-`docs/operations/secret-provisioning.md` documents the reference grammar, the four schemes, and — because MailMcp is deployed several ways — a section per deployment shape: the native systemd path with `LoadCredential=`, `LoadCredentialEncrypted=`, `systemd-creds`, and `$CREDENTIALS_DIRECTORY`; the container path with Compose `secrets:` mounted at `/run/secrets/<name>`; and the Kubernetes path with a Secret mounted as a read-only tmpfs volume — the last two both addressed as `file:`, with an explicit note that no container- or Kubernetes-specific scheme exists or is needed. It states the trailing-newline trimming and that it applies to text secrets only, the accepted certificate encodings, the `plaintext:` Development gate, the recommendation against `env:` in production, and the ADR 0002 classification from decision 12.
+`docs/operations/secret-provisioning.md` documents the reference grammar, the four schemes, and — because MailMcp is deployed several ways — a section per deployment shape: the native systemd path with `LoadCredential=`, `LoadCredentialEncrypted=`, `systemd-creds`, and `$CREDENTIALS_DIRECTORY`; the container path with Compose `secrets:` mounted at `/run/secrets/<name>`; and the Kubernetes path with a Secret mounted as a read-only tmpfs volume — the last two both addressed as `file:`, with an explicit note that no container- or Kubernetes-specific scheme exists or is needed. It states the trailing-newline trimming and that it applies to text secrets only, the accepted certificate encodings, the operational hardening that bounds in-memory exposure — `LimitCORE=0` on the systemd unit, `Storage=none` and `ProcessSizeMax=0` for `systemd-coredump`, and keeping the service out of swap in both the systemd and container shapes, with the honest statement that a dump or debugger can still read managed memory and that no code-level measure changes that — the `plaintext:` Development gate, the recommendation against `env:` in production, and the ADR 0002 classification from decision 16.
 
 A closing section states what a future managed-store provider would add — one `ISecretSchemeResolver`, one registration extension, its own timeouts and caching, platform identity rather than a MailMcp-held credential, and a `LICENSES.md` entry — so an operator reading the page can tell which schemes exist today from which are anticipated. It documents anticipated extension, not unimplemented behavior, and says so plainly; `docs/AGENTS.md` requires documentation to describe verified implemented behavior, and this section is explicitly labelled as the extension contract rather than as a feature.
 
@@ -729,17 +755,21 @@ Run `$finish-change`: commit, push, and open a draft pull request whose body con
 | Resolution returns a result rather than throwing | 1, 2 |
 | Composite dispatch over per-scheme adapters | 2 |
 | Unknown-scheme and missing-reference failures | 1, 2 |
-| A new scheme is one adapter registration, no core edit | decisions 2 and 14, proved by the Task 2 extensibility test |
+| A new scheme is one adapter registration, no core edit | decisions 2 and 18, proved by the Task 2 extensibility test |
 | Contract asynchronous and cancellable for a network provider | decision 4, Tasks 1–3, 6 |
-| Provider concerns confined to the provider's adapter | decisions 14 and 15 |
+| Provider concerns confined to the provider's adapter | decisions 18 and 19 |
 | Resolver contract and adapters live in `Infrastructure` | 1–4 |
 | `Host` invokes resolution once before hosted services start | 6 |
 | No options type binds a raw password | 3, 5, 6 (verified by `grep` in Task 6 Step 6) |
 | Failure message names account, logical secret, and scheme only | 3, 6 |
 | Secrets exposed through an accessor, not an ordinary property | 1, 3 |
-| Rotated material observed without restart | decision 11, Tasks 3 and 9 |
+| Rotated material observed without restart | decision 15, Tasks 3 and 8 |
 | Every secret-bearing setting is a `*Reference` string in JSON | 3, 5, 6 |
 | Bytes-first resolution; PKCS#12 and DER representable | 1, 2 |
+| No `string`, pooled buffer, or `SecureString` holds material | decisions 7 and 8, Task 1 |
+| Pinned buffer zeroed with `CryptographicOperations.ZeroMemory` | 1 |
+| Material owned by its operation and disposed at its end | decision 9, Tasks 3 and 6 |
+| Core-dump and swap exposure documented for both shapes | 9 |
 | Text view decodes UTF-8 and trims one trailing newline | 1 |
 | Rotated material observed by the next operation, no restart | 8 |
 | Reload with an unresolvable reference keeps previous secrets | 8 |
@@ -755,12 +785,12 @@ Run `$finish-change`: commit, push, and open a draft pull request whose body con
 
 **Deliberately out of scope:** Data Protection key-ring provisioning, encrypted secret storage in PostgreSQL, secret rotation without restart, and MCP client certificates (stage 9).
 
-Managed secret stores — Kubernetes-native APIs, Azure Key Vault, HashiCorp Vault, AWS Secrets Manager — are out of scope as implementations but not as constraints. Decisions 2, 4, 14, and 15 exist for them, and the Task 2 extensibility test is what keeps the promise honest. Note that Kubernetes and container deployments need nothing added at all: their secrets are files, so `file:` already serves them today.
+Managed secret stores — Kubernetes-native APIs, Azure Key Vault, HashiCorp Vault, AWS Secrets Manager — are out of scope as implementations but not as constraints. Decisions 2, 4, 18, and 19 exist for them, and the Task 2 extensibility test is what keeps the promise honest. Note that Kubernetes and container deployments need nothing added at all: their secrets are files, so `file:` already serves them today.
 
 **Flagged for the owner**
 
-- **Blocking:** ADR 0002 must be amended before Task 8 begins (decision 12). The dynamic-reload requirement contradicts the ADR's current restart-required classification for credentials and trust anchors, and `docs/AGENTS.md` forbids amending an ADR without explicit owner approval. Tasks 1–7 and 9 are unaffected.
+- **Blocking:** ADR 0002 must be amended before Task 8 begins (decision 17). The dynamic-reload requirement contradicts the ADR's current restart-required classification for credentials and trust anchors, and `docs/AGENTS.md` forbids amending an ADR without explicit owner approval. Tasks 1–7 and 9 are unaffected.
 - **Blocking:** the specification is now estimated at ~1300 lines against `specs/README.md`'s ~1000-line ceiling, and `specs/02` records a proposed 02a/02b split. Whether to split — and therefore whether this plan stays one plan — is the owner's call, because renumbering touches the roadmap board and the dependency chain from specification 03 onward.
 - The specification originally estimated ~500 lines. Loading and validating the trust anchor (Task 4), the database password reference (Task 5), and the asynchronous contract that ripples through `IImapAccountSettingsProvider` and startup validation (decisions 4 and 5) realistically bring this to roughly 850 lines including tests and documentation. Nothing is proposed for deferral; the estimate is what is optimistic. Issue #36's `Size` line should be updated when this plan is accepted.
-- Decision 10 reads "permitted for non-production automation" as guidance rather than an enforced environment gate for `env:`. If it should be enforced, say so and it moves onto the same Development flag as `plaintext:`.
+- Decision 14 reads "permitted for non-production automation" as guidance rather than an enforced environment gate for `env:`. If it should be enforced, say so and it moves onto the same Development flag as `plaintext:`.
 - Decision 4 makes the contract asynchronous before any asynchronous provider exists. The cost is real and visible: `GetSettings` becomes `GetSettingsAsync`, and startup validation moves out of `IValidateOptions` into `IHostedLifecycleService`. It is proposed because retrofitting it alongside a first Key Vault adapter would touch the same files while also introducing SDK, identity, and licensing questions, and doing one of those at a time is cheaper. If managed stores are further off than this assumes, the synchronous contract is defensible and this is the decision to revisit.

--- a/docs/superpowers/plans/2026-07-27-secret-reference-resolution.md
+++ b/docs/superpowers/plans/2026-07-27-secret-reference-resolution.md
@@ -1,0 +1,766 @@
+# Secret Reference Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Governing issue:** [#36 — Spec 02 — Secret reference resolution](https://github.com/Krzysztof318/MailMcp/issues/36)
+**Governing specification:** [`specs/02-secret-reference-resolution.md`](../../../specs/02-secret-reference-resolution.md)
+**Architectural context:** `specs/2026-07-22-mail-mcp-architecture-draft.md` sections 7.3 and 19, ADR `docs/decisions/0002-configuration-reading-mapping-and-reload-boundary.md`
+**Depends on:** [#35 — Spec 01](https://github.com/Krzysztof318/MailMcp/issues/35), merged as `a732e9a`
+
+**Goal:** Replace every raw secret bound from configuration with a scheme-qualified reference that `Infrastructure` resolves and `Host` fails fast on, and load the trust anchor material that specification 01 deliberately left as configuration shape only.
+
+**Architecture:** `Infrastructure` owns the reference grammar, the per-scheme adapters, the composite dispatch, and the certificate-validation path that consumes a resolved trust anchor. `Host` binds reference strings, invokes resolution once before hosted services start, and turns failures into startup errors. `Application` and `Domain` gain nothing: they never see a resolver, a reference, or a scheme, which is the boundary ADR 0002 draws when it forbids normalizing broad secret access into application code.
+
+The shape is chosen so that a future Kubernetes, Azure Key Vault, HashiCorp Vault, or AWS Secrets Manager adapter is a registration rather than a refactor: a scheme is declared by the adapter that serves it, dispatch is a lookup, and the contract is asynchronous and cancellable from the first commit. None of those providers is implemented here.
+
+**Tech Stack:** .NET 10, C# preview, MailKit 4.17.0, Npgsql 10.0.3 (transitive through `Npgsql.EntityFrameworkCore.PostgreSQL`), xUnit.net v3 on Microsoft Testing Platform v2, NSubstitute 6.0.0.
+
+## Global Constraints
+
+- No new third-party packages. `LICENSES.md` therefore needs no dependency entry; `$check-docs-licenses` returns `n/a` for licensing and must still be run.
+- `Domain` and `Application` stay free of every type introduced here. The architecture test in Task 7 is the enforcement, not a review habit.
+- Certificate validation stays enabled unconditionally. Nothing introduced here may expose a "trust any certificate" flag, an `SslProtocols` override, or a callback that returns `true` on an unexamined chain.
+- No resolution failure message, log line, or exception may contain the resolved material, the file path, the environment variable's value, or the credential's contents. The account identifier, the logical secret name, and the scheme are the permitted vocabulary.
+- Unit tests never touch the real file system, environment block, network, or clock. Every scheme adapter reads through an injected in-memory port.
+- Every enum member gets an explicit contiguous value starting at `0`; members are appended, never reordered or renumbered.
+- Synchronization stays read-only: nothing here may set the remote `\Seen` flag.
+- `dotnet msbuild .config/CodeCoverage.proj -t:Collect` must pass the 85% whole-scope gate. `Host` is excluded from coverage, so logic that needs testing belongs in `Infrastructure` — the same constraint that moved `MailAccountTransportSecurityOptions` there in specification 01.
+
+## Deployment shapes this must serve
+
+MailMcp runs both as a container (Docker Compose or rootless Podman Compose under systemd) and as a native systemd service, and draft section 19 treats neither as the fallback. The scheme set covers both without a container-specific scheme, because a container secret *is* a file:
+
+| Deployment | Provisioning | Reference |
+| --- | --- | --- |
+| Native systemd service | `LoadCredential=` / `LoadCredentialEncrypted=`, `systemd-creds` | `systemd-credential:imap-primary-password` |
+| Docker / Podman Compose | Compose `secrets:`, mounted at `/run/secrets/<name>` | `file:/run/secrets/imap-primary-password` |
+| Kubernetes | Secret mounted as a read-only tmpfs volume, one file per key | `file:/etc/mailmcp-secrets/imap-primary-password` |
+| Non-production automation | CI or orchestrator environment block | `env:MAILMCP_IMAP_PRIMARY_PASSWORD` |
+| Local development | `appsettings.Development.json` or user secrets | `plaintext:dev-password` |
+
+Adding `docker-secret:` or `kubernetes-secret:` schemes was rejected: each would resolve to exactly the file read that `file:` already performs, and a scheme whose only distinction is documentation is configuration surface with no behavior behind it. A Kubernetes Secret projected into the environment block is `env:` for the same reason.
+
+A managed store reached over the network — Azure Key Vault, HashiCorp Vault, AWS Secrets Manager — is the case that does earn a scheme, because retrieval behavior genuinely differs: authentication, endpoint, timeout, retry, and caching. Nothing here implements one, but decisions 1, 2, and 14 exist so that adding one later registers an adapter and edits nothing else.
+
+## Design decisions locked before implementation
+
+1. **The reference grammar is `<scheme>:<target>`, split on the first colon only.** A Windows-style path or a URL in the target therefore survives untouched — the latter matters for a future `azure-key-vault:https://vault.example/secrets/imap` style target. An empty scheme or an empty target is a resolution failure, never a fallback to treating the whole string as a literal: silently accepting a malformed reference as plaintext is exactly the leak the specification exists to prevent. Parsing validates the *grammar* only; whether a scheme is supported is a dispatch question, answered by decision 2.
+2. **A scheme is a value an adapter declares, not a closed enum the core owns.** `SecretReferenceScheme` is a `sealed record` wrapping its normalized wire name, with well-known static members for the four schemes shipped here. Each adapter exposes the scheme it serves, and `CompositeSecretReferenceResolver` builds its dispatch from the registered adapter set, so adding Azure Key Vault or Vault later registers one adapter and edits no existing type. This mirrors specification 01's accepted reversal of `MailAuthenticationMechanism` from an enum plus mapping table to a value carrying its own registered name. It is a `record` rather than a `readonly record struct` because `default(T)` would otherwise produce a scheme with a null name, and unlike the SASL mechanism this value is parsed once per resolution and never sits on a hot path.
+3. **Resolution returns a result; it does not throw.** An unresolved reference is an expected configuration failure with a named cause, per the specification. The failure enum is justified here because `Host` acts on it by rendering a startup message; nothing above `Host` branches on it. `SchemeNotSupported` is reported by the dispatch, which is also how an operator learns a provider adapter was not registered.
+4. **The contract is asynchronous and cancellable from the first commit.** Every scheme implemented here reads a local file or an environment variable and would be happy synchronously. A managed-store adapter is a network call, and the root rules forbid blocking on it; retrofitting `ResolveAsync` later would break `IImapAccountSettingsProvider`, the session factory, and startup validation at once. Paying one `Task` allocation per resolution now is cheaper than that change, and resolutions happen once per synchronization run.
+5. **Startup validation runs in `IHostedLifecycleService.StartingAsync`, not in `IValidateOptions`.** Options validation is synchronous, so an async resolver cannot run inside it without blocking — which decision 4 exists to avoid. `StartingAsync` is documented to run before any hosted service's `StartAsync`, so a throw there fails the host before the synchronization worker or any endpoint starts, which is the fail-fast behavior the specification requires. Structural options validation stays in `ValidateOnStart` where it belongs; only secret resolution moves.
+6. **The resolver returns bytes; text is a view over them.** A secret is not always a password: a trust anchor may be PEM or DER, and a private key arrives as a PKCS#12 bundle that is binary and may carry its own password reference. A `string`-returning resolver would make PKCS#12 unrepresentable and would corrupt DER through encoding round-trips. `ResolvedSecret` therefore stores `ReadOnlyMemory<byte>`, which is also what the root rules prescribe for byte payloads crossing async and object boundaries. `Reveal()` returns the UTF-8 text view with one trailing newline stripped; `RevealBytes()` returns the material untouched. The trim belongs to the text view only — trimming a PFX would corrupt it. `plaintext:` and `env:` UTF-8-encode on the way in, which costs nothing and keeps one result shape.
+7. **Typed material is loaded above the resolver, not inside it.** `X509CertificateMaterialLoader` in `Infrastructure` turns resolved bytes into an `X509Certificate2`, accepting PEM and DER and, for key material, PKCS#12 with an optional separately-referenced password. The resolver stays ignorant of X.509 so that adding a future material kind — an SSH key, a JWT signing key — adds a loader rather than touching every scheme adapter.
+8. **`ResolvedSecret` hides its material behind a method, not a property.** `System.Text.Json`, `record` synthesized `ToString()`, and most diagnostic dumps enumerate properties, so a property named `Value` would eventually be serialized by something. `ImapAccountSettings` is a `record`, which makes this concrete: its synthesized `ToString()` prints every member today. `ResolvedSecret.Reveal()` is the single intentional disclosure point and `ToString()` is overridden to return `***`.
+9. **`plaintext:` is gated by a constructor flag, not by `IHostEnvironment`.** `Infrastructure` does not reference `Microsoft.Extensions.Hosting.Abstractions` and gains nothing by starting to. `Host` passes `builder.Environment.IsDevelopment()` at registration, which also makes the rule trivially testable in both directions.
+10. **`env:` resolves in every environment.** The specification gates exactly one scheme on the environment, and the definition of done names only the `plaintext:` rule. `env:` stays permitted with a documented recommendation against production use, rather than inventing a second environment gate the specification did not ask for. *Flagged for the owner: if `env:` should also fail outside Development, it is a one-line change to the same flag.*
+11. **Resolution runs at startup validation and again per use, which is what makes rotation work.** Startup validation resolves every reference and discards the material, so an unresolvable reference fails the host. Each actual use resolves again, so no long-lived copy exists and material rotated behind an unchanged reference — a replaced credential file, a re-issued vault entry — is observed by the next operation with no cache to invalidate and no restart. The material is a few hundred bytes from a tmpfs or an environment block; per-run re-reading is not a measured cost. A network-backed adapter for which per-use retrieval is too expensive caches inside itself under decision 14, without changing this.
+12. **Secrets are reloadable for new operations, not during running operations.** Both halves reload: a changed *reference* arrives through `IOptionsMonitor` and is validated by resolving the whole candidate snapshot before publishing it, with the last known good snapshot retained on failure; changed *material* is picked up by decision 10. Neither is applied mid-operation — a synchronization run that has authenticated finishes with the credential it authenticated with, because swapping a credential or trust anchor underneath an open IMAP session has no coherent meaning. This is ADR 0002's middle classification, chosen deliberately over the strictest one.
+13. **ADR 0002 must be amended before this is implemented.** The ADR currently classifies credentials and certificate trust anchors as restart-required, and decision 12 departs from that. The departure is defensible — the reference indirection means rotation re-resolves a validated reference rather than mutating a bound secret in place — but `docs/AGENTS.md` forbids modifying an ADR without explicit owner approval, so no ADR is touched here. **This is a blocking prerequisite, not a follow-up.**
+14. **Provider-specific concerns stay inside the provider's adapter.** Timeouts, retry, backoff, endpoint and region configuration, SDK client lifetime, platform identity, and caching policy belong to the adapter that needs them, never to `ISecretReferenceResolver`. The contract carries a reference and a cancellation token and returns a result; that is the whole surface. This is what lets a store that must cache aggressively and a local file that must never cache coexist without the contract taking a position, and it keeps SDK types out of everything above the adapter exactly as the root dependency rules require.
+15. **A managed-store adapter authenticates through platform identity, not through a MailMcp secret.** An Azure managed identity, a Kubernetes ServiceAccount token, or a Vault role is issued by the platform the process already runs on. Requiring MailMcp to hold a credential in order to fetch its credentials would be circular and would put the most sensitive value back into the configuration this specification removes it from. Recorded now so a future adapter does not quietly reintroduce the problem; nothing implements it here.
+16. **A custom trust anchor is validated by rebuilding the chain, never by accepting errors.** `RemoteCertificateNotAvailable` and `RemoteCertificateNameMismatch` are rejected outright. Only `RemoteCertificateChainErrors` is re-examined, by building an `X509Chain` with `TrustMode = X509ChainTrustMode.CustomRootTrust` and the anchor in `CustomTrustStore` — which Microsoft documents as respected only under that trust mode — and requiring a clean rebuild. MailKit's own `SslCertificateValidation.cs` example stops at describing errors and does not implement custom-CA trust, so this logic is ours to write and ours to test.
+17. **The database password becomes a reference too.** The specification's goal names it explicitly. `ConnectionStrings:mailmcp` keeps host, database, and user name; an optional `Persistence:PasswordReference` is resolved at startup and applied through `NpgsqlConnectionStringBuilder.Password`, so the connection string in `appsettings.json` never carries the password and the composed string never reaches a log.
+18. **Two resolver names, two scopes.** `ISecretReferenceResolver` resolves one reference. `MailAccountSecretOptions` resolves one account's set of secrets and reports per-account configuration errors. Naming them both "secret resolver" would make the call sites ambiguous, which the root naming rules forbid.
+19. **`UserName` stays a plain configuration value.** The definition of done names raw *passwords*. A mailbox user name is an identifier the operator already writes next to the host, and turning it into a reference would double the provisioning burden for no confidentiality gain. It remains excluded from logs as personal data.
+
+## File structure
+
+**Create**
+
+- `src/Infrastructure/Secrets/SecretReferenceScheme.cs` — the open scheme value and the four well-known members.
+- `src/Infrastructure/Secrets/SecretReference.cs` — parsed scheme and target, with the parse rules of decision 1.
+- `src/Infrastructure/Secrets/SecretResolutionFailure.cs` — machine-readable failure identities.
+- `src/Infrastructure/Secrets/SecretResolutionResult.cs` — success carrying `ResolvedSecret`, or a failure identity.
+- `src/Infrastructure/Secrets/ResolvedSecret.cs` — material behind `Reveal()`, redacted `ToString()`.
+- `src/Infrastructure/Secrets/ISecretReferenceResolver.cs`, `ISecretSchemeResolver.cs` — the one-reference contract and the public per-scheme extension point.
+- `src/Infrastructure/Secrets/ISecretFileReader.cs`, `IEnvironmentVariableReader.cs` — the two in-memory-testable ports.
+- `src/Infrastructure/Secrets/FileSystemSecretFileReader.cs`, `ProcessEnvironmentVariableReader.cs` — the real adapters.
+- `src/Infrastructure/Secrets/X509CertificateMaterialLoader.cs` — PEM, DER, and PKCS#12 loading over resolved bytes.
+- `src/Infrastructure/Secrets/SystemdCredentialSecretReferenceResolver.cs`, `FileSecretReferenceResolver.cs`, `EnvironmentVariableSecretReferenceResolver.cs`, `DevelopmentPlaintextSecretReferenceResolver.cs`, `CompositeSecretReferenceResolver.cs`
+- `src/Infrastructure/Mail/MailAccountSecretOptions.cs` — the account's reference strings and their resolution into `MailAccountSecrets`.
+- `src/Infrastructure/Mail/MailAccountSecrets.cs` — resolved password plus optional trust anchor.
+- `src/Infrastructure/Mail/MailServerCertificateValidator.cs` — the custom-root-trust validation callback.
+- `tests/Infrastructure.UnitTests/SecretReferenceTests.cs`
+- `tests/Infrastructure.UnitTests/SecretReferenceResolverTests.cs`
+- `tests/Infrastructure.UnitTests/MailAccountSecretOptionsTests.cs`
+- `tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs`
+- `tests/Infrastructure.UnitTests/SecretBoundaryArchitectureTests.cs`
+- `src/Host/Hosting/MailSecretReferenceStartupValidator.cs` — `IHostedLifecycleService.StartingAsync` fail-fast resolution.
+- `docs/operations/secret-provisioning.md`
+
+**Modify**
+
+- `src/Infrastructure/Mail/ImapAccountSettings.cs` — `Password` becomes `ResolvedSecret`; the record gains the trust anchor; `IImapAccountSettingsProvider.GetSettings` becomes `GetSettingsAsync`.
+- `src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs` — the client port carries the validation callback; the factory installs it before connecting and reveals the password at the single `AuthenticateAsync` call.
+- `src/Infrastructure/ServiceCollectionExtensions.cs` — `AddMailMcpSecretResolution`, and the resolved database password applied to the connection string.
+- `src/Host/Configuration/MailSynchronizationOptions.cs` — `Password` becomes a nested `Secrets` section; `GetSettings` becomes `GetSettingsAsync` and resolves.
+- `src/Host/Configuration/PersistenceOptions.cs` — optional `PasswordReference`.
+- `src/Host/Program.cs` — register secret resolution with the Development flag, register the startup validator ahead of the worker, compose the connection string.
+- `src/Host/appsettings.json`, `src/Host/appsettings.Development.json` — reference-shaped examples.
+- `docs/features/imap-synchronization.md` — configuration, the two resolved pending items, transport-security trust anchor behavior.
+- `docs/operations/local-development.md` — the Development secret workflow.
+
+---
+
+### Task 1: The reference grammar and the resolution result
+
+**Files:**
+- Create: `src/Infrastructure/Secrets/SecretReferenceScheme.cs`, `SecretReference.cs`, `SecretResolutionFailure.cs`, `SecretResolutionResult.cs`, `ResolvedSecret.cs`
+- Test: `tests/Infrastructure.UnitTests/SecretReferenceTests.cs`
+
+**Interfaces produced:**
+
+```csharp
+public sealed record SecretReferenceScheme
+{
+    public string Name { get; }                       // normalized, lower-case wire name
+
+    public static SecretReferenceScheme SystemdCredential { get; }    // "systemd-credential"
+    public static SecretReferenceScheme File { get; }                 // "file"
+    public static SecretReferenceScheme EnvironmentVariable { get; }  // "env"
+    public static SecretReferenceScheme Plaintext { get; }            // "plaintext"
+
+    public static SecretReferenceScheme Create(string name);          // for adapters declared elsewhere
+}
+
+public enum SecretResolutionFailure
+{
+    ReferenceMissing = 0,
+    SchemeMissing = 1,
+    SchemeNotSupported = 2,
+    TargetMissing = 3,
+    PlaintextPermittedOnlyInDevelopment = 4,
+    CredentialsDirectoryUnavailable = 5,
+    MaterialNotFound = 6,
+    MaterialEmpty = 7,
+    ProviderUnavailable = 8,
+}
+
+public sealed record SecretReference
+{
+    public SecretReferenceScheme Scheme { get; }
+    public string Target { get; }
+
+    public static bool TryParse(string? reference, out SecretReference? parsed, out SecretResolutionFailure failure);
+}
+```
+
+`SecretReferenceScheme` is open by decision 2: a future Azure Key Vault adapter calls `Create("azure-key-vault")` in its own file and registers itself. `ProviderUnavailable` is appended now rather than later so a network-backed adapter has a failure identity to report that is distinguishable from a missing secret; nothing in this change set produces it. Enum values are append-only, so this costs nothing and avoids renumbering a persisted-looking value later.
+
+```csharp
+
+public sealed class ResolvedSecret
+{
+    public ResolvedSecret(ReadOnlyMemory<byte> material);
+
+    public static ResolvedSecret FromText(string material);   // UTF-8 encodes; for plaintext: and env:
+
+    public string Reveal();                       // UTF-8 text view, one trailing newline stripped
+    public ReadOnlyMemory<byte> RevealBytes();    // untouched material, for PKCS#12 and DER
+    public override string ToString();            // "***"
+}
+
+public sealed record SecretResolutionResult
+{
+    public bool Succeeded { get; }
+    public ResolvedSecret? Secret { get; }
+    public SecretResolutionFailure? Failure { get; }
+
+    public static SecretResolutionResult Resolved(ResolvedSecret secret);
+    public static SecretResolutionResult Failed(SecretResolutionFailure failure);
+}
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/Infrastructure.UnitTests/SecretReferenceTests.cs`, one behavior per test:
+
+```csharp
+[Theory]  // "systemd-credential:imap" => SystemdCredential, "file:/run/secrets/imap" => File, ...
+TryParse_SupportedScheme_ParsesSchemeAndTarget
+[Fact]    TryParse_TargetContainsColon_KeepsEverythingAfterTheFirstColon        // "file:C:\\secrets\\imap" => "C:\\secrets\\imap"
+[Fact]    TryParse_MixedCaseScheme_ParsesScheme                                 // "File:/run/secrets/imap"
+[Fact]    TryParse_SurroundingWhitespace_TrimsBeforeParsing
+[Fact]    TryParse_NullOrWhitespace_FailsWithReferenceMissing
+[Fact]    TryParse_NoColon_FailsWithSchemeMissing                               // a bare password must never parse
+[Fact]    TryParse_UnregisteredScheme_ParsesBecauseSupportIsADispatchQuestion   // "azure-key-vault:imap" parses
+[Fact]    TryParse_EmptyTarget_FailsWithTargetMissing                           // "file:"
+[Fact]    TryParse_UrlTarget_KeepsTheWholeUrl                                   // "azure-key-vault:https://v.example/s/imap"
+[Fact]    ToString_ResolvedSecret_DoesNotContainTheMaterial
+[Fact]    Reveal_ResolvedSecret_ReturnsTheUtf8TextView
+[Fact]    Reveal_MaterialEndsWithNewline_StripsOneTrailingNewline
+[Fact]    RevealBytes_BinaryMaterial_ReturnsEveryByteUnchanged      // a PKCS#12 bundle must survive
+[Fact]    RevealBytes_MaterialEndsWithNewline_DoesNotStripIt        // trimming a PFX would corrupt it
+[Fact]    ToString_SecretResolutionResult_DoesNotContainTheMaterial             // the record's synthesized ToString
+```
+
+The last two matter more than they look: they are the regression guard for decision 4.
+
+- [ ] **Step 2: Run the tests and confirm they fail to compile**
+
+Run: `dotnet test --project tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj`
+Expected: FAIL — `SecretReference` does not exist.
+
+- [ ] **Step 3: Implement**
+
+`TryParse` trims, rejects blank, splits on `IndexOf(':')`, normalizes the scheme name to lower case with `ToLowerInvariant`, and rejects an empty remainder. It does not check the name against a list: an unknown scheme is a well-formed reference to a provider that is not registered, and decision 3 puts that answer in the dispatch. `SecretReferenceScheme` compares by normalized name with `StringComparer.Ordinal`, and its well-known members are the four wire names. The member name `EnvironmentVariable` and the wire name `env` deliberately differ, because the configuration prefix should stay short while the member name stays explicit.
+
+`ResolvedSecret` stores the material in a private field, exposes `Reveal()`, and overrides `ToString()` to return `"***"`. XML documentation states that `Reveal()` is the single intentional disclosure point and that callers must not store, log, or re-wrap the returned string.
+
+- [ ] **Step 4: Run the tests**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Infrastructure/Secrets tests/Infrastructure.UnitTests/SecretReferenceTests.cs
+git commit -m "Add the secret reference grammar and resolution result"
+```
+
+---
+
+### Task 2: Per-scheme resolvers and composite dispatch
+
+**Files:**
+- Create: `src/Infrastructure/Secrets/ISecretReferenceResolver.cs`, `ISecretFileReader.cs`, `IEnvironmentVariableReader.cs`, `FileSystemSecretFileReader.cs`, `ProcessEnvironmentVariableReader.cs`, `SystemdCredentialSecretReferenceResolver.cs`, `FileSecretReferenceResolver.cs`, `EnvironmentVariableSecretReferenceResolver.cs`, `DevelopmentPlaintextSecretReferenceResolver.cs`, `CompositeSecretReferenceResolver.cs`
+- Test: `tests/Infrastructure.UnitTests/SecretReferenceResolverTests.cs`
+
+**Interfaces produced:**
+
+```csharp
+public interface ISecretReferenceResolver
+{
+    Task<SecretResolutionResult> ResolveAsync(string? reference, CancellationToken cancellationToken);
+}
+
+public interface ISecretSchemeResolver
+{
+    SecretReferenceScheme Scheme { get; }
+    Task<SecretResolutionResult> ResolveAsync(SecretReference reference, CancellationToken cancellationToken);
+}
+
+internal interface ISecretFileReader
+{
+    bool TryReadAllBytes(string path, out ReadOnlyMemory<byte> material);
+}
+
+internal interface IEnvironmentVariableReader
+{
+    string? GetValue(string name);
+}
+```
+
+`ISecretSchemeResolver` is `public` — unusually for this repository, which defaults to `internal` — because it is the extension point decision 2 promises. A provider adapter in another folder, another project, or a later change set implements it, and an `internal` contract would make that impossible without editing this file. The four adapters implementing it here stay `internal sealed`. The two reader ports stay `internal`: they exist for testability, not for extension, and `InternalsVisibleTo MailMcp.Infrastructure.UnitTests` already covers them.
+
+- [ ] **Step 1: Write the failing tests**
+
+`SecretReferenceResolverTests` uses hand-written in-memory fakes — a dictionary-backed `ISecretFileReader` and `IEnvironmentVariableReader` — never the real file system or environment block:
+
+```csharp
+[Fact] ResolveAsync_SystemdCredential_ReadsTheNameFromTheCredentialsDirectory
+[Fact] ResolveAsync_SystemdCredentialWithoutCredentialsDirectory_FailsWithCredentialsDirectoryUnavailable
+[Fact] ResolveAsync_SystemdCredentialNameContainingPathSeparator_FailsWithTargetMissing   // no escaping the directory
+[Fact] ResolveAsync_SystemdCredentialMaterialEndsWithNewline_TrimsTheTrailingNewline
+[Fact] ResolveAsync_File_ReadsTheProvisionedFile
+[Fact] ResolveAsync_FileMissing_FailsWithMaterialNotFound
+[Fact] ResolveAsync_FileEmpty_FailsWithMaterialEmpty
+[Fact] ResolveAsync_EnvironmentVariable_ReadsTheVariable
+[Fact] ResolveAsync_EnvironmentVariableUnset_FailsWithMaterialNotFound
+[Fact] ResolveAsync_PlaintextInDevelopment_ReturnsTheLiteral
+[Fact] ResolveAsync_PlaintextOutsideDevelopment_FailsWithPlaintextPermittedOnlyInDevelopment
+[Fact] ResolveAsync_UnregisteredScheme_FailsWithSchemeNotSupportedWithoutConsultingAnyReader
+[Fact] ResolveAsync_SchemeAdapterRegisteredOnlyByTheTest_ResolvesThroughTheSameDispatch
+[Fact] ResolveAsync_Cancelled_PropagatesTheCancellation
+[Theory] ResolveAsync_EveryFailure_ReturnsNoSecretMaterial
+```
+
+`ResolveAsync_SchemeAdapterRegisteredOnlyByTheTest_ResolvesThroughTheSameDispatch` is the extensibility proof the specification's definition of done requires: the test project declares an `ISecretSchemeResolver` for a scheme the production code has never heard of, registers it, and resolves a reference through it. If that test ever needs a production edit to pass, the extension point has regressed.
+
+The path-separator test encodes a real hazard: `systemd-credential:../../etc/shadow` must not become a traversal. The trailing-newline test encodes the other: `LoadCredential=` and Compose secrets both commonly carry a file that ends with a newline, and an untrimmed `\n` produces an authentication failure that looks like a wrong password.
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Expected: FAIL — the resolvers do not exist.
+
+- [ ] **Step 3: Implement**
+
+`SystemdCredentialSecretReferenceResolver` reads `CREDENTIALS_DIRECTORY` through `IEnvironmentVariableReader` — systemd documents that "the path to access them is derived from the environment variable `$CREDENTIALS_DIRECTORY`" and that access is restricted to the service's user — rejects a target containing `/`, `\`, or `..`, joins, and reads. `FileSecretReferenceResolver` reads the target directly, which is also the container path: Compose mounts secrets at `/run/secrets/<secret_name>`. Both read bytes and neither modifies them; the newline trim lives in `ResolvedSecret.Reveal()` so binary material is never touched, and both report `MaterialEmpty` when the material has zero length.
+
+`DevelopmentPlaintextSecretReferenceResolver(bool developmentEnvironment)` returns the target verbatim in Development and `PlaintextPermittedOnlyInDevelopment` otherwise, per decision 5.
+
+`CompositeSecretReferenceResolver` parses once and dispatches on the scheme through a dictionary built from the injected `ISecretSchemeResolver` set, so a scheme with no registered adapter fails as `SchemeNotSupported` rather than throwing. Its XML documentation states that no result and no diagnostic derived from it may carry the material.
+
+`FileSystemSecretFileReader` catches only `IOException` and `UnauthorizedAccessException` and maps them to `false`, so a permission error becomes `MaterialNotFound` rather than a startup crash with a path in the stack trace.
+
+- [ ] **Step 4: Run the tests**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Infrastructure/Secrets tests/Infrastructure.UnitTests/SecretReferenceResolverTests.cs
+git commit -m "Resolve secret references through per-scheme adapters"
+```
+
+---
+
+### Task 3: Account secrets replace the raw password
+
+**Files:**
+- Create: `src/Infrastructure/Mail/MailAccountSecretOptions.cs`, `src/Infrastructure/Mail/MailAccountSecrets.cs`
+- Modify: `src/Infrastructure/Mail/ImapAccountSettings.cs`
+- Test: `tests/Infrastructure.UnitTests/MailAccountSecretOptionsTests.cs`
+
+**Interfaces produced:**
+
+```csharp
+public sealed record MailAccountSecretConfigurationError(string PropertyName, SecretResolutionFailure Failure);
+
+public sealed class MailAccountSecretOptions
+{
+    public string PasswordReference { get; set; } = string.Empty;
+
+    public Task<IReadOnlyList<MailAccountSecretConfigurationError>> FindConfigurationErrorsAsync(
+        ISecretReferenceResolver resolver,
+        string? trustedCertificateAuthorityReference,
+        CancellationToken cancellationToken);
+
+    public Task<MailAccountSecrets> ResolveAsync(
+        ISecretReferenceResolver resolver,
+        string? trustedCertificateAuthorityReference,
+        CancellationToken cancellationToken);
+}
+
+public sealed record MailAccountSecrets(ResolvedSecret Password, X509Certificate2? TrustedCertificateAuthority);
+
+public sealed record ImapAccountSettings(
+    string AccountId,
+    string Host,
+    int Port,
+    string UserName,
+    ResolvedSecret Password,
+    X509Certificate2? TrustedCertificateAuthority);
+```
+
+The trust anchor reference is passed in rather than duplicated onto this type, because specification 01 already placed it on `MailAccountTransportSecurityOptions` and moving it now would churn a shipped configuration section for no gain.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+[Fact] FindConfigurationErrorsAsync_ResolvableReferences_ReportsNoError
+[Fact] FindConfigurationErrorsAsync_UnresolvablePasswordReference_ReportsTheFailureAgainstPasswordReference
+[Fact] FindConfigurationErrorsAsync_MissingPasswordReference_ReportsReferenceMissing
+[Fact] FindConfigurationErrorsAsync_UnresolvableTrustAnchorReference_ReportsTheFailureAgainstTheTrustAnchorSetting
+[Fact] FindConfigurationErrorsAsync_TrustAnchorMaterialIsNotACertificate_ReportsMaterialNotFound
+[Fact] FindConfigurationErrorsAsync_NoTrustAnchorConfigured_DoesNotConsultTheResolver
+[Fact] FindConfigurationErrorsAsync_EveryError_CarriesNoSecretMaterial
+[Fact] ResolveAsync_ResolvableReferences_ReturnsThePasswordAndTheParsedTrustAnchor
+[Fact] ResolveAsync_PemTrustAnchor_LoadsTheCertificateSubject
+```
+
+The PEM test builds its certificate in memory with `CertificateRequest` and `CreateSelfSigned`, then exports it with `ExportCertificatePem()` — no file system, no network.
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Expected: FAIL — `MailAccountSecretOptions` does not exist and `ImapAccountSettings.Password` is still a `string`.
+
+- [ ] **Step 3: Implement**
+
+`FindConfigurationErrorsAsync` resolves the password reference and, when a trust anchor reference is present, resolves and parses it, then discards both — decision 11's startup half. Trust anchor parsing uses `X509Certificate2.CreateFromPem` inside a `try`/`catch (CryptographicException)` that becomes a configuration error, so malformed material fails startup instead of failing the first TLS handshake hours later.
+
+`Resolve` performs the same work and returns the values, and throws `InvalidOperationException` if a reference that validated at startup no longer resolves — a fail-closed path, not an ordinary branch.
+
+`ImapAccountSettings` carries `ResolvedSecret` and the optional anchor. Its XML documentation gains a remark that the record's synthesized `ToString()` is safe only because `ResolvedSecret` redacts itself.
+
+- [ ] **Step 4: Run the tests**
+
+Expected: PASS for `Infrastructure.UnitTests`; the solution does not build until Task 6 updates `Host`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Infrastructure/Mail tests/Infrastructure.UnitTests/MailAccountSecretOptionsTests.cs
+git commit -m "Bind account secrets as references and resolve them in Infrastructure"
+```
+
+---
+
+### Task 4: Custom trust anchor in the certificate validation path
+
+**Files:**
+- Create: `src/Infrastructure/Mail/MailServerCertificateValidator.cs`
+- Modify: `src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs`
+- Test: `tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs`
+
+**Interfaces produced:**
+
+```csharp
+internal static class MailServerCertificateValidator
+{
+    internal static RemoteCertificateValidationCallback? CreateCallback(X509Certificate2? trustedCertificateAuthority);
+
+    internal static bool IsTrusted(
+        X509Certificate2? trustedCertificateAuthority,
+        X509Certificate? serverCertificate,
+        SslPolicyErrors sslPolicyErrors);
+}
+```
+
+`IMailKitImapClient` gains `RemoteCertificateValidationCallback? ServerCertificateValidationCallback { get; set; }`, forwarded by `MailKitImapClientAdapter` to `ImapClient.ServerCertificateValidationCallback`.
+
+- [ ] **Step 1: Write the failing tests**
+
+The fixture builds an in-memory CA and a leaf signed by it with `CertificateRequest`, so no file system, network, or real trust store is involved:
+
+```csharp
+[Fact] IsTrusted_NoPolicyErrors_TrustsWithoutConsultingTheAnchor
+[Fact] IsTrusted_ChainErrorsAndLeafChainsToTheConfiguredAnchor_Trusts
+[Fact] IsTrusted_ChainErrorsAndLeafChainsToADifferentAuthority_Rejects
+[Fact] IsTrusted_ChainErrorsWithoutAConfiguredAnchor_Rejects
+[Fact] IsTrusted_NameMismatch_RejectsEvenWhenTheAnchorMatches
+[Fact] IsTrusted_CertificateNotAvailable_Rejects
+[Fact] CreateCallback_NoAnchorConfigured_ReturnsNullSoTheDefaultValidationApplies
+```
+
+`IsTrusted_NameMismatch_RejectsEvenWhenTheAnchorMatches` is the test that stops this task from becoming a certificate-validation bypass.
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+Expected: FAIL — the validator does not exist.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+internal static bool IsTrusted(
+    X509Certificate2? trustedCertificateAuthority,
+    X509Certificate? serverCertificate,
+    SslPolicyErrors sslPolicyErrors)
+{
+    if (sslPolicyErrors == SslPolicyErrors.None)
+    {
+        return true;
+    }
+
+    // Only an untrusted chain is reconsidered. A missing certificate proves nothing, and a name mismatch means the
+    // certificate belongs to a different host, which a private trust anchor does not and must not excuse.
+    if (trustedCertificateAuthority is null || sslPolicyErrors != SslPolicyErrors.RemoteCertificateChainErrors)
+    {
+        return false;
+    }
+
+    if (serverCertificate is not X509Certificate2 presentedCertificate)
+    {
+        return false;
+    }
+
+    using var chain = new X509Chain();
+    chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+    chain.ChainPolicy.CustomTrustStore.Add(trustedCertificateAuthority);
+    chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+    chain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
+
+    return chain.Build(presentedCertificate);
+}
+```
+
+`CustomTrustStore` is documented as respected only when `TrustMode` is `CustomRootTrust`, so both must be set together; setting the collection alone would silently keep the system trust store in effect. `VerificationFlags` is pinned to `NoFlag` so no future edit can relax expiry or basic-constraint checking. `RevocationMode` is `NoCheck` because a private authority typically publishes no reachable CRL or OCSP responder, and a revocation lookup that cannot complete would otherwise reject a correctly provisioned server — this is a deliberate, documented trade-off confined to the custom-anchor path, and the system trust path keeps whatever the platform default applies.
+
+The session factory installs the callback before connecting and reveals the password once:
+
+```csharp
+client.ServerCertificateValidationCallback =
+    MailServerCertificateValidator.CreateCallback(settings.TrustedCertificateAuthority);
+
+await client.ConnectAsync(...);
+...
+await client.AuthenticateAsync(settings.UserName, settings.Password.Reveal(), cancellationToken);
+```
+
+- [ ] **Step 4: Run the tests**
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Infrastructure/Mail tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs
+git commit -m "Validate a private mail server against its configured trust anchor"
+```
+
+---
+
+### Task 5: Database password reference
+
+**Files:**
+- Modify: `src/Host/Configuration/PersistenceOptions.cs`, `src/Infrastructure/ServiceCollectionExtensions.cs`
+
+- [ ] **Step 1: Add the optional reference**
+
+`PersistenceOptions` gains `string? PasswordReference`. When it is null the connection string is used unchanged, which keeps trust-authentication and Aspire-provided connection strings working untouched.
+
+- [ ] **Step 2: Apply it when composing the connection string**
+
+`AddMailMcpInfrastructure` gains an optional resolved password parameter and applies it through `NpgsqlConnectionStringBuilder`:
+
+```csharp
+var connectionStringBuilder = new NpgsqlConnectionStringBuilder(connectionString);
+if (databasePassword is { } password)
+{
+    connectionStringBuilder.Password = password.Reveal();
+}
+```
+
+The composed string is never logged and never returned. An unresolvable reference fails startup through the same validator as the mail secrets.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Host/Configuration/PersistenceOptions.cs src/Infrastructure/ServiceCollectionExtensions.cs
+git commit -m "Resolve the database password from a secret reference"
+```
+
+---
+
+### Task 6: Host binding, wiring, and fail-fast validation
+
+**Files:**
+- Modify: `src/Host/Configuration/MailSynchronizationOptions.cs`, `src/Host/Program.cs`, `src/Host/appsettings.json`, `src/Host/appsettings.Development.json`
+
+New account configuration shape:
+
+```jsonc
+{
+  "AccountId": "primary",
+  "Host": "imap.example.test",
+  "Port": 993,
+  "UserName": "mailmcp@example.test",
+  "Secrets": { "PasswordReference": "systemd-credential:imap-primary-password" },
+  "TransportSecurity": { "ConnectionSecurity": "TlsOnConnect" },
+  "Folders": [ "INBOX" ]
+}
+```
+
+- [ ] **Step 1: Replace the raw password**
+
+`MailSynchronizationAccountOptions` drops `Password` and gains `MailAccountSecretOptions Secrets { get; set; } = new();`, mirroring the `TransportSecurity` nesting specification 01 established. The `Password is required` validation rule becomes a reference rule reported by `MailAccountSecretOptions`.
+
+- [ ] **Step 2: Resolve at the settings boundary**
+
+`IImapAccountSettingsProvider.GetSettings` becomes `GetSettingsAsync(string accountId, CancellationToken cancellationToken)` per decision 4, and `MailSynchronizationOptions` takes `ISecretReferenceResolver` to satisfy it. `MailKitImapMailboxSessionFactory.OpenReadOnlyAsync` is already asynchronous and already holds the token, so the call site changes by one `await`.
+
+- [ ] **Step 3: Fail fast on an unresolvable reference**
+
+Add `MailSecretReferenceStartupValidator : IHostedLifecycleService` in `src/Host/Hosting/`, injected with the options and the resolver. `StartingAsync` calls `MailAccountSecretOptions.FindConfigurationErrorsAsync` for every configured account plus the database reference, and throws `OptionsValidationException` listing every failure at once:
+
+```
+Account 'primary': the PasswordReference could not be resolved [MaterialNotFound].
+```
+
+The account, the setting, and the failure identity — no path, no variable name, no material. Reporting every failure together matters when an operator provisions five accounts and mistypes two names; one-at-a-time discovery costs five restarts.
+
+`StartingAsync` is documented to run before any hosted service's `StartAsync`, so the synchronization worker never starts against an unresolvable secret. The remaining four lifecycle members are empty. The type stays a thin translation because `Host` is excluded from coverage; every rule it reports comes from Task 3.
+
+- [ ] **Step 4: Wire the resolver**
+
+```csharp
+builder.Services.AddMailMcpSecretResolution(builder.Environment.IsDevelopment());
+builder.Services.AddHostedService<MailSecretReferenceStartupValidator>();
+```
+
+`AddMailMcpSecretResolution` is a focused extension owned by `Infrastructure`, per the `src/AGENTS.md` rule that registration lives with the implementation. It registers the two reader ports, the four scheme adapters, and the composite. A future provider adapter adds its own `AddMailMcpAzureKeyVaultSecrets(...)` extension next to this call and needs no edit here — the composite resolves whatever `ISecretSchemeResolver` registrations it is handed, which is decision 2 made concrete in the container.
+
+The validator is registered before the synchronization worker so hosted-service ordering reinforces `StartingAsync` ordering rather than depending on it alone.
+
+- [ ] **Step 5: Update the shipped configuration examples**
+
+`appsettings.json` keeps an empty account list and documents the reference shape by example only. `appsettings.Development.json` shows `plaintext:` with a comment that it is Development-only. No real credential appears in either file.
+
+- [ ] **Step 6: Verify the removal is complete**
+
+```bash
+dotnet build MailMcp.slnx
+grep -rn "\"Password\"" src/ --include=*.cs --include=*.json
+```
+
+Expected: build succeeds; no options type binds a raw password — the specification's first definition-of-done item.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Host
+git commit -m "Bind mail and database secrets as references and fail startup when one is unresolvable"
+```
+
+---
+
+### Task 7: Architecture test for the boundary
+
+**Files:**
+- Create: `tests/Infrastructure.UnitTests/SecretBoundaryArchitectureTests.cs`
+
+- [ ] **Step 1: Write the test**
+
+```csharp
+[Fact]
+public void SecretResolutionTypes_DomainAndApplicationAssemblies_AreNotReachable()
+{
+    // Arrange
+    var secretAssemblyName = typeof(ISecretReferenceResolver).Assembly.GetName().Name;
+    var boundaryAssemblies = new[] { typeof(MailAccountId).Assembly, typeof(MailboxSynchronizer).Assembly };
+
+    // Act
+    var referencedNames = boundaryAssemblies
+        .SelectMany(assembly => assembly.GetReferencedAssemblies())
+        .Select(reference => reference.Name);
+
+    // Assert
+    Assert.DoesNotContain(secretAssemblyName, referencedNames);
+}
+```
+
+No architecture-test package is added: introducing one would require a license review and owner approval for a rule that two lines of reflection already prove. The test lives in `Infrastructure.UnitTests` because that is the only unit-test project referencing all three assemblies.
+
+- [ ] **Step 2: Run and commit**
+
+```bash
+dotnet test --project tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj
+git add tests/Infrastructure.UnitTests/SecretBoundaryArchitectureTests.cs
+git commit -m "Assert secret resolution stays out of Domain and Application"
+```
+
+---
+
+### Task 8: Dynamic reload of references and material
+
+**Files:**
+- Modify: `src/Host/Configuration/MailSynchronizationOptions.cs`, `src/Host/Program.cs`, `src/Infrastructure/Mail/MailAccountSecretOptions.cs`
+- Create: `src/Host/Configuration/MailSecretSnapshotPublisher.cs`
+- Test: `tests/Infrastructure.UnitTests/MailAccountSecretReloadTests.cs`
+
+Decision 12 makes this a blocking prerequisite: **do not start this task until ADR 0002 has been amended with owner approval.** The ADR classifies credentials and trust anchors as restart-required, and this task deliberately reclassifies them as reloadable for new operations.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+[Fact] ReloadAsync_ReferenceChangedToAResolvableTarget_PublishesTheNewSecrets
+[Fact] ReloadAsync_CandidateSnapshotHasAnUnresolvableReference_KeepsThePreviousSecrets
+[Fact] ReloadAsync_RejectedSnapshot_LogsTheAccountAndFailureWithoutMaterial
+[Fact] ResolveAsync_MaterialRotatedBehindAnUnchangedReference_ReturnsTheRotatedValue
+[Fact] ResolveAsync_MaterialRotatedMidOperation_DoesNotAffectTheOperationInFlight
+```
+
+The last two are the pair that distinguishes the two reload halves, and the last one is what keeps decision 11's "not during running operations" honest.
+
+- [ ] **Step 2: Bind for reload**
+
+`Host` switches the mail options consumer from `IOptions<MailSynchronizationOptions>` to `IOptionsMonitor<MailSynchronizationOptions>`. Note that `IOptions<T>` is a singleton captured once, so leaving it in place would silently defeat the reference half of this task.
+
+- [ ] **Step 3: Validate the candidate before publishing it**
+
+`MailSecretSnapshotPublisher` subscribes to `OnChange`, resolves every reference in the candidate snapshot, and publishes an immutable snapshot only when all of them resolve. On failure it retains the previous snapshot and logs the account, the setting, and the `SecretResolutionFailure` — never a path, a variable name, or material. This is the last-known-good behavior ADR 0002 requires of any reloadable group.
+
+Reload validation must not crash the process: ADR 0002 is explicit that a rejected reload leaves the previous valid settings active, unlike a startup failure which is fatal.
+
+- [ ] **Step 4: Resolve material per operation**
+
+No change is needed for the material half — decision 11 already resolves per use, which is what makes rotation behind an unchanged reference work. The test in Step 1 is what proves it, and it exists to catch a future "optimization" that caches the resolved value on the options instance.
+
+- [ ] **Step 5: Run the tests and commit**
+
+```bash
+dotnet test --project tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj
+git add src/Host src/Infrastructure tests/Infrastructure.UnitTests/MailAccountSecretReloadTests.cs
+git commit -m "Reload secret references and material without restarting the host"
+```
+
+---
+
+### Task 9: Documentation and full verification
+
+**Files:**
+- Create: `docs/operations/secret-provisioning.md`
+- Modify: `docs/features/imap-synchronization.md`, `docs/operations/local-development.md`
+
+- [ ] **Step 1: Write the provisioning page**
+
+`docs/operations/secret-provisioning.md` documents the reference grammar, the four schemes, and — because MailMcp is deployed several ways — a section per deployment shape: the native systemd path with `LoadCredential=`, `LoadCredentialEncrypted=`, `systemd-creds`, and `$CREDENTIALS_DIRECTORY`; the container path with Compose `secrets:` mounted at `/run/secrets/<name>`; and the Kubernetes path with a Secret mounted as a read-only tmpfs volume — the last two both addressed as `file:`, with an explicit note that no container- or Kubernetes-specific scheme exists or is needed. It states the trailing-newline trimming and that it applies to text secrets only, the accepted certificate encodings, the `plaintext:` Development gate, the recommendation against `env:` in production, and the ADR 0002 classification from decision 12.
+
+A closing section states what a future managed-store provider would add — one `ISecretSchemeResolver`, one registration extension, its own timeouts and caching, platform identity rather than a MailMcp-held credential, and a `LICENSES.md` entry — so an operator reading the page can tell which schemes exist today from which are anticipated. It documents anticipated extension, not unimplemented behavior, and says so plainly; `docs/AGENTS.md` requires documentation to describe verified implemented behavior, and this section is explicitly labelled as the extension contract rather than as a feature.
+
+- [ ] **Step 2: Update the feature and development pages**
+
+`docs/features/imap-synchronization.md` gets the new account JSON, the resolution and fail-fast behavior, the trust-anchor behavior from Task 4 including the revocation trade-off, and loses the two now-resolved pending items — deployment-specific secret binding, and trust anchor loading. `docs/operations/local-development.md` gains the Development workflow: `plaintext:` in `appsettings.Development.json` or user secrets, and why neither is a production secret store.
+
+- [ ] **Step 3: Run the documentation and licensing gate**
+
+Run `$check-docs-licenses`. No dependency changed, so the licensing verdict is `n/a`; the documentation verdict must be satisfied by Steps 1 and 2.
+
+- [ ] **Step 4: Run the full verification gate**
+
+```bash
+git add -A
+bash scripts/verify-full.sh
+dotnet msbuild .config/CodeCoverage.proj -t:Collect
+```
+
+Expected: build, format, workflow contract, complete unit-test suite, and the 85% whole-scope coverage gate all pass.
+
+- [ ] **Step 5: Review the change**
+
+Run `$review-change`. Check specifically: no secret material in any message, log, or exception; no `Application` or `Domain` reference to a resolver, reference, or scheme; no certificate-validation opt-out and no callback returning `true` on an unexamined chain; no cached secret material outliving its use.
+
+- [ ] **Step 6: Finish**
+
+Run `$finish-change`: commit, push, and open a draft pull request whose body contains `Closes #36`. Patch the body through `gh api repos/Krzysztof318/MailMcp/pulls/<number> -X PATCH -f body="$(cat body.md)"` because `gh pr edit` fails against this repository with a Projects-classic GraphQL error.
+
+---
+
+## Self-review
+
+**Spec coverage**
+
+| Specification requirement | Task |
+| --- | --- |
+| `systemd-credential:`, `file:`, `env:`, `plaintext:` schemes | 1, 2 |
+| `plaintext:` rejected outside Development | 2 |
+| Resolution returns a result rather than throwing | 1, 2 |
+| Composite dispatch over per-scheme adapters | 2 |
+| Unknown-scheme and missing-reference failures | 1, 2 |
+| A new scheme is one adapter registration, no core edit | decisions 2 and 14, proved by the Task 2 extensibility test |
+| Contract asynchronous and cancellable for a network provider | decision 4, Tasks 1–3, 6 |
+| Provider concerns confined to the provider's adapter | decisions 14 and 15 |
+| Resolver contract and adapters live in `Infrastructure` | 1–4 |
+| `Host` invokes resolution once before hosted services start | 6 |
+| No options type binds a raw password | 3, 5, 6 (verified by `grep` in Task 6 Step 6) |
+| Failure message names account, logical secret, and scheme only | 3, 6 |
+| Secrets exposed through an accessor, not an ordinary property | 1, 3 |
+| Rotated material observed without restart | decision 11, Tasks 3 and 9 |
+| Every secret-bearing setting is a `*Reference` string in JSON | 3, 5, 6 |
+| Bytes-first resolution; PKCS#12 and DER representable | 1, 2 |
+| Text view decodes UTF-8 and trims one trailing newline | 1 |
+| Rotated material observed by the next operation, no restart | 8 |
+| Reload with an unresolvable reference keeps previous secrets | 8 |
+| Trust anchor loaded, validated as usable, and installed in the validation path | 3, 4 |
+| Malformed trust anchor fails startup | 3 |
+| Private server connects with validation fully enabled | 4 |
+| No secret-resolution contract reachable from `Application` or `Domain` | 7 |
+| Scheme adapters tested against in-memory file/credential abstractions | 2 |
+| Failure results carry no secret material | 1, 2, 3 |
+| `docs/operations/local-development.md` Development workflow | 8 |
+| `docs/operations/` page for the systemd credential deployment path | 8 |
+| 85% coverage gate | 8 |
+
+**Deliberately out of scope:** Data Protection key-ring provisioning, encrypted secret storage in PostgreSQL, secret rotation without restart, and MCP client certificates (stage 9).
+
+Managed secret stores — Kubernetes-native APIs, Azure Key Vault, HashiCorp Vault, AWS Secrets Manager — are out of scope as implementations but not as constraints. Decisions 2, 4, 14, and 15 exist for them, and the Task 2 extensibility test is what keeps the promise honest. Note that Kubernetes and container deployments need nothing added at all: their secrets are files, so `file:` already serves them today.
+
+**Flagged for the owner**
+
+- **Blocking:** ADR 0002 must be amended before Task 8 begins (decision 12). The dynamic-reload requirement contradicts the ADR's current restart-required classification for credentials and trust anchors, and `docs/AGENTS.md` forbids amending an ADR without explicit owner approval. Tasks 1–7 and 9 are unaffected.
+- **Blocking:** the specification is now estimated at ~1300 lines against `specs/README.md`'s ~1000-line ceiling, and `specs/02` records a proposed 02a/02b split. Whether to split — and therefore whether this plan stays one plan — is the owner's call, because renumbering touches the roadmap board and the dependency chain from specification 03 onward.
+- The specification originally estimated ~500 lines. Loading and validating the trust anchor (Task 4), the database password reference (Task 5), and the asynchronous contract that ripples through `IImapAccountSettingsProvider` and startup validation (decisions 4 and 5) realistically bring this to roughly 850 lines including tests and documentation. Nothing is proposed for deferral; the estimate is what is optimistic. Issue #36's `Size` line should be updated when this plan is accepted.
+- Decision 10 reads "permitted for non-production automation" as guidance rather than an enforced environment gate for `env:`. If it should be enforced, say so and it moves onto the same Development flag as `plaintext:`.
+- Decision 4 makes the contract asynchronous before any asynchronous provider exists. The cost is real and visible: `GetSettings` becomes `GetSettingsAsync`, and startup validation moves out of `IValidateOptions` into `IHostedLifecycleService`. It is proposed because retrofitting it alongside a first Key Vault adapter would touch the same files while also introducing SDK, identity, and licensing questions, and doing one of those at a time is cheaper. If managed stores are further off than this assumes, the synchronous contract is defensible and this is the decision to revisit.

--- a/specs/01-mail-transport-security-policy.md
+++ b/specs/01-mail-transport-security-policy.md
@@ -19,7 +19,7 @@ Replace the current boolean `UseSslOnConnect` switch with the connection-securit
 
 `Application` extends the mailbox session port inputs with the resolved connection policy. `Infrastructure` maps the domain policy onto MailKit's `SecureSocketOptions` and its authentication mechanism set, and removes mechanisms the policy does not permit from the client's advertised mechanism collection before authenticating. Certificate validation stays enabled unconditionally; there is no configuration path that disables it.
 
-Private servers are supported through explicit trusted certificate authority configuration. This specification defines the configuration shape — the policy carries a reference to trust anchor material — and validates that the reference is present when required. Loading that material and installing it into the certificate validation path is assigned to specification 02, which owns deployment-provisioned material and builds the reference-resolution mechanism it arrives through.
+Private servers are supported through explicit trusted certificate authority configuration. This specification defines the configuration shape — the policy carries a reference to trust anchor material — and validates that the reference is present when required. Loading that material and installing it into the certificate validation path is assigned to specification 02b, which builds on the reference-resolution mechanism specification 02a delivers. Specification 02a also renames this setting from `TrustedCertificateAuthorityReference` to `TrustedCertificateAuthority` and changes it from a bare string to a secret block.
 
 `Host` binds the new options, validates them with `ValidateOnStart`, and fails startup with a specific message naming the offending account when a policy is unsafe.
 
@@ -33,7 +33,7 @@ The rejection rule is enforced in the domain object that owns it and again at op
 
 ## Out of scope
 
-Secret reference resolution and trusted certificate authority loading, both of which specification 02 owns; SMTP transport policy; and OAuth-based mailbox authentication mechanisms. GSSAPI/Kerberos remains unsupported per draft section 7.2.
+Secret reference resolution, which specification 02a owns, and trusted certificate authority loading, which specification 02b owns; SMTP transport policy; and OAuth-based mailbox authentication mechanisms. GSSAPI/Kerberos remains unsupported per draft section 7.2.
 
 ## Definition of done
 

--- a/specs/02-secret-reference-resolution.md
+++ b/specs/02-secret-reference-resolution.md
@@ -3,7 +3,7 @@
 **Roadmap group:** A — configuration, transport security, resilience
 **Draft delivery stage:** 2
 **Depends on:** 01
-**Estimated change size:** ~1450 lines including tests and documentation — above the ~1000-line ceiling `specs/README.md` sets per specification, so this specification is a candidate for splitting; see "Delivery size" below
+**Estimated change size:** ~1600 lines including tests and documentation — above the ~1000-line ceiling `specs/README.md` sets per specification, so this specification is a candidate for splitting; see "Delivery size" below
 
 ## Goal
 
@@ -20,7 +20,7 @@ Configuration values that carry secrets become secret references rather than sec
 - `systemd-credential:<name>` reads from the runtime credentials directory that systemd exposes to the service.
 - `file:<path>` reads a deployment-provisioned protected file.
 - `env:<variable>` reads an environment variable, permitted for non-production automation.
-- `plaintext:<value>` exists only for local development and is rejected outside the Development environment.
+- `plaintext:<value>` names a literal value inline. It is not restricted to Development; see "Inline values and pre-resolving configuration providers" for the mode that governs it.
 
 The scheme set is open by design; see "Extensibility to external secret providers" below. The grammar is fixed, the set of schemes that satisfy it is not.
 
@@ -47,6 +47,27 @@ Configuration carries the reference and nothing else. Every secret-bearing setti
 ```
 
 A setting that names a reference is inert on its own: nothing in the file discloses a secret, and a file leaked from a backup or a repository yields only credential names and paths.
+
+## Inline values and pre-resolving configuration providers
+
+A secret-bearing setting does not always carry a reference. Two legitimate cases require the value itself to be accepted, and neither is a mistake to be prevented:
+
+- **The operator chooses to write the secret into configuration.** It is less safe and the documentation says so, but it is the operator's deployment and their call. Refusing it outright pushes people toward worse workarounds.
+- **A configuration provider already resolved the secret before binding.** Azure App Configuration with Key Vault references is the concrete example: App Configuration stores a URI rather than a value, but "because the client provider recognizes the key as a Key Vault reference, it uses Key Vault to retrieve its value", and application code then "access[es] the values of Key Vault references the same way [it] access[es] the values of regular App Configuration keys". By the time MailMcp binds the setting, the value *is* the secret, and it carries no scheme prefix that MailMcp could recognize. A resolver that insists on a scheme would break this integration outright.
+
+Interpretation of a secret-bearing setting is therefore an explicit deployment choice, not an inference:
+
+- `ReferenceOnly` — the value must be `<scheme>:<target>`; anything else fails startup. This is the default, and it is what keeps a mistyped `fil:/run/secrets/imap` a startup failure instead of a password.
+- `ReferenceOrInline` — a recognized scheme resolves through its adapter; any other value is taken as the secret itself. For an operator who wants some secrets inline, and for mixed deployments.
+- `InlineOnly` — every value is already the secret and no scheme is parsed at all. This is the mode for Azure App Configuration with Key Vault references, and for any future provider that pre-resolves. It removes the ambiguity entirely rather than guessing.
+
+`plaintext:<value>` remains available in the two reference-accepting modes as the unambiguous spelling for a literal that would otherwise look like a scheme — a password whose value genuinely begins with `file:`. In `InlineOnly` no such escape hatch is needed, because nothing is parsed.
+
+Modes make the earlier `plaintext:`-outside-Development rule unnecessary as a hard gate. `plaintext:` and inline values are permitted in any environment when the mode allows them; what protects a production deployment is that `ReferenceOnly` is the default and any other mode is a deliberate, visible setting. Startup logs which mode is active and, when it is not `ReferenceOnly`, which settings resolved to an inline value — naming the settings, never the values — so an unintended inline secret is discoverable rather than silent.
+
+One consequence must be stated rather than hidden: an inline value arrives from the configuration system as a `string`, and a `string` cannot be erased from memory (see "Secret material in memory"). The inline modes therefore forfeit part of the in-memory protection that reference resolution provides. That is a real cost of the convenience, it is documented for the operator, and it is another reason `ReferenceOnly` is the default.
+
+Note that this also settles where a pre-resolving provider belongs architecturally. Azure App Configuration is **not** a scheme adapter: its Key Vault mapping happens below MailMcp in the configuration pipeline, so MailMcp needs no code for it beyond accepting the bound value. A provider MailMcp queries itself — direct Key Vault access, HashiCorp Vault — is a scheme adapter. The two integration shapes are different and should not be conflated.
 
 ## Secret material kinds
 
@@ -117,11 +138,11 @@ Two exposures are accepted and must be documented rather than hidden. Some frame
 
 ## Safety and privacy
 
-A resolution failure message names the account identifier, the logical secret name, and the scheme, and never the reference target path, the environment variable value, or any part of the resolved secret. Resolved secrets are excluded from structured logging by construction: the options type exposes them through a dedicated accessor rather than an ordinary public property, so a future serializer or diagnostic dump cannot pick them up incidentally. `plaintext:` outside Development is a startup failure, not a warning.
+A resolution failure message names the account identifier, the logical secret name, and the scheme, and never the reference target path, the environment variable value, or any part of the resolved secret. Resolved secrets are excluded from structured logging by construction: the options type exposes them through a dedicated accessor rather than an ordinary public property, so a future serializer or diagnostic dump cannot pick them up incidentally. An inline or `plaintext:` value outside the default `ReferenceOnly` mode is logged at startup by setting name so it cannot pass unnoticed.
 
 ## Testing
 
-`Infrastructure.UnitTests` cover each scheme adapter against an in-memory abstraction over the credential directory and file system, since unit tests must not touch the real file system. Tests assert the unknown-scheme failure, the missing-reference failure, the Development-only `plaintext:` rule, the composite dispatch, and that failure results carry no secret material. A test registers a scheme adapter that exists only in the test project and asserts it resolves through the same dispatch, which is what proves a future provider is an adapter rather than a refactor. Material-kind tests cover the UTF-8 text view with its newline trim, binary material surviving resolution byte-for-byte, and a PEM and a DER certificate both loading. Memory-hygiene tests cover a disposed secret no longer yielding its material, disposal being idempotent, and no accessor returning a `string` except the documented framework-boundary one. Reload tests cover a rotated reference being adopted, a candidate snapshot with an unresolvable reference being rejected while the previous secrets stay active, and rotated material behind an unchanged reference being observed by the next operation but not mid-operation. Trust-anchor tests cover a valid certificate being installed into the validation path, a malformed one failing startup, and the absence of any configuration path that disables validation. An architecture test asserts that no secret-resolution type is reachable from `Application` or `Domain`.
+`Infrastructure.UnitTests` cover each scheme adapter against an in-memory abstraction over the credential directory and file system, since unit tests must not touch the real file system. Tests assert the unknown-scheme failure, the missing-reference failure, each of the three interpretation modes including a bare value failing under `ReferenceOnly` and resolving under `ReferenceOrInline`, an unparsed value under `InlineOnly`, the composite dispatch, and that failure results carry no secret material. A test registers a scheme adapter that exists only in the test project and asserts it resolves through the same dispatch, which is what proves a future provider is an adapter rather than a refactor. Material-kind tests cover the UTF-8 text view with its newline trim, binary material surviving resolution byte-for-byte, and a PEM and a DER certificate both loading. Memory-hygiene tests cover a disposed secret no longer yielding its material, disposal being idempotent, and no accessor returning a `string` except the documented framework-boundary one. Reload tests cover a rotated reference being adopted, a candidate snapshot with an unresolvable reference being rejected while the previous secrets stay active, and rotated material behind an unchanged reference being observed by the next operation but not mid-operation. Trust-anchor tests cover a valid certificate being installed into the validation path, a malformed one failing startup, and the absence of any configuration path that disables validation. An architecture test asserts that no secret-resolution type is reachable from `Application` or `Domain`.
 
 ## Delivery size
 
@@ -145,7 +166,8 @@ Adapters for external managed secret stores — Kubernetes, Azure Key Vault, Has
 - No options type in the repository exposes a raw password bound directly from configuration.
 - A missing or malformed reference fails startup with a message that identifies the account without disclosing the secret.
 - No secret-resolution contract is reachable from `Application` or `Domain`.
-- Every secret-bearing setting in `appsettings.json` is a `*Reference` string; no committed configuration file contains a secret value.
+- Under the default `ReferenceOnly` mode every secret-bearing setting is a `*Reference` string and a bare value fails startup; the inline modes are reachable only by an explicit, logged configuration choice.
+- A configuration provider that pre-resolves secrets, such as Azure App Configuration with Key Vault references, works without a scheme adapter and without code changes.
 - Resolution yields bytes, so a PKCS#12 bundle or DER certificate is representable without encoding damage, and text secrets are decoded and newline-trimmed only in the text view.
 - A new scheme can be added by registering one adapter, without editing the dispatch, an existing adapter, or any consumer.
 - The resolution contract is asynchronous and cancellable, so a network-backed provider needs no breaking change.

--- a/specs/02-secret-reference-resolution.md
+++ b/specs/02-secret-reference-resolution.md
@@ -3,7 +3,7 @@
 **Roadmap group:** A — configuration, transport security, resilience
 **Draft delivery stage:** 2
 **Depends on:** 01
-**Estimated change size:** ~1600 lines including tests and documentation — above the ~1000-line ceiling `specs/README.md` sets per specification, so this specification is a candidate for splitting; see "Delivery size" below
+**Estimated change size:** ~1700 lines including tests and documentation — above the ~1000-line ceiling `specs/README.md` sets per specification, so this specification is a candidate for splitting; see "Delivery size" below
 
 ## Goal
 
@@ -12,6 +12,8 @@ Implement the secret handling model from draft section 7.3 so that no mailbox pa
 ## Current state
 
 `MailSynchronizationAccountOptions` holds a plain `Password` string bound directly from configuration. The default `appsettings.json` ships an empty account list, so nothing is leaked today, but the shape invites operators to commit credentials.
+
+Specification 01 shipped `MailAccountTransportSecurityOptions.TrustedCertificateAuthorityReference` as a nullable string, already documented as carrying a reference rather than certificate material. It keeps its key name here but changes shape from a string to the secret block defined below, so an operator who configured it edits one line. This is a deliberate break taken now, while the setting has one consumer and no shipped release depends on it; deferring it would mean either two spellings of a secret setting or the same break later against real deployments. `MailTransportSecurityPolicy` in `Domain` continues to receive a nullable string and is unaffected — the block is a configuration-adapter shape and does not cross the boundary.
 
 ## Approved scope
 
@@ -24,7 +26,7 @@ Configuration values that carry secrets become secret references rather than sec
 
 The scheme set is open by design; see "Extensibility to external secret providers" below. The grammar is fixed, the set of schemes that satisfy it is not.
 
-Configuration carries the reference and nothing else. Every secret-bearing setting is a `*Reference` property whose value the host resolves at startup, so the shape an operator commits to Git is:
+Configuration carries the reference and nothing else. Every secret-bearing setting is a JSON *object* whose `SecretReference` property carries the reference the host resolves, never a bare string:
 
 ```json
 {
@@ -34,19 +36,44 @@ Configuration carries the reference and nothing else. Every secret-bearing setti
         "AccountId": "primary",
         "Host": "imap.example.test",
         "UserName": "mailmcp@example.test",
-        "Secrets": { "PasswordReference": "systemd-credential:imap-primary-password" },
+        "Secrets": {
+          "Password": { "SecretReference": "systemd-credential:imap-primary-password" }
+        },
         "TransportSecurity": {
           "CertificateTrust": "AdditionalTrustedAuthority",
-          "TrustedCertificateAuthorityReference": "file:/run/secrets/private-ca.pem"
+          "TrustedCertificateAuthorityReference": { "SecretReference": "file:/run/secrets/private-ca.pem" }
         }
       }
     ]
   },
-  "Persistence": { "PasswordReference": "file:/run/secrets/postgres-password" }
+  "Persistence": {
+    "Password": { "SecretReference": "file:/run/secrets/postgres-password" }
+  }
 }
 ```
 
 A setting that names a reference is inert on its own: nothing in the file discloses a secret, and a file leaked from a backup or a repository yields only credential names and paths.
+
+## The secret block
+
+Every secret-bearing setting uses the same object shape, and the shape is uniform whether the secret is a password, a trust anchor, or a key. Two reasons make the object the right unit rather than a bare string.
+
+**It has room to grow without a breaking configuration change.** A secret is not always one opaque value. A PKCS#12 bundle carries its own password, which is a second reference; a certificate may need an explicit format hint when the extension lies about its encoding; a future managed-store reference may need a version pin. Each of those is a sibling property inside a block that already exists:
+
+```json
+"ClientCertificate": {
+  "SecretReference": "file:/run/secrets/client.pfx",
+  "PasswordSecretReference": "systemd-credential:client-certificate-password"
+}
+```
+
+Had the setting shipped as a bare string, adding the bundle password would change the setting's JSON type from string to object, which breaks every deployment that already configured it. Only the first such setting is free; the block makes all of them free. Nothing beyond `SecretReference` is defined by this specification — the point is that adding one later costs nothing.
+
+**The block's type is what marks a setting as secret-bearing.** A secret block binds to a dedicated options type rather than to `string`, so a setting is secret-bearing because of what it *is*, not because someone remembered to annotate it. A marker attribute can be omitted on a newly added property and nothing would notice; a type cannot, because the property would not bind. Startup validation therefore discovers secret-bearing settings by walking the bound options graph for that type, and every rule below applies to every such setting automatically, including settings added after this specification ships.
+
+This is what makes the `ReferenceOnly` guarantee complete rather than per-setting. Under the default mode a secret block whose `SecretReference` is not a well-formed `<scheme>:<target>` fails startup, naming the configuration path and the failure identity. A value that is merely text — a password pasted where a reference belongs, or a mistyped `fil:/run/secrets/imap` — is a startup failure, never a secret that resolved by accident. There is no path by which an unmarked setting quietly skips the check, because there is no unmarked secret-bearing setting.
+
+A consequence worth stating: the object shape survives configuration providers that flatten hierarchy. Azure App Configuration, environment variables, and command-line arguments address the same setting as `MailSynchronization:Accounts:0:Secrets:Password:SecretReference`, so the block costs a pre-resolving provider nothing.
 
 ## Inline values and pre-resolving configuration providers
 
@@ -95,7 +122,7 @@ Secrets reload without a process restart, on the same terms as the configuration
 
 Two independent things can change, and both are covered:
 
-- **The reference changes.** A configuration reload delivers a new `*Reference` value. The candidate snapshot is validated by resolving every reference in it before it is published; a snapshot containing an unresolvable reference is rejected and the last known good snapshot stays active, exactly as ADR 0002 requires for reloadable groups. A rejected reload is logged with the account, the setting, and the failure identity, never with material.
+- **The reference changes.** A configuration reload delivers a new `SecretReference` inside one of the secret blocks. The candidate snapshot is validated by resolving every reference in it before it is published; a snapshot containing an unresolvable reference is rejected and the last known good snapshot stays active, exactly as ADR 0002 requires for reloadable groups. A rejected reload is logged with the account, the setting, and the failure identity, never with material.
 - **The material behind an unchanged reference changes.** Rotating the credential file, the systemd credential, or the vault entry leaves configuration untouched, so no configuration reload fires. Resolution therefore happens per use rather than once at startup, and the next operation that needs the secret observes the rotated value. A network-backed provider that cannot afford per-use retrieval caches inside its own adapter with its own expiry, which is why caching policy is an adapter concern rather than a contract concern.
 
 Material is applied at operation boundaries, not mid-operation: a synchronization run that has authenticated continues with the credential it authenticated with, and the next run picks up the rotation. This is ADR 0002's "reloadable for new operations" classification, chosen over "reloadable during running operations" because swapping a credential or a trust anchor underneath an open IMAP session has no coherent meaning.
@@ -142,13 +169,13 @@ A resolution failure message names the account identifier, the logical secret na
 
 ## Testing
 
-`Infrastructure.UnitTests` cover each scheme adapter against an in-memory abstraction over the credential directory and file system, since unit tests must not touch the real file system. Tests assert the unknown-scheme failure, the missing-reference failure, each of the three interpretation modes including a bare value failing under `ReferenceOnly` and resolving under `ReferenceOrInline`, an unparsed value under `InlineOnly`, the composite dispatch, and that failure results carry no secret material. A test registers a scheme adapter that exists only in the test project and asserts it resolves through the same dispatch, which is what proves a future provider is an adapter rather than a refactor. Material-kind tests cover the UTF-8 text view with its newline trim, binary material surviving resolution byte-for-byte, and a PEM and a DER certificate both loading. Memory-hygiene tests cover a disposed secret no longer yielding its material, disposal being idempotent, and no accessor returning a `string` except the documented framework-boundary one. Reload tests cover a rotated reference being adopted, a candidate snapshot with an unresolvable reference being rejected while the previous secrets stay active, and rotated material behind an unchanged reference being observed by the next operation but not mid-operation. Trust-anchor tests cover a valid certificate being installed into the validation path, a malformed one failing startup, and the absence of any configuration path that disables validation. An architecture test asserts that no secret-resolution type is reachable from `Application` or `Domain`.
+`Infrastructure.UnitTests` cover each scheme adapter against an in-memory abstraction over the credential directory and file system, since unit tests must not touch the real file system. Tests assert the unknown-scheme failure, the missing-reference failure, each of the three interpretation modes including a bare value failing under `ReferenceOnly` and resolving under `ReferenceOrInline`, an unparsed value under `InlineOnly`, the composite dispatch, and that failure results carry no secret material. A test registers a scheme adapter that exists only in the test project and asserts it resolves through the same dispatch, which is what proves a future provider is an adapter rather than a refactor. Material-kind tests cover the UTF-8 text view with its newline trim, binary material surviving resolution byte-for-byte, and a PEM and a DER certificate both loading. Memory-hygiene tests cover a disposed secret no longer yielding its material, disposal being idempotent, and no accessor returning a `string` except the documented framework-boundary one. Reload tests cover a rotated reference being adopted, a candidate snapshot with an unresolvable reference being rejected while the previous secrets stay active, and rotated material behind an unchanged reference being observed by the next operation but not mid-operation. Trust-anchor tests cover a valid certificate being installed into the validation path, a malformed one failing startup, and the absence of any configuration path that disables validation. Secret-block tests bind the shipped options types from in-memory configuration and assert that a plain-text value in a block fails startup under `ReferenceOnly` while naming its configuration path, that an empty or absent `SecretReference` is reported as a missing reference rather than as an empty secret, and that a sibling property added to a block leaves already-configured settings binding unchanged. An architecture test asserts that no secret-resolution type is reachable from `Application` or `Domain`, and a second one enumerates the bound options graph and fails if any property outside the secret block type carries a name suggesting it holds a secret, so a future raw `Password` string cannot be added silently.
 
 ## Delivery size
 
 `specs/README.md` scopes each specification to roughly 1000 changed lines. Adding certificate and private-key material kinds and dynamic reload pushes this past that ceiling, so the specification is a candidate for splitting into:
 
-- **02a — reference resolution and text secrets:** the grammar, the four schemes, the byte-oriented contract, mailbox and database passwords, fail-fast startup validation.
+- **02a — reference resolution and text secrets:** the grammar, the secret block and its discovery, the four schemes, the byte-oriented contract, mailbox and database passwords, fail-fast startup validation.
 - **02b — certificate material and dynamic reload:** trust anchor loading into the MailKit validation path, PKCS#12 and PEM key material, and the reload behavior with last-known-good rejection.
 
 The split is clean because 02b consumes 02a's contract without changing it, and because 02a alone already satisfies the original goal of keeping passwords out of `appsettings.json`. It is not applied here: renumbering interacts with the roadmap board and the dependency chain of specifications 03 onward, and that is the owner's call. Implementation should not begin until it is made.
@@ -166,7 +193,9 @@ Adapters for external managed secret stores — Kubernetes, Azure Key Vault, Has
 - No options type in the repository exposes a raw password bound directly from configuration.
 - A missing or malformed reference fails startup with a message that identifies the account without disclosing the secret.
 - No secret-resolution contract is reachable from `Application` or `Domain`.
-- Under the default `ReferenceOnly` mode every secret-bearing setting is a `*Reference` string and a bare value fails startup; the inline modes are reachable only by an explicit, logged configuration choice.
+- Every secret-bearing setting binds to the secret block type, so no configuration path carries a secret as a bare string and no setting can be secret-bearing without being subject to the rules below.
+- Under the default `ReferenceOnly` mode a secret block whose `SecretReference` is not a well-formed `<scheme>:<target>` fails startup naming the configuration path; a plain-text value is never accepted as the secret. The inline modes are reachable only by an explicit, logged configuration choice.
+- Adding a second property to a secret block — a bundle password, a format hint — requires no change to the JSON type of any already-configured setting.
 - A configuration provider that pre-resolves secrets, such as Azure App Configuration with Key Vault references, works without a scheme adapter and without code changes.
 - Resolution yields bytes, so a PKCS#12 bundle or DER certificate is representable without encoding damage, and text secrets are decoded and newline-trimmed only in the text view.
 - A new scheme can be added by registering one adapter, without editing the dispatch, an existing adapter, or any consumer.

--- a/specs/02-secret-reference-resolution.md
+++ b/specs/02-secret-reference-resolution.md
@@ -3,7 +3,7 @@
 **Roadmap group:** A — configuration, transport security, resilience
 **Draft delivery stage:** 2
 **Depends on:** 01
-**Estimated change size:** ~500 lines including tests and documentation
+**Estimated change size:** ~1300 lines including tests and documentation — above the ~1000-line ceiling `specs/README.md` sets per specification, so this specification is a candidate for splitting; see "Delivery size" below
 
 ## Goal
 
@@ -15,18 +15,85 @@ Implement the secret handling model from draft section 7.3 so that no mailbox pa
 
 ## Approved scope
 
-Configuration values that carry secrets become secret references rather than secret values. A reference is a string with an explicit scheme:
+Configuration values that carry secrets become secret references rather than secret values. A reference is a string with an explicit scheme, `<scheme>:<target>`, split on the first colon so a path or URL in the target survives intact. This release implements four schemes:
 
 - `systemd-credential:<name>` reads from the runtime credentials directory that systemd exposes to the service.
 - `file:<path>` reads a deployment-provisioned protected file.
 - `env:<variable>` reads an environment variable, permitted for non-production automation.
 - `plaintext:<value>` exists only for local development and is rejected outside the Development environment.
 
-The resolver is not an application-facing capability. ADR 0002 permits the configuration layer to reference secret identifiers or consume already-bound secret values at the host boundary, and explicitly forbids normalizing broad secret access into application code — an `ISecretResolver` visible to `Application` would give every use case the ability to ask for any secret by name, which is exactly that. The resolver contract and its per-scheme adapters therefore live in `Infrastructure`, and `Host` invokes them once during startup validation. Application and domain code receive only the resolved, narrowly scoped settings each operation needs, and cannot ask for anything else.
+The scheme set is open by design; see "Extensibility to external secret providers" below. The grammar is fixed, the set of schemes that satisfy it is not.
+
+Configuration carries the reference and nothing else. Every secret-bearing setting is a `*Reference` property whose value the host resolves at startup, so the shape an operator commits to Git is:
+
+```json
+{
+  "MailSynchronization": {
+    "Accounts": [
+      {
+        "AccountId": "primary",
+        "Host": "imap.example.test",
+        "UserName": "mailmcp@example.test",
+        "Secrets": { "PasswordReference": "systemd-credential:imap-primary-password" },
+        "TransportSecurity": {
+          "CertificateTrust": "AdditionalTrustedAuthority",
+          "TrustedCertificateAuthorityReference": "file:/run/secrets/private-ca.pem"
+        }
+      }
+    ]
+  },
+  "Persistence": { "PasswordReference": "file:/run/secrets/postgres-password" }
+}
+```
+
+A setting that names a reference is inert on its own: nothing in the file discloses a secret, and a file leaked from a backup or a repository yields only credential names and paths.
+
+## Secret material kinds
+
+A secret is not necessarily a password. This specification must serve at least three kinds, and the contract is shaped so a fourth does not force a redesign:
+
+- **Text secrets** — mailbox passwords, database passwords, and API keys. Resolved material is decoded as UTF-8 and stripped of a single trailing newline, because `LoadCredential=`, Compose secrets, and Kubernetes Secret files routinely end with one and an untrailed byte would present as a wrong password.
+- **Certificates** — trust anchors today, and any certificate MailMcp must present later. PEM and DER both occur in deployment; PEM is what an authority hands an operator, DER is what some tooling emits.
+- **Private keys and key pairs** — a PKCS#12 / PFX bundle is binary and may itself be protected by a password, which is a second reference. PEM certificate-plus-key pairs occur equally often.
+
+Resolution therefore yields opaque bytes, not a string. A text accessor performs the UTF-8 decode and newline trim for the first kind; a certificate loader parses the second and third. Returning a string from the resolver would make a PKCS#12 bundle unrepresentable and would corrupt DER material through encoding round-trips, so the byte form is the primitive and text is the view over it. Trimming applies only to the text view: binary material is never modified.
+
+Loading typed material is the responsibility of the consumer that needs the type, above the resolver. The resolver knows about bytes and schemes and nothing about X.509.
+
+The resolver is not an application-facing capability. ADR 0002 permits the configuration layer to reference secret identifiers or consume already-bound secret values at the host boundary, and explicitly forbids normalizing broad secret access into application code — an `ISecretResolver` visible to `Application` would give every use case the ability to ask for any secret by name, which is exactly that. The resolver contract and its per-scheme adapters therefore live in `Infrastructure`, and `Host` invokes them once during startup, before any hosted service begins work. Application and domain code receive only the resolved, narrowly scoped settings each operation needs, and cannot ask for anything else.
 
 Resolution returns a result rather than throwing, because an unresolved reference is an expected configuration failure. `Host` fails fast on the first unresolved reference and lists which account and which logical secret could not be resolved.
 
-Resolved secret material is held in memory only for as long as the owning options instance lives, and the resolver never caches values across configuration reloads. ADR 0002 governs the configuration reading and reload boundary; this specification stays inside it and does not introduce a new reload mechanism.
+Resolution is asynchronous and accepts a cancellation token even though every scheme implemented here reads a local file or an environment variable synchronously. A provider that reaches a network service is the expected next step, and a synchronous contract would force it to block a thread or force a breaking change through every consumer at the moment it is added. Startup validation therefore runs before hosted services start rather than inside synchronous options validation.
+
+Resolved secret material is held in memory only for as long as the owning options instance lives, and the resolver never caches values across configuration reloads.
+
+## Dynamic reload
+
+Secrets reload without a process restart, on the same terms as the configuration that references them. An operator who rotates a mailbox password, replaces an expiring trust anchor, or re-issues a database credential must not have to restart MailMcp and interrupt synchronization to do it.
+
+Two independent things can change, and both are covered:
+
+- **The reference changes.** A configuration reload delivers a new `*Reference` value. The candidate snapshot is validated by resolving every reference in it before it is published; a snapshot containing an unresolvable reference is rejected and the last known good snapshot stays active, exactly as ADR 0002 requires for reloadable groups. A rejected reload is logged with the account, the setting, and the failure identity, never with material.
+- **The material behind an unchanged reference changes.** Rotating the credential file, the systemd credential, or the vault entry leaves configuration untouched, so no configuration reload fires. Resolution therefore happens per use rather than once at startup, and the next operation that needs the secret observes the rotated value. A network-backed provider that cannot afford per-use retrieval caches inside its own adapter with its own expiry, which is why caching policy is an adapter concern rather than a contract concern.
+
+Material is applied at operation boundaries, not mid-operation: a synchronization run that has authenticated continues with the credential it authenticated with, and the next run picks up the rotation. This is ADR 0002's "reloadable for new operations" classification, chosen over "reloadable during running operations" because swapping a credential or a trust anchor underneath an open IMAP session has no coherent meaning.
+
+This departs from ADR 0002's current guidance, which classifies credentials and certificate trust anchors as restart-required. That guidance was written before a secret-reference indirection existed; with it, rotation no longer means mutating a bound secret value in place, but re-resolving a reference whose validity is proven before it is published. **The ADR needs an owner-approved amendment recording this, and this specification must not be implemented against an unamended ADR.** No ADR is modified as part of this specification.
+
+## Extensibility to external secret providers
+
+MailMcp will need more secret sources than the four schemes above — Kubernetes, Azure Key Vault, HashiCorp Vault, AWS Secrets Manager, and comparable managed stores are all plausible. None of them is in scope here, but the shape delivered now decides whether adding one later is an adapter or a refactor. It must be an adapter.
+
+Three consequences bind this specification:
+
+- **A scheme is a value that an adapter declares, not a closed set the core owns.** Each adapter names the scheme it serves, and dispatch is a lookup over the registered adapters. Adding a provider registers one more adapter and changes no existing type, no consumer, and no configuration consumer. An unregistered scheme is a resolution failure, which is also how an operator learns that a provider was not compiled in or not enabled.
+- **The contract is asynchronous and cancellable from the start**, for the reason given above.
+- **Provider-specific concerns stay inside the provider's adapter.** Timeouts, retries, connection pooling, regional endpoints, SDK types, and any caching policy belong to the adapter that needs them. The resolver contract exposes none of it, so a provider that must cache aggressively and a provider that must never cache can coexist without the contract taking a position.
+
+Two things are deliberately *not* built now. A managed-store adapter needs its own authentication — an Azure managed identity, a Kubernetes ServiceAccount token, a Vault role — and that platform-issued identity must come from the platform rather than from a MailMcp secret, or the design becomes circular. And every such SDK is a new dependency subject to the root `AGENTS.md` licensing, service-terms, telemetry, and data-processing review, with a `LICENSES.md` entry in the same change set. Neither is prejudged here.
+
+Note that container and Kubernetes deployments need no new scheme at all. Docker and Podman Compose mount secrets as files under `/run/secrets/<name>`, and Kubernetes mounts a Secret as a read-only tmpfs directory of one file per key at an operator-chosen path; both are addressed by `file:`, and a Kubernetes Secret exposed as an environment variable is addressed by `env:`. A `docker-secret:` or `kubernetes-secret:` scheme would perform exactly the file read that `file:` already performs, so neither is added. Only a provider with genuinely different retrieval behavior earns a scheme.
 
 ## Trusted certificate authority material
 
@@ -40,17 +107,37 @@ A resolution failure message names the account identifier, the logical secret na
 
 ## Testing
 
-`Infrastructure.UnitTests` cover each scheme adapter against an in-memory abstraction over the credential directory and file system, since unit tests must not touch the real file system. Tests assert the unknown-scheme failure, the missing-reference failure, the Development-only `plaintext:` rule, the composite dispatch, and that failure results carry no secret material. Trust-anchor tests cover a valid certificate being installed into the validation path, a malformed one failing startup, and the absence of any configuration path that disables validation. An architecture test asserts that no secret-resolution type is reachable from `Application` or `Domain`.
+`Infrastructure.UnitTests` cover each scheme adapter against an in-memory abstraction over the credential directory and file system, since unit tests must not touch the real file system. Tests assert the unknown-scheme failure, the missing-reference failure, the Development-only `plaintext:` rule, the composite dispatch, and that failure results carry no secret material. A test registers a scheme adapter that exists only in the test project and asserts it resolves through the same dispatch, which is what proves a future provider is an adapter rather than a refactor. Material-kind tests cover the UTF-8 text view with its newline trim, binary material surviving resolution byte-for-byte, and a PEM and a DER certificate both loading. Reload tests cover a rotated reference being adopted, a candidate snapshot with an unresolvable reference being rejected while the previous secrets stay active, and rotated material behind an unchanged reference being observed by the next operation but not mid-operation. Trust-anchor tests cover a valid certificate being installed into the validation path, a malformed one failing startup, and the absence of any configuration path that disables validation. An architecture test asserts that no secret-resolution type is reachable from `Application` or `Domain`.
+
+## Delivery size
+
+`specs/README.md` scopes each specification to roughly 1000 changed lines. Adding certificate and private-key material kinds and dynamic reload pushes this past that ceiling, so the specification is a candidate for splitting into:
+
+- **02a — reference resolution and text secrets:** the grammar, the four schemes, the byte-oriented contract, mailbox and database passwords, fail-fast startup validation.
+- **02b — certificate material and dynamic reload:** trust anchor loading into the MailKit validation path, PKCS#12 and PEM key material, and the reload behavior with last-known-good rejection.
+
+The split is clean because 02b consumes 02a's contract without changing it, and because 02a alone already satisfies the original goal of keeping passwords out of `appsettings.json`. It is not applied here: renumbering interacts with the roadmap board and the dependency chain of specifications 03 onward, and that is the owner's call. Implementation should not begin until it is made.
 
 ## Out of scope
 
-Data Protection key-ring provisioning, encrypted secret storage in PostgreSQL, external secret-provider integrations such as a cloud vault, and secret rotation without restart. Client certificates presented by MCP clients are stage 9 work and unrelated to mail transport trust anchors.
+Data Protection key-ring provisioning and encrypted secret storage in PostgreSQL. Client certificates presented by MCP clients are stage 9 work and unrelated to mail transport trust anchors; this specification delivers the byte-oriented resolution and certificate loading they will reuse, but presents no client certificate itself.
+
+Secret rotation without restart is explicitly *in* scope — see "Dynamic reload" above. It was listed as out of scope in an earlier revision of this specification.
+
+Adapters for external managed secret stores — Kubernetes, Azure Key Vault, HashiCorp Vault, AWS Secrets Manager, and comparable services — are out of scope as implementations, but their eventual addition is a design constraint on this specification rather than a later concern. "Extensibility to external secret providers" above states what that constrains; the adapters themselves, their SDK dependencies, and their platform-identity requirements are separate work under their own licensing and service-terms review.
 
 ## Definition of done
 
 - No options type in the repository exposes a raw password bound directly from configuration.
 - A missing or malformed reference fails startup with a message that identifies the account without disclosing the secret.
 - No secret-resolution contract is reachable from `Application` or `Domain`.
+- Every secret-bearing setting in `appsettings.json` is a `*Reference` string; no committed configuration file contains a secret value.
+- Resolution yields bytes, so a PKCS#12 bundle or DER certificate is representable without encoding damage, and text secrets are decoded and newline-trimmed only in the text view.
+- A new scheme can be added by registering one adapter, without editing the dispatch, an existing adapter, or any consumer.
+- The resolution contract is asynchronous and cancellable, so a network-backed provider needs no breaking change.
+- Rotating the material behind an unchanged reference is observed by the next operation without a process restart.
+- A configuration reload carrying an unresolvable reference is rejected and leaves the previous secrets active.
+- ADR 0002 has been amended, with owner approval, to classify referenced secrets as reloadable for new operations.
 - A private server with a configured trust anchor connects with certificate validation fully enabled.
-- `docs/operations/local-development.md` documents the Development workflow and `docs/operations/` gains a page describing the systemd credential deployment path.
+- `docs/operations/local-development.md` documents the Development workflow and `docs/operations/` gains a page describing the systemd credential deployment path alongside the container path.
 - `dotnet msbuild .config/CodeCoverage.proj -t:Collect` passes the 85% whole-scope gate.

--- a/specs/02-secret-reference-resolution.md
+++ b/specs/02-secret-reference-resolution.md
@@ -3,7 +3,7 @@
 **Roadmap group:** A — configuration, transport security, resilience
 **Draft delivery stage:** 2
 **Depends on:** 01
-**Estimated change size:** ~1300 lines including tests and documentation — above the ~1000-line ceiling `specs/README.md` sets per specification, so this specification is a candidate for splitting; see "Delivery size" below
+**Estimated change size:** ~1450 lines including tests and documentation — above the ~1000-line ceiling `specs/README.md` sets per specification, so this specification is a candidate for splitting; see "Delivery size" below
 
 ## Goal
 
@@ -101,13 +101,27 @@ Specification 01 requires that certificate validation is never disabled and that
 
 A trusted certificate authority is configured as a reference in the same form as any other deployment-provisioned material. `Infrastructure` loads it, validates that it parses as a certificate and is usable as a trust anchor, and supplies it to the MailKit adapter's certificate validation path so a private server chains to it while ordinary validation stays enabled for everything else. A malformed or unreadable trust anchor fails startup, since silently continuing would either reject a working server or, worse, invite an operator to disable validation to work around it.
 
+## Secret material in memory
+
+Resolved material must live as briefly as possible and be erased when it stops being needed. Four rules follow from current .NET guidance, and one common approach is explicitly rejected.
+
+**`SecureString` is not used.** Microsoft's own documentation says "We recommend that you don't use the `SecureString` class for new development on .NET (Core)", and states that because of platform dependencies "`SecureString` does not encrypt the internal storage on non-Windows platform" — which is every environment MailMcp targets. The same documentation names the recommended alternative: "use an opaque handle to credentials that are stored outside of the process." That is precisely what a secret reference already is, so this specification's core design *is* the sanctioned approach and `SecureString` would add ceremony without protection.
+
+**Secret material is never held in a `string`.** A `string` is immutable, so it cannot be overwritten; it cannot be scheduled for deletion; and because its memory is not pinned, the garbage collector makes additional copies when it moves and compacts memory, each of which outlives any attempt to erase the original. Material is therefore held in a byte buffer, which is the other reason resolution is byte-oriented.
+
+**The buffer is pinned and zeroed.** Material is allocated with `GC.AllocateArray<byte>(length, pinned: true)` so the collector cannot relocate it and leave an un-erased copy behind, and erased with `CryptographicOperations.ZeroMemory`, which exists — in its own documented words — "to future-proof against potential optimizations in the .NET runtime that could eliminate memory writes that aren't followed by memory reads." A plain loop assigning zeroes carries no such guarantee. Pooled buffers are not used for secret material at all, because a returned buffer that was not cleared hands the material to the next unrelated caller.
+
+**Resolved material is owned and disposed.** A resolved secret is disposable, is owned by the operation that resolved it, and is erased when that operation ends. This composes with per-use resolution: material exists for the length of one synchronization run or one connection attempt rather than for the process lifetime, so the window in which a dump could contain it is bounded by an operation rather than by uptime. Because each operation owns its own instance, a configuration reload never erases material an in-flight operation is still using.
+
+Two exposures are accepted and must be documented rather than hidden. Some framework contracts take a `string` — the IMAP client's authentication call and the database connection string among them — so a short-lived `string` copy is unavoidable at exactly those call sites; it is created as late as possible, at the boundary itself, and never stored, logged, or passed on. And managed memory remains readable through a process dump, a debugger, or swap. Those are operational controls rather than code: the deployment must disable core dumps for the service and keep its memory out of swap, and the operations documentation must say so. Locking pages with `mlock` is deliberately not attempted — it would require P/Invoke plus elevated capability in every deployment shape, against a repository rule that restricts unsafe and platform-invoke code to measured need, and it does not address dumps or debuggers anyway.
+
 ## Safety and privacy
 
 A resolution failure message names the account identifier, the logical secret name, and the scheme, and never the reference target path, the environment variable value, or any part of the resolved secret. Resolved secrets are excluded from structured logging by construction: the options type exposes them through a dedicated accessor rather than an ordinary public property, so a future serializer or diagnostic dump cannot pick them up incidentally. `plaintext:` outside Development is a startup failure, not a warning.
 
 ## Testing
 
-`Infrastructure.UnitTests` cover each scheme adapter against an in-memory abstraction over the credential directory and file system, since unit tests must not touch the real file system. Tests assert the unknown-scheme failure, the missing-reference failure, the Development-only `plaintext:` rule, the composite dispatch, and that failure results carry no secret material. A test registers a scheme adapter that exists only in the test project and asserts it resolves through the same dispatch, which is what proves a future provider is an adapter rather than a refactor. Material-kind tests cover the UTF-8 text view with its newline trim, binary material surviving resolution byte-for-byte, and a PEM and a DER certificate both loading. Reload tests cover a rotated reference being adopted, a candidate snapshot with an unresolvable reference being rejected while the previous secrets stay active, and rotated material behind an unchanged reference being observed by the next operation but not mid-operation. Trust-anchor tests cover a valid certificate being installed into the validation path, a malformed one failing startup, and the absence of any configuration path that disables validation. An architecture test asserts that no secret-resolution type is reachable from `Application` or `Domain`.
+`Infrastructure.UnitTests` cover each scheme adapter against an in-memory abstraction over the credential directory and file system, since unit tests must not touch the real file system. Tests assert the unknown-scheme failure, the missing-reference failure, the Development-only `plaintext:` rule, the composite dispatch, and that failure results carry no secret material. A test registers a scheme adapter that exists only in the test project and asserts it resolves through the same dispatch, which is what proves a future provider is an adapter rather than a refactor. Material-kind tests cover the UTF-8 text view with its newline trim, binary material surviving resolution byte-for-byte, and a PEM and a DER certificate both loading. Memory-hygiene tests cover a disposed secret no longer yielding its material, disposal being idempotent, and no accessor returning a `string` except the documented framework-boundary one. Reload tests cover a rotated reference being adopted, a candidate snapshot with an unresolvable reference being rejected while the previous secrets stay active, and rotated material behind an unchanged reference being observed by the next operation but not mid-operation. Trust-anchor tests cover a valid certificate being installed into the validation path, a malformed one failing startup, and the absence of any configuration path that disables validation. An architecture test asserts that no secret-resolution type is reachable from `Application` or `Domain`.
 
 ## Delivery size
 
@@ -138,6 +152,8 @@ Adapters for external managed secret stores — Kubernetes, Azure Key Vault, Has
 - Rotating the material behind an unchanged reference is observed by the next operation without a process restart.
 - A configuration reload carrying an unresolvable reference is rejected and leaves the previous secrets active.
 - ADR 0002 has been amended, with owner approval, to classify referenced secrets as reloadable for new operations.
+- No secret material is held in a `string`, a pooled buffer, or a `SecureString`; buffers are pinned and zeroed with `CryptographicOperations.ZeroMemory` when their owning operation ends.
+- `docs/operations/` documents disabling core dumps and swap exposure for the service, in both the systemd and container deployment shapes.
 - A private server with a configured trust anchor connects with certificate validation fully enabled.
 - `docs/operations/local-development.md` documents the Development workflow and `docs/operations/` gains a page describing the systemd credential deployment path alongside the container path.
 - `dotnet msbuild .config/CodeCoverage.proj -t:Collect` passes the 85% whole-scope gate.

--- a/specs/02a-secret-reference-resolution.md
+++ b/specs/02a-secret-reference-resolution.md
@@ -3,17 +3,21 @@
 **Roadmap group:** A — configuration, transport security, resilience
 **Draft delivery stage:** 2
 **Depends on:** 01
-**Estimated change size:** ~1700 lines including tests and documentation — above the ~1000-line ceiling `specs/README.md` sets per specification, so this specification is a candidate for splitting; see "Delivery size" below
+**Estimated change size:** ~950 lines including tests and documentation
 
 ## Goal
 
 Implement the secret handling model from draft section 7.3 so that no mailbox password, database password, or certificate password is ever written into `appsettings.json`, and so that an unresolved secret reference fails startup instead of producing a confusing authentication error later.
 
+This specification builds the resolution mechanism and applies it to text secrets. Specification 02b consumes the same contract for certificate material and adds rotation without restart.
+
 ## Current state
 
 `MailSynchronizationAccountOptions` holds a plain `Password` string bound directly from configuration. The default `appsettings.json` ships an empty account list, so nothing is leaked today, but the shape invites operators to commit credentials.
 
-Specification 01 shipped `MailAccountTransportSecurityOptions.TrustedCertificateAuthorityReference` as a nullable string, already documented as carrying a reference rather than certificate material. It keeps its key name here but changes shape from a string to the secret block defined below, so an operator who configured it edits one line. This is a deliberate break taken now, while the setting has one consumer and no shipped release depends on it; deferring it would mean either two spellings of a secret setting or the same break later against real deployments. `MailTransportSecurityPolicy` in `Domain` continues to receive a nullable string and is unaffected — the block is a configuration-adapter shape and does not cross the boundary.
+Specification 01 shipped `MailAccountTransportSecurityOptions.TrustedCertificateAuthorityReference` as a nullable string, already documented as carrying a reference rather than certificate material. This specification renames it to `TrustedCertificateAuthority` and changes its shape to the secret block defined below. The `Reference` suffix existed because the value *was* the reference string; once the value is a block whose `SecretReference` property holds it, the suffix says the same word twice and the setting reads as the thing it configures. Loading the material behind it belongs to specification 02b; this specification only fixes its configuration shape, so that the block convention holds everywhere from the moment it exists rather than for new settings only.
+
+This is a deliberate break taken now, while the setting has one consumer and no shipped release depends on it. Deferring it would mean either two spellings of a secret setting in the same file or the same break later against real deployments. `MailTransportSecurityPolicy` in `Domain` continues to receive a nullable string and is unaffected — the block is a configuration-adapter shape and does not cross the boundary.
 
 ## Approved scope
 
@@ -41,7 +45,7 @@ Configuration carries the reference and nothing else. Every secret-bearing setti
         },
         "TransportSecurity": {
           "CertificateTrust": "AdditionalTrustedAuthority",
-          "TrustedCertificateAuthorityReference": { "SecretReference": "file:/run/secrets/private-ca.pem" }
+          "TrustedCertificateAuthority": { "SecretReference": "file:/run/secrets/private-ca.pem" }
         }
       }
     ]
@@ -56,7 +60,7 @@ A setting that names a reference is inert on its own: nothing in the file disclo
 
 ## The secret block
 
-Every secret-bearing setting uses the same object shape, and the shape is uniform whether the secret is a password, a trust anchor, or a key. Two reasons make the object the right unit rather than a bare string.
+Every secret-bearing setting uses the same object shape, whether the secret is a password, a trust anchor, or a key. Two reasons make the object the right unit rather than a bare string.
 
 **It has room to grow without a breaking configuration change.** A secret is not always one opaque value. A PKCS#12 bundle carries its own password, which is a second reference; a certificate may need an explicit format hint when the extension lies about its encoding; a future managed-store reference may need a version pin. Each of those is a sibling property inside a block that already exists:
 
@@ -72,8 +76,6 @@ Had the setting shipped as a bare string, adding the bundle password would chang
 **The block's type is what marks a setting as secret-bearing.** A secret block binds to a dedicated options type rather than to `string`, so a setting is secret-bearing because of what it *is*, not because someone remembered to annotate it. A marker attribute can be omitted on a newly added property and nothing would notice; a type cannot, because the property would not bind. Startup validation therefore discovers secret-bearing settings by walking the bound options graph for that type, and every rule below applies to every such setting automatically, including settings added after this specification ships.
 
 This is what makes the `ReferenceOnly` guarantee complete rather than per-setting. Under the default mode a secret block whose `SecretReference` is not a well-formed `<scheme>:<target>` fails startup, naming the configuration path and the failure identity. A value that is merely text — a password pasted where a reference belongs, or a mistyped `fil:/run/secrets/imap` — is a startup failure, never a secret that resolved by accident. There is no path by which an unmarked setting quietly skips the check, because there is no unmarked secret-bearing setting.
-
-A consequence worth stating: the object shape survives configuration providers that flatten hierarchy. Azure App Configuration, environment variables, and command-line arguments address the same setting as `MailSynchronization:Accounts:0:Secrets:Password:SecretReference`, so the block costs a pre-resolving provider nothing.
 
 ## Inline values and pre-resolving configuration providers
 
@@ -96,38 +98,32 @@ One consequence must be stated rather than hidden: an inline value arrives from 
 
 Note that this also settles where a pre-resolving provider belongs architecturally. Azure App Configuration is **not** a scheme adapter: its Key Vault mapping happens below MailMcp in the configuration pipeline, so MailMcp needs no code for it beyond accepting the bound value. A provider MailMcp queries itself — direct Key Vault access, HashiCorp Vault — is a scheme adapter. The two integration shapes are different and should not be conflated.
 
+### The block must survive a flattening provider
+
+The secret block is a nested object in JSON, but nothing about it requires a JSON provider. Every hierarchical configuration provider addresses the same setting by its colon-separated path, so the block adds one path segment and nothing else. This specification is not complete until an Azure App Configuration store bound with Key Vault references works against it, which means the following must hold:
+
+- The App Config key is the full path, `MailSynchronization:Accounts:0:Secrets:Password:SecretReference`, and its value is the Key Vault reference the provider resolves before MailMcp binds it.
+- Environment variables address the same setting as `MailSynchronization__Accounts__0__Secrets__Password__SecretReference`, so a container platform that injects configuration through the environment reaches the block without a JSON file.
+- Binding is verified against an in-memory provider populated with flat colon-separated keys, not only against a JSON document, so a regression that makes the block depend on JSON document structure fails a test rather than a deployment.
+
+Combined with `InlineOnly`, this is the complete Azure App Configuration path: the store holds the key, Key Vault holds the secret, the provider maps one to the other, and MailMcp binds an already-resolved value into `SecretReference` and uses it as material.
+
 ## Secret material kinds
 
-A secret is not necessarily a password. This specification must serve at least three kinds, and the contract is shaped so a fourth does not force a redesign:
+A secret is not necessarily a password. The contract is shaped so that certificates and key bundles — specification 02b's subject — need no change to it:
 
-- **Text secrets** — mailbox passwords, database passwords, and API keys. Resolved material is decoded as UTF-8 and stripped of a single trailing newline, because `LoadCredential=`, Compose secrets, and Kubernetes Secret files routinely end with one and an untrailed byte would present as a wrong password.
-- **Certificates** — trust anchors today, and any certificate MailMcp must present later. PEM and DER both occur in deployment; PEM is what an authority hands an operator, DER is what some tooling emits.
-- **Private keys and key pairs** — a PKCS#12 / PFX bundle is binary and may itself be protected by a password, which is a second reference. PEM certificate-plus-key pairs occur equally often.
+- **Text secrets** — mailbox passwords, database passwords, and API keys. Resolved material is decoded as UTF-8 and stripped of a single trailing newline, because `LoadCredential=`, Compose secrets, and Kubernetes Secret files routinely end with one and an untrimmed byte would present as a wrong password.
+- **Certificates and key bundles** — a PKCS#12 bundle is binary, and DER-encoded material is not text at all. Specification 02b loads them; this specification guarantees they arrive intact.
 
-Resolution therefore yields opaque bytes, not a string. A text accessor performs the UTF-8 decode and newline trim for the first kind; a certificate loader parses the second and third. Returning a string from the resolver would make a PKCS#12 bundle unrepresentable and would corrupt DER material through encoding round-trips, so the byte form is the primitive and text is the view over it. Trimming applies only to the text view: binary material is never modified.
+Resolution therefore yields opaque bytes, not a string. A text accessor performs the UTF-8 decode and newline trim for the first kind. Returning a string from the resolver would make a PKCS#12 bundle unrepresentable and would corrupt DER material through encoding round-trips, so the byte form is the primitive and text is the view over it. Trimming applies only to the text view: binary material is never modified.
 
 Loading typed material is the responsibility of the consumer that needs the type, above the resolver. The resolver knows about bytes and schemes and nothing about X.509.
 
 The resolver is not an application-facing capability. ADR 0002 permits the configuration layer to reference secret identifiers or consume already-bound secret values at the host boundary, and explicitly forbids normalizing broad secret access into application code — an `ISecretResolver` visible to `Application` would give every use case the ability to ask for any secret by name, which is exactly that. The resolver contract and its per-scheme adapters therefore live in `Infrastructure`, and `Host` invokes them once during startup, before any hosted service begins work. Application and domain code receive only the resolved, narrowly scoped settings each operation needs, and cannot ask for anything else.
 
-Resolution returns a result rather than throwing, because an unresolved reference is an expected configuration failure. `Host` fails fast on the first unresolved reference and lists which account and which logical secret could not be resolved.
+Resolution returns a result rather than throwing, because an unresolved reference is an expected configuration failure. `Host` fails fast and reports every unresolved reference at once, each named by its configuration path.
 
 Resolution is asynchronous and accepts a cancellation token even though every scheme implemented here reads a local file or an environment variable synchronously. A provider that reaches a network service is the expected next step, and a synchronous contract would force it to block a thread or force a breaking change through every consumer at the moment it is added. Startup validation therefore runs before hosted services start rather than inside synchronous options validation.
-
-Resolved secret material is held in memory only for as long as the owning options instance lives, and the resolver never caches values across configuration reloads.
-
-## Dynamic reload
-
-Secrets reload without a process restart, on the same terms as the configuration that references them. An operator who rotates a mailbox password, replaces an expiring trust anchor, or re-issues a database credential must not have to restart MailMcp and interrupt synchronization to do it.
-
-Two independent things can change, and both are covered:
-
-- **The reference changes.** A configuration reload delivers a new `SecretReference` inside one of the secret blocks. The candidate snapshot is validated by resolving every reference in it before it is published; a snapshot containing an unresolvable reference is rejected and the last known good snapshot stays active, exactly as ADR 0002 requires for reloadable groups. A rejected reload is logged with the account, the setting, and the failure identity, never with material.
-- **The material behind an unchanged reference changes.** Rotating the credential file, the systemd credential, or the vault entry leaves configuration untouched, so no configuration reload fires. Resolution therefore happens per use rather than once at startup, and the next operation that needs the secret observes the rotated value. A network-backed provider that cannot afford per-use retrieval caches inside its own adapter with its own expiry, which is why caching policy is an adapter concern rather than a contract concern.
-
-Material is applied at operation boundaries, not mid-operation: a synchronization run that has authenticated continues with the credential it authenticated with, and the next run picks up the rotation. This is ADR 0002's "reloadable for new operations" classification, chosen over "reloadable during running operations" because swapping a credential or a trust anchor underneath an open IMAP session has no coherent meaning.
-
-This departs from ADR 0002's current guidance, which classifies credentials and certificate trust anchors as restart-required. That guidance was written before a secret-reference indirection existed; with it, rotation no longer means mutating a bound secret value in place, but re-resolving a reference whose validity is proven before it is published. **The ADR needs an owner-approved amendment recording this, and this specification must not be implemented against an unamended ADR.** No ADR is modified as part of this specification.
 
 ## Extensibility to external secret providers
 
@@ -143,12 +139,6 @@ Two things are deliberately *not* built now. A managed-store adapter needs its o
 
 Note that container and Kubernetes deployments need no new scheme at all. Docker and Podman Compose mount secrets as files under `/run/secrets/<name>`, and Kubernetes mounts a Secret as a read-only tmpfs directory of one file per key at an operator-chosen path; both are addressed by `file:`, and a Kubernetes Secret exposed as an environment variable is addressed by `env:`. A `docker-secret:` or `kubernetes-secret:` scheme would perform exactly the file read that `file:` already performs, so neither is added. Only a provider with genuinely different retrieval behavior earns a scheme.
 
-## Trusted certificate authority material
-
-Specification 01 requires that certificate validation is never disabled and that private or self-signed servers are supported by configuring additional trusted certificate authorities. Nothing else in the roadmap owns loading that material, and it arrives through exactly the mechanism this specification builds — a deployment-provisioned file or credential — so it is assigned here.
-
-A trusted certificate authority is configured as a reference in the same form as any other deployment-provisioned material. `Infrastructure` loads it, validates that it parses as a certificate and is usable as a trust anchor, and supplies it to the MailKit adapter's certificate validation path so a private server chains to it while ordinary validation stays enabled for everything else. A malformed or unreadable trust anchor fails startup, since silently continuing would either reject a working server or, worse, invite an operator to disable validation to work around it.
-
 ## Secret material in memory
 
 Resolved material must live as briefly as possible and be erased when it stops being needed. Four rules follow from current .NET guidance, and one common approach is explicitly rejected.
@@ -159,52 +149,45 @@ Resolved material must live as briefly as possible and be erased when it stops b
 
 **The buffer is pinned and zeroed.** Material is allocated with `GC.AllocateArray<byte>(length, pinned: true)` so the collector cannot relocate it and leave an un-erased copy behind, and erased with `CryptographicOperations.ZeroMemory`, which exists — in its own documented words — "to future-proof against potential optimizations in the .NET runtime that could eliminate memory writes that aren't followed by memory reads." A plain loop assigning zeroes carries no such guarantee. Pooled buffers are not used for secret material at all, because a returned buffer that was not cleared hands the material to the next unrelated caller.
 
-**Resolved material is owned and disposed.** A resolved secret is disposable, is owned by the operation that resolved it, and is erased when that operation ends. This composes with per-use resolution: material exists for the length of one synchronization run or one connection attempt rather than for the process lifetime, so the window in which a dump could contain it is bounded by an operation rather than by uptime. Because each operation owns its own instance, a configuration reload never erases material an in-flight operation is still using.
+**Resolved material is owned and disposed.** A resolved secret is disposable, is owned by the operation that resolved it, and is erased when that operation ends. Material exists for the length of one synchronization run or one connection attempt rather than for the process lifetime, so the window in which a dump could contain it is bounded by an operation rather than by uptime. Because each operation owns its own instance, the reload behavior specification 02b adds can publish new material without erasing what an in-flight operation is still using.
 
 Two exposures are accepted and must be documented rather than hidden. Some framework contracts take a `string` — the IMAP client's authentication call and the database connection string among them — so a short-lived `string` copy is unavoidable at exactly those call sites; it is created as late as possible, at the boundary itself, and never stored, logged, or passed on. And managed memory remains readable through a process dump, a debugger, or swap. Those are operational controls rather than code: the deployment must disable core dumps for the service and keep its memory out of swap, and the operations documentation must say so. Locking pages with `mlock` is deliberately not attempted — it would require P/Invoke plus elevated capability in every deployment shape, against a repository rule that restricts unsafe and platform-invoke code to measured need, and it does not address dumps or debuggers anyway.
 
 ## Safety and privacy
 
-A resolution failure message names the account identifier, the logical secret name, and the scheme, and never the reference target path, the environment variable value, or any part of the resolved secret. Resolved secrets are excluded from structured logging by construction: the options type exposes them through a dedicated accessor rather than an ordinary public property, so a future serializer or diagnostic dump cannot pick them up incidentally. An inline or `plaintext:` value outside the default `ReferenceOnly` mode is logged at startup by setting name so it cannot pass unnoticed.
+A resolution failure message names the configuration path, the logical secret name, and the scheme, and never the reference target path, the environment variable value, or any part of the resolved secret. Resolved secrets are excluded from structured logging by construction: the resolved type exposes material through a dedicated accessor rather than an ordinary public property, so a future serializer or diagnostic dump cannot pick it up incidentally. An inline or `plaintext:` value outside the default `ReferenceOnly` mode is logged at startup by setting name so it cannot pass unnoticed.
 
 ## Testing
 
-`Infrastructure.UnitTests` cover each scheme adapter against an in-memory abstraction over the credential directory and file system, since unit tests must not touch the real file system. Tests assert the unknown-scheme failure, the missing-reference failure, each of the three interpretation modes including a bare value failing under `ReferenceOnly` and resolving under `ReferenceOrInline`, an unparsed value under `InlineOnly`, the composite dispatch, and that failure results carry no secret material. A test registers a scheme adapter that exists only in the test project and asserts it resolves through the same dispatch, which is what proves a future provider is an adapter rather than a refactor. Material-kind tests cover the UTF-8 text view with its newline trim, binary material surviving resolution byte-for-byte, and a PEM and a DER certificate both loading. Memory-hygiene tests cover a disposed secret no longer yielding its material, disposal being idempotent, and no accessor returning a `string` except the documented framework-boundary one. Reload tests cover a rotated reference being adopted, a candidate snapshot with an unresolvable reference being rejected while the previous secrets stay active, and rotated material behind an unchanged reference being observed by the next operation but not mid-operation. Trust-anchor tests cover a valid certificate being installed into the validation path, a malformed one failing startup, and the absence of any configuration path that disables validation. Secret-block tests bind the shipped options types from in-memory configuration and assert that a plain-text value in a block fails startup under `ReferenceOnly` while naming its configuration path, that an empty or absent `SecretReference` is reported as a missing reference rather than as an empty secret, and that a sibling property added to a block leaves already-configured settings binding unchanged. An architecture test asserts that no secret-resolution type is reachable from `Application` or `Domain`, and a second one enumerates the bound options graph and fails if any property outside the secret block type carries a name suggesting it holds a secret, so a future raw `Password` string cannot be added silently.
+`Infrastructure.UnitTests` cover each scheme adapter against an in-memory abstraction over the credential directory and file system, since unit tests must not touch the real file system. Tests assert the unknown-scheme failure, the missing-reference failure, each of the three interpretation modes including a bare value failing under `ReferenceOnly` and resolving under `ReferenceOrInline`, an unparsed value under `InlineOnly`, the composite dispatch, and that failure results carry no secret material. A test registers a scheme adapter that exists only in the test project and asserts it resolves through the same dispatch, which is what proves a future provider is an adapter rather than a refactor.
 
-## Delivery size
+Secret-block tests bind the shipped options types from an in-memory configuration provider populated with flat colon-separated keys, and assert that a plain-text value in a block fails startup under `ReferenceOnly` while naming its configuration path, that an empty or absent `SecretReference` is reported as a missing reference rather than as an empty secret, that a block nested in a list reports its index in the path, and that a sibling property added to a block leaves already-configured settings binding unchanged. Binding from flat keys rather than only from a JSON document is what keeps the Azure App Configuration and environment-variable paths verified.
 
-`specs/README.md` scopes each specification to roughly 1000 changed lines. Adding certificate and private-key material kinds and dynamic reload pushes this past that ceiling, so the specification is a candidate for splitting into:
+Material tests cover the UTF-8 text view with its newline trim and binary material surviving resolution byte-for-byte. Memory-hygiene tests cover a disposed secret no longer yielding its material, disposal being idempotent, and no accessor returning a `string` except the documented framework-boundary one.
 
-- **02a — reference resolution and text secrets:** the grammar, the secret block and its discovery, the four schemes, the byte-oriented contract, mailbox and database passwords, fail-fast startup validation.
-- **02b — certificate material and dynamic reload:** trust anchor loading into the MailKit validation path, PKCS#12 and PEM key material, and the reload behavior with last-known-good rejection.
-
-The split is clean because 02b consumes 02a's contract without changing it, and because 02a alone already satisfies the original goal of keeping passwords out of `appsettings.json`. It is not applied here: renumbering interacts with the roadmap board and the dependency chain of specifications 03 onward, and that is the owner's call. Implementation should not begin until it is made.
+An architecture test asserts that no secret-resolution type is reachable from `Application` or `Domain`, and a second one enumerates the bound options graph and fails if any property outside the secret block type carries a name suggesting it holds a secret, so a future raw `Password` string cannot be added silently.
 
 ## Out of scope
 
-Data Protection key-ring provisioning and encrypted secret storage in PostgreSQL. Client certificates presented by MCP clients are stage 9 work and unrelated to mail transport trust anchors; this specification delivers the byte-oriented resolution and certificate loading they will reuse, but presents no client certificate itself.
+Certificate and private-key material loading, and secret rotation without a process restart, are specification 02b. This specification delivers the byte-oriented contract and the configuration shape both depend on, and renames `TrustedCertificateAuthority` to its block form, but loads nothing from it.
 
-Secret rotation without restart is explicitly *in* scope — see "Dynamic reload" above. It was listed as out of scope in an earlier revision of this specification.
+Data Protection key-ring provisioning and encrypted secret storage in PostgreSQL. Client certificates presented by MCP clients are stage 9 work.
 
 Adapters for external managed secret stores — Kubernetes, Azure Key Vault, HashiCorp Vault, AWS Secrets Manager, and comparable services — are out of scope as implementations, but their eventual addition is a design constraint on this specification rather than a later concern. "Extensibility to external secret providers" above states what that constrains; the adapters themselves, their SDK dependencies, and their platform-identity requirements are separate work under their own licensing and service-terms review.
 
 ## Definition of done
 
 - No options type in the repository exposes a raw password bound directly from configuration.
-- A missing or malformed reference fails startup with a message that identifies the account without disclosing the secret.
-- No secret-resolution contract is reachable from `Application` or `Domain`.
 - Every secret-bearing setting binds to the secret block type, so no configuration path carries a secret as a bare string and no setting can be secret-bearing without being subject to the rules below.
 - Under the default `ReferenceOnly` mode a secret block whose `SecretReference` is not a well-formed `<scheme>:<target>` fails startup naming the configuration path; a plain-text value is never accepted as the secret. The inline modes are reachable only by an explicit, logged configuration choice.
+- Every unresolved reference is reported at once, each named by its configuration path, without disclosing the target or the material.
 - Adding a second property to a secret block — a bundle password, a format hint — requires no change to the JSON type of any already-configured setting.
-- A configuration provider that pre-resolves secrets, such as Azure App Configuration with Key Vault references, works without a scheme adapter and without code changes.
+- A secret block binds correctly from flat colon-separated keys, so a pre-resolving provider such as Azure App Configuration with Key Vault references works without a scheme adapter and without code changes.
+- No secret-resolution contract is reachable from `Application` or `Domain`.
 - Resolution yields bytes, so a PKCS#12 bundle or DER certificate is representable without encoding damage, and text secrets are decoded and newline-trimmed only in the text view.
 - A new scheme can be added by registering one adapter, without editing the dispatch, an existing adapter, or any consumer.
 - The resolution contract is asynchronous and cancellable, so a network-backed provider needs no breaking change.
-- Rotating the material behind an unchanged reference is observed by the next operation without a process restart.
-- A configuration reload carrying an unresolvable reference is rejected and leaves the previous secrets active.
-- ADR 0002 has been amended, with owner approval, to classify referenced secrets as reloadable for new operations.
 - No secret material is held in a `string`, a pooled buffer, or a `SecureString`; buffers are pinned and zeroed with `CryptographicOperations.ZeroMemory` when their owning operation ends.
 - `docs/operations/` documents disabling core dumps and swap exposure for the service, in both the systemd and container deployment shapes.
-- A private server with a configured trust anchor connects with certificate validation fully enabled.
 - `docs/operations/local-development.md` documents the Development workflow and `docs/operations/` gains a page describing the systemd credential deployment path alongside the container path.
 - `dotnet msbuild .config/CodeCoverage.proj -t:Collect` passes the 85% whole-scope gate.

--- a/specs/02a-secret-reference-resolution.md
+++ b/specs/02a-secret-reference-resolution.md
@@ -67,11 +67,13 @@ Every secret-bearing setting uses the same object shape, whether the secret is a
 ```json
 "ClientCertificate": {
   "SecretReference": "file:/run/secrets/client.pfx",
-  "PasswordSecretReference": "systemd-credential:client-certificate-password"
+  "Password": { "SecretReference": "systemd-credential:client-certificate-password" }
 }
 ```
 
-Had the setting shipped as a bare string, adding the bundle password would change the setting's JSON type from string to object, which breaks every deployment that already configured it. Only the first such setting is free; the block makes all of them free. Nothing beyond `SecretReference` is defined by this specification — the point is that adding one later costs nothing.
+Had the setting shipped as a bare string, adding the bundle password would change the setting's JSON type from string to object, which breaks every deployment that already configured it. Only the first such setting is free; the block makes all of them free.
+
+One sibling is defined now: an optional nested `Password` block, itself a secret block. Specification 02b needs it for a password-protected PKCS#12 bundle, and a sibling *string* would not do — the discovery walk finds settings by the block type, so a string would be invisible to binding, validation, resolution, and erasure alike. Defining it here keeps the recursion honest and keeps 02b from having to change a contract this specification already shipped.
 
 **The block's type is what marks a setting as secret-bearing.** A secret block binds to a dedicated options type rather than to `string`, so a setting is secret-bearing because of what it *is*, not because someone remembered to annotate it. A marker attribute can be omitted on a newly added property and nothing would notice; a type cannot, because the property would not bind. Startup validation therefore discovers secret-bearing settings by walking the bound options graph for that type, and every rule below applies to every such setting automatically, including settings added after this specification ships.
 
@@ -115,6 +117,10 @@ A secret is not necessarily a password. The contract is shaped so that certifica
 - **Text secrets** — mailbox passwords, database passwords, and API keys. Resolved material is decoded as UTF-8 and stripped of a single trailing newline, because `LoadCredential=`, Compose secrets, and Kubernetes Secret files routinely end with one and an untrimmed byte would present as a wrong password.
 - **Certificates and key bundles** — a PKCS#12 bundle is binary, and DER-encoded material is not text at all. Specification 02b loads them; this specification guarantees they arrive intact.
 
+Reading material is bounded. A `file:` target can name a log, a database file, or a device-backed pseudo-file by mistake, and reading it whole would exhaust memory or stall the host before validation completes — at startup and again per use. Every read therefore enforces an explicit maximum size while reading, before an owned buffer is allocated, and an oversized target is a named resolution failure rather than an allocation.
+
+A successful resolution records whether its material came from a scheme adapter or was accepted inline. Two things depend on that distinction and neither can be derived from the interpretation mode: naming the settings that resolved inline in the startup log, and specification 02b accepting a binary certificate read through `file:` while rejecting the same bytes supplied inline.
+
 Resolution therefore yields opaque bytes, not a string. A text accessor performs the UTF-8 decode and newline trim for the first kind. Returning a string from the resolver would make a PKCS#12 bundle unrepresentable and would corrupt DER material through encoding round-trips, so the byte form is the primitive and text is the view over it. Trimming applies only to the text view: binary material is never modified.
 
 Loading typed material is the responsibility of the consumer that needs the type, above the resolver. The resolver knows about bytes and schemes and nothing about X.509.
@@ -145,13 +151,15 @@ Resolved material must live as briefly as possible and be erased when it stops b
 
 **`SecureString` is not used.** Microsoft's own documentation says "We recommend that you don't use the `SecureString` class for new development on .NET (Core)", and states that because of platform dependencies "`SecureString` does not encrypt the internal storage on non-Windows platform" — which is every environment MailMcp targets. The same documentation names the recommended alternative: "use an opaque handle to credentials that are stored outside of the process." That is precisely what a secret reference already is, so this specification's core design *is* the sanctioned approach and `SecureString` would add ceremony without protection.
 
-**Secret material is never held in a `string`.** A `string` is immutable, so it cannot be overwritten; it cannot be scheduled for deletion; and because its memory is not pinned, the garbage collector makes additional copies when it moves and compacts memory, each of which outlives any attempt to erase the original. Material is therefore held in a byte buffer, which is the other reason resolution is byte-oriented.
+**Secret material MailMcp allocates is never held in a `string`.** A `string` is immutable, so it cannot be overwritten; it cannot be scheduled for deletion; and because its memory is not pinned, the garbage collector makes additional copies when it moves and compacts memory, each of which outlives any attempt to erase the original. Material is therefore held in a byte buffer, which is the other reason resolution is byte-oriented.
 
 **The buffer is pinned and zeroed.** Material is allocated with `GC.AllocateArray<byte>(length, pinned: true)` so the collector cannot relocate it and leave an un-erased copy behind, and erased with `CryptographicOperations.ZeroMemory`, which exists — in its own documented words — "to future-proof against potential optimizations in the .NET runtime that could eliminate memory writes that aren't followed by memory reads." A plain loop assigning zeroes carries no such guarantee. Pooled buffers are not used for secret material at all, because a returned buffer that was not cleared hands the material to the next unrelated caller.
 
 **Resolved material is owned and disposed.** A resolved secret is disposable, is owned by the operation that resolved it, and is erased when that operation ends. Material exists for the length of one synchronization run or one connection attempt rather than for the process lifetime, so the window in which a dump could contain it is bounded by an operation rather than by uptime. Because each operation owns its own instance, the reload behavior specification 02b adds can publish new material without erasing what an in-flight operation is still using.
 
-Two exposures are accepted and must be documented rather than hidden. Some framework contracts take a `string` — the IMAP client's authentication call and the database connection string among them — so a short-lived `string` copy is unavoidable at exactly those call sites; it is created as late as possible, at the boundary itself, and never stored, logged, or passed on. And managed memory remains readable through a process dump, a debugger, or swap. Those are operational controls rather than code: the deployment must disable core dumps for the service and keep its memory out of swap, and the operations documentation must say so. Locking pages with `mlock` is deliberately not attempted — it would require P/Invoke plus elevated capability in every deployment shape, against a repository rule that restricts unsafe and platform-invoke code to measured need, and it does not address dumps or debuggers anyway.
+Three exposures are accepted and must be documented rather than hidden. `env:` is the first: `Environment.GetEnvironmentVariable` returns a `string`, so an environment-sourced secret arrives already un-erasable and no amount of care downstream changes that. It is a further reason the documentation recommends against `env:` outside non-production automation, and it is why the guarantee above is scoped to material MailMcp allocates rather than material the platform hands it. An inline value under the two inline modes has the same property, for the same reason.
+
+Second, some framework contracts take a `string` — the IMAP client's authentication call and the database connection string among them — so a short-lived `string` copy is unavoidable at exactly those call sites; it is created as late as possible, at the boundary itself, and never stored, logged, or passed on. Third, managed memory remains readable through a process dump, a debugger, or swap. Those are operational controls rather than code: the deployment must disable core dumps for the service and keep its memory out of swap, and the operations documentation must say so. Locking pages with `mlock` is deliberately not attempted — it would require P/Invoke plus elevated capability in every deployment shape, against a repository rule that restricts unsafe and platform-invoke code to measured need, and it does not address dumps or debuggers anyway.
 
 ## Safety and privacy
 
@@ -187,7 +195,11 @@ Adapters for external managed secret stores — Kubernetes, Azure Key Vault, Has
 - Resolution yields bytes, so a PKCS#12 bundle or DER certificate is representable without encoding damage, and text secrets are decoded and newline-trimmed only in the text view.
 - A new scheme can be added by registering one adapter, without editing the dispatch, an existing adapter, or any consumer.
 - The resolution contract is asynchronous and cancellable, so a network-backed provider needs no breaking change.
-- No secret material is held in a `string`, a pooled buffer, or a `SecureString`; buffers are pinned and zeroed with `CryptographicOperations.ZeroMemory` when their owning operation ends.
+- No secret material that MailMcp allocates is held in a `string`, a pooled buffer, or a `SecureString`; buffers are pinned and zeroed with `CryptographicOperations.ZeroMemory` when their owning operation ends, and no intermediate read buffer survives un-erased.
+- The residual exposures — `env:`, inline values, the two framework `string` boundaries, and process memory itself — are documented for the operator rather than implied away.
+- Reading material enforces an explicit maximum size, so a mistaken reference to a large file is a named failure rather than an allocation.
+- A successful resolution records whether its material came from an adapter or was accepted inline.
+- Reading a secret is asynchronous and honours the caller's cancellation token end to end, including at the file-system boundary.
 - `docs/operations/` documents disabling core dumps and swap exposure for the service, in both the systemd and container deployment shapes.
 - `docs/operations/local-development.md` documents the Development workflow and `docs/operations/` gains a page describing the systemd credential deployment path alongside the container path.
 - `dotnet msbuild .config/CodeCoverage.proj -t:Collect` passes the 85% whole-scope gate.

--- a/specs/02b-certificate-material-and-secret-rotation.md
+++ b/specs/02b-certificate-material-and-secret-rotation.md
@@ -27,7 +27,9 @@ Three encodings must load, because all three occur in deployment:
 
 - **PEM** — what a certificate authority hands an operator, and the only encoding that also survives being pasted into configuration.
 - **DER** — what some tooling emits. Binary, so it is reachable through `file:` and `systemd-credential:` but not through an inline value.
-- **PKCS#12 / PFX** — binary, and may itself be protected by a password. That password is a second secret block, which is the concrete case the block shape in 02a exists for. This specification loads a bundle but presents no client certificate; MCP client certificates are stage 9 work.
+- **PKCS#12 / PFX** — binary, and *may* be protected by a password. When it is, that password is the nested secret block 02a defines. When it is not, the bundle is still valid and still loads; requiring a password block unconditionally would reject files an operator is entitled to use. This specification loads a bundle but presents no client certificate; MCP client certificates are stage 9 work.
+
+A trust anchor must not carry a private key. Bundles commonly do, and this feature needs only a public anchor, so a key would sit outside the buffer whose lifetime this design controls — and with default key-storage flags the import can persist it to a key store on disk. Material is therefore imported with ephemeral key storage, and a trust anchor whose certificate carries a private key is rejected rather than silently accepted.
 
 A trust anchor that does not parse, or parses but is unusable as a trust anchor, fails startup. Silently continuing would either reject a working server or invite an operator to disable validation to work around it.
 
@@ -44,7 +46,9 @@ Two limits are stated rather than discovered:
 
 The loaded anchor is supplied to the mail transport's certificate validation path so a private server chains to it while ordinary validation stays enabled for everything else.
 
-Trust is decided by rebuilding the chain against the configured anchor, never by accepting the error the platform reported. A name mismatch and an unavailable certificate are rejected outright; only a chain-trust failure is re-examined, and only by building a chain that trusts the configured anchor as a root and requiring a clean rebuild. No configuration path exists that disables validation, and the definition of done asserts its absence.
+Trust is decided by rebuilding the chain against the configured anchor, never by accepting the error the platform reported. A name mismatch and an unavailable certificate are rejected outright; only a chain-trust failure is re-examined, and only by building a chain that trusts the configured anchor as a root and requiring a clean rebuild.
+
+The rebuild reuses the intermediate certificates the server supplied. A private server whose certificate is signed by an intermediate rather than directly by the configured root is an ordinary deployment, and its intermediate is often available only from the handshake — not from the machine store and not from an AIA-reachable location. Discarding it would reject a correctly provisioned server. The supplied intermediates are candidates for path building only; trust still comes solely from the configured anchor. No configuration path exists that disables validation, and the definition of done asserts its absence.
 
 ### Rotation without restart
 
@@ -55,7 +59,11 @@ Two independent things can change, and both are covered:
 - **The reference changes.** A configuration reload delivers a new `SecretReference` inside one of the secret blocks. The candidate snapshot is validated by resolving every reference in it before it is published; a snapshot containing an unresolvable reference is rejected and the last known good snapshot stays active, exactly as ADR 0002 requires for reloadable groups. A rejected reload is logged with the configuration path and the failure identity, never with material.
 - **The material behind an unchanged reference changes.** Rotating the credential file, the systemd credential, or the vault entry leaves configuration untouched, so no configuration reload fires. Resolution therefore moves from once-at-startup to per use, and the next operation that needs the secret observes the rotated value. A network-backed provider that cannot afford per-use retrieval caches inside its own adapter with its own expiry, which is why caching policy is an adapter concern rather than a contract concern.
 
+The database credential needs its own treatment, because it is composed into a connection source once rather than read per operation. Without explicit handling, neither a changed reference nor rotated material would reach a connection opened afterwards, and revoking the old credential would take MailMcp offline until restart — the outcome rotation exists to prevent. The connection source is therefore rebuilt when the resolved credential changes, and superseded sources are disposed only after their in-flight connections drain.
+
 Material is applied at operation boundaries, not mid-operation: a synchronization run that has authenticated continues with the credential it authenticated with, and the next run picks up the rotation. This is ADR 0002's "reloadable for new operations" classification, chosen over "reloadable during running operations" because swapping a credential or a trust anchor underneath an open IMAP session has no coherent meaning.
+
+"The next operation" needs a definition that survives specification 11. Once a folder holds one authenticated IDLE connection across many synchronization runs, there is no next connect to pick up a rotation, and an old credential and an old trust anchor could stay in use for the process lifetime unless an unrelated disconnect happened to occur. The operation boundary for a long-lived session is therefore the *connection*, and a session whose secrets have rotated is deliberately recycled at the next safe point rather than left running. Specification 11 must honour this; it is recorded here because this specification is what makes the promise.
 
 Per-use resolution composes with 02a's ownership rule rather than fighting it. Each operation owns the material it resolved and erases it when it ends, so publishing a new snapshot never erases material an in-flight operation is still reading.
 
@@ -92,7 +100,11 @@ Managed secret store adapters, which specification 02a's extensibility section c
 - A private server with a configured trust anchor connects with certificate validation fully enabled.
 - No configuration path exists that disables certificate validation, and a test asserts its absence.
 - Trust is decided by rebuilding the chain against the configured anchor; a name mismatch or an unavailable certificate is rejected regardless of the anchor.
-- PEM, DER, and PKCS#12 material all load from resolved bytes, and a PKCS#12 password is supplied by a second secret block.
+- PEM, DER, and PKCS#12 material all load from resolved bytes; a protected bundle takes its password from the nested secret block, and an unprotected bundle loads without one.
+- A trust anchor carrying a private key is rejected, and material is imported with ephemeral key storage so nothing is written to a key store.
+- A server certificate signed by an intermediate the server supplies chains successfully to the configured anchor, and that intermediate gains no trust of its own.
+- A rotated database credential reaches connections opened afterwards without a process restart, and connections already open finish with the credential they authenticated with.
+- A reload never blocks the configuration callback thread, never terminates the process on a resolution failure, and never lets an older candidate publish after a newer one.
 - A trust anchor may be supplied inline as PEM under the inline interpretation modes; inline DER or PKCS#12 fails startup with a message that names the encoding as the reason.
 - Malformed or unusable trust anchor material fails startup with a message that discloses no secret.
 - Rotating the material behind an unchanged reference is observed by the next operation without a process restart.

--- a/specs/02b-certificate-material-and-secret-rotation.md
+++ b/specs/02b-certificate-material-and-secret-rotation.md
@@ -1,0 +1,103 @@
+# Certificate Material and Secret Rotation
+
+**Roadmap group:** A — configuration, transport security, resilience
+**Draft delivery stage:** 2
+**Depends on:** 01, 02a
+**Estimated change size:** ~750 lines including tests and documentation
+
+## Goal
+
+Load deployment-provisioned certificate material through the resolution contract specification 02a builds, install a trusted certificate authority into the mail transport's certificate validation path so a private server is supported with validation fully enabled, and let a rotated secret take effect without restarting the process.
+
+## Current state
+
+Specification 02a delivers the reference grammar, the four scheme adapters, the secret block, the byte-oriented resolution contract, memory hygiene, and fail-fast startup validation. It resolves mailbox and database passwords and it fixes the configuration shape of `TrustedCertificateAuthority`, but nothing reads that block's material.
+
+Specification 01 requires that certificate validation is never disabled and that private or self-signed servers are supported by configuring additional trusted certificate authorities. It defines the policy and validates that a trust anchor is configured when `CertificateTrust` is `AdditionalTrustedAuthority`. It deliberately stops there: `MailAccountTransportSecurityOptions` carries the setting, and no code loads it.
+
+Resolution in 02a happens once, at startup validation. A credential rotated afterwards is not observed until the process restarts.
+
+## Approved scope
+
+### Typed material above the resolver
+
+The resolver yields opaque bytes. A certificate loader in `Infrastructure` turns those bytes into an X.509 certificate and is the only place that knows about X.509 at all, so a future material kind adds a loader rather than touching a scheme adapter.
+
+Three encodings must load, because all three occur in deployment:
+
+- **PEM** — what a certificate authority hands an operator, and the only encoding that also survives being pasted into configuration.
+- **DER** — what some tooling emits. Binary, so it is reachable through `file:` and `systemd-credential:` but not through an inline value.
+- **PKCS#12 / PFX** — binary, and may itself be protected by a password. That password is a second secret block, which is the concrete case the block shape in 02a exists for. This specification loads a bundle but presents no client certificate; MCP client certificates are stage 9 work.
+
+A trust anchor that does not parse, or parses but is unusable as a trust anchor, fails startup. Silently continuing would either reject a working server or invite an operator to disable validation to work around it.
+
+### Inline certificate material
+
+A trust anchor is a public certificate, not a private key, so writing one into configuration leaks nothing. Under `ReferenceOrInline` or `InlineOnly` the block therefore accepts the PEM text directly, which is what makes an Azure App Configuration deployment work end to end: the store holds the certificate, the provider binds it, and MailMcp parses what it was given.
+
+Two limits are stated rather than discovered:
+
+- Only PEM works inline. DER and PKCS#12 are binary and have no faithful representation in a configuration value, so an inline block carrying them is a startup failure that says so, rather than a parse error further down.
+- PEM is multi-line, so a JSON document must escape the newlines. That is ugly but valid, and it is the operator's choice; a store-backed provider has no such problem because the value is transported, not authored in JSON.
+
+### Installing the trust anchor
+
+The loaded anchor is supplied to the mail transport's certificate validation path so a private server chains to it while ordinary validation stays enabled for everything else.
+
+Trust is decided by rebuilding the chain against the configured anchor, never by accepting the error the platform reported. A name mismatch and an unavailable certificate are rejected outright; only a chain-trust failure is re-examined, and only by building a chain that trusts the configured anchor as a root and requiring a clean rebuild. No configuration path exists that disables validation, and the definition of done asserts its absence.
+
+### Rotation without restart
+
+Secrets reload on the same terms as the configuration that references them. An operator who rotates a mailbox password, replaces an expiring trust anchor, or re-issues a database credential must not have to restart MailMcp and interrupt synchronization to do it.
+
+Two independent things can change, and both are covered:
+
+- **The reference changes.** A configuration reload delivers a new `SecretReference` inside one of the secret blocks. The candidate snapshot is validated by resolving every reference in it before it is published; a snapshot containing an unresolvable reference is rejected and the last known good snapshot stays active, exactly as ADR 0002 requires for reloadable groups. A rejected reload is logged with the configuration path and the failure identity, never with material.
+- **The material behind an unchanged reference changes.** Rotating the credential file, the systemd credential, or the vault entry leaves configuration untouched, so no configuration reload fires. Resolution therefore moves from once-at-startup to per use, and the next operation that needs the secret observes the rotated value. A network-backed provider that cannot afford per-use retrieval caches inside its own adapter with its own expiry, which is why caching policy is an adapter concern rather than a contract concern.
+
+Material is applied at operation boundaries, not mid-operation: a synchronization run that has authenticated continues with the credential it authenticated with, and the next run picks up the rotation. This is ADR 0002's "reloadable for new operations" classification, chosen over "reloadable during running operations" because swapping a credential or a trust anchor underneath an open IMAP session has no coherent meaning.
+
+Per-use resolution composes with 02a's ownership rule rather than fighting it. Each operation owns the material it resolved and erases it when it ends, so publishing a new snapshot never erases material an in-flight operation is still reading.
+
+### The ADR this changes
+
+This departs from ADR 0002's current guidance, which classifies credentials and certificate trust anchors as restart-required. That guidance was written before a secret-reference indirection existed; with it, rotation no longer means mutating a bound secret value in place, but re-resolving a reference whose validity is proven before it is published.
+
+**The ADR needs an owner-approved amendment recording this, and this specification must not be implemented against an unamended ADR.** `docs/AGENTS.md` forbids modifying an ADR without explicit owner approval, so no ADR is modified as part of writing this specification.
+
+## Safety and privacy
+
+A trust anchor is public material, so it may be logged by subject and thumbprint. Nothing else changes: a bundle password, like any other secret, is never logged, and a reload failure names the configuration path and the failure identity only.
+
+Rotation shortens the window in which any single credential is valid, which is a privacy and security improvement rather than a cost. The one new exposure is that per-use resolution reads the credential source more often; it stays bounded because material is erased at the end of each operation instead of being cached.
+
+## Testing
+
+Certificate-loading tests cover PEM and DER both loading from bytes, a PKCS#12 bundle loading with a password drawn from a second block, malformed material failing with a named identity rather than an exception escaping, and inline DER being rejected with the encoding-specific failure rather than a generic parse error.
+
+Trust-anchor tests cover a server certificate chaining to the configured anchor being accepted, a name mismatch being rejected even when the anchor would otherwise validate, an unavailable certificate being rejected, an untrusted chain without a configured anchor being rejected, and the absence of any configuration path that disables validation.
+
+Reload tests cover a rotated reference being adopted, a candidate snapshot with an unresolvable reference being rejected while the previous secrets stay active, a rejected reload logging the path and failure without material, rotated material behind an unchanged reference being observed by the next operation, and the same rotation not affecting an operation already in flight.
+
+## Out of scope
+
+Presenting a client certificate. This specification loads PKCS#12 material and proves the bundle-password path works, but MailMcp presents no certificate of its own; MCP client certificates and the ChatGPT mTLS profile are stage 9 work.
+
+Certificate revocation policy beyond what the chain rebuild requires, certificate expiry monitoring and alerting, and automatic renewal.
+
+Managed secret store adapters, which specification 02a's extensibility section constrains and neither specification implements.
+
+## Definition of done
+
+- A private server with a configured trust anchor connects with certificate validation fully enabled.
+- No configuration path exists that disables certificate validation, and a test asserts its absence.
+- Trust is decided by rebuilding the chain against the configured anchor; a name mismatch or an unavailable certificate is rejected regardless of the anchor.
+- PEM, DER, and PKCS#12 material all load from resolved bytes, and a PKCS#12 password is supplied by a second secret block.
+- A trust anchor may be supplied inline as PEM under the inline interpretation modes; inline DER or PKCS#12 fails startup with a message that names the encoding as the reason.
+- Malformed or unusable trust anchor material fails startup with a message that discloses no secret.
+- Rotating the material behind an unchanged reference is observed by the next operation without a process restart.
+- A configuration reload carrying an unresolvable reference is rejected and leaves the previous secrets active.
+- A rotation is never applied to an operation already in flight.
+- ADR 0002 has been amended, with owner approval, to classify referenced secrets as reloadable for new operations.
+- `docs/features/imap-synchronization.md` documents the trust anchor behavior including the revocation trade-off, and `docs/operations/` documents the rotation procedure for both deployment shapes.
+- `dotnet msbuild .config/CodeCoverage.proj -t:Collect` passes the 85% whole-scope gate.

--- a/specs/11-imap-idle-continuous-sync.md
+++ b/specs/11-imap-idle-continuous-sync.md
@@ -25,7 +25,7 @@ Loss of the IDLE connection is a transient failure handled by the session pipeli
 
 The IDLE session opens the folder read-only exactly as the polling path does, and the notification handler performs no fetch of its own; it only signals that a synchronization pass should run. This keeps the `\Seen` invariant proven by the existing synchronizer tests rather than duplicated into a second fetch path, and the specification requires a test asserting the push path performs no direct content fetch.
 
-A long-lived connection holds credentials in memory for the process lifetime; the specification requires that the session obtains its secret through the resolver from specification 02 at connect time and does not retain a copy beyond the session object.
+A long-lived connection holds credentials in memory for the process lifetime; the specification requires that the session obtains its secret through the resolver from specification 02a at connect time and does not retain a copy beyond the session object.
 
 ## Testing
 

--- a/specs/11-imap-idle-continuous-sync.md
+++ b/specs/11-imap-idle-continuous-sync.md
@@ -27,6 +27,8 @@ The IDLE session opens the folder read-only exactly as the polling path does, an
 
 A long-lived connection holds credentials in memory for the process lifetime; the specification requires that the session obtains its secret through the resolver from specification 02a at connect time and does not retain a copy beyond the session object.
 
+A long-lived session also breaks the rotation boundary specification 02b defines. That specification applies a rotated secret at the start of the next operation, which for ordinary polling is the next run's connect. An IDLE session has no next connect, so a rotated password or trust anchor would stay in use for the process lifetime unless an unrelated disconnect happened to occur — and a revoked credential would keep working, which is the opposite of what rotation is for. The connection is therefore the operation boundary here: a session whose secrets have rotated is recycled at the next safe point rather than left running, and this specification owns that recycling because it is what introduces the long-lived session.
+
 ## Testing
 
 `Infrastructure.UnitTests` drive the narrow IMAP client port with NSubstitute to model: a server advertising IDLE, a server not advertising it, renewal firing before the timeout under `FakeTimeProvider`, a notification triggering exactly one synchronization pass, a dropped connection reconnecting, repeated failures degrading to polling and later retrying push, and cancellation exiting IDLE promptly during shutdown. Tests assert the effective mode is reported when it differs from the configured mode.

--- a/specs/README.md
+++ b/specs/README.md
@@ -19,7 +19,8 @@ The first vertical slice is already merged: periodic read-only IMAP reconciliati
 | # | Specification | Draft stage |
 |---|---|---|
 | 01 | [Mail transport security policy](01-mail-transport-security-policy.md) | 2 |
-| 02 | [Secret reference resolution](02-secret-reference-resolution.md) | 2 |
+| 02a | [Secret reference resolution](02a-secret-reference-resolution.md) | 2 |
+| 02b | [Certificate material and secret rotation](02b-certificate-material-and-secret-rotation.md) | 2 |
 | 03 | [Resilience pipeline foundation](03-resilience-pipeline-foundation.md) | cross-cutting |
 | 04 | [IMAP session resilience](04-imap-session-resilience.md) | 3 |
 | 05 | [Mail folder configuration and discovery](05-mail-folder-configuration-and-discovery.md) | 3 |


### PR DESCRIPTION
Plans specification 02 and revises the specification itself for three requirements raised during planning. No production code changes.

Refs #36, Refs #63 — this pull request closes neither issue. It delivers the specifications and plans only; each issue closes when its implementation lands.

## What is here

- `docs/superpowers/plans/2026-07-27-secret-reference-resolution.md` — a nine-task implementation plan with 19 locked design decisions, following the shape of the specification 01 plan.
- `specs/02-secret-reference-resolution.md` — revised for the three requirements below.

## Specification revisions

**Secrets are referenced from JSON, never stored in it.** The specification now shows the concrete `appsettings.json` shape: every secret-bearing setting is a `*Reference` string, so a configuration file leaked from a backup or a repository yields credential names and paths and nothing more.

**Secrets are not only passwords.** Certificates and private keys are first-class. Resolution therefore yields `ReadOnlyMemory<byte>` with text as a view over it — a `string`-returning resolver would make a PKCS#12 bundle unrepresentable and would corrupt DER through encoding round-trips. The UTF-8 decode and trailing-newline trim apply to the text view only, because trimming a PFX would corrupt it.

**Secrets reload dynamically, like the configuration that references them.** Both halves are covered: a changed reference arrives through `IOptionsMonitor` and is validated by resolving the whole candidate snapshot before publishing, retaining last-known-good on failure; rotated material behind an unchanged reference is picked up because resolution happens per use. Neither applies mid-operation.

## Inline values and pre-resolving providers

The earlier "`plaintext:` only in Development" rule was both too strict and too weak, and is replaced.

Too strict, because an operator may knowingly write a secret into JSON — that is their deployment and their call. Too weak, because it did not address the real driver: a configuration provider that resolves the secret *before* MailMcp binds it. Azure App Configuration with Key Vault references does exactly that — its documentation states the app "access[es] the values of Key Vault references the same way [it] access[es] the values of regular App Configuration keys", so the bound setting is the raw secret with no prefix. The previous rule that a value without a scheme fails startup would have broken that integration outright.

Interpretation is now an explicit three-valued mode:

| Mode | Behavior |
| --- | --- |
| `ReferenceOnly` (default) | Value must be `<scheme>:<target>`; a bare value fails startup, so a mistyped `fil:/run/secrets/x` stays a failure rather than becoming a password. |
| `ReferenceOrInline` | Recognized scheme resolves through its adapter; anything else is taken as the secret. |
| `InlineOnly` | Nothing is parsed; every value is already the secret. The Azure App Configuration path — and the only mode where a password that literally begins with `file:` is safe. |

Two consequences are documented rather than hidden: startup logs the active mode and the *names* of settings that resolved inline, and an inline value arrives from `IConfiguration` as a `string`, which cannot be erased — so the inline modes forfeit part of the in-memory protection. Both are why `ReferenceOnly` remains the default.

This also settles an architectural question: a **pre-resolving** provider (Azure App Configuration) is *not* a scheme adapter, because its mapping happens below MailMcp in the configuration pipeline and needs no MailMcp code at all. A store MailMcp **queries itself** (direct Key Vault, HashiCorp Vault) is a scheme adapter. The two shapes should not be conflated.

## Memory protection for resolved secrets

Researched against current Microsoft guidance; two findings changed the design rather than confirming it.

**`SecureString` is rejected.** Microsoft recommends against it for new development on .NET, and it "does not encrypt the internal storage on non-Windows platform" — every environment MailMcp targets. The same page names the recommended alternative: "use an opaque handle to credentials that are stored outside of the process." A secret reference *is* that handle, so this specification's core design was already the sanctioned approach.

**Material is never held in a `string`.** A `string` cannot be overwritten, cannot be scheduled for deletion, and because its memory is not pinned the collector makes additional copies while compacting — so erasing one is not well defined. Material is a pinned `byte[]` from `GC.AllocateArray<byte>(length, pinned: true)`, erased with `CryptographicOperations.ZeroMemory`, which is documented as existing "to future-proof against potential optimizations in the .NET runtime that could eliminate memory writes that aren't followed by memory reads". `ArrayPool` is not used for secret material at all.

`RevealBytes()` becomes the primary accessor. `RevealAsString()` is demoted to a documented escape hatch for the two framework contracts that require a `string` — MailKit's `AuthenticateAsync` and the Npgsql connection-string password — called at the boundary and never stored.

A resolved secret is disposable and owned by the operation that resolved it, which bounds the exposure window to one synchronization run rather than to process uptime, and removes a lifetime hazard from dynamic reload: publishing a new snapshot never erases material an in-flight operation is still reading.

Residual exposure is stated rather than hidden. A dump, a debugger, or swap can still read managed memory; the mitigations are operational (`LimitCORE=0`, `systemd-coredump` `Storage=none`, keeping the service out of swap) and are assigned to the operations documentation. `mlock` is rejected: it needs P/Invoke plus `CAP_IPC_LOCK` in every deployment shape, against the repository rule on unsafe code, and does not address dumps or debuggers anyway.

## Extensibility

The scheme set is open by design. A scheme is a value an adapter declares and dispatch is a lookup, so Kubernetes, Azure Key Vault, HashiCorp Vault, or AWS Secrets Manager is later one adapter registration rather than a refactor. The resolution contract is asynchronous and cancellable from the first commit for the same reason. A test that registers a scheme adapter existing only in the test project is what keeps that promise honest.

Container and Kubernetes deployments need no new scheme at all: their secrets are files, so `file:` already serves them. Only a provider with genuinely different retrieval behavior earns a scheme.

## Uniform secret block

Every secret-bearing setting is a JSON object rather than a bare string, and the object's `SecretReference` property carries the reference:

```json
{
  "MailSynchronization": {
    "Accounts": [
      {
        "AccountId": "primary",
        "Secrets": {
          "Password": { "SecretReference": "systemd-credential:imap-primary-password" }
        },
        "TransportSecurity": {
          "CertificateTrust": "AdditionalTrustedAuthority",
          "TrustedCertificateAuthority": { "SecretReference": "file:/run/secrets/private-ca.pem" }
        }
      }
    ]
  },
  "Persistence": {
    "Password": { "SecretReference": "file:/run/secrets/postgres-password" }
  }
}
```

Two reasons make the object the right unit. It has room to grow: a PKCS#12 bundle needs a second reference for its own password, a certificate may need a format hint, a managed-store reference may need a version pin, and each of those is a sibling property inside a block that already exists. Had the setting shipped as a bare string, the first such addition would change its JSON type from string to object and break every deployment that had configured it.

And the block's type is what marks a setting as secret-bearing. A secret binds to `ConfiguredSecret` rather than to `string`, so startup validation discovers every one of them by walking the bound options graph. An attribute would work identically at the point of use but can be omitted on a property added later, and nothing would notice — the property would bind to `string`, hold a password, and skip every rule in the plan. A type cannot be omitted, because the property would not bind to the block shape at all.

That is what makes the `ReferenceOnly` guarantee total rather than per-setting: a block whose `SecretReference` is not a well-formed `<scheme>:<target>` fails startup naming its configuration path, so a plain-text password pasted where a reference belongs is a startup error, never a secret that resolved by accident. A second architecture test enforces the other direction, failing the build if a secret-looking property is bound as a raw `string`.

This renames `MailAccountTransportSecurityOptions.TrustedCertificateAuthorityReference` to `TrustedCertificateAuthority` and changes it from a string to a block. The `Reference` suffix earned its place while the value *was* the reference string; now that a block holds it in `SecretReference`, the suffix repeats the word. It is a breaking configuration change to a setting specification 01 already shipped, proposed now because it is cheap now (one consumer, no released deployment) and expensive later — an affected operator edits one line. `MailTransportSecurityPolicy` in `Domain` keeps receiving a nullable string and is unaffected: the block is a configuration-adapter shape and does not cross the boundary.

## Split into 02a and 02b

The combined specification reached ~1700 lines against the ~1000-line ceiling in `specs/README.md`, so it is now two:

| | Specification | Issue | Size |
| --- | --- | --- | --- |
| **02a** | [Secret reference resolution](https://github.com/Krzysztof318/MailMcp/blob/main/specs/02a-secret-reference-resolution.md) — grammar, four schemes, the secret block and its discovery, byte-oriented contract, memory hygiene, mailbox and database passwords, fail-fast startup validation | #36 (retitled) | ~950 lines |
| **02b** | [Certificate material and secret rotation](https://github.com/Krzysztof318/MailMcp/blob/main/specs/02b-certificate-material-and-secret-rotation.md) — PEM/DER/PKCS#12 loading, installing the trust anchor in the validation path, rotation without restart | #63 (new) | ~750 lines |

The split turned out cheaper than flagged earlier: nothing in `specs/` declares `Depends on: 02`, so specifications 03 onward needed no renumbering. Only the two prose cross-references in 01 and 11 changed.

02b consumes 02a's contract and changes none of it — a constraint stated in its plan, so that a change that looks necessary there is treated as evidence the split was drawn in the wrong place rather than absorbed quietly. The four design decisions that belong to 02b keep their original numbers (11, 17, 18, 21) so a cross-reference from either plan resolves to the same thing; the decisions stay recorded once, in the 02a plan.

The ADR 0002 blocker now scopes to 02b only. 02a can proceed as soon as it is approved.

## Azure App Configuration binding

Restated as a hard requirement rather than an assumption, since the block adds a path segment: the same setting is addressed as `MailSynchronization:Accounts:0:Secrets:Password:SecretReference` by App Configuration and by its double-underscore form in an environment block. Binding tests populate an in-memory provider with flat colon-separated keys instead of parsing a JSON document, so a change that made the block depend on JSON document structure fails a test rather than a deployment.

Combined with `InlineOnly`, that is the complete path: the store holds the key, Key Vault holds the value, the provider maps one to the other, and MailMcp binds an already-resolved secret. A trust anchor works the same way inline, with one limit stated up front — only PEM survives a configuration value, so inline DER or PKCS#12 fails startup naming the encoding as the reason instead of surfacing a generic parse error.

## Open for the owner

1. **ADR 0002 needs an owner-approved amendment before 02b's rotation task starts.** It currently classifies credentials and certificate trust anchors as restart-required, which the rotation requirement contradicts. `docs/AGENTS.md` forbids amending an ADR without explicit approval, so no ADR is touched here. All of 02a and 02b's certificate tasks are unaffected.

Also flagged in the plan: whether `env:` should be enforced as non-production rather than merely documented as such, and whether the reflection-based options-graph walk that discovers secret blocks is acceptable against the root rule restricting reflection to measured need.

## Verification

`bash scripts/verify-full.sh` — passed (exit 0). Documentation-only change, so no behavior is exercised beyond the existing suite. `$check-docs-licenses`: docs pass, licenses n/a — no dependency, tool, service, image, or sample added.