### PR TITLE
Name the cause when the Claude reviewer stops, instead of failing twice without one

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -291,6 +291,7 @@ jobs:
           echo "Collected ${collected_files} changed files and ${fetched} head-content files."
 
       - name: Review the change
+        id: review
         uses: anthropics/claude-code-action@v1
         with:
           # A Claude Code OAuth token rather than an API key: the review runs on the owner's Claude
@@ -586,6 +587,62 @@ jobs:
             --allowedTools "Read,Grep,Glob,Write"
             --setting-sources user
 
+      # The action hides everything the reviewer produced, which is right: that output is model
+      # text derived from an untrusted diff. It hides the run's own error string with it, and that
+      # string is the only place the cause of a failure is written — an expired credential, an
+      # exhausted subscription, a model the plan cannot use. Without it a failed run is a red job
+      # with nothing to act on, and the only alternative the action offers is `show_full_output`,
+      # which would print the whole review into the log to recover one sentence. The saved
+      # execution log holds that sentence, so this reads it and prints nothing else.
+      - name: Report why the reviewer stopped
+        if: failure() && steps.review.outcome == 'failure'
+        shell: bash
+        env:
+          EXECUTION_FILE: ${{ runner.temp }}/claude-execution-output.json
+          WORKFLOW_TOKEN: ${{ github.token }}
+          CLAUDE_CREDENTIAL: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! -s "$EXECUTION_FILE" ]]; then
+            echo '::error::The reviewer wrote no execution log, so it stopped before the model answered.'
+            exit 0
+          fi
+
+          # The error text of the last result message, flattened to one line because an annotation
+          # is one line, and bounded because a model can be made to say a great deal.
+          reason="$(
+            jq -r '[.[] | select(.type == "result")]
+                   | last
+                   | (.result // .error // "the result message carried no error text")' \
+              "$EXECUTION_FILE" 2>/dev/null || true
+          )"
+          reason="${reason//$'\n'/ }"
+          reason="${reason:0:500}"
+
+          if [[ -z "$reason" || "$reason" == 'null' ]]; then
+            reason='the execution log holds no result message, so the run ended before the model answered'
+          fi
+
+          # The reviewer holds no credential and this text comes from the service rather than from
+          # the change, so a match here is not expected. It is still checked, because printing is
+          # publishing and this is the one step that prints anything the model produced. An empty
+          # secret is reported rather than compared: `grep -F ''` matches everything, which would
+          # turn a missing secret into a permanent false positive.
+          if [[ -z "$CLAUDE_CREDENTIAL" ]]; then
+            echo '::error::CLAUDE_CODE_OAUTH_TOKEN is not set, which is why the reviewer could not run.'
+            exit 0
+          fi
+
+          if grep -qE 'gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{20,}|sk-ant-[A-Za-z0-9_-]{16,}' <<< "$reason" \
+            || grep -qF "$WORKFLOW_TOKEN" <<< "$reason" \
+            || grep -qF "$CLAUDE_CREDENTIAL" <<< "$reason"; then
+            echo '::error::The reviewer stopped, and its reason is shaped like a credential, so it is not printed.'
+            exit 0
+          fi
+
+          printf '::error::The reviewer stopped: %s\n' "$reason"
+
       - name: Submit the review
         if: always() && steps.collect.outcome == 'success'
         shell: bash
@@ -599,6 +656,9 @@ jobs:
           # credential the reviewer was never able to read still cannot be published if it somehow
           # reaches the findings.
           CLAUDE_CREDENTIAL: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Whether the reviewer got as far as an answer, which decides whether a missing findings
+          # file is this step's failure to report or the previous step's, already reported.
+          REVIEW_OUTCOME: ${{ steps.review.outcome }}
           # The two paths the collection step wrote, restated here for the reason given there.
           REVIEW_DIRECTORY: ${{ runner.temp }}/review
           FINDINGS_FILE: ${{ runner.temp }}/findings/findings.json
@@ -608,13 +668,28 @@ jobs:
           payload_file="$(mktemp)"
 
           if [[ ! -s "$FINDINGS_FILE" ]] || ! jq -e '.' "$FINDINGS_FILE" > /dev/null 2>&1; then
-            echo "::error::The reviewer produced no valid ${FINDINGS_FILE}, so there is nothing to submit."
+            # A reviewer that never answered has already failed and said why, and repeating the
+            # consequence as a second error buries the cause. A reviewer that answered and still
+            # produced nothing valid is this workflow's own defect, and fails here.
+            if [[ "$REVIEW_OUTCOME" != 'success' ]]; then
+              echo '::notice::The reviewer did not finish, so there are no findings to submit.'
+              exit 0
+            fi
+
+            echo "::error::The reviewer finished but produced no valid ${FINDINGS_FILE}, so there is nothing to submit."
             exit 1
           fi
 
           # A credential in the payload would be published by the very call that posts it. The
           # reviewer is denied the paths that hold one, and this refuses the review outright if one
           # appears anyway, because a redacted review is not worth the risk of a wrong redaction.
+          # An unset secret is refused rather than compared: `grep -F ''` matches every file, so
+          # comparing against it would reject every review this workflow ever produced.
+          if [[ -z "$CLAUDE_CREDENTIAL" ]]; then
+            echo '::error::CLAUDE_CODE_OAUTH_TOKEN is not set, so the findings cannot be checked against it.'
+            exit 1
+          fi
+
           if grep -qE 'gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{20,}|sk-ant-[A-Za-z0-9_-]{16,}' "$FINDINGS_FILE" \
             || grep -qF "$WORKFLOW_TOKEN" "$FINDINGS_FILE" \
             || grep -qF "$CLAUDE_CREDENTIAL" "$FINDINGS_FILE"; then

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -194,6 +194,27 @@ migration paths, and a request for tests that names no untested case, so the two
 reviewers do not spend threads on findings this repository has already decided
 against.
 
+### When the reviewer stops
+
+`claude-code-action` hides everything the reviewer produced, and rightly so: that output
+is model text derived from an untrusted diff. It hides the run's own error string with
+it, which is the one place a failure says what happened — an expired credential, an
+exhausted subscription, a model the plan cannot use. The action does save every message
+to `$RUNNER_TEMP/claude-execution-output.json`, so a step after it reads the last result
+message's error text and prints that and nothing else, flattened to one line, truncated
+to 500 characters, and withheld if it matches a credential shape or either credential the
+workflow holds. The alternative the action offers is `show_full_output`, which would
+print the entire review into the log to recover one sentence.
+
+The submission step then distinguishes two silences. A reviewer that never answered has
+already failed and said why, so a missing findings file is reported as a notice and the
+run keeps the reviewer's own error as its only cause. A reviewer that answered and still
+produced no valid file is this workflow's defect and fails there.
+
+Both steps refuse to compare against an unset `CLAUDE_CODE_OAUTH_TOKEN` and report the
+missing secret instead, because `grep -F ''` matches every file and an empty pattern
+would otherwise turn every review into a refusal that reads like a credential leak.
+
 ### What the submission step guarantees
 
 It validates each finding's anchor against the same patches the reviewer was


### PR DESCRIPTION
Closes #193

## What the last run showed

#190 made the file valid, and the first run that reached a job — `30666481870` on PR #192 —
collected the change, started the reviewer, and failed after **1948 ms** with
`subtype: success`, `is_error: true`, `num_turns: 1`, no tool calls, and
`permission_denials_count: 0`. Nothing in the log says why.

That is by design in `claude-code-action`: it hides everything the reviewer produced,
because that output is model text derived from an untrusted diff. It hides the run's own
error string along with it, and that string is the only place the cause is written — an
expired credential, an exhausted subscription, a model the plan cannot use. The only
escape the action offers is `show_full_output`, which prints the whole review into the log
to recover one sentence.

The action does write every SDK message to `$RUNNER_TEMP/claude-execution-output.json`
before it fails, so the cause was sitting on the runner and was simply never read.

## What this changes

- **A step that names the cause.** `Report why the reviewer stopped` runs only when the
  reviewer failed, reads the last result message's error text out of the saved execution
  log, flattens it to one line, truncates it to 500 characters, and prints it as one
  annotation. It withholds the text if it matches a credential shape or either credential
  the workflow holds, because printing is publishing and this is the only step that prints
  anything the model produced.
- **One error instead of two.** The submission step reported
  `The reviewer produced no valid findings.json` on top of the reviewer's own failure,
  which was true and buried the cause. It now separates a reviewer that never answered —
  already failed, already explained, so a notice and a clean exit — from one that answered
  and still produced nothing valid, which is this workflow's defect and still fails.
- **A latent refusal-on-empty-secret.** Both steps compare the payload against
  `$CLAUDE_CREDENTIAL` with `grep -qF`. An empty pattern matches every file, so an unset or
  cleared `CLAUDE_CODE_OAUTH_TOKEN` would have turned every review into a refusal reading
  like a credential leak. The missing secret is now reported as a missing secret.

## What this does not do

It does not fix the reviewer's failure, because the failure's cause is not in the
repository. The two candidates the shape fits are an invalid or expired
`CLAUDE_CODE_OAUTH_TOKEN` and a plan that cannot serve the `opus` default; the next run
will print which. Changing the default model is #189's decision, not this change's.

## Verification

`scripts/verify-full.sh` — exit 0: workflow contract suite, locked restore, Release build,
0 failed tests, 96.90% line coverage against a required 85%, `dotnet format
--verify-no-changes` reporting 0 of 649 files reformatted, and clean diff checks. The
workflow parses as YAML, every `run:` block passes `bash -n`, and the `jq` expression was
smoke-tested against both a result message carrying an error string and one carrying none.
