### PR TITLE
Bound synchronization by a configured earliest received date

### DIFF
--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -7,6 +7,7 @@ MailMcp now includes the first vertical slice for read-only IMAP synchronization
 - `Domain` models stable IMAP email occurrence identity as `EmailOccurrenceId`, keyed by `(account, folder, UIDVALIDITY, UID)`. The folder component is a `MailFolderResolutionId` — an alias together with the generation it was bound under — rather than a folder name, for the reason [folder aliases and discovery](#folder-aliases-and-discovery) explains. `Email` is the repository-wide term for the mail artifact; `Message` is reserved so it stays unambiguous once AI conversation types exist.
 - `Application` owns IMAP, metadata repository, content store, and checkpoint ports, the folder-discovery, binding-store, and mapping-audit ports in `MailMcp.Application.Folders`, plus the `IPersistenceSession` write-transaction port in `MailMcp.Application.Persistence`. The persistence session is named separately from `IMailboxSession` because both would otherwise be "the session" at a call site.
 - `MailboxSynchronizer` resolves the configured alias against the folders the server currently advertises before it reads anything, then opens folders through a read-only session port and requests bounded metadata batches. It retains at most one fetched MIME payload at a time: each seen-preserving remote fetch finishes before a short local session atomically upserts that occurrence's metadata, uses the returned local stored-email identifier for its content, and commits and disposes before the next remote fetch starts. After the inspected batch finishes, a separate short session advances the checkpoint only when the mailbox adapter reports a non-speculative UID cursor known safe from the opened folder state.
+- How far back a run reaches is bounded per account by an optional earliest date, which travels into the IMAP search itself rather than filtering what came back. An account that names one pays no `FETCH`, no MIME read, no `bytea` write, and no search-vector computation for the mail it excludes, and the folder checkpoint still advances across the excluded range so a run ends instead of rescanning it every interval. [Bounding how far back a run reaches](#bounding-how-far-back-a-run-reaches) states which date the bound compares against and what widening one later does not do.
 - Batches are bounded by email count, not by UID-space width. The adapter searches the whole remaining assigned UID range — a UID SEARCH returns identifiers only — and then fetches envelopes for at most `MaxMetadataBatchSize` emails. A folder whose UIDs are sparse after deletions therefore still advances a full batch per iteration instead of crawling the UID space, which keeps an initial backfill practical.
 - An email that exceeds `MaxRawMimeBytes` is never silently dropped. Its occurrence metadata is committed with `ContentAvailability = ExceededSizeLimit` before the checkpoint moves past it, so the gap stays queryable and auditable instead of existing only as a counter in a log line. The same applies when the advertised size understated the payload and the bounded stream read abandons it mid-fetch: the session reports that as a `RemoteEmailContentFetchResult` outcome rather than as a failure, because the caller records the occurrence and continues, exactly as it does for MIME the reader cannot parse.
 - Committing occurrences before the window checkpoint means a process failure may cause a later run to fetch an already stored occurrence again. Content and metadata writes use the stable remote occurrence identity and are idempotent, so this retry does not create duplicate stored emails.
@@ -365,6 +366,7 @@ Synchronization is disabled by default:
         "Host": "imap.example.test",
         "Port": 993,
         "UserName": "mailmcp@example.test",
+        "EarliestEmailReceivedDate": "2024-01-01",
         "Secrets": {
           "Password": { "SecretReference": "systemd-credential:imap-primary-password" }
         },
@@ -411,6 +413,50 @@ The extraction backfill has a section of its own rather than a block inside the 
 ```
 
 When enabled, at least one account with a non-blank `AccountId`, host, and user name must be configured. The account password is not a configuration value at all: `Secrets.Password` carries a reference, and startup fails when it cannot be resolved. Each entry of `Folders` names an alias and exactly one of `RemotePath` and `SpecialUse`; naming both, naming neither, or naming a role that does not exist fails startup with a message identifying the alias. Supported roles are `Inbox`, `Archive`, `Drafts`, `Sent`, `Junk`, `Trash`, `All`, `Flagged`, and `Important`. If an account omits `Folders`, the worker applies the post-binding default of one alias `inbox` mapped to the inbox role; explicit folder lists replace that default.
+
+### Bounding how far back a run reaches
+
+`EarliestEmailReceivedDate` is optional and per account. Omitting it synchronizes every email the server still holds,
+which stays the default and keeps existing configuration behaving exactly as before. Naming a date bounds the corpus: an
+account whose archive predates the assistant's usefulness synchronizes the mail worth asking about instead of fifteen
+years of backlog that would otherwise be searched, fetched, parsed, stored as raw MIME, and indexed before anything
+recent arrived. It binds as a plain date — `2024-01-01` — and the date itself is inside the window.
+
+**The bound compares against arrival, not against the sent date.** It becomes the IMAP `SINCE` key, which compares the
+server-assigned `INTERNALDATE`, disregarding time and time zone. It deliberately does not compare the envelope `Date`
+header that MailMcp stores as the email's sent timestamp, and the two disagree for imported and forwarded mail:
+
+- An archive copied onto a new server carries the arrival date of the copy, so a migrated mailbox is *not* bounded by
+  what its mail says it was sent on. A migration that has to be bounded needs the date the migration ran, not the date
+  the mail was written.
+- A message forwarded today carries the old header date of what it quotes. Bounding on the header would have made such a
+  message permanently invisible, because a bound on the sent date keeps excluding newly arriving old-dated mail forever
+  rather than only bounding a first run.
+
+Arrival is also the property that grows with the UID sequence a run walks, and every server keeps it for every email,
+while a `Date` header can be absent or unparseable.
+
+The bound is pushed into the search rather than applied to its answer: the remaining UID range and the date condition go
+to the server in one `UID SEARCH`, so an excluded UID is never fetched. The checkpoint still advances through everything
+the search inspected, not merely through the last email it described, so a folder whose entire backlog is excluded
+advances once to the highest assigned UID, reports no remaining work, and ends. Read-only behavior is unchanged: no path
+introduced by the bound can set `\Seen`.
+
+**Widening the bound later does not revisit mail a run already passed.** The folder checkpoint records how far the UID
+sequence has been walked, and nothing about a changed date rewinds it, so moving the bound further back only affects UIDs
+that have not been reached yet — mail below the checkpoint stays absent, and the absence shows up as a missing search
+result rather than as an error. Recovering it means clearing that folder's `synchronization_checkpoints` row so the next
+run walks the folder from its first UID again, which is safe because metadata and content writes are idempotent on the
+remote occurrence identity, and expensive because everything inside the widened window is fetched and indexed again.
+Narrowing the bound removes nothing that is already stored; pruning stored mail is a separate concern.
+
+A date later than the current UTC date fails startup, naming the account, because it would exclude every email in the
+mailbox — indistinguishable from synchronization silently doing nothing. That rule needs the current date, which no data
+annotation on bound options can reach, so it runs as the options framework's custom validator, at startup and then
+whenever a reload materializes new options, on the same terms as this section's other bound-options rules. It is not gated on `Enabled`, for the same reason secret resolution is not: a date an
+operator wrote is a date they intend to synchronize from. A value that is not a date at all fails startup while binding,
+which is what the section's strict binding buys here — a collection item whose conversion fails is otherwise dropped, and
+a typo in this one setting would remove the whole account from synchronization.
 
 ### Secrets
 

--- a/src/Application/Synchronization/IMailSynchronizationWindowReader.cs
+++ b/src/Application/Synchronization/IMailSynchronizationWindowReader.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Domain.Accounts;
+using MailMcp.Domain.Synchronization;
+
+namespace MailMcp.Application.Synchronization;
+
+/// <summary>Resolves how far back synchronization may reach for one configured mail account.</summary>
+/// <remarks>
+/// The window is read once per run and handed to the mailbox session as an input, for the same reason the transport
+/// security policy is: an adapter may narrow what it is given and must never decide for itself which emails a run is
+/// allowed to see. An account that configured no bound reads as
+/// <see cref="MailSynchronizationWindow.Unbounded" /> rather than as an absent answer.
+/// </remarks>
+public interface IMailSynchronizationWindowReader
+{
+    /// <summary>Gets the configured synchronization window for an account.</summary>
+    /// <param name="accountId">The local account identifier.</param>
+    /// <returns>The account's window.</returns>
+    MailSynchronizationWindow GetWindow(MailAccountId accountId);
+}

--- a/src/Application/Synchronization/IMailboxSession.cs
+++ b/src/Application/Synchronization/IMailboxSession.cs
@@ -2,6 +2,7 @@
 
 using MailMcp.Application.EmailContent;
 using MailMcp.Domain.Emails;
+using MailMcp.Domain.Synchronization;
 
 namespace MailMcp.Application.Synchronization;
 
@@ -22,13 +23,21 @@ public interface IMailboxSession : IAsyncDisposable
     /// <summary>Gets a bounded remote email metadata page after the supplied checkpoint UID.</summary>
     /// <param name="lastSeenUid">The checkpoint to read past, or <see langword="null" /> to start at the first assigned UID.</param>
     /// <param name="maxEmailCount">The maximum number of emails the returned page may describe.</param>
+    /// <param name="synchronizationWindow">How far back the page may reach, which the implementation must apply on the server rather than to the answer.</param>
     /// <param name="cancellationToken">Cancels the read and every remaining attempt.</param>
     /// <returns>The page, with the UID it inspected through and whether more work remains.</returns>
     /// <exception cref="MailboxUnavailableException">Thrown when the mail server did not serve the read within its configured resilience budget.</exception>
     /// <exception cref="MailboxFolderRecreatedException">Thrown when a recovered connection reselected the folder with a different UIDVALIDITY.</exception>
+    /// <remarks>
+    /// An email the window excludes is not described by the page, and the returned cursor still covers it: the page
+    /// reports the UID the search inspected through rather than the UID it last described, so a caller advancing its
+    /// checkpoint by that cursor steps over an excluded range once instead of rescanning it on every run. That is also
+    /// why the window belongs on the server's side of the call — an excluded UID must cost no fetch.
+    /// </remarks>
     Task<RemoteEmailMetadataBatch> GetEmailBatchAfterAsync(
         ImapUid? lastSeenUid,
         int maxEmailCount,
+        MailSynchronizationWindow synchronizationWindow,
         CancellationToken cancellationToken);
 
     /// <summary>Fetches raw MIME content with a BODY.PEEK-style operation that preserves the remote Seen flag.</summary>

--- a/src/Application/Synchronization/MailboxSynchronizer.cs
+++ b/src/Application/Synchronization/MailboxSynchronizer.cs
@@ -19,6 +19,7 @@ public sealed class MailboxSynchronizer
     private readonly MailFolderResolver folderResolver;
     private readonly IMailboxSessionFactory mailboxSessionFactory;
     private readonly IMailTransportSecurityPolicyReader transportSecurityPolicyReader;
+    private readonly IMailSynchronizationWindowReader synchronizationWindowReader;
     private readonly ISynchronizationCheckpointStore checkpointStore;
     private readonly IPersistenceSessionFactory persistenceSessionFactory;
     private readonly IEmailMetadataRepository metadataRepository;
@@ -33,6 +34,7 @@ public sealed class MailboxSynchronizer
         MailFolderResolver folderResolver,
         IMailboxSessionFactory mailboxSessionFactory,
         IMailTransportSecurityPolicyReader transportSecurityPolicyReader,
+        IMailSynchronizationWindowReader synchronizationWindowReader,
         ISynchronizationCheckpointStore checkpointStore,
         IPersistenceSessionFactory persistenceSessionFactory,
         IEmailMetadataRepository metadataRepository,
@@ -45,6 +47,7 @@ public sealed class MailboxSynchronizer
         this.folderResolver = folderResolver;
         this.mailboxSessionFactory = mailboxSessionFactory;
         this.transportSecurityPolicyReader = transportSecurityPolicyReader;
+        this.synchronizationWindowReader = synchronizationWindowReader;
         this.checkpointStore = checkpointStore;
         this.persistenceSessionFactory = persistenceSessionFactory;
         this.metadataRepository = metadataRepository;
@@ -77,9 +80,17 @@ public sealed class MailboxSynchronizer
     /// run was working with no longer name the same emails. The next run starts the folder over.
     /// </exception>
     /// <remarks>
+    /// <para>
     /// The alias is resolved against the server's advertised folders before anything is read, so a run always works
     /// under the binding that is durable at the moment it starts. An alias the server advertises no folder for ends
     /// this run and no other.
+    /// </para>
+    /// <para>
+    /// The account's synchronization window is read at the same moment as its transport security policy and bounds
+    /// every batch the run requests. Excluded mail is left out by the server, so it costs no fetch, no MIME read, and
+    /// no local write, and the folder checkpoint still advances across the excluded range so a run ends instead of
+    /// rescanning it on every interval.
+    /// </para>
     /// </remarks>
     public async Task<MailboxSynchronizationResult> SynchronizeAsync(
         MailAccountId accountId,
@@ -105,6 +116,7 @@ public sealed class MailboxSynchronizer
             accountId,
             folder,
             transportSecurityPolicy,
+            this.synchronizationWindowReader.GetWindow(accountId),
             cancellationToken);
     }
 
@@ -112,6 +124,7 @@ public sealed class MailboxSynchronizer
         MailAccountId accountId,
         MailFolderResolution folder,
         MailTransportSecurityPolicy transportSecurityPolicy,
+        MailSynchronizationWindow synchronizationWindow,
         CancellationToken cancellationToken)
     {
         var persistedCheckpoint =
@@ -138,7 +151,11 @@ public sealed class MailboxSynchronizer
         {
             inspectedBatchCount++;
 
-            var batch = await mailboxSession.GetEmailBatchAfterAsync(checkpoint.LastSeenUid, this.options.MaxMetadataBatchSize, cancellationToken);
+            var batch = await mailboxSession.GetEmailBatchAfterAsync(
+                checkpoint.LastSeenUid,
+                this.options.MaxMetadataBatchSize,
+                synchronizationWindow,
+                cancellationToken);
             foreach (var metadata in batch.Emails.OrderBy(email => email.OccurrenceId.Uid.Value))
             {
                 var occurrence = await this.StoreOccurrenceAsync(mailboxSession, metadata, cancellationToken);

--- a/src/Domain/Synchronization/MailSynchronizationWindow.cs
+++ b/src/Domain/Synchronization/MailSynchronizationWindow.cs
@@ -1,0 +1,36 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+namespace MailMcp.Domain.Synchronization;
+
+/// <summary>States how far back into a folder's history synchronization may reach.</summary>
+/// <remarks>
+/// <para>
+/// The bound compares against the date the mail server received an email, which IMAP keeps as its
+/// <c>INTERNALDATE</c>, and never against the <c>Date</c> header that MailMcp stores as the sent timestamp. The two
+/// disagree for imported and forwarded mail: an archive copied onto a new server carries the arrival date of the copy,
+/// and a message forwarded today carries the old header date of what it quotes. Arrival is what decides whether an
+/// email is part of the backlog this bound exists to keep out of a first run, it grows with the UID sequence a run
+/// walks, and every server keeps it for every email, while a <c>Date</c> header can be absent or unparseable.
+/// </para>
+/// <para>
+/// The bound is a date and not an instant because IMAP compares dates alone, disregarding time and time zone. An email
+/// received at any time of the day named by <see cref="EarliestEmailReceivedDate" /> is inside the window.
+/// </para>
+/// </remarks>
+public readonly record struct MailSynchronizationWindow
+{
+    private MailSynchronizationWindow(DateOnly? earliestEmailReceivedDate) =>
+        this.EarliestEmailReceivedDate = earliestEmailReceivedDate;
+
+    /// <summary>Gets the window that reaches every email a folder still holds.</summary>
+    public static MailSynchronizationWindow Unbounded => default;
+
+    /// <summary>Gets the earliest date a server may have received an email on for it to be synchronized, or <see langword="null" /> when the window is unbounded.</summary>
+    public DateOnly? EarliestEmailReceivedDate { get; }
+
+    /// <summary>Creates a window that reaches no further back than one date.</summary>
+    /// <param name="earliestEmailReceivedDate">The earliest date a server may have received an email on, which is itself inside the window.</param>
+    /// <returns>A window bounded at that date.</returns>
+    public static MailSynchronizationWindow EmailsReceivedSince(DateOnly earliestEmailReceivedDate) =>
+        new(earliestEmailReceivedDate);
+}

--- a/src/Host/Configuration/MailSynchronizationOptions.cs
+++ b/src/Host/Configuration/MailSynchronizationOptions.cs
@@ -4,8 +4,10 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography.X509Certificates;
 using MailMcp.Application.Mail;
+using MailMcp.Application.Synchronization;
 using MailMcp.Domain.Accounts;
 using MailMcp.Domain.Folders;
+using MailMcp.Domain.Synchronization;
 using MailMcp.Domain.Transport;
 using MailMcp.Infrastructure.Certificates;
 using MailMcp.Infrastructure.Mail;
@@ -15,7 +17,7 @@ namespace MailMcp.Host.Configuration;
 
 /// <summary>Configures periodic IMAP synchronization.</summary>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
-internal sealed class MailSynchronizationOptions : IValidatableObject, IMailTransportSecurityPolicyReader
+internal sealed class MailSynchronizationOptions : IValidatableObject, IMailTransportSecurityPolicyReader, IMailSynchronizationWindowReader
 {
     /// <summary>Gets or sets whether periodic synchronization is enabled.</summary>
     public bool Enabled { get; set; }
@@ -101,6 +103,26 @@ internal sealed class MailSynchronizationOptions : IValidatableObject, IMailTran
         return account.CreateTransportSecurityPolicy();
     }
 
+    /// <inheritdoc />
+    public MailSynchronizationWindow GetWindow(MailAccountId accountId)
+    {
+        var account = this.FindAccount(accountId.Value);
+
+        return account.CreateSynchronizationWindow();
+    }
+
+    /// <summary>Finds every configured earliest received date that could not mean anything on the supplied date.</summary>
+    /// <param name="today">The current date the configured bounds are read against.</param>
+    /// <returns>One result per account whose bound lies in the future, empty when every bound is usable.</returns>
+    /// <remarks>
+    /// The rule lives here with the other configuration rules while its clock stays outside, because the current date
+    /// is not something a bound options graph or a data annotation can reach. Nothing gates it on
+    /// <see cref="Enabled" />: a date an operator wrote is a date they intend to synchronize from, and discovering that
+    /// it excludes the whole mailbox at the moment synchronization is switched on is worse than discovering it now.
+    /// </remarks>
+    internal IEnumerable<ValidationResult> FindSynchronizationWindowErrors(DateOnly today) =>
+        this.Accounts?.SelectMany(account => account.ValidateSynchronizationWindow(today)) ?? [];
+
     internal IEnumerable<ValidationResult> ValidateForSynchronization()
     {
         if (this.Accounts is null)
@@ -161,6 +183,16 @@ internal sealed class MailSynchronizationAccountOptions : IValidatableObject
 
     /// <summary>Gets or sets the account's secret-bearing settings, which carry references rather than credentials.</summary>
     public MailAccountSecretOptions Secrets { get; set; } = new();
+
+    /// <summary>Gets or sets the earliest date the mail server may have received an email on for it to be synchronized.</summary>
+    /// <remarks>
+    /// Omitting it synchronizes every email the server still holds, which is the default. It binds as a plain date such
+    /// as <c>2024-01-01</c>, and a value that is not one fails startup: the account is a collection item, and the binder
+    /// would otherwise drop the whole account over a typo in this one setting, which is another reason the section is
+    /// bound with <c>ErrorOnUnknownConfiguration</c>. Which date the bound compares against, and why, is recorded on
+    /// <see cref="MailSynchronizationWindow" />.
+    /// </remarks>
+    public DateOnly? EarliestEmailReceivedDate { get; set; }
 
     /// <summary>Gets or sets the configured folder aliases. When omitted, the worker synchronizes the inbox only.</summary>
     public List<MailFolderMappingOptions> Folders { get; set; } = [];
@@ -224,6 +256,31 @@ internal sealed class MailSynchronizationAccountOptions : IValidatableObject
             }
         }
     }
+
+    /// <summary>Reports an earliest received date that lies ahead of the supplied date.</summary>
+    /// <param name="today">The current date the configured bound is read against.</param>
+    /// <returns>One result when the bound is in the future, none otherwise.</returns>
+    /// <remarks>
+    /// A future bound is refused rather than adopted because it excludes every email the mailbox holds, which is
+    /// indistinguishable from synchronization silently doing nothing. The comparison is made in UTC, so a bound written
+    /// as the operator's local date is refused while UTC has not reached it yet.
+    /// </remarks>
+    internal IEnumerable<ValidationResult> ValidateSynchronizationWindow(DateOnly today)
+    {
+        if (this.EarliestEmailReceivedDate is { } earliestReceivedDate && earliestReceivedDate > today)
+        {
+            yield return new ValidationResult(
+                $"Account '{this.AccountId}': the earliest email received date {earliestReceivedDate:yyyy-MM-dd} is later than the current UTC date {today:yyyy-MM-dd}, so it would exclude every email in the mailbox.",
+                [nameof(this.EarliestEmailReceivedDate)]);
+        }
+    }
+
+    /// <summary>Builds the account's configured synchronization window.</summary>
+    /// <returns>The window the account's bound names, or an unbounded one when it configured none.</returns>
+    internal MailSynchronizationWindow CreateSynchronizationWindow() =>
+        this.EarliestEmailReceivedDate is { } earliestReceivedDate
+            ? MailSynchronizationWindow.EmailsReceivedSince(earliestReceivedDate)
+            : MailSynchronizationWindow.Unbounded;
 
     /// <summary>Builds the account's validated transport security policy.</summary>
     /// <returns>The policy the mailbox adapter must obey.</returns>

--- a/src/Host/Configuration/MailSynchronizationWindowValidator.cs
+++ b/src/Host/Configuration/MailSynchronizationWindowValidator.cs
@@ -1,0 +1,38 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Options;
+
+namespace MailMcp.Host.Configuration;
+
+/// <summary>Refuses a configured synchronization bound that the current date makes meaningless.</summary>
+/// <remarks>
+/// Every other mail synchronization rule is a data annotation or an <see cref="IValidatableObject" /> rule on the bound
+/// options graph, and this one cannot be either: whether an earliest received date is in the future is a question about
+/// the current date, which neither an attribute nor a bound object can reach. It is therefore the options framework's
+/// own custom-validator seam that supplies the clock, and the rule itself stays in
+/// <see cref="MailSynchronizationOptions" /> with the rules it belongs beside. Registering it runs it at startup
+/// through <c>ValidateOnStart</c>, and afterwards whenever a reload materializes new options, on the same terms as the
+/// section's data annotations.
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework resolves this validator through IValidateOptions.")]
+internal sealed class MailSynchronizationWindowValidator(TimeProvider timeProvider)
+    : IValidateOptions<MailSynchronizationOptions>
+{
+    /// <inheritdoc />
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="options" /> is <see langword="null" />.</exception>
+    public ValidateOptionsResult Validate(string? name, MailSynchronizationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var today = DateOnly.FromDateTime(timeProvider.GetUtcNow().UtcDateTime);
+
+        var failures = options
+            .FindSynchronizationWindowErrors(today)
+            .Select(result => result.ErrorMessage ?? string.Empty)
+            .ToArray();
+
+        return failures.Length == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -42,6 +42,9 @@ try
             binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
         .ValidateDataAnnotations()
         .ValidateOnStart();
+    // The one mail synchronization rule that needs the current date, which no attribute on a bound options graph can
+    // reach, arrives through the options framework's own validator seam rather than as a second validation mechanism.
+    builder.Services.AddSingleton<IValidateOptions<MailSynchronizationOptions>, MailSynchronizationWindowValidator>();
     // Bound strictly for the same reason as mail transport: a misspelled "Passwrod" would leave the secret block
     // undiscovered, start the host on a passwordless connection string, and surface as an authentication failure later.
     builder.Services.AddOptions<PersistenceOptions>()
@@ -80,6 +83,7 @@ try
     builder.Services.AddScoped<ScopedMailSynchronizationSettings>();
     builder.Services.AddScoped(provider => provider.GetRequiredService<ScopedMailSynchronizationSettings>().Current);
     builder.Services.AddScoped<IMailTransportSecurityPolicyReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
+    builder.Services.AddScoped<IMailSynchronizationWindowReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IImapAccountSettingsProvider, ConfiguredImapAccountSettingsProvider>();
     builder.Services.AddScoped(provider =>
     {

--- a/src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs
+++ b/src/Infrastructure/Mail/MailKit/MailKitImapMailboxSession.cs
@@ -11,6 +11,7 @@ using MailMcp.Application.Synchronization;
 using MailMcp.Domain.Accounts;
 using MailMcp.Domain.Emails;
 using MailMcp.Domain.Folders;
+using MailMcp.Domain.Synchronization;
 using MailMcp.Domain.Transport;
 using MailMcp.Infrastructure.Resilience;
 
@@ -82,6 +83,7 @@ internal sealed class MailKitImapMailboxSession(
     public Task<RemoteEmailMetadataBatch> GetEmailBatchAfterAsync(
         ImapUid? lastSeenUid,
         int maxEmailCount,
+        MailSynchronizationWindow synchronizationWindow,
         CancellationToken cancellationToken)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxEmailCount);
@@ -92,7 +94,12 @@ internal sealed class MailKitImapMailboxSession(
         }
 
         return connection.ExecuteFolderReadAsync(
-            (openFolder, attemptToken) => this.SearchAndFetchBatchAsync(openFolder, lastSeenUid, maxEmailCount, attemptToken),
+            (openFolder, attemptToken) => this.SearchAndFetchBatchAsync(
+                openFolder,
+                lastSeenUid,
+                maxEmailCount,
+                synchronizationWindow,
+                attemptToken),
             cancellationToken);
     }
 
@@ -113,6 +120,7 @@ internal sealed class MailKitImapMailboxSession(
         IMailFolder openFolder,
         ImapUid? lastSeenUid,
         int maxEmailCount,
+        MailSynchronizationWindow synchronizationWindow,
         CancellationToken cancellationToken)
     {
         var minValue = lastSeenUid is { } uid ? uid.Value + 1U : 1U;
@@ -126,7 +134,9 @@ internal sealed class MailKitImapMailboxSession(
         // be bounded by email count rather than by UID-space width. Bounding by UID-space width would advance a sparse
         // folder by at most maxEmailCount UIDs per batch and make an initial backfill take an impractical number of runs.
         var searchRange = new UniqueIdRange(new UniqueId(minValue), new UniqueId(highestAssignedUid.Value));
-        var matchingUids = await openFolder.SearchAsync(SearchQuery.Uids(searchRange), cancellationToken);
+        var matchingUids = await openFolder.SearchAsync(
+            BuildRangeSearchQuery(searchRange, synchronizationWindow),
+            cancellationToken);
         var assignedUids = matchingUids
             .Where(candidate => candidate.Id >= minValue && candidate.Id <= highestAssignedUid.Value)
             .OrderBy(candidate => candidate.Id)
@@ -179,6 +189,25 @@ internal sealed class MailKitImapMailboxSession(
         }
 
         return RemoteEmailContentFetchResult.Retrieved(new RemoteEmailContent(occurrenceId, memory.ToArray()));
+    }
+
+    /// <summary>Builds the one UID SEARCH that carries both the remaining UID range and the account's earliest-arrival bound.</summary>
+    /// <remarks>
+    /// The date condition travels with the range in the same command, so the server never reports an excluded UID and
+    /// this run never fetches one. MailKit renders <c>DeliveredAfter</c> as the IMAP <c>SINCE</c> key, which compares
+    /// the server-assigned <c>INTERNALDATE</c> disregarding time and time zone and includes the named day itself; the
+    /// envelope <c>Date</c> header MailMcp stores as the sent timestamp is deliberately not what is compared, for the
+    /// reason <see cref="MailSynchronizationWindow" /> records.
+    /// </remarks>
+    private static SearchQuery BuildRangeSearchQuery(
+        UniqueIdRange searchRange,
+        MailSynchronizationWindow synchronizationWindow)
+    {
+        SearchQuery rangeQuery = SearchQuery.Uids(searchRange);
+
+        return synchronizationWindow.EarliestEmailReceivedDate is { } earliestReceivedDate
+            ? rangeQuery.And(SearchQuery.DeliveredAfter(earliestReceivedDate.ToDateTime(TimeOnly.MinValue)))
+            : rangeQuery;
     }
 
     private static uint? GetHighestAssignedUid(UniqueId? uidNext)

--- a/tests/Application.UnitTests/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/MailboxSynchronizerTests.cs
@@ -65,7 +65,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
         session.FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None).Returns(RemoteEmailContentFetchResult.Retrieved(content));
         metadataRepository.UpsertMetadataAsync(persistenceSession, metadata, Arg.Any<ExtractedEmailMetadata?>(), StoredEmailContentAvailability.Available, CancellationToken.None).Returns(_ =>
         {
@@ -84,7 +84,7 @@ public sealed class MailboxSynchronizerTests
         // Assert
         Assert.Equal(1, result.StoredEmailCount);
         Assert.Equal(0, result.SkippedOversizedEmailCount);
-        await session.Received(1).GetEmailBatchAfterAsync(null, 25, CancellationToken.None);
+        await session.Received(1).GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None);
         await session.Received(1).FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None);
         await metadataRepository.Received(1).UpsertMetadataAsync(persistenceSession, metadata, Arg.Any<ExtractedEmailMetadata?>(), StoredEmailContentAvailability.Available, CancellationToken.None);
         await contentStore.Received(1).SaveContentAsync(persistenceSession, storedEmailId, content, CancellationToken.None);
@@ -115,7 +115,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
 
         // Act
         var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
@@ -153,17 +153,162 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([], firstCursor, HasMore: true));
-        session.GetEmailBatchAfterAsync(firstCursor, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([], secondCursor, HasMore: true));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([], firstCursor, HasMore: true));
+        session.GetEmailBatchAfterAsync(firstCursor, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([], secondCursor, HasMore: true));
 
         // Act
         var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
 
         // Assert
         Assert.True(result.HasMoreEmails);
-        await session.Received(2).GetEmailBatchAfterAsync(Arg.Any<ImapUid?>(), 25, CancellationToken.None);
+        await session.Received(2).GetEmailBatchAfterAsync(Arg.Any<ImapUid?>(), 25, MailSynchronizationWindow.Unbounded, CancellationToken.None);
         await checkpointStore.Received(1).SaveCheckpointAsync(persistenceSession, accountId, folder.Id, Arg.Any<SynchronizationCheckpoint?>(), Arg.Is<SynchronizationCheckpoint>(checkpoint => checkpoint!.LastSeenUid == firstCursor), CancellationToken.None);
         await checkpointStore.Received(1).SaveCheckpointAsync(persistenceSession, accountId, folder.Id, Arg.Any<SynchronizationCheckpoint?>(), Arg.Is<SynchronizationCheckpoint>(checkpoint => checkpoint!.LastSeenUid == secondCursor), CancellationToken.None);
+    }
+
+    /// <summary>The configured bound must reach the server, because filtering after a fetch would defeat the point of it.</summary>
+    [Fact]
+    public async Task SynchronizeAsync_AccountBoundsHowFarBackToReach_RequestsEveryBatchUnderThatBound()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var folder = InboxFolder;
+        var uidValidity = ImapUidValidity.Create(5);
+        var uid = ImapUid.Create(10);
+        var occurrence = EmailOccurrenceId.Create(accountId, folder.Id, uidValidity, uid);
+        var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
+        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        sessionScopeFactory.BeginSessionAsync(CancellationToken.None).Returns(persistenceSession);
+        var contentStore = Substitute.For<IEmailContentStore>();
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        var session = Substitute.For<IMailboxSession>();
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
+        var window = MailSynchronizationWindow.EmailsReceivedSince(new DateOnly(2024, 1, 1));
+        var synchronizer = CreateSynchronizer(
+            sessionFactory,
+            checkpointStore,
+            sessionScopeFactory,
+            metadataRepository,
+            contentStore,
+            clock,
+            options,
+            synchronizationWindow: window);
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128);
+        checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
+        sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
+        session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
+        session.GetEmailBatchAfterAsync(null, 25, window, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        session.FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None).Returns(
+            RemoteEmailContentFetchResult.Retrieved(new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]))));
+
+        // Act
+        var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.StoredEmailCount);
+        await session.Received(1).GetEmailBatchAfterAsync(null, 25, window, CancellationToken.None);
+        await session.DidNotReceive().GetEmailBatchAfterAsync(Arg.Any<ImapUid?>(), Arg.Any<int>(), MailSynchronizationWindow.Unbounded, CancellationToken.None);
+    }
+
+    /// <summary>An excluded range must be stepped over once; rescanning it every interval is what a bound is supposed to avoid.</summary>
+    [Fact]
+    public async Task SynchronizeAsync_BoundExcludesEveryEmailInTheRange_AdvancesTheCheckpointPastItAndEndsTheRun()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var folder = InboxFolder;
+        var uidValidity = ImapUidValidity.Create(5);
+        var inspectedThroughUid = ImapUid.Create(4000);
+        var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
+        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        sessionScopeFactory.BeginSessionAsync(CancellationToken.None).Returns(persistenceSession);
+        var contentStore = Substitute.For<IEmailContentStore>();
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        var session = Substitute.For<IMailboxSession>();
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024, MaxMetadataBatchesPerRun = 5 };
+        var window = MailSynchronizationWindow.EmailsReceivedSince(new DateOnly(2026, 1, 1));
+        var synchronizer = CreateSynchronizer(
+            sessionFactory,
+            checkpointStore,
+            sessionScopeFactory,
+            metadataRepository,
+            contentStore,
+            clock,
+            options,
+            synchronizationWindow: window);
+        checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
+        sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
+        session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
+        session.GetEmailBatchAfterAsync(null, 25, window, CancellationToken.None).Returns(
+            new RemoteEmailMetadataBatch([], inspectedThroughUid, HasMore: false));
+
+        // Act
+        var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, result.StoredEmailCount);
+        Assert.False(result.HasMoreEmails);
+        Assert.Equal(inspectedThroughUid, result.Checkpoint!.LastSeenUid);
+        await session.Received(1).GetEmailBatchAfterAsync(Arg.Any<ImapUid?>(), 25, window, CancellationToken.None);
+        await session.DidNotReceive().FetchEmailContentWithoutSettingSeenAsync(Arg.Any<EmailOccurrenceId>(), Arg.Any<long>(), CancellationToken.None);
+        await checkpointStore.Received(1).SaveCheckpointAsync(persistenceSession, accountId, folder.Id, Arg.Any<SynchronizationCheckpoint?>(), Arg.Is<SynchronizationCheckpoint>(checkpoint => checkpoint!.LastSeenUid == inspectedThroughUid), CancellationToken.None);
+    }
+
+    /// <summary>A batch that straddles the bound checkpoints through what the search inspected, not through its last email.</summary>
+    [Fact]
+    public async Task SynchronizeAsync_BatchStraddlesTheBound_StoresTheIncludedEmailAndCheckpointsPastTheExcludedOnes()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var folder = InboxFolder;
+        var uidValidity = ImapUidValidity.Create(5);
+        var includedUid = ImapUid.Create(90);
+        var inspectedThroughUid = ImapUid.Create(120);
+        var includedOccurrence = EmailOccurrenceId.Create(accountId, folder.Id, uidValidity, includedUid);
+        var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
+        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        sessionScopeFactory.BeginSessionAsync(CancellationToken.None).Returns(persistenceSession);
+        var contentStore = Substitute.For<IEmailContentStore>();
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        var session = Substitute.For<IMailboxSession>();
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
+        var window = MailSynchronizationWindow.EmailsReceivedSince(new DateOnly(2026, 7, 1));
+        var synchronizer = CreateSynchronizer(
+            sessionFactory,
+            checkpointStore,
+            sessionScopeFactory,
+            metadataRepository,
+            contentStore,
+            clock,
+            options,
+            synchronizationWindow: window);
+        var includedMetadata = new RemoteEmailMetadata(includedOccurrence, "message-90@example.test", "Subject", new DateTimeOffset(2026, 7, 20, 8, 0, 0, TimeSpan.Zero), 128);
+        checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
+        sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
+        session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
+        session.GetEmailBatchAfterAsync(null, 25, window, CancellationToken.None).Returns(
+            new RemoteEmailMetadataBatch([includedMetadata], inspectedThroughUid, HasMore: false));
+        session.FetchEmailContentWithoutSettingSeenAsync(includedOccurrence, 1024, CancellationToken.None).Returns(
+            RemoteEmailContentFetchResult.Retrieved(new RemoteEmailContent(includedOccurrence, new ReadOnlyMemory<byte>([1, 2, 3]))));
+
+        // Act
+        var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal(inspectedThroughUid, result.Checkpoint!.LastSeenUid);
+        await session.Received(1).FetchEmailContentWithoutSettingSeenAsync(includedOccurrence, 1024, CancellationToken.None);
+        await session.Received(1).FetchEmailContentWithoutSettingSeenAsync(Arg.Any<EmailOccurrenceId>(), Arg.Any<long>(), CancellationToken.None);
+        await checkpointStore.Received(1).SaveCheckpointAsync(persistenceSession, accountId, folder.Id, Arg.Any<SynchronizationCheckpoint?>(), Arg.Is<SynchronizationCheckpoint>(checkpoint => checkpoint!.LastSeenUid == inspectedThroughUid), CancellationToken.None);
     }
 
     [Fact]
@@ -190,7 +335,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
         session.FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None).Returns(RemoteEmailContentFetchResult.ExceededSizeLimit());
 
         // Act
@@ -235,7 +380,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
         session.FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None).Returns(_ =>
         {
             contentFetched = true;
@@ -324,7 +469,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(mailboxSession);
         mailboxSession.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        mailboxSession.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(
+        mailboxSession.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(
             new RemoteEmailMetadataBatch([firstMetadata, secondMetadata], secondUid, HasMore: false));
         mailboxSession.FetchEmailContentWithoutSettingSeenAsync(firstOccurrence, 1024, CancellationToken.None).Returns(RemoteEmailContentFetchResult.Retrieved(firstContent));
         mailboxSession.FetchEmailContentWithoutSettingSeenAsync(secondOccurrence, 1024, CancellationToken.None).Returns(_ =>
@@ -399,7 +544,7 @@ public sealed class MailboxSynchronizerTests
             .Returns(SynchronizationCheckpoint.None(uidValidity));
         mailboxSessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(mailboxSession);
         mailboxSession.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        mailboxSession.GetEmailBatchAfterAsync(null, 25, CancellationToken.None)
+        mailboxSession.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None)
             .Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
         mailboxSession.FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None).Returns(RemoteEmailContentFetchResult.Retrieved(content));
         metadataRepository.UpsertMetadataAsync(
@@ -495,7 +640,7 @@ public sealed class MailboxSynchronizerTests
             .Returns(initialCheckpoint);
         mailboxSessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(mailboxSession);
         mailboxSession.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        mailboxSession.GetEmailBatchAfterAsync(null, 25, CancellationToken.None)
+        mailboxSession.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None)
             .Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
         mailboxSession.FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None).Returns(RemoteEmailContentFetchResult.Retrieved(content));
         metadataRepository.UpsertMetadataAsync(
@@ -569,7 +714,7 @@ public sealed class MailboxSynchronizerTests
         mailboxSessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None)
             .Returns(mailboxSession);
         mailboxSession.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        mailboxSession.GetEmailBatchAfterAsync(null, 25, CancellationToken.None)
+        mailboxSession.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None)
             .Returns(new RemoteEmailMetadataBatch([], inspectedThroughUid, HasMore: false));
 
         // Act
@@ -637,7 +782,7 @@ public sealed class MailboxSynchronizerTests
         mailboxSessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None)
             .Returns(mailboxSession);
         mailboxSession.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        mailboxSession.GetEmailBatchAfterAsync(persistedUid, 25, CancellationToken.None)
+        mailboxSession.GetEmailBatchAfterAsync(persistedUid, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None)
             .Returns(new RemoteEmailMetadataBatch([], inspectedThroughUid, HasMore: false));
 
         // Act
@@ -682,7 +827,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([], null, HasMore: false));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([], null, HasMore: false));
 
         // Act
         var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
@@ -728,15 +873,15 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(staleCheckpoint);
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(currentUidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([], reassignedUid, HasMore: false));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([], reassignedUid, HasMore: false));
 
         // Act
         var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
 
         // Assert
         Assert.Equal(currentUidValidity, result.Checkpoint!.UidValidity);
-        await session.Received(1).GetEmailBatchAfterAsync(null, 25, CancellationToken.None);
-        await session.DidNotReceive().GetEmailBatchAfterAsync(staleCheckpoint.LastSeenUid, 25, CancellationToken.None);
+        await session.Received(1).GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None);
+        await session.DidNotReceive().GetEmailBatchAfterAsync(staleCheckpoint.LastSeenUid, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None);
         await checkpointStore.Received(1).SaveCheckpointAsync(
             persistenceSession,
             accountId,
@@ -773,7 +918,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, cancellation.Token).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), cancellation.Token).Returns(session);
         session.GetUidValidityAsync(cancellation.Token).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, cancellation.Token).Returns<RemoteEmailMetadataBatch>(_ =>
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, cancellation.Token).Returns<RemoteEmailMetadataBatch>(_ =>
         {
             cancellation.Cancel();
             throw new OperationCanceledException(cancellation.Token);
@@ -829,7 +974,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([], null, HasMore: false));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([], null, HasMore: false));
 
         // Act
         await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
@@ -905,7 +1050,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
         session.FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None).Returns(RemoteEmailContentFetchResult.Retrieved(content));
 
         // Act
@@ -956,7 +1101,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
         session.FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None).Returns(RemoteEmailContentFetchResult.Retrieved(content));
 
         // Act
@@ -1008,7 +1153,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
         session.FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None).Returns(RemoteEmailContentFetchResult.Retrieved(content));
 
         // Act
@@ -1065,7 +1210,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch(
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch(
             [
                 new RemoteEmailMetadata(unreadableOccurrence, "message-1@example.test", "Subject", null, 128),
                 new RemoteEmailMetadata(readableOccurrence, "message-2@example.test", "Subject", null, 128),
@@ -1121,7 +1266,7 @@ public sealed class MailboxSynchronizerTests
         checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
         sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
         session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, CancellationToken.None).Returns(new RemoteEmailMetadataBatch(
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch(
             [new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", null, 2048)],
             uid,
             HasMore: false));
@@ -1203,6 +1348,14 @@ public sealed class MailboxSynchronizerTests
         return reader;
     }
 
+    private static IMailSynchronizationWindowReader CreateSynchronizationWindowReader(MailSynchronizationWindow window)
+    {
+        var reader = Substitute.For<IMailSynchronizationWindowReader>();
+        reader.GetWindow(Arg.Any<MailAccountId>()).Returns(window);
+
+        return reader;
+    }
+
     private static MailboxSynchronizer CreateSynchronizer(
         IMailboxSessionFactory mailboxSessionFactory,
         ISynchronizationCheckpointStore checkpointStore,
@@ -1213,11 +1366,13 @@ public sealed class MailboxSynchronizerTests
         MailboxSynchronizationOptions options,
         IMailTransportSecurityPolicyReader? transportSecurityPolicyReader = null,
         MailFolderResolver? folderResolver = null,
-        IEmailMimeReader? mimeReader = null) =>
+        IEmailMimeReader? mimeReader = null,
+        MailSynchronizationWindow synchronizationWindow = default) =>
         new(
             folderResolver ?? CreateFolderResolverBoundToInbox(persistenceSessionFactory, timeProvider),
             mailboxSessionFactory,
             transportSecurityPolicyReader ?? CreateTransportSecurityPolicyReader(RequiredTlsPolicy),
+            CreateSynchronizationWindowReader(synchronizationWindow),
             checkpointStore,
             persistenceSessionFactory,
             metadataRepository,

--- a/tests/Domain.UnitTests/MailSynchronizationWindowTests.cs
+++ b/tests/Domain.UnitTests/MailSynchronizationWindowTests.cs
@@ -1,0 +1,43 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Domain.Synchronization;
+using Xunit;
+
+namespace MailMcp.Domain.UnitTests;
+
+public sealed class MailSynchronizationWindowTests
+{
+    [Fact]
+    public void Unbounded_NamesNoDate_ReachesEveryEmailTheFolderHolds()
+    {
+        // Arrange, Act
+        var window = MailSynchronizationWindow.Unbounded;
+
+        // Assert
+        Assert.Null(window.EarliestEmailReceivedDate);
+    }
+
+    /// <summary>An account that configures no bound must read as unbounded rather than as a distinct third state.</summary>
+    [Fact]
+    public void Unbounded_ComparedWithADefaultValue_IsTheSameWindow()
+    {
+        // Arrange, Act
+        var defaultWindow = default(MailSynchronizationWindow);
+
+        // Assert
+        Assert.Equal(MailSynchronizationWindow.Unbounded, defaultWindow);
+    }
+
+    [Fact]
+    public void EmailsReceivedSince_ADate_CarriesItAsTheEarliestReceivedDate()
+    {
+        // Arrange
+        var earliestReceivedDate = new DateOnly(2024, 1, 1);
+
+        // Act
+        var window = MailSynchronizationWindow.EmailsReceivedSince(earliestReceivedDate);
+
+        // Assert
+        Assert.Equal(earliestReceivedDate, window.EarliestEmailReceivedDate);
+    }
+}

--- a/tests/Host.UnitTests/MailSynchronizationOptionsTests.cs
+++ b/tests/Host.UnitTests/MailSynchronizationOptionsTests.cs
@@ -1,7 +1,9 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
+using System.Globalization;
 using MailMcp.Domain.Accounts;
 using MailMcp.Domain.Folders;
+using MailMcp.Domain.Synchronization;
 using MailMcp.Domain.Transport;
 using MailMcp.Host.Configuration;
 using MailMcp.Infrastructure.Certificates;
@@ -197,6 +199,70 @@ public sealed class MailSynchronizationOptionsTests
     }
 
     [Fact]
+    public void GetWindow_AccountBoundingHowFarBackToReach_ReturnsThatDateAsTheWindow()
+    {
+        // Arrange
+        var account = CreateAccount("primary");
+        account.EarliestEmailReceivedDate = new DateOnly(2024, 1, 1);
+        var options = new MailSynchronizationOptions { Accounts = [account] };
+
+        // Act
+        var window = options.GetWindow(MailAccountId.Create("primary"));
+
+        // Assert
+        Assert.Equal(new DateOnly(2024, 1, 1), window.EarliestEmailReceivedDate);
+    }
+
+    /// <summary>Configuring no bound keeps the behavior every existing deployment has, which is to reach everything.</summary>
+    [Fact]
+    public void GetWindow_AccountWithNoConfiguredDate_ReturnsAnUnboundedWindow()
+    {
+        // Arrange
+        var options = new MailSynchronizationOptions { Accounts = [CreateAccount("primary")] };
+
+        // Act
+        var window = options.GetWindow(MailAccountId.Create("primary"));
+
+        // Assert
+        Assert.Equal(MailSynchronizationWindow.Unbounded, window);
+    }
+
+    [Fact]
+    public void FindSynchronizationWindowErrors_DateLaterThanToday_ReportsTheAccountAndTheProperty()
+    {
+        // Arrange
+        var account = CreateAccount("primary");
+        account.EarliestEmailReceivedDate = new DateOnly(2026, 8, 1);
+        var options = new MailSynchronizationOptions { Accounts = [account] };
+
+        // Act
+        var result = Assert.Single(options.FindSynchronizationWindowErrors(new DateOnly(2026, 7, 24)));
+
+        // Assert
+        Assert.Contains("Account 'primary'", result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains("2026-08-01", result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Equal([nameof(MailSynchronizationAccountOptions.EarliestEmailReceivedDate)], result.MemberNames);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("2026-07-24")]
+    [InlineData("2019-12-31")]
+    public void FindSynchronizationWindowErrors_DateTodayOrEarlierOrAbsent_ReportsNoError(string? earliestEmailReceivedDate)
+    {
+        // Arrange
+        var account = CreateAccount("primary");
+        account.EarliestEmailReceivedDate = earliestEmailReceivedDate is null ? null : DateOnly.Parse(earliestEmailReceivedDate, CultureInfo.InvariantCulture);
+        var options = new MailSynchronizationOptions { Accounts = [account] };
+
+        // Act
+        var results = options.FindSynchronizationWindowErrors(new DateOnly(2026, 7, 24)).ToArray();
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
     public async Task ResolveSettingsAsync_ConfiguredAccount_ResolvesTheAccountPasswordForTheCallerToOwn()
     {
         // Arrange
@@ -282,6 +348,49 @@ public sealed class MailSynchronizationOptionsTests
         var account = Assert.Single(options.Accounts);
         Assert.Equal("systemd-credential:imap-primary-password", account.Secrets.Password.SecretReference);
         Assert.Empty(options.ValidateForSynchronization());
+    }
+
+    [Fact]
+    public void Bind_EarliestEmailReceivedDate_ReadsItAsAPlainDate()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["MailSynchronization:Accounts:0:AccountId"] = "primary",
+                ["MailSynchronization:Accounts:0:EarliestEmailReceivedDate"] = "2024-01-01",
+            })
+            .Build();
+
+        // Act
+        var options = configuration.GetSection("MailSynchronization").Get<MailSynchronizationOptions>()!;
+
+        // Assert
+        Assert.Equal(new DateOnly(2024, 1, 1), Assert.Single(options.Accounts).EarliestEmailReceivedDate);
+    }
+
+    /// <summary>
+    /// A bound nobody can interpret has to fail startup, and only the strict binding the host uses makes it do so: the
+    /// binder treats an account as a collection item and otherwise drops the whole item, which would remove an account
+    /// from synchronization over a typo in one of its dates.
+    /// </summary>
+    [Fact]
+    public void Bind_EarliestEmailReceivedDateThatIsNotADate_FailsInsteadOfDroppingTheAccount()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["MailSynchronization:Accounts:0:AccountId"] = "primary",
+                ["MailSynchronization:Accounts:0:EarliestEmailReceivedDate"] = "last January",
+            })
+            .Build();
+        var options = new MailSynchronizationOptions();
+
+        // Act, Assert
+        Assert.Throws<InvalidOperationException>(() => configuration
+            .GetSection("MailSynchronization")
+            .Bind(options, binderOptions => binderOptions.ErrorOnUnknownConfiguration = true));
     }
 
     private static TrustAnchorLoader CreateTrustAnchorLoader() =>

--- a/tests/Host.UnitTests/MailSynchronizationWindowValidatorTests.cs
+++ b/tests/Host.UnitTests/MailSynchronizationWindowValidatorTests.cs
@@ -1,0 +1,92 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Host.Configuration;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailMcp.Host.UnitTests;
+
+public sealed class MailSynchronizationWindowValidatorTests
+{
+    /// <summary>A bound the clock has not reached excludes the whole mailbox, so startup must stop rather than run empty.</summary>
+    [Fact]
+    public void Validate_EarliestEmailReceivedDateInTheFuture_FailsWithAMessageNamingTheAccount()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var validator = new MailSynchronizationWindowValidator(clock);
+        var options = CreateOptions("primary", new DateOnly(2026, 7, 25));
+
+        // Act
+        var result = validator.Validate(name: null, options);
+
+        // Assert
+        Assert.True(result.Failed);
+        Assert.Contains("Account 'primary'", Assert.Single(result.Failures), StringComparison.Ordinal);
+    }
+
+    /// <summary>The comparison is made in UTC, so the current UTC date itself is still a usable bound.</summary>
+    [Fact]
+    public void Validate_EarliestEmailReceivedDateEqualToTheCurrentUtcDate_Succeeds()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 23, 30, 0, TimeSpan.Zero));
+        var validator = new MailSynchronizationWindowValidator(clock);
+        var options = CreateOptions("primary", new DateOnly(2026, 7, 24));
+
+        // Act
+        var result = validator.Validate(name: null, options);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_NoAccountBoundingHowFarBackToReach_Succeeds()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var validator = new MailSynchronizationWindowValidator(clock);
+        var options = CreateOptions("primary", earliestEmailReceivedDate: null);
+
+        // Act
+        var result = validator.Validate(name: null, options);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    /// <summary>Every offending account is reported at once, so an operator fixes one snapshot rather than one account per restart.</summary>
+    [Fact]
+    public void Validate_SeveralAccountsBoundedInTheFuture_ReportsEachOfThem()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var validator = new MailSynchronizationWindowValidator(clock);
+        var options = new MailSynchronizationOptions
+        {
+            Accounts =
+            [
+                CreateAccount("primary", new DateOnly(2027, 1, 1)),
+                CreateAccount("secondary", new DateOnly(2026, 12, 1)),
+            ],
+        };
+
+        // Act
+        var result = validator.Validate(name: null, options);
+
+        // Assert
+        Assert.Equal(2, result.Failures!.Count());
+    }
+
+    private static MailSynchronizationOptions CreateOptions(string accountId, DateOnly? earliestEmailReceivedDate) =>
+        new() { Accounts = [CreateAccount(accountId, earliestEmailReceivedDate)] };
+
+    private static MailSynchronizationAccountOptions CreateAccount(string accountId, DateOnly? earliestEmailReceivedDate) => new()
+    {
+        AccountId = accountId,
+        Host = "imap.example.test",
+        UserName = "mailmcp@example.test",
+        EarliestEmailReceivedDate = earliestEmailReceivedDate,
+    };
+}

--- a/tests/Host.UnitTests/MailSynchronizationWorkerTests.cs
+++ b/tests/Host.UnitTests/MailSynchronizationWorkerTests.cs
@@ -373,6 +373,7 @@ public sealed class MailSynchronizationWorkerTests
         services.AddSingleton<TimeProvider>(timeProvider);
         services.AddSingleton(sessionFactory);
         services.AddSingleton<IMailTransportSecurityPolicyReader>(options);
+        services.AddSingleton<IMailSynchronizationWindowReader>(options);
         services.AddSingleton(Substitute.For<ISynchronizationCheckpointStore>());
         services.AddSingleton(Substitute.For<IPersistenceSessionFactory>());
         services.AddSingleton(Substitute.For<IEmailMetadataRepository>());

--- a/tests/Infrastructure.UnitTests/MailKitImapMailboxSessionTests.cs
+++ b/tests/Infrastructure.UnitTests/MailKitImapMailboxSessionTests.cs
@@ -8,6 +8,7 @@ using MailMcp.Application.Synchronization;
 using MailMcp.Domain.Accounts;
 using MailMcp.Domain.Emails;
 using MailMcp.Domain.Folders;
+using MailMcp.Domain.Synchronization;
 using MailMcp.Domain.Transport;
 using MailMcp.Infrastructure.Mail;
 using NSubstitute;
@@ -123,7 +124,7 @@ public sealed class MailKitImapMailboxSessionTests
         await using var session = await OpenSessionAsync(resilience, client, folder);
 
         // Act
-        var batch = await session.GetEmailBatchAfterAsync(null, 100, CancellationToken.None);
+        var batch = await session.GetEmailBatchAfterAsync(null, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None);
 
         // Assert
         Assert.Null(batch.InspectedThroughUid);
@@ -157,7 +158,7 @@ public sealed class MailKitImapMailboxSessionTests
         await using var session = await OpenSessionAsync(resilience, client, folder);
 
         // Act
-        var batch = await session.GetEmailBatchAfterAsync(null, 100, CancellationToken.None);
+        var batch = await session.GetEmailBatchAfterAsync(null, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None);
 
         // Assert
         var metadata = Assert.Single(batch.Emails);
@@ -431,7 +432,7 @@ public sealed class MailKitImapMailboxSessionTests
         var exhaustedUid = ImapUid.Create(uint.MaxValue);
 
         // Act
-        var batch = await session.GetEmailBatchAfterAsync(exhaustedUid, 100, CancellationToken.None);
+        var batch = await session.GetEmailBatchAfterAsync(exhaustedUid, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None);
 
         // Assert
         Assert.Empty(batch.Emails);
@@ -471,7 +472,7 @@ public sealed class MailKitImapMailboxSessionTests
         await using var session = await OpenSessionAsync(resilience, client, folder);
 
         // Act
-        var batch = await session.GetEmailBatchAfterAsync(null, 2, CancellationToken.None);
+        var batch = await session.GetEmailBatchAfterAsync(null, 2, MailSynchronizationWindow.Unbounded, CancellationToken.None);
 
         // Assert
         Assert.Equal([100U, 400U], batch.Emails.Select(message => message.OccurrenceId.Uid.Value));
@@ -495,13 +496,99 @@ public sealed class MailKitImapMailboxSessionTests
         await using var session = await OpenSessionAsync(resilience, client, folder);
 
         // Act
-        var batch = await session.GetEmailBatchAfterAsync(ImapUid.Create(400), 2, CancellationToken.None);
+        var batch = await session.GetEmailBatchAfterAsync(ImapUid.Create(400), 2, MailSynchronizationWindow.Unbounded, CancellationToken.None);
 
         // Assert
         Assert.Equal([900U], batch.Emails.Select(message => message.OccurrenceId.Uid.Value));
         Assert.False(batch.HasMore);
         Assert.Equal(1000U, batch.InspectedThroughUid!.Value.Value);
     }
+
+    /// <summary>The bound has to be part of the search the server answers, or an excluded email would still be fetched.</summary>
+    [Fact]
+    public async Task GetEmailBatchAfterAsync_BoundedWindow_SendsTheUidRangeAndTheArrivalDateInOneSearch()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var folder = CreateSelectedFolder();
+        folder.UidNext.Returns(new UniqueId(1001));
+        folder.SearchAsync(Arg.Any<SearchQuery>(), Arg.Any<CancellationToken>()).Returns([new UniqueId(900)]);
+        folder.FetchAsync(
+            Arg.Any<IList<UniqueId>>(),
+            Arg.Any<IFetchRequest>(),
+            Arg.Any<CancellationToken>()).Returns(callInfo => CreateSummaries(callInfo.Arg<IList<UniqueId>>() ?? []));
+        await using var session = await OpenSessionAsync(resilience, client, folder);
+
+        // Act
+        var batch = await session.GetEmailBatchAfterAsync(
+            ImapUid.Create(400),
+            100,
+            MailSynchronizationWindow.EmailsReceivedSince(new DateOnly(2024, 1, 1)),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal([900U], batch.Emails.Select(email => email.OccurrenceId.Uid.Value));
+        var searchQuery = Assert.IsType<BinarySearchQuery>(CaptureSearchQuery(folder));
+        Assert.Equal(SearchTerm.And, searchQuery.Term);
+        var searchedUids = Assert.IsType<UidSearchQuery>(searchQuery.Left).Uids;
+        Assert.Equal(401U, searchedUids[0].Id);
+        Assert.Equal(1000U, searchedUids[^1].Id);
+        var dateQuery = Assert.IsType<DateSearchQuery>(searchQuery.Right);
+        Assert.Equal(SearchTerm.DeliveredAfter, dateQuery.Term);
+        Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Unspecified), dateQuery.Date);
+    }
+
+    [Fact]
+    public async Task GetEmailBatchAfterAsync_UnboundedWindow_SearchesTheUidRangeWithNoDateCondition()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var folder = CreateSelectedFolder();
+        folder.UidNext.Returns(new UniqueId(1001));
+        folder.SearchAsync(Arg.Any<SearchQuery>(), Arg.Any<CancellationToken>()).Returns([]);
+        await using var session = await OpenSessionAsync(resilience, client, folder);
+
+        // Act
+        await session.GetEmailBatchAfterAsync(null, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None);
+
+        // Assert
+        Assert.IsType<UidSearchQuery>(CaptureSearchQuery(folder));
+    }
+
+    /// <summary>A folder whose whole backlog is excluded must terminate, which means checkpointing through what the search covered.</summary>
+    [Fact]
+    public async Task GetEmailBatchAfterAsync_BoundExcludesEveryAssignedUid_ReportsTheWholeRangeInspectedWithoutFetching()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var folder = CreateSelectedFolder();
+        folder.UidNext.Returns(new UniqueId(1001));
+        folder.SearchAsync(Arg.Any<SearchQuery>(), Arg.Any<CancellationToken>()).Returns([]);
+        await using var session = await OpenSessionAsync(resilience, client, folder);
+
+        // Act
+        var batch = await session.GetEmailBatchAfterAsync(
+            null,
+            100,
+            MailSynchronizationWindow.EmailsReceivedSince(new DateOnly(2026, 1, 1)),
+            CancellationToken.None);
+
+        // Assert
+        Assert.Empty(batch.Emails);
+        Assert.False(batch.HasMore);
+        Assert.Equal(1000U, batch.InspectedThroughUid!.Value.Value);
+        await folder.DidNotReceive().FetchAsync(Arg.Any<IList<UniqueId>>(), Arg.Any<IFetchRequest>(), Arg.Any<CancellationToken>());
+        await folder.DidNotReceive().StoreAsync(Arg.Any<IList<UniqueId>>(), Arg.Any<IStoreFlagsRequest>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Reads the one query the session issued, so a test asserts on what the server was actually asked.</summary>
+    private static SearchQuery CaptureSearchQuery(IMailFolder folder) =>
+        Assert.Single(folder.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == nameof(IMailFolder.SearchAsync))
+            .Select(call => (SearchQuery)call.GetArguments()[0]!));
 
     // Building a substitute configures NSubstitute's ambient call context rather than only the returned object, so the
     // construction stays in a loop instead of a Select whose deferred execution could interleave it with another

--- a/tests/Infrastructure.UnitTests/MailKitImapSessionResilienceTests.cs
+++ b/tests/Infrastructure.UnitTests/MailKitImapSessionResilienceTests.cs
@@ -6,6 +6,7 @@ using MailKit.Search;
 using MailMcp.Application.EmailContent;
 using MailMcp.Application.Synchronization;
 using MailMcp.Domain.Emails;
+using MailMcp.Domain.Synchronization;
 using NSubstitute;
 using Xunit;
 using static MailMcp.Infrastructure.UnitTests.MailKitImapSessionTestContext;
@@ -41,7 +42,7 @@ public sealed class MailKitImapSessionResilienceTests
 
         // Act
         var batch = await resilience.CompleteOnVirtualTimeAsync(
-            session.GetEmailBatchAfterAsync(null, 100, CancellationToken.None),
+            session.GetEmailBatchAfterAsync(null, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None),
             BackoffAdvanceStep);
 
         // Assert
@@ -112,7 +113,7 @@ public sealed class MailKitImapSessionResilienceTests
 
         // Act
         var batch = await resilience.CompleteOnVirtualTimeAsync(
-            session.GetEmailBatchAfterAsync(null, 100, CancellationToken.None),
+            session.GetEmailBatchAfterAsync(null, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None),
             BackoffAdvanceStep);
 
         // Assert
@@ -140,7 +141,7 @@ public sealed class MailKitImapSessionResilienceTests
 
         // Act
         await resilience.CompleteOnVirtualTimeAsync(
-            session.GetEmailBatchAfterAsync(null, 100, CancellationToken.None),
+            session.GetEmailBatchAfterAsync(null, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None),
             BackoffAdvanceStep);
 
         // Assert
@@ -168,7 +169,7 @@ public sealed class MailKitImapSessionResilienceTests
         // Act
         var failure = await Assert.ThrowsAsync<MailboxUnavailableException>(
             () => resilience.CompleteOnVirtualTimeAsync(
-                session.GetEmailBatchAfterAsync(null, 100, CancellationToken.None),
+                session.GetEmailBatchAfterAsync(null, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None),
                 BackoffAdvanceStep));
 
         // Assert
@@ -276,7 +277,7 @@ public sealed class MailKitImapSessionResilienceTests
         await using var session = await OpenScriptedSessionAsync(resilience, droppedClient, droppedFolder, recoveredClient, recreatedFolder);
 
         // Act
-        var execution = session.GetEmailBatchAfterAsync(null, 100, CancellationToken.None);
+        var execution = session.GetEmailBatchAfterAsync(null, 100, MailSynchronizationWindow.Unbounded, CancellationToken.None);
         var failure = await Assert.ThrowsAsync<MailboxFolderRecreatedException>(
             () => resilience.CompleteOnVirtualTimeAsync(execution, BackoffAdvanceStep));
 

--- a/tests/IntegrationTests/Synchronization/RemoteSeenFlagPreservationTests.cs
+++ b/tests/IntegrationTests/Synchronization/RemoteSeenFlagPreservationTests.cs
@@ -4,6 +4,7 @@ using MailMcp.Application.Mail;
 using MailMcp.Application.Synchronization;
 using MailMcp.Domain.Emails;
 using MailMcp.Domain.Folders;
+using MailMcp.Domain.Synchronization;
 using MailMcp.IntegrationTests.Mailbox;
 using MailMcp.IntegrationTests.Orchestration;
 using Microsoft.Extensions.DependencyInjection;
@@ -99,7 +100,11 @@ public sealed class RemoteSeenFlagPreservationTests(MailMcpOrchestrationFixture 
                     scope.GetRequiredService<IMailTransportSecurityPolicyReader>().GetPolicy(account),
                     token);
 
-                var batch = await session.GetEmailBatchAfterAsync(checkpointUid, maxEmailCount: 50, token);
+                var batch = await session.GetEmailBatchAfterAsync(
+                    checkpointUid,
+                    maxEmailCount: 50,
+                    MailSynchronizationWindow.Unbounded,
+                    token);
 
                 var contentLengths = new List<int>();
                 foreach (var email in batch.Emails)


### PR DESCRIPTION
## What this changes

`MailboxSynchronizer` walked a folder from UID 1 upward with nothing bounding how far back that reached, so a first run against an established account backfilled the whole archive — searched, fetched, MIME-parsed, stored as raw MIME, and indexed — before anything recent arrived.

An optional per-account `MailSynchronization:Accounts:*:EarliestEmailReceivedDate` now bounds it. Unset stays the default and keeps existing configuration behaving exactly as before.

- `Domain` gains `MailSynchronizationWindow`, a value that is either unbounded or bounded at one date, and records on itself which date the bound compares against.
- `Application` reads it per run through the new `IMailSynchronizationWindowReader` port and hands it to `IMailboxSession.GetEmailBatchAfterAsync`, the same shape the transport security policy already uses: the adapter narrows what it is given and never decides for itself which emails a run may see.
- `Infrastructure` renders it as the IMAP `SINCE` key inside the same `UID SEARCH` that carries the remaining UID range, so the server excludes the mail and an excluded UID costs no `FETCH`, no MIME read, no `bytea` write, and no search-vector computation.
- The checkpoint still advances through everything the search inspected rather than through the last email described, so a folder whose whole backlog is excluded advances once to the highest assigned UID and ends its run instead of rescanning the range every interval.

## The date the bound compares against

`SINCE` compares the server-assigned `INTERNALDATE` — arrival — and not the envelope `Date` header MailMcp stores as the sent timestamp. Arrival is the choice, documented as such, because a bound on the sent date would keep excluding newly arriving forwarded and imported mail forever instead of only bounding a first run, and because arrival exists for every email while a `Date` header can be absent or unparseable. The consequence for a migrated mailbox — imported mail carries the arrival date of the copy — is stated in the documentation rather than left implied.

## Validation

- A date later than the current UTC date fails startup naming the account, through an `IValidateOptions` implementation that owns the clock while the rule itself stays with the other configuration rules. It is not gated on `Enabled`.
- A value that is not a date fails while binding. Worth knowing: an account is a collection item, and the binder drops the whole item on a conversion failure — only the section's strict `ErrorOnUnknownConfiguration` binding turns that into a startup failure instead of an account silently disappearing. A test covers exactly that.

## Verification

`scripts/verify-full.sh` — pass. 858 unit tests, aggregate line coverage 96.52% (required 85%), formatting clean.

New tests cover the bound applied, the bound absent, checkpoint advancement across a fully excluded range, a batch straddling the cutoff, the one search carrying both conditions, startup rejection of a future date, and binding rejection of a non-date. Read-only behavior is unchanged and the excluded-range test also asserts that neither `FetchAsync` nor `StoreAsync` was requested.

Closes #130
