### PR TITLE
Read a mounted ConfigMap as a configuration source

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This documentation set explains the durable design and operating model for MailM
 - [Stored email schema](architecture/stored-email-schema.md) documents the `stored_emails` table, its indexes, and the timeline ordering contract keyset pagination depends on.
 - [Features](features/initial-scope.md) summarizes the first scaffolded capability scope.
 - [Operations](operations/local-development.md) covers local .NET and Aspire development commands.
+- [Configuration sources](operations/configuration-sources.md) covers the source precedence, the deployment-provisioned JSON directory and file, and the Kubernetes ConfigMap and Secret mapping.
 - [Secret provisioning](operations/secret-provisioning.md) covers secret references, the systemd and container provisioning paths, and in-memory exposure.
 - [Host startup telemetry](operations/host-startup-telemetry.md) describes the bootstrap logging pipeline that reports process start, startup failure, and shutdown.
 - [MCP endpoint](operations/mcp-endpoint.md) covers enabling the protocol surface and the interim posture of an endpoint with no transport authentication.

--- a/docs/operations/configuration-sources.md
+++ b/docs/operations/configuration-sources.md
@@ -1,0 +1,169 @@
+# Configuration sources
+
+MailMcp reads its settings through the ordinary .NET configuration pipeline, plus one addition: a deployment may name a directory or a file of JSON configuration that it provisioned outside the application's own content root. That addition is what makes a Kubernetes ConfigMap mounted as a volume ordinary configuration rather than a shape the host cannot see.
+
+Secrets are a separate contract and stay one. A secret-bearing setting holds a reference rather than material, whichever source the setting itself arrived from; [secret provisioning](secret-provisioning.md) is that contract, and the [Kubernetes mapping](#kubernetes) below states how the two meet.
+
+## Precedence
+
+Highest precedence first. Everything except the provisioned layer is the default .NET order.
+
+| # | Source | Set by |
+| --- | --- | --- |
+| 1 | Command-line arguments | `--MailboxSearch:SnippetsPerEmail=3` |
+| 2 | Environment variables | `MailboxSearch__SnippetsPerEmail=3` |
+| 3 | **Provisioned file**, when `ConfigurationSources:File` names one | A mounted file, a systemd drop-in |
+| 4 | **Provisioned directory**, when `ConfigurationSources:Directory` names one | A ConfigMap mounted as a volume |
+| 5 | User secrets, in the `Development` environment only | `dotnet user-secrets` |
+| 6 | `appsettings.{Environment}.json` | The image or the checkout |
+| 7 | `appsettings.json` | The image or the checkout |
+
+The provisioned layer sits below the environment block on purpose. A file states what the deployment configured and an environment variable overrides it, which is the direction an operator can act on: injecting one variable changes one setting for one pod without editing a shared object. Layering the files on top instead would let a ConfigMap that nobody remembered to update silently beat a value injected beside it, and nothing about the running process would show which of the two won.
+
+Within the provisioned layer, the single file wins over the directory, so a deployment that mounts a shared ConfigMap and then names one file of its own gets the specific value rather than an order decided by how the two happen to sort.
+
+## Naming the provisioned sources
+
+Two keys, both unset by default. A deployment that names neither keeps exactly the default source list.
+
+| Key | Environment form | Names |
+| --- | --- | --- |
+| `ConfigurationSources:Directory` | `ConfigurationSources__Directory` | A directory whose `*.json` files are layered in |
+| `ConfigurationSources:File` | `ConfigurationSources__File` | One JSON file layered above that directory |
+
+They are read from configuration rather than from the environment directly, so the same setting arrives as an environment variable in a container, as `--ConfigurationSources:Directory=/etc/mailmcp/config` under systemd, and from `appsettings.json` during local development, without a second mechanism per deployment shape. A blank value reads as unset, because templating a manifest routinely emits an empty string for a setting the operator left alone.
+
+The section takes those two settings and nothing else. A third one — a misspelled `Directroy`, a key from an older draft — fails startup naming it, for the same reason every other security-sensitive section in MailMcp is bound strictly: a setting that bound nothing would leave the host running on defaults while the operator believed their mount was in force.
+
+Both settings are **restart-required**. They decide which sources exist, which is settled while the host is being composed, so repointing `ConfigurationSources:Directory` at a different mount takes effect on the next start. What the named sources *contain* is a different question, and the answer is below.
+
+### What a directory contributes
+
+- Files matching `*.json`, and nothing else. A `notes.txt` or a `settings.json.bak` left beside them is ignored rather than parsed.
+- Ordered by file name, compared ordinally, so the same ConfigMap layers the same way on every machine that mounts it. Later names win: `20-persistence.json` overrides `10-defaults.json`.
+- Top-level entries only. Subdirectories are not searched.
+- Entries beginning with `..` are skipped. Kubernetes updates a mounted volume by writing a new timestamped directory and repointing the `..data` symbolic link at it, which is what makes the update atomic; both entries live beside the keys and neither is configuration.
+
+An existing but empty directory is permitted and contributes nothing. A ConfigMap with no keys is a legitimate state during a rollout, and the startup record below reports the count so the case is visible rather than silent.
+
+## Failure and startup behavior
+
+A configured path that does not exist fails startup, naming the configuration key and the path:
+
+```
+The configuration directory named by ConfigurationSources:Directory does not exist: /etc/mailmcp/config.
+```
+
+So does a setting the section does not define:
+
+```
+ConfigurationSources carries settings MailMcp does not define: Directroy. The section defines Directory and File.
+```
+
+Both are deliberate and are the point of the feature. A host that ignored an absent mount or a misspelled key would report success while serving configuration nobody wrote, and the divergence would only surface later, through behavior. Both carry error code `12001` and end the process through the bootstrap logging pipeline described in [host startup telemetry](host-startup-telemetry.md).
+
+Every start records how many provisioned files were layered in, at `Information`:
+
+```
+Host MailMcp.Host layered 3 deployment-provisioned configuration files below the environment.
+```
+
+A `0` on a deployment that mounts a ConfigMap means the mount is empty or did not arrive where the key says it did.
+
+## Reload
+
+Provisioned files are watched, so a setting group classified reloadable in [ADR 0002](../decisions/0002-configuration-reading-mapping-and-reload-boundary.md) picks up a changed ConfigMap without a restart, through the same validated-snapshot path every other source uses. A candidate snapshot that fails validation is rejected and the last known good one stays active.
+
+Two caveats decide whether that actually happens in Kubernetes, and neither is MailMcp's to fix:
+
+- **A `subPath` mount never updates.** The kubelet updates a mounted ConfigMap by swapping the volume's `..data` link, and a `subPath` mount bypasses that entirely — the file the container sees is the one that existed when the pod started. Mount the whole volume and use `ConfigurationSources:Directory` when reload matters; use `subPath` only where a restart on change is acceptable and say so in the deployment.
+- **Change detection on a mounted volume needs polling.** `FileSystemWatcher` does not reliably observe the symbolic-link swap that an atomic update performs. Setting `DOTNET_USE_POLLING_FILE_WATCHER=1` makes the file provider poll every four seconds instead; the interval is not configurable. Microsoft documents this for container and network-share mounts generally, not only for Kubernetes.
+
+Two further properties belong to Kubernetes rather than to the watcher: an update reaches the container after the kubelet's sync period plus its cache TTL, up to about a minute by default, and an `immutable: true` ConfigMap never updates at all.
+
+## Kubernetes
+
+Nothing here needs a Kubernetes-specific scheme or provider. A mounted ConfigMap is a directory of files and a mounted Secret is a file, which is why `ConfigurationSources:Directory` and the `file:` secret scheme serve both without either one naming Kubernetes.
+
+### Which construct carries what
+
+| MailMcp input | Kubernetes construct | How MailMcp reads it |
+| --- | --- | --- |
+| Non-secret settings, in bulk | ConfigMap mounted as a volume | `ConfigurationSources:Directory` |
+| Non-secret settings, one file | ConfigMap mounted with `subPath` | `ConfigurationSources:File`, without reload |
+| A per-pod override of one setting | ConfigMap key in the environment block | The environment provider, which outranks both |
+| Credential and certificate material | Secret mounted as a volume | `file:/…` in the setting's `SecretReference` |
+| Credential material, without a volume | Secret key in the environment block | `env:…`, subject to the caveats below |
+| Material from an external store | Secrets Store CSI driver | `file:/…`, because the driver mounts files |
+
+A Secret needs no MailMcp support beyond what already exists: `FileSecretReferenceResolver` performs exactly the read a `kubernetes-secret:` scheme would, which is why no such scheme exists. Material is resolved per use and erased immediately, so a Secret rotated behind an unchanged mount path reaches the next IMAP connection or the next database connection without a restart and without a configuration reload — the reference did not change, only what it points at.
+
+`env:` is the exception on both counts. The platform hands the value over as an immutable `string` that cannot be erased from process memory, and a Secret projected into the environment block is fixed for the life of the pod, so rotating it requires a restart. It is documented for non-production automation and is not recommended in production; [secret provisioning](secret-provisioning.md#secret-material-in-process-memory) states the full reasoning.
+
+### A worked deployment
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mailmcp-config
+data:
+  10-mail.json: |
+    {
+      "MailSynchronization": {
+        "Accounts": [
+          {
+            "AccountId": "primary",
+            "Host": "imap.example.test",
+            "Port": 993,
+            "UserName": "mailmcp@example.test",
+            "Secrets": {
+              "Password": { "SecretReference": "file:/etc/mailmcp/secrets/imap-primary-password" }
+            },
+            "TransportSecurity": { "ConnectionSecurity": "TlsOnConnect" },
+            "Folders": [ { "Alias": "inbox", "SpecialUse": "Inbox" } ]
+          }
+        ]
+      }
+    }
+  20-persistence.json: |
+    {
+      "Persistence": {
+        "Password": { "SecretReference": "file:/etc/mailmcp/secrets/postgres-password" }
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mailmcp
+spec:
+  template:
+    spec:
+      containers:
+        - name: mailmcp
+          env:
+            - name: ConfigurationSources__Directory
+              value: /etc/mailmcp/config
+            # Polling is what makes a ConfigMap change reach the running process; see the reload caveats above.
+            - name: DOTNET_USE_POLLING_FILE_WATCHER
+              value: "1"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/mailmcp/config
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/mailmcp/secrets
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: mailmcp-config
+        - name: secrets
+          secret:
+            secretName: mailmcp-secrets
+```
+
+The ConfigMap carries the settings and the secret *references*; the Secret carries the material. That split is the property the reference indirection exists for: this ConfigMap is safe to commit, review, and diff, because a copy of it yields credential paths rather than credentials.
+
+`Secrets:Interpretation` stays at its `ReferenceOnly` default here, so a plain-text password pasted where a reference belongs fails startup instead of authenticating. Read [secret provisioning](secret-provisioning.md#interpretation-modes) before changing it.

--- a/docs/operations/configuration-sources.md
+++ b/docs/operations/configuration-sources.md
@@ -72,9 +72,11 @@ A `0` on a deployment that mounts a ConfigMap means the mount is empty or did no
 
 ## Reload
 
-Provisioned files are watched, so a setting group classified reloadable in [ADR 0002](../decisions/0002-configuration-reading-mapping-and-reload-boundary.md) picks up a changed ConfigMap without a restart, through the same validated-snapshot path every other source uses. A candidate snapshot that fails validation is rejected and the last known good one stays active.
+What reloads is the **content of the files that existed when the host started**. Each of those gets a watched provider, so a setting group classified reloadable in [ADR 0002](../decisions/0002-configuration-reading-mapping-and-reload-boundary.md) picks up an edited ConfigMap key without a restart, through the same validated-snapshot path every other source uses. A candidate snapshot that fails validation is rejected and the last known good one stays active.
 
-Two caveats decide whether that actually happens in Kubernetes, and neither is MailMcp's to fix:
+**Adding or removing a ConfigMap key is restart-required.** The directory is enumerated once, while the host is composing itself, and each file found becomes its own provider; nothing watches the directory for membership. A key added to a mounted ConfigMap therefore produces a file no provider reads, and a key removed empties its provider rather than removing the layer. Restart the pod after changing which keys a ConfigMap holds. Editing the value inside a key that already existed needs no restart.
+
+Two caveats decide whether even a content change actually arrives, and neither is MailMcp's to fix:
 
 - **A `subPath` mount never updates.** The kubelet updates a mounted ConfigMap by swapping the volume's `..data` link, and a `subPath` mount bypasses that entirely — the file the container sees is the one that existed when the pod started. Mount the whole volume and use `ConfigurationSources:Directory` when reload matters; use `subPath` only where a restart on change is acceptable and say so in the deployment.
 - **Change detection on a mounted volume needs polling.** `FileSystemWatcher` does not reliably observe the symbolic-link swap that an atomic update performs. Setting `DOTNET_USE_POLLING_FILE_WATCHER=1` makes the file provider poll every four seconds instead; the interval is not configurable. Microsoft documents this for container and network-share mounts generally, not only for Kubernetes.
@@ -137,11 +139,23 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mailmcp
+  labels:
+    app.kubernetes.io/name: mailmcp
 spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mailmcp
   template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mailmcp
     spec:
       containers:
         - name: mailmcp
+          # Substitute the image your deployment uses. MailMcp publishes none yet; the image contract is
+          # tracked separately and this page does not define it.
+          image: mailmcp:replace-me
           env:
             - name: ConfigurationSources__Directory
               value: /etc/mailmcp/config

--- a/docs/operations/host-startup-telemetry.md
+++ b/docs/operations/host-startup-telemetry.md
@@ -13,13 +13,16 @@ The bootstrap pipeline closes both gaps: it is composed before `CreateBuilder`, 
 
 ## What it emits
 
-Three records, all under the category `MailMcp.Host.Startup`:
+Four records, all under the category `MailMcp.Host.Startup`:
 
 | Record | Level | Named properties |
 | --- | --- | --- |
 | Host is starting | `Information` | `ServiceName`, `EnvironmentName`, `ServiceVersion` |
+| Host layered provisioned configuration files | `Information` | `ServiceName`, `FileCount` |
 | Host ended with an unhandled exception | `Critical` | `ServiceName`, plus the exception |
 | Host stopped | `Information` | `ServiceName` |
+
+The configuration record is a count and never a path, and it is written here rather than through the container pipeline for the same reason the others are: it describes what the host read before a container existed to log it. A `0` against a deployment that mounts a ConfigMap is how an empty or misplaced mount becomes visible; [configuration sources](configuration-sources.md) states what is counted.
 
 Those properties are the whole payload the host composes. Nothing reads a configuration value, a connection string, an account, or secret material into a startup record, and the failure record carries the exception as structured exception data rather than interpolated into its message text.
 
@@ -40,4 +43,4 @@ The resource is whatever the OpenTelemetry SDK resolves on its own — `OTEL_SER
 
 The application name and version are therefore properties of the startup records rather than resource attributes. That is where they are useful in any case, including on a console with no resource attached at all.
 
-Records go through a simple export processor rather than the default batching one. Startup emits three records per process, so the throughput the batch processor exists to protect is irrelevant here, while its scheduled delay is precisely the failure mode being avoided.
+Records go through a simple export processor rather than the default batching one. Startup emits a handful of records per process, so the throughput the batch processor exists to protect is irrelevant here, while its scheduled delay is precisely the failure mode being avoided.

--- a/docs/operations/secret-provisioning.md
+++ b/docs/operations/secret-provisioning.md
@@ -127,6 +127,12 @@ secrets:
 
 A Secret mounted as a read-only tmpfs volume becomes one file per key at the path the operator chose, so the reference is `file:/etc/mailmcp-secrets/imap-primary-password`. A Secret projected into the environment block is `env:` instead, subject to the caveat below.
 
+Mounting is the shape to prefer, for a reason beyond memory hygiene: because material is resolved per use rather than cached, a Secret the cluster rotates behind an unchanged mount path reaches the next connection without a restart and without a configuration reload. A Secret projected into the environment block is fixed for the life of the pod, so rotating it means replacing the pod.
+
+A Secrets Store CSI driver — Vault, Azure Key Vault, AWS Secrets Manager — needs no MailMcp adapter for the same reason no Kubernetes scheme exists: it mounts files, so the reference is `file:` and the store's own authentication stays the driver's concern.
+
+[Configuration sources](configuration-sources.md#kubernetes) states the whole mapping, including how the non-secret half of a deployment reaches MailMcp through a mounted ConfigMap.
+
 ### Non-production automation
 
 `env:MAILMCP_IMAP_PRIMARY_PASSWORD` reads a CI or orchestrator environment variable. It is not recommended in production, for the memory reason stated below as well as for the usual visibility of an environment block to anything that can read `/proc`.

--- a/src/Domain/Failures/MailMcpErrorCode.cs
+++ b/src/Domain/Failures/MailMcpErrorCode.cs
@@ -139,6 +139,7 @@ public readonly record struct MailMcpErrorCode
     public static IReadOnlyList<MailMcpErrorCode> All { get; } =
     [
         MailTransportSecurityPolicyViolated,
+        ProvisionedConfigurationSourceInvalid,
         MailAuthenticationMechanismUnavailable,
         MailboxUnavailable,
         MailboxFolderRecreated,

--- a/src/Domain/Failures/MailMcpErrorCode.cs
+++ b/src/Domain/Failures/MailMcpErrorCode.cs
@@ -41,6 +41,9 @@ public readonly record struct MailMcpErrorCode
     /// <summary>Gets subcategory 1, transport security policy: a configured combination would weaken protection in a way no opt-in allows.</summary>
     public static MailMcpErrorCode MailTransportSecurityPolicyViolated { get; } = new(11001);
 
+    /// <summary>Gets subcategory 2, configuration sources: the deployment's configuration-source settings name a path that is absent or a setting that does not exist.</summary>
+    public static MailMcpErrorCode ProvisionedConfigurationSourceInvalid { get; } = new(12001);
+
     #endregion
 
     #region Category 2 — Mail protocol

--- a/src/Host/Configuration/IProvisionedConfigurationFileSystem.cs
+++ b/src/Host/Configuration/IProvisionedConfigurationFileSystem.cs
@@ -1,0 +1,28 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+namespace MailMcp.Host.Configuration;
+
+/// <summary>Reports what the deployment actually mounted, so the layering policy can be decided without a file system.</summary>
+/// <remarks>
+/// The seam exists for the same reason <c>ISecretFileReader</c> does: which files a directory holds, in what order they
+/// are layered, and which of them are Kubernetes' own bookkeeping entries are all decisions worth proving, and none of
+/// them needs a real directory to be proven. Listing returns names rather than paths so the caller owns the filtering
+/// and the ordering rather than delegating them to a search pattern the tests could not observe.
+/// </remarks>
+internal interface IProvisionedConfigurationFileSystem
+{
+    /// <summary>Reports whether the provisioned configuration directory exists.</summary>
+    /// <param name="directoryPath">The directory the deployment named.</param>
+    /// <returns><see langword="true" /> when the directory exists.</returns>
+    bool DirectoryExists(string directoryPath);
+
+    /// <summary>Reports whether the provisioned configuration file exists.</summary>
+    /// <param name="filePath">The file the deployment named.</param>
+    /// <returns><see langword="true" /> when the file exists.</returns>
+    bool FileExists(string filePath);
+
+    /// <summary>Lists the names of the files the provisioned configuration directory holds, in no particular order.</summary>
+    /// <param name="directoryPath">The directory the deployment named.</param>
+    /// <returns>The file names, without their directory, and without the directory's subdirectories.</returns>
+    IReadOnlyList<string> ListFileNames(string directoryPath);
+}

--- a/src/Host/Configuration/ProvisionedConfigurationExtensions.cs
+++ b/src/Host/Configuration/ProvisionedConfigurationExtensions.cs
@@ -1,0 +1,72 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using Microsoft.Extensions.Configuration.Json;
+
+namespace MailMcp.Host.Configuration;
+
+/// <summary>Layers deployment-provisioned JSON configuration into the sources the host builder has already composed.</summary>
+internal static class ProvisionedConfigurationExtensions
+{
+    /// <summary>Layers in the configuration files the deployment provisioned, reading the real file system.</summary>
+    /// <param name="configuration">The host builder's configuration, which is both the source list and the place the two keys are read from.</param>
+    /// <returns>The number of files layered in, which is zero when the deployment provisioned none.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
+    /// <exception cref="ProvisionedConfigurationSourceInvalidException">Thrown when a configured path does not exist.</exception>
+    public static int AddProvisionedConfiguration(this IConfigurationManager configuration) =>
+        configuration.AddProvisionedConfiguration(new ProvisionedConfigurationFileSystem());
+
+    /// <summary>Layers in the configuration files the deployment provisioned, reading a given file system.</summary>
+    /// <param name="configuration">The host builder's configuration, which is both the source list and the place the two keys are read from.</param>
+    /// <param name="fileSystem">Reports what the deployment actually mounted.</param>
+    /// <returns>The number of files layered in, which is zero when the deployment provisioned none.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> or <paramref name="fileSystem" /> is <see langword="null" />.</exception>
+    /// <exception cref="ProvisionedConfigurationSourceInvalidException">Thrown when a configured path does not exist.</exception>
+    /// <remarks>
+    /// A deployment that names neither path leaves the source list exactly as the host builder composed it, so the
+    /// default configuration order is unchanged for everything that does not mount anything.
+    /// </remarks>
+    internal static int AddProvisionedConfiguration(
+        this IConfigurationManager configuration,
+        IProvisionedConfigurationFileSystem fileSystem)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(fileSystem);
+
+        var paths = ProvisionedConfigurationPaths.ReadFrom(configuration);
+
+        if (!paths.AreConfigured)
+        {
+            return 0;
+        }
+
+        var files = ProvisionedConfigurationLayer.FindFiles(paths, fileSystem);
+        var insertionIndex = ProvisionedConfigurationLayer.FindInsertionIndex([.. configuration.Sources]);
+
+        foreach (var (offset, filePath) in files.Index())
+        {
+            configuration.Sources.Insert(insertionIndex + offset, CreateJsonSource(filePath));
+        }
+
+        return files.Count;
+    }
+
+    private static JsonConfigurationSource CreateJsonSource(string filePath)
+    {
+        var source = new JsonConfigurationSource
+        {
+            Path = filePath,
+
+            // The existence check has already run and produced a message naming the configuration key that pointed at
+            // the path. Letting the provider enforce the same condition again would give one rule two mechanisms, and
+            // the second one reports a bare file path with no indication of which setting named it.
+            Optional = true,
+            ReloadOnChange = true,
+        };
+
+        // AddJsonFile resolves the file provider for a rooted path as part of appending the source, and appending is
+        // exactly what must not happen here. This is the same call that helper makes, without the append.
+        source.ResolveFileProvider();
+
+        return source;
+    }
+}

--- a/src/Host/Configuration/ProvisionedConfigurationExtensions.cs
+++ b/src/Host/Configuration/ProvisionedConfigurationExtensions.cs
@@ -56,10 +56,16 @@ internal static class ProvisionedConfigurationExtensions
         {
             Path = filePath,
 
-            // The existence check has already run and produced a message naming the configuration key that pointed at
-            // the path. Letting the provider enforce the same condition again would give one rule two mechanisms, and
-            // the second one reports a bare file path with no indication of which setting named it.
-            Optional = true,
+            // Required, because the existence check cannot be atomic with the load: a mount being updated could remove
+            // the file in between, and an optional provider would turn that into an empty source and let startup
+            // continue on lower-precedence defaults. The check still owns the ordinary diagnosis — it names the
+            // configuration key, which the provider's own FileNotFoundException does not — and this closes the window
+            // the check structurally cannot cover.
+            //
+            // It costs nothing on the reload path. A watcher-driven reload of a file that has since disappeared empties
+            // the provider and raises the change token without throwing, whatever this flag says; only the initial load
+            // and an explicit IConfigurationRoot.Reload throw, and nothing here calls the latter.
+            Optional = false,
             ReloadOnChange = true,
         };
 

--- a/src/Host/Configuration/ProvisionedConfigurationFileSystem.cs
+++ b/src/Host/Configuration/ProvisionedConfigurationFileSystem.cs
@@ -1,0 +1,17 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+namespace MailMcp.Host.Configuration;
+
+/// <summary>Reports the real file system to the provisioned-configuration layering policy.</summary>
+internal sealed class ProvisionedConfigurationFileSystem : IProvisionedConfigurationFileSystem
+{
+    /// <inheritdoc />
+    public bool DirectoryExists(string directoryPath) => Directory.Exists(directoryPath);
+
+    /// <inheritdoc />
+    public bool FileExists(string filePath) => File.Exists(filePath);
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> ListFileNames(string directoryPath) =>
+        [.. Directory.EnumerateFiles(directoryPath).Select(filePath => Path.GetFileName(filePath))];
+}

--- a/src/Host/Configuration/ProvisionedConfigurationLayer.cs
+++ b/src/Host/Configuration/ProvisionedConfigurationLayer.cs
@@ -1,0 +1,117 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+
+namespace MailMcp.Host.Configuration;
+
+/// <summary>Decides which provisioned configuration files are layered in, and where among the host's own sources.</summary>
+/// <remarks>
+/// The two decisions are kept here, away from the registration that applies them, because both are contracts an
+/// operator depends on and neither needs a real file system or a built host to be proven.
+/// </remarks>
+internal static class ProvisionedConfigurationLayer
+{
+    private const string JsonFileExtension = ".json";
+
+    /// <summary>
+    /// The prefix Kubernetes gives the entries it manages inside a mounted volume: <c>..data</c>, which is a symbolic
+    /// link to the live version, and the timestamped directory that link points at.
+    /// </summary>
+    private const string VolumeBookkeepingPrefix = "..";
+
+    /// <summary>Finds the provisioned configuration files, in the order they are layered.</summary>
+    /// <param name="paths">The directory and file the deployment named.</param>
+    /// <param name="fileSystem">Reports what the deployment actually mounted.</param>
+    /// <returns>The absolute paths to layer, lowest precedence first, empty when the deployment provisioned nothing.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="paths" /> or <paramref name="fileSystem" /> is <see langword="null" />.</exception>
+    /// <exception cref="ProvisionedConfigurationSourceInvalidException">Thrown when a configured path does not exist.</exception>
+    /// <remarks>
+    /// The single file is layered above the directory, so a deployment that mounts a shared ConfigMap and then names one
+    /// file of its own gets the specific value rather than an order decided by how the two happen to sort.
+    /// </remarks>
+    public static IReadOnlyList<string> FindFiles(
+        ProvisionedConfigurationPaths paths,
+        IProvisionedConfigurationFileSystem fileSystem)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+        ArgumentNullException.ThrowIfNull(fileSystem);
+
+        var directoryFiles = paths.DirectoryPath is null
+            ? []
+            : FindDirectoryFiles(paths.DirectoryPath, fileSystem);
+
+        if (paths.FilePath is null)
+        {
+            return directoryFiles;
+        }
+
+        if (!fileSystem.FileExists(paths.FilePath))
+        {
+            throw new ProvisionedConfigurationSourceInvalidException(
+                $"The configuration file named by {ProvisionedConfigurationPaths.FileKey} does not exist: {paths.FilePath}.");
+        }
+
+        return [.. directoryFiles, paths.FilePath];
+    }
+
+    /// <summary>Finds the position at which provisioned configuration is layered into the host's own sources.</summary>
+    /// <param name="sources">The configuration sources the host builder has already composed.</param>
+    /// <returns>The index to insert the first provisioned source at.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sources" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Provisioned files sit immediately below the environment-variable provider, which puts them above
+    /// <c>appsettings.json</c> and its environment overlay and below environment variables and command-line arguments.
+    /// That is the precedence the .NET provider order already promises an operator: a file states the deployment's
+    /// configuration, and an environment variable overrides it. Layering them on top instead would let a stale mounted
+    /// file silently beat a value injected per pod, which is the direction that cannot be diagnosed from the outside.
+    /// </para>
+    /// <para>
+    /// Only the unprefixed provider is the boundary. The prefixed ones carry <c>DOTNET_</c> and <c>ASPNETCORE_</c>
+    /// host settings and are composed before the application's own files, so inserting ahead of those would place
+    /// provisioned configuration below <c>appsettings.json</c> and invert the whole point of mounting it.
+    /// </para>
+    /// </remarks>
+    public static int FindInsertionIndex(IReadOnlyList<IConfigurationSource> sources)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+
+        return sources
+            .Index()
+            .Where(source => source.Item is EnvironmentVariablesConfigurationSource { Prefix: null or "" })
+            .Select(source => source.Index)
+            .DefaultIfEmpty(sources.Count)
+            .First();
+    }
+
+    private static IReadOnlyList<string> FindDirectoryFiles(
+        string directoryPath,
+        IProvisionedConfigurationFileSystem fileSystem)
+    {
+        if (!fileSystem.DirectoryExists(directoryPath))
+        {
+            throw new ProvisionedConfigurationSourceInvalidException(
+                $"The configuration directory named by {ProvisionedConfigurationPaths.DirectoryKey} does not exist: {directoryPath}.");
+        }
+
+        // Ordered ordinally rather than by the host's culture, so the same ConfigMap layers the same way on every
+        // machine that mounts it.
+        return
+        [
+            .. fileSystem.ListFileNames(directoryPath)
+                .Where(IsLayeredJsonFile)
+                .Order(StringComparer.Ordinal)
+                .Select(fileName => Path.Combine(directoryPath, fileName)),
+        ];
+    }
+
+    /// <summary>Reports whether a directory entry is a configuration file rather than the volume's own bookkeeping.</summary>
+    /// <remarks>
+    /// Kubernetes updates a mounted ConfigMap by writing a new timestamped directory and repointing the <c>..data</c>
+    /// symbolic link at it, which is what makes the update atomic. Both entries live beside the keys and neither is
+    /// configuration; skipping them by name keeps that true whichever way an enumerator classifies a link.
+    /// </remarks>
+    private static bool IsLayeredJsonFile(string fileName) =>
+        !fileName.StartsWith(VolumeBookkeepingPrefix, StringComparison.Ordinal)
+        && fileName.EndsWith(JsonFileExtension, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Host/Configuration/ProvisionedConfigurationPaths.cs
+++ b/src/Host/Configuration/ProvisionedConfigurationPaths.cs
@@ -1,0 +1,95 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+namespace MailMcp.Host.Configuration;
+
+/// <summary>Names the configuration files a deployment provisions outside the application's own content root.</summary>
+/// <param name="DirectoryPath">A directory whose JSON files are layered in, or <see langword="null" /> when none is configured.</param>
+/// <param name="FilePath">One JSON file layered in above the directory, or <see langword="null" /> when none is configured.</param>
+/// <remarks>
+/// <para>
+/// The two shapes exist because provisioning systems produce both and neither is the fallback. A Kubernetes ConfigMap
+/// mounted as a volume becomes a directory holding one file per key, while a Compose bind mount, a systemd drop-in, or
+/// a ConfigMap mounted with <c>subPath</c> produces a single file. Naming them separately keeps an operator's intent
+/// explicit, so an absent path is reported against the shape they configured rather than against a guess.
+/// </para>
+/// <para>
+/// Both values are read from ordinary configuration rather than from the environment directly, which is what lets the
+/// same setting arrive as an environment variable in a container, as a command-line argument under systemd, and from
+/// <c>appsettings.json</c> during local development, without a second mechanism per deployment shape.
+/// </para>
+/// </remarks>
+internal sealed record ProvisionedConfigurationPaths(string? DirectoryPath, string? FilePath)
+{
+    /// <summary>The configuration section both settings live in.</summary>
+    public const string SectionName = "ConfigurationSources";
+
+    /// <summary>The configuration key naming a directory of JSON configuration files.</summary>
+    public const string DirectoryKey = $"{SectionName}:{DirectorySettingName}";
+
+    /// <summary>The configuration key naming a single JSON configuration file.</summary>
+    public const string FileKey = $"{SectionName}:{FileSettingName}";
+
+    private const string DirectorySettingName = "Directory";
+    private const string FileSettingName = "File";
+
+    /// <summary>Gets a value indicating whether the deployment provisioned any configuration at all.</summary>
+    public bool AreConfigured => this.DirectoryPath is not null || this.FilePath is not null;
+
+    /// <summary>Reads both paths from the configuration the host has already bound.</summary>
+    /// <param name="configuration">The configuration to read the section from.</param>
+    /// <returns>The provisioned paths, each <see langword="null" /> when the deployment configured none.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
+    /// <exception cref="ProvisionedConfigurationSourceInvalidException">Thrown when the section carries a setting MailMcp does not define.</exception>
+    /// <remarks>
+    /// A blank value reads as unconfigured rather than as a path that happens to be empty. Templating a deployment
+    /// manifest routinely produces an empty string for a value the operator left unset, and treating that as a path
+    /// would fail startup over a setting nobody chose.
+    /// </remarks>
+    public static ProvisionedConfigurationPaths ReadFrom(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var section = configuration.GetSection(SectionName);
+
+        RejectUnknownSettings(section);
+
+        return new ProvisionedConfigurationPaths(
+            NullWhenBlank(section[DirectorySettingName]),
+            NullWhenBlank(section[FileSettingName]));
+    }
+
+    /// <summary>Fails when the section carries a setting MailMcp does not define.</summary>
+    /// <remarks>
+    /// The section is checked by hand rather than through <c>ErrorOnUnknownConfiguration</c>, which the rest of the host
+    /// uses, because these two settings decide which sources exist and are therefore read before the options framework
+    /// the binder belongs to. The rule is the same one, for the same reason: a misspelled <c>Directroy</c> that bound
+    /// nothing would leave the host running on defaults while the operator believed their mount was in force, which is
+    /// precisely the failure these settings exist to remove.
+    /// </remarks>
+    private static void RejectUnknownSettings(IConfigurationSection section)
+    {
+        string[] unknownSettingNames =
+        [
+            .. section.GetChildren()
+                .Select(child => child.Key)
+                .Where(IsUnknownSettingName)
+                .Order(StringComparer.OrdinalIgnoreCase),
+        ];
+
+        if (unknownSettingNames.Length == 0)
+        {
+            return;
+        }
+
+        throw new ProvisionedConfigurationSourceInvalidException(
+            $"{SectionName} carries settings MailMcp does not define: {string.Join(", ", unknownSettingNames)}. "
+            + $"The section defines {DirectorySettingName} and {FileSettingName}.");
+    }
+
+    private static bool IsUnknownSettingName(string settingName) =>
+        !string.Equals(settingName, DirectorySettingName, StringComparison.OrdinalIgnoreCase)
+        && !string.Equals(settingName, FileSettingName, StringComparison.OrdinalIgnoreCase);
+
+    private static string? NullWhenBlank(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/Host/Configuration/ProvisionedConfigurationPaths.cs
+++ b/src/Host/Configuration/ProvisionedConfigurationPaths.cs
@@ -51,39 +51,52 @@ internal sealed record ProvisionedConfigurationPaths(string? DirectoryPath, stri
 
         var section = configuration.GetSection(SectionName);
 
-        RejectUnknownSettings(section);
+        RejectUnusableSettings(section);
 
         return new ProvisionedConfigurationPaths(
             NullWhenBlank(section[DirectorySettingName]),
             NullWhenBlank(section[FileSettingName]));
     }
 
-    /// <summary>Fails when the section carries a setting MailMcp does not define.</summary>
+    /// <summary>Fails when the section carries a setting MailMcp does not define, or a defined one that is not a path.</summary>
     /// <remarks>
+    /// <para>
     /// The section is checked by hand rather than through <c>ErrorOnUnknownConfiguration</c>, which the rest of the host
     /// uses, because these two settings decide which sources exist and are therefore read before the options framework
     /// the binder belongs to. The rule is the same one, for the same reason: a misspelled <c>Directroy</c> that bound
     /// nothing would leave the host running on defaults while the operator believed their mount was in force, which is
     /// precisely the failure these settings exist to remove.
+    /// </para>
+    /// <para>
+    /// A defined setting that carries descendants rather than a value is the same failure wearing the right name. A
+    /// flattening provider can express one — <c>ConfigurationSources__Directory__Path=/etc/mailmcp/config</c> produces a
+    /// child called <c>Directory</c> whose own value is absent — and reading it as a path yields nothing, so a check
+    /// that looked only at the name would accept the setting and start the host without the mount.
+    /// </para>
     /// </remarks>
-    private static void RejectUnknownSettings(IConfigurationSection section)
+    private static void RejectUnusableSettings(IConfigurationSection section)
     {
-        string[] unknownSettingNames =
-        [
-            .. section.GetChildren()
-                .Select(child => child.Key)
-                .Where(IsUnknownSettingName)
-                .Order(StringComparer.OrdinalIgnoreCase),
-        ];
+        string[] children = [.. section.GetChildren().Select(child => child.Key).Order(StringComparer.OrdinalIgnoreCase)];
 
-        if (unknownSettingNames.Length == 0)
+        var unknownSettingNames = children.Where(IsUnknownSettingName).ToArray();
+
+        if (unknownSettingNames.Length > 0)
         {
-            return;
+            throw new ProvisionedConfigurationSourceInvalidException(
+                $"{SectionName} carries settings MailMcp does not define: {string.Join(", ", unknownSettingNames)}. "
+                + $"The section defines {DirectorySettingName} and {FileSettingName}.");
         }
 
-        throw new ProvisionedConfigurationSourceInvalidException(
-            $"{SectionName} carries settings MailMcp does not define: {string.Join(", ", unknownSettingNames)}. "
-            + $"The section defines {DirectorySettingName} and {FileSettingName}.");
+        var structuredSettingNames = children
+            .Where(settingName => section.GetSection(settingName).GetChildren().Any())
+            .ToArray();
+
+        if (structuredSettingNames.Length > 0)
+        {
+            throw new ProvisionedConfigurationSourceInvalidException(
+                $"{SectionName} carries settings that are not a path: {string.Join(", ", structuredSettingNames)}. "
+                + $"{DirectorySettingName} and {FileSettingName} each take one path and no nested value.");
+        }
     }
 
     private static bool IsUnknownSettingName(string settingName) =>

--- a/src/Host/Configuration/ProvisionedConfigurationSourceInvalidException.cs
+++ b/src/Host/Configuration/ProvisionedConfigurationSourceInvalidException.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Domain.Failures;
+
+namespace MailMcp.Host.Configuration;
+
+/// <summary>Indicates that the deployment's configuration-source settings do not describe configuration MailMcp can load.</summary>
+/// <remarks>
+/// <para>
+/// One failure covers a path that is not there and a setting name MailMcp does not define, because both are the same
+/// mistake seen from two sides: the deployment believes it provisioned configuration and the host would not read it.
+/// Nothing acts differently on the two, so splitting them would publish an identity no caller distinguishes.
+/// </para>
+/// <para>
+/// The failure exists so that either mistake stops the process instead of leaving it running on defaults. A host that
+/// silently ignored an absent mount or a misspelled key would report success while serving configuration nobody wrote,
+/// and the divergence would only be discovered later, through behavior rather than through a message.
+/// </para>
+/// <para>
+/// The message names the configuration key and, where one is involved, the path. Both are safe to publish: they are
+/// values the operator wrote into their own deployment, in the same class as an account alias or a folder alias. This
+/// is deliberately unlike a secret reference target, which names where credential material lives and is therefore kept
+/// out of every diagnostic; a configuration path names where non-secret settings live and is useless without them.
+/// </para>
+/// </remarks>
+public sealed class ProvisionedConfigurationSourceInvalidException : MailMcpException
+{
+    /// <summary>Initializes a new failure naming the configuration key that does not describe loadable configuration.</summary>
+    /// <param name="operatorSafeMessage">A message naming the configuration key and, where one is involved, the path.</param>
+    public ProvisionedConfigurationSourceInvalidException(string operatorSafeMessage)
+        : base(operatorSafeMessage)
+    {
+    }
+
+    /// <inheritdoc />
+    public override MailMcpErrorCode ErrorCode => MailMcpErrorCode.ProvisionedConfigurationSourceInvalid;
+}

--- a/src/Host/Observability/BootstrapLogger.cs
+++ b/src/Host/Observability/BootstrapLogger.cs
@@ -17,7 +17,7 @@ namespace MailMcp.Host.Observability;
 /// exporter batches records for five seconds by default. When host startup throws, nothing disposes the application,
 /// and the runtime does not guarantee that <c>finally</c> blocks run for an unhandled exception, so the record that
 /// explains the crash would never leave the process. Every record written here is therefore exported synchronously,
-/// which makes delivery independent of process teardown; three records per process make the cost irrelevant.
+/// which makes delivery independent of process teardown; a handful of records per process make the cost irrelevant.
 /// </para>
 /// <para>
 /// The pipeline is composed before <c>WebApplication.CreateBuilder</c>, which is where a malformed
@@ -67,6 +67,16 @@ internal sealed partial class BootstrapLogger : IDisposable
     /// <summary>Reports that the host process has begun composing itself.</summary>
     public void RecordHostStarting() =>
         this.LogHostStarting(this.settings.ServiceName, this.settings.EnvironmentName, this.settings.ServiceVersion);
+
+    /// <summary>Reports how many deployment-provisioned configuration files were layered into the host's configuration.</summary>
+    /// <param name="fileCount">The number of files layered in, which is zero when the deployment provisioned none.</param>
+    /// <remarks>
+    /// The count is what makes a mount that did not arrive visible at the moment it matters. A directory the deployment
+    /// named is required to exist, so an absent one already fails startup; a mounted directory that is empty is a
+    /// legitimate intermediate state during a rollout and reports itself here as zero rather than as a failure.
+    /// </remarks>
+    public void RecordProvisionedConfigurationFiles(int fileCount) =>
+        this.LogProvisionedConfigurationFiles(this.settings.ServiceName, fileCount);
 
     /// <summary>Reports that the host process is ending because of an exception that escaped composition or the run.</summary>
     /// <param name="exception">The exception that ended the process.</param>
@@ -122,6 +132,11 @@ internal sealed partial class BootstrapLogger : IDisposable
         Level = LogLevel.Information,
         Message = "Host {ServiceName} is starting in environment {EnvironmentName} at version {ServiceVersion}.")]
     private partial void LogHostStarting(string serviceName, string environmentName, string serviceVersion);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Host {ServiceName} layered {FileCount} deployment-provisioned configuration files below the environment.")]
+    private partial void LogProvisionedConfigurationFiles(string serviceName, int fileCount);
 
     [LoggerMessage(
         Level = LogLevel.Critical,

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -27,6 +27,12 @@ try
 {
     var builder = WebApplication.CreateBuilder(args);
 
+    // Before anything reads configuration, so a mounted ConfigMap is ordinary configuration to every binding below
+    // rather than a second source consulted afterwards. The files land beneath the environment-variable provider, which
+    // keeps an environment variable an override of a mounted file rather than something a stale mount can beat.
+    var provisionedConfigurationFileCount = builder.Configuration.AddProvisionedConfiguration();
+    bootstrapLogger.RecordProvisionedConfigurationFiles(provisionedConfigurationFileCount);
+
     builder.AddServiceDefaults();
     builder.Services.AddProblemDetails();
     builder.Services.AddSingleton(TimeProvider.System);

--- a/tests/Domain.UnitTests/MailMcpErrorCodeTests.cs
+++ b/tests/Domain.UnitTests/MailMcpErrorCodeTests.cs
@@ -1,5 +1,6 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
+using System.Reflection;
 using System.Text.Json;
 using MailMcp.Domain.Failures;
 using Xunit;
@@ -20,6 +21,27 @@ public sealed class MailMcpErrorCodeTests
         Assert.Equal(MailMcpErrorCode.All.Count, distinctValues);
     }
 
+    /// <summary>
+    /// A declared code left out of the registry is invisible to every other assertion here, because they all iterate
+    /// the registry. It is also silently unpublishable: <see cref="MailMcpErrorCode.TryParse" /> and JSON reading
+    /// resolve a number through the registry alone, so a boundary would reject the very code it just raised.
+    /// </summary>
+    [Fact]
+    public void All_ListsEveryDeclaredCode()
+    {
+        // Arrange
+        var declaredCodes = typeof(MailMcpErrorCode)
+            .GetProperties(BindingFlags.Public | BindingFlags.Static)
+            .Where(property => property.PropertyType == typeof(MailMcpErrorCode))
+            .Select(property => (MailMcpErrorCode)property.GetValue(null)!);
+
+        // Act
+        var unregistered = declaredCodes.Where(code => !MailMcpErrorCode.All.Contains(code)).ToArray();
+
+        // Assert
+        Assert.Empty(unregistered);
+    }
+
     /// <summary>A code shorter or longer than five digits would not decompose into a category and a subcategory.</summary>
     [Fact]
     public void All_CodesAreFiveDigits()
@@ -33,6 +55,7 @@ public sealed class MailMcpErrorCodeTests
 
     [Theory]
     [InlineData(11001, 1, 1)]
+    [InlineData(12001, 1, 2)]
     [InlineData(21001, 2, 1)]
     [InlineData(22001, 2, 2)]
     [InlineData(23001, 2, 3)]

--- a/tests/Host.UnitTests/FakeProvisionedConfigurationFileSystem.cs
+++ b/tests/Host.UnitTests/FakeProvisionedConfigurationFileSystem.cs
@@ -1,0 +1,42 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Host.Configuration;
+
+namespace MailMcp.Host.UnitTests;
+
+/// <summary>Reports a mount the test describes, so layering can be proven without a directory on disk.</summary>
+internal sealed class FakeProvisionedConfigurationFileSystem : IProvisionedConfigurationFileSystem
+{
+    private readonly Dictionary<string, IReadOnlyList<string>> directories = new(StringComparer.Ordinal);
+    private readonly HashSet<string> files = new(StringComparer.Ordinal);
+
+    /// <summary>Describes a mounted directory holding the given entry names.</summary>
+    /// <param name="directoryPath">The directory the deployment named.</param>
+    /// <param name="fileNames">The entry names the directory holds, in whatever order the file system reports them.</param>
+    /// <returns>The same instance, so a test can describe a mount in one expression.</returns>
+    public FakeProvisionedConfigurationFileSystem WithDirectory(string directoryPath, params string[] fileNames)
+    {
+        this.directories[directoryPath] = fileNames;
+
+        return this;
+    }
+
+    /// <summary>Describes a mounted single file.</summary>
+    /// <param name="filePath">The file the deployment named.</param>
+    /// <returns>The same instance, so a test can describe a mount in one expression.</returns>
+    public FakeProvisionedConfigurationFileSystem WithFile(string filePath)
+    {
+        this.files.Add(filePath);
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public bool DirectoryExists(string directoryPath) => this.directories.ContainsKey(directoryPath);
+
+    /// <inheritdoc />
+    public bool FileExists(string filePath) => this.files.Contains(filePath);
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> ListFileNames(string directoryPath) => this.directories[directoryPath];
+}

--- a/tests/Host.UnitTests/ProvisionedConfigurationLayerTests.cs
+++ b/tests/Host.UnitTests/ProvisionedConfigurationLayerTests.cs
@@ -1,0 +1,187 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Domain.Failures;
+using MailMcp.Host.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.EnvironmentVariables;
+using Microsoft.Extensions.Configuration.Json;
+using Microsoft.Extensions.Configuration.Memory;
+using Xunit;
+
+namespace MailMcp.Host.UnitTests;
+
+/// <summary>Covers which provisioned configuration files are layered in, and where among the host's own sources.</summary>
+/// <remarks>
+/// Both decisions are contracts an operator reasons about: which files a mounted ConfigMap contributes, and whether an
+/// environment variable still overrides them. Neither needs a directory on disk to be proven, which is what keeps them
+/// here rather than in the integration suite.
+/// </remarks>
+public sealed class ProvisionedConfigurationLayerTests
+{
+    private const string MountPath = "/etc/mailmcp/config";
+
+    [Fact]
+    public void FindFiles_NothingProvisioned_LayersNoFile()
+    {
+        // Arrange
+        var paths = new ProvisionedConfigurationPaths(null, null);
+
+        // Act
+        var files = ProvisionedConfigurationLayer.FindFiles(paths, new FakeProvisionedConfigurationFileSystem());
+
+        // Assert
+        Assert.Empty(files);
+    }
+
+    [Fact]
+    public void FindFiles_MountedDirectory_LayersEveryJsonFileInOrdinalNameOrder()
+    {
+        // Arrange
+        var fileSystem = new FakeProvisionedConfigurationFileSystem()
+            .WithDirectory(MountPath, "persistence.json", "Accounts.json", "search.json");
+
+        // Act
+        var files = ProvisionedConfigurationLayer.FindFiles(new ProvisionedConfigurationPaths(MountPath, null), fileSystem);
+
+        // Assert
+        Assert.Equal(
+            [MountedFile("Accounts.json"), MountedFile("persistence.json"), MountedFile("search.json")],
+            files);
+    }
+
+    [Fact]
+    public void FindFiles_MountedDirectory_SkipsEntriesThatAreNotJsonFiles()
+    {
+        // Arrange
+        var fileSystem = new FakeProvisionedConfigurationFileSystem()
+            .WithDirectory(MountPath, "settings.json", "notes.txt", "settings.json.bak", "README");
+
+        // Act
+        var files = ProvisionedConfigurationLayer.FindFiles(new ProvisionedConfigurationPaths(MountPath, null), fileSystem);
+
+        // Assert
+        Assert.Equal([MountedFile("settings.json")], files);
+    }
+
+    /// <summary>The atomic-update entries Kubernetes writes beside the keys are bookkeeping, never configuration.</summary>
+    [Fact]
+    public void FindFiles_MountedDirectory_SkipsKubernetesVolumeBookkeepingEntries()
+    {
+        // Arrange
+        var fileSystem = new FakeProvisionedConfigurationFileSystem()
+            .WithDirectory(MountPath, "..data", "..2026_07_31_10_15_00.1234.json", "settings.json");
+
+        // Act
+        var files = ProvisionedConfigurationLayer.FindFiles(new ProvisionedConfigurationPaths(MountPath, null), fileSystem);
+
+        // Assert
+        Assert.Equal([MountedFile("settings.json")], files);
+    }
+
+    /// <summary>A ConfigMap with no keys is a legitimate state during a rollout, not a reason to refuse to start.</summary>
+    [Fact]
+    public void FindFiles_EmptyMountedDirectory_LayersNoFileAndDoesNotThrow()
+    {
+        // Arrange
+        var fileSystem = new FakeProvisionedConfigurationFileSystem().WithDirectory(MountPath);
+
+        // Act
+        var files = ProvisionedConfigurationLayer.FindFiles(new ProvisionedConfigurationPaths(MountPath, null), fileSystem);
+
+        // Assert
+        Assert.Empty(files);
+    }
+
+    [Fact]
+    public void FindFiles_MountedFileBesideADirectory_LayersTheFileLast()
+    {
+        // Arrange
+        var overridePath = "/etc/mailmcp/override.json";
+        var fileSystem = new FakeProvisionedConfigurationFileSystem()
+            .WithDirectory(MountPath, "settings.json")
+            .WithFile(overridePath);
+
+        // Act
+        var files = ProvisionedConfigurationLayer.FindFiles(
+            new ProvisionedConfigurationPaths(MountPath, overridePath),
+            fileSystem);
+
+        // Assert
+        Assert.Equal([MountedFile("settings.json"), overridePath], files);
+    }
+
+    /// <summary>A mount that never arrived must stop the host rather than leave it running on defaults.</summary>
+    [Fact]
+    public void FindFiles_DirectoryThatDoesNotExist_FailsNamingTheConfigurationKeyAndThePath()
+    {
+        // Arrange
+        var paths = new ProvisionedConfigurationPaths(MountPath, null);
+
+        // Act
+        var failure = Assert.Throws<ProvisionedConfigurationSourceInvalidException>(
+            () => ProvisionedConfigurationLayer.FindFiles(paths, new FakeProvisionedConfigurationFileSystem()));
+
+        // Assert
+        Assert.Equal(MailMcpErrorCode.ProvisionedConfigurationSourceInvalid, failure.ErrorCode);
+        Assert.Contains(ProvisionedConfigurationPaths.DirectoryKey, failure.Message, StringComparison.Ordinal);
+        Assert.Contains(MountPath, failure.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindFiles_FileThatDoesNotExist_FailsNamingTheConfigurationKeyAndThePath()
+    {
+        // Arrange
+        var missingPath = "/etc/mailmcp/override.json";
+        var paths = new ProvisionedConfigurationPaths(null, missingPath);
+
+        // Act
+        var failure = Assert.Throws<ProvisionedConfigurationSourceInvalidException>(
+            () => ProvisionedConfigurationLayer.FindFiles(paths, new FakeProvisionedConfigurationFileSystem()));
+
+        // Assert
+        Assert.Equal(MailMcpErrorCode.ProvisionedConfigurationSourceInvalid, failure.ErrorCode);
+        Assert.Contains(ProvisionedConfigurationPaths.FileKey, failure.Message, StringComparison.Ordinal);
+        Assert.Contains(missingPath, failure.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>An environment variable overrides a mounted file, which is what the insertion point decides.</summary>
+    [Fact]
+    public void FindInsertionIndex_HostSources_LandsBelowTheUnprefixedEnvironmentProvider()
+    {
+        // Arrange
+        IReadOnlyList<IConfigurationSource> sources =
+        [
+            new EnvironmentVariablesConfigurationSource { Prefix = "DOTNET_" },
+            new JsonConfigurationSource { Path = "appsettings.json" },
+            new JsonConfigurationSource { Path = "appsettings.Production.json" },
+            new EnvironmentVariablesConfigurationSource(),
+            new MemoryConfigurationSource(),
+        ];
+
+        // Act
+        var insertionIndex = ProvisionedConfigurationLayer.FindInsertionIndex(sources);
+
+        // Assert
+        Assert.Equal(3, insertionIndex);
+    }
+
+    /// <summary>Without an environment provider there is nothing to sit below, so provisioned files take precedence.</summary>
+    [Fact]
+    public void FindInsertionIndex_NoUnprefixedEnvironmentProvider_LandsAboveEverySource()
+    {
+        // Arrange
+        IReadOnlyList<IConfigurationSource> sources =
+        [
+            new JsonConfigurationSource { Path = "appsettings.json" },
+            new EnvironmentVariablesConfigurationSource { Prefix = "ASPNETCORE_" },
+        ];
+
+        // Act
+        var insertionIndex = ProvisionedConfigurationLayer.FindInsertionIndex(sources);
+
+        // Assert
+        Assert.Equal(2, insertionIndex);
+    }
+
+    private static string MountedFile(string fileName) => Path.Combine(MountPath, fileName);
+}

--- a/tests/Host.UnitTests/ProvisionedConfigurationPathsTests.cs
+++ b/tests/Host.UnitTests/ProvisionedConfigurationPathsTests.cs
@@ -1,0 +1,109 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Domain.Failures;
+using MailMcp.Host.Configuration;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MailMcp.Host.UnitTests;
+
+/// <summary>Covers how a deployment states where it provisioned configuration.</summary>
+public sealed class ProvisionedConfigurationPathsTests
+{
+    [Fact]
+    public void ReadFrom_ConfiguredKeys_NamesBothProvisionedPaths()
+    {
+        // Arrange
+        var configuration = Build(
+            (ProvisionedConfigurationPaths.DirectoryKey, "/etc/mailmcp/config"),
+            (ProvisionedConfigurationPaths.FileKey, "/etc/mailmcp/override.json"));
+
+        // Act
+        var paths = ProvisionedConfigurationPaths.ReadFrom(configuration);
+
+        // Assert
+        Assert.Equal(new ProvisionedConfigurationPaths("/etc/mailmcp/config", "/etc/mailmcp/override.json"), paths);
+        Assert.True(paths.AreConfigured);
+    }
+
+    [Fact]
+    public void ReadFrom_NoKeys_ProvisionsNothing()
+    {
+        // Arrange
+        var configuration = Build();
+
+        // Act
+        var paths = ProvisionedConfigurationPaths.ReadFrom(configuration);
+
+        // Assert
+        Assert.Equal(new ProvisionedConfigurationPaths(null, null), paths);
+        Assert.False(paths.AreConfigured);
+    }
+
+    /// <summary>Templating a manifest routinely emits an empty value for a setting the operator left unset.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void ReadFrom_BlankValue_ProvisionsNothing(string configuredValue)
+    {
+        // Arrange
+        var configuration = Build(
+            (ProvisionedConfigurationPaths.DirectoryKey, configuredValue),
+            (ProvisionedConfigurationPaths.FileKey, configuredValue));
+
+        // Act
+        var paths = ProvisionedConfigurationPaths.ReadFrom(configuration);
+
+        // Assert
+        Assert.False(paths.AreConfigured);
+    }
+
+    [Fact]
+    public void ReadFrom_SurroundingWhitespace_NamesThePathWithoutIt()
+    {
+        // Arrange
+        var configuration = Build((ProvisionedConfigurationPaths.DirectoryKey, "  /etc/mailmcp/config\n"));
+
+        // Act
+        var paths = ProvisionedConfigurationPaths.ReadFrom(configuration);
+
+        // Assert
+        Assert.Equal("/etc/mailmcp/config", paths.DirectoryPath);
+    }
+
+    /// <summary>A misspelling that bound nothing would leave the host on defaults with the mount believed in force.</summary>
+    [Fact]
+    public void ReadFrom_SettingMailMcpDoesNotDefine_FailsNamingIt()
+    {
+        // Arrange
+        var configuration = Build(($"{ProvisionedConfigurationPaths.SectionName}:Directroy", "/etc/mailmcp/config"));
+
+        // Act
+        var failure = Assert.Throws<ProvisionedConfigurationSourceInvalidException>(
+            () => ProvisionedConfigurationPaths.ReadFrom(configuration));
+
+        // Assert
+        Assert.Equal(MailMcpErrorCode.ProvisionedConfigurationSourceInvalid, failure.ErrorCode);
+        Assert.Contains("Directroy", failure.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>Configuration keys are case-insensitive, so a differently cased setting is the defined one.</summary>
+    [Fact]
+    public void ReadFrom_DifferentlyCasedSetting_NamesTheProvisionedPath()
+    {
+        // Arrange
+        var configuration = Build(($"{ProvisionedConfigurationPaths.SectionName}:directory", "/etc/mailmcp/config"));
+
+        // Act
+        var paths = ProvisionedConfigurationPaths.ReadFrom(configuration);
+
+        // Assert
+        Assert.Equal("/etc/mailmcp/config", paths.DirectoryPath);
+    }
+
+    private static IConfiguration Build(params (string Key, string Value)[] entries) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(entries.Select(entry => new KeyValuePair<string, string?>(entry.Key, entry.Value)))
+            .Build();
+}

--- a/tests/Host.UnitTests/ProvisionedConfigurationPathsTests.cs
+++ b/tests/Host.UnitTests/ProvisionedConfigurationPathsTests.cs
@@ -88,6 +88,23 @@ public sealed class ProvisionedConfigurationPathsTests
         Assert.Contains("Directroy", failure.Message, StringComparison.Ordinal);
     }
 
+    /// <summary>A flattening provider can express a shape that is a defined name over no path at all.</summary>
+    [Fact]
+    public void ReadFrom_DefinedSettingCarryingNestedValues_FailsNamingIt()
+    {
+        // Arrange
+        var configuration = Build(
+            ($"{ProvisionedConfigurationPaths.DirectoryKey}:Path", "/etc/mailmcp/config"));
+
+        // Act
+        var failure = Assert.Throws<ProvisionedConfigurationSourceInvalidException>(
+            () => ProvisionedConfigurationPaths.ReadFrom(configuration));
+
+        // Assert
+        Assert.Equal(MailMcpErrorCode.ProvisionedConfigurationSourceInvalid, failure.ErrorCode);
+        Assert.Contains("Directory", failure.Message, StringComparison.Ordinal);
+    }
+
     /// <summary>Configuration keys are case-insensitive, so a differently cased setting is the defined one.</summary>
     [Fact]
     public void ReadFrom_DifferentlyCasedSetting_NamesTheProvisionedPath()


### PR DESCRIPTION
Closes #166

## What changed

`src/Host/Program.cs` composed the host from a bare `WebApplication.CreateBuilder(args)` and added no configuration source of its own. Of the three usual Kubernetes ConfigMap shapes, the one a Helm chart produces by default — a ConfigMap mounted as a directory — was reachable by nobody, and an operator who mounted it saw no error: the host started on defaults.

Two settings now name what the deployment provisioned, both unset by default so a deployment that mounts nothing keeps exactly today's source list.

| Key | Environment form | Layers in |
| --- | --- | --- |
| `ConfigurationSources:Directory` | `ConfigurationSources__Directory` | Every `*.json` file the directory holds |
| `ConfigurationSources:File` | `ConfigurationSources__File` | One JSON file, above the directory |

## The decisions worth reviewing

**Precedence.** The provisioned files land immediately below the unprefixed environment-variable provider, which puts them above `appsettings.json` and its environment overlay and below environment variables and command-line arguments. That is the direction an operator can act on — injecting one variable overrides one setting for one pod — and it keeps a ConfigMap nobody remembered to update from silently beating a value injected beside it. Only the unprefixed provider is the boundary; inserting ahead of the `DOTNET_`/`ASPNETCORE_` ones would place provisioned configuration *below* `appsettings.json` and invert the point of mounting it.

**Fail fast, twice.** A configured path that does not exist fails startup, and so does a setting the section does not define. The second one is the reason the section is checked by hand rather than bound through `ErrorOnUnknownConfiguration`: these two settings decide which sources exist, so they are read before the options framework the binder belongs to. The rule is the same one the three strictly-bound sections in `Program.cs` already state, for the same reason — a misspelled `Directroy` that bound nothing would leave the host on defaults while the operator believed their mount was in force.

**Optional providers, one failure mechanism.** The `JsonConfigurationSource` instances are added with `Optional = true` even though an absent path is a startup failure. The existence check has already run and produced a message naming the configuration key; letting the provider enforce the same rule again would give one condition two mechanisms, and the framework's reports a bare path with no indication of which setting named it.

**Kubernetes bookkeeping.** Directory enumeration skips `..`-prefixed entries. The kubelet updates a mounted volume by writing a new timestamped directory and repointing the `..data` symbolic link at it; both live beside the keys and neither is configuration. Skipping them by name keeps that true whichever way an enumerator classifies a link.

**One failure identity.** `ProvisionedConfigurationSourceInvalidException` carries code `12001` and covers both mistakes, because nothing acts differently on them — splitting would publish an identity no caller distinguishes. Category 1 gains subcategory 2 for configuration sources.

## Testing

19 new unit tests across `ProvisionedConfigurationLayerTests` and `ProvisionedConfigurationPathsTests`, over a hand-written `FakeProvisionedConfigurationFileSystem`: file ordering, the JSON filter, the `..` skip, an empty directory, the file-above-directory rule, both failure paths, the insertion index with and without an unprefixed environment provider, blank and differently cased setting values, and the unknown-setting rejection.

The seam exists so none of this needs a directory on disk. What a unit test deliberately does not prove is a value-level precedence assertion, which would need real files to load; the insertion index is asserted structurally instead, and the value-level behavior belongs to the integration suite.

## Documentation

- `docs/operations/configuration-sources.md` is new: source precedence, both settings, the failure behavior, reload including the two Kubernetes caveats (`subPath` mounts never update; `DOTNET_USE_POLLING_FILE_WATCHER` is what makes change detection reliable on a mounted volume), and a mapping table plus a worked manifest covering Secrets and ConfigMaps together.
- `docs/operations/secret-provisioning.md` gains the rotation property of a mounted Secret — per-use resolution means rotation behind an unchanged path needs no restart — and the CSI-driver case.
- `docs/operations/host-startup-telemetry.md` goes from three records to four; the new one carries a count and never a path.

Secrets needed no work. `file:` already serves a mounted Secret by design, which `FileSecretReferenceResolver` records; this is the non-secret half of the same operator story.

## Verification

`scripts/verify-full.sh` — exit 0, 1264 tests, 0 failed, aggregate line coverage 96.76% (required 85%), formatting clean, 0 warnings.

## Out of scope

A key-per-file provider, which would be a second mechanism owning this concern in a different shape; a managed secret-store adapter; and the Helm chart and Compose assets, which are #158 and depend on this.
