### PR TITLE
Bound MCP traffic with per-client and process-wide rate limits

### DIFF
--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -1,8 +1,9 @@
 # The MCP endpoint and what protects it
 
 The MCP endpoint is how an agent reaches MailMcp. This page records what enabling it means operationally, what a client
-has to present to reach it, which browser origins it answers, and which client applications it accepts a certificate
-from. The tools it serves are described in `docs/features/mcp-tools.md`.
+has to present to reach it, which browser origins it answers, which client applications it accepts a certificate from,
+and how much traffic it accepts before it starts refusing. The tools it serves are described in
+`docs/features/mcp-tools.md`.
 
 ## The endpoint is off by default
 
@@ -31,6 +32,7 @@ endpoint exposes synchronized mailboxes to whoever can reach it and satisfy what
 | `ApiKeys` | empty | The keys a client may present, each a named secret with its own lifetime |
 | `Cors.AllowedOrigins` | `["*"]` | The browser origins served: `*` for every one, a list for exactly those, an empty list for none |
 | `ClientCertificateProfiles` | empty | The client applications whose certificates are accepted, each with its own authorities and expected names |
+| `RateLimiting` | bounded — see [Rate limiting](#rate-limiting) | How much traffic the endpoint accepts, per process and per client |
 
 The endpoint always answers on **`/mcp`**, which is a constant rather than a setting. An MCP client is configured with a
 server URL, so a deployment could only move the path in step with every client pointed at it — the configurability would
@@ -343,6 +345,126 @@ than accepting one, because an anchor that has become unreadable must never wide
 That refusal is the *profile's*, not the endpoint's. Another profile still accepts a certificate its own anchors verify,
 because the broken material took no part in that verdict — one deleted file closes the clients it belongs to, not the
 ones whose trust material is intact.
+
+## Rate limiting
+
+An enabled endpoint is bounded. Two controls run in front of it, and they bound different things:
+
+- **A process-wide concurrency limit** caps how many MCP requests are being served at any instant, across every client.
+  It protects what the machine has one set of: database connections, threads, and open response streams.
+- **A per-client token bucket** caps how often one client may ask. A client that goes into a loop spends its own capacity
+  rather than everyone's.
+
+Unlike the settings above, **every value here has a product default**, so an endpoint someone enabled is bounded by the
+act of enabling it. There is no correct default for who may read a mailbox, which is why `Authentication` refuses to be
+guessed; there is a sane default for how fast one client may ask, and leaving the endpoint unbounded because nobody wrote
+a number is not a decision anyone made.
+
+```json
+{
+  "McpEndpoint": {
+    "RateLimiting": {
+      "Enabled": true,
+      "MaxConcurrentRequests": 20,
+      "ConcurrencyQueueLimit": 0,
+      "TokenCapacity": 60,
+      "TokensPerReplenishmentPeriod": 60,
+      "ReplenishmentPeriod": "00:01:00",
+      "RequestQueueLimit": 0
+    }
+  }
+}
+```
+
+| Setting | Default | Range | Meaning |
+|---|---|---|---|
+| `Enabled` | `true` | — | Whether the limits below are applied at all |
+| `MaxConcurrentRequests` | `20` | 1–1000 | MCP requests served at once, across every client |
+| `ConcurrencyQueueLimit` | `0` | 0–1000 | Requests that wait for a concurrency slot before the rest are refused |
+| `TokenCapacity` | `60` | 1–1000000 | The largest burst one client may spend at once |
+| `TokensPerReplenishmentPeriod` | `60` | 1–`TokenCapacity` | How much of that burst one client gets back each period |
+| `ReplenishmentPeriod` | `00:01:00` | 1s–1h | How often a client's spent capacity is restored |
+| `RequestQueueLimit` | `0` | 0–1000 | One client's requests that wait for capacity before the rest are refused |
+
+The defaults are sized for the work an MCP request actually does here. Every tool answers from the local mailbox copy
+with a bounded query, so a request is short and database-bound rather than long and compute-bound. Twenty concurrent
+requests keep the endpoint well inside the connection pool the synchronization workers share; one request per second with
+a sixty-request burst covers an agent that lists a page and then reads what it found, while still costing an unattended
+loop its capacity within a second.
+
+Whatever is in force is stated once at startup, so a deployment running on defaults can read back what it is enforcing
+rather than having to know these numbers:
+
+```text
+info: MailMcp.Host.Hosting.McpRateLimitingStartupReport
+      The MCP endpoint on /mcp serves at most 20 requests at once across every client, queueing 0 beyond that, and
+      allows each client a burst of 60 requests restored at 60 every 00:01:00, queueing 0 of its requests beyond that.
+```
+
+**Queue limits default to zero throughout.** A queued request holds memory and a connection while it waits for capacity
+that is already gone, which turns an overload into a slower, larger overload; refusing it immediately tells the client to
+back off while the server is still healthy. A deployment that would rather absorb a short burst can configure a queue,
+and a bounded queue is the only shape available.
+
+Configuration that could never work is refused at startup rather than applied: a limit of zero or below, an unbounded
+queue, a replenishment period below what the timer can resolve, and a period that restores more than the bucket holds —
+which is not a faster limit but a different one, because the surplus is discarded every time and the rate written down is
+never the rate that applies.
+
+### Whose capacity a request spends
+
+The per-client limit is counted under **the name of the API key the request authenticated with** — MailMcp's own
+configured identity for that credential, never the credential itself. The set of partitions an authenticated deployment
+keeps is therefore as large as the key list and no larger.
+
+Everything else shares **one anonymous partition**: a request under `None`, and a request whose credential was refused.
+That is deliberately coarse. Every partition a request can name is a dictionary entry the process keeps, so a key an
+attacker chooses is memory an attacker allocates. Nothing a caller writes — a header, a path, a query string, an
+`Origin`, a user agent — reaches a partition key, and neither does a forwarded address, because a proxy header is chosen
+by whoever is upstream. The remote address is not used either, not even as a fallback: it is spoofable on the traffic
+this is aimed at, and one client behind a shared address would otherwise be limited by another's behaviour.
+
+Counting refused credentials against the anonymous partition is what makes a flood of bad credentials cost the sender
+something. The limiter runs **behind authentication**, so the identity it counts under is the one authentication
+established, and **ahead of authorization**, so a request about to be refused for its credential has still spent capacity
+rather than being the one kind of traffic served without limit.
+
+Readiness, liveness, and the root endpoint are outside all of this and keep answering while the MCP endpoint is refusing.
+
+### What a refused request receives
+
+A request over either limit is answered `429 Too Many Requests` with `Cache-Control: no-store` and **no body**. A body
+would have to say either nothing useful or something about the configured limits, and the second describes the deployment
+to every refused caller — including one whose credential is about to be refused, which must not learn that a named key
+exists. Refusals are identical whoever provoked them.
+
+`Retry-After` is included when the limiter can compute one, which means when the per-client bucket refused the request:
+it knows when the next replenishment lands. A refusal for concurrency carries none, because a concurrency limit has no
+scheduled moment at which a slot frees and a guess would be worse than silence. The advertised value is never below one
+second, so a client never reads it as "immediately" and retries into the same refusal.
+
+Rejections, active leases, queued requests, and lease durations are recorded through the built-in
+`Microsoft.AspNetCore.RateLimiting` metrics, tagged with the policy name. Nothing MailMcp adds records a client name, an
+address, an origin, a credential, or anything from a request or its response.
+
+### What this is not
+
+**The limits are counted in this process alone.** A deployment running several instances enforces them once per process
+rather than once in total; there is no shared state and no coordination between them. Put the total behind a reverse
+proxy or load balancer that bounds it if that matters.
+
+**It is not DDoS protection.** It bounds what one client can take from the process it is talking to. A flood arriving
+from many sources is a job for a WAF, a CDN, or a hosting provider's own protection, and none of that is in MailMcp.
+
+Turning the limits off is an explicit value and costs one startup warning:
+
+```text
+warn: MailMcp.Host.Hosting.McpRateLimitingStartupReport
+      The MCP endpoint is enabled on /mcp with rate limiting turned off, so one client can hold every database
+      connection, response stream, and thread the process has until something runs out. This is the right setting only
+      where something in front of this process already bounds the traffic reaching it. Remove
+      McpEndpoint:RateLimiting:Enabled to run under the product defaults.
+```
 
 ## What the endpoint records
 

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -122,6 +122,13 @@ whatever the answer, and both sides of the comparison are reduced to a digest an
 is where the difference is — an expired key is recorded by name at `Warning`, and a key whose material has disappeared at
 `Error` — and neither line carries the presented credential, the configured material, or the reference target.
 
+**That challenge is what a refused request receives while there is capacity to serve it.** The challenge is written by
+authorization, which runs behind the rate limiter, and a request carrying no usable credential is counted against the
+shared anonymous partition on the way there. Once that partition or the process-wide concurrency limit is exhausted, the
+same request is answered `429 Too Many Requests` with no body and never reaches the point where a challenge is written.
+That is deliberate — it is what makes a flood of bad credentials cost the sender something — and it means a client
+retrying against an exhausted partition sees `429` where it expected `401`. See [Rate limiting](#rate-limiting).
+
 ### `None`
 
 `None` is the unauthenticated posture, and it is reachable only by writing it down. It never arises from a missing key, a
@@ -386,7 +393,7 @@ a number is not a decision anyone made.
 | `TokenCapacity` | `60` | 1–1000000 | The largest burst one client may spend at once |
 | `TokensPerReplenishmentPeriod` | `60` | 1–`TokenCapacity` | How much of that burst one client gets back each period |
 | `ReplenishmentPeriod` | `00:01:00` | 1s–1h | How often a client's spent capacity is restored |
-| `RequestQueueLimit` | `0` | 0–1000 | One client's requests that wait for capacity before the rest are refused |
+| `RequestQueueLimit` | `0` | 0 to `MaxConcurrentRequests` − 1 | One client's requests that wait for capacity before the rest are refused |
 
 The defaults are sized for the work an MCP request actually does here. Every tool answers from the local mailbox copy
 with a bounded query, so a request is short and database-bound rather than long and compute-bound. Twenty concurrent
@@ -408,10 +415,18 @@ that is already gone, which turns an overload into a slower, larger overload; re
 back off while the server is still healthy. A deployment that would rather absorb a short burst can configure a queue,
 and a bounded queue is the only shape available.
 
+**A client queue is bounded by the concurrency limit as well as by its own range.** The two limiters are acquired in
+order — the process-wide one first, the client's bucket second — so a request waiting for its client's tokens is already
+holding a concurrency permit and keeps it until the next replenishment, which can be an hour away. A queue as large as
+`MaxConcurrentRequests` would therefore let one client that has run out of capacity park every permit the process has
+and refuse everyone else, through the very limit that exists to keep one client's behaviour to itself. `RequestQueueLimit`
+has to stay below `MaxConcurrentRequests`, and `0` — refuse immediately, and tell the client when to come back — remains
+the setting to prefer.
+
 Configuration that could never work is refused at startup rather than applied: a limit of zero or below, an unbounded
-queue, a replenishment period below what the timer can resolve, and a period that restores more than the bucket holds —
+queue, a replenishment period below what the timer can resolve, a period that restores more than the bucket holds —
 which is not a faster limit but a different one, because the surplus is discarded every time and the rate written down is
-never the rate that applies.
+never the rate that applies — and a client queue that could hold every concurrency permit.
 
 ### Whose capacity a request spends
 
@@ -473,6 +488,14 @@ proxy or load balancer that bounds it if that matters.
 
 **It is not DDoS protection.** It bounds what one client can take from the process it is talking to. A flood arriving
 from many sources is a job for a WAF, a CDN, or a hosting provider's own protection, and none of that is in MailMcp.
+
+**It bounds what the endpoint serves, not what the server spends deciding whether to serve it.** The limiter runs behind
+the origin check, the certificate check, and authentication, so the work those do — reading every configured trust anchor
+and comparing every configured key, on every request — happens before a permit is taken. The order is what makes the
+per-client limit possible at all: run ahead of authentication and there is no client to count against, and every request
+shares the anonymous bucket. What a bad credential costs the sender is therefore a partition it shares with every other
+unidentified request, not the work the server already did to refuse it. Bounding connections that never authenticate is a
+job for whatever fronts the process.
 
 Turning the limits off is an explicit value and costs one startup warning:
 

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -304,6 +304,8 @@ Several deliberate strictnesses are worth knowing before a profile is written:
   on the next request, with no restart.
 - **Requesting a certificate is not requiring one.** Kestrel asks every HTTPS connection for one and accepts whatever
   arrives, so the decision is made here rather than in the handshake, where a refusal would say nothing to anybody.
+- **A matched profile also names a rate-limit partition**, but only where no API key identified the caller. See
+  [Whose capacity a request spends](#whose-capacity-a-request-spends) for the rule between the two.
 
 **mTLS needs an HTTPS endpoint.** A client certificate only exists on a TLS connection, so a deployment serving plain
 HTTP presents none: an `Optional` profile then identifies nothing, and a `Required` profile refuses every request.
@@ -413,21 +415,37 @@ never the rate that applies.
 
 ### Whose capacity a request spends
 
-The per-client limit is counted under **the name of the API key the request authenticated with** — MailMcp's own
-configured identity for that credential, never the credential itself. The set of partitions an authenticated deployment
-keeps is therefore as large as the key list and no larger.
+Two identities can name a caller, and they are consulted in a fixed order:
 
-Everything else shares **one anonymous partition**: a request under `None`, and a request whose credential was refused.
-That is deliberately coarse. Every partition a request can name is a dictionary entry the process keeps, so a key an
-attacker chooses is memory an attacker allocates. Nothing a caller writes — a header, a path, a query string, an
-`Origin`, a user agent — reaches a partition key, and neither does a forwarded address, because a proxy header is chosen
-by whoever is upstream. The remote address is not used either, not even as a fallback: it is spoofable on the traffic
-this is aimed at, and one client behind a shared address would otherwise be limited by another's behaviour.
+1. **The name of the API key the request authenticated with**, whenever there is one.
+2. **The name of the client-certificate profile the connection matched**, when no key authenticated the request.
+3. **One shared anonymous partition** otherwise.
+
+Both are MailMcp's own configured identities — never the credential, and never anything the certificate itself carried.
+The partitions a deployment keeps therefore number no more than its key list plus its profile list.
+
+**The key wins wherever both exist, and the two are never combined.** A key names one client of this deployment, which is
+exactly what an operator partitioned their clients into; a profile names a client *application*, and several keys may sit
+behind one profile. Taking the profile instead would let one key starve another that happens to share its certificate,
+and combining the two into a pair would hand the same credential a fresh bucket for every profile it could present
+under — capacity bought by holding one more certificate.
+
+A profile's partition is written `<profile:name>` and a key's is written bare, because the two are configured under the
+same grammar and a profile named after a key would otherwise share its bucket. Under `ApiKey` both kinds exist at once,
+since a request whose credential was refused still arrives carrying the profile its certificate matched.
+
+Everything unidentified shares **one anonymous partition**: a request under `None` presenting no certificate, and a
+request whose credential was refused. That is deliberately coarse. Every partition a request can name is a dictionary
+entry the process keeps, so a key an attacker chooses is memory an attacker allocates. Nothing a caller writes — a
+header, a path, a query string, an `Origin`, a user agent — reaches a partition key, and neither does a forwarded
+address, because a proxy header is chosen by whoever is upstream. The remote address is not used either, not even as a
+fallback: it is spoofable on the traffic this is aimed at, and one client behind a shared address would otherwise be
+limited by another's behaviour.
 
 Counting refused credentials against the anonymous partition is what makes a flood of bad credentials cost the sender
-something. The limiter runs **behind authentication**, so the identity it counts under is the one authentication
-established, and **ahead of authorization**, so a request about to be refused for its credential has still spent capacity
-rather than being the one kind of traffic served without limit.
+something. The limiter runs **behind the certificate check and behind authentication**, so both identities are settled
+before it counts, and **ahead of authorization**, so a request about to be refused for its credential has still spent
+capacity rather than being the one kind of traffic served without limit.
 
 Readiness, liveness, and the root endpoint are outside all of this and keep answering while the MCP endpoint is refusing.
 

--- a/src/AppHost/OrchestrationContract.cs
+++ b/src/AppHost/OrchestrationContract.cs
@@ -38,6 +38,31 @@ public static class OrchestrationContract
     /// </remarks>
     public const string McpApiKey = "integration-tests-only-mcp-api-key";
 
+    /// <summary>The name the integration-test topology configures a second, deliberately expendable MCP API key under.</summary>
+    /// <remarks>
+    /// A rate limit is counted per client, so a test that exhausts one has to exhaust a client nothing else in the suite
+    /// depends on. This key exists to be spent: the burst that proves the limiter is wired takes it to zero, and
+    /// <see cref="McpApiKeyName" /> keeps its own capacity untouched, which is also what makes the partitions'
+    /// independence observable from outside the process.
+    /// </remarks>
+    public const string McpExpendableApiKeyName = "integration-tests-expendable";
+
+    /// <summary>The second MCP API key the integration-test topology's host accepts.</summary>
+    /// <remarks>A literal under the same restriction as <see cref="McpApiKey" />, and it authenticates the same ephemeral host.</remarks>
+    public const string McpExpendableApiKey = "integration-tests-only-mcp-expendable-key";
+
+    /// <summary>The burst one MCP client may spend in the integration-test topology before it is refused.</summary>
+    /// <remarks>
+    /// Declared here because the suite has to send more than this to observe a refusal, and a value that reached only
+    /// the app model would leave the burst either too small to refuse anything or needlessly large. It is deliberately
+    /// well above what any other test in the suite spends, and it is restored every
+    /// <see cref="McpRateLimitReplenishmentPeriod" />, so exhausting it disturbs nothing that runs afterwards.
+    /// </remarks>
+    public const int McpRateLimitTokenCapacity = 20;
+
+    /// <summary>How often the integration-test topology restores a client's spent MCP capacity.</summary>
+    public const string McpRateLimitReplenishmentPeriod = "00:00:01";
+
     /// <summary>The one browser origin the integration-test topology's MCP endpoint serves.</summary>
     /// <remarks>
     /// The topology narrows the origins deliberately rather than leaving the permissive default, because a suite that

--- a/src/AppHost/OrchestrationContract.cs
+++ b/src/AppHost/OrchestrationContract.cs
@@ -63,6 +63,16 @@ public static class OrchestrationContract
     /// <summary>How often the integration-test topology restores a client's spent MCP capacity.</summary>
     public const string McpRateLimitReplenishmentPeriod = "00:00:01";
 
+    /// <summary>How many MCP requests the integration-test topology's host serves at once, across every client.</summary>
+    /// <remarks>
+    /// Raised far above the product default, and above any burst the suite sends, so that the process-wide concurrency
+    /// limit cannot be what refuses a request. Left at the default it would sit at the same order as
+    /// <see cref="McpRateLimitTokenCapacity" />, and a burst large enough to exhaust a client's tokens would also exceed
+    /// the permits — leaving a test unable to say which of the two limiters answered, and passing even if the per-client
+    /// policy were never attached to the route.
+    /// </remarks>
+    public const int McpRateLimitMaxConcurrentRequests = 200;
+
     /// <summary>The one browser origin the integration-test topology's MCP endpoint serves.</summary>
     /// <remarks>
     /// The topology narrows the origins deliberately rather than leaving the permissive default, because a suite that

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -111,7 +111,12 @@ if (runsIntegrationTests)
             OrchestrationContract.McpRateLimitTokenCapacity.ToString(CultureInfo.InvariantCulture))
         .WithEnvironment(
             "McpEndpoint__RateLimiting__ReplenishmentPeriod",
-            OrchestrationContract.McpRateLimitReplenishmentPeriod);
+            OrchestrationContract.McpRateLimitReplenishmentPeriod)
+        // Raised rather than narrowed, so the concurrency limit cannot refuse anything the suite sends and a 429 it
+        // observes can only have come from the per-client bucket the route's policy carries.
+        .WithEnvironment(
+            "McpEndpoint__RateLimiting__MaxConcurrentRequests",
+            OrchestrationContract.McpRateLimitMaxConcurrentRequests.ToString(CultureInfo.InvariantCulture));
 }
 
 // Host is the startup project because it is the project resource the connection string is issued to; Infrastructure

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -1,5 +1,6 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
+using System.Globalization;
 using MailMcp.AppHost;
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -91,7 +92,26 @@ if (runsIntegrationTests)
         .WithEnvironment("McpEndpoint__Authentication", "ApiKey")
         .WithEnvironment("McpEndpoint__ApiKeys__0__Name", OrchestrationContract.McpApiKeyName)
         .WithEnvironment("McpEndpoint__ApiKeys__0__SecretReference", $"plaintext:{OrchestrationContract.McpApiKey}")
-        .WithEnvironment("McpEndpoint__Cors__AllowedOrigins__0", OrchestrationContract.McpPermittedOrigin);
+        // A second key exists to be spent. Rate limits are counted per client, so proving one is enforced means taking a
+        // client to zero, and doing that to the key every other test authenticates with would make this suite's results
+        // depend on the order it ran in.
+        .WithEnvironment("McpEndpoint__ApiKeys__1__Name", OrchestrationContract.McpExpendableApiKeyName)
+        .WithEnvironment(
+            "McpEndpoint__ApiKeys__1__SecretReference",
+            $"plaintext:{OrchestrationContract.McpExpendableApiKey}")
+        .WithEnvironment("McpEndpoint__Cors__AllowedOrigins__0", OrchestrationContract.McpPermittedOrigin)
+        // Narrowed from the product defaults for the same reason the origins are: a burst small enough to exhaust
+        // deliberately is what makes the difference between a limiter that is wired in and one that is not observable.
+        // The period is a second, so a spent client is whole again long before anything else in the suite runs.
+        .WithEnvironment(
+            "McpEndpoint__RateLimiting__TokenCapacity",
+            OrchestrationContract.McpRateLimitTokenCapacity.ToString(CultureInfo.InvariantCulture))
+        .WithEnvironment(
+            "McpEndpoint__RateLimiting__TokensPerReplenishmentPeriod",
+            OrchestrationContract.McpRateLimitTokenCapacity.ToString(CultureInfo.InvariantCulture))
+        .WithEnvironment(
+            "McpEndpoint__RateLimiting__ReplenishmentPeriod",
+            OrchestrationContract.McpRateLimitReplenishmentPeriod);
 }
 
 // Host is the startup project because it is the project resource the connection string is issued to; Infrastructure

--- a/src/Host/Configuration/McpEndpointOptions.cs
+++ b/src/Host/Configuration/McpEndpointOptions.cs
@@ -61,6 +61,10 @@ internal sealed class McpEndpointOptions
     /// </remarks>
     public IList<McpClientCertificateProfileOptions> ClientCertificateProfiles { get; } = [];
 
+    /// <summary>Gets or sets how much traffic the endpoint accepts before it starts refusing.</summary>
+    /// <remarks>Unlike the settings above, every value in this section has a product default, so an endpoint an operator enabled is bounded whether or not they wrote a number.</remarks>
+    public McpRateLimitingOptions RateLimiting { get; set; } = new();
+
     /// <summary>Reads the section the way composition does, defaults included.</summary>
     /// <param name="configuration">The application configuration.</param>
     /// <returns>The bound settings, with the defaults no binder can apply already applied.</returns>
@@ -109,6 +113,9 @@ internal sealed class McpEndpointOptions
 
         errors.AddRange(this.Cors.FindConfigurationErrors()
             .Select(error => $"{SectionName}:{nameof(this.Cors)}:{error}"));
+
+        errors.AddRange(this.RateLimiting.FindConfigurationErrors()
+            .Select(error => $"{SectionName}:{nameof(this.RateLimiting)}:{error}"));
 
         errors.AddRange(this.FindClientCertificateProfileErrors());
 

--- a/src/Host/Configuration/McpRateLimitingOptions.cs
+++ b/src/Host/Configuration/McpRateLimitingOptions.cs
@@ -54,6 +54,7 @@ internal sealed class McpRateLimitingOptions
     public TimeSpan ReplenishmentPeriod { get; set; } = McpRateLimits.Default.ReplenishmentPeriod;
 
     /// <summary>Gets or sets how many of one client's requests wait for capacity before the rest are refused.</summary>
+    /// <remarks>Has to stay below <see cref="MaxConcurrentRequests" />, because a request waiting here is already holding a concurrency permit.</remarks>
     public int RequestQueueLimit { get; set; } = McpRateLimits.Default.RequestQueueLimit;
 
     /// <summary>Finds everything an operator must fix before these limits can be applied.</summary>
@@ -140,6 +141,14 @@ internal sealed class McpRateLimitingOptions
         if (bothValuesAreUsable && this.TokensPerReplenishmentPeriod > this.TokenCapacity)
         {
             yield return $"{nameof(this.TokensPerReplenishmentPeriod)} — '{this.TokensPerReplenishmentPeriod}' restores more capacity than {nameof(this.TokenCapacity)} of '{this.TokenCapacity}' can hold, so the surplus is discarded on every replenishment and the rate written here is never the rate that applies; raise {nameof(this.TokenCapacity)} or lower this.";
+        }
+
+        var bothLimitsAreUsable = this.RequestQueueLimit is >= 0 and <= MaximumQueueLimit
+            && this.MaxConcurrentRequests is >= 1 and <= MaximumConcurrentRequests;
+
+        if (bothLimitsAreUsable && this.RequestQueueLimit >= this.MaxConcurrentRequests)
+        {
+            yield return $"{nameof(this.RequestQueueLimit)} — '{this.RequestQueueLimit}' is not below {nameof(this.MaxConcurrentRequests)} of '{this.MaxConcurrentRequests}', and a queued request holds a concurrency permit while it waits for its client's capacity to return; one client out of capacity could therefore hold every permit the process has until its next replenishment; lower this below {nameof(this.MaxConcurrentRequests)} or write 0 to refuse instead of queueing.";
         }
     }
 }

--- a/src/Host/Configuration/McpRateLimitingOptions.cs
+++ b/src/Host/Configuration/McpRateLimitingOptions.cs
@@ -1,0 +1,145 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Diagnostics.CodeAnalysis;
+using MailMcp.Infrastructure.Security;
+
+namespace MailMcp.Host.Configuration;
+
+/// <summary>How much MCP traffic the endpoint accepts before it starts refusing.</summary>
+/// <remarks>
+/// <para>
+/// Every setting here has a product default, so a deployment that writes none of them still runs bounded. That is the
+/// opposite of how the endpoint itself is configured — <see cref="McpEndpointOptions.Enabled" /> and
+/// <see cref="McpEndpointOptions.Authentication" /> have no safe default and refuse to be guessed — because the two
+/// questions are different. There is no such thing as a correct posture for who may read a mailbox, but there is such a
+/// thing as a sane bound on how fast one client may ask, and leaving the endpoint unbounded because nobody wrote a
+/// number is not a decision an operator made.
+/// </para>
+/// <para>
+/// Turning limiting off is therefore an explicit value rather than an omission, and it costs one startup warning. It is
+/// the right setting where something in front of the process already bounds the traffic and a second limit would only
+/// refuse requests the first one already shaped.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed class McpRateLimitingOptions
+{
+    private const int MaximumConcurrentRequests = 1000;
+
+    private const int MaximumQueueLimit = 1000;
+
+    private const int MaximumTokenCapacity = 1_000_000;
+
+    private static readonly TimeSpan ShortestReplenishmentPeriod = TimeSpan.FromSeconds(1);
+
+    private static readonly TimeSpan LongestReplenishmentPeriod = TimeSpan.FromHours(1);
+
+    /// <summary>Gets or sets whether the endpoint refuses traffic beyond the limits below.</summary>
+    /// <remarks>On unless a deployment states otherwise, so an endpoint someone enabled is bounded by the act of enabling it.</remarks>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Gets or sets how many MCP requests the process serves at once, across every client.</summary>
+    public int MaxConcurrentRequests { get; set; } = McpRateLimits.Default.MaxConcurrentRequests;
+
+    /// <summary>Gets or sets how many requests wait for a concurrency slot before the rest are refused.</summary>
+    public int ConcurrencyQueueLimit { get; set; } = McpRateLimits.Default.ConcurrencyQueueLimit;
+
+    /// <summary>Gets or sets the largest burst one client may spend at once.</summary>
+    public int TokenCapacity { get; set; } = McpRateLimits.Default.TokenCapacity;
+
+    /// <summary>Gets or sets how much of that burst one client gets back each <see cref="ReplenishmentPeriod" />.</summary>
+    public int TokensPerReplenishmentPeriod { get; set; } = McpRateLimits.Default.TokensPerReplenishmentPeriod;
+
+    /// <summary>Gets or sets how often a client's spent capacity is restored.</summary>
+    public TimeSpan ReplenishmentPeriod { get; set; } = McpRateLimits.Default.ReplenishmentPeriod;
+
+    /// <summary>Gets or sets how many of one client's requests wait for capacity before the rest are refused.</summary>
+    public int RequestQueueLimit { get; set; } = McpRateLimits.Default.RequestQueueLimit;
+
+    /// <summary>Finds everything an operator must fix before these limits can be applied.</summary>
+    /// <returns>One message per faulty setting, relative to this section, empty when the limits are usable.</returns>
+    /// <remarks>Every message is produced in one pass, so an operator who mistyped several numbers reads all of them rather than the first to be reached.</remarks>
+    public IReadOnlyList<string> FindConfigurationErrors()
+    {
+        if (!this.Enabled)
+        {
+            return [];
+        }
+
+        var errors = new List<string>();
+
+        errors.AddRange(this.FindRangeErrors());
+        errors.AddRange(this.FindCombinationErrors());
+
+        return errors;
+    }
+
+    /// <summary>Maps the configured settings onto the limits the endpoint runs under.</summary>
+    /// <returns>The limits.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
+    public McpRateLimits ToRateLimits()
+    {
+        try
+        {
+            return McpRateLimits.Create(
+                this.MaxConcurrentRequests,
+                this.ConcurrencyQueueLimit,
+                this.TokenCapacity,
+                this.TokensPerReplenishmentPeriod,
+                this.ReplenishmentPeriod,
+                this.RequestQueueLimit);
+        }
+        catch (ArgumentOutOfRangeException exception)
+        {
+            throw new InvalidOperationException(
+                "The configured rate limits were mapped before they were validated, so at least one of them is unusable.",
+                exception);
+        }
+    }
+
+    private IEnumerable<string> FindRangeErrors()
+    {
+        if (this.MaxConcurrentRequests is < 1 or > MaximumConcurrentRequests)
+        {
+            yield return $"{nameof(this.MaxConcurrentRequests)} — '{this.MaxConcurrentRequests}' is outside 1 to {MaximumConcurrentRequests}; the endpoint must serve at least one request at a time and cannot be told to serve an unbounded number.";
+        }
+
+        if (this.ConcurrencyQueueLimit is < 0 or > MaximumQueueLimit)
+        {
+            yield return $"{nameof(this.ConcurrencyQueueLimit)} — '{this.ConcurrencyQueueLimit}' is outside 0 to {MaximumQueueLimit}; write 0 to refuse a request the moment no slot is free, and any queue that waits instead has to be bounded.";
+        }
+
+        if (this.TokenCapacity is < 1 or > MaximumTokenCapacity)
+        {
+            yield return $"{nameof(this.TokenCapacity)} — '{this.TokenCapacity}' is outside 1 to {MaximumTokenCapacity}; a client that may spend nothing could never call a tool.";
+        }
+
+        if (this.TokensPerReplenishmentPeriod is < 1 or > MaximumTokenCapacity)
+        {
+            yield return $"{nameof(this.TokensPerReplenishmentPeriod)} — '{this.TokensPerReplenishmentPeriod}' is outside 1 to {MaximumTokenCapacity}; capacity that is never restored would refuse every client permanently once the first burst was spent.";
+        }
+
+        if (this.ReplenishmentPeriod < ShortestReplenishmentPeriod || this.ReplenishmentPeriod > LongestReplenishmentPeriod)
+        {
+            yield return $"{nameof(this.ReplenishmentPeriod)} — '{this.ReplenishmentPeriod}' is outside {ShortestReplenishmentPeriod} to {LongestReplenishmentPeriod}; a shorter period is below what the replenishment timer can resolve, and a longer one makes a spent burst look like an outage.";
+        }
+
+        if (this.RequestQueueLimit is < 0 or > MaximumQueueLimit)
+        {
+            yield return $"{nameof(this.RequestQueueLimit)} — '{this.RequestQueueLimit}' is outside 0 to {MaximumQueueLimit}; write 0 to refuse a request the moment a client is out of capacity, and any queue that waits instead has to be bounded.";
+        }
+    }
+
+    /// <summary>Reports settings that are each in range and wrong together.</summary>
+    /// <remarks>Reported only once both values are usable on their own, so a single mistyped number produces one message rather than two describing the same typo.</remarks>
+    private IEnumerable<string> FindCombinationErrors()
+    {
+        var bothValuesAreUsable = this.TokenCapacity is >= 1 and <= MaximumTokenCapacity
+            && this.TokensPerReplenishmentPeriod is >= 1 and <= MaximumTokenCapacity;
+
+        if (bothValuesAreUsable && this.TokensPerReplenishmentPeriod > this.TokenCapacity)
+        {
+            yield return $"{nameof(this.TokensPerReplenishmentPeriod)} — '{this.TokensPerReplenishmentPeriod}' restores more capacity than {nameof(this.TokenCapacity)} of '{this.TokenCapacity}' can hold, so the surplus is discarded on every replenishment and the rate written here is never the rate that applies; raise {nameof(this.TokenCapacity)} or lower this.";
+        }
+    }
+}

--- a/src/Host/Hosting/McpRateLimitingStartupReport.cs
+++ b/src/Host/Hosting/McpRateLimitingStartupReport.cs
@@ -1,0 +1,104 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Diagnostics.CodeAnalysis;
+using MailMcp.Host.Configuration;
+using MailMcp.Mcp;
+using Microsoft.Extensions.Options;
+
+namespace MailMcp.Host.Hosting;
+
+/// <summary>States at startup what bounds the MCP endpoint is serving under, or that it has none.</summary>
+/// <remarks>
+/// <para>
+/// The limits are the one part of this section that applies whether or not an operator wrote it down, so they are also
+/// the one part nobody would otherwise see. Reporting them makes a deployment running on defaults verifiable without
+/// reading the source, and makes a deployment running on a number somebody mistyped visible at the moment it starts
+/// rather than the first time a client is refused.
+/// </para>
+/// <para>
+/// Turning the limits off is reported as a warning, because from that point the endpoint will serve whatever it is
+/// asked for until something runs out. It is a defensible posture behind a proxy that already shapes the traffic, and
+/// an accident everywhere else, and only the operator can tell those apart.
+/// </para>
+/// <para>
+/// It reports what an operator configured and nothing about who is calling: no client name, no address, no origin. It
+/// runs as a hosted service so it appears among the other startup diagnostics, and it is registered whether or not the
+/// endpoint is enabled, because it is the report that decides whether it has anything to say.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this hosted service.")]
+internal sealed partial class McpRateLimitingStartupReport : IHostedService
+{
+    private readonly McpEndpointOptions endpointSettings;
+    private readonly ILogger<McpRateLimitingStartupReport> logger;
+
+    /// <summary>Initializes a new startup report.</summary>
+    /// <param name="endpointSettings">The endpoint settings startup was composed from.</param>
+    /// <param name="logger">The startup logger.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpointSettings" /> is <see langword="null" />.</exception>
+    public McpRateLimitingStartupReport(
+        IOptions<McpEndpointOptions> endpointSettings,
+        ILogger<McpRateLimitingStartupReport> logger)
+    {
+        ArgumentNullException.ThrowIfNull(endpointSettings);
+
+        this.endpointSettings = endpointSettings.Value;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!this.endpointSettings.Enabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        var rateLimitingSettings = this.endpointSettings.RateLimiting;
+
+        if (!rateLimitingSettings.Enabled)
+        {
+            this.LogEndpointServedWithoutRateLimits(McpEndpointRoute.Path);
+
+            return Task.CompletedTask;
+        }
+
+        this.LogEndpointRateLimits(
+            McpEndpointRoute.Path,
+            rateLimitingSettings.MaxConcurrentRequests,
+            rateLimitingSettings.ConcurrencyQueueLimit,
+            rateLimitingSettings.TokenCapacity,
+            rateLimitingSettings.TokensPerReplenishmentPeriod,
+            rateLimitingSettings.ReplenishmentPeriod,
+            rateLimitingSettings.RequestQueueLimit);
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The MCP endpoint is enabled on {McpEndpointPath} with rate limiting turned off, so one client can hold "
+            + "every database connection, response stream, and thread the process has until something runs out. This is "
+            + "the right setting only where something in front of this process already bounds the traffic reaching it. "
+            + "Remove McpEndpoint:RateLimiting:Enabled to run under the product defaults.")]
+    private partial void LogEndpointServedWithoutRateLimits(string mcpEndpointPath);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The MCP endpoint on {McpEndpointPath} serves at most {MaxConcurrentRequests} requests at once across "
+            + "every client, queueing {ConcurrencyQueueLimit} beyond that, and allows each client a burst of "
+            + "{TokenCapacity} requests restored at {TokensPerReplenishmentPeriod} every {ReplenishmentPeriod}, queueing "
+            + "{RequestQueueLimit} of its requests beyond that. The limits are counted in this process alone, so a "
+            + "deployment running several enforces them once per process rather than once in total.")]
+    private partial void LogEndpointRateLimits(
+        string mcpEndpointPath,
+        int maxConcurrentRequests,
+        int concurrencyQueueLimit,
+        int tokenCapacity,
+        int tokensPerReplenishmentPeriod,
+        TimeSpan replenishmentPeriod,
+        int requestQueueLimit);
+}

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -202,6 +202,7 @@ try
     // Registered whether or not the endpoint is enabled, because it is the warning that decides whether it has anything
     // to say. Registering it conditionally would put the same condition in two places.
     builder.Services.AddHostedService<MailMcp.Host.Hosting.McpTransportAuthenticationWarning>();
+    builder.Services.AddHostedService<MailMcp.Host.Hosting.McpRateLimitingStartupReport>();
 
     // Read once and registered, so the value that decides the route is the one every consumer resolves. Whether the
     // endpoint exists is decided while the application is being built, before a container that could resolve a snapshot
@@ -225,6 +226,13 @@ try
             mcpEndpointConfigurationErrors);
     }
 
+    // Mapped once, next to the decision that reads it, so the numbers the limiters are built from and the numbers the
+    // startup report states are the same reading of the same settings. Null means an operator turned limiting off, which
+    // is the one case in which no limiter is registered at all rather than one configured to permit everything.
+    var mcpRateLimits = mcpEndpointSettings is { Enabled: true, RateLimiting.Enabled: true }
+        ? mcpEndpointSettings.RateLimiting.ToRateLimits()
+        : null;
+
     if (mcpEndpointSettings.Enabled)
     {
         // The tools read the local mailbox copy through the use cases the infrastructure registration above already
@@ -238,6 +246,11 @@ try
             // is a decision the server has to take before it is listening rather than one a request can reach.
             builder.WebHost.RequestMcpClientCertificates();
         }
+    }
+
+    if (mcpRateLimits is not null)
+    {
+        builder.Services.AddMcpRateLimiting(mcpRateLimits);
     }
 
     var app = builder.Build();
@@ -267,9 +280,29 @@ try
             .MapMcp(McpEndpointRoute.Path)
             .RequireCors(McpTransportSecurityExtensions.CorsPolicyName);
 
-        if (mcpEndpointSettings.Authentication == McpTransportAuthenticationMode.ApiKey)
+        var authenticatesClients = mcpEndpointSettings.Authentication == McpTransportAuthenticationMode.ApiKey;
+
+        if (authenticatesClients)
         {
             app.UseAuthentication();
+        }
+
+        if (mcpRateLimits is not null)
+        {
+            // Behind authentication, so a per-client limit is counted under the identity that established rather than
+            // under something the caller chose, and ahead of authorization, so a request that is about to be refused for
+            // its credential still spends anonymous capacity — otherwise a flood of bad credentials would be the one
+            // kind of traffic the endpoint served without limit.
+            app.UseRateLimiter();
+
+            // On the endpoint for the same reason authorization is: the readiness and liveness endpoints have to keep
+            // answering while this one is refusing. The process-wide half of the policy cannot be attached here, because
+            // an endpoint resolves one limiter, so it rides on the global limiter and excludes every other route itself.
+            mcpEndpoint.RequireRateLimiting(McpRateLimiting.PolicyName);
+        }
+
+        if (authenticatesClients)
+        {
             app.UseAuthorization();
 
             // On the endpoint rather than as a fallback policy, so the readiness response and the health endpoints keep

--- a/src/Host/Security/McpClientCertificateIdentity.cs
+++ b/src/Host/Security/McpClientCertificateIdentity.cs
@@ -1,0 +1,34 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+namespace MailMcp.Host.Security;
+
+/// <summary>The client application a request's connection certificate identified.</summary>
+/// <remarks>
+/// <para>
+/// Carried as a request feature rather than as a claim, because the certificate is judged before authentication runs and
+/// <c>UseAuthentication</c> replaces the principal with the one its ticket carries — a claim set beforehand would be
+/// gone by the time anything downstream looked for it. A feature is the seam the pipeline already has for a fact one
+/// middleware established and a later one needs.
+/// </para>
+/// <para>
+/// It is present only when a profile actually matched a presented certificate. A request served because every profile
+/// was content without one carries no feature, because no client application was identified — the two are different
+/// answers and only the first names anybody.
+/// </para>
+/// </remarks>
+internal sealed class McpClientCertificateIdentity
+{
+    /// <summary>Records the profile whose client the connection certificate identified.</summary>
+    /// <param name="profileName">The matching profile's configured name.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="profileName" /> names no profile.</exception>
+    internal McpClientCertificateIdentity(string profileName)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(profileName);
+
+        this.ProfileName = profileName;
+    }
+
+    /// <summary>Gets the configured name of the profile the certificate matched.</summary>
+    /// <remarks>The operator's own name for a client application, never anything the certificate itself carried.</remarks>
+    internal string ProfileName { get; }
+}

--- a/src/Host/Security/McpClientCertificateValidation.cs
+++ b/src/Host/Security/McpClientCertificateValidation.cs
@@ -77,6 +77,14 @@ internal static class McpClientCertificateValidation
             return;
         }
 
+        // Published for the rate limiter, which keeps a client application's capacity apart under an authentication mode
+        // that establishes no other identity. Set only when a profile actually matched, because a request served on the
+        // strength of every profile being content without a certificate identifies nobody.
+        if (result.MatchedProfileName is { } matchedProfileName)
+        {
+            context.Features.Set(new McpClientCertificateIdentity(matchedProfileName));
+        }
+
         await next(context);
     }
 }

--- a/src/Host/Security/McpRateLimiting.cs
+++ b/src/Host/Security/McpRateLimiting.cs
@@ -1,0 +1,195 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Globalization;
+using System.Threading.RateLimiting;
+using MailMcp.Infrastructure.Security;
+using MailMcp.Mcp;
+using Microsoft.AspNetCore.RateLimiting;
+
+namespace MailMcp.Host.Security;
+
+/// <summary>Bounds what the MCP endpoint accepts, per process and per client.</summary>
+/// <remarks>
+/// <para>
+/// The two controls are attached to different parts of the framework, and the reason is a limitation worth stating
+/// rather than a preference. A named policy resolves to exactly one limiter, so two controls cannot share one; the
+/// per-client bucket takes the policy, because it is the one that belongs to this endpoint and the one whose name a
+/// metric should carry, and the process-wide concurrency limit rides on the global limiter, which is the only other
+/// place a limiter can be attached. Being global, it then has to exclude everything that is not this endpoint itself,
+/// which it does on the published route — the same test the origin check applies, for the same reason: readiness and
+/// liveness must keep answering while the endpoint is refusing.
+/// </para>
+/// <para>
+/// The global limiter is acquired first and the policy second, so a request that is out of client capacity has briefly
+/// held a concurrency slot before being refused. The slot is released on rejection and the default queue limits are
+/// zero, so nothing waits and nothing is held; a deployment that configures a concurrency queue should know that a
+/// request can wait in it and then still be refused for its own rate.
+/// </para>
+/// </remarks>
+internal static class McpRateLimiting
+{
+    /// <summary>The rate-limiting policy the MCP endpoint requires, named so the endpoint asks for this one and a metric can report it.</summary>
+    internal const string PolicyName = "MailMcpEndpoint";
+
+    /// <summary>The one partition every MCP request shares for the process-wide concurrency limit.</summary>
+    private const string ProcessPartitionKey = "mcp";
+
+    /// <summary>The partition standing for everything the process-wide limit does not apply to.</summary>
+    private const string UnlimitedPartitionKey = "unlimited";
+
+    /// <summary>The shortest retry a refusal asks for, so a client that is told to retry never reads it as "immediately".</summary>
+    private static readonly TimeSpan ShortestAdvertisedRetry = TimeSpan.FromSeconds(1);
+
+    /// <summary>Adds the limiters the endpoint runs under and the refusal they share.</summary>
+    /// <param name="services">The container to add to.</param>
+    /// <param name="limits">The limits composition read.</param>
+    /// <returns>The container, so composition reads as one sequence.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services" /> or <paramref name="limits" /> is <see langword="null" />.</exception>
+    internal static IServiceCollection AddMcpRateLimiting(this IServiceCollection services, McpRateLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(limits);
+
+        services.AddRateLimiter(rateLimiterOptions =>
+        {
+            rateLimiterOptions.GlobalLimiter = PartitionedRateLimiter.Create<HttpContext, string>(
+                httpContext => PartitionForProcess(httpContext, limits));
+
+            rateLimiterOptions.AddPolicy(PolicyName, httpContext => PartitionForClient(httpContext, limits));
+
+            rateLimiterOptions.OnRejected = RefuseAsync;
+        });
+
+        return services;
+    }
+
+    /// <summary>Names the process-wide concurrency partition an MCP request is served under.</summary>
+    /// <param name="httpContext">The request being admitted.</param>
+    /// <param name="limits">The limits the endpoint runs under.</param>
+    /// <returns>The one shared concurrency partition for an MCP request, and an unlimited partition for anything else.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpContext" /> or <paramref name="limits" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// One partition for every client rather than one each, because what it bounds is the process: the connections, the
+    /// threads, and the response streams a machine has one set of. Splitting it per client would let the total grow with
+    /// the number of clients, which is the opposite of what a concurrency limit is for.
+    /// </remarks>
+    internal static RateLimitPartition<string> PartitionForProcess(HttpContext httpContext, McpRateLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        ArgumentNullException.ThrowIfNull(limits);
+
+        if (!httpContext.Request.Path.StartsWithSegments(McpEndpointRoute.Path))
+        {
+            return RateLimitPartition.GetNoLimiter(UnlimitedPartitionKey);
+        }
+
+        return RateLimitPartition.GetConcurrencyLimiter(ProcessPartitionKey, _ => ProcessConcurrencyOptions(limits));
+    }
+
+    /// <summary>Describes the process-wide concurrency limiter the endpoint runs under.</summary>
+    /// <param name="limits">The limits the endpoint runs under.</param>
+    /// <returns>The limiter description.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="limits" /> is <see langword="null" />.</exception>
+    /// <remarks>Oldest first, so a queue that is configured drains in the order requests arrived rather than rewarding whichever client retried most recently.</remarks>
+    internal static ConcurrencyLimiterOptions ProcessConcurrencyOptions(McpRateLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(limits);
+
+        return new ConcurrencyLimiterOptions
+        {
+            PermitLimit = limits.MaxConcurrentRequests,
+            QueueLimit = limits.ConcurrencyQueueLimit,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+        };
+    }
+
+    /// <summary>Names the per-client partition a request spends capacity from.</summary>
+    /// <param name="httpContext">The request being admitted, after authentication has run.</param>
+    /// <param name="limits">The limits the endpoint runs under.</param>
+    /// <returns>The token bucket kept for the client this request authenticated as, or the shared anonymous one.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpContext" /> or <paramref name="limits" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// It reads the identity rather than the request, so it must run behind authentication; the composition root places
+    /// it there. A request whose credential was refused has no authenticated identity at this point and is counted under
+    /// the anonymous partition, which is what makes a flood of bad credentials cost the sender something.
+    /// </remarks>
+    internal static RateLimitPartition<string> PartitionForClient(HttpContext httpContext, McpRateLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+        ArgumentNullException.ThrowIfNull(limits);
+
+        return RateLimitPartition.GetTokenBucketLimiter(
+            McpRateLimitPartitions.KeyFor(AuthenticatedClientName(httpContext)),
+            _ => ClientBucketOptions(limits));
+    }
+
+    /// <summary>Describes the token bucket kept for one client.</summary>
+    /// <param name="limits">The limits the endpoint runs under.</param>
+    /// <returns>The limiter description.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="limits" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Replenishment is automatic, which is what makes a client's capacity return without anything in this process
+    /// having to remember to restore it. The framework's own timer owns that schedule; what is decided here is how much
+    /// comes back and how often, and how much a client may hold at once.
+    /// </remarks>
+    internal static TokenBucketRateLimiterOptions ClientBucketOptions(McpRateLimits limits)
+    {
+        ArgumentNullException.ThrowIfNull(limits);
+
+        return new TokenBucketRateLimiterOptions
+        {
+            AutoReplenishment = true,
+            TokenLimit = limits.TokenCapacity,
+            TokensPerPeriod = limits.TokensPerReplenishmentPeriod,
+            ReplenishmentPeriod = limits.ReplenishmentPeriod,
+            QueueLimit = limits.RequestQueueLimit,
+            QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+        };
+    }
+
+    /// <summary>Refuses a request that is over either limit.</summary>
+    /// <param name="context">The rejection the limiter reported.</param>
+    /// <param name="cancellationToken">Unused; the refusal writes no body and so cannot be interrupted part way.</param>
+    /// <returns>A completed task.</returns>
+    /// <remarks>
+    /// <para>
+    /// The response is a bare <c>429</c>. A body would have to say either nothing useful or something about the limits,
+    /// and the second is a description of the deployment that every refused caller would receive — including one whose
+    /// credential was refused a moment later, which must not learn that its name exists. What a client needs is the
+    /// status code and, where the limiter can compute one, how long to wait.
+    /// </para>
+    /// <para>
+    /// Only the token bucket can compute that; a concurrency limit has no scheduled moment at which a slot frees, so a
+    /// refusal for concurrency carries no <c>Retry-After</c> rather than a guess. The advertised value is never below a
+    /// second, because a client reading <c>Retry-After: 0</c> would retry into the same refusal without pausing.
+    /// </para>
+    /// </remarks>
+    internal static ValueTask RefuseAsync(OnRejectedContext context, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var response = context.HttpContext.Response;
+
+        response.StatusCode = StatusCodes.Status429TooManyRequests;
+        response.Headers.CacheControl = "no-store";
+
+        if (context.Lease.TryGetMetadata(MetadataName.RetryAfter, out var retryAfter))
+        {
+            var advertisedRetry = retryAfter < ShortestAdvertisedRetry ? ShortestAdvertisedRetry : retryAfter;
+
+            response.Headers.RetryAfter = ((int)Math.Ceiling(advertisedRetry.TotalSeconds))
+                .ToString(CultureInfo.InvariantCulture);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>Reads the name of the credential a request authenticated with.</summary>
+    /// <remarks>
+    /// An unauthenticated principal is what both an endpoint running without authentication and a request whose
+    /// credential was refused leave behind, and the two are deliberately indistinguishable here: the partition is a
+    /// question about capacity, not about why the identity is absent.
+    /// </remarks>
+    private static string? AuthenticatedClientName(HttpContext httpContext) =>
+        httpContext.User.Identity is { IsAuthenticated: true } identity ? identity.Name : null;
+}

--- a/src/Host/Security/McpRateLimiting.cs
+++ b/src/Host/Security/McpRateLimiting.cs
@@ -119,7 +119,9 @@ internal static class McpRateLimiting
         ArgumentNullException.ThrowIfNull(limits);
 
         return RateLimitPartition.GetTokenBucketLimiter(
-            McpRateLimitPartitions.KeyFor(AuthenticatedClientName(httpContext)),
+            McpRateLimitPartitions.KeyFor(
+                AuthenticatedClientName(httpContext),
+                httpContext.Features.Get<McpClientCertificateIdentity>()?.ProfileName),
             _ => ClientBucketOptions(limits));
     }
 

--- a/src/Host/Security/McpRateLimiting.cs
+++ b/src/Host/Security/McpRateLimiting.cs
@@ -25,6 +25,12 @@ namespace MailMcp.Host.Security;
 /// zero, so nothing waits and nothing is held; a deployment that configures a concurrency queue should know that a
 /// request can wait in it and then still be refused for its own rate.
 /// </para>
+/// <para>
+/// That order is also why a client queue cannot be as large as the concurrency limit, which
+/// <see cref="McpRateLimits" /> refuses to construct: a request waiting for its client's tokens keeps the concurrency
+/// permit it took on the way in, and would otherwise let one client out of capacity park every permit in the process
+/// until its next replenishment.
+/// </para>
 /// </remarks>
 internal static class McpRateLimiting
 {

--- a/src/Infrastructure/Security/McpRateLimitPartitions.cs
+++ b/src/Infrastructure/Security/McpRateLimitPartitions.cs
@@ -1,0 +1,58 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Infrastructure.Secrets;
+
+namespace MailMcp.Infrastructure.Security;
+
+/// <summary>Whose capacity an MCP request spends.</summary>
+/// <remarks>
+/// <para>
+/// A per-client limit needs a name to keep the count under, and which name it is decides whether the limit protects the
+/// endpoint or becomes the way to bring it down. Every partition a request can name is a dictionary entry the process
+/// keeps for as long as the limiter does, so a key an attacker chooses is memory an attacker allocates. This type
+/// therefore admits exactly one source of names: the identity authentication established. Nothing a caller writes into
+/// a header, a path, a query string, an <c>Origin</c>, or a user agent reaches a key, and no forwarded address does
+/// either, because a proxy header is chosen by whoever is upstream and trusting one is a separate design with its own
+/// review.
+/// </para>
+/// <para>
+/// Everything else shares one anonymous partition. That is deliberately coarse: under
+/// <c>None</c> there is no identity to tell one caller from another, so a single bucket is the only bound that cannot be
+/// grown by asking for it, and unauthenticated callers being able to exhaust each other's capacity is a smaller problem
+/// than unauthenticated callers being able to exhaust the process's memory. The same partition absorbs a request whose
+/// credential was refused, so a flood of bad credentials is counted and limited rather than served for free.
+/// </para>
+/// <para>
+/// The remote address is deliberately not part of any key, not even as a fallback. It is spoofable on the traffic this
+/// is aimed at, and one client behind a shared address would otherwise be limited by another's behaviour.
+/// </para>
+/// </remarks>
+public static class McpRateLimitPartitions
+{
+    /// <summary>The one partition every request without an authenticated identity is counted under.</summary>
+    /// <remarks>
+    /// <para>
+    /// The angle brackets are what keep it from being a client's partition as well. An authenticated request is counted
+    /// under the configured name itself, and <see cref="SecretName" /> accepts letters, digits, dots, hyphens, and
+    /// underscores — so a sentinel spelled in those characters could be claimed by an operator who named a key after it,
+    /// which would hand that one client the whole unauthenticated stream's capacity and hand unauthenticated callers
+    /// theirs. A bracketed value cannot be spelled as a name at all, and a test holds that grammar to it.
+    /// </para>
+    /// <para>
+    /// The value never appears in a response. It is a dictionary key inside one process, named so a log or a test can
+    /// refer to it.
+    /// </para>
+    /// </remarks>
+    public const string AnonymousKey = "<anonymous>";
+
+    /// <summary>Names the partition a request's capacity is taken from.</summary>
+    /// <param name="authenticatedClientName">The name of the credential the request authenticated with, or <see langword="null" /> when it authenticated with none.</param>
+    /// <returns>The configured name of the authenticated client, or <see cref="AnonymousKey" />.</returns>
+    /// <remarks>
+    /// The name is MailMcp's own configured identity for a credential, never the credential. It is chosen by the
+    /// operator who wrote the configuration, so the set of partitions an authenticated deployment keeps is as large as
+    /// the key list and no larger. A blank name is treated as no name at all rather than as a partition of its own.
+    /// </remarks>
+    public static string KeyFor(string? authenticatedClientName) =>
+        string.IsNullOrWhiteSpace(authenticatedClientName) ? AnonymousKey : authenticatedClientName;
+}

--- a/src/Infrastructure/Security/McpRateLimitPartitions.cs
+++ b/src/Infrastructure/Security/McpRateLimitPartitions.cs
@@ -23,6 +23,15 @@ namespace MailMcp.Infrastructure.Security;
 /// credential was refused, so a flood of bad credentials is counted and limited rather than served for free.
 /// </para>
 /// <para>
+/// Two identities can be established at once, and the rule between them is fixed rather than merged. A configured API
+/// key names one client of this deployment, which is what the operator partitioned their clients into; a client
+/// certificate profile names a client *application*, and several keys may sit behind one profile. Taking the key
+/// wherever there is one therefore keeps the partitions exactly as narrow as the key list, while taking the profile
+/// would let one key starve another that happens to share its certificate. Combining the two is the rule not taken: a
+/// pair-shaped key would hand the same credential a second bucket for every profile it could present under, which is
+/// capacity bought by holding one more certificate.
+/// </para>
+/// <para>
 /// The remote address is deliberately not part of any key, not even as a fallback. It is spoofable on the traffic this
 /// is aimed at, and one client behind a shared address would otherwise be limited by another's behaviour.
 /// </para>
@@ -47,12 +56,31 @@ public static class McpRateLimitPartitions
 
     /// <summary>Names the partition a request's capacity is taken from.</summary>
     /// <param name="authenticatedClientName">The name of the credential the request authenticated with, or <see langword="null" /> when it authenticated with none.</param>
-    /// <returns>The configured name of the authenticated client, or <see cref="AnonymousKey" />.</returns>
+    /// <param name="matchedCertificateProfileName">The name of the trust profile the connection certificate matched, or <see langword="null" /> when no certificate identified a client application.</param>
+    /// <returns>The configured name of the authenticated client, a partition of the identified client application, or <see cref="AnonymousKey" />.</returns>
     /// <remarks>
-    /// The name is MailMcp's own configured identity for a credential, never the credential. It is chosen by the
-    /// operator who wrote the configuration, so the set of partitions an authenticated deployment keeps is as large as
-    /// the key list and no larger. A blank name is treated as no name at all rather than as a partition of its own.
+    /// <para>
+    /// Both names are MailMcp's own configured identities, never a credential and never anything a certificate carried.
+    /// They are chosen by the operator who wrote the configuration, so the partitions an identified deployment keeps
+    /// number no more than its key list plus its profile list. A blank name is treated as no name at all rather than as
+    /// a partition of its own.
+    /// </para>
+    /// <para>
+    /// A profile's partition is bracketed and a key's is not, because the two grammars are the same — both accept
+    /// letters, digits, dots, dashes, and underscores — so a profile and a key sharing a name would otherwise share a
+    /// bucket. Under <c>ApiKey</c> both kinds occur at once, since a request whose credential was refused still reaches
+    /// this with the profile its certificate matched.
+    /// </para>
     /// </remarks>
-    public static string KeyFor(string? authenticatedClientName) =>
-        string.IsNullOrWhiteSpace(authenticatedClientName) ? AnonymousKey : authenticatedClientName;
+    public static string KeyFor(string? authenticatedClientName, string? matchedCertificateProfileName)
+    {
+        if (!string.IsNullOrWhiteSpace(authenticatedClientName))
+        {
+            return authenticatedClientName;
+        }
+
+        return string.IsNullOrWhiteSpace(matchedCertificateProfileName)
+            ? AnonymousKey
+            : $"<profile:{matchedCertificateProfileName}>";
+    }
 }

--- a/src/Infrastructure/Security/McpRateLimits.cs
+++ b/src/Infrastructure/Security/McpRateLimits.cs
@@ -1,0 +1,118 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+namespace MailMcp.Infrastructure.Security;
+
+/// <summary>How much MCP traffic one process serves, and how fast one client may ask for it.</summary>
+/// <remarks>
+/// <para>
+/// Two controls rather than one, because they bound different resources. The concurrency limit bounds what the process
+/// is doing at any instant — database connections, CPU, open response streams — and is shared by every client, since a
+/// machine has one set of them. The token bucket bounds how often a single client may ask, and is kept per client, so a
+/// client that goes into a loop spends its own capacity rather than everyone's.
+/// </para>
+/// <para>
+/// Both are in-process. Nothing here coordinates across instances, so a deployment running several processes enforces
+/// these numbers once per process rather than once in total, and none of it is protection against a distributed flood.
+/// The controls exist so that one misbehaving client cannot exhaust the resources of the process it is talking to.
+/// </para>
+/// <para>
+/// Queue limits default to zero throughout. A queued request is a request holding memory and a connection while it waits
+/// for capacity that is already gone, which turns an overload into a slower, larger overload; refusing it immediately
+/// tells the client to back off while the server is still healthy. A deployment that would rather absorb a short burst
+/// can configure a bounded queue, and bounded is the only shape available.
+/// </para>
+/// </remarks>
+public sealed class McpRateLimits
+{
+    private McpRateLimits(
+        int maxConcurrentRequests,
+        int concurrencyQueueLimit,
+        int tokenCapacity,
+        int tokensPerReplenishmentPeriod,
+        TimeSpan replenishmentPeriod,
+        int requestQueueLimit)
+    {
+        this.MaxConcurrentRequests = maxConcurrentRequests;
+        this.ConcurrencyQueueLimit = concurrencyQueueLimit;
+        this.TokenCapacity = tokenCapacity;
+        this.TokensPerReplenishmentPeriod = tokensPerReplenishmentPeriod;
+        this.ReplenishmentPeriod = replenishmentPeriod;
+        this.RequestQueueLimit = requestQueueLimit;
+    }
+
+    /// <summary>Gets the limits a deployment that configures nothing runs under.</summary>
+    /// <remarks>
+    /// The numbers are sized for the work an MCP request actually does here: every tool answers from the local mailbox
+    /// copy with a bounded query, so a request is short and database-bound rather than long and compute-bound. Twenty
+    /// concurrent requests keep the endpoint well inside the connection pool the synchronization workers share, and one
+    /// request per second with a sixty-request burst covers an agent that lists a page and then reads what it found
+    /// while still costing an unattended loop its capacity within a second.
+    /// </remarks>
+    public static McpRateLimits Default { get; } = Create(
+        maxConcurrentRequests: 20,
+        concurrencyQueueLimit: 0,
+        tokenCapacity: 60,
+        tokensPerReplenishmentPeriod: 60,
+        replenishmentPeriod: TimeSpan.FromMinutes(1),
+        requestQueueLimit: 0);
+
+    /// <summary>Gets how many MCP requests the process serves at once, across every client.</summary>
+    public int MaxConcurrentRequests { get; }
+
+    /// <summary>Gets how many requests wait for a concurrency slot before the rest are refused.</summary>
+    public int ConcurrencyQueueLimit { get; }
+
+    /// <summary>Gets the largest burst one client may spend at once.</summary>
+    public int TokenCapacity { get; }
+
+    /// <summary>Gets how much of that burst one client gets back each <see cref="ReplenishmentPeriod" />.</summary>
+    public int TokensPerReplenishmentPeriod { get; }
+
+    /// <summary>Gets how often a client's spent capacity is restored.</summary>
+    public TimeSpan ReplenishmentPeriod { get; }
+
+    /// <summary>Gets how many of one client's requests wait for capacity before the rest are refused.</summary>
+    public int RequestQueueLimit { get; }
+
+    /// <summary>Creates the limits an endpoint runs under.</summary>
+    /// <param name="maxConcurrentRequests">How many MCP requests the process serves at once.</param>
+    /// <param name="concurrencyQueueLimit">How many requests wait for a concurrency slot.</param>
+    /// <param name="tokenCapacity">The largest burst one client may spend at once.</param>
+    /// <param name="tokensPerReplenishmentPeriod">How much capacity one client gets back each period.</param>
+    /// <param name="replenishmentPeriod">How often a client's spent capacity is restored.</param>
+    /// <param name="requestQueueLimit">How many of one client's requests wait for capacity.</param>
+    /// <returns>The limits.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a value would leave the endpoint unbounded, unable to serve anything, or unable to recover the capacity it hands out.</exception>
+    /// <remarks>
+    /// The guards here are the invariants the type cannot exist without, not the ranges an operator is held to. A
+    /// deployment's settings are checked against those before they reach this method, so that an operator reads every
+    /// mistake at once instead of the first one to throw.
+    /// </remarks>
+    public static McpRateLimits Create(
+        int maxConcurrentRequests,
+        int concurrencyQueueLimit,
+        int tokenCapacity,
+        int tokensPerReplenishmentPeriod,
+        TimeSpan replenishmentPeriod,
+        int requestQueueLimit)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxConcurrentRequests, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(concurrencyQueueLimit);
+        ArgumentOutOfRangeException.ThrowIfLessThan(tokenCapacity, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(tokensPerReplenishmentPeriod, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(replenishmentPeriod, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfNegative(requestQueueLimit);
+
+        // A period that hands out more than the bucket holds is not a faster limit, it is a different one: the surplus
+        // is discarded on every replenishment, so the rate an operator wrote down is never the rate that applies.
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(tokensPerReplenishmentPeriod, tokenCapacity);
+
+        return new McpRateLimits(
+            maxConcurrentRequests,
+            concurrencyQueueLimit,
+            tokenCapacity,
+            tokensPerReplenishmentPeriod,
+            replenishmentPeriod,
+            requestQueueLimit);
+    }
+}

--- a/src/Infrastructure/Security/McpRateLimits.cs
+++ b/src/Infrastructure/Security/McpRateLimits.cs
@@ -21,6 +21,14 @@ namespace MailMcp.Infrastructure.Security;
 /// tells the client to back off while the server is still healthy. A deployment that would rather absorb a short burst
 /// can configure a bounded queue, and bounded is the only shape available.
 /// </para>
+/// <para>
+/// A client queue costs more than it looks like it does, which is why <see cref="RequestQueueLimit" /> is bounded by
+/// <see cref="MaxConcurrentRequests" /> rather than only by its own range. The two limiters are acquired in order, so a
+/// request waiting for its client's tokens has already taken a concurrency permit and holds it until the next
+/// replenishment — up to an hour away. Keeping the queue smaller than the permit count is what stops one client out of
+/// capacity from parking every permit the process has and refusing everyone else through a limit that is supposed to be
+/// its own.
+/// </para>
 /// </remarks>
 public sealed class McpRateLimits
 {
@@ -82,7 +90,7 @@ public sealed class McpRateLimits
     /// <param name="replenishmentPeriod">How often a client's spent capacity is restored.</param>
     /// <param name="requestQueueLimit">How many of one client's requests wait for capacity.</param>
     /// <returns>The limits.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when a value would leave the endpoint unbounded, unable to serve anything, or unable to recover the capacity it hands out.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a value would leave the endpoint unbounded, unable to serve anything, unable to recover the capacity it hands out, or able to let one client hold every concurrency permit.</exception>
     /// <remarks>
     /// The guards here are the invariants the type cannot exist without, not the ranges an operator is held to. A
     /// deployment's settings are checked against those before they reach this method, so that an operator reads every
@@ -106,6 +114,12 @@ public sealed class McpRateLimits
         // A period that hands out more than the bucket holds is not a faster limit, it is a different one: the surplus
         // is discarded on every replenishment, so the rate an operator wrote down is never the rate that applies.
         ArgumentOutOfRangeException.ThrowIfGreaterThan(tokensPerReplenishmentPeriod, tokenCapacity);
+
+        // A request waiting for its client's capacity is already holding a concurrency permit, because the two limiters
+        // are acquired in that order. A client queue as large as the permit count therefore lets one client out of
+        // tokens hold every permit the process has until its next replenishment, which is the isolation these two
+        // controls exist to provide, inverted.
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(requestQueueLimit, maxConcurrentRequests);
 
         return new McpRateLimits(
             maxConcurrentRequests,

--- a/tests/Host.UnitTests/McpClientCertificateValidationTests.cs
+++ b/tests/Host.UnitTests/McpClientCertificateValidationTests.cs
@@ -63,6 +63,56 @@ public sealed class McpClientCertificateValidationTests
         Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
     }
 
+    /// <summary>
+    /// The matched profile is the only identity a deployment authenticating with no API key has, and the rate limiter
+    /// reads it from this feature to keep one client application's capacity apart from another's. Nothing else carries
+    /// it: the certificate is judged before authentication runs, and <c>UseAuthentication</c> replaces the principal, so
+    /// a claim set here would be gone by the time the limiter looked.
+    /// </summary>
+    [Fact]
+    public async Task ServeWhenTheConnectionCertificateIsAccepted_AMatchedProfile_PublishesTheClientItIdentified()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Client Root");
+        using var clientCertificate = TestCertificates.IssueClientAuthenticationCertificate(authority, ClientDnsName);
+        var context = RequestCarrying(clientCertificate);
+
+        // Act
+        await McpClientCertificateValidation.ServeWhenTheConnectionCertificateIsAcceptedAsync(
+            context,
+            _ => Task.CompletedTask,
+            AuthenticatorTrusting(authority),
+            [RequiredProfile()]);
+
+        // Assert
+        var identity = context.Features.Get<McpClientCertificateIdentity>();
+        Assert.NotNull(identity);
+        Assert.Equal(RequiredProfile().Name, identity.ProfileName);
+    }
+
+    /// <summary>
+    /// A request served because every profile was content without a certificate identified nobody, so publishing a
+    /// client would name one the deployment never saw — and would give unauthenticated traffic a partition of its own.
+    /// </summary>
+    [Fact]
+    public async Task ServeWhenTheConnectionCertificateIsAccepted_NoCertificateAndNoProfileRequiringOne_PublishesNoClient()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Client Root");
+        var context = RequestCarrying(connectionCertificate: null);
+
+        // Act
+        await McpClientCertificateValidation.ServeWhenTheConnectionCertificateIsAcceptedAsync(
+            context,
+            _ => Task.CompletedTask,
+            AuthenticatorTrusting(authority),
+            [OptionalProfile()]);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.Null(context.Features.Get<McpClientCertificateIdentity>());
+    }
+
     /// <summary>The certificate a request claims in a header is not a certificate; it is a value the sender wrote.</summary>
     [Fact]
     public async Task ServeWhenTheConnectionCertificateIsAccepted_AValidCertificateOfferedInAHeader_RefusesTheRequest()
@@ -144,6 +194,13 @@ public sealed class McpClientCertificateValidationTests
         McpClientCertificateTrustProfile.Create(
             "client",
             McpClientCertificateRequirement.Required,
+            [new ConfiguredSecret { Name = "client-ca", SecretReference = "file:/run/secrets/client-ca.pem" }],
+            [ClientDnsName]);
+
+    private static McpClientCertificateTrustProfile OptionalProfile() =>
+        McpClientCertificateTrustProfile.Create(
+            "client",
+            McpClientCertificateRequirement.Optional,
             [new ConfiguredSecret { Name = "client-ca", SecretReference = "file:/run/secrets/client-ca.pem" }],
             [ClientDnsName]);
 

--- a/tests/Host.UnitTests/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/McpEndpointOptionsBindingTests.cs
@@ -41,6 +41,10 @@ public sealed class McpEndpointOptionsBindingTests
             ["McpEndpoint:ApiKeys:1:Lifetime"] = "2027-01-31T00:00:00Z",
             ["McpEndpoint:Cors:AllowedOrigins:0"] = "https://client.example.test",
             ["McpEndpoint:Cors:AllowedOrigins:1"] = "https://console.example.test:8443",
+            ["McpEndpoint:RateLimiting:MaxConcurrentRequests"] = "12",
+            ["McpEndpoint:RateLimiting:TokenCapacity"] = "40",
+            ["McpEndpoint:RateLimiting:TokensPerReplenishmentPeriod"] = "10",
+            ["McpEndpoint:RateLimiting:ReplenishmentPeriod"] = "00:00:30",
         });
 
         // Act
@@ -56,6 +60,37 @@ public sealed class McpEndpointOptionsBindingTests
         Assert.Equal(
             ["https://client.example.test", "https://console.example.test:8443"],
             options.Cors.AllowedOrigins);
+        Assert.Equal(12, options.RateLimiting.MaxConcurrentRequests);
+        Assert.Equal(40, options.RateLimiting.TokenCapacity);
+        Assert.Equal(10, options.RateLimiting.TokensPerReplenishmentPeriod);
+        Assert.Equal(TimeSpan.FromSeconds(30), options.RateLimiting.ReplenishmentPeriod);
+        Assert.Empty(options.FindConfigurationErrors());
+    }
+
+    /// <summary>
+    /// The limits are the one part of this section with product defaults, so an operator narrowing a single value must
+    /// not silently reset the rest to zero the way a partially bound section otherwise would.
+    /// </summary>
+    [Fact]
+    public void ReadFrom_OneConfiguredLimit_LeavesTheRemainingLimitsAtTheirDefaults()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["McpEndpoint:Enabled"] = "true",
+            ["McpEndpoint:Authentication"] = "None",
+            ["McpEndpoint:RateLimiting:MaxConcurrentRequests"] = "5",
+        });
+
+        // Act
+        var options = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        var defaults = new McpRateLimitingOptions();
+        Assert.Equal(5, options.RateLimiting.MaxConcurrentRequests);
+        Assert.Equal(defaults.TokenCapacity, options.RateLimiting.TokenCapacity);
+        Assert.Equal(defaults.TokensPerReplenishmentPeriod, options.RateLimiting.TokensPerReplenishmentPeriod);
+        Assert.Equal(defaults.ReplenishmentPeriod, options.RateLimiting.ReplenishmentPeriod);
         Assert.Empty(options.FindConfigurationErrors());
     }
 
@@ -148,6 +183,9 @@ public sealed class McpEndpointOptionsBindingTests
     [InlineData("McpEndpoint:Authentication ", "None")]
     [InlineData("McpEndpoint:ApiKey", "workstation")]
     [InlineData("McpEndpoint:Cors:AllowedOrigin", "https://client.example.test")]
+    [InlineData("McpEndpoint:RateLimiting:Enabeld", "false")]
+    [InlineData("McpEndpoint:RateLimiting:MaxConcurrentRequest", "5")]
+    [InlineData("McpEndpoint:RateLimit:MaxConcurrentRequests", "5")]
     public void ReadFrom_AnUnrecognizedKey_FailsRatherThanBeingIgnored(string key, string value)
     {
         // Arrange

--- a/tests/Host.UnitTests/McpEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/McpEndpointOptionsTests.cs
@@ -144,6 +144,37 @@ public sealed class McpEndpointOptionsTests
         Assert.StartsWith("McpEndpoint:Cors:AllowedOrigins", error, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void FindConfigurationErrors_AnUnusableRateLimit_IsReportedUnderTheSectionThatCarriesIt()
+    {
+        // Arrange
+        var options = EnabledWith(McpTransportAuthenticationMode.None);
+        options.RateLimiting.MaxConcurrentRequests = 0;
+
+        // Act
+        var error = Assert.Single(options.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith("McpEndpoint:RateLimiting:MaxConcurrentRequests", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The limits apply to an enabled endpoint whether or not an operator wrote any of them down, so a section nobody
+    /// configured has to pass validation rather than demanding numbers the product already has.
+    /// </summary>
+    [Fact]
+    public void FindConfigurationErrors_AnEndpointConfiguringNoLimits_ReportsNothing()
+    {
+        // Arrange
+        var options = EnabledWith(McpTransportAuthenticationMode.None);
+
+        // Act
+        var errors = options.FindConfigurationErrors();
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
     /// <summary>Every fault is reported together, so an operator fixing a section reads all of it rather than one restart at a time.</summary>
     [Fact]
     public void FindConfigurationErrors_SeveralFaults_ReportsThemAllAtOnce()

--- a/tests/Host.UnitTests/McpRateLimitingOptionsTests.cs
+++ b/tests/Host.UnitTests/McpRateLimitingOptionsTests.cs
@@ -1,0 +1,224 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Host.Configuration;
+using MailMcp.Infrastructure.Security;
+using Xunit;
+
+namespace MailMcp.Host.UnitTests;
+
+public sealed class McpRateLimitingOptionsTests
+{
+    [Fact]
+    public void Enabled_WithNothingConfigured_BoundsTheEndpoint()
+    {
+        // Act
+        var settings = new McpRateLimitingOptions();
+
+        // Assert
+        Assert.True(settings.Enabled);
+    }
+
+    [Fact]
+    public void Defaults_WithNothingConfigured_AreTheProductLimits()
+    {
+        // Arrange
+        var expected = McpRateLimits.Default;
+
+        // Act
+        var settings = new McpRateLimitingOptions();
+
+        // Assert
+        Assert.Equal(expected.MaxConcurrentRequests, settings.MaxConcurrentRequests);
+        Assert.Equal(expected.ConcurrencyQueueLimit, settings.ConcurrencyQueueLimit);
+        Assert.Equal(expected.TokenCapacity, settings.TokenCapacity);
+        Assert.Equal(expected.TokensPerReplenishmentPeriod, settings.TokensPerReplenishmentPeriod);
+        Assert.Equal(expected.ReplenishmentPeriod, settings.ReplenishmentPeriod);
+        Assert.Equal(expected.RequestQueueLimit, settings.RequestQueueLimit);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_WithNothingConfigured_ReportsNothing()
+    {
+        // Arrange
+        var settings = new McpRateLimitingOptions();
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_WhenLimitingIsOff_LeavesTheRemainingValuesAlone()
+    {
+        // Arrange
+        var settings = new McpRateLimitingOptions
+        {
+            Enabled = false,
+            MaxConcurrentRequests = 0,
+            TokenCapacity = -5,
+            ReplenishmentPeriod = TimeSpan.Zero,
+        };
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Theory]
+    [InlineData(nameof(McpRateLimitingOptions.MaxConcurrentRequests), 0)]
+    [InlineData(nameof(McpRateLimitingOptions.MaxConcurrentRequests), -1)]
+    [InlineData(nameof(McpRateLimitingOptions.MaxConcurrentRequests), 1001)]
+    [InlineData(nameof(McpRateLimitingOptions.ConcurrencyQueueLimit), -1)]
+    [InlineData(nameof(McpRateLimitingOptions.ConcurrencyQueueLimit), 1001)]
+    [InlineData(nameof(McpRateLimitingOptions.TokenCapacity), 0)]
+    [InlineData(nameof(McpRateLimitingOptions.TokenCapacity), 1_000_001)]
+    [InlineData(nameof(McpRateLimitingOptions.TokensPerReplenishmentPeriod), 0)]
+    [InlineData(nameof(McpRateLimitingOptions.RequestQueueLimit), -1)]
+    [InlineData(nameof(McpRateLimitingOptions.RequestQueueLimit), 1001)]
+    public void FindConfigurationErrors_WithAnOutOfRangeValue_NamesTheSetting(string settingName, int configuredValue)
+    {
+        // Arrange
+        var settings = new McpRateLimitingOptions();
+        ApplyCountSetting(settings, settingName, configuredValue);
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.StartsWith(settingName, error, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(3601)]
+    public void FindConfigurationErrors_WithAnUnusableReplenishmentPeriod_NamesTheSetting(int configuredSeconds)
+    {
+        // Arrange
+        var settings = new McpRateLimitingOptions { ReplenishmentPeriod = TimeSpan.FromSeconds(configuredSeconds) };
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.StartsWith(nameof(McpRateLimitingOptions.ReplenishmentPeriod), error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_RestoringMoreThanTheBucketHolds_ReportsTheCombination()
+    {
+        // Arrange
+        var settings = new McpRateLimitingOptions { TokenCapacity = 10, TokensPerReplenishmentPeriod = 11 };
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.StartsWith(nameof(McpRateLimitingOptions.TokensPerReplenishmentPeriod), error, StringComparison.Ordinal);
+        Assert.Contains(nameof(McpRateLimitingOptions.TokenCapacity), error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_WithOneMistypedCapacity_ReportsItOnce()
+    {
+        // Arrange
+        // Zero capacity is out of range and is also below the tokens restored each period; reporting both would describe
+        // one typo twice and send an operator looking for a second mistake they did not make.
+        var settings = new McpRateLimitingOptions { TokenCapacity = 0 };
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.StartsWith(nameof(McpRateLimitingOptions.TokenCapacity), error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_WithSeveralMistakes_ReportsEveryOne()
+    {
+        // Arrange
+        var settings = new McpRateLimitingOptions
+        {
+            MaxConcurrentRequests = 0,
+            ConcurrencyQueueLimit = -1,
+            RequestQueueLimit = -1,
+        };
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        Assert.Equal(3, errors.Count);
+    }
+
+    [Fact]
+    public void ToRateLimits_WithConfiguredValues_CarriesEveryOne()
+    {
+        // Arrange
+        var settings = new McpRateLimitingOptions
+        {
+            MaxConcurrentRequests = 9,
+            ConcurrencyQueueLimit = 4,
+            TokenCapacity = 30,
+            TokensPerReplenishmentPeriod = 5,
+            ReplenishmentPeriod = TimeSpan.FromSeconds(20),
+            RequestQueueLimit = 1,
+        };
+
+        // Act
+        var limits = settings.ToRateLimits();
+
+        // Assert
+        Assert.Equal(9, limits.MaxConcurrentRequests);
+        Assert.Equal(4, limits.ConcurrencyQueueLimit);
+        Assert.Equal(30, limits.TokenCapacity);
+        Assert.Equal(5, limits.TokensPerReplenishmentPeriod);
+        Assert.Equal(TimeSpan.FromSeconds(20), limits.ReplenishmentPeriod);
+        Assert.Equal(1, limits.RequestQueueLimit);
+    }
+
+    [Fact]
+    public void ToRateLimits_BeforeValidation_RefusesToMapAnUnusableValue()
+    {
+        // Arrange
+        var settings = new McpRateLimitingOptions { MaxConcurrentRequests = 0 };
+
+        // Act, Assert
+        Assert.Throws<InvalidOperationException>(settings.ToRateLimits);
+    }
+
+    private static void ApplyCountSetting(McpRateLimitingOptions settings, string settingName, int configuredValue)
+    {
+        switch (settingName)
+        {
+            case nameof(McpRateLimitingOptions.MaxConcurrentRequests):
+                settings.MaxConcurrentRequests = configuredValue;
+                break;
+            case nameof(McpRateLimitingOptions.ConcurrencyQueueLimit):
+                settings.ConcurrencyQueueLimit = configuredValue;
+                break;
+            case nameof(McpRateLimitingOptions.TokenCapacity):
+                settings.TokenCapacity = configuredValue;
+                // Kept at or below the capacity under test, so the assertion reads the range error rather than the
+                // combination error a default of sixty tokens per period would also produce.
+                settings.TokensPerReplenishmentPeriod = 1;
+                break;
+            case nameof(McpRateLimitingOptions.TokensPerReplenishmentPeriod):
+                settings.TokensPerReplenishmentPeriod = configuredValue;
+                break;
+            case nameof(McpRateLimitingOptions.RequestQueueLimit):
+                settings.RequestQueueLimit = configuredValue;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(settingName), settingName, "The test names no such setting.");
+        }
+    }
+}

--- a/tests/Host.UnitTests/McpRateLimitingOptionsTests.cs
+++ b/tests/Host.UnitTests/McpRateLimitingOptionsTests.cs
@@ -126,6 +126,51 @@ public sealed class McpRateLimitingOptionsTests
     }
 
     [Fact]
+    public void FindConfigurationErrors_WithAClientQueueThatCouldHoldEveryPermit_ReportsTheCombination()
+    {
+        // Arrange
+        // The two limiters are acquired in order, so a request waiting for its client's capacity is already holding a
+        // concurrency permit. A queue this size lets one client out of tokens park every permit the process has.
+        var settings = new McpRateLimitingOptions { MaxConcurrentRequests = 4, RequestQueueLimit = 4 };
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.StartsWith(nameof(McpRateLimitingOptions.RequestQueueLimit), error, StringComparison.Ordinal);
+        Assert.Contains(nameof(McpRateLimitingOptions.MaxConcurrentRequests), error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_WithAClientQueueBelowThePermitCount_ReportsNothing()
+    {
+        // Arrange
+        var settings = new McpRateLimitingOptions { MaxConcurrentRequests = 4, RequestQueueLimit = 3 };
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_WithOneMistypedQueueLimit_ReportsItOnce()
+    {
+        // Arrange
+        // A queue beyond its own range is also beyond the permit count; reporting both would describe one typo twice.
+        var settings = new McpRateLimitingOptions { RequestQueueLimit = 1001 };
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.StartsWith(nameof(McpRateLimitingOptions.RequestQueueLimit), error, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void FindConfigurationErrors_WithOneMistypedCapacity_ReportsItOnce()
     {
         // Arrange

--- a/tests/Host.UnitTests/McpRateLimitingStartupReportTests.cs
+++ b/tests/Host.UnitTests/McpRateLimitingStartupReportTests.cs
@@ -1,0 +1,153 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Host.Configuration;
+using MailMcp.Host.Hosting;
+using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
+using MailMcp.TestSupport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MailMcp.Host.UnitTests;
+
+/// <summary>Covers what an operator is told about the bounds an enabled endpoint serves under.</summary>
+/// <remarks>
+/// The limits apply whether or not anyone configured them, which makes this report the only place a deployment running
+/// on defaults can read what it is actually enforcing. Turning them off is the case the report exists for: from that
+/// point the endpoint serves whatever it is asked for, and nothing else in the process would say so.
+/// </remarks>
+public sealed class McpRateLimitingStartupReportTests
+{
+    [Fact]
+    public async Task StartAsync_DisabledEndpoint_SaysNothing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(new McpEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledEndpointWithoutRateLimits_WarnsThatNothingBoundsTheTraffic()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(EnabledEndpoint(new McpRateLimitingOptions { Enabled = false }), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("rate limiting turned off", record.Message, StringComparison.Ordinal);
+        Assert.Equal("/mcp", Assert.Contains("McpEndpointPath", record.Properties));
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledEndpointWithRateLimits_StatesEveryLimitInForce()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(
+            EnabledEndpoint(new McpRateLimitingOptions
+            {
+                MaxConcurrentRequests = 12,
+                ConcurrencyQueueLimit = 3,
+                TokenCapacity = 40,
+                TokensPerReplenishmentPeriod = 10,
+                ReplenishmentPeriod = TimeSpan.FromSeconds(30),
+                RequestQueueLimit = 2,
+            }),
+            logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.Equal(12, Assert.Contains("MaxConcurrentRequests", record.Properties));
+        Assert.Equal(3, Assert.Contains("ConcurrencyQueueLimit", record.Properties));
+        Assert.Equal(40, Assert.Contains("TokenCapacity", record.Properties));
+        Assert.Equal(10, Assert.Contains("TokensPerReplenishmentPeriod", record.Properties));
+        Assert.Equal(TimeSpan.FromSeconds(30), Assert.Contains("ReplenishmentPeriod", record.Properties));
+        Assert.Equal(2, Assert.Contains("RequestQueueLimit", record.Properties));
+    }
+
+    [Fact]
+    public async Task StartAsync_EnabledEndpointWithNothingConfigured_StatesTheDefaultsRatherThanStayingSilent()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(EnabledEndpoint(new McpRateLimitingOptions()), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        // A deployment that wrote no numbers is the one running on limits nobody has seen, so it is the one that most
+        // needs them reported.
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.Equal(
+            McpRateLimits.Default.MaxConcurrentRequests,
+            Assert.Contains("MaxConcurrentRequests", record.Properties));
+    }
+
+    [Fact]
+    public async Task StartAsync_WithApiKeysConfigured_NamesNoClient()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var endpointSettings = EnabledEndpoint(new McpRateLimitingOptions());
+        endpointSettings.Authentication = McpTransportAuthenticationMode.ApiKey;
+        endpointSettings.ApiKeys.Add(new ConfiguredSecret { Name = "desktop-agent" });
+        var report = ReportFor(endpointSettings, logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        // The report describes the deployment's own limits and never who is calling or who may call.
+        var record = Assert.Single(logs.Records);
+        Assert.DoesNotContain("desktop-agent", record.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StopAsync_AfterReporting_SaysNothingFurther()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(EnabledEndpoint(new McpRateLimitingOptions { Enabled = false }), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+        await report.StopAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(logs.Records);
+    }
+
+    private static McpEndpointOptions EnabledEndpoint(McpRateLimitingOptions rateLimitingSettings) => new()
+    {
+        Enabled = true,
+        Authentication = McpTransportAuthenticationMode.None,
+        RateLimiting = rateLimitingSettings,
+    };
+
+    private static McpRateLimitingStartupReport ReportFor(McpEndpointOptions settings, RecordingLoggerProvider logs)
+    {
+        using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(logs));
+
+        return new McpRateLimitingStartupReport(
+            Options.Create(settings),
+            loggerFactory.CreateLogger<McpRateLimitingStartupReport>());
+    }
+}

--- a/tests/Host.UnitTests/McpRateLimitingTests.cs
+++ b/tests/Host.UnitTests/McpRateLimitingTests.cs
@@ -14,13 +14,14 @@ namespace MailMcp.Host.UnitTests;
 
 /// <summary>Covers the limits the MCP endpoint admits traffic under.</summary>
 /// <remarks>
-/// Nothing here observes a clock. The configured replenishment period is a minute throughout, so every test finishes
-/// inside one period and no capacity returns part way through an assertion; what a replenishment restores is asserted
-/// against the limiter description the endpoint is built from rather than by waiting for one, because
-/// <c>TokenBucketRateLimiter.TryReplenish</c> is itself gated on elapsed wall-clock time and a test that drove it would
-/// be a test of the clock. Restoring capacity on that schedule is the framework's own contract; what belongs here is
-/// that the schedule reaching it is the one an operator configured, and that automatic replenishment is on so nothing
-/// in this process has to pump it.
+/// Nothing here observes a clock, and nothing here is raced by one. A test that spends a client's capacity builds its
+/// bucket with the replenishment timer off, so a process that is suspended, debugged, or merely slow between two
+/// assertions cannot have capacity returned underneath it and turn an expected refusal into a pass. That leaves
+/// replenishment itself untested by construction, which is deliberate: <c>TokenBucketRateLimiter.TryReplenish</c> is
+/// gated on elapsed wall-clock time, so driving it would be a test of the clock. Restoring capacity on schedule is the
+/// framework's own contract; what belongs here is that the schedule reaching it is the one an operator configured, and
+/// that automatic replenishment is on in production so nothing in this process has to pump it — both asserted against
+/// the limiter description the endpoint is built from.
 /// </remarks>
 public sealed class McpRateLimitingTests
 {
@@ -465,9 +466,33 @@ public sealed class McpRateLimitingTests
         PartitionedRateLimiter.Create<HttpContext, string>(
             httpContext => McpRateLimiting.PartitionForProcess(httpContext, limits));
 
+    /// <summary>
+    /// Builds the endpoint's own partitions, with the replenishment timer left off so a test that spends capacity is
+    /// not racing it.
+    /// </summary>
+    /// <remarks>
+    /// The partition key is the one <see cref="McpRateLimiting.PartitionForClient" /> computed, because which client a
+    /// request is counted under is what these tests are about, and the bucket is the one
+    /// <see cref="McpRateLimiting.ClientBucketOptions" /> described apart from
+    /// <see cref="TokenBucketRateLimiterOptions.AutoReplenishment" />. That the endpoint leaves it on is asserted
+    /// against those options directly, which is the only place it can be asserted without waiting for a clock.
+    /// </remarks>
     private static PartitionedRateLimiter<HttpContext> ClientLimiter(McpRateLimits limits) =>
-        PartitionedRateLimiter.Create<HttpContext, string>(
-            httpContext => McpRateLimiting.PartitionForClient(httpContext, limits));
+        PartitionedRateLimiter.Create<HttpContext, string>(httpContext =>
+            RateLimitPartition.GetTokenBucketLimiter(
+                McpRateLimiting.PartitionForClient(httpContext, limits).PartitionKey,
+                _ => WithoutTheReplenishmentTimer(McpRateLimiting.ClientBucketOptions(limits))));
+
+    private static TokenBucketRateLimiterOptions WithoutTheReplenishmentTimer(TokenBucketRateLimiterOptions options) =>
+        new()
+        {
+            AutoReplenishment = false,
+            TokenLimit = options.TokenLimit,
+            TokensPerPeriod = options.TokensPerPeriod,
+            ReplenishmentPeriod = options.ReplenishmentPeriod,
+            QueueLimit = options.QueueLimit,
+            QueueProcessingOrder = options.QueueProcessingOrder,
+        };
 
     private static DefaultHttpContext McpRequest(
         string? authenticatedClientName = null,

--- a/tests/Host.UnitTests/McpRateLimitingTests.cs
+++ b/tests/Host.UnitTests/McpRateLimitingTests.cs
@@ -1,0 +1,474 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Security.Claims;
+using System.Threading.RateLimiting;
+using MailMcp.Host.Security;
+using MailMcp.Infrastructure.Security;
+using MailMcp.Mcp;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace MailMcp.Host.UnitTests;
+
+/// <summary>Covers the limits the MCP endpoint admits traffic under.</summary>
+/// <remarks>
+/// Nothing here observes a clock. The configured replenishment period is a minute throughout, so every test finishes
+/// inside one period and no capacity returns part way through an assertion; what a replenishment restores is asserted
+/// against the limiter description the endpoint is built from rather than by waiting for one, because
+/// <c>TokenBucketRateLimiter.TryReplenish</c> is itself gated on elapsed wall-clock time and a test that drove it would
+/// be a test of the clock. Restoring capacity on that schedule is the framework's own contract; what belongs here is
+/// that the schedule reaching it is the one an operator configured, and that automatic replenishment is on so nothing
+/// in this process has to pump it.
+/// </remarks>
+public sealed class McpRateLimitingTests
+{
+    [Fact]
+    public void ProcessConcurrencyOptions_CarriesTheConfiguredConcurrency()
+    {
+        // Arrange
+        var limits = Limits(maxConcurrentRequests: 9, concurrencyQueueLimit: 4);
+
+        // Act
+        var limiterOptions = McpRateLimiting.ProcessConcurrencyOptions(limits);
+
+        // Assert
+        Assert.Equal(9, limiterOptions.PermitLimit);
+        Assert.Equal(4, limiterOptions.QueueLimit);
+        Assert.Equal(QueueProcessingOrder.OldestFirst, limiterOptions.QueueProcessingOrder);
+    }
+
+    [Fact]
+    public void ClientBucketOptions_CarriesTheConfiguredBurstAndSchedule()
+    {
+        // Arrange
+        var limits = Limits(
+            tokenCapacity: 30,
+            tokensPerReplenishmentPeriod: 5,
+            replenishmentPeriod: TimeSpan.FromSeconds(20),
+            requestQueueLimit: 2);
+
+        // Act
+        var limiterOptions = McpRateLimiting.ClientBucketOptions(limits);
+
+        // Assert
+        Assert.Equal(30, limiterOptions.TokenLimit);
+        Assert.Equal(5, limiterOptions.TokensPerPeriod);
+        Assert.Equal(TimeSpan.FromSeconds(20), limiterOptions.ReplenishmentPeriod);
+        Assert.Equal(2, limiterOptions.QueueLimit);
+        Assert.Equal(QueueProcessingOrder.OldestFirst, limiterOptions.QueueProcessingOrder);
+    }
+
+    [Fact]
+    public void ClientBucketOptions_RestoresCapacityWithoutBeingPumped()
+    {
+        // Arrange
+        var limits = Limits();
+
+        // Act
+        var limiterOptions = McpRateLimiting.ClientBucketOptions(limits);
+
+        // Assert
+        // Automatic replenishment is what makes a client's capacity return on the framework's own timer. With it off,
+        // something in this process would have to call TryReplenish, and nothing does, so a spent bucket would stay
+        // spent for the life of the process.
+        Assert.True(limiterOptions.AutoReplenishment);
+    }
+
+    [Fact]
+    public void PartitionForProcess_ForARequestOutsideTheEndpoint_AppliesNoLimit()
+    {
+        // Arrange
+        var limits = Limits(maxConcurrentRequests: 1);
+        using var limiter = ProcessLimiter(limits);
+
+        // Act
+        var leases = AcquireAll(limiter, () => RequestTo("/health"), attempts: 5);
+
+        // Assert
+        // Readiness and liveness have to keep answering while the endpoint is refusing, so the process-wide limiter
+        // excludes every route that is not the MCP endpoint rather than counting them against the same permits.
+        Assert.All(leases, lease => Assert.True(lease.IsAcquired));
+
+        DisposeAll(leases);
+    }
+
+    [Fact]
+    public void PartitionForProcess_ForMcpRequests_AdmitsExactlyTheConfiguredConcurrency()
+    {
+        // Arrange
+        var limits = Limits(maxConcurrentRequests: 3);
+        using var limiter = ProcessLimiter(limits);
+
+        // Act
+        var leases = AcquireAll(limiter, () => McpRequest(), attempts: 4);
+
+        // Assert
+        Assert.Equal([true, true, true, false], leases.Select(lease => lease.IsAcquired));
+
+        DisposeAll(leases);
+    }
+
+    [Fact]
+    public void PartitionForProcess_ForSeveralClients_CountsThemAgainstOneLimit()
+    {
+        // Arrange
+        var limits = Limits(maxConcurrentRequests: 2);
+        using var limiter = ProcessLimiter(limits);
+
+        // Act
+        var first = limiter.AttemptAcquire(McpRequest("desktop-agent"));
+        var second = limiter.AttemptAcquire(McpRequest("nightly-indexer"));
+        var third = limiter.AttemptAcquire(McpRequest("third-client"));
+
+        // Assert
+        // The concurrency limit bounds the process, which has one set of connections and threads however many clients
+        // there are; splitting it per client would let the total grow with the client list.
+        Assert.True(first.IsAcquired);
+        Assert.True(second.IsAcquired);
+        Assert.False(third.IsAcquired);
+
+        DisposeAll([first, second, third]);
+    }
+
+    [Fact]
+    public async Task PartitionForProcess_WithNoQueue_RefusesRatherThanWaiting()
+    {
+        // Arrange
+        var limits = Limits(maxConcurrentRequests: 1, concurrencyQueueLimit: 0);
+        using var limiter = ProcessLimiter(limits);
+        using var held = limiter.AttemptAcquire(McpRequest());
+
+        // Act
+        var refusal = limiter
+            .AcquireAsync(McpRequest(), permitCount: 1, TestContext.Current.CancellationToken)
+            .AsTask();
+
+        // Assert
+        Assert.True(refusal.IsCompleted);
+        using var refusedLease = await refusal;
+        Assert.False(refusedLease.IsAcquired);
+    }
+
+    [Fact]
+    public async Task PartitionForProcess_WithABoundedQueue_LetsThatManyWaitAndRefusesTheRest()
+    {
+        // Arrange
+        var limits = Limits(maxConcurrentRequests: 1, concurrencyQueueLimit: 1);
+        using var limiter = ProcessLimiter(limits);
+        var held = limiter.AttemptAcquire(McpRequest());
+
+        // Act
+        var queued = limiter
+            .AcquireAsync(McpRequest(), permitCount: 1, TestContext.Current.CancellationToken)
+            .AsTask();
+        var beyondTheQueue = limiter
+            .AcquireAsync(McpRequest(), permitCount: 1, TestContext.Current.CancellationToken)
+            .AsTask();
+
+        // Assert
+        Assert.False(queued.IsCompleted);
+        Assert.True(beyondTheQueue.IsCompleted);
+        using var refusedLease = await beyondTheQueue;
+        Assert.False(refusedLease.IsAcquired);
+
+        held.Dispose();
+
+        using var admittedLease = await queued;
+        Assert.True(admittedLease.IsAcquired);
+    }
+
+    [Fact]
+    public void PartitionForClient_ExhaustingOneClientsBurst_LeavesAnotherClientUntouched()
+    {
+        // Arrange
+        var limits = Limits(tokenCapacity: 2, tokensPerReplenishmentPeriod: 2);
+        using var limiter = ClientLimiter(limits);
+
+        // Act
+        var spent = AcquireAll(limiter, () => McpRequest("desktop-agent"), attempts: 3);
+        var otherClient = limiter.AttemptAcquire(McpRequest("nightly-indexer"));
+
+        // Assert
+        Assert.Equal([true, true, false], spent.Select(lease => lease.IsAcquired));
+        Assert.True(otherClient.IsAcquired);
+
+        DisposeAll([.. spent, otherClient]);
+    }
+
+    [Fact]
+    public void PartitionForClient_WithoutAnAuthenticatedIdentity_SharesOneAnonymousPartition()
+    {
+        // Arrange
+        var limits = Limits(tokenCapacity: 2, tokensPerReplenishmentPeriod: 2);
+        using var limiter = ClientLimiter(limits);
+
+        // Act
+        // A request that presented nothing and a request whose credential was refused both arrive with an
+        // unauthenticated principal, and both are counted under the one anonymous partition — which is what stops an
+        // attacker minting a partition per request and stops a flood of bad credentials being served for free.
+        var presentedNothing = limiter.AttemptAcquire(McpRequest());
+        var credentialRefused = limiter.AttemptAcquire(McpRequest(authenticatedClientName: null));
+        var beyondTheSharedBurst = limiter.AttemptAcquire(McpRequest());
+
+        // Assert
+        Assert.True(presentedNothing.IsAcquired);
+        Assert.True(credentialRefused.IsAcquired);
+        Assert.False(beyondTheSharedBurst.IsAcquired);
+
+        DisposeAll([presentedNothing, credentialRefused, beyondTheSharedBurst]);
+    }
+
+    [Fact]
+    public void PartitionForClient_ForAnAuthenticatedClient_KeepsItOutOfTheAnonymousPartition()
+    {
+        // Arrange
+        var limits = Limits(tokenCapacity: 1, tokensPerReplenishmentPeriod: 1);
+        using var limiter = ClientLimiter(limits);
+
+        // Act
+        var anonymous = limiter.AttemptAcquire(McpRequest());
+        var authenticated = limiter.AttemptAcquire(McpRequest("desktop-agent"));
+
+        // Assert
+        Assert.True(anonymous.IsAcquired);
+        Assert.True(authenticated.IsAcquired);
+
+        DisposeAll([anonymous, authenticated]);
+    }
+
+    [Fact]
+    public async Task RefuseAsync_ForAnyRejection_AnswersTooManyRequestsWithoutABody()
+    {
+        // Arrange
+        var limits = Limits(maxConcurrentRequests: 1);
+        using var limiter = ProcessLimiter(limits);
+        using var held = limiter.AttemptAcquire(McpRequest());
+        using var refusedLease = limiter.AttemptAcquire(McpRequest());
+        var httpContext = McpRequest();
+
+        // Act
+        await McpRateLimiting.RefuseAsync(
+            new OnRejectedContext { HttpContext = httpContext, Lease = refusedLease },
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, httpContext.Response.StatusCode);
+        Assert.Equal("no-store", httpContext.Response.Headers.CacheControl);
+        Assert.Equal(0, httpContext.Response.Body.Length);
+    }
+
+    [Fact]
+    public async Task RefuseAsync_WhenTheLimiterKnowsWhenCapacityReturns_AdvertisesTheRetry()
+    {
+        // Arrange
+        var limits = Limits(
+            tokenCapacity: 1,
+            tokensPerReplenishmentPeriod: 1,
+            replenishmentPeriod: TimeSpan.FromSeconds(30));
+        using var limiter = ClientLimiter(limits);
+        using var spent = limiter.AttemptAcquire(McpRequest("desktop-agent"));
+        using var refusedLease = limiter.AttemptAcquire(McpRequest("desktop-agent"));
+        var httpContext = McpRequest();
+
+        // Act
+        await McpRateLimiting.RefuseAsync(
+            new OnRejectedContext { HttpContext = httpContext, Lease = refusedLease },
+            CancellationToken.None);
+
+        // Assert
+        Assert.False(refusedLease.IsAcquired);
+        Assert.Equal("30", httpContext.Response.Headers.RetryAfter);
+    }
+
+    [Fact]
+    public async Task RefuseAsync_WhenTheLimiterCannotSayWhenCapacityReturns_OmitsTheRetry()
+    {
+        // Arrange
+        var limits = Limits(maxConcurrentRequests: 1);
+        using var limiter = ProcessLimiter(limits);
+        using var held = limiter.AttemptAcquire(McpRequest());
+        using var refusedLease = limiter.AttemptAcquire(McpRequest());
+        var httpContext = McpRequest();
+
+        // Act
+        await McpRateLimiting.RefuseAsync(
+            new OnRejectedContext { HttpContext = httpContext, Lease = refusedLease },
+            CancellationToken.None);
+
+        // Assert
+        // A concurrency limit has no scheduled moment at which a slot frees, so a refusal for concurrency carries no
+        // guess about when to come back.
+        Assert.False(refusedLease.IsAcquired);
+        Assert.True(StringValues.IsNullOrEmpty(httpContext.Response.Headers.RetryAfter));
+    }
+
+    [Fact]
+    public async Task RefuseAsync_ForDifferentClients_AnswersIdentically()
+    {
+        // Arrange
+        var limits = Limits(tokenCapacity: 1, tokensPerReplenishmentPeriod: 1);
+        using var limiter = ClientLimiter(limits);
+        using var spentByFirst = limiter.AttemptAcquire(McpRequest("desktop-agent"));
+        using var refusedFirst = limiter.AttemptAcquire(McpRequest("desktop-agent"));
+        using var spentBySecond = limiter.AttemptAcquire(McpRequest("nightly-indexer"));
+        using var refusedSecond = limiter.AttemptAcquire(McpRequest("nightly-indexer"));
+
+        var firstResponse = McpRequest("desktop-agent");
+        var secondResponse = McpRequest("nightly-indexer");
+
+        // Act
+        await McpRateLimiting.RefuseAsync(
+            new OnRejectedContext { HttpContext = firstResponse, Lease = refusedFirst },
+            CancellationToken.None);
+        await McpRateLimiting.RefuseAsync(
+            new OnRejectedContext { HttpContext = secondResponse, Lease = refusedSecond },
+            CancellationToken.None);
+
+        // Assert
+        // A refusal describes the deployment to whoever provoked it, so it must not describe one client's limits to
+        // another, nor differ in a way that says whether a named credential exists.
+        Assert.Equal(firstResponse.Response.StatusCode, secondResponse.Response.StatusCode);
+        Assert.Equal(
+            firstResponse.Response.Headers.OrderBy(header => header.Key, StringComparer.Ordinal),
+            secondResponse.Response.Headers.OrderBy(header => header.Key, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task PartitionForProcess_UnderConcurrentLoad_AdmitsTheLimitAndRefusesTheRest()
+    {
+        // Arrange
+        const int PermitLimit = 4;
+        const int Attempts = 40;
+
+        var limits = Limits(maxConcurrentRequests: PermitLimit);
+        using var limiter = ProcessLimiter(limits);
+
+        var everyAttemptSettled = new TaskCompletionSource();
+        var attemptsSettled = 0;
+        var refusedCount = 0;
+        var concurrency = 0;
+        var peakConcurrency = 0;
+
+        async Task AttemptAsync()
+        {
+            using var lease = await limiter.AcquireAsync(
+                McpRequest(),
+                permitCount: 1,
+                TestContext.Current.CancellationToken);
+
+            if (lease.IsAcquired)
+            {
+                RaiseTo(ref peakConcurrency, Interlocked.Increment(ref concurrency));
+            }
+            else
+            {
+                Interlocked.Increment(ref refusedCount);
+            }
+
+            // Nothing is released until every attempt has been made, so the counts below describe what the limit
+            // admitted rather than what the scheduler happened to interleave.
+            if (Interlocked.Increment(ref attemptsSettled) == Attempts)
+            {
+                everyAttemptSettled.TrySetResult();
+            }
+
+            await everyAttemptSettled.Task;
+
+            if (lease.IsAcquired)
+            {
+                Interlocked.Decrement(ref concurrency);
+            }
+        }
+
+        // Act
+        await Task.WhenAll(Enumerable.Range(0, Attempts).Select(_ => AttemptAsync()));
+
+        // Assert
+        Assert.Equal(PermitLimit, peakConcurrency);
+        Assert.Equal(Attempts - PermitLimit, refusedCount);
+
+        // A compliant client is not starved by the load that was refused: the permits came back as the leases were
+        // released, so the next request is served rather than paying for the burst that preceded it.
+        using var afterTheLoad = limiter.AttemptAcquire(McpRequest());
+        Assert.True(afterTheLoad.IsAcquired);
+    }
+
+    private static McpRateLimits Limits(
+        int maxConcurrentRequests = 8,
+        int concurrencyQueueLimit = 0,
+        int tokenCapacity = 100,
+        int tokensPerReplenishmentPeriod = 100,
+        TimeSpan? replenishmentPeriod = null,
+        int requestQueueLimit = 0) =>
+        McpRateLimits.Create(
+            maxConcurrentRequests,
+            concurrencyQueueLimit,
+            tokenCapacity,
+            tokensPerReplenishmentPeriod,
+            replenishmentPeriod ?? TimeSpan.FromMinutes(1),
+            requestQueueLimit);
+
+    private static PartitionedRateLimiter<HttpContext> ProcessLimiter(McpRateLimits limits) =>
+        PartitionedRateLimiter.Create<HttpContext, string>(
+            httpContext => McpRateLimiting.PartitionForProcess(httpContext, limits));
+
+    private static PartitionedRateLimiter<HttpContext> ClientLimiter(McpRateLimits limits) =>
+        PartitionedRateLimiter.Create<HttpContext, string>(
+            httpContext => McpRateLimiting.PartitionForClient(httpContext, limits));
+
+    private static DefaultHttpContext McpRequest(string? authenticatedClientName = null)
+    {
+        var httpContext = RequestTo(McpEndpointRoute.Path);
+
+        if (authenticatedClientName is not null)
+        {
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.Name, authenticatedClientName)],
+                authenticationType: "test"));
+        }
+
+        return httpContext;
+    }
+
+    private static DefaultHttpContext RequestTo(string path)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Path = path;
+
+        return httpContext;
+    }
+
+    private static RateLimitLease[] AcquireAll(
+        PartitionedRateLimiter<HttpContext> limiter,
+        Func<HttpContext> request,
+        int attempts) =>
+        [.. Enumerable.Range(0, attempts).Select(_ => limiter.AttemptAcquire(request()))];
+
+    private static void DisposeAll(IEnumerable<RateLimitLease> leases)
+    {
+        foreach (var lease in leases)
+        {
+            lease.Dispose();
+        }
+    }
+
+    /// <summary>Raises a shared maximum to the observed value without losing a concurrent raise.</summary>
+    private static void RaiseTo(ref int target, int candidate)
+    {
+        var observed = Volatile.Read(ref target);
+
+        while (candidate > observed)
+        {
+            var previous = Interlocked.CompareExchange(ref target, candidate, observed);
+
+            if (previous == observed)
+            {
+                return;
+            }
+
+            observed = previous;
+        }
+    }
+}

--- a/tests/Host.UnitTests/McpRateLimitingTests.cs
+++ b/tests/Host.UnitTests/McpRateLimitingTests.cs
@@ -238,6 +238,57 @@ public sealed class McpRateLimitingTests
         DisposeAll([anonymous, authenticated]);
     }
 
+    /// <summary>
+    /// Under <c>None</c> a client certificate is the only identity there is, so a deployment that trusts several client
+    /// applications keeps a bucket per application instead of pooling them all into the anonymous one.
+    /// </summary>
+    [Fact]
+    public void PartitionForClient_WithACertificateProfileAndNoCredential_KeepsEachClientApplicationApart()
+    {
+        // Arrange
+        var limits = Limits(tokenCapacity: 1, tokensPerReplenishmentPeriod: 1);
+        using var limiter = ClientLimiter(limits);
+
+        // Act
+        var chatgpt = limiter.AttemptAcquire(McpRequest(certificateProfileName: "chatgpt-connector"));
+        var workstation = limiter.AttemptAcquire(McpRequest(certificateProfileName: "workstation-connector"));
+        var chatgptAgain = limiter.AttemptAcquire(McpRequest(certificateProfileName: "chatgpt-connector"));
+        var unidentified = limiter.AttemptAcquire(McpRequest());
+
+        // Assert
+        Assert.True(chatgpt.IsAcquired);
+        Assert.True(workstation.IsAcquired);
+        Assert.False(chatgptAgain.IsAcquired);
+        Assert.True(unidentified.IsAcquired);
+
+        DisposeAll([chatgpt, workstation, chatgptAgain, unidentified]);
+    }
+
+    /// <summary>
+    /// A key names one client of this deployment and a profile names a client application several keys may sit behind,
+    /// so the key decides. Were the two combined, one credential would earn a fresh bucket for every certificate it
+    /// could present under — capacity bought by holding one more certificate.
+    /// </summary>
+    [Fact]
+    public void PartitionForClient_WithBothIdentities_SpendsTheAuthenticatedClientsCapacityOnly()
+    {
+        // Arrange
+        var limits = Limits(tokenCapacity: 1, tokensPerReplenishmentPeriod: 1);
+        using var limiter = ClientLimiter(limits);
+
+        // Act
+        var underOneProfile = limiter.AttemptAcquire(
+            McpRequest("desktop-agent", certificateProfileName: "chatgpt-connector"));
+        var underAnotherProfile = limiter.AttemptAcquire(
+            McpRequest("desktop-agent", certificateProfileName: "workstation-connector"));
+
+        // Assert
+        Assert.True(underOneProfile.IsAcquired);
+        Assert.False(underAnotherProfile.IsAcquired);
+
+        DisposeAll([underOneProfile, underAnotherProfile]);
+    }
+
     [Fact]
     public async Task RefuseAsync_ForAnyRejection_AnswersTooManyRequestsWithoutABody()
     {
@@ -418,7 +469,9 @@ public sealed class McpRateLimitingTests
         PartitionedRateLimiter.Create<HttpContext, string>(
             httpContext => McpRateLimiting.PartitionForClient(httpContext, limits));
 
-    private static DefaultHttpContext McpRequest(string? authenticatedClientName = null)
+    private static DefaultHttpContext McpRequest(
+        string? authenticatedClientName = null,
+        string? certificateProfileName = null)
     {
         var httpContext = RequestTo(McpEndpointRoute.Path);
 
@@ -427,6 +480,13 @@ public sealed class McpRateLimitingTests
             httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
                 [new Claim(ClaimTypes.Name, authenticatedClientName)],
                 authenticationType: "test"));
+        }
+
+        if (certificateProfileName is not null)
+        {
+            // The same feature the client-certificate middleware publishes, so the limiter reads the identity it will
+            // actually be handed rather than one shaped for the test.
+            httpContext.Features.Set(new McpClientCertificateIdentity(certificateProfileName));
         }
 
         return httpContext;

--- a/tests/Infrastructure.UnitTests/McpRateLimitPartitionsTests.cs
+++ b/tests/Infrastructure.UnitTests/McpRateLimitPartitionsTests.cs
@@ -1,0 +1,61 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
+using Xunit;
+
+namespace MailMcp.Infrastructure.UnitTests;
+
+public sealed class McpRateLimitPartitionsTests
+{
+    [Fact]
+    public void KeyFor_WithAnAuthenticatedName_CountsTheClientUnderIt()
+    {
+        // Act
+        var partitionKey = McpRateLimitPartitions.KeyFor("desktop-agent");
+
+        // Assert
+        Assert.Equal("desktop-agent", partitionKey);
+    }
+
+    [Fact]
+    public void KeyFor_WithDifferentAuthenticatedNames_KeepsThemApart()
+    {
+        // Act
+        var first = McpRateLimitPartitions.KeyFor("desktop-agent");
+        var second = McpRateLimitPartitions.KeyFor("nightly-indexer");
+
+        // Assert
+        Assert.NotEqual(first, second);
+    }
+
+    /// <summary>
+    /// The anonymous partition holds every caller the deployment cannot tell apart, so a configured client sharing it
+    /// would both spend that stream's capacity and have its own spent by it. Nothing but the spelling keeps them apart,
+    /// which is why the spelling is asserted against the grammar a configured name is actually accepted under rather
+    /// than left as an assumption about what an operator is likely to write.
+    /// </summary>
+    [Fact]
+    public void AnonymousKey_CannotBeSpelledAsAConfiguredName()
+    {
+        // Act
+        var isAcceptedAsASecretName = SecretName.TryCreate(McpRateLimitPartitions.AnonymousKey, out _);
+
+        // Assert
+        Assert.False(isAcceptedAsASecretName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    public void KeyFor_WithoutAnAuthenticatedName_SharesOneAnonymousPartition(string? authenticatedClientName)
+    {
+        // Act
+        var partitionKey = McpRateLimitPartitions.KeyFor(authenticatedClientName);
+
+        // Assert
+        Assert.Equal(McpRateLimitPartitions.AnonymousKey, partitionKey);
+    }
+}

--- a/tests/Infrastructure.UnitTests/McpRateLimitPartitionsTests.cs
+++ b/tests/Infrastructure.UnitTests/McpRateLimitPartitionsTests.cs
@@ -12,7 +12,7 @@ public sealed class McpRateLimitPartitionsTests
     public void KeyFor_WithAnAuthenticatedName_CountsTheClientUnderIt()
     {
         // Act
-        var partitionKey = McpRateLimitPartitions.KeyFor("desktop-agent");
+        var partitionKey = McpRateLimitPartitions.KeyFor("desktop-agent", matchedCertificateProfileName: null);
 
         // Assert
         Assert.Equal("desktop-agent", partitionKey);
@@ -22,11 +22,67 @@ public sealed class McpRateLimitPartitionsTests
     public void KeyFor_WithDifferentAuthenticatedNames_KeepsThemApart()
     {
         // Act
-        var first = McpRateLimitPartitions.KeyFor("desktop-agent");
-        var second = McpRateLimitPartitions.KeyFor("nightly-indexer");
+        var first = McpRateLimitPartitions.KeyFor("desktop-agent", matchedCertificateProfileName: null);
+        var second = McpRateLimitPartitions.KeyFor("nightly-indexer", matchedCertificateProfileName: null);
 
         // Assert
         Assert.NotEqual(first, second);
+    }
+
+    /// <summary>
+    /// A key names one client of this deployment; a profile names a client application several keys may sit behind.
+    /// Taking the key keeps the partitions as narrow as the operator's key list, and refusing to combine the two is what
+    /// stops one credential earning a second bucket for every profile it could present under.
+    /// </summary>
+    [Fact]
+    public void KeyFor_WithBothIdentities_CountsTheClientUnderTheKeyAlone()
+    {
+        // Act
+        var withCertificate = McpRateLimitPartitions.KeyFor("desktop-agent", "chatgpt-connector");
+        var withoutCertificate = McpRateLimitPartitions.KeyFor("desktop-agent", matchedCertificateProfileName: null);
+
+        // Assert
+        Assert.Equal("desktop-agent", withCertificate);
+        Assert.Equal(withoutCertificate, withCertificate);
+    }
+
+    [Fact]
+    public void KeyFor_WithBothIdentities_GivesOneKeyNoExtraCapacityPerProfile()
+    {
+        // Act
+        var underOneProfile = McpRateLimitPartitions.KeyFor("desktop-agent", "chatgpt-connector");
+        var underAnother = McpRateLimitPartitions.KeyFor("desktop-agent", "workstation-connector");
+
+        // Assert
+        Assert.Equal(underOneProfile, underAnother);
+    }
+
+    [Fact]
+    public void KeyFor_WithACertificateProfileAlone_CountsTheClientApplicationUnderIt()
+    {
+        // Act
+        var first = McpRateLimitPartitions.KeyFor(authenticatedClientName: null, "chatgpt-connector");
+        var second = McpRateLimitPartitions.KeyFor(authenticatedClientName: null, "workstation-connector");
+
+        // Assert
+        Assert.NotEqual(first, second);
+        Assert.NotEqual(McpRateLimitPartitions.AnonymousKey, first);
+    }
+
+    /// <summary>
+    /// Both names come from the same grammar, and under <c>ApiKey</c> both kinds of partition exist at once — a request
+    /// whose credential was refused still arrives carrying the profile its certificate matched. A profile named after a
+    /// key would otherwise hand that key's client the profile's capacity and the other way about.
+    /// </summary>
+    [Fact]
+    public void KeyFor_ForAProfileNamedAfterAKey_KeepsTheTwoApart()
+    {
+        // Act
+        var underTheKey = McpRateLimitPartitions.KeyFor("workstation", matchedCertificateProfileName: null);
+        var underTheProfile = McpRateLimitPartitions.KeyFor(authenticatedClientName: null, "workstation");
+
+        // Assert
+        Assert.NotEqual(underTheKey, underTheProfile);
     }
 
     /// <summary>
@@ -45,15 +101,26 @@ public sealed class McpRateLimitPartitionsTests
         Assert.False(isAcceptedAsASecretName);
     }
 
+    /// <summary>A profile's partition is bracketed for the same reason, so it cannot be claimed by an operator naming a key after it.</summary>
+    [Fact]
+    public void KeyFor_ACertificateProfilePartition_CannotBeSpelledAsAConfiguredName()
+    {
+        // Act
+        var partitionKey = McpRateLimitPartitions.KeyFor(authenticatedClientName: null, "chatgpt-connector");
+
+        // Assert
+        Assert.False(SecretName.TryCreate(partitionKey, out _));
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
     [InlineData("\t")]
-    public void KeyFor_WithoutAnAuthenticatedName_SharesOneAnonymousPartition(string? authenticatedClientName)
+    public void KeyFor_WithoutAnyIdentity_SharesOneAnonymousPartition(string? absentName)
     {
         // Act
-        var partitionKey = McpRateLimitPartitions.KeyFor(authenticatedClientName);
+        var partitionKey = McpRateLimitPartitions.KeyFor(absentName, absentName);
 
         // Assert
         Assert.Equal(McpRateLimitPartitions.AnonymousKey, partitionKey);

--- a/tests/Infrastructure.UnitTests/McpRateLimitsTests.cs
+++ b/tests/Infrastructure.UnitTests/McpRateLimitsTests.cs
@@ -1,0 +1,95 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Infrastructure.Security;
+using Xunit;
+
+namespace MailMcp.Infrastructure.UnitTests;
+
+public sealed class McpRateLimitsTests
+{
+    [Fact]
+    public void Default_BoundsBothResourcesWithoutQueueing()
+    {
+        // Act
+        var limits = McpRateLimits.Default;
+
+        // Assert
+        Assert.True(limits.MaxConcurrentRequests > 0);
+        Assert.True(limits.TokenCapacity > 0);
+        Assert.True(limits.TokensPerReplenishmentPeriod > 0);
+        Assert.True(limits.ReplenishmentPeriod > TimeSpan.Zero);
+        Assert.Equal(0, limits.ConcurrencyQueueLimit);
+        Assert.Equal(0, limits.RequestQueueLimit);
+    }
+
+    [Fact]
+    public void Default_RestoresEveryTokenItHandsOut()
+    {
+        // Act
+        var limits = McpRateLimits.Default;
+
+        // Assert
+        Assert.True(limits.TokensPerReplenishmentPeriod <= limits.TokenCapacity);
+    }
+
+    [Fact]
+    public void Create_WithUsableValues_CarriesEveryLimit()
+    {
+        // Act
+        var limits = McpRateLimits.Create(
+            maxConcurrentRequests: 7,
+            concurrencyQueueLimit: 3,
+            tokenCapacity: 40,
+            tokensPerReplenishmentPeriod: 10,
+            replenishmentPeriod: TimeSpan.FromSeconds(15),
+            requestQueueLimit: 2);
+
+        // Assert
+        Assert.Equal(7, limits.MaxConcurrentRequests);
+        Assert.Equal(3, limits.ConcurrencyQueueLimit);
+        Assert.Equal(40, limits.TokenCapacity);
+        Assert.Equal(10, limits.TokensPerReplenishmentPeriod);
+        Assert.Equal(TimeSpan.FromSeconds(15), limits.ReplenishmentPeriod);
+        Assert.Equal(2, limits.RequestQueueLimit);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 10, 10, 1, 0)]
+    [InlineData(-1, 0, 10, 10, 1, 0)]
+    [InlineData(1, -1, 10, 10, 1, 0)]
+    [InlineData(1, 0, 0, 10, 1, 0)]
+    [InlineData(1, 0, 10, 0, 1, 0)]
+    [InlineData(1, 0, 10, 10, 0, 0)]
+    [InlineData(1, 0, 10, 10, -1, 0)]
+    [InlineData(1, 0, 10, 10, 1, -1)]
+    public void Create_WithAnUnusableValue_Throws(
+        int maxConcurrentRequests,
+        int concurrencyQueueLimit,
+        int tokenCapacity,
+        int tokensPerReplenishmentPeriod,
+        int replenishmentPeriodSeconds,
+        int requestQueueLimit)
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => McpRateLimits.Create(
+            maxConcurrentRequests,
+            concurrencyQueueLimit,
+            tokenCapacity,
+            tokensPerReplenishmentPeriod,
+            TimeSpan.FromSeconds(replenishmentPeriodSeconds),
+            requestQueueLimit));
+    }
+
+    [Fact]
+    public void Create_RestoringMoreThanTheBucketHolds_Throws()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => McpRateLimits.Create(
+            maxConcurrentRequests: 4,
+            concurrencyQueueLimit: 0,
+            tokenCapacity: 10,
+            tokensPerReplenishmentPeriod: 11,
+            replenishmentPeriod: TimeSpan.FromSeconds(1),
+            requestQueueLimit: 0));
+    }
+}

--- a/tests/Infrastructure.UnitTests/McpRateLimitsTests.cs
+++ b/tests/Infrastructure.UnitTests/McpRateLimitsTests.cs
@@ -92,4 +92,44 @@ public sealed class McpRateLimitsTests
             replenishmentPeriod: TimeSpan.FromSeconds(1),
             requestQueueLimit: 0));
     }
+
+    /// <summary>
+    /// A queued request is holding a concurrency permit while it waits, because the process-wide limiter is acquired
+    /// first and the client's bucket second. A queue that could hold every permit would let one client out of capacity
+    /// stop the whole process until its next replenishment, which is the isolation the per-client bucket exists for,
+    /// inverted.
+    /// </summary>
+    [Theory]
+    [InlineData(4, 4)]
+    [InlineData(4, 5)]
+    public void Create_WithAClientQueueThatCouldHoldEveryPermit_Throws(
+        int maxConcurrentRequests,
+        int requestQueueLimit)
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => McpRateLimits.Create(
+            maxConcurrentRequests,
+            concurrencyQueueLimit: 0,
+            tokenCapacity: 10,
+            tokensPerReplenishmentPeriod: 10,
+            replenishmentPeriod: TimeSpan.FromSeconds(1),
+            requestQueueLimit));
+    }
+
+    [Fact]
+    public void Create_WithAClientQueueBelowThePermitCount_LeavesAPermitForEveryoneElse()
+    {
+        // Act
+        var limits = McpRateLimits.Create(
+            maxConcurrentRequests: 4,
+            concurrencyQueueLimit: 0,
+            tokenCapacity: 10,
+            tokensPerReplenishmentPeriod: 10,
+            replenishmentPeriod: TimeSpan.FromSeconds(1),
+            requestQueueLimit: 3);
+
+        // Assert
+        Assert.Equal(3, limits.RequestQueueLimit);
+        Assert.True(limits.RequestQueueLimit < limits.MaxConcurrentRequests);
+    }
 }

--- a/tests/IntegrationTests/Hosting/ComposedMcpEndpointSecurityTests.cs
+++ b/tests/IntegrationTests/Hosting/ComposedMcpEndpointSecurityTests.cs
@@ -155,6 +155,46 @@ public sealed class ComposedMcpEndpointSecurityTests
     }
 
     /// <summary>
+    /// What the limiter does with a partition is unit-tested; what only a composed host shows is that a limiter is on
+    /// this route at all. Two of its parts are invisible from a unit test and are asserted together here rather than in
+    /// tests of their own: that the route carries the policy, and that one client's exhausted capacity is not another's,
+    /// which is the whole point of partitioning and would look identical from inside the process if it were broken.
+    /// </summary>
+    /// <remarks>
+    /// The burst is dispatched together rather than one request after another, so what the limiter sees is a burst
+    /// however fast the host answers. Sending them in sequence against a slow machine would let capacity replenish
+    /// between them and leave the test passing because nothing was ever over the limit.
+    /// </remarks>
+    [Fact]
+    public async Task McpEndpoint_AClientBurstingPastItsCapacity_IsRefusedWithoutSpendingAnotherClients()
+    {
+        // Arrange
+        using var client = await this.ComposedHostClientAsync();
+        var burstSize = OrchestrationContract.McpRateLimitTokenCapacity * 3;
+
+        // Act
+        var burst = await Task.WhenAll(Enumerable
+            .Range(0, burstSize)
+            .Select(_ => this.AnswerToAsync(client, OrchestrationContract.McpExpendableApiKey)));
+
+        using var afterTheBurst = ListToolsRequest(OrchestrationContract.McpApiKey);
+        afterTheBurst.Headers.Add("Origin", OrchestrationContract.McpPermittedOrigin);
+        using var otherClient = await client.SendAsync(afterTheBurst, TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusals = burst.Where(answer => answer.StatusCode == HttpStatusCode.TooManyRequests).ToArray();
+
+        Assert.NotEmpty(refusals);
+        Assert.All(refusals, refusal => Assert.Empty(refusal.Body));
+        Assert.All(refusals, refusal => Assert.Equal("no-store", refusal.CacheControl));
+        Assert.Equal(HttpStatusCode.OK, otherClient.StatusCode);
+        Assert.Contains(
+            ToolListedByTheProtocolSurface,
+            await otherClient.Content.ReadAsStringAsync(TestContext.Current.CancellationToken),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// The requirement is carried by the MCP route rather than by a fallback policy, and the difference is not visible
     /// from configuration. A probe has no credential to present, so a readiness response that started asking for one
     /// would take the deployment out of rotation rather than protect anything.
@@ -234,4 +274,25 @@ public sealed class ComposedMcpEndpointSecurityTests
     {
         BaseAddress = await this.orchestration.StartMailMcpHostAsync(TestContext.Current.CancellationToken),
     };
+
+    /// <summary>Sends one tool listing and reads everything a burst is judged on before the response is released.</summary>
+    /// <remarks>
+    /// The response is disposed here rather than handed back, so a burst of them cannot hold connections open while the
+    /// rest of the assertions run. What the caller keeps is the small record below, which is why the body is read now.
+    /// </remarks>
+    private async Task<McpAnswer> AnswerToAsync(HttpClient client, string apiKey)
+    {
+        using var request = ListToolsRequest(apiKey);
+        request.Headers.Add("Origin", OrchestrationContract.McpPermittedOrigin);
+
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        return new McpAnswer(
+            response.StatusCode,
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken),
+            response.Headers.CacheControl?.ToString());
+    }
+
+    /// <summary>What one request in a burst is judged on, read before its response was released.</summary>
+    private sealed record McpAnswer(HttpStatusCode StatusCode, string Body, string? CacheControl);
 }

--- a/tests/IntegrationTests/Hosting/ComposedMcpEndpointSecurityTests.cs
+++ b/tests/IntegrationTests/Hosting/ComposedMcpEndpointSecurityTests.cs
@@ -161,9 +161,18 @@ public sealed class ComposedMcpEndpointSecurityTests
     /// which is the whole point of partitioning and would look identical from inside the process if it were broken.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// The burst is dispatched together rather than one request after another, so what the limiter sees is a burst
     /// however fast the host answers. Sending them in sequence against a slow machine would let capacity replenish
     /// between them and leave the test passing because nothing was ever over the limit.
+    /// </para>
+    /// <para>
+    /// Two limiters can answer <c>429</c> on this route, so the refusals are checked for the one signal only the client
+    /// bucket produces: a <c>Retry-After</c>, which it can compute because it knows when the next replenishment lands
+    /// and which a concurrency refusal never carries. The topology also raises its concurrency ceiling well above this
+    /// burst, so the process-wide limiter is not merely distinguishable here but cannot have refused anything at all.
+    /// Without both, this test would pass on concurrency refusals alone even if the route carried no policy.
+    /// </para>
     /// </remarks>
     [Fact]
     public async Task McpEndpoint_AClientBurstingPastItsCapacity_IsRefusedWithoutSpendingAnotherClients()
@@ -187,6 +196,7 @@ public sealed class ComposedMcpEndpointSecurityTests
         Assert.NotEmpty(refusals);
         Assert.All(refusals, refusal => Assert.Empty(refusal.Body));
         Assert.All(refusals, refusal => Assert.Equal("no-store", refusal.CacheControl));
+        Assert.All(refusals, refusal => Assert.NotNull(refusal.RetryAfter));
         Assert.Equal(HttpStatusCode.OK, otherClient.StatusCode);
         Assert.Contains(
             ToolListedByTheProtocolSurface,
@@ -290,9 +300,11 @@ public sealed class ComposedMcpEndpointSecurityTests
         return new McpAnswer(
             response.StatusCode,
             await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken),
-            response.Headers.CacheControl?.ToString());
+            response.Headers.CacheControl?.ToString(),
+            response.Headers.RetryAfter?.ToString());
     }
 
     /// <summary>What one request in a burst is judged on, read before its response was released.</summary>
-    private sealed record McpAnswer(HttpStatusCode StatusCode, string Body, string? CacheControl);
+    /// <remarks><c>RetryAfter</c> is what says which limiter refused: only the per-client bucket knows when capacity returns.</remarks>
+    private sealed record McpAnswer(HttpStatusCode StatusCode, string Body, string? CacheControl, string? RetryAfter);
 }


### PR DESCRIPTION
Closes #141.

An enabled MCP endpoint served whatever it was asked for. This adds the two controls #141 asks for, on the identity #164 already establishes.

## What runs in front of the endpoint

- **A process-wide concurrency limit** — what the machine has one set of: database connections, threads, open response streams. Shared by every client, because splitting it per client would let the total grow with the client list.
- **A per-client token bucket** — how often one client may ask. A client in a loop spends its own capacity.

Both are on by default. There is no correct default for who may read a mailbox, which is why `Authentication` still refuses to be guessed; there *is* a sane default for how fast one client may ask, and leaving the endpoint unbounded because nobody wrote a number is not a decision an operator made. Turning limiting off is an explicit value and costs one startup warning.

Defaults: 20 concurrent requests, and 60 requests per client per minute after a 60-request burst. Queue limits are zero throughout — a queued request holds memory and a connection waiting for capacity that is already gone. Configuration that could never work is refused at startup, including a period that restores more than the bucket holds.

## Partitioning

The per-client key is the validated API-key `Name` that `McpApiKeyAuthenticationHandler` already publishes as the identity's name claim, so nothing new resolves an identity. Everything else — a request under `None`, and a request whose credential was refused — shares one anonymous partition.

That coarseness is the point. Every partition a request can name is a dictionary entry the process keeps, so a key an attacker chooses is memory an attacker allocates. No header, path, query string, `Origin`, user agent, or forwarded address reaches a key, and neither does the remote address. The anonymous sentinel is `<anonymous>`, spelled with characters `SecretName` rejects, so an operator cannot name a key into the unauthenticated stream's bucket; a test holds that grammar to it.

## Ordering

`UseRateLimiter` sits **behind** authentication, so a per-client limit counts under the identity that established, and **ahead** of authorization, so a request about to be refused for its credential still spends anonymous capacity — otherwise a flood of bad credentials would be the one kind of traffic served without limit. Readiness and liveness keep answering while the endpoint refuses.

The two controls attach to different parts of the framework, and that is a limitation worth stating rather than a preference: a named policy resolves to exactly one limiter. The per-client bucket takes the policy, because it belongs to this endpoint and its name is what a metric carries; the process-wide limit rides on the global limiter, which then excludes every route that is not `/mcp` itself.

## Refusals

A bare `429` with `Cache-Control: no-store` and no body. A body would have to say either nothing useful or something about the configured limits, and the second describes the deployment to every refused caller — including one whose credential is about to be refused, which must not learn a named key exists. `Retry-After` is included only where the bucket can compute one; a concurrency limit has no scheduled moment at which a slot frees.

Built-in `Microsoft.AspNetCore.RateLimiting` metrics are already subscribed by `AddAspNetCoreInstrumentation()` — verified against the upstream meter list in `opentelemetry-dotnet-contrib`, which names that meter explicitly. Nothing added here records a client name, address, origin, or credential.

## Not in scope

The mTLS profile name is **not** part of the partition identity. That composition belongs to #165, whose own acceptance already covers proving mTLS composes with what came before. Distributed state, DDoS protection, per-tool weighting, and trusting proxy headers stay out, as #141 says.

## Verification

- `scripts/verify-full.sh` — green. 1550 unit tests, 0 failures, aggregate line coverage 97.02% (required 85%).
- `scripts/run-integration-tests.sh` — green. 42 tests, 0 failures. The suite gained one test proving the limiter is on the route in a composed host: a burst past one client's capacity is refused with an empty body while another client's capacity is untouched. It spends a second, deliberately expendable API key, so exhausting it cannot make the rest of the suite depend on the order it ran in.
- No dependency added. `Directory.Packages.props` and every `.csproj` are untouched; the rate-limiting types come from the shared framework. `THIRD_PARTY_LICENSES.md` needs no entry.

### A deliberate test omission

Token *replenishment* is asserted against the limiter description rather than by driving one. `TokenBucketRateLimiter.TryReplenish` is itself gated on elapsed wall-clock time — measured, not assumed — so a test that drove it would be a test of the clock, which `tests/AGENTS.md` forbids. What is asserted instead is that the schedule reaching the limiter is the configured one and that automatic replenishment is on, so nothing in the process has to pump it. Restoring capacity on that schedule is the framework's own contract.
