### PR TITLE
Fix review findings on secret reference resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ The product and solution name is `MailMcp`. The solution file is `MailMcp.slnx`;
 ## Development environment
 
 - Development runs locally. The repository does not provision agent environments, so install the SDK pinned in `global.json` and any command-line tooling such as `dotnet-ef` or the Aspire CLI on the developer machine. `docs/operations/local-development.md` lists the commands that must work.
+- Never invoke `dotnet ef` directly. EF Core design-time and migration commands must run through `aspire exec`, so they see the orchestrated resources and the connection strings the AppHost issues rather than an ad-hoc local environment that can differ from every real one. That path is not wired up yet, so do not run EF Core tooling at all for now; work that needs a migration is blocked until it is, and the block is reported rather than worked around.
 
 ## Critical repository rules
 

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -73,14 +73,13 @@ dotnet tool install --global Aspire.Cli --version 13.4.6
 
 `dotnet ef` runs EF Core migrations and design-time commands. `aspire` is only required for Aspire CLI workflows against the AppHost. Both versions are recorded in `LICENSES.md`; keep the register aligned when you move to a newer one.
 
-Design-time commands do not start the host and resolve no secret, because the host composes its connection string during startup and a deployment credential does not belong on a workstation. A design-time context therefore uses `Host=localhost;Database=mailmcp;Username=mailmcp`. Point a command at a different local database by exporting `MAILMCP_DESIGN_TIME_CONNECTION_STRING`:
+### EF Core design-time commands
 
-```bash
-export MAILMCP_DESIGN_TIME_CONNECTION_STRING='Host=localhost;Port=5433;Database=mailmcp;Username=dev'
-dotnet ef migrations add InitialSchema --project src/Infrastructure --startup-project src/Host
-```
+**Do not invoke `dotnet ef` directly.** Design-time and migration commands must run through `aspire exec`, so they see the orchestrated resources and the connection strings the AppHost issues rather than a local environment that can differ from every real one. That path is not wired up yet, so EF Core tooling is not to be run at all for now, and work that needs a migration is blocked until it is.
 
-`migrations add` and `dbcontext script` need only the model, so they work without a reachable server.
+The pieces the tooling will need are already in place. `MailMcpDbContextDesignTimeFactory` gives EF Core a context without starting the host, which matters because the host composes its connection string during startup and design-time tooling never runs that. It resolves no secret: `migrations add` and `dbcontext script` need the model rather than a reachable server, and a deployment credential does not belong on a workstation. A command that does need a live database reads `MAILMCP_DESIGN_TIME_CONNECTION_STRING`, falling back to `Host=localhost;Database=mailmcp;Username=mailmcp`.
+
+`Infrastructure` is its own startup project for these commands. It owns the context, the factory, and the only reference to `Microsoft.EntityFrameworkCore.Design`; `Host` references that package nowhere, so naming it as the startup project fails.
 
 The GitHub CLI (`gh`) is installed separately through the operating system package manager and is required for the issue and pull-request workflow in root `AGENTS.md`. It needs the `project` scope on top of its default scopes so it can read and update the roadmap board.
 

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -73,6 +73,15 @@ dotnet tool install --global Aspire.Cli --version 13.4.6
 
 `dotnet ef` runs EF Core migrations and design-time commands. `aspire` is only required for Aspire CLI workflows against the AppHost. Both versions are recorded in `LICENSES.md`; keep the register aligned when you move to a newer one.
 
+Design-time commands do not start the host and resolve no secret, because the host composes its connection string during startup and a deployment credential does not belong on a workstation. A design-time context therefore uses `Host=localhost;Database=mailmcp;Username=mailmcp`. Point a command at a different local database by exporting `MAILMCP_DESIGN_TIME_CONNECTION_STRING`:
+
+```bash
+export MAILMCP_DESIGN_TIME_CONNECTION_STRING='Host=localhost;Port=5433;Database=mailmcp;Username=dev'
+dotnet ef migrations add InitialSchema --project src/Infrastructure --startup-project src/Host
+```
+
+`migrations add` and `dbcontext script` need only the model, so they work without a reachable server.
+
 The GitHub CLI (`gh`) is installed separately through the operating system package manager and is required for the issue and pull-request workflow in root `AGENTS.md`. It needs the `project` scope on top of its default scopes so it can read and update the roadmap board.
 
 On a machine that has never authenticated, log in and request the scope in the same step:

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -28,8 +28,12 @@ builder.Services.AddOptions<MailSynchronizationOptions>()
         binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
     .ValidateDataAnnotations()
     .ValidateOnStart();
+// Bound strictly for the same reason as mail transport: a misspelled "Passwrod" would leave the secret block
+// undiscovered, start the host on a passwordless connection string, and surface as an authentication failure later.
 builder.Services.AddOptions<PersistenceOptions>()
-    .Bind(builder.Configuration.GetSection("Persistence"))
+    .Bind(
+        builder.Configuration.GetSection("Persistence"),
+        binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
     .ValidateDataAnnotations()
     .ValidateOnStart();
 builder.Services.AddScoped<IImapAccountSettingsProvider, ConfiguredImapAccountSettingsProvider>();
@@ -54,7 +58,8 @@ builder.Services.AddSingleton(provider => new PersistenceConcurrencyOptions
 builder.Services.AddHostedService<MailMcp.Host.Hosting.SecretReferenceStartupValidator>();
 // The blocks are read here rather than through IOptions because the data source they configure is registered before
 // any options instance can be resolved. Only the references are read; resolution happens during startup.
-var persistenceSecrets = builder.Configuration.GetSection("Persistence").Get<PersistenceOptions>();
+var persistenceSecrets = builder.Configuration.GetSection("Persistence").Get<PersistenceOptions>(
+    binderOptions => binderOptions.ErrorOnUnknownConfiguration = true);
 builder.Services.AddInfrastructure(new PostgresConnectionSettings(
     builder.Configuration.GetConnectionString("mailmcp"),
     persistenceSecrets?.ConnectionString,

--- a/src/Infrastructure/Persistence/MailMcpDbContextDesignTimeFactory.cs
+++ b/src/Infrastructure/Persistence/MailMcpDbContextDesignTimeFactory.cs
@@ -1,0 +1,45 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace MailMcp.Infrastructure.Persistence;
+
+/// <summary>Creates a context for <c>dotnet ef</c> without starting the host.</summary>
+/// <remarks>
+/// <para>
+/// EF Core's design-time tooling otherwise falls back to the application's service provider, where the connection
+/// string is composed during <see cref="Microsoft.Extensions.Hosting.IHostedLifecycleService.StartingAsync" />. The
+/// tooling never runs that, so every model and migration command would fail on a connection string that startup has
+/// not composed yet. EF looks for this factory first, so it never reaches that path.
+/// </para>
+/// <para>
+/// Design time deliberately resolves no secret. <c>migrations add</c> and <c>dbcontext script</c> need the model
+/// rather than a reachable server, and a developer's workstation is not where a deployment credential belongs. A
+/// command that does need a live database takes its connection string from
+/// <see cref="DesignTimeConnectionStringVariableName" />, which is a developer's own local database.
+/// </para>
+/// </remarks>
+internal sealed class MailMcpDbContextDesignTimeFactory : IDesignTimeDbContextFactory<MailMcpDbContext>
+{
+    /// <summary>The environment variable a design-time command reads its connection string from.</summary>
+    internal const string DesignTimeConnectionStringVariableName = "MAILMCP_DESIGN_TIME_CONNECTION_STRING";
+
+    /// <summary>The local development database assumed when the variable is unset.</summary>
+    /// <remarks>It carries no password, so a design-time default can never become a credential in source control.</remarks>
+    internal const string LocalDevelopmentConnectionString = "Host=localhost;Database=mailmcp;Username=mailmcp";
+
+    /// <inheritdoc />
+    public MailMcpDbContext CreateDbContext(string[] args) => new(BuildOptions(
+        Environment.GetEnvironmentVariable(DesignTimeConnectionStringVariableName)));
+
+    /// <summary>Builds the design-time options for a connection string that may be absent.</summary>
+    /// <param name="configuredConnectionString">The value of the design-time environment variable, or <see langword="null" />.</param>
+    /// <returns>Options bound to the configured database, or to the local development default.</returns>
+    internal static DbContextOptions<MailMcpDbContext> BuildOptions(string? configuredConnectionString) =>
+        new DbContextOptionsBuilder<MailMcpDbContext>()
+            .UseNpgsql(string.IsNullOrWhiteSpace(configuredConnectionString)
+                ? LocalDevelopmentConnectionString
+                : configuredConnectionString)
+            .Options;
+}

--- a/src/Infrastructure/Persistence/PostgresConnectionStringProvider.cs
+++ b/src/Infrastructure/Persistence/PostgresConnectionStringProvider.cs
@@ -7,44 +7,46 @@ using Npgsql;
 
 namespace MailMcp.Infrastructure.Persistence;
 
-/// <summary>Builds the PostgreSQL data source once, before anything opens a connection.</summary>
+/// <summary>Composes the PostgreSQL connection string once, before anything opens a connection.</summary>
 /// <remarks>
 /// <para>
-/// Composing the data source needs the database credentials, and resolving a secret is asynchronous. A dependency
-/// injection factory is not: doing the work there would mean blocking a thread on a read that a slow or unreachable
-/// credential source can stall, with no token to cancel it, so a host could hang during startup or shutdown instead of
-/// failing. Startup is the one place where asynchronous work has a natural home, so the composition happens in
-/// <see cref="IHostedLifecycleService.StartingAsync" /> under the host's own cancellation and the factory only hands
-/// out what is already built.
+/// Composing it needs the database credentials, and resolving a secret is asynchronous. A dependency injection factory
+/// is not: doing the work there would mean blocking a thread on a read that a slow or unreachable credential source
+/// can stall, with no token to cancel it, so a host could hang during startup or shutdown instead of failing. Startup
+/// is the one place where asynchronous work has a natural home, so the composition happens in
+/// <see cref="IHostedLifecycleService.StartingAsync" /> under the host's own cancellation.
+/// </para>
+/// <para>
+/// This type deliberately stops at the connection string and never builds the <see cref="NpgsqlDataSource" />. Building
+/// it here would create a disposable the container has not made and therefore does not track, so a host that never
+/// resolves a context — synchronization disabled, no request served — would shut down leaving a connection pool open.
+/// Handing the container a plain string keeps creation and disposal in one place, and building a data source from an
+/// already-composed string is synchronous and cheap.
 /// </para>
 /// <para>
 /// The host runs <see cref="IHostedLifecycleService.StartingAsync" /> for every hosted service before any
-/// <see cref="IHostedService.StartAsync" />, so no worker can reach the database first. Requesting the data source
-/// before that throws rather than quietly building a second one from an unresolved connection string.
-/// </para>
-/// <para>
-/// Disposal belongs to the container, which tracks the data source the registered factory returns. This type must not
-/// dispose it as well; a data source disposed twice would tear down a connection pool another owner still believes in.
+/// <see cref="IHostedService.StartAsync" />, so no worker can reach the database first. Requesting the connection
+/// string before that throws rather than quietly falling back to an unresolved one.
 /// </para>
 /// </remarks>
-internal sealed partial class PostgresDataSourceProvider : IHostedLifecycleService
+internal sealed partial class PostgresConnectionStringProvider : IHostedLifecycleService
 {
     private readonly PostgresConnectionSettings connectionSettings;
     private readonly ISecretReferenceResolver secretReferenceResolver;
     private readonly SecretResolutionOptions resolutionOptions;
-    private readonly ILogger<PostgresDataSourceProvider> logger;
+    private readonly ILogger<PostgresConnectionStringProvider> logger;
 
-    /// <summary>Initializes a new PostgreSQL data source provider.</summary>
+    /// <summary>Initializes a new PostgreSQL connection string provider.</summary>
     /// <param name="connectionSettings">Where the connection string and the password come from.</param>
     /// <param name="secretReferenceResolver">The resolver that turns a reference into material.</param>
     /// <param name="resolutionOptions">The deployment's interpretation mode.</param>
     /// <param name="logger">The startup logger.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
-    public PostgresDataSourceProvider(
+    public PostgresConnectionStringProvider(
         PostgresConnectionSettings connectionSettings,
         ISecretReferenceResolver secretReferenceResolver,
         SecretResolutionOptions resolutionOptions,
-        ILogger<PostgresDataSourceProvider> logger)
+        ILogger<PostgresConnectionStringProvider> logger)
     {
         ArgumentNullException.ThrowIfNull(connectionSettings);
         ArgumentNullException.ThrowIfNull(secretReferenceResolver);
@@ -57,14 +59,14 @@ internal sealed partial class PostgresDataSourceProvider : IHostedLifecycleServi
         this.logger = logger;
     }
 
-    /// <summary>Gets or sets the data source once startup composed it.</summary>
-    private NpgsqlDataSource? ComposedDataSource { get; set; }
+    /// <summary>Gets or sets the connection string once startup composed it.</summary>
+    private string? ComposedConnectionString { get; set; }
 
-    /// <summary>Gets the composed data source.</summary>
+    /// <summary>Gets the composed connection string, credentials included.</summary>
     /// <exception cref="InvalidOperationException">Thrown when the host has not run startup composition yet.</exception>
-    internal NpgsqlDataSource DataSource => this.ComposedDataSource
+    internal string ConnectionString => this.ComposedConnectionString
         ?? throw new InvalidOperationException(
-            "The PostgreSQL data source is requested before host startup composed it. Register the infrastructure services on a host that runs hosted service lifecycle events.");
+            "The PostgreSQL connection string is requested before host startup composed it. Register the infrastructure services on a host that runs hosted service lifecycle events, or use the design-time context factory outside a host.");
 
     /// <inheritdoc />
     /// <exception cref="InvalidOperationException">Thrown when a configured reference does not resolve or a password is configured twice.</exception>
@@ -79,7 +81,7 @@ internal sealed partial class PostgresDataSourceProvider : IHostedLifecycleServi
 
         this.WarnWhenTheCredentialBypassedTheSecretBlock(composed);
 
-        this.ComposedDataSource = new NpgsqlDataSourceBuilder(composed.ConnectionString).Build();
+        this.ComposedConnectionString = composed.ConnectionString;
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Secrets/EnvironmentVariableSecretReferenceResolver.cs
+++ b/src/Infrastructure/Secrets/EnvironmentVariableSecretReferenceResolver.cs
@@ -4,11 +4,17 @@ namespace MailMcp.Infrastructure.Secrets;
 
 /// <summary>Resolves <c>env:&lt;variable&gt;</c> against the process environment block.</summary>
 /// <remarks>
+/// <para>
 /// The platform returns the value as a <see cref="string" />, which cannot be erased, so an environment-sourced secret
 /// leaves an un-erasable copy behind exactly as an inline value does. That is a documented residual exposure and the
 /// reason the operations documentation recommends against this scheme outside non-production automation. It is not
 /// gated on the environment, because the interpretation mode rather than the hosting environment is what governs how
 /// permissive a deployment is.
+/// </para>
+/// <para>
+/// The value is bounded like every other secret. An environment block is not a size an operator controls as
+/// deliberately as a provisioned file, and pinning an oversized copy of one is the same failure whatever supplied it.
+/// </para>
 /// </remarks>
 internal sealed class EnvironmentVariableSecretReferenceResolver(IEnvironmentVariableReader environmentVariableReader)
     : ISecretSchemeResolver
@@ -27,6 +33,8 @@ internal sealed class EnvironmentVariableSecretReferenceResolver(IEnvironmentVar
         {
             null => SecretResolutionResult.Failed(SecretResolutionFailure.MaterialNotFound),
             { Length: 0 } => SecretResolutionResult.Failed(SecretResolutionFailure.MaterialEmpty),
+            _ when SecretMaterialLimits.ExceedsMaximumByteCount(value) =>
+                SecretResolutionResult.Failed(SecretResolutionFailure.MaterialTooLarge),
             _ => SecretResolutionResult.Resolved(ResolvedSecret.FromText(value), SecretMaterialSource.SchemeAdapter),
         });
     }

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -81,13 +81,15 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
         ArgumentNullException.ThrowIfNull(connectionSettings);
 
-        services.AddSingleton(provider => new PostgresDataSourceProvider(
+        services.AddSingleton(provider => new PostgresConnectionStringProvider(
             connectionSettings,
             provider.GetRequiredService<ISecretReferenceResolver>(),
             provider.GetRequiredService<SecretResolutionOptions>(),
-            provider.GetRequiredService<ILogger<PostgresDataSourceProvider>>()));
-        services.AddHostedService(provider => provider.GetRequiredService<PostgresDataSourceProvider>());
-        services.AddSingleton(provider => provider.GetRequiredService<PostgresDataSourceProvider>().DataSource);
+            provider.GetRequiredService<ILogger<PostgresConnectionStringProvider>>()));
+        services.AddHostedService(provider => provider.GetRequiredService<PostgresConnectionStringProvider>());
+        // The container both creates and disposes the data source, so no second owner can leave its pool open.
+        services.AddSingleton(provider => new NpgsqlDataSourceBuilder(
+            provider.GetRequiredService<PostgresConnectionStringProvider>().ConnectionString).Build());
         services.AddDbContext<MailMcpDbContext>((provider, options) =>
             options.UseNpgsql(provider.GetRequiredService<NpgsqlDataSource>()));
         services.AddScoped<IPersistenceSessionFactory, PersistenceSessionFactory>();

--- a/tests/Infrastructure.UnitTests/MailMcpDbContextDesignTimeFactoryTests.cs
+++ b/tests/Infrastructure.UnitTests/MailMcpDbContextDesignTimeFactoryTests.cs
@@ -1,0 +1,48 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace MailMcp.Infrastructure.UnitTests;
+
+/// <summary>Keeps <c>dotnet ef</c> working without a running host, which composes the connection string at startup.</summary>
+public sealed class MailMcpDbContextDesignTimeFactoryTests
+{
+    [Fact]
+    public void BuildOptions_NoDesignTimeConnectionString_FallsBackToTheLocalDevelopmentDatabase()
+    {
+        // Act
+        var options = MailMcpDbContextDesignTimeFactory.BuildOptions(configuredConnectionString: null);
+
+        // Assert
+        using var context = new MailMcpDbContext(options);
+        Assert.Equal(
+            MailMcpDbContextDesignTimeFactory.LocalDevelopmentConnectionString,
+            context.Database.GetConnectionString());
+    }
+
+    [Fact]
+    public void BuildOptions_ConfiguredDesignTimeConnectionString_UsesIt()
+    {
+        // Act
+        var options = MailMcpDbContextDesignTimeFactory.BuildOptions("Host=db.test;Database=mailmcp;Username=dev");
+
+        // Assert
+        using var context = new MailMcpDbContext(options);
+        Assert.Equal("Host=db.test;Database=mailmcp;Username=dev", context.Database.GetConnectionString());
+    }
+
+    [Fact]
+    public void CreateDbContext_DesignTimeTooling_ProducesAUsableModelWithoutAHost()
+    {
+        // Arrange
+        var factory = new MailMcpDbContextDesignTimeFactory();
+
+        // Act
+        using var context = factory.CreateDbContext([]);
+
+        // Assert
+        Assert.NotEmpty(context.Model.GetEntityTypes());
+    }
+}

--- a/tests/Infrastructure.UnitTests/PostgresConnectionStringProviderTests.cs
+++ b/tests/Infrastructure.UnitTests/PostgresConnectionStringProviderTests.cs
@@ -7,22 +7,22 @@ using Xunit;
 
 namespace MailMcp.Infrastructure.UnitTests;
 
-public sealed class PostgresDataSourceProviderTests
+public sealed class PostgresConnectionStringProviderTests
 {
     private const string ConnectionStringWithoutPassword = "Host=localhost;Database=mailmcp;Username=mailmcp";
 
     [Fact]
-    public void DataSource_BeforeStartup_ThrowsRatherThanBuildingOneFromAnUnresolvedConnectionString()
+    public void ConnectionString_BeforeStartup_ThrowsRatherThanFallingBackToAnUnresolvedOne()
     {
         // Arrange
         var provider = CreateProvider();
 
         // Act, Assert
-        Assert.Throws<InvalidOperationException>(() => provider.DataSource);
+        Assert.Throws<InvalidOperationException>(() => provider.ConnectionString);
     }
 
     [Fact]
-    public async Task StartingAsync_ResolvablePassword_ComposesTheDataSourceBeforeAnyWorkerStarts()
+    public async Task StartingAsync_ResolvablePassword_ComposesTheConnectionStringBeforeAnyWorkerStarts()
     {
         // Arrange
         var provider = CreateProvider(new ConfiguredSecret { SecretReference = "plaintext:postgres-password" });
@@ -31,7 +31,7 @@ public sealed class PostgresDataSourceProviderTests
         await provider.StartingAsync(TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Contains("Username=mailmcp", provider.DataSource.ConnectionString, StringComparison.Ordinal);
+        Assert.Contains("Password=postgres-password", provider.ConnectionString, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -45,11 +45,11 @@ public sealed class PostgresDataSourceProviderTests
             () => provider.StartingAsync(TestContext.Current.CancellationToken));
     }
 
-    private static PostgresDataSourceProvider CreateProvider(ConfiguredSecret? password = null) => new(
+    private static PostgresConnectionStringProvider CreateProvider(ConfiguredSecret? password = null) => new(
         new PostgresConnectionSettings(ConnectionStringWithoutPassword, ConnectionStringSecret: null, password),
         new PlaintextOnlySecretReferenceResolver(),
         new SecretResolutionOptions(SecretValueInterpretation.ReferenceOnly),
-        NullLogger<PostgresDataSourceProvider>.Instance);
+        NullLogger<PostgresConnectionStringProvider>.Instance);
 
     private sealed class PlaintextOnlySecretReferenceResolver : ISecretReferenceResolver
     {

--- a/tests/Infrastructure.UnitTests/SecretReferenceResolverTests.cs
+++ b/tests/Infrastructure.UnitTests/SecretReferenceResolverTests.cs
@@ -423,6 +423,24 @@ public sealed class SecretReferenceResolverTests
     }
 
     [Fact]
+    public async Task ResolveAsync_EnvironmentValueAboveTheCeiling_FailsLikeAnyOtherOversizedMaterial()
+    {
+        // Arrange
+        var environment = new InMemoryEnvironmentVariableReader
+        {
+            Variables = { ["MAILMCP_OVERSIZED"] = new string('p', SecretMaterialLimits.MaximumMaterialByteCount + 1) },
+        };
+        var resolver = CreateResolver(SecretValueInterpretation.ReferenceOnly, new InMemorySecretFileReader(), environment);
+
+        // Act
+        var result = await resolver.ResolveAsync("env:MAILMCP_OVERSIZED", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(SecretResolutionFailure.MaterialTooLarge, result.Failure);
+        Assert.Null(result.Secret);
+    }
+
+    [Fact]
     public async Task ResolveAsync_PlaintextLiteralAboveTheCeiling_FailsLikeAnyOtherOversizedMaterial()
     {
         // Arrange

--- a/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -1,7 +1,10 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
+using MailMcp.Infrastructure.Persistence;
 using MailMcp.Infrastructure.Secrets;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Npgsql;
 using Xunit;
 
 namespace MailMcp.Infrastructure.UnitTests;
@@ -36,5 +39,50 @@ public sealed class ServiceCollectionExtensionsTests
         // Assert
         using var provider = services.BuildServiceProvider();
         Assert.Equal(interpretation, provider.GetRequiredService<SecretResolutionOptions>().Interpretation);
+    }
+
+    /// <summary>
+    /// The container must be the only owner of the data source. It was previously built inside the startup provider,
+    /// which the container never sees, so a host that resolved no context shut down leaving a connection pool open.
+    /// </summary>
+    [Fact]
+    public async Task AddInfrastructure_AfterStartup_HandsTheContainerADataSourceItCreatedItself()
+    {
+        // Arrange
+        await using var provider = BuildConfiguredProvider();
+        var connectionStringProvider = provider.GetServices<IHostedService>()
+            .OfType<IHostedLifecycleService>()
+            .Single();
+
+        // Act
+        await connectionStringProvider.StartingAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(provider.GetRequiredService<NpgsqlDataSource>(), provider.GetRequiredService<NpgsqlDataSource>());
+        Assert.IsNotAssignableFrom<IDisposable>(connectionStringProvider);
+        Assert.IsNotAssignableFrom<IAsyncDisposable>(connectionStringProvider);
+    }
+
+    [Fact]
+    public async Task AddInfrastructure_DataSourceRequestedBeforeStartup_ThrowsInsteadOfUsingAnUncomposedConnectionString()
+    {
+        // Arrange
+        await using var provider = BuildConfiguredProvider();
+
+        // Act, Assert
+        Assert.Throws<InvalidOperationException>(provider.GetRequiredService<NpgsqlDataSource>);
+    }
+
+    private static ServiceProvider BuildConfiguredProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSecretResolution(SecretValueInterpretation.ReferenceOnly);
+        services.AddInfrastructure(new PostgresConnectionSettings(
+            "Host=localhost;Database=mailmcp;Username=mailmcp",
+            ConnectionStringSecret: null,
+            Password: null));
+
+        return services.BuildServiceProvider();
     }
 }


### PR DESCRIPTION
Closes #36

Follow-up to #64, which merged before this round of automated review comments arrived. Four of the six findings were real; one was rejected with evidence and one is deferred to a tracked issue.

## Fixed

**`dotnet ef` no longer fails.** #64 moved connection-string composition into `IHostedLifecycleService.StartingAsync`, and EF Core's design-time tooling falls back to the application's service provider without starting the host — so every model and migration command hit "requested before host startup". `MailMcpDbContextDesignTimeFactory` is found first and resolves no secret at all: `migrations add` and `dbcontext script` need the model, not a reachable server, and a deployment credential does not belong on a workstation. A command that does need a live database reads `MAILMCP_DESIGN_TIME_CONNECTION_STRING`. `dotnet ef` is documented as required tooling in `AGENTS.md` and `docs/operations/local-development.md`, so this was a real break.

**The data source has one owner.** `PostgresDataSourceProvider` built the `NpgsqlDataSource` itself, so the container never saw the disposable and a host that resolved no context shut down leaving a connection pool open. It is now `PostgresConnectionStringProvider` and stops at the string; the container builds and disposes the data source. Building one from an already-composed string is synchronous and cheap, so nothing is lost. Two owners with a "disposal is probably idempotent" assumption was the alternative, and it was worse.

**`Persistence` binds strictly**, like `MailSynchronization` already did. `Persistence:Passwrod` previously left the secret block undiscovered, started the host on a passwordless connection string, and surfaced much later as an authentication failure.

**`env:` material is bounded** by `SecretMaterialLimits`, like file, inline, and `plaintext:` material already was.

## Rejected

**Invalid `env:` target names.** The finding claims `Environment.GetEnvironmentVariable` throws `ArgumentException` for a NUL or `=` in the name, aborting aggregated startup validation. On .NET 10 it returns `null` for `A\0B`, `A=B`, `""`, and `"  "` alike — verified by running it — so the resolver already reports `MaterialNotFound` and aggregation is unaffected. That exception is documented for .NET Framework's `SetEnvironmentVariable`, not this path. No change made.

## Deferred

**A `file:` target that is a FIFO or sits on a stalled mount can block in `open` before cancellation is consulted.** The finding is correct, but rejecting non-regular files needs the file *type*, which .NET exposes nowhere portably — `File.GetUnixFileMode` returns permission bits and `File.Exists` is true for a FIFO — so it means P/Invoking `stat`, which `AGENTS.md` restricts to a measured requirement. A deadline is the alternative, but one that returns while the thread stays blocked in the kernel trades a hang for a leaked thread and needs an explicit design. Tracked as #68 rather than guessed at here.

## Verification

`scripts/verify-full.sh` passes: 291 tests, aggregate line coverage 95.55% (944/988) against the 85% gate, `dotnet format` reports 0 of 179 files.


## EF Core tooling is not run by hand

Verifying the design-time fix meant running `dotnet ef` directly, which is exactly what the repository should not do: a command run by hand sees an ad-hoc local environment and a hand-written connection string rather than the orchestrated resources and connection strings the AppHost issues, so a model or migration check can pass against something no real deployment resembles.

`AGENTS.md` now states the rule, and `docs/operations/local-development.md` explains it. Design-time and migration commands go through `aspire exec`; that path is not wired up yet, so EF Core tooling is blocked entirely and work needing a migration reports the block rather than working around it. The orchestrated wiring lands with #67.

The design-time factory stays, because it is what gives EF Core a context at all once the tooling can run.

### What the verification showed

Run before the rule was written, against `origin/main` plus this branch:

- Without `MailMcpDbContextDesignTimeFactory`: `Unable to create a 'DbContext' of type 'MailMcpDbContext'. Unable to resolve service for type 'DbContextOptions<MailMcpDbContext>'`.
- With it: `dotnet ef dbcontext info` reports the context, the Npgsql provider, and database `mailmcp`.
- `--startup-project src/Host` fails either way — `Host` references `Microsoft.EntityFrameworkCore.Design` nowhere. That is pre-existing, and the documentation now names `Infrastructure` as its own startup project instead.