### PR TITLE
Fail full verification when the branch is not based on current origin/main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,5 +199,6 @@ Work is tracked as GitHub issues on the `MailMcp roadmap` project board, which i
 - Use `scripts/inspect-workspace.sh` for a read-only workspace preflight.
 - Use `scripts/verify-fast.sh` during implementation.
 - Stage the task files before running `scripts/verify-full.sh`; the gate rejects remaining untracked files so newly added files cannot bypass diff validation.
-- Use `scripts/verify-full.sh` before committing. It runs the workflow contract suite, restores tools and packages, builds, runs the complete unit-test and coverage gate, verifies formatting, and checks the diff.
+- Use `scripts/verify-full.sh` before committing. It fetches `origin main` and rejects a branch that does not contain that freshly fetched base, then runs the workflow contract suite, restores tools and packages, builds, runs the complete unit-test and coverage gate, verifies formatting, and checks the diff.
+- Rebase onto the fetched `origin/main` when the base check fails, and treat an unreachable remote as a blocked gate. Verification against a stale base proves nothing about the branch that will actually merge.
 - Inspect the final diff for accidental secrets, unrelated edits, generated files, and dependency-boundary violations.

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -25,13 +25,22 @@ git add <task-files>
 bash scripts/verify-full.sh
 ```
 
-The full gate rejects remaining untracked files, runs the workflow contract
-suite, restores repository tools and the solution, builds Release, executes all
-unit tests through the aggregate 85% coverage target, verifies formatting, and
-checks committed branch changes, staged changes, and unstaged changes for
-whitespace errors. It stops at the first failure. Restore, build, test,
-coverage, and formatting can create ignored local artifacts but the scripts do
-not commit, push, or change branches.
+The full gate rejects remaining untracked files, fetches `origin main` and
+requires the branch to contain that freshly fetched base, runs the workflow
+contract suite, restores repository tools and the solution, builds Release,
+executes all unit tests through the aggregate 85% coverage target, verifies
+formatting, and checks committed branch changes, staged changes, and unstaged
+changes for whitespace errors. It stops at the first failure. Restore, build,
+test, coverage, and formatting can create ignored local artifacts, and the fetch
+updates `refs/remotes/origin/main`, but the scripts do not commit, push, or
+change branches.
+
+The base check runs before any `dotnet` invocation, so a branch cut from a
+`main` that has since moved fails in seconds rather than after the Release build
+and coverage run. It fetches rather than trusting the local remote-tracking ref,
+because a ref left behind by an earlier fetch describes the base as it was, not
+as it is. An unreachable remote is a failure and never degrades into verifying
+against the stale ref.
 
 ## Skills
 
@@ -80,6 +89,13 @@ to test code. Each nested `CLAUDE.md` imports its sibling `AGENTS.md`.
   `git status --short --untracked-files=all` has identified every existing path
   and the user has approved a preservation plan. Never assume pre-existing
   changes are unrelated.
+- `HEAD does not contain the current origin/main` means `main` moved after the
+  branch was cut. Rebase onto the fetched base, resolve any conflicts, and rerun
+  the complete gate; earlier passing results describe a base that no longer
+  exists.
+- `verify-full.sh cannot fetch origin main` means the remote is unreachable or
+  the credentials failed. Restore access and rerun. Do not work around it by
+  verifying against the local remote-tracking ref.
 - `Untracked files must be staged or removed before full verification` means
   the focused task files have not all entered the index. Stage only those task
   files, inspect the staged diff, and rerun the complete gate.

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -39,8 +39,12 @@ The base check runs before any `dotnet` invocation, so a branch cut from a
 `main` that has since moved fails in seconds rather than after the Release build
 and coverage run. It fetches rather than trusting the local remote-tracking ref,
 because a ref left behind by an earlier fetch describes the base as it was, not
-as it is. An unreachable remote is a failure and never degrades into verifying
-against the stale ref.
+as it is. The fetch names its destination explicitly as
+`+refs/heads/main:refs/remotes/origin/main`: a bare `git fetch origin main` only
+writes `FETCH_HEAD`, so a repository with a missing or remapped
+`remote.origin.fetch` would keep a stale `refs/remotes/origin/main` and satisfy
+the base check against it. An unreachable remote is a failure and never degrades
+into verifying against the stale ref.
 
 ## Skills
 

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -25,6 +25,11 @@ remaining untracked files, so inspect the staged diff before running it. See
 [Agent workflow](agent-workflow.md) for the workspace inspection command and
 shared skills.
 
+The full script fetches `origin main` and refuses to continue when the branch
+does not contain that base, so it needs access to the remote and cannot run
+offline. Rebase onto the fetched base when it reports the branch is behind.
+The fast script performs no Git operations and remains available offline.
+
 Run the web host directly:
 
 ```bash

--- a/docs/superpowers/specs/2026-07-25-agent-workflow-optimization-design.md
+++ b/docs/superpowers/specs/2026-07-25-agent-workflow-optimization-design.md
@@ -1,5 +1,12 @@
 # Agent Workflow Optimization Design
 
+> **Partly superseded on 2026-07-28.** `scripts/verify-full.sh` now fetches
+> `origin main` into `refs/remotes/origin/main` and rejects a branch that does
+> not contain that base, before the workflow contract suite. The final-gate step
+> list and the "no hidden mutation" statement below therefore no longer describe
+> the script; see [Agent workflow](../../operations/agent-workflow.md) for the
+> current contract.
+
 ## Goal
 
 Reduce repeated repository discovery, verification mistakes, and always-on

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -20,6 +20,7 @@ scripts_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source_repository_root="$(cd "$scripts_directory/.." && pwd -P)"
 test_directory="$(mktemp -d)"
 repository_root="$test_directory/repository"
+remote_repository_root="$test_directory/remote"
 fake_bin_directory="$test_directory/bin"
 invocation_log="$test_directory/dotnet-invocations.log"
 workflow_invocation_log="$test_directory/workflow-invocations.log"
@@ -55,7 +56,12 @@ printf '%s\n' \
 chmod +x "$repository_root/scripts/test-agent-workflow.sh"
 git -C "$repository_root" add MailMcp.slnx scripts/test-agent-workflow.sh tracked.txt
 git -C "$repository_root" commit --quiet -m 'test fixture'
-git -C "$repository_root" update-ref refs/remotes/origin/main HEAD
+
+git clone --quiet "$repository_root" "$remote_repository_root"
+git -C "$remote_repository_root" config user.email agent-workflow@example.invalid
+git -C "$remote_repository_root" config user.name 'Agent Workflow Tests'
+git -C "$repository_root" remote add origin "$remote_repository_root"
+git -C "$repository_root" fetch --quiet origin main
 
 export FAKE_DOTNET_LOG="$invocation_log"
 export FAKE_WORKFLOW_LOG="$workflow_invocation_log"
@@ -226,6 +232,93 @@ verify_full_rejects_untracked_files() {
   assert_contains 'untracked.txt' "$untracked_output"
 }
 
+verify_full_fetches_the_remote_base_before_verifying() {
+  git -C "$repository_root" update-ref -d refs/remotes/origin/main
+
+  (
+    cd "$repository_root"
+    "$scripts_directory/verify-full.sh"
+  )
+
+  [[ "$(git -C "$repository_root" rev-parse refs/remotes/origin/main)" == "$(git -C "$remote_repository_root" rev-parse main)" ]]
+}
+
+verify_full_stops_when_head_is_behind_origin_main() {
+  local behind_output="$test_directory/behind-origin-main-output"
+  local script_status=0
+
+  : > "$invocation_log"
+  : > "$workflow_invocation_log"
+  git -C "$remote_repository_root" commit --quiet --allow-empty -m 'remote main moved ahead'
+
+  (
+    cd "$repository_root"
+    "$scripts_directory/verify-full.sh"
+  ) > "$behind_output" 2>&1 || script_status=$?
+
+  git -C "$remote_repository_root" reset --quiet --hard HEAD~1
+  git -C "$repository_root" fetch --quiet --force origin main
+
+  if ((script_status == 0)); then
+    printf 'verify-full.sh accepted a branch behind origin/main\n' >&2
+    return 1
+  fi
+
+  assert_contains 'HEAD does not contain the current origin/main.' "$behind_output"
+  assert_file_content '' "$invocation_log"
+  assert_file_content '' "$workflow_invocation_log"
+}
+
+verify_full_stops_when_the_remote_is_unreachable() {
+  local unreachable_output="$test_directory/unreachable-remote-output"
+  local script_status=0
+
+  : > "$invocation_log"
+  : > "$workflow_invocation_log"
+  git -C "$repository_root" remote set-url origin "$test_directory/missing-remote"
+
+  (
+    cd "$repository_root"
+    "$scripts_directory/verify-full.sh"
+  ) > "$unreachable_output" 2>&1 || script_status=$?
+
+  git -C "$repository_root" remote set-url origin "$remote_repository_root"
+
+  if ((script_status == 0)); then
+    printf 'verify-full.sh continued despite an unreachable remote\n' >&2
+    return 1
+  fi
+
+  assert_contains 'verify-full.sh cannot fetch origin main.' "$unreachable_output"
+  assert_file_content '' "$invocation_log"
+  assert_file_content '' "$workflow_invocation_log"
+}
+
+verify_full_stops_when_the_fetch_leaves_no_remote_tracking_base() {
+  local missing_base_output="$test_directory/missing-remote-tracking-base-output"
+  local script_status=0
+
+  : > "$invocation_log"
+  git -C "$repository_root" config --unset remote.origin.fetch
+  git -C "$repository_root" update-ref -d refs/remotes/origin/main
+
+  (
+    cd "$repository_root"
+    "$scripts_directory/verify-full.sh"
+  ) > "$missing_base_output" 2>&1 || script_status=$?
+
+  git -C "$repository_root" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+  git -C "$repository_root" fetch --quiet origin main
+
+  if ((script_status == 0)); then
+    printf 'verify-full.sh continued without a remote-tracking base\n' >&2
+    return 1
+  fi
+
+  assert_contains 'Fetching origin main left no refs/remotes/origin/main.' "$missing_base_output"
+  assert_file_content '' "$invocation_log"
+}
+
 verification_stops_after_first_failure() {
   : > "$invocation_log"
 
@@ -309,6 +402,10 @@ run_test verify_full_runs_workflow_contracts
 run_test verify_full_stops_when_workflow_contracts_fail
 run_test verify_full_checks_committed_staged_and_unstaged_changes
 run_test verify_full_rejects_untracked_files
+run_test verify_full_fetches_the_remote_base_before_verifying
+run_test verify_full_stops_when_head_is_behind_origin_main
+run_test verify_full_stops_when_the_remote_is_unreachable
+run_test verify_full_stops_when_the_fetch_leaves_no_remote_tracking_base
 run_test verification_stops_after_first_failure
 run_test workspace_inspection_is_read_only_and_labeled
 run_test workspace_inspection_reports_unavailable_sdk

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -294,28 +294,30 @@ verify_full_stops_when_the_remote_is_unreachable() {
   assert_file_content '' "$workflow_invocation_log"
 }
 
-verify_full_stops_when_the_fetch_leaves_no_remote_tracking_base() {
-  local missing_base_output="$test_directory/missing-remote-tracking-base-output"
+verify_full_stops_when_a_stale_tracking_ref_hides_remote_movement() {
+  local stale_base_output="$test_directory/stale-tracking-ref-output"
   local script_status=0
 
   : > "$invocation_log"
   git -C "$repository_root" config --unset remote.origin.fetch
-  git -C "$repository_root" update-ref -d refs/remotes/origin/main
+  git -C "$repository_root" update-ref refs/remotes/origin/main HEAD
+  git -C "$remote_repository_root" commit --quiet --allow-empty -m 'remote main moved past the stale tracking ref'
 
   (
     cd "$repository_root"
     "$scripts_directory/verify-full.sh"
-  ) > "$missing_base_output" 2>&1 || script_status=$?
+  ) > "$stale_base_output" 2>&1 || script_status=$?
 
+  git -C "$remote_repository_root" reset --quiet --hard HEAD~1
   git -C "$repository_root" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
-  git -C "$repository_root" fetch --quiet origin main
+  git -C "$repository_root" fetch --quiet --force origin main
 
   if ((script_status == 0)); then
-    printf 'verify-full.sh continued without a remote-tracking base\n' >&2
+    printf 'verify-full.sh accepted a stale remote-tracking ref\n' >&2
     return 1
   fi
 
-  assert_contains 'Fetching origin main left no refs/remotes/origin/main.' "$missing_base_output"
+  assert_contains 'HEAD does not contain the current origin/main.' "$stale_base_output"
   assert_file_content '' "$invocation_log"
 }
 
@@ -405,7 +407,7 @@ run_test verify_full_rejects_untracked_files
 run_test verify_full_fetches_the_remote_base_before_verifying
 run_test verify_full_stops_when_head_is_behind_origin_main
 run_test verify_full_stops_when_the_remote_is_unreachable
-run_test verify_full_stops_when_the_fetch_leaves_no_remote_tracking_base
+run_test verify_full_stops_when_a_stale_tracking_ref_hides_remote_movement
 run_test verification_stops_after_first_failure
 run_test workspace_inspection_is_read_only_and_labeled
 run_test workspace_inspection_reports_unavailable_sdk

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -15,13 +15,12 @@ if ((${#untracked_files[@]} > 0)); then
   exit 1
 fi
 
-if ! git fetch --quiet origin main; then
+# The explicit destination refspec is what makes the next check meaningful. A bare
+# `git fetch origin main` only writes FETCH_HEAD, so a repository whose
+# remote.origin.fetch is missing or remapped would keep a stale
+# refs/remotes/origin/main and pass the base check against it.
+if ! git fetch --quiet origin '+refs/heads/main:refs/remotes/origin/main'; then
   printf 'verify-full.sh cannot fetch origin main. Restore access to the remote instead of verifying against a stale base.\n' >&2
-  exit 1
-fi
-
-if ! git show-ref --verify --quiet refs/remotes/origin/main; then
-  printf 'Fetching origin main left no refs/remotes/origin/main. Restore the standard origin fetch refspec so the remote-tracking base exists.\n' >&2
   exit 1
 fi
 

--- a/scripts/verify-full.sh
+++ b/scripts/verify-full.sh
@@ -15,17 +15,27 @@ if ((${#untracked_files[@]} > 0)); then
   exit 1
 fi
 
+if ! git fetch --quiet origin main; then
+  printf 'verify-full.sh cannot fetch origin main. Restore access to the remote instead of verifying against a stale base.\n' >&2
+  exit 1
+fi
+
+if ! git show-ref --verify --quiet refs/remotes/origin/main; then
+  printf 'Fetching origin main left no refs/remotes/origin/main. Restore the standard origin fetch refspec so the remote-tracking base exists.\n' >&2
+  exit 1
+fi
+
+if ! git merge-base --is-ancestor origin/main HEAD; then
+  printf 'HEAD does not contain the current origin/main. Rebase the branch onto the fetched base before verifying.\n' >&2
+  exit 1
+fi
+
 bash scripts/test-agent-workflow.sh
 dotnet tool restore
 dotnet restore MailMcp.slnx
 dotnet build MailMcp.slnx --configuration Release --no-restore
 dotnet msbuild .config/CodeCoverage.proj -t:Collect -p:Configuration=Release
 dotnet format MailMcp.slnx --no-restore --verify-no-changes --verbosity diagnostic
-if ! git show-ref --verify --quiet refs/remotes/origin/main; then
-  printf 'verify-full.sh requires refs/remotes/origin/main.\n' >&2
-  exit 1
-fi
-
 git diff --check origin/main...HEAD
 git diff --cached --check
 git diff --check


### PR DESCRIPTION
Closes #90

## Problem

`scripts/verify-full.sh` referenced `origin/main` twice, and neither reference could detect a branch built on a base that has since moved:

- the existence check asserted only that `refs/remotes/origin/main` was present;
- `git diff --check origin/main...HEAD` uses three-dot notation, so it diffs from the merge base and by construction ignores every commit that landed on `main` after the branch was cut.

No verification script ran `git fetch`, so the remote-tracking ref was whatever the last manual fetch left behind. `scripts/inspect-workspace.sh` could therefore report `Contains origin/main: yes` for a branch weeks behind the real base, and drift was guarded only by prose in the `start-task` and `finish-change` skills rather than by a gate with an exit code.

This branch itself started on `03f8ba5` while `origin/main` was already at `0005f5a`.

## Change

`scripts/verify-full.sh` fetches `origin main` and requires `HEAD` to contain the fetched base. The block sits before the workflow contract suite and every `dotnet` invocation, so a stale base fails in seconds instead of after the Release build and coverage run.

Three failure modes are separated, each with its own message:

| Condition | Message |
| --- | --- |
| Remote unreachable or credentials failed | `verify-full.sh cannot fetch origin main.` |
| Fetch succeeded but no remote-tracking ref (non-standard refspec) | `Fetching origin main left no refs/remotes/origin/main.` |
| Branch does not contain the fetched base | `HEAD does not contain the current origin/main.` |

An unreachable remote is a hard failure. It deliberately never degrades into verifying against the stale local ref, and there is no override flag, because an escape hatch would restore exactly the gap this closes.

Moving the existence check up also means `git diff --check origin/main...HEAD` now runs against a freshly fetched ref rather than an arbitrarily old one.

## Tests

`scripts/test-agent-workflow.sh` gained a real local remote in its fixture — a clone of the fixture repository — replacing the hand-written `update-ref refs/remotes/origin/main HEAD`. The suite still runs offline and needs no network access. Four new contracts:

- `verify_full_fetches_the_remote_base_before_verifying` — deletes the remote-tracking ref and asserts the script restores it from the remote, proving it fetches rather than trusting local state;
- `verify_full_stops_when_head_is_behind_origin_main`;
- `verify_full_stops_when_the_remote_is_unreachable`;
- `verify_full_stops_when_the_fetch_leaves_no_remote_tracking_base`.

The three rejection tests also assert the `dotnet` and workflow-contract invocation logs are empty, pinning the ordering property rather than leaving it incidental. Each test restores the state it changed, so execution order is not a hidden dependency.

Removing the gate makes the new tests fail (`10 passed, 3 failed` at the time of the first three); restoring it returns `14 passed, 0 failed`.

## Documentation

- `docs/operations/agent-workflow.md` — the gate, why it fetches instead of trusting the local ref, and two recovery entries matching the exact messages;
- `docs/operations/local-development.md` — the full gate now needs remote access and cannot run offline; the fast loop is unaffected;
- root `AGENTS.md` — the verification bullet and the recovery rule.

## Notes

- `.github/workflows/` does not invoke `verify-full.sh`, so the new network requirement does not touch CI or interact with shallow clones.
- `scripts/inspect-workspace.sh` is unchanged and stays read-only; its contract is pinned by a test comparing refs before and after.
- No dependency, service, or licensing impact. `LICENSES.md` needs no entry.
