### PR TITLE
Authenticate MCP clients with configurable mTLS trust profiles

### DIFF
--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -340,6 +340,10 @@ An anchor that stops loading — a deleted file, a corrupted certificate — is 
 other anchors of that profile keep working. A profile whose anchors all fail to load refuses every certificate rather
 than accepting one, because an anchor that has become unreadable must never widen what a profile trusts.
 
+That refusal is the *profile's*, not the endpoint's. Another profile still accepts a certificate its own anchors verify,
+because the broken material took no part in that verdict — one deleted file closes the clients it belongs to, not the
+ones whose trust material is intact.
+
 ## What the endpoint records
 
 Every tool call is logged once with the tool name, whether it ended in an error, and how long it took. Nothing else:

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -1,8 +1,8 @@
 # The MCP endpoint and what protects it
 
 The MCP endpoint is how an agent reaches MailMcp. This page records what enabling it means operationally, what a client
-has to present to reach it, and which browser origins it answers. The tools it serves are described in
-`docs/features/mcp-tools.md`.
+has to present to reach it, which browser origins it answers, and which client applications it accepts a certificate
+from. The tools it serves are described in `docs/features/mcp-tools.md`.
 
 ## The endpoint is off by default
 
@@ -29,8 +29,8 @@ endpoint exposes synchronized mailboxes to whoever can reach it and satisfy what
 | `Enabled` | `false` | Whether the Streamable HTTP endpoint is mapped at all |
 | `Authentication` | none — an enabled endpoint must state one | `ApiKey` or `None` |
 | `ApiKeys` | empty | The keys a client may present, each a named secret with its own lifetime |
-| `Cors.AllowAnyOrigin` | `true` | Whether every browser origin is served |
-| `Cors.AllowedOrigins` | empty | The exact origins served when `AllowAnyOrigin` is off |
+| `Cors.AllowedOrigins` | `["*"]` | The browser origins served: `*` for every one, a list for exactly those, an empty list for none |
+| `ClientCertificateProfiles` | empty | The client applications whose certificates are accepted, each with its own authorities and expected names |
 
 The endpoint always answers on **`/mcp`**, which is a constant rather than a setting. An MCP client is configured with a
 server URL, so a deployment could only move the path in step with every client pointed at it — the configurability would
@@ -145,16 +145,17 @@ warn: MailMcp.Host.Hosting.McpTransportAuthenticationWarning
       person whose mail is served.
 ```
 
-Leaving `Cors.AllowAnyOrigin` on under `None` — which is the default, and what makes the endpoint work behind a reverse
-proxy or on a trusted network without further configuration — adds a second warning rather than a startup failure:
+Leaving `Cors.AllowedOrigins` at its default of `["*"]` under `None` — which is what makes the endpoint work behind a
+reverse proxy or on a trusted network without further configuration — adds a second warning rather than a startup
+failure:
 
 ```text
 warn: MailMcp.Host.Hosting.McpTransportAuthenticationWarning
       Every browser origin is served while no credential is required, so a web page the user never visited can reach this
       endpoint through DNS rebinding and read what it returns. This is the right posture only where the address is
       unreachable from a browser that could be aimed at it, such as an intranet or a reverse proxy that authenticates.
-      Turn McpEndpoint:Cors:AllowAnyOrigin off and list the origins served in McpEndpoint:Cors:AllowedOrigins wherever a
-      browser could be pointed at this address.
+      Replace the '*' in McpEndpoint:Cors:AllowedOrigins with the origins served wherever a browser could be pointed at
+      this address.
 ```
 
 Refusing that combination would make the ordinary intranet and reverse-proxy deployment the one needing extra settings,
@@ -192,14 +193,19 @@ Neither is authentication, and neither is why a request is trusted. A non-browse
 exactly as before; any client that chooses its own headers can send whichever origin it likes. The check is worth
 something against exactly one attacker — a browser, which sets the header itself and does not let a page forge it.
 
-Every origin is served by default, because the endpoint is protected by the credential a caller presents rather than by
-where it was loaded from. Narrowing is a deliberate step:
+**One setting carries the whole policy.** `McpEndpoint:Cors:AllowedOrigins` has three postures, and each is a
+consequence of what the list holds rather than a switch of its own:
+
+| The list | What is served |
+|---|---|
+| `["*"]`, which is the default | Every browser origin |
+| `["https://client.example.test"]` | Exactly the origins listed |
+| `[]` | No browser origin at all — only clients that send no `Origin`, which is every non-browser client |
 
 ```json
 {
   "McpEndpoint": {
     "Cors": {
-      "AllowAnyOrigin": false,
       "AllowedOrigins": [
         "https://client.example.test",
         "https://console.example.test:8443"
@@ -209,14 +215,22 @@ where it was loaded from. Narrowing is a deliberate step:
 }
 ```
 
+Every origin is served by default because the endpoint is protected by the credential a caller presents rather than by
+where it was loaded from. Narrowing is a deliberate step, and so is the empty list: a deployment whose only clients are
+agents and command-line tools states it and serves no browser anything.
+
 An origin is a scheme, a host, and a port where the port is not the scheme's default — nothing else. A path, a query, a
 fragment, or user information means a URL was written where an origin belongs and is refused at startup, as is a value
 that is not an origin at all. Entries are normalized to the form a browser sends, so `https://Client.Example.Test:443/`
 and `https://client.example.test` are one entry and listing both is refused rather than quietly collapsed.
 
-Two combinations are refused as ambiguous rather than guessed at: `AllowAnyOrigin` together with a list, and
-`AllowAnyOrigin` off with an empty list. Guessing would either widen a deployment an operator narrowed or narrow one they
-widened.
+`*` beside a real origin is refused at startup. It states two policies at once, and guessing would either widen a
+deployment an operator narrowed or narrow one they widened. `*` itself is answered before the entries are read as
+origins, so it needs no escaping and cannot collide with anything an operator could configure.
+
+An empty list has to be written as one — `"AllowedOrigins": []` in a JSON source, which every file-based provider
+supports. Environment variables cannot express an empty list, so a deployment configured entirely through them narrows
+by listing origins rather than by emptying the list.
 
 A request whose `Origin` is outside the configured list is answered `403` before any tool runs. Preflight is handled by
 the CORS middleware ahead of that check, so a browser's `OPTIONS` never reaches it as a request to refuse, and handling
@@ -229,10 +243,102 @@ bearer authentication need, rather than everything a browser might ask to send.
 
 ## Client certificates
 
-Not implemented yet. mTLS trust profiles, including the ChatGPT connector profile OpenAI publishes, are tracked
-separately. When they arrive they will authenticate a client *application* and compose with `ApiKey` or `None` — they do
-not replace end-user authentication, and the warning above will keep firing under `None` even with a certificate
-configured.
+Mutual TLS is off unless `McpEndpoint:ClientCertificateProfiles` names at least one client. A profile identifies a client
+*application* — the ChatGPT connector, a reporting service, a workstation fleet — and it composes with `ApiKey` or
+`None` rather than replacing either. A certificate says which program is calling; it never says on whose behalf.
+
+```json
+{
+  "McpEndpoint": {
+    "Enabled": true,
+    "Authentication": "ApiKey",
+    "ClientCertificateProfiles": [
+      {
+        "Name": "chatgpt-connector",
+        "Requirement": "Optional",
+        "TrustAnchors": [
+          {
+            "Name": "openai-connectors-ca",
+            "SecretReference": "file:/etc/mailmcp/openai-connectors-ca.pem"
+          }
+        ],
+        "SubjectAlternativeNames": ["mtls.prod.connectors.openai.com"]
+      }
+    ]
+  }
+}
+```
+
+| Setting | Meaning |
+|---|---|
+| `Name` | The operator-chosen name of the client, which is what a refusal in the log is read by. Required and unique |
+| `Requirement` | `Required` refuses a request that presents no certificate at all; `Optional` serves it and identifies no client. Required to state |
+| `TrustAnchors` | The certificate authorities a presented certificate must chain to. Ordinary [named secrets](secret-provisioning.md#the-secret-block), several of them so an authority can rotate by overlap |
+| `SubjectAlternativeNames` | The DNS names of which a presented certificate must carry at least one. Required, because an authority alone accepts every certificate it has ever issued |
+
+**A certificate has to pass all four checks**, against one profile: it carries an extended key usage naming client
+authentication, it carries one of that profile's expected DNS names as a subject alternative name, it is inside its
+validity period, and it chains to one of that profile's anchors. Profiles are tried in configuration order and the first
+one that accepts ends the walk, so a deployment can serve several clients whose authorities have nothing to do with each
+other.
+
+**Every refusal is an empty `403`.** Which profile objected, and why, is in the server log — recorded by the
+certificate's thumbprint, which is public material — and never in the response, because what a client could act on is
+what to present next.
+
+Several deliberate strictnesses are worth knowing before a profile is written:
+
+- **The certificate comes from the TLS connection.** No header is read, however a proxy in front of MailMcp spells one.
+  Terminating TLS elsewhere and forwarding what it saw is a design with its own trust boundary and is not this one.
+- **A certificate carrying no extended key usage is refused**, even though X.509 reads absence as every usage. A profile
+  that names client authentication asked for a certificate that says so, and the same authority commonly issues server
+  certificates too.
+- **The subject common name is never consulted** — only subject alternative names, which is what a certificate authority
+  actually attests to.
+- **Only the leaf is validated against the anchors.** The server does not see the chain a client sent, so a client whose
+  certificate chains through an intermediate needs that intermediate listed as a trust anchor beside its root.
+- **No revocation is checked.** The authorities behind a client profile are commonly private and publish neither a
+  revocation list nor a responder, so withdrawing a client means removing its profile or its anchor — which takes effect
+  on the next request, with no restart.
+- **Requesting a certificate is not requiring one.** Kestrel asks every HTTPS connection for one and accepts whatever
+  arrives, so the decision is made here rather than in the handshake, where a refusal would say nothing to anybody.
+
+**mTLS needs an HTTPS endpoint.** A client certificate only exists on a TLS connection, so a deployment serving plain
+HTTP presents none: an `Optional` profile then identifies nothing, and a `Required` profile refuses every request.
+Serving MCP over HTTPS with operator-provided certificates is
+[#142](https://github.com/Krzysztof318/MailMcp/issues/142); until it lands, terminate TLS in front of MailMcp only if you
+are not using these profiles, because a proxy that terminates TLS is exactly what stops the certificate from arriving.
+
+### The ChatGPT connector profile
+
+OpenAI publishes a managed client certificate for its MCP connector, and the profile above is the shape it asks for: the
+leaf chains to the published OpenAI Connectors mTLS certificate authority, is valid for client authentication, and
+carries the subject alternative name `mtls.prod.connectors.openai.com`. Nothing pins the leaf, because that certificate
+rotates and a pinned fingerprint would turn a routine rotation into an outage.
+
+The authority itself is **supplied by you**, as an ordinary secret reference. No third-party certificate ships in this
+repository, which is what keeps OpenAI rotating their authority an operator change rather than a MailMcp release. Fetch
+the current certificate from OpenAI's published location, provision it like any other trust anchor, and add the
+successor beside it while a rotation is in flight.
+
+`Requirement` is `Optional` above on purpose. A `Required` profile refuses every request that presents no certificate,
+which includes the workstation reaching the same endpoint with an API key alone; state `Required` only once every client
+of the deployment holds a certificate.
+
+**This is not complete ChatGPT production authentication.** OpenAI's connector expects an OAuth 2.1 authorization flow
+alongside the client certificate, and that is later work. What mTLS provides here is confidence about which application
+is connecting, which is worth having and is not the same thing as knowing whose mailbox is being read.
+
+### Rotating an authority
+
+Add the successor to the same `TrustAnchors` list, restart, let clients move onto certificates the new authority signed,
+then remove the predecessor and restart. Both are accepted in between, so nothing is refused while the change is in
+flight. Restarts are needed because the profile *list* is read once during composition; the material behind an anchor is
+re-read on every request, so replacing a certificate file in place needs no restart at all.
+
+An anchor that stops loading — a deleted file, a corrupted certificate — is recorded at `Error` and skipped, so the
+other anchors of that profile keep working. A profile whose anchors all fail to load refuses every certificate rather
+than accepting one, because an anchor that has become unreadable must never widen what a profile trusts.
 
 ## What the endpoint records
 

--- a/docs/operations/secret-provisioning.md
+++ b/docs/operations/secret-provisioning.md
@@ -201,7 +201,9 @@ A trust anchor is provisioned like any other secret, but the bytes behind it are
 
 An anchor that carries a private key is rejected. Provision the public certificate — `openssl x509 -in ca.pem -out ca-public.pem` if the file you have holds more than that — because a trust anchor needs nothing else, and a private key MailMcp holds is an authority MailMcp could impersonate.
 
-[IMAP synchronization](../features/imap-synchronization.md) describes how the anchor is used, including the revocation trade-off a private authority implies.
+Two things are provisioned this way and they are judged differently. A mail account's anchor decides whether MailMcp trusts the *server* it connects to; an [MCP client certificate profile](mcp-endpoint.md#client-certificates)'s anchors decide whether MailMcp trusts a *client* connecting to it, and a profile names several so an authority can rotate by overlap.
+
+[IMAP synchronization](../features/imap-synchronization.md) describes how the server-side anchor is used, including the revocation trade-off a private authority implies.
 
 ## Interpretation modes
 

--- a/docs/operations/secret-rotation.md
+++ b/docs/operations/secret-rotation.md
@@ -16,7 +16,8 @@ Material is applied at operation boundaries, never mid-operation:
 | Secret | The operation that picks up a rotation |
 | --- | --- |
 | Mailbox password | The next connection attempt. A synchronization run that has already authenticated finishes with the credential it authenticated with. |
-| Trust anchor | The next connection attempt, which loads the anchor alongside the password. |
+| Mail account trust anchor | The next connection attempt, which loads the anchor alongside the password. |
+| MCP client certificate trust anchor | The next MCP request. Every anchor of the profile being judged is loaded again on each one. |
 | Database credential | The next **physical** connection the pool opens. Connections already open finish with the credential they authenticated with, and a pooled logical connection reusing an open physical one keeps it too. |
 | MCP API key | The next MCP request. Every configured key is read again on each one, so a rotated file takes effect immediately. |
 
@@ -70,13 +71,26 @@ kubectl create secret generic mailmcp-imap --from-literal=imap-primary-password=
 
 Projected Secret volumes refresh on the kubelet's own sync period, so allow for that delay before revoking the old credential. A Secret mounted with `subPath` does **not** refresh; mount the directory instead.
 
-## Rotating a trust anchor
+## Rotating a mail account's trust anchor
 
 Replace the certificate behind the reference the account names, exactly as for a password, and follow the same per-shape rules above. The next connection attempt loads the new anchor.
 
-Provision the replacement **before** the current one expires and keep the server's own certificate chaining to whichever anchor is active at that moment. There is no overlap mechanism: one anchor is configured at a time, so the cut-over is the moment the file changes.
+Provision the replacement **before** the current one expires and keep the server's own certificate chaining to whichever anchor is active at that moment. There is no overlap mechanism here: an account names one anchor, so the cut-over is the moment the file changes. An MCP client certificate profile is the exception and names several, which is the section below.
 
 Because the chain rebuild does not check revocation, replacing the provisioned material is how a compromised private authority is retired. That is the reason this rotation path matters more for a trust anchor than the equivalent path would for a publicly trusted one.
+
+## Rotating an MCP client certificate authority
+
+A [client certificate profile](mcp-endpoint.md#client-certificates) names several trust anchors precisely so an authority can be replaced without a window in which clients are refused.
+
+1. Provision the successor certificate and add it to that profile's `TrustAnchors` under a **new** `Name`.
+2. Restart the host. The endpoint section is read once during composition, so a new entry needs one; the material behind an existing entry does not.
+3. Let clients move onto certificates the successor signed. Both authorities are accepted in between, and each request loads the anchors again.
+4. Remove the predecessor entry and restart.
+
+Replacing the certificate *behind* an existing reference is the other shape and needs no restart at all: the next request loads what the file now holds. Use it when the authority keeps its identity and only its material changed, and use the overlap above when the authority itself is being replaced.
+
+An anchor that stops loading is recorded at `Error` and skipped, so the rest of that profile keeps working; a profile whose anchors all fail to load refuses every certificate rather than accepting one. Startup loads every configured anchor and fails the host on one that does not, so this state means the deployment changed underneath a running process.
 
 ## Rotating an MCP API key
 

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -91,7 +91,6 @@ if (runsIntegrationTests)
         .WithEnvironment("McpEndpoint__Authentication", "ApiKey")
         .WithEnvironment("McpEndpoint__ApiKeys__0__Name", OrchestrationContract.McpApiKeyName)
         .WithEnvironment("McpEndpoint__ApiKeys__0__SecretReference", $"plaintext:{OrchestrationContract.McpApiKey}")
-        .WithEnvironment("McpEndpoint__Cors__AllowAnyOrigin", "false")
         .WithEnvironment("McpEndpoint__Cors__AllowedOrigins__0", OrchestrationContract.McpPermittedOrigin);
 }
 

--- a/src/Host/Configuration/McpClientCertificateProfileOptions.cs
+++ b/src/Host/Configuration/McpClientCertificateProfileOptions.cs
@@ -1,0 +1,136 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Diagnostics.CodeAnalysis;
+using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
+
+namespace MailMcp.Host.Configuration;
+
+/// <summary>One client application the endpoint accepts a certificate from, and what that certificate must be.</summary>
+/// <remarks>
+/// <para>
+/// Mutual TLS is off unless profiles are configured, and it composes with whatever <see cref="McpEndpointOptions.Authentication" />
+/// states rather than replacing it. A certificate names the program making a request; the API key, and later an OAuth
+/// 2.1 token, is what names the person on whose behalf it is made.
+/// </para>
+/// <para>
+/// The ChatGPT connector is configured as an ordinary profile rather than as a built-in mode: OpenAI publishes the
+/// authority, the usage, and the name to expect, so the deployment states them and rotating that authority stays an
+/// operator change. No third-party certificate ships in this repository, which is what keeps a rotation from becoming
+/// a release.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed class McpClientCertificateProfileOptions
+{
+    /// <summary>Gets or sets the operator-chosen name of the client this profile identifies, for example <c>chatgpt-connector</c>.</summary>
+    /// <remarks>It is the identity a refusal, a rotation, and an audit record name, so it is required and unique within the section.</remarks>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether a request that presents no certificate at all is refused.</summary>
+    /// <remarks>
+    /// Nullable rather than defaulted, for the reason the authentication mode is: both candidate defaults are postures.
+    /// Assuming the permissive one would leave a deployment believing certificates are required when they are not, and
+    /// assuming the strict one would lock out every client of a deployment that added a profile for one of them.
+    /// </remarks>
+    public McpClientCertificateRequirement? Requirement { get; set; }
+
+    /// <summary>Gets the certificate authorities a presented certificate must chain to.</summary>
+    /// <remarks>
+    /// Several entries so an authority rotates by overlap: add its successor, let clients move across, remove the
+    /// predecessor. Each is an ordinary named secret block, which is how the material is provisioned and erased —
+    /// the certificate itself is public, and its expiry is the X.509 one rather than the configured lifetime.
+    /// </remarks>
+    public IList<ConfiguredSecret> TrustAnchors { get; } = [];
+
+    /// <summary>Gets the DNS names of which a presented certificate must carry at least one, for example <c>mtls.prod.connectors.openai.com</c>.</summary>
+    public IList<string> SubjectAlternativeNames { get; } = [];
+
+    /// <summary>Finds everything an operator must fix before this profile can judge a certificate.</summary>
+    /// <returns>One message per faulty setting, relative to this profile, empty when the profile is usable.</returns>
+    public IReadOnlyList<string> FindConfigurationErrors() =>
+    [
+        .. this.FindNameErrors(),
+        .. this.FindRequirementErrors(),
+        .. this.FindTrustAnchorErrors(),
+        .. this.FindSubjectAlternativeNameErrors(),
+    ];
+
+    /// <summary>Maps the configured settings onto the profile a presented certificate is judged against.</summary>
+    /// <returns>The trust profile.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
+    public McpClientCertificateTrustProfile ToTrustProfile()
+    {
+        try
+        {
+            return McpClientCertificateTrustProfile.Create(
+                this.Name,
+                this.Requirement ?? McpClientCertificateRequirement.Required,
+                this.TrustAnchors,
+                this.SubjectAlternativeNames);
+        }
+        catch (ArgumentException exception)
+        {
+            throw new InvalidOperationException(
+                "A client certificate profile was mapped before it was validated, so it cannot identify a client.",
+                exception);
+        }
+    }
+
+    private IEnumerable<string> FindNameErrors()
+    {
+        if (!McpClientCertificateTrustProfile.IsAcceptedName(this.Name))
+        {
+            yield return $"{nameof(this.Name)} — a profile is named after the client it identifies; write up to {McpClientCertificateTrustProfile.MaximumNameLength} letters, digits, dots, dashes, and underscores, beginning with a letter or a digit.";
+        }
+    }
+
+    private IEnumerable<string> FindRequirementErrors()
+    {
+        if (this.Requirement is not { } requirement)
+        {
+            yield return $"{nameof(this.Requirement)} — state '{nameof(McpClientCertificateRequirement.Required)}' when every client of this deployment presents a certificate, or '{nameof(McpClientCertificateRequirement.Optional)}' when this client does and others authenticate otherwise.";
+
+            yield break;
+        }
+
+        // The binder accepts any number for an enum, and a value no member declares would be neither requirement while
+        // reading as one, so a request presenting no certificate would be judged by a rule nobody wrote.
+        if (!Enum.IsDefined(requirement))
+        {
+            yield return $"{nameof(this.Requirement)} — '{(int)requirement}' names no requirement; state '{nameof(McpClientCertificateRequirement.Required)}' or '{nameof(McpClientCertificateRequirement.Optional)}'.";
+        }
+    }
+
+    private IEnumerable<string> FindTrustAnchorErrors()
+    {
+        if (this.TrustAnchors.Count == 0)
+        {
+            yield return $"{nameof(this.TrustAnchors)} — a profile trusts the certificate authority that signed for its client; configure at least one.";
+        }
+    }
+
+    /// <summary>Reports a profile that would accept every certificate its authority ever issued.</summary>
+    /// <remarks>
+    /// At least one name is required rather than optional. An authority alone identifies no client — for a public or
+    /// shared certificate authority it identifies most of the internet — so a profile that named none would be trusting
+    /// whoever else that authority signs for, which is never what listing it meant.
+    /// </remarks>
+    private IEnumerable<string> FindSubjectAlternativeNameErrors()
+    {
+        if (this.SubjectAlternativeNames.Count == 0)
+        {
+            yield return $"{nameof(this.SubjectAlternativeNames)} — a profile names the client it identifies; configure at least one DNS name its certificate carries, because the authority alone would accept every certificate it has ever issued.";
+
+            yield break;
+        }
+
+        foreach (var (index, configuredName) in this.SubjectAlternativeNames.Index())
+        {
+            if (!McpClientCertificateTrustProfile.IsAcceptedDnsName(configuredName))
+            {
+                yield return $"{nameof(this.SubjectAlternativeNames)}:{index} — '{configuredName}' is not a DNS name; write the host name a certificate carries as a subject alternative name, and nothing else.";
+            }
+        }
+    }
+}

--- a/src/Host/Configuration/McpCorsOptions.cs
+++ b/src/Host/Configuration/McpCorsOptions.cs
@@ -14,55 +14,77 @@ namespace MailMcp.Host.Configuration;
 /// authenticates nothing on its own and is never the reason a request is trusted.
 /// </para>
 /// <para>
-/// The two settings are alternatives rather than layers. An operator who lists origins while leaving
-/// <see cref="AllowAnyOrigin" /> on has stated two policies, and guessing which one they meant would either widen a
-/// deployment they narrowed or narrow one they widened; both are refused at startup instead.
+/// One setting carries the whole policy. A pair of them — an allow-any switch beside a list — states one decision twice,
+/// and half of its combinations are startup errors for exactly that reason: the pair can say two things at once and
+/// guessing which was meant would either widen a deployment an operator narrowed or narrow one they widened.
+/// <see cref="AnyOriginValue" /> written in the list says the same thing and cannot contradict itself.
+/// </para>
+/// <para>
+/// The three postures are consequences of the list rather than settings of their own: <see cref="AnyOriginValue" /> alone
+/// serves every browser origin, a list of origins serves exactly those, and an empty list serves no browser at all —
+/// which still serves every client that sends no <c>Origin</c>, meaning every non-browser client.
 /// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
 internal sealed class McpCorsOptions
 {
-    /// <summary>Gets or sets whether every browser origin is served.</summary>
-    /// <remarks>Credentials are never enabled alongside it, so a browser may read a response it obtained with an explicit bearer credential and may never attach an ambient cookie to the request that produced it.</remarks>
-    public bool AllowAnyOrigin { get; set; } = true;
+    /// <summary>The entry that stands for every browser origin rather than for one an operator could have written.</summary>
+    public const string AnyOriginValue = "*";
 
-    /// <summary>Gets the exact origins served when <see cref="AllowAnyOrigin" /> is off, for example <c>https://client.example.test</c>.</summary>
+    /// <summary>Gets the browser origins served, for example <c>https://client.example.test</c>, or <see cref="AnyOriginValue" /> for all of them.</summary>
+    /// <remarks>
+    /// It reads as <see cref="AnyOriginValue" /> when a deployment configures no list at all, which
+    /// <see cref="McpEndpointOptions.ReadFrom" /> applies, because the binder cannot tell an absent list from an empty
+    /// one and the two mean opposite things here. The property's own default is therefore the empty list rather than
+    /// the permissive one: the permissive default belongs to the configured section, and an object built any other way
+    /// starts from the posture that serves no browser rather than from the one that serves every page on the internet.
+    /// </remarks>
     public IList<string> AllowedOrigins { get; } = [];
+
+    /// <summary>Gets whether every browser origin is served, which is the posture the startup warning reports under an unauthenticated endpoint.</summary>
+    public bool ServesEveryBrowserOrigin => this.AllowedOrigins.Contains(AnyOriginValue, StringComparer.Ordinal);
+
+    /// <summary>Serves every browser origin, which is what a deployment that configured no list gets.</summary>
+    /// <remarks>Called once while the section is read, never after the policy has been derived from the list.</remarks>
+    public void ServeEveryBrowserOrigin() => this.AllowedOrigins.Add(AnyOriginValue);
 
     /// <summary>Finds everything an operator must fix before this policy can be applied.</summary>
     /// <returns>One message per faulty setting, relative to this section, empty when the policy is usable.</returns>
+    /// <remarks>
+    /// <see cref="AnyOriginValue" /> is answered before the entries are read as origins, because it is not one and no
+    /// operator could configure a real origin that collides with it. What is left to refuse is the list that carries it
+    /// beside something else, which states two policies for the same reason the removed allow-any switch could.
+    /// </remarks>
     public IReadOnlyList<string> FindConfigurationErrors()
     {
-        var errors = new List<string>();
-
-        if (this.AllowAnyOrigin && this.AllowedOrigins.Count > 0)
+        if (this.ServesEveryBrowserOrigin)
         {
-            errors.Add($"{nameof(this.AllowAnyOrigin)} — every origin is served and an exact origin list is configured; state one policy or the other.");
+            return this.AllowedOrigins.Count > 1
+                ? [$"{nameof(this.AllowedOrigins)} — '{AnyOriginValue}' is listed beside another entry, which states two policies at once; list the origins served, or '{AnyOriginValue}' on its own."]
+                : [];
         }
 
-        if (!this.AllowAnyOrigin && this.AllowedOrigins.Count == 0)
-        {
-            errors.Add($"{nameof(this.AllowedOrigins)} — no origin is served and none is listed, so no browser client could reach the endpoint.");
-        }
-
-        errors.AddRange(this.FindAllowedOriginErrors());
-
-        return errors;
+        return [.. this.FindAllowedOriginErrors()];
     }
 
-    /// <summary>Maps the configured settings onto the policy the endpoint judges a request's origin by.</summary>
+    /// <summary>Maps the configured list onto the policy the endpoint judges a request's origin by.</summary>
     /// <returns>The origin policy.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
     public McpOriginPolicy ToOriginPolicy()
     {
-        if (this.AllowAnyOrigin)
+        if (this.ServesEveryBrowserOrigin)
         {
             return McpOriginPolicy.AllowingAnyOrigin;
         }
 
+        if (this.AllowedOrigins.Count == 0)
+        {
+            return McpOriginPolicy.ServingNoBrowserOrigin;
+        }
+
         var normalizedOrigins = this.NormalizedAllowedOrigins().ToArray();
 
-        return normalizedOrigins.Length == this.AllowedOrigins.Count && normalizedOrigins.Length > 0
+        return normalizedOrigins.Length == this.AllowedOrigins.Count
             ? McpOriginPolicy.Restricting(normalizedOrigins)
             : throw new InvalidOperationException(
                 "The configured origins were mapped before they were validated, so at least one of them is unusable.");
@@ -72,7 +94,8 @@ internal sealed class McpCorsOptions
     /// <remarks>
     /// Duplicates are reported after normalization rather than before, because two spellings of one origin are one
     /// entry to every browser and an operator who listed both has said something about their intent that the accepted
-    /// list would silently discard.
+    /// list would silently discard. <see cref="AnyOriginValue" /> never reaches this: it is not an origin any
+    /// normalization accepts, and a list carrying it beside anything else was already refused.
     /// </remarks>
     private IEnumerable<string> FindAllowedOriginErrors()
     {

--- a/src/Host/Configuration/McpEndpointOptions.cs
+++ b/src/Host/Configuration/McpEndpointOptions.cs
@@ -2,6 +2,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
 
 namespace MailMcp.Host.Configuration;
 
@@ -51,6 +52,45 @@ internal sealed class McpEndpointOptions
     /// <summary>Gets or sets which browser origins the endpoint answers.</summary>
     public McpCorsOptions Cors { get; set; } = new();
 
+    /// <summary>Gets the client applications whose certificates the endpoint accepts, empty when mutual TLS is off.</summary>
+    /// <remarks>
+    /// Several named profiles rather than one certificate setting, so each client's policy is stated separately and one
+    /// client's authority rotating cannot widen what another is trusted for. They compose with
+    /// <see cref="Authentication" /> instead of replacing it, and a certificate reaches them only over an HTTPS
+    /// endpoint — a deployment serving plain HTTP presents none, which a required profile refuses.
+    /// </remarks>
+    public IList<McpClientCertificateProfileOptions> ClientCertificateProfiles { get; } = [];
+
+    /// <summary>Reads the section the way composition does, defaults included.</summary>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The bound settings, with the defaults no binder can apply already applied.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Strict binding is part of the read rather than something a caller opts into: this section is security-sensitive
+    /// throughout, and a misspelled key that bound quietly would leave a decision reading as one nobody made.
+    /// <para>
+    /// The origin list is the one setting whose default cannot be a property initializer. A collection the binder finds
+    /// values for is added to rather than replaced, so a pre-populated default would survive beside the configured
+    /// entries; and an empty JSON list binds identically to an absent one, which is why the two are told apart by asking
+    /// configuration whether the key exists at all rather than by looking at what was bound.
+    /// </para>
+    /// </remarks>
+    public static McpEndpointOptions ReadFrom(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var section = configuration.GetSection(SectionName);
+        var settings = section.Get<McpEndpointOptions>(binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
+            ?? new McpEndpointOptions();
+
+        if (!section.GetSection($"{nameof(Cors)}:{nameof(McpCorsOptions.AllowedOrigins)}").Exists())
+        {
+            settings.Cors.ServeEveryBrowserOrigin();
+        }
+
+        return settings;
+    }
+
     /// <summary>Finds everything an operator must fix before the endpoint can be served.</summary>
     /// <returns>One message per faulty setting, each naming its configuration path, empty when the settings are usable.</returns>
     /// <remarks>
@@ -70,7 +110,41 @@ internal sealed class McpEndpointOptions
         errors.AddRange(this.Cors.FindConfigurationErrors()
             .Select(error => $"{SectionName}:{nameof(this.Cors)}:{error}"));
 
+        errors.AddRange(this.FindClientCertificateProfileErrors());
+
         return errors;
+    }
+
+    /// <summary>Maps the configured profiles onto the ones a presented certificate is judged against.</summary>
+    /// <returns>The trust profiles, in configuration order, empty when mutual TLS is off.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
+    public IReadOnlyList<McpClientCertificateTrustProfile> ToClientCertificateTrustProfiles() =>
+        [.. this.ClientCertificateProfiles.Select(profile => profile.ToTrustProfile())];
+
+    /// <summary>Reports the profiles an operator must fix, and the names two of them share.</summary>
+    /// <remarks>
+    /// A duplicated name is refused rather than resolved by position, for the reason every other configured name is:
+    /// the name is what a refusal in the log and an audit record are read by, and two profiles answering to one name
+    /// make both records ambiguous.
+    /// </remarks>
+    private IEnumerable<string> FindClientCertificateProfileErrors()
+    {
+        var claimedNames = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (index, profile) in this.ClientCertificateProfiles.Index())
+        {
+            var profilePath = $"{SectionName}:{nameof(this.ClientCertificateProfiles)}:{index}";
+
+            foreach (var error in profile.FindConfigurationErrors())
+            {
+                yield return $"{profilePath}:{error}";
+            }
+
+            if (!claimedNames.Add(profile.Name))
+            {
+                yield return $"{profilePath}:{nameof(McpClientCertificateProfileOptions.Name)} — another profile in this section already carries this name, so neither could be named unambiguously.";
+            }
+        }
     }
 
     private IEnumerable<string> FindAuthenticationErrors()

--- a/src/Host/Configuration/SecretConfigurationValidator.cs
+++ b/src/Host/Configuration/SecretConfigurationValidator.cs
@@ -170,9 +170,54 @@ internal sealed partial class SecretConfigurationValidator
     {
         ArgumentNullException.ThrowIfNull(candidate);
 
-        return candidate.Enabled
-            ? await this.FindSecretReferenceErrorsAsync(McpEndpointOptions.SectionName, candidate, cancellationToken)
-            : [];
+        if (!candidate.Enabled)
+        {
+            return [];
+        }
+
+        var errors = new List<string>(
+            await this.FindSecretReferenceErrorsAsync(McpEndpointOptions.SectionName, candidate, cancellationToken));
+
+        errors.AddRange(await this.FindClientCertificateTrustAnchorErrorsAsync(candidate, cancellationToken));
+
+        return errors;
+    }
+
+    /// <summary>Loads every trust anchor a client certificate profile names and reports the ones no request could use.</summary>
+    /// <remarks>
+    /// Resolving the reference is not enough, for the reason the mail anchors are loaded too: material that resolves but
+    /// does not parse as a certificate would pass a reference check and then refuse every client the profile exists to
+    /// serve. Each anchor is discarded once it has proven loadable, because a request loads its own.
+    /// </remarks>
+    private async Task<IReadOnlyList<string>> FindClientCertificateTrustAnchorErrorsAsync(
+        McpEndpointOptions candidate,
+        CancellationToken cancellationToken)
+    {
+        var errors = new List<string>();
+
+        // The positions are part of the reported configuration path, so they come from Index rather than from counters
+        // the loop bodies could forget to advance. The loops themselves stay, because each step awaits a retrieval.
+        foreach (var (profileIndex, profile) in candidate.ClientCertificateProfiles.Index())
+        {
+            foreach (var (anchorIndex, configuredAnchor) in profile.TrustAnchors.Index())
+            {
+                var configurationPath =
+                    $"{McpEndpointOptions.SectionName}:{nameof(McpEndpointOptions.ClientCertificateProfiles)}:{profileIndex}:{nameof(McpClientCertificateProfileOptions.TrustAnchors)}:{anchorIndex}";
+
+                using var loadResult = await this.trustAnchorLoader.LoadAsync(configuredAnchor, cancellationToken);
+
+                if (loadResult.TrustAnchor is { } trustAnchor)
+                {
+                    this.LogTrustAnchorLoaded(configurationPath, trustAnchor.Subject, trustAnchor.Thumbprint);
+                }
+                else
+                {
+                    errors.Add($"{configurationPath} — the trust anchor material could not be loaded [{loadResult.Failure}].");
+                }
+            }
+        }
+
+        return errors;
     }
 
     /// <summary>Resolves every secret reference in a bound options graph and reports the ones an operator must fix.</summary>

--- a/src/Host/Hosting/McpTransportAuthenticationWarning.cs
+++ b/src/Host/Hosting/McpTransportAuthenticationWarning.cs
@@ -66,7 +66,7 @@ internal sealed partial class McpTransportAuthenticationWarning : IHostedService
 
         this.LogEndpointServedWithoutTransportAuthentication(McpEndpointRoute.Path);
 
-        if (this.endpointSettings.Cors.AllowAnyOrigin)
+        if (this.endpointSettings.Cors.ServesEveryBrowserOrigin)
         {
             this.LogEveryBrowserOriginServedWithoutTransportAuthentication();
         }
@@ -91,7 +91,7 @@ internal sealed partial class McpTransportAuthenticationWarning : IHostedService
         Message = "Every browser origin is served while no credential is required, so a web page the user never visited "
             + "can reach this endpoint through DNS rebinding and read what it returns. This is the right posture only "
             + "where the address is unreachable from a browser that could be aimed at it, such as an intranet or a "
-            + "reverse proxy that authenticates. Turn McpEndpoint:Cors:AllowAnyOrigin off and list the origins served "
-            + "in McpEndpoint:Cors:AllowedOrigins wherever a browser could be pointed at this address.")]
+            + "reverse proxy that authenticates. Replace the '*' in McpEndpoint:Cors:AllowedOrigins with the origins "
+            + "served wherever a browser could be pointed at this address.")]
     private partial void LogEveryBrowserOriginServedWithoutTransportAuthentication();
 }

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -210,10 +210,7 @@ try
     //
     // Bound strictly like the other security-sensitive sections: a misspelled "Enabeld" would leave the endpoint off
     // while an operator believed they had turned it on.
-    var mcpEndpointSettings = builder.Configuration
-        .GetSection(McpEndpointOptions.SectionName)
-        .Get<McpEndpointOptions>(binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
-        ?? new McpEndpointOptions();
+    var mcpEndpointSettings = McpEndpointOptions.ReadFrom(builder.Configuration);
     builder.Services.AddSingleton(Options.Create(mcpEndpointSettings));
 
     // Validated here rather than through ValidateOnStart, because the section is read before a container exists and the
@@ -234,6 +231,13 @@ try
         // added, so the protocol surface adds no port of its own.
         builder.Services.AddMailMcpServer();
         builder.Services.AddMcpTransportSecurity(mcpEndpointSettings);
+
+        if (mcpEndpointSettings.ClientCertificateProfiles.Count > 0)
+        {
+            // A certificate is asked for while the connection is being established or it never arrives at all, so this
+            // is a decision the server has to take before it is listening rather than one a request can reach.
+            builder.WebHost.RequestMcpClientCertificates();
+        }
     }
 
     var app = builder.Build();
@@ -250,6 +254,14 @@ try
         // deployment serves a page's origin does not depend on which credential the page attached.
         app.UseCors();
         app.UseMcpOriginValidation();
+
+        if (mcpEndpointSettings.ClientCertificateProfiles.Count > 0)
+        {
+            // Ahead of authentication, because which client application is calling and which credential it presents are
+            // separate questions: a request from a program this deployment does not serve is turned away before any
+            // credential is read.
+            app.UseMcpClientCertificateValidation(mcpEndpointSettings.ToClientCertificateTrustProfiles());
+        }
 
         var mcpEndpoint = app
             .MapMcp(McpEndpointRoute.Path)

--- a/src/Host/Security/McpClientCertificateValidation.cs
+++ b/src/Host/Security/McpClientCertificateValidation.cs
@@ -1,0 +1,82 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Infrastructure.Security;
+using MailMcp.Mcp;
+
+namespace MailMcp.Host.Security;
+
+/// <summary>Refuses an MCP request whose client certificate no configured trust profile accepts.</summary>
+/// <remarks>
+/// <para>
+/// The certificate is taken from the TLS connection and from nowhere else. A header naming a certificate — however it
+/// is spelled, and whichever proxy is in the habit of setting it — is written by whoever sent the request, so trusting
+/// one would turn client authentication into a value a client fills in for itself. Terminating TLS at a proxy and
+/// forwarding what it saw is a design with its own trust boundary and is deliberately not this one.
+/// </para>
+/// <para>
+/// It runs behind the origin check and ahead of authentication. A certificate identifies the client application, a key
+/// identifies the deployment's own credential, and neither answer depends on the other; running this first means a
+/// request from a program this deployment does not serve is turned away before any credential is read.
+/// </para>
+/// <para>
+/// The refusal is a <c>403</c> with no body, as the origin refusal is. There is nothing safe to add: a client learning
+/// which profile objected, and why, would learn what to present next.
+/// </para>
+/// </remarks>
+internal static class McpClientCertificateValidation
+{
+    /// <summary>Applies the configured trust profiles to every request addressed to the MCP endpoint.</summary>
+    /// <param name="app">The application being composed.</param>
+    /// <param name="trustProfiles">The profiles composition mapped from configuration.</param>
+    /// <returns>The application, so composition reads as one sequence.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="app" /> or <paramref name="trustProfiles" /> is <see langword="null" />.</exception>
+    internal static WebApplication UseMcpClientCertificateValidation(
+        this WebApplication app,
+        IReadOnlyList<McpClientCertificateTrustProfile> trustProfiles)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(trustProfiles);
+
+        var authenticator = app.Services.GetRequiredService<McpClientCertificateAuthenticator>();
+
+        app.UseWhen(
+            context => context.Request.Path.StartsWithSegments(McpEndpointRoute.Path),
+            mcpEndpoint => mcpEndpoint.Use((context, next) =>
+                ServeWhenTheConnectionCertificateIsAcceptedAsync(context, next, authenticator, trustProfiles)));
+
+        return app;
+    }
+
+    /// <summary>Judges one request's connection certificate and serves it only when a profile accepted it.</summary>
+    /// <param name="context">The request being judged, whose connection carries the certificate.</param>
+    /// <param name="next">The rest of the pipeline, reached only when the certificate was accepted.</param>
+    /// <param name="authenticator">The authenticator that judges the certificate against the profiles.</param>
+    /// <param name="trustProfiles">The profiles composition mapped from configuration.</param>
+    /// <returns>A task that completes when the request has been refused or served.</returns>
+    /// <remarks>
+    /// The certificate is read from the connection rather than awaited from it, because Kestrel is configured to ask
+    /// for one during the handshake. Awaiting would invite a renegotiation on the request thread for a client that
+    /// simply has no certificate, which is an ordinary case here rather than something to recover from. No header takes
+    /// any part in this, which is what a test on this method rather than on the pipeline is able to state.
+    /// </remarks>
+    internal static async Task ServeWhenTheConnectionCertificateIsAcceptedAsync(
+        HttpContext context,
+        RequestDelegate next,
+        McpClientCertificateAuthenticator authenticator,
+        IReadOnlyList<McpClientCertificateTrustProfile> trustProfiles)
+    {
+        var result = await authenticator.AuthenticateAsync(
+            trustProfiles,
+            context.Connection.ClientCertificate,
+            context.RequestAborted);
+
+        if (!result.Succeeded)
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+
+            return;
+        }
+
+        await next(context);
+    }
+}

--- a/src/Host/Security/McpTransportSecurityExtensions.cs
+++ b/src/Host/Security/McpTransportSecurityExtensions.cs
@@ -4,6 +4,7 @@ using MailMcp.Host.Configuration;
 using MailMcp.Infrastructure.Security;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Net.Http.Headers;
 
 namespace MailMcp.Host.Security;
@@ -47,6 +48,11 @@ internal static class McpTransportSecurityExtensions
             CorsPolicyName,
             policy => ConfigureCorsPolicy(policy, originPolicy)));
 
+        if (endpointSettings.ClientCertificateProfiles.Count > 0)
+        {
+            services.AddSingleton<McpClientCertificateAuthenticator>();
+        }
+
         if (endpointSettings.Authentication != McpTransportAuthenticationMode.ApiKey)
         {
             return services;
@@ -63,12 +69,48 @@ internal static class McpTransportSecurityExtensions
         return services;
     }
 
+    /// <summary>Asks every HTTPS connection for a client certificate and leaves the decision to the trust profiles.</summary>
+    /// <param name="webHost">The web host being configured.</param>
+    /// <returns>The web host, so composition reads as one sequence.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="webHost" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// A certificate has to be asked for during the handshake or it never arrives, and it is asked for rather than
+    /// demanded so that a client without one reaches the middleware and is refused there. A handshake failure would say
+    /// nothing to the operator reading a log and nothing to a client that could act on it.
+    /// </para>
+    /// <para>
+    /// The connection-level validation accepts every certificate on purpose, and it grants nothing by doing so. Kestrel
+    /// would otherwise validate against the machine's own trust store, which is both too narrow and too wide for this
+    /// design: it would fail the handshake for the private authority a profile names, and it would accept a certificate
+    /// from any public authority the machine happens to trust. Whether a certificate is trusted is
+    /// <see cref="McpClientCertificateValidation" />'s decision, made against the profile's anchors, and this line
+    /// exists so that decision is reached at all.
+    /// </para>
+    /// </remarks>
+    internal static IWebHostBuilder RequestMcpClientCertificates(this IWebHostBuilder webHost)
+    {
+        ArgumentNullException.ThrowIfNull(webHost);
+
+        return webHost.ConfigureKestrel(kestrel => kestrel.ConfigureHttpsDefaults(https =>
+        {
+            https.ClientCertificateMode = ClientCertificateMode.AllowCertificate;
+            https.ClientCertificateValidation = static (_, _, _) => true;
+        }));
+    }
+
     /// <summary>Builds the CORS policy from the configured origins.</summary>
     /// <remarks>
-    /// Credentials are never allowed, under either policy. A browser that could attach an ambient cookie to an MCP
+    /// <para>
+    /// A policy that names no origin at all is the deliberate third posture rather than an oversight: it advertises
+    /// nothing to a browser, which is what a deployment whose only clients are agents and command-line tools wants.
+    /// </para>
+    /// <para>
+    /// Credentials are never allowed, under any policy. A browser that could attach an ambient cookie to an MCP
     /// request would let a page act as whoever is logged in somewhere else, and the endpoint has no use for one anyway:
     /// its credential is a bearer token a client sets deliberately. Allowing any origin and allowing credentials is
     /// also a combination the CORS specification forbids outright.
+    /// </para>
     /// </remarks>
     private static void ConfigureCorsPolicy(CorsPolicyBuilder policy, McpOriginPolicy originPolicy)
     {

--- a/src/Infrastructure/Security/McpClientCertificateAuthenticationResult.cs
+++ b/src/Infrastructure/Security/McpClientCertificateAuthenticationResult.cs
@@ -1,0 +1,50 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+namespace MailMcp.Infrastructure.Security;
+
+/// <summary>The outcome of judging the certificate a TLS connection carried against the configured trust profiles.</summary>
+/// <remarks>
+/// Two questions are answered rather than one, and they are independent. <see cref="Succeeded" /> says whether the
+/// request is served, and <see cref="MatchedProfileName" /> says which client application was identified — which is
+/// nobody when a served request presented no certificate and every profile was content without one. Reading the second
+/// as the answer to the first would report an unidentified client as a refused one.
+/// </remarks>
+public sealed record McpClientCertificateAuthenticationResult
+{
+    private McpClientCertificateAuthenticationResult(string? matchedProfileName, McpClientCertificateRejection? rejection)
+    {
+        this.MatchedProfileName = matchedProfileName;
+        this.Rejection = rejection;
+    }
+
+    /// <summary>Gets the result of a request no profile required a certificate of, which identifies no client application.</summary>
+    public static McpClientCertificateAuthenticationResult AcceptedWithoutCertificate { get; } =
+        new(matchedProfileName: null, rejection: null);
+
+    /// <summary>Gets whether the request is served.</summary>
+    public bool Succeeded => this.Rejection is null;
+
+    /// <summary>Gets the name of the profile whose client the certificate identified, or <see langword="null" /> when no certificate identified one.</summary>
+    public string? MatchedProfileName { get; }
+
+    /// <summary>Gets why the certificate was refused, or <see langword="null" /> when the request is served.</summary>
+    /// <remarks>It reaches the server log only. Every value produces the same response to the caller.</remarks>
+    public McpClientCertificateRejection? Rejection { get; }
+
+    /// <summary>Creates a successful result naming the profile the certificate matched.</summary>
+    /// <param name="matchedProfileName">The name of the matching profile.</param>
+    /// <returns>The successful result.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="matchedProfileName" /> names no profile.</exception>
+    public static McpClientCertificateAuthenticationResult AcceptedByProfile(string matchedProfileName) =>
+        string.IsNullOrEmpty(matchedProfileName)
+            ? throw new ArgumentException(
+                "A result accepted by a profile must name that profile.",
+                nameof(matchedProfileName))
+            : new McpClientCertificateAuthenticationResult(matchedProfileName, rejection: null);
+
+    /// <summary>Creates a refused result.</summary>
+    /// <param name="rejection">Why the certificate was refused.</param>
+    /// <returns>The refused result.</returns>
+    public static McpClientCertificateAuthenticationResult Rejected(McpClientCertificateRejection rejection) =>
+        new(matchedProfileName: null, rejection);
+}

--- a/src/Infrastructure/Security/McpClientCertificateAuthenticator.cs
+++ b/src/Infrastructure/Security/McpClientCertificateAuthenticator.cs
@@ -1,0 +1,191 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Security.Cryptography.X509Certificates;
+using MailMcp.Infrastructure.Certificates;
+using Microsoft.Extensions.Logging;
+
+namespace MailMcp.Infrastructure.Security;
+
+/// <summary>Judges the certificate a TLS connection carried against the trust profiles a deployment configured.</summary>
+/// <remarks>
+/// <para>
+/// This identifies a client <em>application</em> and nothing more. It is not end-user authentication, it does not
+/// replace an API key, and a deployment that runs unauthenticated stays unauthenticated with every profile in place:
+/// a certificate names the program making the request, never the person whose mail is being read.
+/// </para>
+/// <para>
+/// Anchors are loaded per request rather than held, which is what makes an authority rotate without a restart, on the
+/// same terms the API keys are resolved on. Nothing here is timing-sensitive the way a credential comparison is: a
+/// certificate is public material a client sends in the clear, so profiles are evaluated in order and the first one
+/// that accepts ends the walk.
+/// </para>
+/// <para>
+/// A profile whose anchors have all become unloadable refuses the request rather than falling through to the next
+/// profile's answer being the deployment's answer. Startup proved every anchor loads, so reaching that state means the
+/// deployment changed underneath a running process, and widening what is accepted is never the right response to it.
+/// </para>
+/// </remarks>
+public sealed partial class McpClientCertificateAuthenticator
+{
+    private readonly TrustAnchorLoader trustAnchorLoader;
+    private readonly ILogger<McpClientCertificateAuthenticator> logger;
+
+    /// <summary>Initializes a new client certificate authenticator.</summary>
+    /// <param name="trustAnchorLoader">The loader that turns configured material into a trust anchor.</param>
+    /// <param name="logger">The log a refusal and an unloadable anchor are recorded in.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="trustAnchorLoader" /> is <see langword="null" />.</exception>
+    public McpClientCertificateAuthenticator(
+        TrustAnchorLoader trustAnchorLoader,
+        ILogger<McpClientCertificateAuthenticator> logger)
+    {
+        ArgumentNullException.ThrowIfNull(trustAnchorLoader);
+
+        this.trustAnchorLoader = trustAnchorLoader;
+        this.logger = logger;
+    }
+
+    /// <summary>Judges the certificate a connection presented.</summary>
+    /// <param name="profiles">The trust profiles the deployment configured, in configuration order.</param>
+    /// <param name="presentedCertificate">The certificate the TLS connection carried, or <see langword="null" /> when it carried none.</param>
+    /// <param name="cancellationToken">Cancels the retrieval of the configured anchor material.</param>
+    /// <returns>The profile whose client the certificate identified, or the reason it was refused.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="profiles" /> is <see langword="null" />.</exception>
+    /// <remarks>The certificate is judged as the connection supplied it. No header is read here or anywhere else: a header naming a certificate is written by whoever sent the request.</remarks>
+    public async Task<McpClientCertificateAuthenticationResult> AuthenticateAsync(
+        IReadOnlyList<McpClientCertificateTrustProfile> profiles,
+        X509Certificate2? presentedCertificate,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(profiles);
+
+        if (profiles.Count == 0)
+        {
+            return McpClientCertificateAuthenticationResult.AcceptedWithoutCertificate;
+        }
+
+        if (presentedCertificate is null)
+        {
+            return profiles.Any(profile => profile.Requirement == McpClientCertificateRequirement.Required)
+                ? McpClientCertificateAuthenticationResult.Rejected(McpClientCertificateRejection.CertificateMissing)
+                : McpClientCertificateAuthenticationResult.AcceptedWithoutCertificate;
+        }
+
+        McpClientCertificateRejection? firstObjection = null;
+
+        // A loop rather than a query: each step awaits the retrieval of that profile's anchor material, and the walk
+        // stops at the first profile that accepts.
+        foreach (var profile in profiles)
+        {
+            var rejection = await this.FindRejectionAsync(profile, presentedCertificate, cancellationToken);
+
+            if (rejection is null)
+            {
+                return McpClientCertificateAuthenticationResult.AcceptedByProfile(profile.Name);
+            }
+
+            this.LogProfileRefusedCertificate(profile.Name, rejection.Value, presentedCertificate.Thumbprint);
+            firstObjection ??= rejection;
+        }
+
+        var reportedRejection = firstObjection ?? McpClientCertificateRejection.ChainNotTrusted;
+        this.LogClientCertificateRefused(presentedCertificate.Thumbprint, reportedRejection, profiles.Count);
+
+        return McpClientCertificateAuthenticationResult.Rejected(reportedRejection);
+    }
+
+    /// <summary>Judges one certificate against one profile.</summary>
+    /// <remarks>
+    /// The two checks the certificate answers on its own come first, so a certificate meant for a different profile is
+    /// turned away before that profile's anchor material is retrieved at all.
+    /// </remarks>
+    private async Task<McpClientCertificateRejection?> FindRejectionAsync(
+        McpClientCertificateTrustProfile profile,
+        X509Certificate2 presentedCertificate,
+        CancellationToken cancellationToken)
+    {
+        if (!McpClientCertificateChainValidator.CarriesClientAuthenticationUsage(presentedCertificate))
+        {
+            return McpClientCertificateRejection.ClientAuthenticationUsageMissing;
+        }
+
+        if (!profile.NamesClient(McpClientCertificateChainValidator.ReadSubjectAlternativeDnsNames(presentedCertificate)))
+        {
+            return McpClientCertificateRejection.SubjectAlternativeNameMismatch;
+        }
+
+        var loadedAnchors = await this.LoadTrustAnchorsAsync(profile, cancellationToken);
+
+        try
+        {
+            return loadedAnchors.Count > 0
+                ? McpClientCertificateChainValidator.FindChainRejection(
+                    [.. loadedAnchors.Select(anchor => anchor.TrustAnchor!)],
+                    presentedCertificate)
+                : McpClientCertificateRejection.TrustAnchorUnavailable;
+        }
+        finally
+        {
+            foreach (var anchor in loadedAnchors)
+            {
+                anchor.Dispose();
+            }
+        }
+    }
+
+    /// <summary>Loads the anchors of one profile, keeping the ones that loaded.</summary>
+    /// <remarks>
+    /// An anchor that fails to load is recorded and skipped rather than failing the profile outright, because a profile
+    /// carries several anchors precisely so an authority can be replaced by overlap, and half a rotation must not stop
+    /// the certificates the other half still signs for. A profile whose anchors all fail refuses every certificate,
+    /// which the caller reports.
+    /// </remarks>
+    private async Task<IReadOnlyList<TrustAnchorLoadResult>> LoadTrustAnchorsAsync(
+        McpClientCertificateTrustProfile profile,
+        CancellationToken cancellationToken)
+    {
+        var loadedAnchors = new List<TrustAnchorLoadResult>(profile.TrustAnchors.Count);
+
+        foreach (var configuredAnchor in profile.TrustAnchors)
+        {
+            var loadResult = await this.trustAnchorLoader.LoadAsync(configuredAnchor, cancellationToken);
+
+            if (loadResult.TrustAnchor is not null)
+            {
+                loadedAnchors.Add(loadResult);
+
+                continue;
+            }
+
+            loadResult.Dispose();
+            this.LogTrustAnchorUnavailable(profile.Name, loadResult.Failure);
+        }
+
+        return loadedAnchors;
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "The client certificate {ClientCertificateThumbprint} was not accepted by MCP trust profile "
+            + "{TrustProfileName} [{Rejection}].")]
+    private partial void LogProfileRefusedCertificate(
+        string trustProfileName,
+        McpClientCertificateRejection rejection,
+        string clientCertificateThumbprint);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "A request presented the client certificate {ClientCertificateThumbprint}, which none of the "
+            + "{TrustProfileCount} configured MCP trust profiles accepted [{Rejection}]. The request was refused with "
+            + "the same response as any other refusal.")]
+    private partial void LogClientCertificateRefused(
+        string clientCertificateThumbprint,
+        McpClientCertificateRejection rejection,
+        int trustProfileCount);
+
+    [LoggerMessage(
+        Level = LogLevel.Error,
+        Message = "A trust anchor configured for MCP trust profile {TrustProfileName} could not be loaded [{Failure}], "
+            + "so it trusts nothing until the material is readable again. Startup validates this, which means the "
+            + "configuration changed underneath the running process.")]
+    private partial void LogTrustAnchorUnavailable(string trustProfileName, CertificateMaterialFailure? failure);
+}

--- a/src/Infrastructure/Security/McpClientCertificateAuthenticator.cs
+++ b/src/Infrastructure/Security/McpClientCertificateAuthenticator.cs
@@ -20,27 +20,40 @@ namespace MailMcp.Infrastructure.Security;
 /// that accepts ends the walk.
 /// </para>
 /// <para>
-/// A profile whose anchors have all become unloadable refuses the request rather than falling through to the next
-/// profile's answer being the deployment's answer. Startup proved every anchor loads, so reaching that state means the
-/// deployment changed underneath a running process, and widening what is accepted is never the right response to it.
+/// One instant is read per request and every profile judges against that one, so a certificate cannot be inside its
+/// validity period for one profile and outside it for the next. It comes from the injected clock rather than from the
+/// chain builder's ambient one, which is what makes the expiry boundary a thing a test can stand on.
+/// </para>
+/// <para>
+/// A profile whose anchors have all become unloadable accepts nothing: it refuses the certificate and the failure is
+/// recorded, so unreadable material can never widen what that profile trusts. It does not refuse the request on behalf
+/// of the other profiles, because a certificate a later profile accepts was judged entirely on that profile's own
+/// anchors and the broken material took no part in the verdict. Refusing everything instead would let one deleted file
+/// close the endpoint to clients whose trust material is intact. Startup proves every anchor loads, so reaching this
+/// state at all means the deployment changed underneath a running process, which is why it is recorded at error level.
 /// </para>
 /// </remarks>
 public sealed partial class McpClientCertificateAuthenticator
 {
     private readonly TrustAnchorLoader trustAnchorLoader;
+    private readonly TimeProvider timeProvider;
     private readonly ILogger<McpClientCertificateAuthenticator> logger;
 
     /// <summary>Initializes a new client certificate authenticator.</summary>
     /// <param name="trustAnchorLoader">The loader that turns configured material into a trust anchor.</param>
+    /// <param name="timeProvider">The clock every certificate's validity period is judged against.</param>
     /// <param name="logger">The log a refusal and an unloadable anchor are recorded in.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="trustAnchorLoader" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="trustAnchorLoader" /> or <paramref name="timeProvider" /> is <see langword="null" />.</exception>
     public McpClientCertificateAuthenticator(
         TrustAnchorLoader trustAnchorLoader,
+        TimeProvider timeProvider,
         ILogger<McpClientCertificateAuthenticator> logger)
     {
         ArgumentNullException.ThrowIfNull(trustAnchorLoader);
+        ArgumentNullException.ThrowIfNull(timeProvider);
 
         this.trustAnchorLoader = trustAnchorLoader;
+        this.timeProvider = timeProvider;
         this.logger = logger;
     }
 
@@ -70,13 +83,18 @@ public sealed partial class McpClientCertificateAuthenticator
                 : McpClientCertificateAuthenticationResult.AcceptedWithoutCertificate;
         }
 
-        McpClientCertificateRejection? firstObjection = null;
+        var verificationTime = this.timeProvider.GetUtcNow();
+        var objections = new List<McpClientCertificateRejection>(profiles.Count);
 
         // A loop rather than a query: each step awaits the retrieval of that profile's anchor material, and the walk
         // stops at the first profile that accepts.
         foreach (var profile in profiles)
         {
-            var rejection = await this.FindRejectionAsync(profile, presentedCertificate, cancellationToken);
+            var rejection = await this.FindRejectionAsync(
+                profile,
+                presentedCertificate,
+                verificationTime,
+                cancellationToken);
 
             if (rejection is null)
             {
@@ -84,14 +102,27 @@ public sealed partial class McpClientCertificateAuthenticator
             }
 
             this.LogProfileRefusedCertificate(profile.Name, rejection.Value, presentedCertificate.Thumbprint);
-            firstObjection ??= rejection;
+            objections.Add(rejection.Value);
         }
 
-        var reportedRejection = firstObjection ?? McpClientCertificateRejection.ChainNotTrusted;
+        var reportedRejection = ReportedObjection(objections);
         this.LogClientCertificateRefused(presentedCertificate.Thumbprint, reportedRejection, profiles.Count);
 
         return McpClientCertificateAuthenticationResult.Rejected(reportedRejection);
     }
+
+    /// <summary>Picks the objection that describes what an operator has to repair.</summary>
+    /// <remarks>
+    /// A deployment serving several clients produces a name mismatch from every profile the certificate was not meant
+    /// for, and those say nothing about the certificate: they say the walk passed a profile describing somebody else.
+    /// The objection worth reporting therefore comes from a profile that did name this client, and the mismatch is
+    /// reported only when no profile did — which is itself the accurate answer for a client this deployment does not
+    /// serve at all.
+    /// </remarks>
+    private static McpClientCertificateRejection ReportedObjection(IReadOnlyList<McpClientCertificateRejection> objections) =>
+        objections.FirstOrDefault(
+            objection => objection != McpClientCertificateRejection.SubjectAlternativeNameMismatch,
+            McpClientCertificateRejection.SubjectAlternativeNameMismatch);
 
     /// <summary>Judges one certificate against one profile.</summary>
     /// <remarks>
@@ -101,6 +132,7 @@ public sealed partial class McpClientCertificateAuthenticator
     private async Task<McpClientCertificateRejection?> FindRejectionAsync(
         McpClientCertificateTrustProfile profile,
         X509Certificate2 presentedCertificate,
+        DateTimeOffset verificationTime,
         CancellationToken cancellationToken)
     {
         if (!McpClientCertificateChainValidator.CarriesClientAuthenticationUsage(presentedCertificate))
@@ -120,7 +152,8 @@ public sealed partial class McpClientCertificateAuthenticator
             return loadedAnchors.Count > 0
                 ? McpClientCertificateChainValidator.FindChainRejection(
                     [.. loadedAnchors.Select(anchor => anchor.TrustAnchor!)],
-                    presentedCertificate)
+                    presentedCertificate,
+                    verificationTime)
                 : McpClientCertificateRejection.TrustAnchorUnavailable;
         }
         finally
@@ -134,10 +167,17 @@ public sealed partial class McpClientCertificateAuthenticator
 
     /// <summary>Loads the anchors of one profile, keeping the ones that loaded.</summary>
     /// <remarks>
+    /// <para>
     /// An anchor that fails to load is recorded and skipped rather than failing the profile outright, because a profile
     /// carries several anchors precisely so an authority can be replaced by overlap, and half a rotation must not stop
     /// the certificates the other half still signs for. A profile whose anchors all fail refuses every certificate,
     /// which the caller reports.
+    /// </para>
+    /// <para>
+    /// Ownership of what has already loaded passes to the caller only on the way out. A retrieval that throws —
+    /// a cancelled request being the ordinary case — releases the anchors gathered so far here, because the caller's
+    /// own release runs on a result it never received.
+    /// </para>
     /// </remarks>
     private async Task<IReadOnlyList<TrustAnchorLoadResult>> LoadTrustAnchorsAsync(
         McpClientCertificateTrustProfile profile,
@@ -145,19 +185,31 @@ public sealed partial class McpClientCertificateAuthenticator
     {
         var loadedAnchors = new List<TrustAnchorLoadResult>(profile.TrustAnchors.Count);
 
-        foreach (var configuredAnchor in profile.TrustAnchors)
+        try
         {
-            var loadResult = await this.trustAnchorLoader.LoadAsync(configuredAnchor, cancellationToken);
-
-            if (loadResult.TrustAnchor is not null)
+            foreach (var configuredAnchor in profile.TrustAnchors)
             {
-                loadedAnchors.Add(loadResult);
+                var loadResult = await this.trustAnchorLoader.LoadAsync(configuredAnchor, cancellationToken);
 
-                continue;
+                if (loadResult.TrustAnchor is not null)
+                {
+                    loadedAnchors.Add(loadResult);
+
+                    continue;
+                }
+
+                loadResult.Dispose();
+                this.LogTrustAnchorUnavailable(profile.Name, loadResult.Failure);
+            }
+        }
+        catch
+        {
+            foreach (var loadedAnchor in loadedAnchors)
+            {
+                loadedAnchor.Dispose();
             }
 
-            loadResult.Dispose();
-            this.LogTrustAnchorUnavailable(profile.Name, loadResult.Failure);
+            throw;
         }
 
         return loadedAnchors;

--- a/src/Infrastructure/Security/McpClientCertificateChainValidator.cs
+++ b/src/Infrastructure/Security/McpClientCertificateChainValidator.cs
@@ -1,0 +1,162 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace MailMcp.Infrastructure.Security;
+
+/// <summary>Decides whether a client certificate chains to one of a profile's configured authorities.</summary>
+/// <remarks>
+/// <para>
+/// Trust is decided by building the chain against the configured anchors and nothing else. The machine's own trust
+/// store takes no part: a deployment that trusts the certificate authorities a server happens to ship would accept
+/// every client certificate the public infrastructure has ever issued, which is the opposite of naming the client this
+/// endpoint serves.
+/// </para>
+/// <para>
+/// The server sees the leaf certificate alone. A TLS client sends its issuing chain, but the connection exposes only
+/// the certificate that identifies it, so a client chaining through an intermediate is trusted by configuring that
+/// intermediate as an anchor beside its root rather than by hoping the handshake supplied it. An intermediate
+/// configured on its own completes no path to a root and therefore trusts nothing, which is the safe direction: it
+/// refuses the client rather than trusting everything that authority ever signed for.
+/// </para>
+/// </remarks>
+internal static class McpClientCertificateChainValidator
+{
+    /// <summary>The extended key usage a certificate must carry to authenticate a TLS client, <c>id-kp-clientAuth</c>.</summary>
+    private const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
+
+    /// <summary>The extended key usage extension, <c>id-ce-extKeyUsage</c>.</summary>
+    private const string EnhancedKeyUsageExtensionOid = "2.5.29.37";
+
+    /// <summary>The subject alternative name extension, <c>id-ce-subjectAltName</c>.</summary>
+    private const string SubjectAlternativeNameExtensionOid = "2.5.29.17";
+
+    /// <summary>Reports whether a certificate carries the extended key usage that makes it a client certificate.</summary>
+    /// <param name="certificate">The certificate the connection presented.</param>
+    /// <returns><see langword="true" /> when the certificate names client authentication; otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="certificate" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A certificate carrying no extended key usage at all is refused rather than read as unrestricted. The X.509 rule
+    /// that absence means every usage is what would let a server certificate, or a signing certificate the same
+    /// authority issued, be presented here; a profile that names client authentication asked for a certificate that
+    /// says so.
+    /// </remarks>
+    internal static bool CarriesClientAuthenticationUsage(X509Certificate2 certificate)
+    {
+        ArgumentNullException.ThrowIfNull(certificate);
+
+        return certificate.Extensions
+            .Where(extension => extension.Oid?.Value == EnhancedKeyUsageExtensionOid)
+            .SelectMany(DecodeUsages)
+            .Any(usage => usage.Value == ClientAuthenticationOid);
+    }
+
+    /// <summary>Reads the DNS names a certificate carries as subject alternative names.</summary>
+    /// <param name="certificate">The certificate the connection presented.</param>
+    /// <returns>The DNS names, empty when the certificate carries no subject alternative name extension.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="certificate" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The subject common name is deliberately not consulted. It has not identified a certificate's subject since
+    /// RFC 2818 was superseded, no certificate authority is obliged to make it meaningful, and reading it would let a
+    /// certificate be accepted for a name no authority ever attested to.
+    /// </remarks>
+    internal static IReadOnlyList<string> ReadSubjectAlternativeDnsNames(X509Certificate2 certificate)
+    {
+        ArgumentNullException.ThrowIfNull(certificate);
+
+        return
+        [
+            .. certificate.Extensions
+                .Where(extension => extension.Oid?.Value == SubjectAlternativeNameExtensionOid)
+                .SelectMany(DecodeDnsNames),
+        ];
+    }
+
+    /// <summary>Decodes one extension into the usages it names.</summary>
+    /// <remarks>
+    /// Decoded from the raw extension rather than read off a typed one the certificate handed back, because which
+    /// extensions the platform materializes as typed instances is its own detail and a type filter would silently skip
+    /// an extension it did not recognize. Malformed contents name no usage rather than throwing: this runs against
+    /// whatever a stranger opened a connection with, so an unparseable extension has to end in an ordinary refusal
+    /// instead of an unhandled failure in the request pipeline.
+    /// </remarks>
+    private static IReadOnlyList<Oid> DecodeUsages(X509Extension extension)
+    {
+        try
+        {
+            return [.. new X509EnhancedKeyUsageExtension(extension, extension.Critical).EnhancedKeyUsages.OfType<Oid>()];
+        }
+        catch (CryptographicException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>Decodes one extension into the DNS names it carries, on the same terms as the usages above.</summary>
+    private static IReadOnlyList<string> DecodeDnsNames(X509Extension extension)
+    {
+        try
+        {
+            return [.. new X509SubjectAlternativeNameExtension(extension.RawData, extension.Critical).EnumerateDnsNames()];
+        }
+        catch (CryptographicException)
+        {
+            return [];
+        }
+    }
+
+    /// <summary>Builds the certificate's chain against a profile's anchors.</summary>
+    /// <param name="trustAnchors">The anchors that were loaded for the profile, at least one.</param>
+    /// <param name="certificate">The certificate the connection presented.</param>
+    /// <returns><see langword="null" /> when the certificate is trusted; otherwise why it is not.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="trustAnchors" /> or <paramref name="certificate" /> is <see langword="null" />.</exception>
+    internal static McpClientCertificateRejection? FindChainRejection(
+        IReadOnlyList<X509Certificate2> trustAnchors,
+        X509Certificate2 certificate)
+    {
+        ArgumentNullException.ThrowIfNull(trustAnchors);
+        ArgumentNullException.ThrowIfNull(certificate);
+
+        using var chain = new X509Chain();
+
+        chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
+
+        foreach (var trustAnchor in trustAnchors)
+        {
+            chain.ChainPolicy.CustomTrustStore.Add(trustAnchor);
+        }
+
+        // Re-applied to the chain as well as checked outright, because a chain error also covers a certificate rejected
+        // for its usage and leaving it out would trust an issuing certificate the same authority signed.
+        chain.ChainPolicy.ApplicationPolicy.Add(new Oid(ClientAuthenticationOid));
+
+        // A client certificate arrives without its issuing chain, so there is nothing to download that this deployment
+        // configured. Leaving downloads enabled would let a certificate a stranger presented send this synchronous
+        // validation to a URL of their choosing, on the request thread, with no cancellation reaching it.
+        chain.ChainPolicy.DisableCertificateDownloads = true;
+
+        // The authorities behind a client profile are commonly private and publish neither a revocation list nor a
+        // responder, so an online check would refuse every client this feature exists to serve. Withdrawing a client is
+        // therefore removing its profile or its anchor, which takes effect on the next request.
+        chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+
+        // Pinned rather than left at its default, so no later edit can relax expiry or basic-constraint checking without
+        // deleting a line that says what it is doing.
+        chain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
+
+        return chain.Build(certificate) ? null : DescribeChainFailure(chain);
+    }
+
+    /// <summary>Names what the chain objected to, in the terms an operator reads.</summary>
+    /// <remarks>
+    /// Validity is separated from trust because the two are different operator problems: an expired certificate is a
+    /// client that has to renew, while an untrusted one is a deployment that has to be told about an authority. Every
+    /// other status collapses into the untrusted answer, because the response is the same and a finer vocabulary would
+    /// only describe the platform rather than the deployment.
+    /// </remarks>
+    private static McpClientCertificateRejection DescribeChainFailure(X509Chain chain) =>
+        chain.ChainStatus.Any(status => status.Status.HasFlag(X509ChainStatusFlags.NotTimeValid))
+            ? McpClientCertificateRejection.CertificateExpired
+            : McpClientCertificateRejection.ChainNotTrusted;
+}

--- a/src/Infrastructure/Security/McpClientCertificateChainValidator.cs
+++ b/src/Infrastructure/Security/McpClientCertificateChainValidator.cs
@@ -109,11 +109,13 @@ internal static class McpClientCertificateChainValidator
     /// <summary>Builds the certificate's chain against a profile's anchors.</summary>
     /// <param name="trustAnchors">The anchors that were loaded for the profile, at least one.</param>
     /// <param name="certificate">The certificate the connection presented.</param>
+    /// <param name="verificationTime">The instant every validity period in the chain is judged against, taken from the caller's injected clock.</param>
     /// <returns><see langword="null" /> when the certificate is trusted; otherwise why it is not.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="trustAnchors" /> or <paramref name="certificate" /> is <see langword="null" />.</exception>
     internal static McpClientCertificateRejection? FindChainRejection(
         IReadOnlyList<X509Certificate2> trustAnchors,
-        X509Certificate2 certificate)
+        X509Certificate2 certificate,
+        DateTimeOffset verificationTime)
     {
         ArgumentNullException.ThrowIfNull(trustAnchors);
         ArgumentNullException.ThrowIfNull(certificate);
@@ -144,6 +146,11 @@ internal static class McpClientCertificateChainValidator
         // Pinned rather than left at its default, so no later edit can relax expiry or basic-constraint checking without
         // deleting a line that says what it is doing.
         chain.ChainPolicy.VerificationFlags = X509VerificationFlags.NoFlag;
+
+        // Supplied rather than left to the chain builder, which would otherwise read the machine's own clock — the one
+        // ambient clock the analyzers cannot see. Setting it keeps the moment a certificate expires a decision of the
+        // injected clock, which is what makes the boundary reachable from a test.
+        chain.ChainPolicy.VerificationTime = verificationTime.UtcDateTime;
 
         return chain.Build(certificate) ? null : DescribeChainFailure(chain);
     }

--- a/src/Infrastructure/Security/McpClientCertificateRejection.cs
+++ b/src/Infrastructure/Security/McpClientCertificateRejection.cs
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+namespace MailMcp.Infrastructure.Security;
+
+/// <summary>Why a client certificate was not accepted by a trust profile.</summary>
+/// <remarks>
+/// Every value produces the same response, so this vocabulary exists for the server log and never for the caller. It is
+/// safe to record in full: a certificate a client presented is public material, and the values here describe the
+/// certificate rather than the configuration it was judged against.
+/// </remarks>
+public enum McpClientCertificateRejection
+{
+    /// <summary>The connection carried no client certificate while a profile requires one.</summary>
+    CertificateMissing = 0,
+
+    /// <summary>The certificate carries no extended key usage naming client authentication, so it is not a certificate for authenticating a client.</summary>
+    ClientAuthenticationUsageMissing = 1,
+
+    /// <summary>The certificate names none of the subject alternative names the profile expects.</summary>
+    SubjectAlternativeNameMismatch = 2,
+
+    /// <summary>None of the profile's trust anchors could be loaded, so no chain could be built at all.</summary>
+    /// <remarks>This describes the deployment rather than the certificate, and it refuses the request for that reason: an anchor that has become unreadable must never widen what the profile accepts.</remarks>
+    TrustAnchorUnavailable = 3,
+
+    /// <summary>The certificate is outside its validity period.</summary>
+    CertificateExpired = 4,
+
+    /// <summary>The certificate does not chain to any of the profile's trust anchors.</summary>
+    ChainNotTrusted = 5,
+}

--- a/src/Infrastructure/Security/McpClientCertificateRequirement.cs
+++ b/src/Infrastructure/Security/McpClientCertificateRequirement.cs
@@ -1,0 +1,25 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+namespace MailMcp.Infrastructure.Security;
+
+/// <summary>Whether the client a trust profile identifies has to present its certificate.</summary>
+/// <remarks>
+/// <para>
+/// The distinction is about the request that arrives without a certificate at all, because that is the only one no
+/// profile can be matched against. A deployment carrying at least one <see cref="Required" /> profile refuses such a
+/// request; one whose profiles are all <see cref="Optional" /> serves it and simply identifies no client application.
+/// </para>
+/// <para>
+/// <see cref="Optional" /> is therefore what a profile beside another authentication mechanism states: the ChatGPT
+/// connector presents its managed certificate while a workstation reaches the same endpoint with an API key alone.
+/// <see cref="Required" /> is what a deployment states once every client it serves holds a certificate.
+/// </para>
+/// </remarks>
+public enum McpClientCertificateRequirement
+{
+    /// <summary>A request without a client certificate is served; a certificate that is presented is still validated against every profile.</summary>
+    Optional = 0,
+
+    /// <summary>A request without a client certificate is refused, whichever other credential it carries.</summary>
+    Required = 1,
+}

--- a/src/Infrastructure/Security/McpClientCertificateTrustProfile.cs
+++ b/src/Infrastructure/Security/McpClientCertificateTrustProfile.cs
@@ -1,0 +1,136 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Text.RegularExpressions;
+using MailMcp.Infrastructure.Secrets;
+
+namespace MailMcp.Infrastructure.Security;
+
+/// <summary>One client application a deployment trusts, and the certificate policy that identifies it.</summary>
+/// <remarks>
+/// <para>
+/// A profile is named after the client rather than after the authority that signed for it, because that is what an
+/// operator reasons about: the ChatGPT connector, the reporting service, the workstation fleet. Several profiles stand
+/// beside each other so one client's authority rotating, widening, or being withdrawn changes what that client may
+/// present and nothing about the others — which one global certificate setting could not express.
+/// </para>
+/// <para>
+/// The trust anchors are configured references rather than loaded certificates, so the material is retrieved when a
+/// request is judged rather than held for the life of the process. Rotating an authority is then adding its successor
+/// beside it and removing the predecessor once clients have moved, with both accepted in between and no restart in the
+/// middle. Anchors are public certificates and are recorded by subject and thumbprint; the reference machinery carries
+/// them for provisioning and erasure alone, and their validity is the X.509 one rather than a configured lifetime.
+/// </para>
+/// <para>
+/// A profile always names the client it identifies through <see cref="ExpectedDnsNames" />. A trusted authority on its
+/// own would accept every certificate that authority has ever issued, which for a public or shared certificate
+/// authority is a great many clients that are not this deployment's.
+/// </para>
+/// </remarks>
+public sealed partial class McpClientCertificateTrustProfile
+{
+    /// <summary>The greatest number of characters a profile name may carry.</summary>
+    public const int MaximumNameLength = 64;
+
+    private McpClientCertificateTrustProfile(
+        string name,
+        McpClientCertificateRequirement requirement,
+        IReadOnlyList<ConfiguredSecret> trustAnchors,
+        IReadOnlyCollection<string> expectedDnsNames)
+    {
+        this.Name = name;
+        this.Requirement = requirement;
+        this.TrustAnchors = trustAnchors;
+        this.ExpectedDnsNames = expectedDnsNames;
+    }
+
+    /// <summary>Gets the operator-chosen name of the client this profile identifies, which is safe to record.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets whether a request that presents no certificate at all is refused.</summary>
+    public McpClientCertificateRequirement Requirement { get; }
+
+    /// <summary>Gets the configured certificate authorities a presented certificate must chain to, several of them so an authority can be rotated by overlap.</summary>
+    public IReadOnlyList<ConfiguredSecret> TrustAnchors { get; }
+
+    /// <summary>Gets the DNS names of which a presented certificate must carry at least one as a subject alternative name.</summary>
+    /// <remarks>Membership is answered without regard to case, which is what a host name is.</remarks>
+    public IReadOnlyCollection<string> ExpectedDnsNames { get; }
+
+    /// <summary>Reports whether a configured value may name a profile.</summary>
+    /// <param name="configuredValue">The bound name.</param>
+    /// <returns><see langword="true" /> when the value is an accepted name; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// The accepted characters are narrow for the reason <see cref="SecretName" /> gives: the name reaches a log line
+    /// and an audit record, where escaping or truncation must not be what decides its meaning.
+    /// </remarks>
+    public static bool IsAcceptedName(string? configuredValue) =>
+        configuredValue is { Length: <= MaximumNameLength } && AcceptedName().IsMatch(configuredValue);
+
+    /// <summary>Reports whether a configured value may be an expected subject alternative name.</summary>
+    /// <param name="configuredValue">The bound value.</param>
+    /// <returns><see langword="true" /> when the value is a DNS name a certificate could carry; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// Only DNS names are compared. A certificate for a client application names it by host name — OpenAI's connector
+    /// presents <c>mtls.prod.connectors.openai.com</c> — and accepting an address or a URI here would invite a profile
+    /// to be written against a name the comparison never reads.
+    /// </remarks>
+    public static bool IsAcceptedDnsName(string? configuredValue) =>
+        configuredValue is not null && Uri.CheckHostName(configuredValue) == UriHostNameType.Dns;
+
+    /// <summary>Creates a profile from settings that have already been validated.</summary>
+    /// <param name="name">The operator-chosen name of the client this profile identifies.</param>
+    /// <param name="requirement">Whether a request presenting no certificate is refused.</param>
+    /// <param name="trustAnchors">The configured certificate authorities, at least one.</param>
+    /// <param name="expectedDnsNames">The subject alternative names expected of a presented certificate, at least one.</param>
+    /// <returns>The profile.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="trustAnchors" /> or <paramref name="expectedDnsNames" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when a value would leave the profile unable to identify a client, which means it was mapped before it was validated.</exception>
+    public static McpClientCertificateTrustProfile Create(
+        string name,
+        McpClientCertificateRequirement requirement,
+        IEnumerable<ConfiguredSecret> trustAnchors,
+        IEnumerable<string> expectedDnsNames)
+    {
+        ArgumentNullException.ThrowIfNull(trustAnchors);
+        ArgumentNullException.ThrowIfNull(expectedDnsNames);
+
+        if (!IsAcceptedName(name))
+        {
+            throw new ArgumentException("A trust profile must carry an accepted name.", nameof(name));
+        }
+
+        var configuredAnchors = trustAnchors.ToArray();
+
+        // A host name is case-insensitive, so the comparer carries that rather than a normalization pass: two spellings
+        // of one name are one entry here for the same reason a certificate carrying either satisfies the profile.
+        var expectedNames = expectedDnsNames.OfType<string>().ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (configuredAnchors.Length == 0)
+        {
+            throw new ArgumentException(
+                "A trust profile must name at least one certificate authority.",
+                nameof(trustAnchors));
+        }
+
+        return expectedNames.Count > 0 && expectedNames.All(IsAcceptedDnsName)
+            ? new McpClientCertificateTrustProfile(name, requirement, configuredAnchors, expectedNames)
+            : throw new ArgumentException(
+                "A trust profile must name at least one DNS name a presented certificate carries.",
+                nameof(expectedDnsNames));
+    }
+
+    /// <summary>Reports whether a certificate carrying given DNS names is the client this profile identifies.</summary>
+    /// <param name="presentedDnsNames">The subject alternative DNS names the certificate carries.</param>
+    /// <returns><see langword="true" /> when at least one expected name is present; otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="presentedDnsNames" /> is <see langword="null" />.</exception>
+    /// <remarks>DNS names are compared without regard to case, which is what a host name is, and never by suffix: a profile names the client rather than a domain a client happens to sit under.</remarks>
+    public bool NamesClient(IEnumerable<string> presentedDnsNames)
+    {
+        ArgumentNullException.ThrowIfNull(presentedDnsNames);
+
+        return presentedDnsNames.Any(this.ExpectedDnsNames.Contains);
+    }
+
+    [GeneratedRegex("^[A-Za-z0-9][A-Za-z0-9._-]*$", RegexOptions.CultureInvariant)]
+    private static partial Regex AcceptedName();
+}

--- a/src/Infrastructure/Security/McpOriginPolicy.cs
+++ b/src/Infrastructure/Security/McpOriginPolicy.cs
@@ -30,6 +30,14 @@ public sealed class McpOriginPolicy
     /// <summary>Gets the policy that serves every origin, which is what a deployment configuring none receives.</summary>
     public static McpOriginPolicy AllowingAnyOrigin { get; } = new(allowsAnyOrigin: true, []);
 
+    /// <summary>Gets the policy that serves no browser at all, which a deployment states by configuring an empty origin list.</summary>
+    /// <remarks>
+    /// It refuses every request carrying an <c>Origin</c> and serves every request carrying none, so what it excludes is
+    /// browsers rather than clients. That is the accurate posture for a deployment whose only consumers are agents and
+    /// command-line clients, and it is the one posture a list of origins cannot express.
+    /// </remarks>
+    public static McpOriginPolicy ServingNoBrowserOrigin { get; } = new(allowsAnyOrigin: false, []);
+
     /// <summary>Gets whether every origin is served.</summary>
     public bool AllowsAnyOrigin { get; }
 
@@ -40,7 +48,7 @@ public sealed class McpOriginPolicy
     /// <param name="allowedOrigins">The configured origins, which must already have passed <see cref="TryNormalize" />.</param>
     /// <returns>The restricting policy.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="allowedOrigins" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="allowedOrigins" /> is empty, which would serve no browser at all and is a configuration mistake rather than a policy.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="allowedOrigins" /> is empty; serving no browser at all is <see cref="ServingNoBrowserOrigin" />, which says so by its name rather than by a list that happens to be short.</exception>
     public static McpOriginPolicy Restricting(IEnumerable<string> allowedOrigins)
     {
         ArgumentNullException.ThrowIfNull(allowedOrigins);

--- a/tests/Host.UnitTests/Host.UnitTests.csproj
+++ b/tests/Host.UnitTests/Host.UnitTests.csproj
@@ -11,6 +11,7 @@
     <Compile Include="..\shared\RecordingLoggerProvider.cs" Link="RecordingLoggerProvider.cs" />
     <Compile Include="..\shared\RecordingLoggerFactory.cs" Link="RecordingLoggerFactory.cs" />
     <Compile Include="..\shared\ExceptionHierarchyAssertion.cs" Link="ExceptionHierarchyAssertion.cs" />
+    <Compile Include="..\shared\TestCertificates.cs" Link="TestCertificates.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Host.UnitTests/McpClientCertificateProfileOptionsTests.cs
+++ b/tests/Host.UnitTests/McpClientCertificateProfileOptionsTests.cs
@@ -1,0 +1,158 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Host.Configuration;
+using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
+using Xunit;
+
+namespace MailMcp.Host.UnitTests;
+
+/// <summary>Covers what a client certificate profile must state before a deployment can start with it.</summary>
+public sealed class McpClientCertificateProfileOptionsTests
+{
+    [Fact]
+    public void FindConfigurationErrors_AProfileNamingItsClientItsAuthorityAndItsRequirement_ReportsNothing()
+    {
+        // Arrange
+        var profile = ConnectorProfile();
+
+        // Act, Assert
+        Assert.Empty(profile.FindConfigurationErrors());
+    }
+
+    /// <summary>Both candidate defaults are postures: one would lock out every other client, the other would report a control nobody configured.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AProfileNamingNoRequirement_IsRefused()
+    {
+        // Arrange
+        var profile = ConnectorProfile();
+        profile.Requirement = null;
+
+        // Act
+        var error = Assert.Single(profile.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith(nameof(McpClientCertificateProfileOptions.Requirement), error, StringComparison.Ordinal);
+    }
+
+    /// <summary>The binder accepts any number for an enum, and a value no member declares would be judged by a rule nobody wrote.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ARequirementThatIsNeitherOfTheTwo_IsRefused()
+    {
+        // Arrange
+        var profile = ConnectorProfile();
+        profile.Requirement = (McpClientCertificateRequirement)7;
+
+        // Act
+        var error = Assert.Single(profile.FindConfigurationErrors());
+
+        // Assert
+        Assert.Contains("names no requirement", error, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("chatgpt connector")]
+    public void FindConfigurationErrors_AProfileWithNoUsableName_IsRefused(string configuredName)
+    {
+        // Arrange
+        var profile = ConnectorProfile();
+        profile.Name = configuredName;
+
+        // Act
+        var error = Assert.Single(profile.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith(nameof(McpClientCertificateProfileOptions.Name), error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_AProfileTrustingNoAuthority_IsRefused()
+    {
+        // Arrange
+        var profile = ConnectorProfile();
+        profile.TrustAnchors.Clear();
+
+        // Act
+        var error = Assert.Single(profile.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith(nameof(McpClientCertificateProfileOptions.TrustAnchors), error, StringComparison.Ordinal);
+    }
+
+    /// <summary>An authority alone accepts every certificate it has ever issued, which for a public one is most of the internet.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AProfileNamingNoClient_IsRefused()
+    {
+        // Arrange
+        var profile = ConnectorProfile();
+        profile.SubjectAlternativeNames.Clear();
+
+        // Act
+        var error = Assert.Single(profile.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith(nameof(McpClientCertificateProfileOptions.SubjectAlternativeNames), error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_SomethingThatIsNotADnsName_IsReportedAgainstItsPositionInTheList()
+    {
+        // Arrange
+        var profile = ConnectorProfile();
+        profile.SubjectAlternativeNames.Add("https://mtls.prod.connectors.openai.com");
+
+        // Act
+        var error = Assert.Single(profile.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith($"{nameof(McpClientCertificateProfileOptions.SubjectAlternativeNames)}:1", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ToTrustProfile_AValidatedProfile_CarriesWhatWasConfigured()
+    {
+        // Arrange
+        var profile = ConnectorProfile();
+
+        // Act
+        var trustProfile = profile.ToTrustProfile();
+
+        // Assert
+        Assert.Equal("chatgpt-connector", trustProfile.Name);
+        Assert.Equal(McpClientCertificateRequirement.Required, trustProfile.Requirement);
+        Assert.Equal(["mtls.prod.connectors.openai.com"], trustProfile.ExpectedDnsNames);
+        Assert.Equal(
+            ["file:/run/secrets/openai-connectors-ca.pem"],
+            trustProfile.TrustAnchors.Select(anchor => anchor.SecretReference));
+    }
+
+    [Fact]
+    public void ToTrustProfile_SettingsThatWereNeverValidated_ThrowsRatherThanTrustingLessThanWasConfigured()
+    {
+        // Arrange
+        var profile = ConnectorProfile();
+        profile.SubjectAlternativeNames.Clear();
+
+        // Act, Assert
+        Assert.Throws<InvalidOperationException>(profile.ToTrustProfile);
+    }
+
+    private static McpClientCertificateProfileOptions ConnectorProfile()
+    {
+        var profile = new McpClientCertificateProfileOptions
+        {
+            Name = "chatgpt-connector",
+            Requirement = McpClientCertificateRequirement.Required,
+        };
+
+        profile.TrustAnchors.Add(new ConfiguredSecret
+        {
+            Name = "openai-connectors-ca",
+            SecretReference = "file:/run/secrets/openai-connectors-ca.pem",
+        });
+        profile.SubjectAlternativeNames.Add("mtls.prod.connectors.openai.com");
+
+        return profile;
+    }
+}

--- a/tests/Host.UnitTests/McpClientCertificateValidationTests.cs
+++ b/tests/Host.UnitTests/McpClientCertificateValidationTests.cs
@@ -9,6 +9,7 @@ using MailMcp.TestSupport;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace MailMcp.Host.UnitTests;
@@ -23,6 +24,9 @@ namespace MailMcp.Host.UnitTests;
 public sealed class McpClientCertificateValidationTests
 {
     private const string ClientDnsName = "client.example.test";
+
+    /// <summary>The instant the certificates here are judged at, inside the validity period the test certificates carry.</summary>
+    private static readonly DateTimeOffset JudgedAt = new(2026, 7, 31, 12, 0, 0, TimeSpan.Zero);
 
     private static readonly string[] CertificateLikeHeaderNames =
     [
@@ -132,6 +136,7 @@ public sealed class McpClientCertificateValidationTests
 
         return new McpClientCertificateAuthenticator(
             new TrustAnchorLoader(resolver),
+            new FakeTimeProvider(JudgedAt),
             NullLogger<McpClientCertificateAuthenticator>.Instance);
     }
 

--- a/tests/Host.UnitTests/McpClientCertificateValidationTests.cs
+++ b/tests/Host.UnitTests/McpClientCertificateValidationTests.cs
@@ -1,0 +1,166 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Security.Cryptography.X509Certificates;
+using MailMcp.Host.Security;
+using MailMcp.Infrastructure.Certificates;
+using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
+using MailMcp.TestSupport;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MailMcp.Host.UnitTests;
+
+/// <summary>Covers where the certificate an MCP request is judged by comes from.</summary>
+/// <remarks>
+/// The rules a certificate is judged by belong to the authenticator and are covered there. What only a test at this
+/// level can state is which certificate reaches it: the one the TLS connection carried, never one a request said it
+/// carried. A header naming a certificate is written by whoever sent the request, so reading one would turn client
+/// authentication into a value a client fills in for itself.
+/// </remarks>
+public sealed class McpClientCertificateValidationTests
+{
+    private const string ClientDnsName = "client.example.test";
+
+    private static readonly string[] CertificateLikeHeaderNames =
+    [
+        "X-Client-Cert",
+        "X-SSL-Client-Cert",
+        "X-Forwarded-Client-Cert",
+        "X-ARR-ClientCert",
+    ];
+
+    /// <summary>The certificate the connection carried is what a profile judges, and it is what lets the request through.</summary>
+    [Fact]
+    public async Task ServeWhenTheConnectionCertificateIsAccepted_ACertificateOnTheConnection_ServesTheRequest()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Client Root");
+        using var clientCertificate = TestCertificates.IssueClientAuthenticationCertificate(authority, ClientDnsName);
+        var context = RequestCarrying(clientCertificate);
+        var served = false;
+
+        // Act
+        await McpClientCertificateValidation.ServeWhenTheConnectionCertificateIsAcceptedAsync(
+            context,
+            _ =>
+            {
+                served = true;
+
+                return Task.CompletedTask;
+            },
+            AuthenticatorTrusting(authority),
+            [RequiredProfile()]);
+
+        // Assert
+        Assert.True(served);
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+    }
+
+    /// <summary>The certificate a request claims in a header is not a certificate; it is a value the sender wrote.</summary>
+    [Fact]
+    public async Task ServeWhenTheConnectionCertificateIsAccepted_AValidCertificateOfferedInAHeader_RefusesTheRequest()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Client Root");
+        using var clientCertificate = TestCertificates.IssueClientAuthenticationCertificate(authority, ClientDnsName);
+        var context = RequestCarrying(connectionCertificate: null);
+
+        foreach (var headerName in CertificateLikeHeaderNames)
+        {
+            context.Request.Headers[headerName] = clientCertificate.ExportCertificatePem();
+        }
+
+        var served = false;
+
+        // Act
+        await McpClientCertificateValidation.ServeWhenTheConnectionCertificateIsAcceptedAsync(
+            context,
+            _ =>
+            {
+                served = true;
+
+                return Task.CompletedTask;
+            },
+            AuthenticatorTrusting(authority),
+            [RequiredProfile()]);
+
+        // Assert
+        Assert.False(served);
+        Assert.Equal(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+    }
+
+    /// <summary>A refusal says nothing a client could act on, because what it could act on is what to present next.</summary>
+    [Fact]
+    public async Task ServeWhenTheConnectionCertificateIsAccepted_ACertificateNoProfileTrusts_RefusesWithNoBody()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Client Root");
+        using var strangerAuthority = TestCertificates.CreateCertificateAuthority("Stranger Root");
+        using var strangerCertificate = TestCertificates.IssueClientAuthenticationCertificate(
+            strangerAuthority,
+            ClientDnsName);
+        var context = RequestCarrying(strangerCertificate);
+
+        // Act
+        await McpClientCertificateValidation.ServeWhenTheConnectionCertificateIsAcceptedAsync(
+            context,
+            _ => Task.FromException(new InvalidOperationException("A refused request must not reach the endpoint.")),
+            AuthenticatorTrusting(authority),
+            [RequiredProfile()]);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, context.Response.StatusCode);
+        Assert.Equal(0, context.Response.ContentLength ?? 0);
+    }
+
+    private static DefaultHttpContext RequestCarrying(X509Certificate2? connectionCertificate)
+    {
+        var context = new DefaultHttpContext();
+        context.Features.Set<ITlsConnectionFeature>(new ConnectionCertificate(connectionCertificate));
+
+        return context;
+    }
+
+    private static McpClientCertificateAuthenticator AuthenticatorTrusting(X509Certificate2 authority)
+    {
+        var resolver = new ProvisionedTrustAnchorResolver();
+        using var publicAnchor = TestCertificates.WithoutPrivateKey(authority);
+        resolver.Provision(TestCertificates.ToPem(publicAnchor));
+
+        return new McpClientCertificateAuthenticator(
+            new TrustAnchorLoader(resolver),
+            NullLogger<McpClientCertificateAuthenticator>.Instance);
+    }
+
+    private static McpClientCertificateTrustProfile RequiredProfile() =>
+        McpClientCertificateTrustProfile.Create(
+            "client",
+            McpClientCertificateRequirement.Required,
+            [new ConfiguredSecret { Name = "client-ca", SecretReference = "file:/run/secrets/client-ca.pem" }],
+            [ClientDnsName]);
+
+    /// <summary>Carries the certificate a TLS handshake produced, which is the only place this middleware reads one from.</summary>
+    private sealed class ConnectionCertificate(X509Certificate2? clientCertificate) : ITlsConnectionFeature
+    {
+        public X509Certificate2? ClientCertificate { get; set; } = clientCertificate;
+
+        public Task<X509Certificate2?> GetClientCertificateAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(this.ClientCertificate);
+    }
+
+    /// <summary>Hands back one provisioned anchor whatever reference is asked for, because which reference resolves is not what these tests are about.</summary>
+    private sealed class ProvisionedTrustAnchorResolver : ISecretReferenceResolver
+    {
+        private byte[] material = [];
+
+        public void Provision(byte[] anchorMaterial) => this.material = anchorMaterial;
+
+        public Task<SecretResolutionResult> ResolveAsync(string? configuredValue, CancellationToken cancellationToken) =>
+            Task.FromResult(SecretResolutionResult.Resolved(
+                ResolvedSecret.FromBytes(this.material),
+                SecretMaterialSource.SchemeAdapter));
+    }
+}

--- a/tests/Host.UnitTests/McpCorsOptionsTests.cs
+++ b/tests/Host.UnitTests/McpCorsOptionsTests.cs
@@ -5,19 +5,22 @@ using Xunit;
 
 namespace MailMcp.Host.UnitTests;
 
-/// <summary>Covers which origins a deployment serves and how an ambiguous policy is refused.</summary>
+/// <summary>Covers which origins a deployment serves and how a list that states two policies is refused.</summary>
 public sealed class McpCorsOptionsTests
 {
     /// <summary>The endpoint is protected by the credential a caller presents, not by where it was loaded from, so narrowing origins is a choice rather than the starting point.</summary>
     [Fact]
-    public void AllowAnyOrigin_UnconfiguredDeployment_ServesEveryOrigin()
+    public void ServeEveryBrowserOrigin_TheDefaultAnUnconfiguredDeploymentReceives_ServesEveryOrigin()
     {
-        // Arrange, Act
+        // Arrange
         var options = new McpCorsOptions();
 
+        // Act
+        options.ServeEveryBrowserOrigin();
+
         // Assert
-        Assert.True(options.AllowAnyOrigin);
-        Assert.Empty(options.AllowedOrigins);
+        Assert.True(options.ServesEveryBrowserOrigin);
+        Assert.Equal([McpCorsOptions.AnyOriginValue], options.AllowedOrigins);
         Assert.Empty(options.FindConfigurationErrors());
         Assert.True(options.ToOriginPolicy().AllowsAnyOrigin);
     }
@@ -26,7 +29,7 @@ public sealed class McpCorsOptionsTests
     public void ToOriginPolicy_ConfiguredOrigins_ServesExactlyThemInTheFormABrowserSends()
     {
         // Arrange
-        var options = new McpCorsOptions { AllowAnyOrigin = false };
+        var options = new McpCorsOptions();
         options.AllowedOrigins.Add("https://client.example.test");
         options.AllowedOrigins.Add("https://Other-Client.Example.Test:8443/");
 
@@ -41,42 +44,49 @@ public sealed class McpCorsOptionsTests
             policy.AllowedOrigins.Order(StringComparer.Ordinal));
     }
 
-    /// <summary>Guessing which of two stated policies was meant would either widen a deployment an operator narrowed or narrow one they widened.</summary>
+    /// <summary>An empty list is the third posture rather than a mistake: no browser is served, and every client that sends no origin still is.</summary>
     [Fact]
-    public void FindConfigurationErrors_AllowAnyOriginBesideAnExactList_IsRefusedAsAmbiguous()
+    public void ToOriginPolicy_AnEmptyList_ServesNoBrowserAndEveryClientThatSendsNoOrigin()
     {
         // Arrange
         var options = new McpCorsOptions();
+
+        // Act
+        var policy = options.ToOriginPolicy();
+
+        // Assert
+        Assert.Empty(options.FindConfigurationErrors());
+        Assert.False(policy.AllowsAnyOrigin);
+        Assert.Empty(policy.AllowedOrigins);
+        Assert.False(policy.Permits("https://client.example.test"));
+        Assert.True(policy.Permits(origin: null));
+    }
+
+    /// <summary>Guessing which of two stated policies was meant would either widen a deployment an operator narrowed or narrow one they widened.</summary>
+    [Fact]
+    public void FindConfigurationErrors_EveryOriginListedBesideAnExactOne_IsRefusedAsAmbiguous()
+    {
+        // Arrange
+        var options = new McpCorsOptions();
+        options.ServeEveryBrowserOrigin();
         options.AllowedOrigins.Add("https://client.example.test");
 
         // Act
         var error = Assert.Single(options.FindConfigurationErrors());
 
         // Assert
-        Assert.StartsWith(nameof(McpCorsOptions.AllowAnyOrigin), error, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void FindConfigurationErrors_NeitherAllowAnyOriginNorAList_IsRefusedBecauseNoBrowserCouldReachIt()
-    {
-        // Arrange
-        var options = new McpCorsOptions { AllowAnyOrigin = false };
-
-        // Act
-        var error = Assert.Single(options.FindConfigurationErrors());
-
-        // Assert
         Assert.StartsWith(nameof(McpCorsOptions.AllowedOrigins), error, StringComparison.Ordinal);
+        Assert.Contains("states two policies at once", error, StringComparison.Ordinal);
     }
 
     [Theory]
     [InlineData("client.example.test")]
-    [InlineData("*")]
     [InlineData("https://client.example.test/mcp")]
+    [InlineData("https://user@client.example.test")]
     public void FindConfigurationErrors_SomethingThatIsNotAnOrigin_IsReportedAgainstItsPositionInTheList(string configuredOrigin)
     {
         // Arrange
-        var options = new McpCorsOptions { AllowAnyOrigin = false };
+        var options = new McpCorsOptions();
         options.AllowedOrigins.Add("https://client.example.test");
         options.AllowedOrigins.Add(configuredOrigin);
 
@@ -92,7 +102,7 @@ public sealed class McpCorsOptionsTests
     public void FindConfigurationErrors_TheSameOriginSpelledTwice_IsRefusedRatherThanCollapsed()
     {
         // Arrange
-        var options = new McpCorsOptions { AllowAnyOrigin = false };
+        var options = new McpCorsOptions();
         options.AllowedOrigins.Add("https://client.example.test");
         options.AllowedOrigins.Add("https://CLIENT.example.test:443");
 
@@ -107,7 +117,7 @@ public sealed class McpCorsOptionsTests
     public void ToOriginPolicy_SettingsThatWereNeverValidated_ThrowsRatherThanServingAShorterList()
     {
         // Arrange
-        var options = new McpCorsOptions { AllowAnyOrigin = false };
+        var options = new McpCorsOptions();
         options.AllowedOrigins.Add("https://client.example.test");
         options.AllowedOrigins.Add("not-an-origin");
 

--- a/tests/Host.UnitTests/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/McpEndpointOptionsBindingTests.cs
@@ -1,7 +1,9 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 
+using System.Text;
 using MailMcp.Host.Configuration;
 using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -11,21 +13,24 @@ namespace MailMcp.Host.UnitTests;
 /// <remarks>
 /// <para>
 /// Every other test in this project builds the options object directly, which proves what the rules do and nothing about
-/// whether an operator's configuration ever reaches them. Two of the settings here bind into collections exposed through
-/// getter-only properties, and a key list that silently stayed empty would leave every rule passing while no client could
-/// authenticate. That gap is the reason this file binds real configuration instead.
+/// whether an operator's configuration ever reaches them. Several of the settings here bind into collections exposed
+/// through getter-only properties, and a key list that silently stayed empty would leave every rule passing while no
+/// client could authenticate. That gap is the reason this file binds real configuration instead.
 /// </para>
 /// <para>
-/// The section is bound strictly, exactly as composition binds it, so the tests also state what a misspelling does.
+/// The section is bound strictly, exactly as composition binds it, so the tests also state what a misspelling does. The
+/// origin list is read from a JSON document rather than from an in-memory dictionary wherever the difference between an
+/// absent list and an empty one is what is under test, because that difference is a property of the JSON provider and a
+/// dictionary would only restate what this file assumed about it.
 /// </para>
 /// </remarks>
 public sealed class McpEndpointOptionsBindingTests
 {
     [Fact]
-    public void Bind_AConfiguredSection_ReadsEveryDecisionCompositionActsOn()
+    public void ReadFrom_AConfiguredSection_ReadsEveryDecisionCompositionActsOn()
     {
         // Arrange
-        var configuration = SectionFrom(new Dictionary<string, string?>
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
         {
             ["McpEndpoint:Enabled"] = "true",
             ["McpEndpoint:Authentication"] = "ApiKey",
@@ -34,13 +39,12 @@ public sealed class McpEndpointOptionsBindingTests
             ["McpEndpoint:ApiKeys:1:Name"] = "chatgpt-connector",
             ["McpEndpoint:ApiKeys:1:SecretReference"] = "file:/run/secrets/mailmcp-mcp-chatgpt-key",
             ["McpEndpoint:ApiKeys:1:Lifetime"] = "2027-01-31T00:00:00Z",
-            ["McpEndpoint:Cors:AllowAnyOrigin"] = "false",
             ["McpEndpoint:Cors:AllowedOrigins:0"] = "https://client.example.test",
             ["McpEndpoint:Cors:AllowedOrigins:1"] = "https://console.example.test:8443",
         });
 
         // Act
-        var options = Bind(configuration);
+        var options = McpEndpointOptions.ReadFrom(configuration);
 
         // Assert
         Assert.True(options.Enabled);
@@ -55,20 +59,87 @@ public sealed class McpEndpointOptionsBindingTests
         Assert.Empty(options.FindConfigurationErrors());
     }
 
+    /// <summary>A profile binds through three collections, any of which silently staying empty would leave a client certificate judged by less than was configured.</summary>
     [Fact]
-    public void Bind_AnUnconfiguredDeployment_LeavesTheEndpointOffAndNamesNoMode()
+    public void ReadFrom_ConfiguredClientCertificateProfiles_ReadsEachProfileWhole()
     {
         // Arrange
-        var configuration = SectionFrom([]);
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["McpEndpoint:Enabled"] = "true",
+            ["McpEndpoint:Authentication"] = "None",
+            ["McpEndpoint:ClientCertificateProfiles:0:Name"] = "chatgpt-connector",
+            ["McpEndpoint:ClientCertificateProfiles:0:Requirement"] = "Optional",
+            ["McpEndpoint:ClientCertificateProfiles:0:TrustAnchors:0:Name"] = "openai-connectors-ca",
+            ["McpEndpoint:ClientCertificateProfiles:0:TrustAnchors:0:SecretReference"] = "file:/etc/mailmcp/openai-connectors-ca.pem",
+            ["McpEndpoint:ClientCertificateProfiles:0:TrustAnchors:1:Name"] = "openai-connectors-ca-next",
+            ["McpEndpoint:ClientCertificateProfiles:0:TrustAnchors:1:SecretReference"] = "file:/etc/mailmcp/openai-connectors-ca-next.pem",
+            ["McpEndpoint:ClientCertificateProfiles:0:SubjectAlternativeNames:0"] = "mtls.prod.connectors.openai.com",
+        });
 
         // Act
-        var options = Bind(configuration);
+        var options = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        var profile = Assert.Single(options.ClientCertificateProfiles);
+        Assert.Equal("chatgpt-connector", profile.Name);
+        Assert.Equal(McpClientCertificateRequirement.Optional, profile.Requirement);
+        Assert.Equal(
+            ["openai-connectors-ca", "openai-connectors-ca-next"],
+            profile.TrustAnchors.Select(anchor => anchor.Name));
+        Assert.Equal(["mtls.prod.connectors.openai.com"], profile.SubjectAlternativeNames);
+        Assert.Empty(options.FindConfigurationErrors());
+    }
+
+    [Fact]
+    public void ReadFrom_AnUnconfiguredDeployment_LeavesTheEndpointOffAndNamesNoMode()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom([]);
+
+        // Act
+        var options = McpEndpointOptions.ReadFrom(configuration);
 
         // Assert
         Assert.False(options.Enabled);
         Assert.Null(options.Authentication);
         Assert.Empty(options.ApiKeys);
-        Assert.True(options.Cors.AllowAnyOrigin);
+        Assert.True(options.Cors.ServesEveryBrowserOrigin);
+    }
+
+    /// <summary>A configured list replaces the default rather than being added to it, which a pre-populated collection could not achieve.</summary>
+    [Fact]
+    public void ReadFrom_AConfiguredOriginList_CarriesThoseOriginsAndNotTheDefault()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            { "McpEndpoint": { "Cors": { "AllowedOrigins": ["https://client.example.test"] } } }
+            """);
+
+        // Act
+        var options = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Equal(["https://client.example.test"], options.Cors.AllowedOrigins);
+        Assert.False(options.Cors.ServesEveryBrowserOrigin);
+    }
+
+    /// <summary>An empty list states the posture that serves no browser, which an absent list must not be read as.</summary>
+    [Fact]
+    public void ReadFrom_AnEmptyOriginList_ServesNoBrowserRatherThanEveryOne()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            { "McpEndpoint": { "Cors": { "AllowedOrigins": [] } } }
+            """);
+
+        // Act
+        var options = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Empty(options.Cors.AllowedOrigins);
+        Assert.False(options.Cors.ServesEveryBrowserOrigin);
+        Assert.Empty(options.FindConfigurationErrors());
     }
 
     /// <summary>A misspelling that bound quietly would leave a security decision reading as one nobody made.</summary>
@@ -76,42 +147,61 @@ public sealed class McpEndpointOptionsBindingTests
     [InlineData("McpEndpoint:Enabeld", "true")]
     [InlineData("McpEndpoint:Authentication ", "None")]
     [InlineData("McpEndpoint:ApiKey", "workstation")]
-    [InlineData("McpEndpoint:Cors:AllowAnyOrigins", "false")]
-    public void Bind_AnUnrecognizedKey_FailsRatherThanBeingIgnored(string key, string value)
+    [InlineData("McpEndpoint:Cors:AllowedOrigin", "https://client.example.test")]
+    public void ReadFrom_AnUnrecognizedKey_FailsRatherThanBeingIgnored(string key, string value)
     {
         // Arrange
-        var configuration = SectionFrom(new Dictionary<string, string?>
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
         {
             ["McpEndpoint:Enabled"] = "true",
             [key] = value,
         });
 
         // Act, Assert
-        Assert.ThrowsAny<InvalidOperationException>(() => Bind(configuration));
+        Assert.ThrowsAny<InvalidOperationException>(() => McpEndpointOptions.ReadFrom(configuration));
+    }
+
+    /// <summary>The removed allow-any switch is refused rather than ignored, so a deployment carrying it is corrected instead of quietly widened.</summary>
+    [Fact]
+    public void ReadFrom_TheRemovedAllowAnyOriginKey_FailsRatherThanBeingIgnored()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["McpEndpoint:Enabled"] = "true",
+            ["McpEndpoint:Cors:AllowAnyOrigin"] = "false",
+        });
+
+        // Act, Assert
+        Assert.ThrowsAny<InvalidOperationException>(() => McpEndpointOptions.ReadFrom(configuration));
     }
 
     /// <summary>A mode the binder cannot read is a startup failure, never a silent fall back to the unauthenticated posture.</summary>
     [Fact]
-    public void Bind_AnAuthenticationModeThatIsNotOneOfTheTwo_Fails()
+    public void ReadFrom_AnAuthenticationModeThatIsNotOneOfTheTwo_Fails()
     {
         // Arrange
-        var configuration = SectionFrom(new Dictionary<string, string?>
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
         {
             ["McpEndpoint:Enabled"] = "true",
             ["McpEndpoint:Authentication"] = "Nonee",
         });
 
         // Act, Assert
-        Assert.ThrowsAny<InvalidOperationException>(() => Bind(configuration));
+        Assert.ThrowsAny<InvalidOperationException>(() => McpEndpointOptions.ReadFrom(configuration));
     }
 
-    private static IConfigurationSection SectionFrom(Dictionary<string, string?> values) =>
+    private static IConfiguration ConfigurationFrom(Dictionary<string, string?> values) =>
         new ConfigurationBuilder()
             .AddInMemoryCollection(values)
-            .Build()
-            .GetSection(McpEndpointOptions.SectionName);
+            .Build();
 
-    private static McpEndpointOptions Bind(IConfigurationSection section) =>
-        section.Get<McpEndpointOptions>(binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
-        ?? new McpEndpointOptions();
+    private static IConfiguration ConfigurationFromJson(string document)
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(document));
+
+        return new ConfigurationBuilder()
+            .AddJsonStream(stream)
+            .Build();
+    }
 }

--- a/tests/Host.UnitTests/McpEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/McpEndpointOptionsTests.cs
@@ -2,6 +2,7 @@
 
 using MailMcp.Host.Configuration;
 using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
 using Xunit;
 
 namespace MailMcp.Host.UnitTests;
@@ -133,13 +134,14 @@ public sealed class McpEndpointOptionsTests
     {
         // Arrange
         var options = EnabledWith(McpTransportAuthenticationMode.None);
+        options.Cors.ServeEveryBrowserOrigin();
         options.Cors.AllowedOrigins.Add("https://client.example.test");
 
         // Act
         var error = Assert.Single(options.FindConfigurationErrors());
 
         // Assert
-        Assert.StartsWith("McpEndpoint:Cors:AllowAnyOrigin", error, StringComparison.Ordinal);
+        Assert.StartsWith("McpEndpoint:Cors:AllowedOrigins", error, StringComparison.Ordinal);
     }
 
     /// <summary>Every fault is reported together, so an operator fixing a section reads all of it rather than one restart at a time.</summary>
@@ -147,7 +149,8 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_SeveralFaults_ReportsThemAllAtOnce()
     {
         // Arrange
-        var options = new McpEndpointOptions { Enabled = true, Cors = new McpCorsOptions { AllowAnyOrigin = false } };
+        var options = new McpEndpointOptions { Enabled = true };
+        options.Cors.AllowedOrigins.Add("not-an-origin");
 
         // Act
         var errors = options.FindConfigurationErrors();
@@ -166,8 +169,90 @@ public sealed class McpEndpointOptionsTests
         Assert.Empty(options.ApiKeys);
     }
 
+    /// <summary>Mutual TLS is off unless a profile says otherwise, and it composes with the mode rather than replacing it.</summary>
+    [Fact]
+    public void ClientCertificateProfiles_UnconfiguredDeployment_IsEmptyRatherThanNull()
+    {
+        // Arrange, Act
+        var options = EnabledWith(McpTransportAuthenticationMode.None);
+
+        // Assert
+        Assert.Empty(options.ClientCertificateProfiles);
+        Assert.Empty(options.FindConfigurationErrors());
+        Assert.Empty(options.ToClientCertificateTrustProfiles());
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_AnUnusableClientCertificateProfile_IsReportedUnderItsPosition()
+    {
+        // Arrange
+        var options = EnabledWith(McpTransportAuthenticationMode.None);
+        var profile = ConnectorProfile();
+        profile.TrustAnchors.Clear();
+        options.ClientCertificateProfiles.Add(profile);
+
+        // Act
+        var error = Assert.Single(options.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith("McpEndpoint:ClientCertificateProfiles:0:TrustAnchors", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>A refusal in the log and an audit record are read by the profile's name, so two profiles answering to one name make both ambiguous.</summary>
+    [Fact]
+    public void FindConfigurationErrors_TwoProfilesSharingAName_IsRefused()
+    {
+        // Arrange
+        var options = EnabledWith(McpTransportAuthenticationMode.None);
+        options.ClientCertificateProfiles.Add(ConnectorProfile());
+        options.ClientCertificateProfiles.Add(ConnectorProfile());
+
+        // Act
+        var error = Assert.Single(options.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith("McpEndpoint:ClientCertificateProfiles:1:Name", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ToClientCertificateTrustProfiles_SeveralProfiles_MapsThemInConfigurationOrder()
+    {
+        // Arrange
+        var options = EnabledWith(McpTransportAuthenticationMode.None);
+        options.ClientCertificateProfiles.Add(ConnectorProfile());
+        var reportingProfile = ConnectorProfile();
+        reportingProfile.Name = "reporting-service";
+        options.ClientCertificateProfiles.Add(reportingProfile);
+
+        // Act
+        var trustProfiles = options.ToClientCertificateTrustProfiles();
+
+        // Assert
+        Assert.Equal(
+            ["chatgpt-connector", "reporting-service"],
+            trustProfiles.Select(profile => profile.Name));
+    }
+
     private static McpEndpointOptions EnabledWith(McpTransportAuthenticationMode authentication) =>
         new() { Enabled = true, Authentication = authentication };
+
+    private static McpClientCertificateProfileOptions ConnectorProfile()
+    {
+        var profile = new McpClientCertificateProfileOptions
+        {
+            Name = "chatgpt-connector",
+            Requirement = McpClientCertificateRequirement.Optional,
+        };
+
+        profile.TrustAnchors.Add(new ConfiguredSecret
+        {
+            Name = "openai-connectors-ca",
+            SecretReference = "file:/run/secrets/openai-connectors-ca.pem",
+        });
+        profile.SubjectAlternativeNames.Add("mtls.prod.connectors.openai.com");
+
+        return profile;
+    }
 
     private static ConfiguredSecret Key(string name) => new()
     {

--- a/tests/Host.UnitTests/McpTransportAuthenticationWarningTests.cs
+++ b/tests/Host.UnitTests/McpTransportAuthenticationWarningTests.cs
@@ -46,9 +46,7 @@ public sealed class McpTransportAuthenticationWarningTests
     {
         // Arrange
         using var logs = new RecordingLoggerProvider();
-        var warning = WarningFor(
-            new McpEndpointOptions { Enabled = true, Authentication = McpTransportAuthenticationMode.None },
-            logs);
+        var warning = WarningFor(UnauthenticatedServingEveryBrowserOrigin(), logs);
 
         // Act
         await warning.StartAsync(TestContext.Current.CancellationToken);
@@ -134,17 +132,28 @@ public sealed class McpTransportAuthenticationWarningTests
     /// <summary>The unauthenticated posture with the origin question already answered, so only the credential warning is left to fire.</summary>
     private static McpEndpointOptions UnauthenticatedServingOneBrowserOrigin()
     {
-        var settings = new McpEndpointOptions
-        {
-            Enabled = true,
-            Authentication = McpTransportAuthenticationMode.None,
-            Cors = new McpCorsOptions { AllowAnyOrigin = false },
-        };
+        var settings = Unauthenticated();
 
         settings.Cors.AllowedOrigins.Add("https://client.example.test");
 
         return settings;
     }
+
+    /// <summary>The unauthenticated posture a deployment that configured no origin list receives, which is what composition applies.</summary>
+    private static McpEndpointOptions UnauthenticatedServingEveryBrowserOrigin()
+    {
+        var settings = Unauthenticated();
+
+        settings.Cors.ServeEveryBrowserOrigin();
+
+        return settings;
+    }
+
+    private static McpEndpointOptions Unauthenticated() => new()
+    {
+        Enabled = true,
+        Authentication = McpTransportAuthenticationMode.None,
+    };
 
     private static McpTransportAuthenticationWarning WarningFor(McpEndpointOptions settings, RecordingLoggerProvider logs)
     {

--- a/tests/Host.UnitTests/SecretConfigurationStartupValidatorTests.cs
+++ b/tests/Host.UnitTests/SecretConfigurationStartupValidatorTests.cs
@@ -7,6 +7,7 @@ using MailMcp.Infrastructure;
 using MailMcp.Infrastructure.Certificates;
 using MailMcp.Infrastructure.Persistence;
 using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
@@ -452,6 +453,39 @@ public sealed class SecretConfigurationStartupValidatorTests
         // Assert
         var failure = Assert.Single(exception.Failures);
         Assert.StartsWith("McpEndpoint:ApiKeys:1:Name", failure, StringComparison.Ordinal);
+    }
+
+    /// <summary>Material that resolves but is not a certificate would pass a reference check and then refuse every client the profile exists to serve.</summary>
+    [Fact]
+    public async Task StartingAsync_AClientCertificateTrustAnchorThatIsNotACertificate_FailsStartupNamingItsPosition()
+    {
+        // Arrange
+        var endpoint = new McpEndpointOptions { Enabled = true, Authentication = McpTransportAuthenticationMode.None };
+        var profile = new McpClientCertificateProfileOptions
+        {
+            Name = "chatgpt-connector",
+            Requirement = McpClientCertificateRequirement.Optional,
+        };
+        profile.TrustAnchors.Add(new ConfiguredSecret
+        {
+            Name = "openai-connectors-ca",
+            SecretReference = "plaintext:not-a-certificate",
+        });
+        profile.SubjectAlternativeNames.Add("mtls.prod.connectors.openai.com");
+        endpoint.ClientCertificateProfiles.Add(profile);
+        var harness = CreateHarness(new MailSynchronizationOptions(), new PersistenceOptions(), mcpEndpointOptions: endpoint);
+
+        // Act
+        var exception = await Assert.ThrowsAsync<OptionsValidationException>(() =>
+            harness.Validator.StartingAsync(CancellationToken.None));
+
+        // Assert
+        var failure = Assert.Single(exception.Failures);
+        Assert.StartsWith(
+            "McpEndpoint:ClientCertificateProfiles:0:TrustAnchors:0",
+            failure,
+            StringComparison.Ordinal);
+        Assert.Contains(nameof(CertificateMaterialFailure.EncodingNotRecognized), failure, StringComparison.Ordinal);
     }
 
     /// <summary>A disabled endpoint reads no key, so failing a host over one nothing was going to use would be a rule with no purpose.</summary>

--- a/tests/Infrastructure.UnitTests/CertificateMaterialEncodingDetectorTests.cs
+++ b/tests/Infrastructure.UnitTests/CertificateMaterialEncodingDetectorTests.cs
@@ -2,6 +2,7 @@
 
 using System.Text;
 using MailMcp.Infrastructure.Certificates;
+using MailMcp.TestSupport;
 using Xunit;
 
 namespace MailMcp.Infrastructure.UnitTests;

--- a/tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj
+++ b/tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj
@@ -16,5 +16,6 @@
   <ItemGroup>
     <Compile Include="..\shared\RecordingLoggerProvider.cs" Link="RecordingLoggerProvider.cs" />
     <Compile Include="..\shared\ExceptionHierarchyAssertion.cs" Link="ExceptionHierarchyAssertion.cs" />
+    <Compile Include="..\shared\TestCertificates.cs" Link="TestCertificates.cs" />
   </ItemGroup>
 </Project>

--- a/tests/Infrastructure.UnitTests/MailAccountTransportSecurityOptionsTests.cs
+++ b/tests/Infrastructure.UnitTests/MailAccountTransportSecurityOptionsTests.cs
@@ -3,6 +3,7 @@
 using MailMcp.Domain.Transport;
 using MailMcp.Infrastructure.Mail;
 using MailMcp.Infrastructure.Secrets;
+using MailMcp.TestSupport;
 using Xunit;
 
 namespace MailMcp.Infrastructure.UnitTests;

--- a/tests/Infrastructure.UnitTests/MailKitImapMailboxSessionTests.cs
+++ b/tests/Infrastructure.UnitTests/MailKitImapMailboxSessionTests.cs
@@ -12,6 +12,7 @@ using MailMcp.Domain.Synchronization;
 using MailMcp.Domain.Transport;
 using MailMcp.Infrastructure.Mail;
 using MailMcp.Infrastructure.Mail.MailKit;
+using MailMcp.TestSupport;
 using NSubstitute;
 using Xunit;
 using static MailMcp.Infrastructure.UnitTests.MailKitImapSessionTestContext;

--- a/tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs
+++ b/tests/Infrastructure.UnitTests/MailServerCertificateValidatorTests.cs
@@ -4,6 +4,7 @@ using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using MailMcp.Domain.Transport;
 using MailMcp.Infrastructure.Mail;
+using MailMcp.TestSupport;
 using Xunit;
 
 namespace MailMcp.Infrastructure.UnitTests;

--- a/tests/Infrastructure.UnitTests/McpClientCertificateAuthenticatorTests.cs
+++ b/tests/Infrastructure.UnitTests/McpClientCertificateAuthenticatorTests.cs
@@ -1,0 +1,462 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Security.Cryptography.X509Certificates;
+using MailMcp.Infrastructure.Certificates;
+using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
+using MailMcp.TestSupport;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MailMcp.Infrastructure.UnitTests;
+
+/// <summary>Covers which client certificates a deployment's trust profiles accept, and what each refusal is called.</summary>
+/// <remarks>
+/// Every certificate here is built in memory, and the authorities are unrelated to anything the machine trusts, which is
+/// the point: a profile decides by the anchors it names, so a test whose certificates chained to a real root would pass
+/// while proving nothing about the configuration.
+/// </remarks>
+public sealed class McpClientCertificateAuthenticatorTests
+{
+    private const string ConnectorDnsName = "mtls.prod.connectors.openai.com";
+
+    private const string ReportingDnsName = "reporting.example.test";
+
+    private const string ConnectorAnchorReference = "file:/run/secrets/connector-ca.pem";
+
+    private const string ReportingAnchorReference = "file:/run/secrets/reporting-ca.pem";
+
+    /// <summary>Several profiles stand beside each other, so one client's authority says nothing about another's.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_ACertificateOneProfileTrustsAndAnotherDoesNot_IsAcceptedByTheProfileThatDoes()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var connectorCertificate = harness.IssueConnectorCertificate();
+
+        // Act
+        var result = await harness.AuthenticateAsync(
+            [harness.ReportingProfile(), harness.ConnectorProfile()],
+            connectorCertificate);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.Equal("chatgpt-connector", result.MatchedProfileName);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_ACertificateFromAnAuthorityNoProfileNames_IsRefusedAsUntrusted()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var strangerAuthority = TestCertificates.CreateCertificateAuthority("Stranger Root");
+        using var strangerCertificate = TestCertificates.IssueClientAuthenticationCertificate(
+            strangerAuthority,
+            ConnectorDnsName);
+
+        // Act
+        var result = await harness.AuthenticateAsync([harness.ConnectorProfile()], strangerCertificate);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.ChainNotTrusted, result.Rejection);
+    }
+
+    /// <summary>A profile that requires a certificate refuses the request that presents none, whatever else it carries.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_NoCertificateAgainstARequiredProfile_IsRefused()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+
+        // Act
+        var result = await harness.AuthenticateAsync(
+            [harness.ConnectorProfile(McpClientCertificateRequirement.Required)],
+            presentedCertificate: null);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.CertificateMissing, result.Rejection);
+    }
+
+    /// <summary>An optional profile is what stands beside another authentication mechanism, so a client without a certificate is served and simply identified by nothing.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_NoCertificateAgainstOptionalProfilesOnly_IsServedAndIdentifiesNoClient()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+
+        // Act
+        var result = await harness.AuthenticateAsync(
+            [harness.ConnectorProfile(), harness.ReportingProfile()],
+            presentedCertificate: null);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.Null(result.MatchedProfileName);
+    }
+
+    /// <summary>One required profile is enough: the request carries no certificate at all, so no profile can be the one it was meant for.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_NoCertificateAgainstOneRequiredProfileBesideAnOptionalOne_IsRefused()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+
+        // Act
+        var result = await harness.AuthenticateAsync(
+            [harness.ReportingProfile(), harness.ConnectorProfile(McpClientCertificateRequirement.Required)],
+            presentedCertificate: null);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.CertificateMissing, result.Rejection);
+    }
+
+    /// <summary>The authority alone would accept every certificate it has ever issued, which is what naming the client prevents.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_ACertificateTheAuthoritySignedForAnotherName_IsRefused()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var otherClientCertificate = TestCertificates.IssueClientAuthenticationCertificate(
+            harness.ConnectorAuthority,
+            "someone-else.example.test");
+
+        // Act
+        var result = await harness.AuthenticateAsync([harness.ConnectorProfile()], otherClientCertificate);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.SubjectAlternativeNameMismatch, result.Rejection);
+    }
+
+    /// <summary>A host name is case-insensitive, so a certificate spelling it differently is the same client.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_ACertificateNamingTheClientInAnotherCase_IsAccepted()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var connectorCertificate = TestCertificates.IssueClientAuthenticationCertificate(
+            harness.ConnectorAuthority,
+            "MTLS.Prod.Connectors.OpenAI.com");
+
+        // Act
+        var result = await harness.AuthenticateAsync([harness.ConnectorProfile()], connectorCertificate);
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    /// <summary>The same authority issues server and client certificates, so one must never be presented as the other.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_ACertificateThatIsNotForClientAuthentication_IsRefused()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var serverCertificate = TestCertificates.IssueServerAuthenticationCertificate(
+            harness.ConnectorAuthority,
+            ConnectorDnsName);
+
+        // Act
+        var result = await harness.AuthenticateAsync([harness.ConnectorProfile()], serverCertificate);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.ClientAuthenticationUsageMissing, result.Rejection);
+    }
+
+    /// <summary>Absence of an extended key usage means every usage in X.509, which is exactly the certificate a client profile must not take on trust.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_ACertificateCarryingNoExtendedKeyUsage_IsRefused()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var unrestrictedCertificate = TestCertificates.IssueServerCertificate(
+            harness.ConnectorAuthority,
+            ConnectorDnsName);
+
+        // Act
+        var result = await harness.AuthenticateAsync([harness.ConnectorProfile()], unrestrictedCertificate);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.ClientAuthenticationUsageMissing, result.Rejection);
+    }
+
+    [Fact]
+    public async Task AuthenticateAsync_AnExpiredCertificate_IsRefusedAsExpiredRatherThanAsUntrusted()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var expiredCertificate = TestCertificates.IssueExpiredClientAuthenticationCertificate(
+            harness.ConnectorAuthority,
+            ConnectorDnsName);
+
+        // Act
+        var result = await harness.AuthenticateAsync([harness.ConnectorProfile()], expiredCertificate);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.CertificateExpired, result.Rejection);
+    }
+
+    /// <summary>
+    /// The server sees the leaf alone, so an intermediate the client chained through has to come from configuration.
+    /// Listing it beside its root is what completes the path; the root is still where trust comes from.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateAsync_ACertificateIssuedByAnIntermediateListedBesideItsRoot_IsAccepted()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var intermediate = TestCertificates.IssueIntermediateAuthority(
+            harness.ConnectorAuthority,
+            "Connector Intermediate");
+        harness.Provision("file:/run/secrets/connector-intermediate.pem", intermediate);
+        using var certificateFromIntermediate = TestCertificates.IssueClientAuthenticationCertificate(
+            intermediate,
+            ConnectorDnsName);
+
+        // Act
+        var withoutTheIntermediate = await harness.AuthenticateAsync(
+            [harness.ConnectorProfile()],
+            certificateFromIntermediate);
+        var withTheIntermediate = await harness.AuthenticateAsync(
+            [
+                harness.ConnectorProfile(anchorReferences:
+                    [ConnectorAnchorReference, "file:/run/secrets/connector-intermediate.pem"]),
+            ],
+            certificateFromIntermediate);
+
+        // Assert
+        Assert.Equal(McpClientCertificateRejection.ChainNotTrusted, withoutTheIntermediate.Rejection);
+        Assert.True(withTheIntermediate.Succeeded);
+    }
+
+    /// <summary>An intermediate is not a root: listing one on its own trusts nothing, rather than trusting everything under it.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_AnIntermediateListedWithoutItsRoot_IsRefused()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var intermediate = TestCertificates.IssueIntermediateAuthority(
+            harness.ConnectorAuthority,
+            "Connector Intermediate");
+        harness.Provision("file:/run/secrets/connector-intermediate.pem", intermediate);
+        using var certificateFromIntermediate = TestCertificates.IssueClientAuthenticationCertificate(
+            intermediate,
+            ConnectorDnsName);
+
+        // Act
+        var result = await harness.AuthenticateAsync(
+            [harness.ConnectorProfile(anchorReferences: ["file:/run/secrets/connector-intermediate.pem"])],
+            certificateFromIntermediate);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.ChainNotTrusted, result.Rejection);
+    }
+
+    /// <summary>Rotating an authority is an overlap: both are listed, both are accepted, and the predecessor is removed once clients have moved.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_TwoAnchorsDuringARotation_AcceptsCertificatesFromBoth()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var successorAuthority = TestCertificates.CreateCertificateAuthority("Connector Root 2027");
+        harness.Provision("file:/run/secrets/connector-ca-2027.pem", successorAuthority);
+        var profile = harness.ConnectorProfile(
+            anchorReferences: [ConnectorAnchorReference, "file:/run/secrets/connector-ca-2027.pem"]);
+
+        using var certificateFromPredecessor = harness.IssueConnectorCertificate();
+        using var certificateFromSuccessor = TestCertificates.IssueClientAuthenticationCertificate(
+            successorAuthority,
+            ConnectorDnsName);
+
+        // Act
+        var fromPredecessor = await harness.AuthenticateAsync([profile], certificateFromPredecessor);
+        var fromSuccessor = await harness.AuthenticateAsync([profile], certificateFromSuccessor);
+
+        // Assert
+        Assert.True(fromPredecessor.Succeeded);
+        Assert.True(fromSuccessor.Succeeded);
+    }
+
+    /// <summary>Half a rotation must not stop the certificates the other half still signs for.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_OneAnchorThatCannotBeLoadedBesideOneThatCan_StillAcceptsWhatTheReadableAnchorSignedFor()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        var profile = harness.ConnectorProfile(
+            anchorReferences: ["file:/run/secrets/absent-ca.pem", ConnectorAnchorReference]);
+        using var connectorCertificate = harness.IssueConnectorCertificate();
+
+        // Act
+        var result = await harness.AuthenticateAsync([profile], connectorCertificate);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        var record = Assert.Single(harness.Logs.Records, entry => entry.Level == LogLevel.Error);
+        Assert.Equal("chatgpt-connector", Assert.Contains("TrustProfileName", record.Properties));
+        Assert.DoesNotContain("/run/secrets", record.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>An anchor that has become unreadable must never widen what a profile accepts, so the profile refuses instead of falling through.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_AProfileWhoseAnchorsAllFailToLoad_RefusesRatherThanTrustingNothingSilently()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        var profile = harness.ConnectorProfile(anchorReferences: ["file:/run/secrets/absent-ca.pem"]);
+        using var connectorCertificate = harness.IssueConnectorCertificate();
+
+        // Act
+        var result = await harness.AuthenticateAsync([profile], connectorCertificate);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.TrustAnchorUnavailable, result.Rejection);
+    }
+
+    /// <summary>Nothing is cached, so an authority replaced behind an unchanged reference reaches the next request rather than the next restart.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_AnAnchorReplacedBehindTheSameReference_TakesEffectOnTheNextRequest()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var successorAuthority = TestCertificates.CreateCertificateAuthority("Connector Root 2027");
+        using var certificateFromSuccessor = TestCertificates.IssueClientAuthenticationCertificate(
+            successorAuthority,
+            ConnectorDnsName);
+        var profile = harness.ConnectorProfile();
+
+        // Act
+        var beforeRotation = await harness.AuthenticateAsync([profile], certificateFromSuccessor);
+        harness.Provision(ConnectorAnchorReference, successorAuthority);
+        var afterRotation = await harness.AuthenticateAsync([profile], certificateFromSuccessor);
+
+        // Assert
+        Assert.False(beforeRotation.Succeeded);
+        Assert.True(afterRotation.Succeeded);
+    }
+
+    /// <summary>A deployment that configured no profile has no certificate policy, so nothing is judged and nothing is identified.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_NoProfilesAtAll_ServesTheRequest()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var connectorCertificate = harness.IssueConnectorCertificate();
+
+        // Act
+        var result = await harness.AuthenticateAsync([], connectorCertificate);
+
+        // Assert
+        Assert.True(result.Succeeded);
+        Assert.Null(result.MatchedProfileName);
+    }
+
+    /// <summary>A refusal is recorded by thumbprint, which is public material, and never by anything the deployment configured.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_ARefusedCertificate_IsRecordedByThumbprintWithoutTheConfiguredReference()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var strangerAuthority = TestCertificates.CreateCertificateAuthority("Stranger Root");
+        using var strangerCertificate = TestCertificates.IssueClientAuthenticationCertificate(
+            strangerAuthority,
+            ConnectorDnsName);
+
+        // Act
+        await harness.AuthenticateAsync([harness.ConnectorProfile()], strangerCertificate);
+
+        // Assert
+        var record = Assert.Single(harness.Logs.Records, entry => entry.Level == LogLevel.Warning);
+        Assert.Equal(
+            strangerCertificate.Thumbprint,
+            Assert.Contains("ClientCertificateThumbprint", record.Properties));
+        Assert.DoesNotContain("/run/secrets", record.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>Holds the two authorities a deployment might configure, and provisions their material the way a mounted file supplies it.</summary>
+    private sealed class TrustProfileHarness : IDisposable
+    {
+        private readonly ProvisionedMaterialResolver resolver = new();
+        private readonly ILoggerFactory loggerFactory;
+
+        internal TrustProfileHarness()
+        {
+            this.ConnectorAuthority = TestCertificates.CreateCertificateAuthority("Connector Root");
+            this.ReportingAuthority = TestCertificates.CreateCertificateAuthority("Reporting Root");
+            this.Provision(ConnectorAnchorReference, this.ConnectorAuthority);
+            this.Provision(ReportingAnchorReference, this.ReportingAuthority);
+
+            this.Logs = new RecordingLoggerProvider();
+            this.loggerFactory = LoggerFactory.Create(logging => logging
+                .SetMinimumLevel(LogLevel.Debug)
+                .AddProvider(this.Logs));
+            this.Authenticator = new McpClientCertificateAuthenticator(
+                new TrustAnchorLoader(this.resolver),
+                this.loggerFactory.CreateLogger<McpClientCertificateAuthenticator>());
+        }
+
+        internal X509Certificate2 ConnectorAuthority { get; }
+
+        internal X509Certificate2 ReportingAuthority { get; }
+
+        internal RecordingLoggerProvider Logs { get; }
+
+        internal McpClientCertificateAuthenticator Authenticator { get; }
+
+        public void Dispose()
+        {
+            this.ConnectorAuthority.Dispose();
+            this.ReportingAuthority.Dispose();
+            this.loggerFactory.Dispose();
+            this.Logs.Dispose();
+        }
+
+        internal void Provision(string secretReference, X509Certificate2 authority)
+        {
+            using var publicAnchor = TestCertificates.WithoutPrivateKey(authority);
+
+            this.resolver.Provision(secretReference, TestCertificates.ToPem(publicAnchor));
+        }
+
+        internal X509Certificate2 IssueConnectorCertificate() =>
+            TestCertificates.IssueClientAuthenticationCertificate(this.ConnectorAuthority, ConnectorDnsName);
+
+        internal McpClientCertificateTrustProfile ConnectorProfile(
+            McpClientCertificateRequirement requirement = McpClientCertificateRequirement.Optional,
+            IEnumerable<string>? anchorReferences = null) =>
+            McpClientCertificateTrustProfile.Create(
+                "chatgpt-connector",
+                requirement,
+                Anchors(anchorReferences ?? [ConnectorAnchorReference]),
+                [ConnectorDnsName]);
+
+        internal McpClientCertificateTrustProfile ReportingProfile() =>
+            McpClientCertificateTrustProfile.Create(
+                "reporting-service",
+                McpClientCertificateRequirement.Optional,
+                Anchors([ReportingAnchorReference]),
+                [ReportingDnsName]);
+
+        internal Task<McpClientCertificateAuthenticationResult> AuthenticateAsync(
+            IReadOnlyList<McpClientCertificateTrustProfile> profiles,
+            X509Certificate2? presentedCertificate) =>
+            this.Authenticator.AuthenticateAsync(
+                profiles,
+                presentedCertificate,
+                TestContext.Current.CancellationToken);
+
+        private static IEnumerable<ConfiguredSecret> Anchors(IEnumerable<string> anchorReferences) =>
+            anchorReferences.Select(reference => new ConfiguredSecret
+            {
+                Name = "connector-ca",
+                SecretReference = reference,
+            });
+    }
+}

--- a/tests/Infrastructure.UnitTests/McpClientCertificateAuthenticatorTests.cs
+++ b/tests/Infrastructure.UnitTests/McpClientCertificateAuthenticatorTests.cs
@@ -6,6 +6,7 @@ using MailMcp.Infrastructure.Secrets;
 using MailMcp.Infrastructure.Security;
 using MailMcp.TestSupport;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
 namespace MailMcp.Infrastructure.UnitTests;
@@ -25,6 +26,9 @@ public sealed class McpClientCertificateAuthenticatorTests
     private const string ConnectorAnchorReference = "file:/run/secrets/connector-ca.pem";
 
     private const string ReportingAnchorReference = "file:/run/secrets/reporting-ca.pem";
+
+    /// <summary>The instant every certificate here is judged at, inside the validity period the test certificates carry.</summary>
+    private static readonly DateTimeOffset JudgedAt = new(2026, 7, 31, 12, 0, 0, TimeSpan.Zero);
 
     /// <summary>Several profiles stand beside each other, so one client's authority says nothing about another's.</summary>
     [Fact]
@@ -258,6 +262,67 @@ public sealed class McpClientCertificateAuthenticatorTests
         Assert.Equal(McpClientCertificateRejection.ChainNotTrusted, result.Rejection);
     }
 
+    /// <summary>The validity period is judged against the injected clock, not the machine's, which is what makes the expiry boundary reachable at all.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_ACertificateJudgedBeyondItsValidityPeriod_IsRefusedAsExpired()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var connectorCertificate = harness.IssueConnectorCertificate();
+
+        // Act
+        var whileValid = await harness.AuthenticateAsync([harness.ConnectorProfile()], connectorCertificate);
+        harness.Clock.SetUtcNow(new DateTimeOffset(2101, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var afterExpiry = await harness.AuthenticateAsync([harness.ConnectorProfile()], connectorCertificate);
+
+        // Assert
+        Assert.True(whileValid.Succeeded);
+        Assert.False(afterExpiry.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.CertificateExpired, afterExpiry.Rejection);
+    }
+
+    /// <summary>
+    /// A profile the certificate was never meant for objects that the name does not match, which says nothing about the
+    /// certificate. Reporting that would send an operator to fix a name while the actual fault is elsewhere.
+    /// </summary>
+    [Fact]
+    public async Task AuthenticateAsync_ANameMismatchFromAnotherProfile_ReportsWhatTheProfileNamingTheClientObjectedTo()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var expiredConnectorCertificate = TestCertificates.IssueExpiredClientAuthenticationCertificate(
+            harness.ConnectorAuthority,
+            ConnectorDnsName);
+
+        // Act
+        var result = await harness.AuthenticateAsync(
+            [harness.ReportingProfile(), harness.ConnectorProfile()],
+            expiredConnectorCertificate);
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal(McpClientCertificateRejection.CertificateExpired, result.Rejection);
+    }
+
+    /// <summary>A certificate no profile names is exactly what a name mismatch describes, so that is what is reported.</summary>
+    [Fact]
+    public async Task AuthenticateAsync_ACertificateNoProfileNames_ReportsTheNameMismatch()
+    {
+        // Arrange
+        using var harness = new TrustProfileHarness();
+        using var strangerCertificate = TestCertificates.IssueClientAuthenticationCertificate(
+            harness.ConnectorAuthority,
+            "someone-else.example.test");
+
+        // Act
+        var result = await harness.AuthenticateAsync(
+            [harness.ReportingProfile(), harness.ConnectorProfile()],
+            strangerCertificate);
+
+        // Assert
+        Assert.Equal(McpClientCertificateRejection.SubjectAlternativeNameMismatch, result.Rejection);
+    }
+
     /// <summary>Rotating an authority is an overlap: both are listed, both are accepted, and the predecessor is removed once clients have moved.</summary>
     [Fact]
     public async Task AuthenticateAsync_TwoAnchorsDuringARotation_AcceptsCertificatesFromBoth()
@@ -397,8 +462,10 @@ public sealed class McpClientCertificateAuthenticatorTests
             this.loggerFactory = LoggerFactory.Create(logging => logging
                 .SetMinimumLevel(LogLevel.Debug)
                 .AddProvider(this.Logs));
+            this.Clock = new FakeTimeProvider(JudgedAt);
             this.Authenticator = new McpClientCertificateAuthenticator(
                 new TrustAnchorLoader(this.resolver),
+                this.Clock,
                 this.loggerFactory.CreateLogger<McpClientCertificateAuthenticator>());
         }
 
@@ -407,6 +474,8 @@ public sealed class McpClientCertificateAuthenticatorTests
         internal X509Certificate2 ReportingAuthority { get; }
 
         internal RecordingLoggerProvider Logs { get; }
+
+        internal FakeTimeProvider Clock { get; }
 
         internal McpClientCertificateAuthenticator Authenticator { get; }
 

--- a/tests/Infrastructure.UnitTests/McpClientCertificateTrustProfileTests.cs
+++ b/tests/Infrastructure.UnitTests/McpClientCertificateTrustProfileTests.cs
@@ -1,0 +1,121 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Infrastructure.Secrets;
+using MailMcp.Infrastructure.Security;
+using Xunit;
+
+namespace MailMcp.Infrastructure.UnitTests;
+
+/// <summary>Covers what a profile has to carry before it can identify a client, and what it answers about a name.</summary>
+public sealed class McpClientCertificateTrustProfileTests
+{
+    [Theory]
+    [InlineData("chatgpt-connector")]
+    [InlineData("reporting.service")]
+    [InlineData("client_2")]
+    public void IsAcceptedName_ANameSafeToRecord_IsAccepted(string configuredValue)
+    {
+        // Arrange, Act, Assert
+        Assert.True(McpClientCertificateTrustProfile.IsAcceptedName(configuredValue));
+    }
+
+    /// <summary>A name reaches a log line and an audit record, so escaping or truncation must never be what decides its meaning.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("-leading-dash")]
+    [InlineData("carries a space")]
+    [InlineData("carries\na newline")]
+    public void IsAcceptedName_AnythingElse_IsRefused(string? configuredValue)
+    {
+        // Arrange, Act, Assert
+        Assert.False(McpClientCertificateTrustProfile.IsAcceptedName(configuredValue));
+    }
+
+    [Fact]
+    public void IsAcceptedName_ANameLongerThanTheMaximum_IsRefused()
+    {
+        // Arrange
+        var configuredValue = new string('a', McpClientCertificateTrustProfile.MaximumNameLength + 1);
+
+        // Act, Assert
+        Assert.False(McpClientCertificateTrustProfile.IsAcceptedName(configuredValue));
+    }
+
+    /// <summary>Only DNS names are compared, so anything else would be a profile written against a name nothing reads.</summary>
+    [Theory]
+    [InlineData("mtls.prod.connectors.openai.com", true)]
+    [InlineData("client", true)]
+    [InlineData("192.0.2.10", false)]
+    [InlineData("https://client.example.test", false)]
+    [InlineData("", false)]
+    public void IsAcceptedDnsName_AConfiguredValue_IsAcceptedOnlyWhenItIsAHostName(string configuredValue, bool accepted)
+    {
+        // Arrange, Act, Assert
+        Assert.Equal(accepted, McpClientCertificateTrustProfile.IsAcceptedDnsName(configuredValue));
+    }
+
+    [Fact]
+    public void Create_AProfileNamingItsClientAndItsAuthority_CarriesBoth()
+    {
+        // Arrange, Act
+        var profile = McpClientCertificateTrustProfile.Create(
+            "chatgpt-connector",
+            McpClientCertificateRequirement.Required,
+            [Anchor()],
+            ["mtls.prod.connectors.openai.com", "MTLS.PROD.CONNECTORS.OPENAI.COM"]);
+
+        // Assert
+        Assert.Equal("chatgpt-connector", profile.Name);
+        Assert.Equal(McpClientCertificateRequirement.Required, profile.Requirement);
+        Assert.Single(profile.TrustAnchors);
+        Assert.Single(profile.ExpectedDnsNames);
+        Assert.True(profile.NamesClient(["mtls.prod.connectors.openai.com"]));
+    }
+
+    /// <summary>A host name is case-insensitive, and a certificate carrying any of the expected names is the client.</summary>
+    [Fact]
+    public void NamesClient_ACertificateCarryingOneOfSeveralExpectedNames_IsTheClient()
+    {
+        // Arrange
+        var profile = McpClientCertificateTrustProfile.Create(
+            "reporting-service",
+            McpClientCertificateRequirement.Optional,
+            [Anchor()],
+            ["reporting.example.test", "reporting-standby.example.test"]);
+
+        // Act, Assert
+        Assert.True(profile.NamesClient(["other.example.test", "REPORTING-STANDBY.example.test"]));
+        Assert.False(profile.NamesClient(["someone-else.example.test"]));
+        Assert.False(profile.NamesClient([]));
+    }
+
+    /// <summary>Every one of these means the profile was mapped before it was validated, which the options rules refuse first.</summary>
+    [Theory]
+    [InlineData("", true, true)]
+    [InlineData("chatgpt connector", true, true)]
+    [InlineData("chatgpt-connector", false, true)]
+    [InlineData("chatgpt-connector", true, false)]
+    public void Create_SettingsThatCouldNotIdentifyAClient_Throws(
+        string name,
+        bool carriesAnAnchor,
+        bool carriesADnsName)
+    {
+        // Arrange
+        ConfiguredSecret[] anchors = carriesAnAnchor ? [Anchor()] : [];
+        string[] dnsNames = carriesADnsName ? ["client.example.test"] : [];
+
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() => McpClientCertificateTrustProfile.Create(
+            name,
+            McpClientCertificateRequirement.Optional,
+            anchors,
+            dnsNames));
+    }
+
+    private static ConfiguredSecret Anchor() => new()
+    {
+        Name = "connector-ca",
+        SecretReference = "file:/run/secrets/connector-ca.pem",
+    };
+}

--- a/tests/Infrastructure.UnitTests/McpOriginPolicyTests.cs
+++ b/tests/Infrastructure.UnitTests/McpOriginPolicyTests.cs
@@ -59,6 +59,21 @@ public sealed class McpOriginPolicyTests
         Assert.True(policy.Permits("null"));
     }
 
+    /// <summary>What it excludes is browsers rather than clients: a request carrying no origin is every non-browser client and is still served.</summary>
+    [Fact]
+    public void Permits_TheNoBrowserOriginPolicy_RefusesEveryOriginAndServesARequestCarryingNone()
+    {
+        // Arrange
+        var policy = McpOriginPolicy.ServingNoBrowserOrigin;
+
+        // Act, Assert
+        Assert.False(policy.AllowsAnyOrigin);
+        Assert.Empty(policy.AllowedOrigins);
+        Assert.False(policy.Permits("https://client.example.test"));
+        Assert.False(policy.Permits("null"));
+        Assert.True(policy.Permits(origin: null));
+    }
+
     [Fact]
     public void Permits_AListedOrigin_IsServedAndAnUnlistedOneIsNot()
     {

--- a/tests/Infrastructure.UnitTests/ProvisionedMaterialResolver.cs
+++ b/tests/Infrastructure.UnitTests/ProvisionedMaterialResolver.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using MailMcp.Infrastructure.Secrets;
+
+namespace MailMcp.Infrastructure.UnitTests;
+
+/// <summary>Hands back exactly the bytes a deployment provisioned, without touching the file system.</summary>
+internal sealed class ProvisionedMaterialResolver : ISecretReferenceResolver
+{
+    private readonly Dictionary<string, (byte[] Material, SecretMaterialSource Source)> provisioned = new(StringComparer.Ordinal);
+    private readonly List<ResolvedSecret> issued = [];
+
+    public IReadOnlyList<ResolvedSecret> IssuedMaterial => this.issued;
+
+    public void Provision(
+        string secretReference,
+        byte[] material,
+        SecretMaterialSource source = SecretMaterialSource.SchemeAdapter) =>
+        this.provisioned[secretReference] = (material, source);
+
+    public Task<SecretResolutionResult> ResolveAsync(string? configuredValue, CancellationToken cancellationToken)
+    {
+        if (configuredValue is null || !this.provisioned.TryGetValue(configuredValue, out var entry))
+        {
+            return Task.FromResult(SecretResolutionResult.Failed(SecretResolutionFailure.MaterialNotFound));
+        }
+
+        var material = ResolvedSecret.FromBytes(entry.Material);
+        this.issued.Add(material);
+
+        return Task.FromResult(SecretResolutionResult.Resolved(material, entry.Source));
+    }
+}

--- a/tests/Infrastructure.UnitTests/TrustAnchorLoaderTests.cs
+++ b/tests/Infrastructure.UnitTests/TrustAnchorLoaderTests.cs
@@ -3,6 +3,7 @@
 using System.Text;
 using MailMcp.Infrastructure.Certificates;
 using MailMcp.Infrastructure.Secrets;
+using MailMcp.TestSupport;
 using Xunit;
 
 namespace MailMcp.Infrastructure.UnitTests;
@@ -308,32 +309,4 @@ public sealed class TrustAnchorLoaderTests
     }
 
     private static ConfiguredSecret Reference(string secretReference) => new() { SecretReference = secretReference };
-
-    /// <summary>Hands back exactly the bytes a deployment provisioned, without touching the file system.</summary>
-    private sealed class ProvisionedMaterialResolver : ISecretReferenceResolver
-    {
-        private readonly Dictionary<string, (byte[] Material, SecretMaterialSource Source)> provisioned = new(StringComparer.Ordinal);
-        private readonly List<ResolvedSecret> issued = [];
-
-        public IReadOnlyList<ResolvedSecret> IssuedMaterial => this.issued;
-
-        public void Provision(
-            string secretReference,
-            byte[] material,
-            SecretMaterialSource source = SecretMaterialSource.SchemeAdapter) =>
-            this.provisioned[secretReference] = (material, source);
-
-        public Task<SecretResolutionResult> ResolveAsync(string? configuredValue, CancellationToken cancellationToken)
-        {
-            if (configuredValue is null || !this.provisioned.TryGetValue(configuredValue, out var entry))
-            {
-                return Task.FromResult(SecretResolutionResult.Failed(SecretResolutionFailure.MaterialNotFound));
-            }
-
-            var material = ResolvedSecret.FromBytes(entry.Material);
-            this.issued.Add(material);
-
-            return Task.FromResult(SecretResolutionResult.Resolved(material, entry.Source));
-        }
-    }
 }

--- a/tests/SharedSources.UnitTests/TestCertificatesTests.cs
+++ b/tests/SharedSources.UnitTests/TestCertificatesTests.cs
@@ -1,0 +1,194 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using MailMcp.TestSupport;
+using Xunit;
+
+namespace MailMcp.SharedSources.UnitTests;
+
+/// <summary>
+/// Proves the shared certificate builder, because every trust decision the mail and MCP suites assert is asserted
+/// against what this issues. A certificate that quietly carried the wrong usage, the wrong name, or the wrong validity
+/// would let a validator pass its tests while accepting what it must refuse, and the failure would show up nowhere.
+/// </summary>
+public sealed class TestCertificatesTests
+{
+    private const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
+
+    private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
+
+    private const string DnsName = "client.example.test";
+
+    [Fact]
+    public void CreateCertificateAuthority_AnAuthority_CanIssueAndIsMarkedAsOne()
+    {
+        // Arrange, Act
+        using var authority = TestCertificates.CreateCertificateAuthority("Test Root");
+
+        // Assert
+        Assert.True(authority.HasPrivateKey);
+        var basicConstraints = Assert.Single(authority.Extensions.OfType<X509BasicConstraintsExtension>());
+        Assert.True(basicConstraints.CertificateAuthority);
+    }
+
+    [Fact]
+    public void IssueClientAuthenticationCertificate_AnIssuedCertificate_ChainsToItsAuthorityAndNamesItsClient()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Test Root");
+
+        // Act
+        using var certificate = TestCertificates.IssueClientAuthenticationCertificate(authority, DnsName);
+
+        // Assert
+        Assert.Equal(authority.Subject, certificate.Issuer);
+        Assert.False(certificate.HasPrivateKey);
+        Assert.Equal([ClientAuthenticationOid], ExtendedKeyUsagesOf(certificate));
+        Assert.Equal([DnsName], DnsNamesOf(certificate));
+    }
+
+    /// <summary>The same authority issues both kinds, which is the whole reason a validator has to tell them apart.</summary>
+    [Fact]
+    public void IssueServerAuthenticationCertificate_AnIssuedCertificate_IsLimitedToServerAuthentication()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Test Root");
+
+        // Act
+        using var certificate = TestCertificates.IssueServerAuthenticationCertificate(authority, DnsName);
+
+        // Assert
+        Assert.Equal([ServerAuthenticationOid], ExtendedKeyUsagesOf(certificate));
+    }
+
+    /// <summary>Absence of the extension means every usage in X.509, so a test for that case needs a certificate that genuinely carries none.</summary>
+    [Fact]
+    public void IssueServerCertificate_AnIssuedCertificate_CarriesNoExtendedKeyUsageAtAll()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Test Root");
+
+        // Act
+        using var certificate = TestCertificates.IssueServerCertificate(authority, DnsName);
+
+        // Assert
+        Assert.Empty(ExtendedKeyUsagesOf(certificate));
+        Assert.Equal([DnsName], DnsNamesOf(certificate));
+    }
+
+    /// <summary>Chain building compares against the system clock, so the validity is a fixed instant well in the past rather than an offset from now.</summary>
+    [Fact]
+    public void IssueExpiredClientAuthenticationCertificate_AnIssuedCertificate_IsAlreadyOutOfItsValidityPeriod()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Test Root");
+
+        // Act
+        using var certificate = TestCertificates.IssueExpiredClientAuthenticationCertificate(authority, DnsName);
+
+        // Assert
+        Assert.Equal(
+            new DateTime(2001, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            certificate.NotAfter.ToUniversalTime());
+        Assert.Equal([ClientAuthenticationOid], ExtendedKeyUsagesOf(certificate));
+    }
+
+    /// <summary>A trust anchor a deployment provisions carries no private key, and a loader that refuses one needs material that has none.</summary>
+    [Fact]
+    public void WithoutPrivateKey_AnAuthority_KeepsItsIdentityAndDropsItsKey()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Test Root");
+
+        // Act
+        using var publicAnchor = TestCertificates.WithoutPrivateKey(authority);
+
+        // Assert
+        Assert.False(publicAnchor.HasPrivateKey);
+        Assert.Equal(authority.Thumbprint, publicAnchor.Thumbprint);
+    }
+
+    [Fact]
+    public void ToPemAndToDer_AnAuthority_ProduceMaterialThatLoadsBackAsTheSameCertificate()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Test Root");
+        using var publicAnchor = TestCertificates.WithoutPrivateKey(authority);
+
+        // Act
+        using var fromPem = X509CertificateLoader.LoadCertificate(TestCertificates.ToPem(publicAnchor));
+        using var fromDer = X509CertificateLoader.LoadCertificate(TestCertificates.ToDer(publicAnchor));
+
+        // Assert
+        Assert.Equal(authority.Thumbprint, fromPem.Thumbprint);
+        Assert.Equal(authority.Thumbprint, fromDer.Thumbprint);
+    }
+
+    [Fact]
+    public void ToBundle_AProtectedBundle_OpensWithThePasswordItWasBuiltWith()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Test Root");
+        using var publicAnchor = TestCertificates.WithoutPrivateKey(authority);
+
+        // Act
+        var bundle = TestCertificates.ToBundle(publicAnchor, "bundle-password");
+
+        // Assert
+        using var opened = X509CertificateLoader.LoadPkcs12(
+            bundle,
+            "bundle-password",
+            X509KeyStorageFlags.EphemeralKeySet);
+        Assert.Equal(authority.Thumbprint, opened.Thumbprint);
+    }
+
+    [Fact]
+    public void IssueIntermediateAuthority_AnIntermediate_IsAnAuthorityUnderItsIssuerAndCanIssueInTurn()
+    {
+        // Arrange
+        using var rootAuthority = TestCertificates.CreateCertificateAuthority("Test Root");
+
+        // Act
+        using var intermediate = TestCertificates.IssueIntermediateAuthority(rootAuthority, "Test Intermediate");
+        using var certificate = TestCertificates.IssueClientAuthenticationCertificate(intermediate, DnsName);
+
+        // Assert
+        Assert.True(intermediate.HasPrivateKey);
+        Assert.Equal(rootAuthority.Subject, intermediate.Issuer);
+        Assert.Equal(intermediate.Subject, certificate.Issuer);
+    }
+
+    /// <summary>Serial numbers must be unique per issuer, or a chain built from two of them is not the chain the test described.</summary>
+    [Fact]
+    public void IssueClientAuthenticationCertificate_TwoCertificatesFromOneAuthority_CarryDifferentSerialNumbers()
+    {
+        // Arrange
+        using var authority = TestCertificates.CreateCertificateAuthority("Test Root");
+
+        // Act
+        using var first = TestCertificates.IssueClientAuthenticationCertificate(authority, DnsName);
+        using var second = TestCertificates.IssueClientAuthenticationCertificate(authority, DnsName);
+
+        // Assert
+        Assert.NotEqual(first.SerialNumber, second.SerialNumber);
+    }
+
+    private static IReadOnlyList<string> ExtendedKeyUsagesOf(X509Certificate2 certificate) =>
+    [
+        .. certificate.Extensions
+            .OfType<X509EnhancedKeyUsageExtension>()
+            .SelectMany(extension => extension.EnhancedKeyUsages.OfType<Oid>())
+            .Select(usage => usage.Value)
+            .OfType<string>(),
+    ];
+
+    private static IReadOnlyList<string> DnsNamesOf(X509Certificate2 certificate) =>
+    [
+        .. certificate.Extensions
+            .Where(extension => extension.Oid?.Value == "2.5.29.17")
+            .SelectMany(extension => new X509SubjectAlternativeNameExtension(
+                extension.RawData,
+                extension.Critical).EnumerateDnsNames()),
+    ];
+}

--- a/tests/shared/TestCertificates.cs
+++ b/tests/shared/TestCertificates.cs
@@ -3,7 +3,7 @@
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
-namespace MailMcp.Infrastructure.UnitTests;
+namespace MailMcp.TestSupport;
 
 /// <summary>Builds the certificates a trust-anchor test needs, entirely in memory.</summary>
 /// <remarks>
@@ -18,8 +18,12 @@ internal static class TestCertificates
     /// <summary><c>id-kp-clientAuth</c>, which a TLS server certificate must not be limited to.</summary>
     private const string ClientAuthenticationOid = "1.3.6.1.5.5.7.3.2";
 
+    /// <summary><c>id-kp-serverAuth</c>, which a TLS client certificate must not be limited to.</summary>
+    private const string ServerAuthenticationOid = "1.3.6.1.5.5.7.3.1";
+
     private static readonly DateTimeOffset ValidFrom = new(2000, 1, 1, 0, 0, 0, TimeSpan.Zero);
     private static readonly DateTimeOffset ValidUntil = new(2100, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset ExpiredBy = new(2001, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
     private static long issuedCount;
 
@@ -61,6 +65,28 @@ internal static class TestCertificates
             keepPrivateKey: false,
             extendedKeyUsageOid: ClientAuthenticationOid);
 
+    /// <summary>Issues a certificate limited to server authentication, which a client profile must not accept.</summary>
+    internal static X509Certificate2 IssueServerAuthenticationCertificate(X509Certificate2 issuer, string dnsName) =>
+        Issue(
+            issuer,
+            commonName: dnsName,
+            certificateAuthority: false,
+            dnsName,
+            keepPrivateKey: false,
+            extendedKeyUsageOid: ServerAuthenticationOid);
+
+    /// <summary>Issues a client certificate whose validity ended long ago, so no clock the test runs under revives it.</summary>
+    internal static X509Certificate2 IssueExpiredClientAuthenticationCertificate(X509Certificate2 issuer, string dnsName) =>
+        Issue(
+            issuer,
+            commonName: dnsName,
+            certificateAuthority: false,
+            dnsName,
+            keepPrivateKey: false,
+            extendedKeyUsageOid: ClientAuthenticationOid,
+            validFrom: ValidFrom,
+            validUntil: ExpiredBy);
+
     /// <summary>Strips the private key, which is what a deployment provisions as a trust anchor.</summary>
     internal static X509Certificate2 WithoutPrivateKey(X509Certificate2 certificate) =>
         X509CertificateLoader.LoadCertificate(certificate.Export(X509ContentType.Cert));
@@ -83,7 +109,9 @@ internal static class TestCertificates
         bool certificateAuthority,
         string? dnsName,
         bool keepPrivateKey,
-        string? extendedKeyUsageOid = null)
+        string? extendedKeyUsageOid = null,
+        DateTimeOffset? validFrom = null,
+        DateTimeOffset? validUntil = null)
     {
         using var subjectKey = ECDsa.Create(ECCurve.NamedCurves.nistP256);
         var request = new CertificateRequest($"CN={commonName}", subjectKey, HashAlgorithmName.SHA256);
@@ -109,7 +137,11 @@ internal static class TestCertificates
             request.CertificateExtensions.Add(subjectAlternativeNames.Build());
         }
 
-        var issued = request.Create(issuer, ValidFrom, ValidUntil, NextSerialNumber());
+        var issued = request.Create(
+            issuer,
+            validFrom ?? ValidFrom,
+            validUntil ?? ValidUntil,
+            NextSerialNumber());
         if (!keepPrivateKey)
         {
             return issued;


### PR DESCRIPTION
Closes #165

Second of the two stages that clear #140. #164 delivered named expiring API keys, the `ApiKey`/`None` modes, CORS, and Origin validation; this adds the optional mTLS trust profiles that compose with them, and — by the owner's decision carried on this issue — collapses the CORS pair into one property.

## Trust profiles

`McpEndpoint:ClientCertificateProfiles` names the client applications whose certificates the endpoint accepts. A profile is named after the client rather than after the authority that signed for it, so one client's authority rotating, widening, or being withdrawn changes what that client may present and nothing about the others.

```json
{
  "McpEndpoint": {
    "Enabled": true,
    "Authentication": "ApiKey",
    "ClientCertificateProfiles": [
      {
        "Name": "chatgpt-connector",
        "Requirement": "Optional",
        "TrustAnchors": [
          { "Name": "openai-connectors-ca", "SecretReference": "file:/etc/mailmcp/openai-connectors-ca.pem" }
        ],
        "SubjectAlternativeNames": ["mtls.prod.connectors.openai.com"]
      }
    ]
  }
}
```

A certificate passes a profile only when it carries an extended key usage naming client authentication, carries one of that profile's expected DNS names, is inside its validity period, and chains to one of its anchors. Three strictnesses are deliberate and each closes a way in:

- **Absence of an extended key usage is refused** rather than read as every usage, because the same authority commonly issues server certificates.
- **The subject common name is never consulted.** Only subject alternative names are something an authority attested to.
- **A profile always names its client.** An authority on its own accepts every certificate it has ever issued, which for a public one is most of the internet.

The certificate is taken from the TLS connection and from nowhere else. A header naming one is written by whoever sent the request, so reading one would turn client authentication into a value a client fills in for itself; `McpClientCertificateValidationTests` states that with four spellings of such a header beside an empty connection.

Kestrel asks every HTTPS connection for a certificate and defers the verdict, so a refusal is a `403` an operator reads in the log rather than a handshake failure that says nothing to anybody. Connection-level validation grants nothing: it exists so the middleware's decision is reached at all, instead of the machine trust store deciding — which would both fail the private authority a profile names and accept any public one.

**Rotation.** Anchors are configured references rather than loaded certificates, so replacing the material behind one reaches the next request, and a profile names several so an authority rotates by overlap. An anchor that stops loading is recorded at `Error` and skipped; a profile whose anchors all fail to load refuses every certificate, because unreadable material must never widen what a profile trusts. Startup loads every configured anchor and fails the host on one that does not.

**The ChatGPT connector is an ordinary profile**, not a built-in mode, and the OpenAI authority is supplied by the operator through a secret reference. No third-party certificate enters the repository, which keeps a rotation on OpenAI's side an operator change rather than a MailMcp release. mTLS composes with `ApiKey` and with `None`, and the unauthenticated warning still fires under `None` with every profile in place: a certificate names the program calling, never the person whose mail is served. Complete ChatGPT production authentication still needs the later OAuth 2.1 profile, which the documentation says.

**mTLS needs an HTTPS endpoint**, which is #142 and not merged. That is fail-closed rather than silent: over plain HTTP no certificate is presented, so an `Optional` profile identifies nothing and a `Required` profile refuses every request. The documentation says so.

## One CORS property instead of two

`AllowAnyOrigin` is removed rather than deprecated, and every caller is corrected here. `AllowedOrigins` is now the whole policy, with three postures that are consequences of the list rather than settings: `["*"]` (the default) serves every browser origin, a list serves those origins, and `[]` serves no browser at all — only clients that send no `Origin`, which is every non-browser client. `McpOriginPolicy` gains `ServingNoBrowserOrigin` back for the third one.

`*` beside a real origin stays a startup error, for the reason the pair was refused: it states two policies at once. `*` is answered before the entries are read as origins, since no operator could configure a real origin that collides with it.

The section is now read through `McpEndpointOptions.ReadFrom`, because the permissive default cannot be a property initializer: the binder adds to a collection it finds values for rather than replacing it, and an empty JSON list binds identically to an absent one. Whether the key exists is what tells the two apart, and that is a question only configuration can answer. The property's own default is therefore the empty list — an object built any other way starts from the posture that serves no browser rather than the one that serves every page on the internet.

## Verification

`scripts/verify-full.sh`: 1552 unit tests pass, aggregate line coverage 96.99% (required 85%), formatting clean over 590 files, workflow contracts 18/18.

`McpClientCertificateAuthenticatorTests` covers several profiles, a certificate one profile trusts and another does not, a missing certificate against an optional and a required profile, a SAN mismatch, a certificate limited to server authentication, one carrying no usage at all, an expired certificate, overlapping CA rotation, an anchor replaced behind an unchanged reference, an intermediate listed beside its root and one listed without it, a half-broken rotation, and a profile whose anchors all fail to load. `TestCertificates` moved to `tests/shared` because two suites now need it and is covered from `SharedSources.UnitTests`, as the shared-helper rule requires.

Host-level verification proves the validation reads the TLS connection certificate and ignores certificate-like headers. End-to-end proof over a real handshake is deliberately absent: it needs the HTTPS endpoint #142 delivers, and the integration suite serves the composed host over plain HTTP.

## Documentation

`docs/operations/mcp-endpoint.md` gains the profile settings, the four checks, the deliberate strictnesses, the ChatGPT profile with its OAuth caveat, the rotation procedure, and the HTTPS dependency; its CORS section states the three postures. `secret-rotation.md` gains the overlap procedure and scopes the existing no-overlap statement to a mail account's anchor. `secret-provisioning.md` tells the two kinds of anchor apart.

No dependency, service, image, or asset changed, so the third-party register is untouched.
