### PR TITLE
Exclude integration-verified code from the unit coverage gate

### DIFF
--- a/docs/architecture/solution-structure.md
+++ b/docs/architecture/solution-structure.md
@@ -20,6 +20,8 @@ That linked-source arrangement also cost visibility, because both CI workflows f
 
 If a second executable service ever needs these defaults, the answer is a project that both reference, not a source file linked into each.
 
+`src/shared/` is the one deliberate exception, and it holds one file: `RequiresIntegrationCoverageAttribute.cs`, linked into `Infrastructure` with a `Compile Include` item. The coverage collector recognizes the marker by attribute name, not by declaring assembly, so a shared project would buy nothing a shared file does not already give and would put a build-tooling reference into every boundary that marks a class — including `Domain`, whose reference set is the point of the architecture. The file sits under `src/**`, so the CI path filters that made the Aspire scaffold a problem still cover it, and the exception stays limited to markers that carry no behavior: anything with executable logic gets a project.
+
 ## Naming an adapter after its library
 
 A type inside an adapter carries the library's name only when its own members traffic in that library's types. `IMailKitImapClient` and `MailKitTransportSecurityMapping` take or return `SecureSocketOptions` and `IMailFolder`, so their names are accurate. `ImapAccountSettings` and `IImapAccountSettingsProvider` describe a host, a port, and credentials in plain IMAP vocabulary and would survive replacing the client library unchanged, so they live directly under `Infrastructure/Mail/` and name no vendor. The test is mechanical: if swapping the library would not change a single member, the name must not say the library.

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -121,5 +121,5 @@ The application layer exposes only `FetchEmailContentWithoutSettingSeenAsync` fo
 - OAuth mailbox authentication. `XOAUTH2` and `OAUTHBEARER` are deliberately absent from the allow-list because no token source exists yet.
 - IMAP IDLE and NOTIFY support.
 - Explicit EF Core migrations after schema review.
-- Integration tests with PostgreSQL and a real IMAP server in the later integration-test phase, including EF mapping, `xmin` conflict detection across transactions, same-transaction token semantics, PK/FK, integrity-metadata, and uniqueness-constraint verification required by ADR 001. Temporary provider-bound coverage exclusions carry adjacent TODOs for removal at that point.
+- Integration tests with PostgreSQL and a real IMAP server in the later integration-test phase, including EF mapping, `xmin` conflict detection across transactions, same-transaction token semantics, PK/FK, integrity-metadata, and uniqueness-constraint verification required by ADR 001. The provider-bound types those tests will prove carry `[RequiresIntegrationCoverage]`, which keeps them out of the unit-test coverage denominator and stays in place afterwards, because the integration suite collects no coverage of its own.
 - MCP read tools, RAG indexing, and SMTP outbox integration.

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -109,6 +109,8 @@ dotnet msbuild .config/CodeCoverage.proj -t:Collect
 
 The command produces one uniquely prefixed Cobertura report per unit-test project, merges the reports, and requires at least 85% aggregate line coverage across `Domain`, `Application`, `Infrastructure`, `AI`, and `Mcp`. The result always represents the whole configured scope, not only changed lines. `Host` and `AppHost` are excluded as thin executable composition roots.
 
+Two attributes take code out of that denominator, and `testconfig.json` configures the collector to honor both. `[ExcludeFromCodeCoverage]` marks code that should never participate in coverage. `[RequiresIntegrationCoverage]`, declared in `src/shared/RequiresIntegrationCoverageAttribute.cs`, marks code whose verification needs a real database, a real mail server, or a composed host: the EF Core context and its entities, the persistence stores, the MailKit client adapter, the file-system and environment secret readers, and the infrastructure registration extensions carry it today. Integration tests will prove that code once they exist, and they will collect no coverage, so a marked class is measured by neither run. Removing the marker from a class puts every line of it back into the denominator, which is how to check that the exclusion is still earned.
+
 Raw Cobertura reports and TRX files are written under `artifacts/coverage/raw/`. The merged Cobertura and HTML reports are written under `artifacts/coverage/report/`.
 
 ## Pull request checks

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -18,6 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\shared\RequiresIntegrationCoverageAttribute.cs" Link="RequiresIntegrationCoverageAttribute.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="MailMcp.Infrastructure.UnitTests" />
   </ItemGroup>
 </Project>

--- a/src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs
+++ b/src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs
@@ -9,6 +9,7 @@ using MailKit.Search;
 using MailKit.Security;
 using MailMcp.Application.EmailContent;
 using MailMcp.Application.Synchronization;
+using MailMcp.CodeCoverage;
 using MailMcp.Domain.Accounts;
 using MailMcp.Domain.Emails;
 using MailMcp.Domain.Folders;
@@ -43,8 +44,7 @@ internal interface IMailKitImapClient : IAsyncDisposable
         CancellationToken cancellationToken);
 }
 
-// TODO: Remove this exclusion when the planned MailKit integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by MailKit integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class MailKitImapClientAdapter(ImapClient client) : IMailKitImapClient
 {
     public bool IsConnected => client.IsConnected;

--- a/src/Infrastructure/Persistence/EmailContentStore.cs
+++ b/src/Infrastructure/Persistence/EmailContentStore.cs
@@ -1,19 +1,18 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using MailMcp.Application.EmailContent;
 using MailMcp.Application.Persistence;
+using MailMcp.CodeCoverage;
 using MailMcp.Domain.Emails;
 using Microsoft.EntityFrameworkCore;
 
 namespace MailMcp.Infrastructure.Persistence;
 
 /// <summary>EF Core raw MIME content store.</summary>
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class EmailContentStore(TimeProvider timeProvider) : IEmailContentStore
 {
     /// <inheritdoc />

--- a/src/Infrastructure/Persistence/EmailMessageContentEntity.cs
+++ b/src/Infrastructure/Persistence/EmailMessageContentEntity.cs
@@ -1,10 +1,10 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
+using MailMcp.CodeCoverage;
+
 namespace MailMcp.Infrastructure.Persistence;
 
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class EmailMessageContentEntity
 {
     public Guid StoredEmailId { get; set; }

--- a/src/Infrastructure/Persistence/MailFolderEntity.cs
+++ b/src/Infrastructure/Persistence/MailFolderEntity.cs
@@ -1,10 +1,10 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
+using MailMcp.CodeCoverage;
+
 namespace MailMcp.Infrastructure.Persistence;
 
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class MailFolderEntity
 {
     public long Id { get; set; }

--- a/src/Infrastructure/Persistence/MailFolderEntityResolver.cs
+++ b/src/Infrastructure/Persistence/MailFolderEntityResolver.cs
@@ -1,13 +1,12 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
+using MailMcp.CodeCoverage;
 using MailMcp.Domain.Accounts;
 using MailMcp.Domain.Folders;
 
 namespace MailMcp.Infrastructure.Persistence;
 
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal static class MailFolderEntityResolver
 {
     public static async Task<MailFolderEntity> GetOrAddAsync(

--- a/src/Infrastructure/Persistence/MailMcpDbContext.cs
+++ b/src/Infrastructure/Persistence/MailMcpDbContext.cs
@@ -1,13 +1,12 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
+using MailMcp.CodeCoverage;
 using Microsoft.EntityFrameworkCore;
 
 namespace MailMcp.Infrastructure.Persistence;
 
 /// <summary>EF Core context for local MailMcp persistence.</summary>
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class MailMcpDbContext : DbContext
 {
     internal const string SynchronizationCheckpointPrimaryKeyConstraintName = "pk_synchronization_checkpoints";

--- a/src/Infrastructure/Persistence/MailboxAccountEntity.cs
+++ b/src/Infrastructure/Persistence/MailboxAccountEntity.cs
@@ -1,12 +1,12 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
 using System.Diagnostics.CodeAnalysis;
+using MailMcp.CodeCoverage;
 
 namespace MailMcp.Infrastructure.Persistence;
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "EF Core materializes this entity through the DbSet and model metadata.")]
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class MailboxAccountEntity
 {
     public required string Id { get; set; }

--- a/src/Infrastructure/Persistence/PersistenceSessionFactory.cs
+++ b/src/Infrastructure/Persistence/PersistenceSessionFactory.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using MailMcp.Application.Persistence;
+using MailMcp.CodeCoverage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
 using Npgsql;
@@ -9,8 +10,7 @@ using Npgsql;
 namespace MailMcp.Infrastructure.Persistence;
 
 /// <summary>Creates EF Core-backed persistence sessions for application write transactions.</summary>
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class PersistenceSessionFactory(MailMcpDbContext dbContext) : IPersistenceSessionFactory
 {
     /// <inheritdoc />

--- a/src/Infrastructure/Persistence/StoredEmailEntity.cs
+++ b/src/Infrastructure/Persistence/StoredEmailEntity.cs
@@ -1,12 +1,11 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
+using MailMcp.CodeCoverage;
 using MailMcp.Domain.Emails;
 
 namespace MailMcp.Infrastructure.Persistence;
 
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class StoredEmailEntity
 {
     public Guid Id { get; set; }

--- a/src/Infrastructure/Persistence/StoredEmailMetadataRepository.cs
+++ b/src/Infrastructure/Persistence/StoredEmailMetadataRepository.cs
@@ -1,16 +1,15 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
 using MailMcp.Application.Persistence;
 using MailMcp.Application.Synchronization;
+using MailMcp.CodeCoverage;
 using MailMcp.Domain.Emails;
 using Microsoft.EntityFrameworkCore;
 
 namespace MailMcp.Infrastructure.Persistence;
 
 /// <summary>EF Core implementation for email metadata persistence.</summary>
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class StoredEmailMetadataRepository(TimeProvider timeProvider) : IEmailMetadataRepository
 {
     /// <inheritdoc />

--- a/src/Infrastructure/Persistence/SynchronizationCheckpointEntity.cs
+++ b/src/Infrastructure/Persistence/SynchronizationCheckpointEntity.cs
@@ -1,11 +1,10 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
+using MailMcp.CodeCoverage;
 
 namespace MailMcp.Infrastructure.Persistence;
 
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class SynchronizationCheckpointEntity
 {
     public long MailFolderId { get; set; }

--- a/src/Infrastructure/Persistence/SynchronizationCheckpointStore.cs
+++ b/src/Infrastructure/Persistence/SynchronizationCheckpointStore.cs
@@ -1,8 +1,8 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
 using MailMcp.Application.Persistence;
 using MailMcp.Application.Synchronization;
+using MailMcp.CodeCoverage;
 using MailMcp.Domain.Accounts;
 using MailMcp.Domain.Emails;
 using MailMcp.Domain.Folders;
@@ -16,8 +16,7 @@ namespace MailMcp.Infrastructure.Persistence;
 /// The read path uses the scoped context because it joins no transaction. The write path uses the context enlisted in
 /// the caller's session, so a checkpoint can only be written inside the transaction the caller opened.
 /// </remarks>
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class SynchronizationCheckpointStore(MailMcpDbContext readContext) : ISynchronizationCheckpointStore
 {
     /// <inheritdoc />

--- a/src/Infrastructure/Persistence/TrackedEntityLookup.cs
+++ b/src/Infrastructure/Persistence/TrackedEntityLookup.cs
@@ -1,7 +1,7 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
+using MailMcp.CodeCoverage;
 using Microsoft.EntityFrameworkCore;
 
 namespace MailMcp.Infrastructure.Persistence;
@@ -16,9 +16,7 @@ namespace MailMcp.Infrastructure.Persistence;
 /// natively. This helper exists for lookups by an alternate key, where no such framework shortcut applies.
 /// </para>
 /// </remarks>
-// TODO: Remove this exclusion when the planned PostgreSQL integration tests are enabled. Both passes need a real
-// DbSet and change tracker, so this cannot be proven without a database.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by PostgreSQL integration tests.")]
+[RequiresIntegrationCoverage]
 internal static class TrackedEntityLookup
 {
     /// <summary>Gets the single entity matching <paramref name="match" />, preferring one pending in the session.</summary>

--- a/src/Infrastructure/Secrets/FileSystemSecretFileReader.cs
+++ b/src/Infrastructure/Secrets/FileSystemSecretFileReader.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Security;
+using MailMcp.CodeCoverage;
 
 namespace MailMcp.Infrastructure.Secrets;
 
@@ -15,8 +16,7 @@ namespace MailMcp.Infrastructure.Secrets;
 /// quotes the path, defeating both fail-fast aggregation and the guarantee that no diagnostic carries a target. A failure that
 /// only appears after the file opened is translated by <see cref="BoundedSecretMaterialReader" />, which owns the read.
 /// </remarks>
-// TODO: Remove this exclusion when the planned host integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Real file-system access will be covered later by host integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class FileSystemSecretFileReader : ISecretFileReader
 {
     /// <inheritdoc />

--- a/src/Infrastructure/Secrets/ProcessEnvironmentVariableReader.cs
+++ b/src/Infrastructure/Secrets/ProcessEnvironmentVariableReader.cs
@@ -1,12 +1,11 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
+using MailMcp.CodeCoverage;
 
 namespace MailMcp.Infrastructure.Secrets;
 
 /// <summary>Reads environment variables from the running process.</summary>
-// TODO: Remove this exclusion when the planned host integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Real environment access will be covered later by host integration tests.")]
+[RequiresIntegrationCoverage]
 internal sealed class ProcessEnvironmentVariableReader : IEnvironmentVariableReader
 {
     /// <inheritdoc />

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,10 +1,10 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
-using System.Diagnostics.CodeAnalysis;
 using MailKit.Net.Imap;
 using MailMcp.Application.EmailContent;
 using MailMcp.Application.Persistence;
 using MailMcp.Application.Synchronization;
+using MailMcp.CodeCoverage;
 using MailMcp.Infrastructure.Mail;
 using MailMcp.Infrastructure.Mail.MailKit;
 using MailMcp.Infrastructure.Persistence;
@@ -17,8 +17,7 @@ using Npgsql;
 namespace MailMcp.Infrastructure;
 
 /// <summary>Infrastructure dependency registration.</summary>
-// TODO: Remove this exclusion when the planned host integration tests are enabled.
-[ExcludeFromCodeCoverage(Justification = "Will be covered later by host integration tests.")]
+[RequiresIntegrationCoverage]
 public static class ServiceCollectionExtensions
 {
     /// <summary>Registers the secret reference grammar, the shipped scheme adapters, and the composite dispatch.</summary>

--- a/src/shared/RequiresIntegrationCoverageAttribute.cs
+++ b/src/shared/RequiresIntegrationCoverageAttribute.cs
@@ -1,0 +1,28 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+namespace MailMcp.CodeCoverage;
+
+/// <summary>
+/// Marks production code whose meaningful verification requires real infrastructure or cross-component behavior,
+/// so the unit-test coverage gate leaves it out of the measured denominator.
+/// </summary>
+/// <remarks>
+/// The unit-test coverage collector is configured to drop every element carrying this attribute, and integration
+/// tests never collect coverage, so marked code is measured by neither run. Apply it only where a unit test could
+/// not prove anything a real database, mail server, or composed host proves; business logic stays unmarked and
+/// subject to the configured minimum. It differs from <see cref="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />,
+/// which states that code should never participate in coverage at all, whereas this attribute states that the
+/// verification exists elsewhere.
+/// <para>
+/// The attribute is compiled into each assembly that needs it from <c>src/shared/</c>, because the coverage
+/// collector matches it by name rather than by declaring assembly.
+/// </para>
+/// </remarks>
+[AttributeUsage(
+    AttributeTargets.Class |
+    AttributeTargets.Struct |
+    AttributeTargets.Method |
+    AttributeTargets.Constructor |
+    AttributeTargets.Property,
+    Inherited = false)]
+internal sealed class RequiresIntegrationCoverageAttribute : Attribute;

--- a/testconfig.json
+++ b/testconfig.json
@@ -3,7 +3,7 @@
     "Coverlet": {
       "Include": "[MailMcp.*]*",
       "Exclude": "[MailMcp.Host]*,[MailMcp.AppHost]*,[MailMcp.*.UnitTests]*,[coverlet.*]*,[xunit.*]*,[Microsoft.Testing.*]*,[Microsoft.TestPlatform.*]*,[Microsoft.VisualStudio.TestPlatform.*]*,[testhost*]*",
-      "ExcludeByAttribute": "ExcludeFromCodeCoverage,ExcludeFromCodeCoverageAttribute,GeneratedCodeAttribute",
+      "ExcludeByAttribute": "ExcludeFromCodeCoverage,ExcludeFromCodeCoverageAttribute,GeneratedCodeAttribute,RequiresIntegrationCoverage,RequiresIntegrationCoverageAttribute",
       "Format": "cobertura",
       "IncludeTestAssembly": false,
       "DeterministicReport": true,

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -29,11 +29,15 @@ These instructions apply under `tests/` in addition to the repository root instr
 - Keep `Host` and `AppHost` excluded as thin composition roots. Do not add other exclusions merely to pass the threshold.
 - The exclusion is about the coverage denominator, not about testing. `Host.UnitTests` runs in the same suite and its assertions are as binding as any other project's; its subject simply does not count towards the aggregate, because a composition root's uncovered wiring would otherwise dilute the measurement of the boundaries that hold the logic.
 - Add `using System.Diagnostics.CodeAnalysis;` and apply `[ExcludeFromCodeCoverage]` only to a class with no executable application, domain, mapping, validation, policy, or infrastructure logic. Do not fully qualify the attribute.
-- Never exclude meaningfully testable behavior. Remove the exclusion and add coverage when logic enters an excluded class.
+- Add `using MailMcp.CodeCoverage;` and apply `[RequiresIntegrationCoverage]` to a class or member whose behavior is real but can only be proven against a real database, a real mail server, or a composed host. The two attributes answer different questions: `[ExcludeFromCodeCoverage]` says the code never participates in coverage, `[RequiresIntegrationCoverage]` says the verification lives in the integration suite, which collects no coverage of its own. Choosing the accurate one keeps the reason for an exclusion readable years later.
+- The marker is declared once in `src/shared/RequiresIntegrationCoverageAttribute.cs` and compiled into each project that applies it through a `Compile Include` item, because the collector matches it by name rather than by declaring assembly. Add that item when a second project needs the marker; do not reference a project for it.
+- Never exclude meaningfully testable behavior with either attribute. Business logic, mapping, validation, and policy stay in the denominator, and needing a marker to reach the threshold means the test is missing, not the exclusion.
+- Remove the exclusion and add coverage when unit-testable logic enters an excluded class. `[RequiresIntegrationCoverage]` survives the arrival of the integration suite, because integration runs never feed the unit-test metric; `[ExcludeFromCodeCoverage]` is removed as soon as executable logic appears.
 - Run `dotnet msbuild .config/CodeCoverage.proj -t:Collect` before committing production or test changes.
 
 ## Integration tests
 
 - Integration tests are planned for a later phase and currently exist only in the architecture draft.
+- When they arrive they must not collect, merge, publish, or enforce code coverage. Unit tests stay the only source of the metric, so an expensive suite never has to run to know whether the gate passes.
 - Do not add integration-test projects, Testcontainers, Docker fixtures, real PostgreSQL dependencies, or real or mock network mail servers yet.
 - MailKit wire behavior against an IMAP or SMTP server belongs to the future integration suite; do not mislabel it as a unit test.

--- a/tests/Infrastructure.UnitTests/RequiresIntegrationCoverageAttributeTests.cs
+++ b/tests/Infrastructure.UnitTests/RequiresIntegrationCoverageAttributeTests.cs
@@ -1,0 +1,71 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using MailMcp.CodeCoverage;
+using MailMcp.Infrastructure.Secrets;
+using Xunit;
+
+namespace MailMcp.Infrastructure.UnitTests;
+
+/// <summary>Keeps the integration-coverage marker aligned with the coverage collector that reads it.</summary>
+public sealed class RequiresIntegrationCoverageAttributeTests
+{
+    /// <summary>
+    /// The collector matches the marker by name through the <c>ExcludeByAttribute</c> entry in <c>testconfig.json</c>,
+    /// which no rename refactoring updates. A renamed attribute would still compile and would silently pull every
+    /// marked type back into the measured denominator, so the name is asserted here.
+    /// </summary>
+    [Fact]
+    public void AttributeName_ConfiguredCoverageExclusion_MatchesTheCollectedName()
+    {
+        // Arrange
+        const string ConfiguredExclusionName = "RequiresIntegrationCoverageAttribute";
+
+        // Act
+        var attributeName = nameof(RequiresIntegrationCoverageAttribute);
+
+        // Assert
+        Assert.Equal(ConfiguredExclusionName, attributeName);
+    }
+
+    [Fact]
+    public void AttributeUsage_MarkedElement_CoversTypesAndMembersWithoutInheritance()
+    {
+        // Arrange
+        const AttributeTargets ExpectedTargets =
+            AttributeTargets.Class |
+            AttributeTargets.Struct |
+            AttributeTargets.Method |
+            AttributeTargets.Constructor |
+            AttributeTargets.Property;
+
+        // Act
+        var usage = typeof(RequiresIntegrationCoverageAttribute).GetCustomAttribute<AttributeUsageAttribute>();
+
+        // Assert
+        Assert.NotNull(usage);
+        Assert.Equal(ExpectedTargets, usage.ValidOn);
+        Assert.False(usage.Inherited);
+    }
+
+    /// <summary>
+    /// The two attributes state different things: one defers verification to the integration suite, the other says the
+    /// code never participates in coverage. Carrying both leaves the reason for the exclusion unreadable.
+    /// </summary>
+    [Fact]
+    public void InfrastructureTypes_MarkedForIntegrationCoverage_AreNotAlsoExcludedFromCodeCoverage()
+    {
+        // Arrange
+        var infrastructureTypes = typeof(ISecretReferenceResolver).Assembly.GetTypes();
+
+        // Act
+        var doublyMarkedTypeNames = infrastructureTypes
+            .Where(type => type.IsDefined(typeof(RequiresIntegrationCoverageAttribute), inherit: false)
+                && type.IsDefined(typeof(ExcludeFromCodeCoverageAttribute), inherit: false))
+            .Select(type => type.FullName);
+
+        // Assert
+        Assert.Empty(doublyMarkedTypeNames);
+    }
+}


### PR DESCRIPTION
Closes #74

## What changed

`RequiresIntegrationCoverageAttribute` marks production code whose meaningful verification needs a real database, a real mail server, or a composed host, and `testconfig.json` tells the Coverlet collector to drop every element carrying it. The unit-test run stays the only source of the coverage metric and keeps its 85% aggregate threshold; the future integration suite will collect no coverage at all, so a marked class is measured by neither run.

The marker is declared once in `src/shared/RequiresIntegrationCoverageAttribute.cs` and linked into `Infrastructure` with a `Compile Include` item. The collector matches an exclusion by attribute name rather than by declaring assembly, so a shared project would buy nothing a shared file does not and would push a build-tooling reference into every boundary that marks a class, `Domain` included. `docs/architecture/solution-structure.md` records this as the one deliberate exception to keeping compiled source inside its project, limited to markers that carry no behavior.

Sixteen types that were using `[ExcludeFromCodeCoverage(Justification = "…integration tests")]` plus an adjacent `TODO` are migrated: the EF Core context and its entities, the persistence stores and helpers, the MailKit client adapter, the file-system and environment secret readers, and the infrastructure registration extensions. `[ExcludeFromCodeCoverage]` keeps its narrower meaning — code that should never participate in coverage — and the `TODO`s are gone, because the marker survives the arrival of the integration suite instead of being removed by it.

No integration tests, integration-test project, or CI job is added here; that remains specification 20's work.

## Verification

- `scripts/verify-full.sh` passes: workflow contract suite 10/10, 294 unit tests green, aggregate line coverage 95.52% (938/982) against the required 85%, `dotnet format --verify-no-changes` clean.
- Control experiment: removing `[RequiresIntegrationCoverage]` from `MailMcpDbContext` puts the class back into the report and grows the denominator from 982 to 1054 lines (95.35%), so marked code is excluded and equivalent unmarked code still counts.
- New unit tests pin the attribute name that `testconfig.json` matches, its `AttributeUsage` targets and `Inherited = false`, and that no infrastructure type carries both exclusion attributes.

## Documentation

`tests/AGENTS.md` states when each attribute is allowed, that neither may be used to reach the threshold, and that integration runs never feed the metric. `docs/operations/local-development.md` and `docs/features/imap-synchronization.md` describe the implemented behavior.
