### PR TITLE
Serve the probes on a listener of their own, and let a deployment turn them off

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -35,6 +35,14 @@
 # `frontend` network is what listens publicly.
 # MAILFATHOM_HTTP_BIND=127.0.0.1
 # MAILFATHOM_HTTP_PORT=8080
+#
+# The probes — `/started`, `/health`, and `/alive` — answer on a listener of their own, and never on the port above: a
+# probe path asked on 8080 is answered with 404, and `/mcp` asked on this one is too. They carry no credential, so this
+# bind address is the whole of their access control; keep it on loopback unless the machine asking is not this one.
+# Moving the container-side port is `HealthEndpoints:Port`, not a variable here — see
+# docs/operations/health-endpoints.md.
+# MAILFATHOM_HEALTH_BIND=127.0.0.1
+# MAILFATHOM_HEALTH_PORT=8081
 
 ### The database
 #

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -118,10 +118,13 @@ services:
       # port to a network means exposing synchronized mail without transport protection; put a reverse proxy in front
       # of it and change MAILFATHOM_HTTP_BIND only once that proxy is what listens publicly.
       - "${MAILFATHOM_HTTP_BIND:-127.0.0.1}:${MAILFATHOM_HTTP_PORT:-8080}:8080"
+      # The probes, on a listener of their own. They answer without a credential, so what controls who can ask them is
+      # which network the port is published to — here loopback, and never the same port the MCP endpoint is served on.
+      # A probe path asked on 8080 is answered with 404, and so is `/mcp` asked on this one.
+      - "${MAILFATHOM_HEALTH_BIND:-127.0.0.1}:${MAILFATHOM_HEALTH_PORT:-8081}:8081"
     # No health check. The image declares none — a chiseled image has no shell or HTTP client to run one in — and one
-    # written here would need the same thing: a client inside the container. `/health` and `/alive` are served on the
-    # published port and can be asked from outside; #179 is what makes the probe surface something a deployment
-    # configures rather than something each shape improvises.
+    # written here would need the same thing: a client inside the container. The probes are asked from outside instead,
+    # on the port published above; docs/operations/health-endpoints.md states what each one answers.
     read_only: true
     tmpfs:
       # The one path the runtime needs to write. Everything else, /app included, is owned by root and mounted

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -127,9 +127,9 @@ COPY --from=build --chown=root:root /app .
 # path of its own; mount a tmpfs at /tmp, which is where the runtime expects to be able to write.
 USER $APP_UID
 
-# No HEALTHCHECK, deliberately. The host serves `/health` and `/alive`, and Kubernetes probes them over HTTP without
-# needing anything from the image — but Docker and Podman run a health check as a command *inside* the container, and a
-# chiseled image has no shell and no HTTP client for one to be written in. Asking the endpoint would therefore mean
-# adding a probe mode to the application itself, which is #179's: it decides the listener, the transport, and whether
-# the probes are served at all. A check written here would be replaced by that change rather than extended by it.
+# No HEALTHCHECK, deliberately. The host serves `/started`, `/health`, and `/alive` on a listener of their own — port
+# 8081 unless a deployment configures another — and Kubernetes probes them over HTTP without needing anything from the
+# image. Docker and Podman run a health check as a command *inside* the container instead, and a chiseled image has no
+# shell and no HTTP client for one to be written in; adding either to reach an endpoint that is already reachable from
+# outside would grow the image's attack surface for nothing. Compose publishes the probe port and asks from there.
 ENTRYPOINT ["dotnet", "/app/MailFathom.Host.dll"]

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -113,7 +113,10 @@ ENV ASPNETCORE_HTTP_PORTS=8080 \
     # for one session, when a dump is genuinely needed.
     DOTNET_EnableDiagnostics=0
 
-EXPOSE 8080
+# Two ports, because the image serves two listeners: 8080 for `/` and `/mcp`, and 8081 for the probes, which
+# HealthEndpoints:Port moves. Declaring only the first would leave `docker image inspect`, `docker run -P`, and a
+# registry's port list describing an image that answers on one socket more than it admits to.
+EXPOSE 8080 8081
 
 # Owned by root and copied with the default mode, so the unprivileged account below can read and execute the
 # application and write none of it. An explicit `--chmod` is deliberately not used: it applies one mode to directories

--- a/deploy/helm/mailfathom/templates/deployment.yaml
+++ b/deploy/helm/mailfathom/templates/deployment.yaml
@@ -66,11 +66,21 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            {{- /*
+              The probes get a listener of their own so that reaching them never means reaching the MCP endpoint. It is
+              a container port and not a Service port: the kubelet dials it on the pod's address, and nothing the
+              Service publishes reaches it.
+            */}}
+            - name: health
+              containerPort: {{ .Values.probes.port }}
+              protocol: TCP
           env:
             - name: ASPNETCORE_ENVIRONMENT
               value: Production
             - name: ASPNETCORE_HTTP_PORTS
               value: "8080"
+            - name: HealthEndpoints__Port
+              value: {{ .Values.probes.port | quote }}
             - name: ConfigurationSources__Directory
               value: {{ .Values.config.mountPath | quote }}
             {{- if .Values.config.pollForChanges }}
@@ -110,14 +120,14 @@ spec:
           startupProbe:
             httpGet:
               path: {{ .Values.probes.startup.path }}
-              port: http
+              port: health
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
           readinessProbe:
             httpGet:
               path: {{ .Values.probes.readiness.path }}
-              port: http
+              port: health
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
@@ -125,7 +135,7 @@ spec:
           livenessProbe:
             httpGet:
               path: {{ .Values.probes.liveness.path }}
-              port: http
+              port: health
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}

--- a/deploy/helm/mailfathom/values.schema.json
+++ b/deploy/helm/mailfathom/values.schema.json
@@ -189,9 +189,9 @@
               },
               {
                 "not": {
-                  "pattern": "^(ConnectionStrings__|Persistence__Password__|ConfigurationSources__|ASPNETCORE_)"
+                  "pattern": "^(ConnectionStrings__|Persistence__Password__|ConfigurationSources__|HealthEndpoints__|ASPNETCORE_)"
                 },
-                "description": "These settings are the chart's, not an override's. The environment block outranks every mounted file, so re-declaring one of them here would silently replace what the templates emit \u2014 and `ConnectionStrings__mailfathom` is the one that matters: the conventional Npgsql form carries `Password=`, which would put a credential into the rendered Deployment and bypass the mounted-file path entirely. Change `database`, `config`, and `secrets` instead."
+                "description": "These settings are the chart's, not an override's. The environment block outranks every mounted file, so re-declaring one of them here would silently replace what the templates emit \u2014 and `ConnectionStrings__mailfathom` is the one that matters: the conventional Npgsql form carries `Password=`, which would put a credential into the rendered Deployment and bypass the mounted-file path entirely. `HealthEndpoints__` is the chart's for a different reason: `probes.port` sets both the container port the kubelet dials and the port the host binds, so moving one of them here would leave all three probes dialling a port nothing listens on and the pod never becoming ready. Change `database`, `config`, `secrets`, and `probes` instead."
               }
             ]
           },

--- a/deploy/helm/mailfathom/values.schema.json
+++ b/deploy/helm/mailfathom/values.schema.json
@@ -520,7 +520,7 @@
       "properties": {
         "path": {
           "const": "/health",
-          "description": "Readiness consults every registered check, the database included, so a pod that cannot serve leaves the Service's endpoints. /alive would report a process that is running but cannot answer, which is the opposite of what readiness decides."
+          "description": "Readiness consults the dependencies a request needs, the database included, so a pod that cannot serve leaves the Service's endpoints. /alive would report a process that is running but cannot answer, which is the opposite of what readiness decides."
         },
         "initialDelaySeconds": {
           "$ref": "#/definitions/probeTiming/initialDelaySeconds"

--- a/deploy/helm/mailfathom/values.schema.json
+++ b/deploy/helm/mailfathom/values.schema.json
@@ -440,19 +440,29 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "port",
         "readiness",
         "liveness",
         "startup"
       ],
       "properties": {
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "not": {
+            "const": 8080
+          },
+          "description": "The port the probes are served on, reaching both the container port and HealthEndpoints:Port. 8080 is refused: it is the application listener's, the probes would either fail to bind or answer to whoever can reach the MCP endpoint, and the host refuses that collision at startup anyway."
+        },
         "readiness": {
           "$ref": "#/definitions/readinessProbe"
         },
         "liveness": {
-          "$ref": "#/definitions/processProbe"
+          "$ref": "#/definitions/livenessProbe"
         },
         "startup": {
-          "$ref": "#/definitions/processProbe"
+          "$ref": "#/definitions/startupProbe"
         }
       }
     },
@@ -526,7 +536,32 @@
         }
       }
     },
-    "processProbe": {
+    "startupProbe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "const": "/started",
+          "description": "Startup reports whether the host's own startup gates have completed — every secret reference resolved, the database schema verified. Every other path is refused: /alive answers before those gates have run and would end the startup grace period while the pod is still coming up, and /health consults the database."
+        },
+        "initialDelaySeconds": {
+          "$ref": "#/definitions/probeTiming/initialDelaySeconds"
+        },
+        "periodSeconds": {
+          "$ref": "#/definitions/probeTiming/periodSeconds"
+        },
+        "timeoutSeconds": {
+          "$ref": "#/definitions/probeTiming/timeoutSeconds"
+        },
+        "failureThreshold": {
+          "$ref": "#/definitions/probeTiming/failureThreshold"
+        }
+      }
+    },
+    "livenessProbe": {
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -535,7 +570,7 @@
       "properties": {
         "path": {
           "const": "/alive",
-          "description": "Liveness and startup consult only the checks that report the process itself. /health is refused rather than discouraged: it consults the database, so an outage would fail liveness and Kubernetes would restart a healthy process repeatedly without repairing the dependency."
+          "description": "Liveness consults only the checks that report the process itself. /health is refused rather than discouraged: it consults the database, so an outage would fail liveness and Kubernetes would restart a healthy process repeatedly without repairing the dependency."
         },
         "initialDelaySeconds": {
           "$ref": "#/definitions/probeTiming/initialDelaySeconds"

--- a/deploy/helm/mailfathom/values.yaml
+++ b/deploy/helm/mailfathom/values.yaml
@@ -172,8 +172,20 @@ temporaryDirectory:
 terminationGracePeriodSeconds: 60
 
 probes:
-  # Readiness consults every health check, the database included, so a pod that cannot serve leaves the Service's
-  # endpoints instead of answering requests it cannot fulfil.
+  # The port the probes are served on, which is never the port the MCP endpoint is. It is set here once and reaches
+  # both the container port the kubelet dials and the `HealthEndpoints:Port` the host binds, so the two cannot drift.
+  # The Service publishes 8080 alone, so nothing outside the node reaches this listener: an unauthenticated endpoint
+  # reporting dependency state is exposed by which network its port is on, and by nothing else.
+  port: 8081
+  # Startup reports whether MailFathom has finished coming up — every secret reference resolved and the database schema
+  # verified. Its budget is what a slow first start is allowed, and it holds the liveness probe off until it succeeds.
+  startup:
+    path: /started
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 30
+  # Readiness consults the dependencies a request needs, the database included, so a pod that cannot serve leaves the
+  # Service's endpoints instead of answering requests it cannot fulfil.
   readiness:
     path: /health
     initialDelaySeconds: 10
@@ -188,13 +200,6 @@ probes:
     periodSeconds: 20
     timeoutSeconds: 5
     failureThreshold: 3
-  # Startup covers the interval in which MailFathom validates every secret reference and verifies the database schema.
-  # Its budget is what a slow first start is allowed, and it holds the liveness probe off until it succeeds.
-  startup:
-    path: /alive
-    periodSeconds: 5
-    timeoutSeconds: 5
-    failureThreshold: 30
 
 ### Scheduling
 nodeSelector: {}

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This documentation set explains the durable design and operating model for MailF
 - [Secret provisioning](operations/secret-provisioning.md) covers secret references, the systemd and container provisioning paths, and in-memory exposure.
 - [Host startup telemetry](operations/host-startup-telemetry.md) describes the bootstrap logging pipeline that reports process start, startup failure, and shutdown.
 - [MCP endpoint](operations/mcp-endpoint.md) covers enabling the protocol surface, the API keys and explicit unauthenticated mode that guard it, the origins it answers, and the domains and certificates it terminates TLS for.
+- [Health endpoints](operations/health-endpoints.md) covers the startup, readiness, and liveness probes, the dedicated listener they are served on, the transports it supports, and why the surface carries no credential and no rate limit.
 - [The container image](operations/container-image.md) documents the image `deploy/docker/Dockerfile` produces, how the service runs, its health endpoints, and why it carries no schema tool.
 - [Deploying with Docker Compose](operations/deployment-compose.md) is the supported single-machine deployment, including secret and configuration provisioning, the explicit schema step, backup, and what survives removal.
 - [Deploying to Kubernetes](operations/deployment-kubernetes.md) documents the Helm chart, its required inputs, what the pod serves by default, TLS at the ingress, and the Restricted Pod Security Standard defaults.

--- a/docs/features/initial-scope.md
+++ b/docs/features/initial-scope.md
@@ -2,7 +2,7 @@
 
 The initial scaffold creates the project boundaries needed for the first release without implementing mail, persistence, retrieval, or MCP behavior yet.
 
-The ASP.NET Core host exposes a root readiness response. `Host`'s own service defaults expose `/health` and `/alive` in every environment, because a container platform decides whether to route traffic to the process and whether to restart it by probing them; `docs/operations/container-image.md` states what each one consults and why they differ, and `docs/architecture/solution-structure.md` records why that source belongs to `Host`. The same defaults wire OpenTelemetry, HTTP resilience, and service discovery. The Aspire AppHost wires the host to a PostgreSQL resource for future persistence work.
+The ASP.NET Core host exposes a root readiness response. It also serves three probes — `/started`, `/health`, and `/alive` — on a listener of their own, on port 8081 unless a deployment configures another, in every environment; `docs/operations/health-endpoints.md` states what each one consults, why they are kept off the port that serves `/` and `/mcp`, and how a deployment turns them off or puts TLS in front of them, and `docs/architecture/solution-structure.md` records why the service defaults belong to `Host`. Those defaults wire OpenTelemetry, HTTP resilience, and service discovery. The Aspire AppHost wires the host to a PostgreSQL resource for future persistence work.
 
 
 ## IMAP synchronization status

--- a/docs/operations/container-image.md
+++ b/docs/operations/container-image.md
@@ -42,7 +42,7 @@ Every base image is pinned to an explicit patch version. `scripts/verify-deploym
 | Property | Value |
 | --- | --- |
 | User | `1654`, the unprivileged `app` account the .NET base images define |
-| Port | `8080`, plain HTTP |
+| Ports | `8080`, plain HTTP, for `/` and `/mcp`; `8081` for the probes, on a listener of its own |
 | Writable paths | `/tmp` only, which a deployment supplies as a tmpfs or an `emptyDir` |
 | Entrypoint | `dotnet /app/MailFathom.Host.dll` |
 | Health check | None. See [the health endpoints](#the-health-endpoints) below. |
@@ -62,25 +62,29 @@ close. Set it back to `1` deliberately, for one session, when a dump is genuinel
 
 ### The health endpoints
 
-The host serves `/health` and `/alive` on its own port, in every environment. Kubernetes probes them over HTTP from the
-kubelet and needs nothing inside the container, which is what the chart's probes use.
+The host serves three probes on a listener of their own — port `8081` unless a deployment configures another — in every
+environment. Kubernetes probes them over HTTP from the kubelet and needs nothing inside the container, which is what
+the chart's probes use.
 
 **The image declares no `HEALTHCHECK`.** Docker and Podman run one as a command *inside* the container, and a chiseled
-image has no shell and no HTTP client for one to be written in, so asking the endpoint would mean adding a probe mode
-to the application itself. That belongs to issue #179, which decides the listener the probes are served on, the
-transport they use, and whether they are served at all. Under Compose, ask the endpoints from outside the container
-instead.
+image has no shell and no HTTP client for one to be written in. Adding either so the container could ask an endpoint
+that is already reachable from outside would grow its attack surface for nothing; under Compose, the published probe
+port is asked from the host instead.
 
-The two endpoints answer different questions and are wired to different probes on purpose:
+The three answer different questions and are wired to different probes on purpose:
 
-- **`/health`** runs every registered check, the database among them. It is readiness: a process that cannot reach its
-  database stops receiving requests it cannot fulfil.
-- **`/alive`** runs only the checks tagged `live`, which report the process itself. It is liveness: a database outage
-  must never become a restart loop that cannot fix what is actually broken.
+- **`/started`** reports whether the host's startup gates have completed: every secret reference resolved and the
+  database schema verified. It is what an orchestrator's startup probe reads, so a slow first start extends the grace
+  period rather than counting as a failure.
+- **`/health`** consults the dependencies a request needs, the database among them. It is readiness: a process that
+  cannot reach its database stops receiving requests it cannot fulfil.
+- **`/alive`** consults only process-local state. It is liveness: a database outage must never become a restart loop
+  that cannot fix what is actually broken.
 
-Both are unauthenticated. Neither carries mailbox data — the body is one word — and a probe has no credential to
-present. This is the same split [the MCP endpoint](mcp-endpoint.md) describes: the authorization requirement sits on
-the MCP route rather than on the pipeline.
+All three are unauthenticated, and none of them is served on port 8080 — a probe path asked there is answered with
+`404`, and `/mcp` asked on the probe port is too. The exposure control is which network the probe port is published on.
+[The health endpoints](health-endpoints.md) records the full contract, including the TLS transports and the switch that
+turns the surface off.
 
 ### Shutdown
 

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -109,15 +109,20 @@ deployment.
 
 ```bash
 docker compose ps                                    # PostgreSQL reports healthy; MailFathom reports running
-curl -fsS http://127.0.0.1:8080/health               # readiness, including the database
-curl -fsS http://127.0.0.1:8080/alive                # liveness, the process alone
+curl -fsS http://127.0.0.1:8081/started              # has it finished coming up
+curl -fsS http://127.0.0.1:8081/health               # readiness, including the database
+curl -fsS http://127.0.0.1:8081/alive                # liveness, the process alone
 docker compose logs -f mailfathom
 ```
 
+The probes answer on **8081**, not on the port the MCP endpoint is served on. They carry no credential, so which network
+their port is published to is what controls who may ask them; one of those paths asked on 8080 is answered with `404`,
+and so is `/mcp` asked on 8081. `MAILFATHOM_HEALTH_BIND` and `MAILFATHOM_HEALTH_PORT` move the published address, and
+[the health endpoints](health-endpoints.md) states what each probe consults and how to turn the surface off or serve it
+over TLS.
+
 The MailFathom container declares no Docker health check. Its image carries no shell and no HTTP client for one to run
-in, so the two endpoints above are asked from outside the container instead;
-[issue #179](https://github.com/Krzysztof318/MailFathom/issues/179) is what turns the probe surface into something a
-deployment configures.
+in, so the endpoints above are asked from outside the container instead.
 
 The MCP endpoint answers at `/mcp` and is off until the configuration enables it. Read
 [the MCP endpoint](mcp-endpoint.md) before you do; an enabled endpoint must state how it is authenticated, and there is
@@ -125,9 +130,14 @@ no default.
 
 ## The network boundary
 
-The port is published on **loopback** by default. MailFathom speaks plain HTTP and terminates no TLS, so publishing it on
-another interface exposes synchronized mail without transport protection. Change `MAILFATHOM_HTTP_BIND` only once a
-reverse proxy on the `frontend` network is what listens publicly, and give that proxy the certificate.
+Both ports are published on **loopback** by default. MailFathom speaks plain HTTP and terminates no TLS, so publishing
+the application port on another interface exposes synchronized mail without transport protection. Change
+`MAILFATHOM_HTTP_BIND` only once a reverse proxy on the `frontend` network is what listens publicly, and give that
+proxy the certificate.
+
+The probe port is separate and stays loopback unless the machine asking is not this one. It answers without a
+credential, so `MAILFATHOM_HEALTH_BIND` is the whole of its access control; a probe path is never served on the
+application port, so widening one does not widen the other.
 
 PostgreSQL publishes no port at all. It sits on `backend`, which is declared `internal`, so it is reachable from
 MailFathom and from whatever else you attach to that network — a schema step or a backup container — and from nothing

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -183,8 +183,8 @@ Every one of those is a MailFathom setting rather than a chart value, so turning
 | Client certificates | `McpEndpoint:ClientCertificateProfiles` | [Client certificates](mcp-endpoint.md#client-certificates) |
 | Rate limits | `McpEndpoint:RateLimiting` | [Rate limiting](mcp-endpoint.md#rate-limiting) |
 
-Configuring `Https:Endpoints` takes over the host's listeners, so the chart's `service.port` and the container port have
-to match what the profiles bind. That is a deliberate step rather than the default: in a cluster, TLS at the ingress is
+Configuring `Https:Endpoints` takes over the host's application listener, so the chart's `service.port` and the `http`
+container port have to match what the profiles bind. The probe listener is unaffected and keeps its own transport. That is a deliberate step rather than the default: in a cluster, TLS at the ingress is
 usually what an operator already has.
 
 The credentials any of them reads stay `file:` references into the mounted Secret. Keep them out of `config.files` and
@@ -206,12 +206,19 @@ with nothing to authenticate to and one more thing to steal.
 
 | Probe | Path | Consults |
 | --- | --- | --- |
-| Startup | `/alive` | The process. Its budget is what a slow first start is allowed, and it holds liveness off until it succeeds. |
-| Readiness | `/health` | Every check, the database included. A pod that cannot serve leaves the Service's endpoints. |
+| Startup | `/started` | The host's own startup gates: every secret reference resolved, the database schema verified. Its budget is what a slow first start is allowed, and it holds liveness off until it succeeds. |
+| Readiness | `/health` | The dependencies a request needs, the database included. A pod that cannot serve leaves the Service's endpoints. |
 | Liveness | `/alive` | The process alone, so a database outage never becomes a restart loop that cannot fix it. |
 
-The schema restricts a probe path to one of those two, because pointing liveness at `/health` is exactly the mistake
-that turns an outage into a crash loop.
+All three are served on a container port of their own — `probes.port`, `8081` by default — which sets both the port the
+kubelet dials and the `HealthEndpoints:Port` the host binds, so the two cannot drift. The Service publishes 8080 alone,
+so nothing outside the node reaches the probe listener: the probes answer without a credential, and which network their
+port is on is what controls who may ask them. Setting `probes.port` to 8080 is refused, and so is a probe pointed at
+another endpoint's path — pointing liveness at `/health` is exactly the mistake that turns an outage into a crash loop,
+and pointing startup at `/alive` ends the startup grace period while the pod is still coming up.
+
+[The health endpoints](health-endpoints.md) states what each probe consults and how a deployment turns the surface off
+or serves it over TLS.
 
 ## Configuration reload
 

--- a/docs/operations/health-endpoints.md
+++ b/docs/operations/health-endpoints.md
@@ -185,6 +185,12 @@ operator wrote.
 kubelet's HTTPS probe skips certificate validation entirely — which does not make the claim optional: the operator
 still says which certificate this is, and a certificate provisioned for another name is a mistake worth failing on.
 
+It has to be a DNS name, and startup refuses anything else. **An IP address does not work here**, which is worth
+stating because the probe listener is the one thing an orchestrator dials by address: matching is against the
+certificate's DNS subject alternative names, and those never carry an address, so a certificate with an IP SAN would be
+refused too. Wildcards belong in the certificate rather than in this setting — a certificate whose SAN is
+`*.example.test` covers a `Domain` of `probe.example.test`, one label deep, exactly as a client would accept it.
+
 **A TLS transport never downgrades.** Material that is missing, unresolvable, expired, or unusable fails startup with
 nothing listening. There is no development-certificate fallback and no self-signed fallback, because a probe answering
 on a port an operator believed was TLS is worse than one that does not answer.

--- a/docs/operations/health-endpoints.md
+++ b/docs/operations/health-endpoints.md
@@ -1,0 +1,260 @@
+# The health endpoints and the listener they are served on
+
+An orchestrator decides three things about a process by asking it: whether it has finished coming up, whether it can
+serve a request right now, and whether it is still running rather than stuck. MailFathom answers those three questions on
+three paths, served on a listener of their own. This page records what each one consults, which port it answers on, how
+to turn the surface off, how to put TLS in front of it, and why it carries no credential and no rate limit.
+
+## The probes are on their own port
+
+```json
+{
+  "HealthEndpoints": {
+    "Enabled": true,
+    "BindAddress": "0.0.0.0",
+    "Port": 8081,
+    "Transport": "Http"
+  }
+}
+```
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `Enabled` | `true` | Whether the probes are served at all. `false` maps no route and opens no listener |
+| `BindAddress` | `0.0.0.0` | The IP address the probe listener binds. `127.0.0.1` restricts the probes to the machine, `::` binds IPv6 |
+| `Port` | `8081` | The port the probes answer on. Under `HttpsOnly` this is the TLS port |
+| `Transport` | `Http` | `Http`, `HttpAndHttps`, or `HttpsOnly` — see [Transports](#transports) |
+| `HttpsPort` | none | The TLS port, required by `HttpAndHttps` and unused by the other two |
+| `Domain` | none | The DNS domain the configured certificate covers, required by the two TLS transports |
+| `ServerCertificate` | none | Where the certificate and its private key come from, on the same terms [the MCP endpoint](mcp-endpoint.md#https-and-your-own-domain) states them |
+
+The section is bound strictly. A misspelled key fails startup instead of leaving the probes on a port an operator
+believed they had moved, because a listener published to the wrong network is not a setting that failed to apply.
+
+Every setting here is **restart-required**. The section decides which sockets are opened and which routes exist, and
+both are settled while the host is composing itself, so an edited value takes effect on the next start. The material
+behind a configured certificate reference is the exception the [secret machinery](secret-rotation.md) already covers:
+rotating what a reference points at needs no configuration change, though this listener reads its certificate once,
+while starting.
+
+**The probe listener is never the application listener.** A probe path asked on the port that serves `/` and `/mcp` is
+answered with `404`, and `/mcp` asked on the probe port is answered with `404` as well. The decision is taken from the
+port the connection arrived at — a property of the socket the operating system accepted it on, not a header the caller
+wrote — so publishing the probe port to an orchestrator's network does not publish the mailbox to it, and publishing the
+application port to clients does not hand them an unauthenticated dependency report.
+
+A probe port that collides with the application listener fails startup with a message naming both, rather than failing
+to bind with an address-in-use error that names a socket.
+
+### Nothing changes with the environment
+
+The endpoints behave identically in every environment. `ASPNETCORE_ENVIRONMENT` decides nothing here, so what a
+developer tests is what runs in production, and the only difference between two deployments is what each one
+configured. The service-defaults scaffold MailFathom started from served the probes in Development only, which left
+every container and Kubernetes deployment with nothing to ask and every development run serving them on the listener
+its MCP clients reach.
+
+### The application listener is preserved
+
+Kestrel ignores the URL-shaped addresses — `ASPNETCORE_URLS`, `ASPNETCORE_HTTP_PORTS` — as soon as any listener is
+bound in code, and the probe listener is one. MailFathom therefore restates those addresses as `Kestrel:Endpoints`
+entries before opening the probe listener, which hands the same strings back to the framework's own parser and binds
+the same sockets. Nothing is restated where the addresses were already being ignored: a deployment that names its own
+`Kestrel:Endpoints` keeps exactly those, and one whose [MCP HTTPS profiles](mcp-endpoint.md#https-and-your-own-domain) bind their own
+listeners keeps the promise that no clear-text listener stays open behind them.
+
+The consequence worth knowing is in the log. A host that opens the probe listener writes Kestrel's
+`Overriding address(es)` warning once at startup and then binds every address the warning named, plus the probe port.
+
+## The three probes
+
+| Probe | Path | Consults | A failure means |
+|---|---|---|---|
+| Startup | `/started` | The host's own startup gates: every secret reference resolved, the database schema verified | The process has not finished coming up; the grace period continues |
+| Readiness | `/health` | The dependencies a request needs, the database included | The instance stops receiving traffic; it is not restarted |
+| Liveness | `/alive` | Process-local state only | The container is restarted |
+
+One endpoint cannot answer all three, because the three have different consequences. Wiring liveness to the readiness
+answer is the mistake that turns a database outage into a restart loop across every replica of a process that is
+working correctly; the Helm chart's values schema refuses that configuration rather than discouraging it.
+
+**Membership is decided by a health-check tag.** A check states which probes it belongs to once, where it is
+registered — `live`, `ready`, `startup` — and a check that states none reaches no probe. That is deliberate: the
+framework's default is to include every registered check in every endpoint, which is how a dependency check ends up
+able to restart the process. Because a probe over no checks reports healthy, composition refuses to start when any of
+the three would answer without consulting anything.
+
+The startup gates are reported rather than re-run. The probe reads a flag the gates set as they complete, so polling it
+opens no connection and costs nothing, and once it turns healthy it stays healthy. Under the host builder MailFathom
+composes with, those gates run before the listener opens, so an orchestrator ordinarily sees a refused connection
+during a slow start and counts it exactly as it counts a failed probe.
+
+## What a response carries
+
+The body is one word: `Healthy`, `Degraded`, or `Unhealthy`, with `200` for the first two and `503` for the last.
+
+Check names, exception messages, stack traces, durations, connection strings, host names, and dependency descriptions
+are all absent, and this is a security property rather than a minimalism preference. The endpoint answers without a
+credential, so everything in the body is disclosed to whoever can reach the port; a check name says which dependencies
+exist and a description says what is wrong with one. An orchestrator compares the one word.
+
+Probe requests are excluded from tracing, and the host's own log configuration keeps `Microsoft.AspNetCore` at
+`Warning`, so polling every few seconds for the lifetime of the process produces neither a span nor a log record per
+request.
+
+## No credential, no origin gate, no rate limit
+
+The probe endpoints carry no authentication, no authorization, no API-key check, no CORS or `Origin` gate, and no rate
+limiting. That is the stated posture, not an omission:
+
+- An orchestrator holds no credential and has nowhere to get one. A probe that could be refused for its credential is a
+  probe that reports a process as failed while it is working.
+- A throttled probe fails, and a failed liveness probe restarts the container. A limiter on this listener would convert
+  a burst of polling into an outage, so the [MCP endpoint's rate limits](mcp-endpoint.md#rate-limiting) never extend to
+  it — the process-wide limiter explicitly applies no limit to a probe request.
+
+Exposure is controlled by which network the port is published on, and by the transport it is served under. Nothing
+else on this listener depends on a credential, and the TLS listener asks for no client certificate even where the MCP
+endpoint's own listeners ask every client for one.
+
+## Transports
+
+| `Transport` | Clear-text listener | TLS listener |
+|---|---|---|
+| `Http` | `Port` | none |
+| `HttpAndHttps` | `Port` | `HttpsPort`, which must be stated |
+| `HttpsOnly` | none | `Port` |
+
+`Http` is the default and the whole first-release posture for most deployments: adopting the release costs no
+certificate work, and a probe network that is already trusted needs none. TLS is a deliberate upgrade.
+
+One socket serves one scheme, which is why `HttpAndHttps` needs a second port rather than a flag. The port is stated by
+the operator rather than defaulted, because a default would pick a port nobody published and could collide with
+something already listening. It exists for the interval in which a deployment moves from clear text to TLS and both
+have to answer.
+
+```json
+{
+  "HealthEndpoints": {
+    "Port": 8081,
+    "HttpsPort": 8443,
+    "Transport": "HttpAndHttps",
+    "Domain": "probe.example.test",
+    "ServerCertificate": {
+      "CertificateChain": {
+        "Name": "probe-chain",
+        "SecretReference": "file:/etc/mailfathom/tls/probe-fullchain.pem"
+      },
+      "PrivateKey": {
+        "Name": "probe-key",
+        "SecretReference": "file:/etc/mailfathom/tls/probe-privkey.pem"
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "HealthEndpoints": {
+    "Port": 8443,
+    "Transport": "HttpsOnly",
+    "Domain": "probe.example.test",
+    "ServerCertificate": {
+      "Bundle": {
+        "Name": "probe-bundle",
+        "SecretReference": "file:/etc/mailfathom/tls/probe.pfx",
+        "Password": {
+          "Name": "probe-bundle-password",
+          "SecretReference": "systemd-credential:mailfathom-probe-bundle-password"
+        }
+      }
+    }
+  }
+}
+```
+
+### Certificate material
+
+The material is resolved by the loader the MCP endpoint's HTTPS profiles use, through the same named-secret references
+[secret provisioning](secret-provisioning.md) describes. Either a PKCS#12 bundle or a PEM chain beside its private key;
+configuring both is refused, because which of them states the identity would otherwise be decided by nothing an
+operator wrote.
+
+`Domain` is what the material is proven against. An orchestrator dialling the pod's own address verifies nothing — the
+kubelet's HTTPS probe skips certificate validation entirely — which does not make the claim optional: the operator
+still says which certificate this is, and a certificate provisioned for another name is a mistake worth failing on.
+
+**A TLS transport never downgrades.** Material that is missing, unresolvable, expired, or unusable fails startup with
+nothing listening. There is no development-certificate fallback and no self-signed fallback, because a probe answering
+on a port an operator believed was TLS is worse than one that does not answer.
+
+The certificate is loaded before the server starts, so an expired one is a startup failure rather than a handshake
+every probe meets afterwards. Startup also warns when the certificate expires within thirty days.
+
+## Turning the probes off
+
+```json
+{
+  "HealthEndpoints": {
+    "Enabled": false
+  }
+}
+```
+
+No probe route is mapped and no probe listener is opened. Nothing else about the host changes, and no second setting
+decides the same thing. A deployment behind something that already tracks process health, or one where the probe port
+cannot be published to anything that would use it, is the case this exists for.
+
+## Kubernetes
+
+The chart wires all three probes to a container port of its own and never to the Service:
+
+```yaml
+probes:
+  port: 8081
+  startup:
+    path: /started
+    periodSeconds: 5
+    failureThreshold: 30
+  readiness:
+    path: /health
+    periodSeconds: 10
+  liveness:
+    path: /alive
+    periodSeconds: 20
+```
+
+`probes.port` sets the container port the kubelet dials and the `HealthEndpoints__Port` the host binds, so the two
+cannot drift. The kubelet reaches a container port on the pod's own address without the Service publishing it, which is
+what keeps the probe listener off the network the MCP endpoint is served on. Setting it to `8080` is refused by the
+values schema, and the host would refuse the same collision at startup.
+
+The rendered probes are the ones the schema pins: `/started` for startup, `/health` for readiness, `/alive` for
+liveness. Each path is a `const` in the schema, so a probe pointed at the wrong endpoint is refused at install time
+rather than producing a deployment whose restarts nobody can explain. See
+[deploying to Kubernetes](deployment-kubernetes.md#probes).
+
+## Docker Compose
+
+The Compose deployment publishes the probe port to loopback:
+
+```yaml
+ports:
+  - "127.0.0.1:8080:8080"
+  - "127.0.0.1:8081:8081"
+```
+
+```bash
+curl -fsS http://127.0.0.1:8081/started    # has it finished coming up
+curl -fsS http://127.0.0.1:8081/health     # can it serve, database included
+curl -fsS http://127.0.0.1:8081/alive      # is the process still running
+```
+
+`MAILFATHOM_HEALTH_BIND` and `MAILFATHOM_HEALTH_PORT` move the published address, the way `MAILFATHOM_HTTP_BIND` and
+`MAILFATHOM_HTTP_PORT` do for the application listener. Keep it on loopback unless the machine asking is not this one.
+
+The container declares no Docker `HEALTHCHECK`. Docker and Podman run one as a command *inside* the container, and the
+image is chiseled: it carries no shell and no HTTP client for one to be written in. Adding either so the container could
+ask an endpoint that is already reachable from outside would grow its attack surface for nothing. See
+[the container image](container-image.md#the-health-endpoints).

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -91,8 +91,9 @@ Authorization: Bearer <the key>
 ```
 
 Every MCP method and response path is covered — the JSON-RPC post, the stream it reads back, and the delete that ends a
-session — and the check runs before any protocol handling. The readiness response and the health endpoints are not
-covered; they carry no mailbox data and a probe has no credential to present.
+session — and the check runs before any protocol handling. The readiness response is not covered, and neither are the
+[health endpoints](health-endpoints.md), which are served on a listener of their own and deliberately carry no
+credential at all.
 
 Each entry is an ordinary [named secret](secret-provisioning.md#the-secret-block): the key material is provisioned like
 every other credential, the `Name` is what a diagnostic and an audit record correlate on, and the `Lifetime` is enforced.
@@ -546,13 +547,15 @@ needs a handshake this process terminated, and configuring one here is how it ge
 ### Configuring a profile takes over the host's listeners
 
 Binding a listener explicitly replaces whatever URLs the host was otherwise configured with, so **no clear-text listener
-stays open behind an HTTPS profile**. That applies to everything this process serves, the health endpoints included,
-because one Kestrel serves them all. There is no mixed posture in which the MCP route is protected while a second
+stays open behind an HTTPS profile**. There is no mixed posture in which the MCP route is protected while a second
 listener offers the same mailbox without protection.
 
 `ASPNETCORE_URLS`, `--urls`, and the Aspire-issued endpoints are therefore all ignored once a profile is configured.
-A deployment that needs a plain HTTP health endpoint beside HTTPS should keep the clear-text posture and terminate TLS
-at a reverse proxy instead.
+
+The [health endpoints](health-endpoints.md) are the one thing this does not take over. They are served on a listener of
+their own, and that listener keeps its own transport: a deployment terminating TLS for the MCP endpoint still serves
+plain HTTP probes unless it configures `HealthEndpoints:Transport` as well. Nothing is lost by that, because the probe
+listener serves no mailbox — a request for `/mcp` that arrives on it is answered with `404`.
 
 Kestrel's own `Kestrel:Endpoints` section is the one listener a profile cannot displace: those endpoints are bound
 alongside the ones bound in code rather than replaced by them, so an endpoint configured there would keep its socket and

--- a/scripts/verify-deployment-assets.sh
+++ b/scripts/verify-deployment-assets.sh
@@ -292,6 +292,16 @@ verify_the_chart() {
     helm_command template verification mailfathom --values mailfathom/ci/release-values.yaml --set probes.liveness.path=/health
 
   expect_rejection \
+    'A startup probe pointed at the liveness endpoint is refused.' \
+    'probes/startup/path' \
+    helm_command template verification mailfathom --values mailfathom/ci/release-values.yaml --set probes.startup.path=/alive
+
+  expect_rejection \
+    'A probe port that collides with the application listener is refused.' \
+    'probes/port' \
+    helm_command template verification mailfathom --values mailfathom/ci/release-values.yaml --set probes.port=8080
+
+  expect_rejection \
     'A misspelled values key is refused rather than silently ignored.' \
     "additional properties 'pullPolcy' not allowed" \
     helm_command template verification mailfathom --values mailfathom/ci/release-values.yaml --set image.pullPolcy=Always

--- a/scripts/verify-deployment-assets.sh
+++ b/scripts/verify-deployment-assets.sh
@@ -302,6 +302,12 @@ verify_the_chart() {
     helm_command template verification mailfathom --values mailfathom/ci/release-values.yaml --set probes.port=8080
 
   expect_rejection \
+    'Moving the probe listener through extraEnvironment is refused, so it cannot drift from the container port.' \
+    "invalid propertyName 'HealthEndpoints__Port'" \
+    helm_command template verification mailfathom --values mailfathom/ci/release-values.yaml \
+    --set 'config.extraEnvironment.HealthEndpoints__Port=9000'
+
+  expect_rejection \
     'A misspelled values key is refused rather than silently ignored.' \
     "additional properties 'pullPolcy' not allowed" \
     helm_command template verification mailfathom --values mailfathom/ci/release-values.yaml --set image.pullPolcy=Always

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -74,7 +74,12 @@ var database = postgres.AddDatabase(OrchestrationContract.DatabaseResourceName);
 
 var mailFathomHost = builder.AddProject<Projects.Host>(OrchestrationContract.HostResourceName)
     .WithReference(database)
-    .WaitFor(database);
+    .WaitFor(database)
+    // The probe listener binds every interface by default, which is what a container wants and what a developer
+    // machine does not: the probes answer without a credential, and nothing on a local network has any business asking
+    // them. It is not published as an Aspire endpoint either, because Aspire issues ASPNETCORE_URLS from the endpoints
+    // it knows about and the host would then serve `/` and `/mcp` on the probe port as well.
+    .WithEnvironment("HealthEndpoints__BindAddress", "127.0.0.1");
 
 if (runsIntegrationTests)
 {

--- a/src/Host/Configuration/ConfiguredApplicationListeners.cs
+++ b/src/Host/Configuration/ConfiguredApplicationListeners.cs
@@ -1,0 +1,129 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace MailFathom.Host.Configuration;
+
+/// <summary>Reads the listener the application itself is served on, and restates it where adding a second one would drop it.</summary>
+/// <remarks>
+/// <para>
+/// Kestrel takes its listeners from three places and the three do not compose. A listener bound in code and an endpoint
+/// named in <c>Kestrel:Endpoints</c> are both kept, but either one makes Kestrel ignore the URL-shaped addresses
+/// entirely — <c>ASPNETCORE_URLS</c>, <c>ASPNETCORE_HTTP_PORTS</c>, and everything that reaches
+/// <c>WebApplication.Urls</c> — and log that it is overriding them. That is by design where MailFathom binds the MCP
+/// HTTPS profiles, because no clear-text listener may stay open behind them. It is a defect where the health-endpoint
+/// listener is opened: a deployment that states its application port as <c>ASPNETCORE_HTTP_PORTS=8080</c> would keep
+/// its probes and lose the port its clients connect to.
+/// </para>
+/// <para>
+/// So the addresses are restated as <c>Kestrel:Endpoints</c> entries before the health listener is bound, which hands
+/// the URL strings back to the framework's own parser rather than reimplementing it here: the same value binds the same
+/// socket, under the same scheme, with the same certificate configuration it would have used. Only the two decisions
+/// this file makes are its own — which configuration key supplies the addresses, and what "nothing configured" means.
+/// </para>
+/// <para>
+/// Restating is confined to the case where the addresses were going to bind. A deployment that already names endpoints
+/// in <c>Kestrel:Endpoints</c>, or one whose MCP HTTPS profiles bind in code, is one where the URL addresses were
+/// already being ignored, and reinstating them there would open a listener the operator had removed.
+/// </para>
+/// </remarks>
+internal static class ConfiguredApplicationListeners
+{
+    /// <summary>The endpoint name the restated addresses are written under, suffixed by their position.</summary>
+    /// <remarks>Named after the product so it cannot collide with an endpoint an operator wrote, and readable in the "Now listening on" line it produces.</remarks>
+    internal const string EndpointNamePrefix = "MailFathomApplication";
+
+    /// <summary>The address the process serves when a deployment configures none.</summary>
+    /// <remarks>
+    /// Kestrel's own fallback is this address plus <c>https://localhost:5001</c> when an ASP.NET Core development
+    /// certificate happens to be installed. The clear-text half is restated and the HTTPS half deliberately is not:
+    /// MailFathom never serves a listener out of a development certificate, and a fallback that did would make the
+    /// schemes a process listens on depend on what is installed on the machine rather than on what was configured.
+    /// </remarks>
+    private const string DefaultUrl = "http://localhost:5000";
+
+    private const char UrlSeparator = ';';
+
+    private const string UrlKey = "Url";
+
+    /// <summary>Reads the URL-shaped addresses the application listener would be bound from.</summary>
+    /// <param name="configuration">The application configuration, read at the root because the host's own keys are not nested under this product's section.</param>
+    /// <returns>The addresses, in configuration order, never empty.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The precedence is the host's own: an explicit URL list wins over the port lists, and the port lists expand to
+    /// every interface, which is what <c>ASPNETCORE_HTTP_PORTS</c> means. Reproducing it here rather than reading the
+    /// result is unavoidable, because the host resolves it while starting and the listener has to be bound before that.
+    /// </remarks>
+    internal static IReadOnlyList<string> ResolveUrls(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var configuredUrls = Split(configuration[WebHostDefaults.ServerUrlsKey]);
+
+        if (configuredUrls.Count > 0)
+        {
+            return configuredUrls;
+        }
+
+        string[] portUrls =
+        [
+            .. ExpandPorts(configuration[WebHostDefaults.HttpPortsKey], Uri.UriSchemeHttp),
+            .. ExpandPorts(configuration[WebHostDefaults.HttpsPortsKey], Uri.UriSchemeHttps),
+        ];
+
+        return portUrls.Length > 0 ? portUrls : [DefaultUrl];
+    }
+
+    /// <summary>Writes the addresses as the configuration section Kestrel binds its endpoints from.</summary>
+    /// <param name="urls">The addresses the application listener serves.</param>
+    /// <returns>One <c>Kestrel:Endpoints</c> entry per address.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="urls" /> is <see langword="null" />.</exception>
+    internal static IReadOnlyList<KeyValuePair<string, string?>> AsKestrelEndpointConfiguration(IReadOnlyList<string> urls)
+    {
+        ArgumentNullException.ThrowIfNull(urls);
+
+        return
+        [
+            .. urls.Index().Select(static entry => KeyValuePair.Create<string, string?>(
+                $"{ConfiguredKestrelEndpoints.SectionName}:{EndpointNamePrefix}{entry.Index}:{UrlKey}",
+                entry.Item)),
+        ];
+    }
+
+    /// <summary>Reads the TCP ports the addresses bind, which is what a second listener must not collide with.</summary>
+    /// <param name="urls">The addresses the application listener serves.</param>
+    /// <returns>The ports, without duplicates.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="urls" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// An address the parser does not recognize contributes no port rather than a failure. Kestrel parses the same
+    /// value moments later and reports it against the key an operator wrote; producing a second message here would
+    /// describe the same mistake in this product's words and hide which setting the framework actually refused.
+    /// </remarks>
+    internal static IReadOnlyList<int> ListenerPorts(IReadOnlyList<string> urls)
+    {
+        ArgumentNullException.ThrowIfNull(urls);
+
+        return [.. urls.Select(ParsePort).Where(static port => port.HasValue).Select(static port => port!.Value).Distinct()];
+    }
+
+    private static int? ParsePort(string url)
+    {
+        try
+        {
+            return BindingAddress.Parse(url).Port;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static IReadOnlyList<string> Split(string? configuredValue) =>
+    [
+        .. (configuredValue ?? string.Empty)
+            .Split(UrlSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries),
+    ];
+
+    private static IEnumerable<string> ExpandPorts(string? configuredPorts, string scheme) =>
+        Split(configuredPorts).Select(port => $"{scheme}://*:{port}");
+}

--- a/src/Host/Configuration/ConfiguredDnsName.cs
+++ b/src/Host/Configuration/ConfiguredDnsName.cs
@@ -1,0 +1,59 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace MailFathom.Host.Configuration;
+
+/// <summary>Decides whether a configured name could be the DNS name a TLS listener claims.</summary>
+/// <remarks>
+/// <para>
+/// Every listener MailFathom terminates TLS on states a name, and every one of them is matched the same way: against
+/// the certificate's DNS subject alternative names, which carry neither an IP address nor a catch-all. What a name may
+/// be is therefore a property of that matching rather than of the endpoint that configured it, which is why the rules
+/// live here instead of once per section.
+/// </para>
+/// <para>
+/// Emptiness is deliberately not reported here. A missing name means something different to each caller — an MCP
+/// profile that publishes nothing could select no certificate, while a probe listener has nothing to prove its
+/// material against — so each section says so in its own words.
+/// </para>
+/// </remarks>
+internal static class ConfiguredDnsName
+{
+    /// <summary>Finds the reasons a configured name is not a DNS name.</summary>
+    /// <param name="configuredName">The name as an operator wrote it, or <see langword="null" /> when none is configured.</param>
+    /// <param name="settingPath">The configuration path of the setting, which prefixes every reported error.</param>
+    /// <returns>One message per reason, empty when the name is a DNS name or when none is configured.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="settingPath" /> is <see langword="null" />.</exception>
+    internal static IEnumerable<string> FindErrors(string? configuredName, string settingPath)
+    {
+        ArgumentNullException.ThrowIfNull(settingPath);
+
+        var name = configuredName?.Trim() ?? string.Empty;
+
+        if (name.Length == 0)
+        {
+            yield break;
+        }
+
+        if (!name.All(char.IsAscii))
+        {
+            yield return $"{settingPath} — state an internationalized domain in its punycode A-label form, because that is what a client sends and what a certificate's subject alternative names carry.";
+
+            yield break;
+        }
+
+        var hostNameKind = Uri.CheckHostName(name);
+
+        if (hostNameKind is UriHostNameType.IPv4 or UriHostNameType.IPv6)
+        {
+            yield return $"{settingPath} — an IP address cannot be the name a listener claims: a certificate is matched against its DNS subject alternative names, which never carry one, and a client sends no server name for an address. State the DNS name and bind the address through 'BindAddress'.";
+
+            yield break;
+        }
+
+        if (hostNameKind != UriHostNameType.Dns)
+        {
+            yield return $"{settingPath} — '{name}' is not a DNS name. Wildcard and catch-all names are deliberately not accepted; state the exact name this listener claims.";
+        }
+    }
+}

--- a/src/Host/Configuration/ConfiguredKestrelEndpoints.cs
+++ b/src/Host/Configuration/ConfiguredKestrelEndpoints.cs
@@ -42,6 +42,29 @@ internal static class ConfiguredKestrelEndpoints
             .Any(static endpoint => !string.IsNullOrWhiteSpace(endpoint[UrlKey]));
     }
 
+    /// <summary>Reads the TCP ports the configured endpoints bind.</summary>
+    /// <param name="configuration">The application configuration, read at the root because the Kestrel section is not nested under this product's own.</param>
+    /// <returns>The ports, without duplicates, empty when the deployment names no endpoint of its own.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// These are the application listener's ports whenever this section is populated, because the URL-shaped addresses
+    /// are ignored as soon as it is. A second listener that has to avoid the application's therefore has to read them
+    /// from here rather than from the addresses the deployment is no longer being bound from.
+    /// </remarks>
+    internal static IReadOnlyList<int> ListenerPorts(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return ConfiguredApplicationListeners.ListenerPorts(
+        [
+            .. configuration.GetSection(SectionName)
+                .GetChildren()
+                .Select(static endpoint => endpoint[UrlKey])
+                .Where(static url => !string.IsNullOrWhiteSpace(url))
+                .Select(static url => url!),
+        ]);
+    }
+
     /// <summary>Finds the configured Kestrel endpoints that would stay open behind the configured HTTPS profiles.</summary>
     /// <param name="configuration">The application configuration, read at the root because the Kestrel section is not nested under this product's own.</param>
     /// <param name="httpsSettings">The HTTPS profiles the MCP endpoint is served over.</param>

--- a/src/Host/Configuration/ConfiguredKestrelEndpoints.cs
+++ b/src/Host/Configuration/ConfiguredKestrelEndpoints.cs
@@ -24,6 +24,24 @@ internal static class ConfiguredKestrelEndpoints
 
     private const string UrlKey = "Url";
 
+    /// <summary>Reports whether the deployment names any Kestrel endpoint of its own.</summary>
+    /// <param name="configuration">The application configuration, read at the root because the Kestrel section is not nested under this product's own.</param>
+    /// <returns><see langword="true" /> when at least one configured endpoint binds a listener, otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A deployment that names its own endpoints is one whose URL-shaped addresses Kestrel is already ignoring, which is
+    /// what <see cref="ConfiguredApplicationListeners" /> must not undo by restating them beside the endpoints an
+    /// operator wrote.
+    /// </remarks>
+    internal static bool AnyConfigured(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return configuration.GetSection(SectionName)
+            .GetChildren()
+            .Any(static endpoint => !string.IsNullOrWhiteSpace(endpoint[UrlKey]));
+    }
+
     /// <summary>Finds the configured Kestrel endpoints that would stay open behind the configured HTTPS profiles.</summary>
     /// <param name="configuration">The application configuration, read at the root because the Kestrel section is not nested under this product's own.</param>
     /// <param name="httpsSettings">The HTTPS profiles the MCP endpoint is served over.</param>

--- a/src/Host/Configuration/HealthEndpointOptions.cs
+++ b/src/Host/Configuration/HealthEndpointOptions.cs
@@ -4,7 +4,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using MailFathom.Infrastructure.Certificates;
-using MailFathom.Infrastructure.Secrets;
 
 namespace MailFathom.Host.Configuration;
 
@@ -216,9 +215,7 @@ internal sealed class HealthEndpointOptions
 
         if (!this.TerminatesTls)
         {
-            if (IsConfigured(this.ServerCertificate?.Bundle)
-                || IsConfigured(this.ServerCertificate?.CertificateChain)
-                || IsConfigured(this.ServerCertificate?.PrivateKey))
+            if (this.ServerCertificate.IsConfigured)
             {
                 yield return $"{SectionName}:{nameof(this.ServerCertificate)} — a server certificate is configured while '{nameof(this.Transport)}' opens no TLS listener, so nothing presents it; select '{nameof(HealthEndpointTransport.HttpAndHttps)}' or '{nameof(HealthEndpointTransport.HttpsOnly)}', or remove the material.";
             }
@@ -226,53 +223,39 @@ internal sealed class HealthEndpointOptions
             yield break;
         }
 
-        if (string.IsNullOrWhiteSpace(this.Domain))
+        foreach (var error in this.FindDomainErrors())
         {
-            yield return $"{SectionName}:{nameof(this.Domain)} — a TLS transport must state the DNS domain its certificate covers, which is what the configured material is proven against before the listener is opened.";
+            yield return error;
         }
 
-        foreach (var error in this.FindServerCertificateErrors())
+        // The shape of the material block is the same question for every listener that terminates TLS, so it is asked
+        // by the type that carries it rather than restated per section.
+        foreach (var error in this.ServerCertificate.FindConfigurationErrors($"{SectionName}:{nameof(this.ServerCertificate)}"))
         {
             yield return error;
         }
     }
 
-    /// <summary>Refuses a certificate block that names neither kind of material or both of them.</summary>
-    /// <remarks>Only the shape is decided here, on the same terms the MCP HTTPS profiles state it. Whether the referenced material resolves, parses, carries a matching private key, and covers the domain is the loader's question.</remarks>
-    private IEnumerable<string> FindServerCertificateErrors()
+    /// <summary>Refuses a name the configured certificate could not be proven against.</summary>
+    /// <remarks>
+    /// The shape rules are the ones every TLS listener's name is subject to, because the certificate is matched against
+    /// DNS subject alternative names either way. An IP address is worth stating separately here: an orchestrator dials
+    /// this listener by address, so it is the plausible mistake, and a certificate's DNS names never carry one.
+    /// </remarks>
+    private IEnumerable<string> FindDomainErrors()
     {
-        var settingPath = $"{SectionName}:{nameof(this.ServerCertificate)}";
-        var bundleConfigured = IsConfigured(this.ServerCertificate?.Bundle);
-        var chainConfigured = IsConfigured(this.ServerCertificate?.CertificateChain);
-        var privateKeyConfigured = IsConfigured(this.ServerCertificate?.PrivateKey);
+        var settingPath = $"{SectionName}:{nameof(this.Domain)}";
 
-        if (bundleConfigured && (chainConfigured || privateKeyConfigured))
+        if (string.IsNullOrWhiteSpace(this.Domain))
         {
-            yield return $"{settingPath} — a PKCS#12 bundle and separate PEM material are both configured; state one or the other, because which of them supplies the identity would otherwise be decided by nothing an operator wrote.";
+            yield return $"{settingPath} — a TLS transport must state the DNS name its certificate covers, which is what the configured material is proven against before the listener is opened.";
 
             yield break;
         }
 
-        if (bundleConfigured)
+        foreach (var error in ConfiguredDnsName.FindErrors(this.Domain, settingPath))
         {
-            yield break;
-        }
-
-        if (!chainConfigured && !privateKeyConfigured)
-        {
-            yield return $"{settingPath} — a TLS transport must state where its certificate comes from: a '{nameof(TlsServerCertificateOptions.Bundle)}' holding a PKCS#12 bundle, or a '{nameof(TlsServerCertificateOptions.CertificateChain)}' beside its '{nameof(TlsServerCertificateOptions.PrivateKey)}'. There is no development-certificate fallback and no self-signed one, because a probe answering on a port an operator believed was TLS is worse than one that does not answer.";
-
-            yield break;
-        }
-
-        if (!chainConfigured)
-        {
-            yield return $"{settingPath}:{nameof(TlsServerCertificateOptions.CertificateChain)} — a private key is configured with no certificate to pair it with.";
-        }
-
-        if (!privateKeyConfigured)
-        {
-            yield return $"{settingPath}:{nameof(TlsServerCertificateOptions.PrivateKey)} — a certificate is configured with no private key, so the listener could name the domain but not prove it is the domain.";
+            yield return error;
         }
     }
 
@@ -283,7 +266,4 @@ internal sealed class HealthEndpointOptions
             yield return $"{SectionName}:{settingName} — '{port}' is not a TCP port; state a value between 1 and 65535.";
         }
     }
-
-    private static bool IsConfigured(ConfiguredSecret? block) =>
-        block is not null && !string.IsNullOrWhiteSpace(block.SecretReference);
 }

--- a/src/Host/Configuration/HealthEndpointOptions.cs
+++ b/src/Host/Configuration/HealthEndpointOptions.cs
@@ -1,0 +1,289 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using MailFathom.Infrastructure.Certificates;
+using MailFathom.Infrastructure.Secrets;
+
+namespace MailFathom.Host.Configuration;
+
+/// <summary>Configures whether the startup, readiness, and liveness probes are served, on which socket, and under which transport.</summary>
+/// <remarks>
+/// <para>
+/// The probes answer without a credential, so what controls their exposure is which network their port is published on.
+/// That is why they get a listener of their own instead of sharing the one that serves <c>/</c> and <c>/mcp</c>: an
+/// operator publishes the probe port to the orchestrator and publishes the application port to clients, and neither
+/// port answers the other's paths. The scaffold this replaced controlled the same exposure by environment name, which
+/// left every container and Kubernetes deployment with no probe to call and a development run serving them on the
+/// listener its MCP clients reach.
+/// </para>
+/// <para>
+/// The decision is identical in every environment. Nothing here reads <c>IHostEnvironment</c>, so what a developer
+/// tests is what runs in production, and the only difference between two deployments is what each one configured.
+/// </para>
+/// <para>
+/// The section is read once, while the host is being composed, because it decides which sockets are opened and which
+/// routes exist. A change takes effect on restart; the material behind a configured certificate reference is a
+/// different matter and is retrieved before the server starts.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed class HealthEndpointOptions
+{
+    /// <summary>The configuration section the health-endpoint settings are bound from.</summary>
+    public const string SectionName = "HealthEndpoints";
+
+    /// <summary>The port the probes are served on when a deployment configures none.</summary>
+    /// <remarks>Above 1024 so the process needs no privilege to bind it, and beside the 8080 an application listener conventionally takes, so the two defaults do not collide.</remarks>
+    internal const int DefaultPort = 8081;
+
+    /// <summary>Gets or sets whether the probes are served at all.</summary>
+    /// <remarks>
+    /// Enabled unless a deployment states otherwise, because a process an orchestrator cannot probe is one it cannot
+    /// gate traffic to or restart. Turning it off maps no probe route and opens no probe listener, and changes nothing
+    /// else about the host.
+    /// </remarks>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Gets or sets the IP address the probe listener binds, defaulting to every IPv4 address.</summary>
+    /// <remarks>Use <c>127.0.0.1</c> to restrict the probes to the machine, one interface's address to restrict them to that interface, and <c>::</c> to bind IPv6, which on most systems accepts IPv4 connections as well.</remarks>
+    public string BindAddress { get; set; } = "0.0.0.0";
+
+    /// <summary>Gets or sets the TCP port the probes are served on.</summary>
+    /// <remarks>Under <see cref="HealthEndpointTransport.HttpsOnly" /> this port is the TLS one, because that mode opens no clear-text listener at all.</remarks>
+    public int Port { get; set; } = DefaultPort;
+
+    /// <summary>Gets or sets the TCP port the TLS listener binds when both schemes are served.</summary>
+    /// <remarks>
+    /// Unset by default and required by <see cref="HealthEndpointTransport.HttpAndHttps" /> alone. One socket serves one
+    /// scheme, so the second port is what makes that mode possible; defaulting it would pick a port an operator never
+    /// published and could collide with something already listening.
+    /// </remarks>
+    public int? HttpsPort { get; set; }
+
+    /// <summary>Gets or sets which schemes the probe listener is opened under.</summary>
+    public HealthEndpointTransport Transport { get; set; } = HealthEndpointTransport.Http;
+
+    /// <summary>Gets or sets the exact DNS domain the TLS listener's certificate covers, in its ASCII form.</summary>
+    /// <remarks>
+    /// Required by the two TLS modes, because a server certificate is issued for a name and the loader proves the
+    /// configured material covers the one this endpoint claims. An orchestrator dialling the pod's address rather than
+    /// this name is the ordinary case and verifies nothing, which does not make the claim optional: the operator still
+    /// has to say which certificate this is, and a mismatch is a provisioning mistake worth failing on.
+    /// </remarks>
+    public string Domain { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets where the certificate and private key the TLS listener presents come from.</summary>
+    /// <remarks>The same named-secret contract the MCP endpoint's HTTPS profiles use, resolved by the same loader. There is no second loader, no development-certificate fallback, and no self-signed fallback.</remarks>
+    public TlsServerCertificateOptions ServerCertificate { get; set; } = new();
+
+    /// <summary>Gets whether the configured transport opens a TLS listener.</summary>
+    public bool TerminatesTls => this.Transport is HealthEndpointTransport.HttpAndHttps or HealthEndpointTransport.HttpsOnly;
+
+    /// <summary>Gets whether the configured transport opens a clear-text listener.</summary>
+    public bool ServesClearText => this.Transport is HealthEndpointTransport.Http or HealthEndpointTransport.HttpAndHttps;
+
+    /// <summary>Gets the port the TLS listener binds, or <see langword="null" /> when the transport opens none.</summary>
+    /// <remarks><see cref="HealthEndpointTransport.HttpsOnly" /> serves TLS on <see cref="Port" /> itself, because it opens no clear-text listener for that port to belong to.</remarks>
+    public int? TlsListenerPort => this.Transport switch
+    {
+        HealthEndpointTransport.HttpsOnly => this.Port,
+        HealthEndpointTransport.HttpAndHttps => this.HttpsPort,
+        _ => null,
+    };
+
+    /// <summary>Gets the ports the probes answer on, which is what tells a probe request apart from an application one.</summary>
+    /// <remarks>Empty when the probes are disabled, which is the state in which no listener of this kind exists and every probe path is unmapped.</remarks>
+    public IReadOnlySet<int> ListenerPorts
+    {
+        get
+        {
+            if (!this.Enabled)
+            {
+                return new HashSet<int>();
+            }
+
+            var ports = new HashSet<int> { this.Port };
+
+            if (this.TlsListenerPort is { } tlsPort)
+            {
+                ports.Add(tlsPort);
+            }
+
+            return ports;
+        }
+    }
+
+    /// <summary>Reads the section the way composition does, defaults included.</summary>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The bound settings.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Strict binding is part of the read rather than something a caller opts into. The section decides which sockets
+    /// are opened and whether they carry TLS, so a misspelled key that bound quietly would leave a deployment serving a
+    /// posture nobody selected — a probe port an operator believed was off, or clear text where they wrote TLS.
+    /// </remarks>
+    public static HealthEndpointOptions ReadFrom(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return configuration.GetSection(SectionName)
+            .Get<HealthEndpointOptions>(binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
+            ?? new HealthEndpointOptions();
+    }
+
+    /// <summary>Finds everything an operator must fix before the probes can be served.</summary>
+    /// <param name="applicationListenerPorts">The ports the application listener binds, which the probe listener must not take.</param>
+    /// <returns>One message per faulty setting, each naming its configuration path, empty when the settings are usable.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="applicationListenerPorts" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Whether the configured certificate material resolves and is usable is not asked here. It is proven against the
+    /// real material before the server starts, so an unusable certificate fails startup with nothing listening rather
+    /// than with a TLS listener already bound.
+    /// </remarks>
+    public IReadOnlyList<string> FindConfigurationErrors(IReadOnlyCollection<int> applicationListenerPorts)
+    {
+        ArgumentNullException.ThrowIfNull(applicationListenerPorts);
+
+        if (!this.Enabled)
+        {
+            return [];
+        }
+
+        var errors = new List<string>(this.FindListenerErrors(applicationListenerPorts));
+
+        errors.AddRange(this.FindTransportErrors());
+
+        return errors;
+    }
+
+    private IEnumerable<string> FindListenerErrors(IReadOnlyCollection<int> applicationListenerPorts)
+    {
+        if (!IPAddress.TryParse(this.BindAddress?.Trim(), out _))
+        {
+            yield return $"{SectionName}:{nameof(this.BindAddress)} — state the IP address to bind, for example '0.0.0.0' for every IPv4 address, '127.0.0.1' to serve the probes to this machine only, or '::' for IPv6.";
+        }
+
+        foreach (var error in FindPortRangeErrors(this.Port, nameof(this.Port)))
+        {
+            yield return error;
+        }
+
+        if (this.HttpsPort is { } httpsPort)
+        {
+            foreach (var error in FindPortRangeErrors(httpsPort, nameof(this.HttpsPort)))
+            {
+                yield return error;
+            }
+        }
+
+        // The application listener is what MCP clients reach. A probe listener sharing its port would either fail to
+        // bind and take the process down with an address-in-use error naming a socket rather than a setting, or — where
+        // the addresses differ — serve the probes to whoever can reach the application port, which is the exposure this
+        // section exists to control.
+        foreach (var port in this.ListenerPorts.Where(applicationListenerPorts.Contains))
+        {
+            yield return $"{SectionName} — port {port} is already the application listener's, and the probes are served on a listener of their own so that reaching them does not mean reaching the MCP endpoint. State a port no application listener binds.";
+        }
+
+        if (this.Transport is HealthEndpointTransport.HttpAndHttps && this.HttpsPort == this.Port)
+        {
+            yield return $"{SectionName}:{nameof(this.HttpsPort)} — '{this.Port}' is already the clear-text probe port, and one socket cannot serve both schemes. State a second port for the TLS listener.";
+        }
+    }
+
+    private IEnumerable<string> FindTransportErrors()
+    {
+        if (!Enum.IsDefined(this.Transport))
+        {
+            yield return $"{SectionName}:{nameof(this.Transport)} — '{(int)this.Transport}' names no transport; state '{nameof(HealthEndpointTransport.Http)}', '{nameof(HealthEndpointTransport.HttpAndHttps)}', or '{nameof(HealthEndpointTransport.HttpsOnly)}'.";
+
+            yield break;
+        }
+
+        if (this.Transport is HealthEndpointTransport.HttpAndHttps && this.HttpsPort is null)
+        {
+            yield return $"{SectionName}:{nameof(this.HttpsPort)} — '{nameof(HealthEndpointTransport.HttpAndHttps)}' serves both schemes and one socket serves one scheme, so the TLS listener needs a port of its own. State one, or select '{nameof(HealthEndpointTransport.Http)}' or '{nameof(HealthEndpointTransport.HttpsOnly)}'.";
+        }
+
+        // Refused rather than ignored, for the reason the certificate block below is: a port an operator published and
+        // nothing binds is a deployment believing its probes answer somewhere they do not.
+        if (this.Transport is not HealthEndpointTransport.HttpAndHttps && this.HttpsPort is not null)
+        {
+            yield return $"{SectionName}:{nameof(this.HttpsPort)} — a second port is configured while '{nameof(this.Transport)}' opens one listener, so nothing binds it. Select '{nameof(HealthEndpointTransport.HttpAndHttps)}', or remove it and state the port through '{nameof(this.Port)}'.";
+        }
+
+        if (!this.TerminatesTls)
+        {
+            if (IsConfigured(this.ServerCertificate?.Bundle)
+                || IsConfigured(this.ServerCertificate?.CertificateChain)
+                || IsConfigured(this.ServerCertificate?.PrivateKey))
+            {
+                yield return $"{SectionName}:{nameof(this.ServerCertificate)} — a server certificate is configured while '{nameof(this.Transport)}' opens no TLS listener, so nothing presents it; select '{nameof(HealthEndpointTransport.HttpAndHttps)}' or '{nameof(HealthEndpointTransport.HttpsOnly)}', or remove the material.";
+            }
+
+            yield break;
+        }
+
+        if (string.IsNullOrWhiteSpace(this.Domain))
+        {
+            yield return $"{SectionName}:{nameof(this.Domain)} — a TLS transport must state the DNS domain its certificate covers, which is what the configured material is proven against before the listener is opened.";
+        }
+
+        foreach (var error in this.FindServerCertificateErrors())
+        {
+            yield return error;
+        }
+    }
+
+    /// <summary>Refuses a certificate block that names neither kind of material or both of them.</summary>
+    /// <remarks>Only the shape is decided here, on the same terms the MCP HTTPS profiles state it. Whether the referenced material resolves, parses, carries a matching private key, and covers the domain is the loader's question.</remarks>
+    private IEnumerable<string> FindServerCertificateErrors()
+    {
+        var settingPath = $"{SectionName}:{nameof(this.ServerCertificate)}";
+        var bundleConfigured = IsConfigured(this.ServerCertificate?.Bundle);
+        var chainConfigured = IsConfigured(this.ServerCertificate?.CertificateChain);
+        var privateKeyConfigured = IsConfigured(this.ServerCertificate?.PrivateKey);
+
+        if (bundleConfigured && (chainConfigured || privateKeyConfigured))
+        {
+            yield return $"{settingPath} — a PKCS#12 bundle and separate PEM material are both configured; state one or the other, because which of them supplies the identity would otherwise be decided by nothing an operator wrote.";
+
+            yield break;
+        }
+
+        if (bundleConfigured)
+        {
+            yield break;
+        }
+
+        if (!chainConfigured && !privateKeyConfigured)
+        {
+            yield return $"{settingPath} — a TLS transport must state where its certificate comes from: a '{nameof(TlsServerCertificateOptions.Bundle)}' holding a PKCS#12 bundle, or a '{nameof(TlsServerCertificateOptions.CertificateChain)}' beside its '{nameof(TlsServerCertificateOptions.PrivateKey)}'. There is no development-certificate fallback and no self-signed one, because a probe answering on a port an operator believed was TLS is worse than one that does not answer.";
+
+            yield break;
+        }
+
+        if (!chainConfigured)
+        {
+            yield return $"{settingPath}:{nameof(TlsServerCertificateOptions.CertificateChain)} — a private key is configured with no certificate to pair it with.";
+        }
+
+        if (!privateKeyConfigured)
+        {
+            yield return $"{settingPath}:{nameof(TlsServerCertificateOptions.PrivateKey)} — a certificate is configured with no private key, so the listener could name the domain but not prove it is the domain.";
+        }
+    }
+
+    private static IEnumerable<string> FindPortRangeErrors(int port, string settingName)
+    {
+        if (port is < 1 or > 65535)
+        {
+            yield return $"{SectionName}:{settingName} — '{port}' is not a TCP port; state a value between 1 and 65535.";
+        }
+    }
+
+    private static bool IsConfigured(ConfiguredSecret? block) =>
+        block is not null && !string.IsNullOrWhiteSpace(block.SecretReference);
+}

--- a/src/Host/Configuration/HealthEndpointTransport.cs
+++ b/src/Host/Configuration/HealthEndpointTransport.cs
@@ -1,0 +1,29 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace MailFathom.Host.Configuration;
+
+/// <summary>Which schemes the health-endpoint listener is opened under.</summary>
+/// <remarks>
+/// <para>
+/// One socket serves one scheme, which is why the two-scheme member needs a second port rather than a flag. The set is
+/// closed at three members because those are the three postures a probe network has: clear text on a network the
+/// operator already trusts, TLS everywhere, and the interval during which a deployment is moving from the first to the
+/// second and both have to answer.
+/// </para>
+/// <para>
+/// Clear text is the default, so adopting the release costs no certificate work. TLS is an upgrade a deployment takes
+/// deliberately, and taking it never leaves a clear-text listener behind: <see cref="HttpsOnly" /> opens no such socket.
+/// </para>
+/// </remarks>
+internal enum HealthEndpointTransport
+{
+    /// <summary>Serve the probes over clear-text HTTP on the configured port, and open no TLS listener.</summary>
+    Http = 0,
+
+    /// <summary>Serve the probes over clear-text HTTP on the configured port and over TLS on the configured HTTPS port.</summary>
+    HttpAndHttps = 1,
+
+    /// <summary>Serve the probes over TLS on the configured port, and open no clear-text listener.</summary>
+    HttpsOnly = 2,
+}

--- a/src/Host/Configuration/McpHttpsEndpointOptions.cs
+++ b/src/Host/Configuration/McpHttpsEndpointOptions.cs
@@ -3,7 +3,6 @@
 
 using System.Net;
 using MailFathom.Infrastructure.Certificates;
-using MailFathom.Infrastructure.Secrets;
 
 namespace MailFathom.Host.Configuration;
 
@@ -107,7 +106,9 @@ internal sealed class McpHttpsEndpointOptions
             yield return error;
         }
 
-        foreach (var error in this.FindServerCertificateErrors(configurationPath))
+        // The shape of the material block is the same question for every listener that terminates TLS, so it is asked
+        // by the type that carries it rather than restated per section.
+        foreach (var error in this.ServerCertificate.FindConfigurationErrors($"{configurationPath}:{nameof(this.ServerCertificate)}"))
         {
             yield return error;
         }
@@ -115,35 +116,18 @@ internal sealed class McpHttpsEndpointOptions
 
     private IEnumerable<string> FindDomainErrors(string configurationPath)
     {
-        var domain = this.Domain?.Trim() ?? string.Empty;
         var settingPath = $"{configurationPath}:{nameof(this.Domain)}";
 
-        if (string.IsNullOrEmpty(domain))
+        if (string.IsNullOrWhiteSpace(this.Domain))
         {
             yield return $"{settingPath} — an HTTPS profile must state the DNS domain it publishes, which is the name clients connect to and the name its certificate has to cover.";
 
             yield break;
         }
 
-        if (!domain.All(char.IsAscii))
+        foreach (var error in ConfiguredDnsName.FindErrors(this.Domain, settingPath))
         {
-            yield return $"{settingPath} — state an internationalized domain in its punycode A-label form, because that is what a client sends and what a certificate's subject alternative names carry.";
-
-            yield break;
-        }
-
-        var hostNameKind = Uri.CheckHostName(domain);
-
-        if (hostNameKind is UriHostNameType.IPv4 or UriHostNameType.IPv6)
-        {
-            yield return $"{settingPath} — an IP address cannot be the published identity: a client sends no server name for one, so no profile could be selected. State the DNS domain and bind the address through '{nameof(this.BindAddress)}'.";
-
-            yield break;
-        }
-
-        if (hostNameKind != UriHostNameType.Dns)
-        {
-            yield return $"{settingPath} — '{domain}' is not a DNS domain. Wildcard and catch-all names are deliberately not accepted; state the exact name this profile serves.";
+            yield return error;
         }
     }
 
@@ -182,49 +166,4 @@ internal sealed class McpHttpsEndpointOptions
             yield return $"{settingPath} — '{nameof(McpHttpProtocol.Http3)}' is configured and this host cannot provide the QUIC transport it needs; install the platform's QUIC support or remove the version rather than have it quietly fall back.";
         }
     }
-
-    /// <summary>Refuses a certificate block that names neither material or both kinds of it.</summary>
-    /// <remarks>
-    /// Only the shape is decided here. Whether the referenced material resolves, parses, carries a matching private
-    /// key, and covers the domain is the loader's question, answered against real material before the endpoint serves.
-    /// </remarks>
-    private IEnumerable<string> FindServerCertificateErrors(string configurationPath)
-    {
-        var settingPath = $"{configurationPath}:{nameof(this.ServerCertificate)}";
-        var bundleConfigured = IsConfigured(this.ServerCertificate?.Bundle);
-        var chainConfigured = IsConfigured(this.ServerCertificate?.CertificateChain);
-        var privateKeyConfigured = IsConfigured(this.ServerCertificate?.PrivateKey);
-
-        if (bundleConfigured && (chainConfigured || privateKeyConfigured))
-        {
-            yield return $"{settingPath} — a PKCS#12 bundle and separate PEM material are both configured; state one or the other, because which of them supplies the identity would otherwise be decided by nothing an operator wrote.";
-
-            yield break;
-        }
-
-        if (bundleConfigured)
-        {
-            yield break;
-        }
-
-        if (!chainConfigured && !privateKeyConfigured)
-        {
-            yield return $"{settingPath} — an HTTPS profile must state where its certificate comes from: a '{nameof(TlsServerCertificateOptions.Bundle)}' holding a PKCS#12 bundle, or a '{nameof(TlsServerCertificateOptions.CertificateChain)}' beside its '{nameof(TlsServerCertificateOptions.PrivateKey)}'.";
-
-            yield break;
-        }
-
-        if (!chainConfigured)
-        {
-            yield return $"{settingPath}:{nameof(TlsServerCertificateOptions.CertificateChain)} — a private key is configured with no certificate to pair it with.";
-        }
-
-        if (!privateKeyConfigured)
-        {
-            yield return $"{settingPath}:{nameof(TlsServerCertificateOptions.PrivateKey)} — a certificate is configured with no private key, so the endpoint could name the domain but not prove it is the domain.";
-        }
-    }
-
-    private static bool IsConfigured(ConfiguredSecret? block) =>
-        block is not null && !string.IsNullOrWhiteSpace(block.SecretReference);
 }

--- a/src/Host/Hosting/DatabaseSchemaStartupGate.cs
+++ b/src/Host/Hosting/DatabaseSchemaStartupGate.cs
@@ -32,19 +32,26 @@ internal sealed partial class DatabaseSchemaStartupGate : IHostedService
 {
     private readonly IServiceScopeFactory scopeFactory;
     private readonly PostgresTextSearchConfiguration configuredTextSearchConfiguration;
+    private readonly HostStartupGates startupGates;
     private readonly ILogger<DatabaseSchemaStartupGate> logger;
 
     /// <summary>Initializes a new database schema startup gate.</summary>
     /// <param name="scopeFactory">Creates the scope the inspector is resolved from.</param>
     /// <param name="configuredTextSearchConfiguration">The configuration the EF Core model was built from.</param>
+    /// <param name="startupGates">The tracker this gate reports its completion to, which is what the startup probe reads.</param>
     /// <param name="logger">The startup logger.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="startupGates" /> is <see langword="null" />.</exception>
     public DatabaseSchemaStartupGate(
         IServiceScopeFactory scopeFactory,
         PostgresTextSearchConfiguration configuredTextSearchConfiguration,
+        HostStartupGates startupGates,
         ILogger<DatabaseSchemaStartupGate> logger)
     {
+        ArgumentNullException.ThrowIfNull(startupGates);
+
         this.scopeFactory = scopeFactory;
         this.configuredTextSearchConfiguration = configuredTextSearchConfiguration;
+        this.startupGates = startupGates;
         this.logger = logger;
     }
 
@@ -73,6 +80,8 @@ internal sealed partial class DatabaseSchemaStartupGate : IHostedService
         await this.VerifyTheLexicalIndexMatchesTheConfigurationAsync(inspector, cancellationToken);
 
         this.LogSchemaCurrent();
+
+        this.startupGates.MarkCompleted(HostStartupGate.DatabaseSchema);
     }
 
     /// <summary>Fails startup when the search vector was built with a configuration this process is not configured for.</summary>

--- a/src/Host/Hosting/HealthEndpointIsolation.cs
+++ b/src/Host/Hosting/HealthEndpointIsolation.cs
@@ -1,0 +1,66 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace MailFathom.Host.Hosting;
+
+/// <summary>Keeps the probe paths off the application listener and everything else off the probe listener.</summary>
+/// <remarks>
+/// <para>
+/// The decision is taken from the port the connection arrived at, which is a property of the socket the operating
+/// system accepted it on and therefore something a caller cannot state, spoof, or forward. A host header or a path
+/// prefix would be a claim the request makes about itself; this is what the deployment published.
+/// </para>
+/// <para>
+/// It runs ahead of everything the MCP endpoint adds, so a request for <c>/mcp</c> that arrived on the probe port is
+/// refused before it reaches CORS, authentication, the client-certificate check, or the rate limiter — none of which
+/// are configured on that listener and none of which should be reached from it. A probe request on the application
+/// port is refused just as early, which is what keeps an unauthenticated dependency report off the network MCP clients
+/// connect to.
+/// </para>
+/// <para>
+/// The refusal is a bare <c>404</c>, the same answer an unmapped path receives. A response distinguishing "wrong
+/// listener" from "no such route" would tell an unauthenticated caller that the probes exist and where to look for
+/// them.
+/// </para>
+/// </remarks>
+internal static class HealthEndpointIsolation
+{
+    /// <summary>Reports whether the listener a request arrived at serves the path it asked for.</summary>
+    /// <param name="localPort">The TCP port the connection was accepted on.</param>
+    /// <param name="path">The request path.</param>
+    /// <param name="probeListenerPorts">The ports the probes are served on.</param>
+    /// <returns><see langword="true" /> when this listener serves this path, otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="probeListenerPorts" /> is <see langword="null" />.</exception>
+    /// <remarks>The two directions are one rule: a probe listener serves probe paths and nothing else, and every other listener serves everything else.</remarks>
+    internal static bool ListenerServesPath(int localPort, PathString path, IReadOnlySet<int> probeListenerPorts)
+    {
+        ArgumentNullException.ThrowIfNull(probeListenerPorts);
+
+        return probeListenerPorts.Contains(localPort) == HealthProbe.IsProbePath(path);
+    }
+
+    /// <summary>Refuses every request whose listener does not serve its path.</summary>
+    /// <param name="app">The application pipeline being composed.</param>
+    /// <param name="probeListenerPorts">The ports the probes are served on.</param>
+    /// <returns>The same application instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal static IApplicationBuilder UseHealthEndpointIsolation(
+        this IApplicationBuilder app,
+        IReadOnlySet<int> probeListenerPorts)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(probeListenerPorts);
+
+        return app.Use(async (context, next) =>
+        {
+            if (!ListenerServesPath(context.Connection.LocalPort, context.Request.Path, probeListenerPorts))
+            {
+                context.Response.StatusCode = StatusCodes.Status404NotFound;
+
+                return;
+            }
+
+            await next(context);
+        });
+    }
+}

--- a/src/Host/Hosting/HealthProbe.cs
+++ b/src/Host/Hosting/HealthProbe.cs
@@ -44,15 +44,25 @@ internal sealed record HealthProbe(string Path, string Tag)
     /// <remarks>Declared last so the members it lists are already initialized when this initializer runs.</remarks>
     internal static IReadOnlyList<HealthProbe> All { get; } = [Startup, Readiness, Liveness];
 
-    /// <summary>Reports whether a request path is one of the probe paths.</summary>
+    /// <summary>Reports whether a request path is one a probe endpoint answers.</summary>
     /// <param name="path">The request path.</param>
-    /// <returns><see langword="true" /> when the path is served by a probe, otherwise <see langword="false" />.</returns>
+    /// <returns><see langword="true" /> when a probe endpoint would answer the path, otherwise <see langword="false" />.</returns>
     /// <remarks>
-    /// The comparison is exact rather than by segment prefix. A probe answers one path, so treating <c>/health/x</c> as
-    /// a probe path would keep a request off the application listener that no probe was ever going to answer.
+    /// <para>
+    /// This has to match what routing matches, not what the path literally reads as, because the two decide the same
+    /// request. Routing ignores a trailing slash, so <c>/health/</c> reaches the readiness endpoint; a comparison for
+    /// exact equality would call that path an application one, let it past the listener isolation, and serve the
+    /// aggregate dependency status on the listener MCP clients reach.
+    /// </para>
+    /// <para>
+    /// The trailing slash is the whole of the tolerance. A path beneath a probe — <c>/health/details</c> — is not a
+    /// probe path, because no probe answers it and treating it as one would keep a request off the application
+    /// listener that nothing here was ever going to serve.
+    /// </para>
     /// </remarks>
     internal static bool IsProbePath(PathString path) =>
-        All.Any(probe => path.Equals(probe.Path, StringComparison.OrdinalIgnoreCase));
+        All.Any(probe => path.StartsWithSegments(probe.Path, StringComparison.OrdinalIgnoreCase, out var remaining)
+            && (!remaining.HasValue || string.Equals(remaining.Value, "/", StringComparison.Ordinal)));
 
     /// <summary>Reports whether a registered health check belongs to this probe.</summary>
     /// <param name="registration">The health-check registration.</param>

--- a/src/Host/Hosting/HealthProbe.cs
+++ b/src/Host/Hosting/HealthProbe.cs
@@ -20,14 +20,31 @@ namespace MailFathom.Host.Hosting;
 /// restart the process.
 /// </para>
 /// <para>
-/// Both the path and the tag are published identities: the path is what a Kubernetes probe or a Compose health check
-/// names, and the tag is what a registration writes. Neither is renamed without changing what a deployment configured.
+/// It is a closed enumeration rather than a C# <see langword="enum" />, because each member carries the two published
+/// identities that make it what it is: the path a Kubernetes probe or a Compose health check names, and the tag a
+/// registration writes. Keeping either in a table beside the members would let the two drift, and neither is renamed
+/// without changing what a deployment configured. The set is closed because these three are the questions an
+/// orchestrator asks; a fourth probe is a change to what the listener serves, not a value a caller constructs.
+/// </para>
+/// <para>
+/// Nothing parses this from outside the process or serializes it out of one — the paths reach configuration as literals
+/// an operator writes and the tags reach registrations as literals the host writes — so the type carries no
+/// <c>TryParse</c> and no JSON converter. Being a struct, <see langword="default" /> is reachable and is not a probe;
+/// it reports itself through <see cref="IsSpecified" /> and refuses to answer for a path or a tag.
 /// </para>
 /// </remarks>
-/// <param name="Path">The request path this probe answers on, served only on the health-endpoint listener.</param>
-/// <param name="Tag">The health-check tag that selects the checks this probe reports.</param>
-internal sealed record HealthProbe(string Path, string Tag)
+internal readonly record struct HealthProbe
 {
+    private readonly string? path;
+
+    private readonly string? tag;
+
+    private HealthProbe(string path, string tag)
+    {
+        this.path = path;
+        this.tag = tag;
+    }
+
     /// <summary>Gets the probe reporting whether the host's startup gates have completed.</summary>
     /// <remarks>It answers "has this process finished coming up", which is what distinguishes a slow first start from one that is failing.</remarks>
     internal static HealthProbe Startup { get; } = new("/started", "startup");
@@ -43,6 +60,19 @@ internal sealed record HealthProbe(string Path, string Tag)
     /// <summary>Gets every probe the health-endpoint listener serves.</summary>
     /// <remarks>Declared last so the members it lists are already initialized when this initializer runs.</remarks>
     internal static IReadOnlyList<HealthProbe> All { get; } = [Startup, Readiness, Liveness];
+
+    /// <summary>Gets whether this value names a probe rather than the unusable struct default.</summary>
+    internal bool IsSpecified => this.path is not null;
+
+    /// <summary>Gets the request path this probe answers on, served only on the health-endpoint listener.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a probe.</exception>
+    internal string Path => this.path
+        ?? throw new InvalidOperationException("The value is the default of the struct and answers no probe path.");
+
+    /// <summary>Gets the health-check tag that selects the checks this probe reports.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a probe.</exception>
+    internal string Tag => this.tag
+        ?? throw new InvalidOperationException("The value is the default of the struct and selects no health check.");
 
     /// <summary>Reports whether a request path is one a probe endpoint answers.</summary>
     /// <param name="path">The request path.</param>
@@ -74,4 +104,8 @@ internal sealed record HealthProbe(string Path, string Tag)
 
         return registration.Tags.Contains(this.Tag);
     }
+
+    /// <inheritdoc />
+    /// <remarks>The path, because that is the identity a probe is read by wherever this reaches a diagnostic.</remarks>
+    public override string ToString() => this.path ?? "(unspecified)";
 }

--- a/src/Host/Hosting/HealthProbe.cs
+++ b/src/Host/Hosting/HealthProbe.cs
@@ -1,0 +1,67 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace MailFathom.Host.Hosting;
+
+/// <summary>One of the three questions an orchestrator asks a process, and the checks that answer it.</summary>
+/// <remarks>
+/// <para>
+/// Three probes rather than one endpoint, because the three have different consequences. A failed startup probe extends
+/// the grace period a slow first start is allowed, a failed readiness probe removes the instance from traffic, and a
+/// failed liveness probe kills the container. One answer wired to all three turns any of those outcomes into all of
+/// them: a database outage would restart every replica of a process that is working correctly.
+/// </para>
+/// <para>
+/// Which checks a probe consults is decided by <see cref="Tag" /> rather than by three lists maintained beside the
+/// registrations. A check states its probe membership once, where it is registered, and a check that states none
+/// reaches no probe — deliberately, because silently landing in all three is how a dependency check ends up able to
+/// restart the process.
+/// </para>
+/// <para>
+/// Both the path and the tag are published identities: the path is what a Kubernetes probe or a Compose health check
+/// names, and the tag is what a registration writes. Neither is renamed without changing what a deployment configured.
+/// </para>
+/// </remarks>
+/// <param name="Path">The request path this probe answers on, served only on the health-endpoint listener.</param>
+/// <param name="Tag">The health-check tag that selects the checks this probe reports.</param>
+internal sealed record HealthProbe(string Path, string Tag)
+{
+    /// <summary>Gets the probe reporting whether the host's startup gates have completed.</summary>
+    /// <remarks>It answers "has this process finished coming up", which is what distinguishes a slow first start from one that is failing.</remarks>
+    internal static HealthProbe Startup { get; } = new("/started", "startup");
+
+    /// <summary>Gets the probe reporting whether the process can serve a request right now.</summary>
+    /// <remarks>It consults the dependencies a request actually needs, the database among them, so an unreachable database removes the instance from traffic without restarting it.</remarks>
+    internal static HealthProbe Readiness { get; } = new("/health", "ready");
+
+    /// <summary>Gets the probe reporting whether the process is still running rather than stuck.</summary>
+    /// <remarks>It consults process-local state only. A dependency outage must never reach it, because the restart it would trigger cannot fix anything outside this process and turns one outage into two.</remarks>
+    internal static HealthProbe Liveness { get; } = new("/alive", "live");
+
+    /// <summary>Gets every probe the health-endpoint listener serves.</summary>
+    /// <remarks>Declared last so the members it lists are already initialized when this initializer runs.</remarks>
+    internal static IReadOnlyList<HealthProbe> All { get; } = [Startup, Readiness, Liveness];
+
+    /// <summary>Reports whether a request path is one of the probe paths.</summary>
+    /// <param name="path">The request path.</param>
+    /// <returns><see langword="true" /> when the path is served by a probe, otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// The comparison is exact rather than by segment prefix. A probe answers one path, so treating <c>/health/x</c> as
+    /// a probe path would keep a request off the application listener that no probe was ever going to answer.
+    /// </remarks>
+    internal static bool IsProbePath(PathString path) =>
+        All.Any(probe => path.Equals(probe.Path, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>Reports whether a registered health check belongs to this probe.</summary>
+    /// <param name="registration">The health-check registration.</param>
+    /// <returns><see langword="true" /> when the registration carries this probe's tag, otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="registration" /> is <see langword="null" />.</exception>
+    internal bool Selects(HealthCheckRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+
+        return registration.Tags.Contains(this.Tag);
+    }
+}

--- a/src/Host/Hosting/HealthProbeEndpoints.cs
+++ b/src/Host/Hosting/HealthProbeEndpoints.cs
@@ -1,0 +1,93 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Net.Mime;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace MailFathom.Host.Hosting;
+
+/// <summary>Maps the three probe paths and decides what a probe response says.</summary>
+/// <remarks>
+/// The endpoints carry no authentication, no authorization, no API-key check, no origin gate, and no rate limiting.
+/// That is the posture rather than an omission: an orchestrator holds no credential, and a throttled probe fails, which
+/// for the liveness probe means restarting a process that was answering correctly. Exposure is controlled by which
+/// network the probe port is published on and by the transport it is served under, and by nothing else.
+/// </remarks>
+internal static class HealthProbeEndpoints
+{
+    /// <summary>Maps one endpoint per probe onto the routes the health-endpoint listener answers.</summary>
+    /// <param name="app">The application being composed.</param>
+    /// <returns>The same application instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="app" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Each endpoint states its own predicate, so a check with no tag reaches no probe. The default predicate would
+    /// include every registered check in every probe, which is how a dependency check ends up able to restart the
+    /// process.
+    /// </remarks>
+    internal static WebApplication MapHealthProbes(this WebApplication app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        foreach (var probe in HealthProbe.All)
+        {
+            app.MapHealthChecks(probe.Path, new HealthCheckOptions
+            {
+                Predicate = probe.Selects,
+                ResponseWriter = WriteAggregateStatusAsync,
+            })
+
+            // Stated rather than inferred from the absence of a policy, so a deployment that later acquires a fallback
+            // authorization policy cannot close the one surface an orchestrator has no credential for.
+            .AllowAnonymous();
+        }
+
+        return app;
+    }
+
+    /// <summary>Writes the aggregate status and nothing else.</summary>
+    /// <param name="context">The request being answered.</param>
+    /// <param name="report">The report the probe's checks produced.</param>
+    /// <returns>A task that completes once the status has been written.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Check names, exception messages, stack traces, durations, connection strings, host names, and dependency
+    /// descriptions are all absent. The endpoint's exposure is decided by which network its port is on, and a richer
+    /// body would make that decision an information-disclosure decision as well: what a probe needs is the one word an
+    /// orchestrator compares, and everything beyond it describes this deployment's internals to whoever can reach the
+    /// port.
+    /// </remarks>
+    internal static Task WriteAggregateStatusAsync(HttpContext context, HealthReport report)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(report);
+
+        context.Response.ContentType = MediaTypeNames.Text.Plain;
+
+        return context.Response.WriteAsync(report.Status.ToString());
+    }
+
+    /// <summary>Reports the probes no registered check answers.</summary>
+    /// <param name="registrations">Every health check registered anywhere in the host.</param>
+    /// <returns>One message per probe that selects no check, empty when all three are answered.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="registrations" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A probe over no checks reports healthy, because the aggregate of nothing is healthy. For readiness that is the
+    /// worst possible answer: an instance that cannot reach its database would keep receiving traffic and report itself
+    /// fit while doing so. Membership is decided by a tag rather than by a list, and a tag is exactly the kind of thing
+    /// that stops matching without anything failing, so composition asserts the result rather than the wiring.
+    /// </remarks>
+    internal static IReadOnlyList<string> FindUnansweredProbes(IEnumerable<HealthCheckRegistration> registrations)
+    {
+        ArgumentNullException.ThrowIfNull(registrations);
+
+        var registered = registrations.ToArray();
+
+        return
+        [
+            .. HealthProbe.All
+                .Where(probe => !registered.Any(probe.Selects))
+                .Select(static probe => $"No registered health check carries the '{probe.Tag}' tag, so the probe served at {probe.Path} would report healthy without consulting anything."),
+        ];
+    }
+}

--- a/src/Host/Hosting/HostStartupGate.cs
+++ b/src/Host/Hosting/HostStartupGate.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace MailFathom.Host.Hosting;
+
+/// <summary>A step the host completes before it is finished coming up.</summary>
+/// <remarks>
+/// Both steps reach a remote dependency and both take as long as that dependency does, which is the interval a startup
+/// probe exists to cover. Under the builder MailFathom composes with, they run before the web host opens its listener,
+/// so an orchestrator ordinarily sees a refused connection rather than an unhealthy probe during that interval and
+/// counts it the same way. The probe reports the gates regardless, because that ordering is an implementation detail of
+/// the framework's composition and not something the answer should depend on.
+/// </remarks>
+internal enum HostStartupGate
+{
+    /// <summary>Every configured secret reference has been resolved and the material behind it proven usable.</summary>
+    SecretConfiguration = 0,
+
+    /// <summary>The database carries every migration this build defines, and its lexical index matches the configured text search configuration.</summary>
+    DatabaseSchema = 1,
+}

--- a/src/Host/Hosting/HostStartupGates.cs
+++ b/src/Host/Hosting/HostStartupGates.cs
@@ -1,0 +1,62 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace MailFathom.Host.Hosting;
+
+/// <summary>Tracks which of the host's startup gates have completed, which is what the startup probe reports.</summary>
+/// <remarks>
+/// <para>
+/// The expected gates are stated once, by the composition root that registers the services performing them, so a gate
+/// that is added and never reported keeps the probe unhealthy rather than being silently absent from the answer.
+/// </para>
+/// <para>
+/// A gate that fails does not report itself. It throws instead and takes the host down, so the states this distinguishes
+/// are "still coming up" and "finished", which is exactly what a startup probe asks. Completion is latching: a gate runs
+/// once during startup and nothing sets it back, so an orchestrator that has seen a healthy startup probe keeps seeing
+/// one and hands the process over to the liveness and readiness probes. Nothing here re-runs a gate's work either — the
+/// startup probe reads a flag rather than reaching a dependency, which is what keeps polling it free.
+/// </para>
+/// <para>
+/// The instance is a singleton written from the startup path and read from probe requests arriving on another thread,
+/// so every read and write of the pending set is taken under the same lock.
+/// </para>
+/// </remarks>
+internal sealed class HostStartupGates
+{
+    private readonly Lock mutex = new();
+    private readonly HashSet<HostStartupGate> pendingGates;
+
+    /// <summary>Initializes the tracker over the gates this host runs.</summary>
+    /// <param name="expectedGates">Every gate that must complete before the host has finished coming up.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="expectedGates" /> is <see langword="null" />.</exception>
+    /// <remarks>An empty set reports completion immediately, which is the honest answer for a host that runs no gate rather than a reason to refuse the configuration.</remarks>
+    public HostStartupGates(params IReadOnlyList<HostStartupGate> expectedGates)
+    {
+        ArgumentNullException.ThrowIfNull(expectedGates);
+
+        this.pendingGates = [.. expectedGates];
+    }
+
+    /// <summary>Gets whether every expected gate has completed.</summary>
+    internal bool Completed
+    {
+        get
+        {
+            lock (this.mutex)
+            {
+                return this.pendingGates.Count == 0;
+            }
+        }
+    }
+
+    /// <summary>Records that a gate has completed.</summary>
+    /// <param name="gate">The gate that finished.</param>
+    /// <remarks>Reporting a gate this host does not expect changes nothing, so a service that is registered conditionally can report unconditionally.</remarks>
+    internal void MarkCompleted(HostStartupGate gate)
+    {
+        lock (this.mutex)
+        {
+            this.pendingGates.Remove(gate);
+        }
+    }
+}

--- a/src/Host/Hosting/HostStartupGatesHealthCheck.cs
+++ b/src/Host/Hosting/HostStartupGatesHealthCheck.cs
@@ -1,0 +1,39 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace MailFathom.Host.Hosting;
+
+/// <summary>Reports whether the host has finished coming up, which is the one question the startup probe asks.</summary>
+/// <remarks>
+/// It consults process-local state only and reaches no dependency. The gates it reports on are the ones that talk to a
+/// dependency, and they have already failed the host if the dependency refused them, so asking again here would turn a
+/// startup probe into a second readiness probe.
+/// </remarks>
+internal sealed class HostStartupGatesHealthCheck : IHealthCheck
+{
+    /// <summary>The name the check is registered under.</summary>
+    internal const string Name = "startup-gates";
+
+    private readonly HostStartupGates startupGates;
+
+    /// <summary>Initializes a new startup-gate health check.</summary>
+    /// <param name="startupGates">The tracker the host's gates report their completion to.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="startupGates" /> is <see langword="null" />.</exception>
+    public HostStartupGatesHealthCheck(HostStartupGates startupGates)
+    {
+        ArgumentNullException.ThrowIfNull(startupGates);
+
+        this.startupGates = startupGates;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>The description names no gate. A probe response carries the aggregate status alone, and a description that named the pending step would only reach a log an operator already has the startup records in.</remarks>
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(this.startupGates.Completed
+            ? HealthCheckResult.Healthy("The host has completed every startup gate.")
+            : HealthCheckResult.Unhealthy("The host is still completing its startup gates."));
+}

--- a/src/Host/Hosting/SecretConfigurationStartupValidator.cs
+++ b/src/Host/Hosting/SecretConfigurationStartupValidator.cs
@@ -32,10 +32,11 @@ internal sealed partial class SecretConfigurationStartupValidator : IHostedLifec
     private readonly McpEndpointOptions mcpEndpointSettings;
     private readonly SecretConfigurationValidator validator;
     private readonly SecretResolutionOptions resolutionOptions;
+    private readonly HostStartupGates startupGates;
     private readonly ILogger<SecretConfigurationStartupValidator> logger;
 
     /// <summary>Initializes a new secret configuration startup validator.</summary>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="mcpEndpointSettings" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="mcpEndpointSettings" /> or <paramref name="startupGates" /> is <see langword="null" />.</exception>
     /// <remarks>The endpoint settings arrive as the composed value rather than as a snapshot, because the section is read once while the host is built and takes a restart to change.</remarks>
     public SecretConfigurationStartupValidator(
         ISettingsSnapshot<MailSynchronizationOptions> mailSynchronizationSettings,
@@ -43,15 +44,18 @@ internal sealed partial class SecretConfigurationStartupValidator : IHostedLifec
         IOptions<McpEndpointOptions> mcpEndpointSettings,
         SecretConfigurationValidator validator,
         SecretResolutionOptions resolutionOptions,
+        HostStartupGates startupGates,
         ILogger<SecretConfigurationStartupValidator> logger)
     {
         ArgumentNullException.ThrowIfNull(mcpEndpointSettings);
+        ArgumentNullException.ThrowIfNull(startupGates);
 
         this.mailSynchronizationSettings = mailSynchronizationSettings;
         this.persistenceSettings = persistenceSettings;
         this.mcpEndpointSettings = mcpEndpointSettings.Value;
         this.validator = validator;
         this.resolutionOptions = resolutionOptions;
+        this.startupGates = startupGates;
         this.logger = logger;
     }
 
@@ -82,6 +86,8 @@ internal sealed partial class SecretConfigurationStartupValidator : IHostedLifec
             // after one options type; each message already names the exact path an operator edits.
             throw new OptionsValidationException("Secrets", typeof(SecretResolutionOptions), failures);
         }
+
+        this.startupGates.MarkCompleted(HostStartupGate.SecretConfiguration);
     }
 
     /// <inheritdoc />

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -18,6 +18,7 @@ using MailFathom.Infrastructure.Persistence;
 using MailFathom.Infrastructure.Resilience;
 using MailFathom.Infrastructure.Secrets;
 using MailFathom.Mcp;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 
 // Composed before anything else, CreateBuilder included, so that a malformed appsettings.json, a failure during
@@ -168,6 +169,15 @@ try
         var searchSettings = provider.GetRequiredService<IOptions<MailboxSearchOptions>>().Value;
         return EmailSearchSnippetBounds.Create(searchSettings.SnippetsPerEmail, searchSettings.WordsPerSnippet);
     });
+    // What the startup probe reports. Both gates reach a remote dependency, so both take as long as that dependency
+    // does, and an orchestrator's startup probe is what turns that interval into an extended grace period rather than
+    // into a failing instance. The probe answers from this tracker rather than from the order the framework happens to
+    // start its hosted services in.
+    builder.Services.AddSingleton(new HostStartupGates(
+        HostStartupGate.SecretConfiguration,
+        HostStartupGate.DatabaseSchema));
+    builder.Services.AddHealthChecks()
+        .AddCheck<HostStartupGatesHealthCheck>(HostStartupGatesHealthCheck.Name, tags: [HealthProbe.Startup.Tag]);
     // The validator is registered ahead of the worker so hosted-service ordering reinforces the StartingAsync ordering
     // rather than depending on it alone, and ahead of the infrastructure so an operator who mistyped several references
     // reads one aggregated report rather than whichever failure the database happened to hit first.
@@ -193,9 +203,14 @@ try
     // one, and read from configuration directly for the same reason the text search configuration is: the value has to
     // be known before the container that would resolve an options snapshot exists. PersistenceOptions validates the
     // same key on start, which is what reports an out-of-range value to an operator.
-    builder.AddDatabaseHealthAndTelemetry(TimeSpan.FromSeconds(builder.Configuration.GetValue(
-        "Persistence:CommandTimeoutSeconds",
-        HostApplicationBuilderExtensions.DefaultDatabaseCommandTimeoutSeconds)));
+    // Readiness alone. The database is a dependency a request needs, so an unreachable one must remove this instance
+    // from traffic; it must never reach the liveness probe, because restarting a process cannot fix a database and
+    // would turn one outage into an outage plus a restart loop.
+    builder.AddDatabaseHealthAndTelemetry(
+        TimeSpan.FromSeconds(builder.Configuration.GetValue(
+            "Persistence:CommandTimeoutSeconds",
+            HostApplicationBuilderExtensions.DefaultDatabaseCommandTimeoutSeconds)),
+        probeTags: [HealthProbe.Readiness.Tag]);
     // Ahead of the workers so no unit of work reads or writes mail before the schema this build expects is proven, and
     // after the infrastructure that registers the inspector it resolves.
     builder.Services.AddHostedService<DatabaseSchemaStartupGate>();
@@ -285,20 +300,99 @@ try
         builder.Services.AddMcpRateLimiting(mcpRateLimits);
     }
 
+    // Read once, like the MCP section and for the same reason: it decides which sockets are opened and which routes
+    // exist, both of which are settled while the application is being built. Bound strictly, so a misspelled key cannot
+    // leave a deployment serving a posture nobody selected.
+    var healthEndpointSettings = HealthEndpointOptions.ReadFrom(builder.Configuration);
+    builder.Services.AddSingleton(Options.Create(healthEndpointSettings));
+
+    // The addresses the application listener would bind, read before anything is added to the Kestrel configuration
+    // below. Where the MCP HTTPS profiles bind their own listeners, they are the application listener, and the
+    // URL-shaped addresses are already being ignored.
+    var applicationListenerUrls = ConfiguredApplicationListeners.ResolveUrls(builder.Configuration);
+    var mcpTerminatesTls = mcpEndpointSettings.Enabled && mcpEndpointSettings.Https.TerminatesTls;
+    IReadOnlyCollection<int> applicationListenerPorts = mcpTerminatesTls
+        ? [.. mcpEndpointSettings.Https.Endpoints.Select(static endpoint => endpoint.Port)]
+        : ConfiguredApplicationListeners.ListenerPorts(applicationListenerUrls);
+
+    var healthEndpointConfigurationErrors = healthEndpointSettings.FindConfigurationErrors(applicationListenerPorts);
+
+    if (healthEndpointConfigurationErrors.Count > 0)
+    {
+        throw new OptionsValidationException(
+            HealthEndpointOptions.SectionName,
+            typeof(HealthEndpointOptions),
+            healthEndpointConfigurationErrors);
+    }
+
+    // Registered whether or not the transport terminates TLS, because the holder is what a certificate is loaded into
+    // and disposed from, and a clear-text deployment simply loads none.
+    builder.Services.AddSingleton<HealthEndpointCertificate>();
+
+    if (healthEndpointSettings.Enabled)
+    {
+        // Kestrel ignores the URL-shaped addresses as soon as any listener is bound in code, so opening the probe
+        // listener would silently take the application listener away from a deployment that states its port through
+        // ASPNETCORE_HTTP_PORTS or ASPNETCORE_URLS. Restating those addresses as Kestrel endpoints hands the same
+        // strings back to the framework's own parser, which binds the same sockets it would have bound. Nothing is
+        // restated where the addresses were already being ignored: a deployment that names its own Kestrel endpoints
+        // keeps them, and one whose MCP HTTPS profiles bind in code keeps the promise that no clear-text listener
+        // stays open behind them.
+        if (!mcpTerminatesTls && !ConfiguredKestrelEndpoints.AnyConfigured(builder.Configuration))
+        {
+            builder.Configuration.AddInMemoryCollection(
+                ConfiguredApplicationListeners.AsKestrelEndpointConfiguration(applicationListenerUrls));
+        }
+
+        // The callback runs when the server is constructed, after the container exists and after the composition root
+        // below has loaded the certificate the TLS listener presents.
+        builder.WebHost.ConfigureKestrel(kestrelOptions => HealthEndpointListenerBinder.Bind(
+            kestrelOptions,
+            healthEndpointSettings,
+            kestrelOptions.ApplicationServices.GetRequiredService<HealthEndpointCertificate>()));
+    }
+
     var app = builder.Build();
 
-    // Before the server starts rather than from a hosted service, because the web host is the first hosted service to
-    // start and a certificate proven after it has already bound would be proven after the listener was open. A profile
-    // whose material is missing, expired, or issued for another domain therefore fails startup with nothing listening.
+    // Before the server starts rather than from a hosted service, because a hosted service could be started after the
+    // web host and a certificate proven then would be proven after the listener was already open. A profile whose
+    // material is missing, expired, or issued for another domain therefore fails startup with nothing listening.
     if (mcpEndpointSettings.Enabled && mcpEndpointSettings.Https.TerminatesTls)
     {
         await app.Services.GetRequiredService<McpServerCertificateStore>()
             .LoadAsync(app.Lifetime.ApplicationStopping);
     }
 
+    // For the same reason, and with the same outcome: a TLS transport whose material is unusable fails startup with
+    // nothing listening rather than downgrading the probe port to clear text.
+    await app.Services.GetRequiredService<HealthEndpointCertificate>()
+        .LoadAsync(app.Lifetime.ApplicationStopping);
+
     app.UseExceptionHandler();
 
-    app.MapDefaultEndpoints();
+    if (healthEndpointSettings.Enabled)
+    {
+        // A probe reports healthy over no checks at all, because the aggregate of nothing is healthy. Asserting the
+        // composed result rather than the wiring is what catches a tag that stopped matching: readiness answering
+        // without consulting the database would keep an instance in traffic that cannot serve a request.
+        var unansweredProbes = HealthProbeEndpoints.FindUnansweredProbes(
+            app.Services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value.Registrations);
+
+        if (unansweredProbes.Count > 0)
+        {
+            throw new OptionsValidationException(
+                HealthEndpointOptions.SectionName,
+                typeof(HealthEndpointOptions),
+                unansweredProbes);
+        }
+
+        // Ahead of everything the MCP endpoint adds, so a request for the protocol surface that arrived on the probe
+        // port is refused before it reaches CORS, authentication, or the rate limiter, and a probe request that arrived
+        // on the application port is refused before it can report dependency state to whoever can reach it.
+        app.UseHealthEndpointIsolation(healthEndpointSettings.ListenerPorts);
+        app.MapHealthProbes();
+    }
+
     app.MapGet("/", () => Results.Ok(new { service = "MailFathom", status = "ready" }));
 
     if (mcpEndpointSettings.Enabled)

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -307,13 +307,20 @@ try
     builder.Services.AddSingleton(Options.Create(healthEndpointSettings));
 
     // The addresses the application listener would bind, read before anything is added to the Kestrel configuration
-    // below. Where the MCP HTTPS profiles bind their own listeners, they are the application listener, and the
-    // URL-shaped addresses are already being ignored.
+    // below, and read from whichever of the three sources Kestrel would actually have bound: the MCP HTTPS profiles
+    // when they bind their own listeners, the endpoints an operator named otherwise, and the URL-shaped addresses only
+    // when neither exists. Reading the wrong one would leave the collision check comparing the probe port against
+    // sockets nothing opens, which is the check passing on the strength of a number nobody binds.
     var applicationListenerUrls = ConfiguredApplicationListeners.ResolveUrls(builder.Configuration);
     var mcpTerminatesTls = mcpEndpointSettings.Enabled && mcpEndpointSettings.Https.TerminatesTls;
-    IReadOnlyCollection<int> applicationListenerPorts = mcpTerminatesTls
-        ? [.. mcpEndpointSettings.Https.Endpoints.Select(static endpoint => endpoint.Port)]
-        : ConfiguredApplicationListeners.ListenerPorts(applicationListenerUrls);
+    var configuredKestrelEndpoints = ConfiguredKestrelEndpoints.AnyConfigured(builder.Configuration);
+
+    IReadOnlyCollection<int> applicationListenerPorts = (mcpTerminatesTls, configuredKestrelEndpoints) switch
+    {
+        (true, _) => [.. mcpEndpointSettings.Https.Endpoints.Select(static endpoint => endpoint.Port)],
+        (false, true) => ConfiguredKestrelEndpoints.ListenerPorts(builder.Configuration),
+        _ => ConfiguredApplicationListeners.ListenerPorts(applicationListenerUrls),
+    };
 
     var healthEndpointConfigurationErrors = healthEndpointSettings.FindConfigurationErrors(applicationListenerPorts);
 
@@ -338,7 +345,7 @@ try
         // restated where the addresses were already being ignored: a deployment that names its own Kestrel endpoints
         // keeps them, and one whose MCP HTTPS profiles bind in code keeps the promise that no clear-text listener
         // stays open behind them.
-        if (!mcpTerminatesTls && !ConfiguredKestrelEndpoints.AnyConfigured(builder.Configuration))
+        if (!mcpTerminatesTls && !configuredKestrelEndpoints)
         {
             builder.Configuration.AddInMemoryCollection(
                 ConfiguredApplicationListeners.AsKestrelEndpointConfiguration(applicationListenerUrls));

--- a/src/Host/Security/HealthEndpointCertificate.cs
+++ b/src/Host/Security/HealthEndpointCertificate.cs
@@ -29,10 +29,6 @@ namespace MailFathom.Host.Security;
 /// </remarks>
 internal sealed partial class HealthEndpointCertificate : IDisposable
 {
-    /// <summary>How close to expiry the certificate has to be before startup reports it as something to act on.</summary>
-    /// <remarks>Thirty days is the window in which a renewal is still routine rather than urgent, and it is long enough that an operator reading the log on a Monday has not already lost the weekend.</remarks>
-    private static readonly TimeSpan ExpiryNoticeWindow = TimeSpan.FromDays(30);
-
     private readonly HealthEndpointOptions healthEndpointSettings;
     private readonly TlsServerCertificateLoader certificateLoader;
     private readonly TimeProvider timeProvider;
@@ -112,9 +108,9 @@ internal sealed partial class HealthEndpointCertificate : IDisposable
     /// <remarks>The expiry instant is the whole of it. The subject, the serial number, and the thumbprint identify the certificate wherever this log is read or shipped, and an operator renewing it needs to know by when rather than which certificate it was.</remarks>
     private void ReportLoaded(X509Certificate2 leaf)
     {
-        var expiration = leaf.NotAfter.ToUniversalTime();
+        var expiration = ServerCertificateExpiry.ExpirationOf(leaf);
 
-        if (expiration - this.timeProvider.GetUtcNow() <= ExpiryNoticeWindow)
+        if (ServerCertificateExpiry.IsExpiringSoon(expiration, this.timeProvider.GetUtcNow()))
         {
             this.LogServerCertificateExpiringSoon(expiration);
 

--- a/src/Host/Security/HealthEndpointCertificate.cs
+++ b/src/Host/Security/HealthEndpointCertificate.cs
@@ -1,0 +1,150 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+using MailFathom.Host.Configuration;
+using MailFathom.Infrastructure.Certificates;
+using Microsoft.Extensions.Options;
+
+namespace MailFathom.Host.Security;
+
+/// <summary>Holds the TLS identity the health-endpoint listener presents, loaded before the listener is opened.</summary>
+/// <remarks>
+/// <para>
+/// The material is retrieved through the same loader the MCP endpoint's HTTPS profiles use, so a deployment provisions
+/// one kind of certificate reference for both. There is no second loader, no ASP.NET Core development-certificate
+/// fallback, and no self-signed fallback: material that is missing, unresolvable, expired, or unusable fails startup
+/// with nothing listening, because a probe answering on a port an operator believed was TLS is worse than one that
+/// does not answer at all.
+/// </para>
+/// <para>
+/// Loading happens in the composition root, before the server is started, for the same reason it does for the MCP
+/// profiles: a certificate proven after the listener has bound would be proven after the port was already open, and an
+/// operator whose certificate expired last night would learn it from a probe failure rather than from a host that
+/// refused to start.
+/// </para>
+/// <para>
+/// The instance owns the certificate it loaded and releases it on disposal, which the container performs at shutdown.
+/// </para>
+/// </remarks>
+internal sealed partial class HealthEndpointCertificate : IDisposable
+{
+    /// <summary>How close to expiry the certificate has to be before startup reports it as something to act on.</summary>
+    /// <remarks>Thirty days is the window in which a renewal is still routine rather than urgent, and it is long enough that an operator reading the log on a Monday has not already lost the weekend.</remarks>
+    private static readonly TimeSpan ExpiryNoticeWindow = TimeSpan.FromDays(30);
+
+    private readonly HealthEndpointOptions healthEndpointSettings;
+    private readonly TlsServerCertificateLoader certificateLoader;
+    private readonly TimeProvider timeProvider;
+    private readonly ILogger<HealthEndpointCertificate> logger;
+
+    private TlsServerCertificate? identity;
+    private bool disposed;
+
+    /// <summary>Initializes a new health-endpoint certificate holder.</summary>
+    /// <param name="healthEndpointSettings">The health-endpoint settings composition read.</param>
+    /// <param name="certificateLoader">The loader that turns configured material into a validated identity.</param>
+    /// <param name="timeProvider">The clock the expiry notice is measured against.</param>
+    /// <param name="logger">The startup logger.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public HealthEndpointCertificate(
+        IOptions<HealthEndpointOptions> healthEndpointSettings,
+        TlsServerCertificateLoader certificateLoader,
+        TimeProvider timeProvider,
+        ILogger<HealthEndpointCertificate> logger)
+    {
+        ArgumentNullException.ThrowIfNull(healthEndpointSettings);
+        ArgumentNullException.ThrowIfNull(certificateLoader);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.healthEndpointSettings = healthEndpointSettings.Value;
+        this.certificateLoader = certificateLoader;
+        this.timeProvider = timeProvider;
+        this.logger = logger;
+    }
+
+    /// <summary>Gets the leaf certificate the TLS listener presents, which carries the private key the handshake signs with.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the listener is being bound before the material has been loaded, which is a composition-order defect rather than a configuration one.</exception>
+    internal X509Certificate2 Leaf => this.identity?.Leaf
+        ?? throw new InvalidOperationException(
+            "The health endpoint's server certificate is being read before it was loaded. Composition loads it before the server starts.");
+
+    /// <summary>Gets the intermediate certificates presented after the leaf, so a client can build a path to a root it trusts.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the listener is being bound before the material has been loaded.</exception>
+    internal X509Certificate2Collection Chain => this.identity is { } loaded
+        ? [.. loaded.Intermediates]
+        : throw new InvalidOperationException(
+            "The health endpoint's server certificate is being read before it was loaded. Composition loads it before the server starts.");
+
+    /// <summary>Loads the identity the TLS listener presents, or refuses to start the host.</summary>
+    /// <param name="cancellationToken">Cancels the material retrieval.</param>
+    /// <returns>A task that completes once the identity is usable, or immediately when the configured transport opens no TLS listener.</returns>
+    /// <exception cref="OptionsValidationException">Thrown when the configured material produced no usable identity.</exception>
+    internal async Task LoadAsync(CancellationToken cancellationToken)
+    {
+        if (!this.healthEndpointSettings.Enabled || !this.healthEndpointSettings.TerminatesTls)
+        {
+            return;
+        }
+
+        var domain = this.healthEndpointSettings.Domain.Trim();
+
+        var result = await this.certificateLoader.LoadAsync(
+            this.healthEndpointSettings.ServerCertificate,
+            domain,
+            cancellationToken);
+
+        if (result.Certificate is not { } certificate)
+        {
+            throw new OptionsValidationException(
+                HealthEndpointOptions.SectionName,
+                typeof(HealthEndpointOptions),
+                [
+                    $"{HealthEndpointOptions.SectionName}:{nameof(HealthEndpointOptions.ServerCertificate)} — the health endpoint has no usable server certificate [{result.Failure}]. The configured transport serves TLS and never falls back to clear text, so the host does not start.",
+                ]);
+        }
+
+        this.identity = certificate;
+        this.ReportLoaded(certificate.Leaf);
+    }
+
+    /// <summary>Records that the listener has an identity, and how long that identity lasts.</summary>
+    /// <remarks>The expiry instant is the whole of it. The subject, the serial number, and the thumbprint identify the certificate wherever this log is read or shipped, and an operator renewing it needs to know by when rather than which certificate it was.</remarks>
+    private void ReportLoaded(X509Certificate2 leaf)
+    {
+        var expiration = leaf.NotAfter.ToUniversalTime();
+
+        if (expiration - this.timeProvider.GetUtcNow() <= ExpiryNoticeWindow)
+        {
+            this.LogServerCertificateExpiringSoon(expiration);
+
+            return;
+        }
+
+        this.LogServerCertificateLoaded(expiration);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (this.disposed)
+        {
+            return;
+        }
+
+        this.disposed = true;
+        this.identity?.Dispose();
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The health endpoint presents a server certificate valid until {ServerCertificateExpiration:u}.")]
+    private partial void LogServerCertificateLoaded(DateTimeOffset serverCertificateExpiration);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The health endpoint presents a server certificate that expires at {ServerCertificateExpiration:u}. "
+            + "Renew it before then: once it expires the host stops starting, because a certificate outside its validity "
+            + "period is refused rather than served.")]
+    private partial void LogServerCertificateExpiringSoon(DateTimeOffset serverCertificateExpiration);
+}

--- a/src/Host/Security/HealthEndpointListenerBinder.cs
+++ b/src/Host/Security/HealthEndpointListenerBinder.cs
@@ -1,0 +1,71 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Net;
+using MailFathom.Host.Configuration;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
+
+namespace MailFathom.Host.Security;
+
+/// <summary>Opens the listener the startup, readiness, and liveness probes are served on.</summary>
+/// <remarks>
+/// <para>
+/// A listener of its own is the exposure control this section delivers. The probes answer without a credential, so what
+/// decides who can ask them is which network their port is published on, and that only means anything while the port is
+/// not the one MCP clients connect to. The routes are kept apart from the other direction as well, by
+/// <see cref="Hosting.HealthEndpointIsolation" />, which is what makes the separation a property of the
+/// connection rather than of a request header a caller writes.
+/// </para>
+/// <para>
+/// One socket serves one scheme, so serving both means two listeners on two ports. The TLS listener presents the
+/// identity the composition root has already loaded and asks for no client certificate — deliberately, because
+/// requesting one is a deployment-wide default the MCP endpoint sets for its own listeners and a probe has no
+/// certificate to present.
+/// </para>
+/// </remarks>
+internal static class HealthEndpointListenerBinder
+{
+    /// <summary>Binds the probe listeners the configured transport calls for.</summary>
+    /// <param name="kestrelOptions">The server options being composed.</param>
+    /// <param name="healthEndpointSettings">The validated health-endpoint settings.</param>
+    /// <param name="certificate">The identity the TLS listener presents, loaded before the server starts.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="FormatException">Thrown when the configured bind address is not an IP address, which validation reports before anything reaches this.</exception>
+    internal static void Bind(
+        KestrelServerOptions kestrelOptions,
+        HealthEndpointOptions healthEndpointSettings,
+        HealthEndpointCertificate certificate)
+    {
+        ArgumentNullException.ThrowIfNull(kestrelOptions);
+        ArgumentNullException.ThrowIfNull(healthEndpointSettings);
+        ArgumentNullException.ThrowIfNull(certificate);
+
+        var address = IPAddress.Parse(healthEndpointSettings.BindAddress.Trim());
+
+        if (healthEndpointSettings.ServesClearText)
+        {
+            kestrelOptions.Listen(address, healthEndpointSettings.Port);
+        }
+
+        if (!healthEndpointSettings.TerminatesTls)
+        {
+            return;
+        }
+
+        // Never null once the transport terminates TLS, which validation has already proven by the time composition
+        // reaches this: HttpAndHttps without a stated port is refused rather than defaulted.
+        var tlsPort = healthEndpointSettings.TlsListenerPort!.Value;
+
+        kestrelOptions.Listen(address, tlsPort, listenOptions => listenOptions.UseHttps(httpsOptions =>
+        {
+            httpsOptions.ServerCertificate = certificate.Leaf;
+            httpsOptions.ServerCertificateChain = certificate.Chain;
+
+            // Stated rather than left to the default, because the default is deployment-wide: a deployment whose MCP
+            // endpoint accepts client certificates configures Kestrel to ask every HTTPS listener's clients for one,
+            // and this listener would otherwise inherit a question no probe can answer.
+            httpsOptions.ClientCertificateMode = ClientCertificateMode.NoCertificate;
+        }));
+    }
+}

--- a/src/Host/Security/McpServerCertificateStore.cs
+++ b/src/Host/Security/McpServerCertificateStore.cs
@@ -33,10 +33,6 @@ namespace MailFathom.Host.Security;
 /// </remarks>
 internal sealed partial class McpServerCertificateStore : IDisposable
 {
-    /// <summary>How close to expiry a certificate has to be before startup reports it as something to act on.</summary>
-    /// <remarks>Thirty days is the window in which a renewal is still routine rather than urgent, and it is long enough that an operator reading the log on a Monday has not already lost the weekend.</remarks>
-    private static readonly TimeSpan ExpiryNoticeWindow = TimeSpan.FromDays(30);
-
     private readonly McpHttpsOptions httpsSettings;
     private readonly TlsServerCertificateLoader certificateLoader;
     private readonly TimeProvider timeProvider;
@@ -178,9 +174,9 @@ internal sealed partial class McpServerCertificateStore : IDisposable
     /// </remarks>
     private void ReportLoaded(string profileName, X509Certificate2 leaf)
     {
-        var expiration = leaf.NotAfter.ToUniversalTime();
+        var expiration = ServerCertificateExpiry.ExpirationOf(leaf);
 
-        if (expiration - this.timeProvider.GetUtcNow() <= ExpiryNoticeWindow)
+        if (ServerCertificateExpiry.IsExpiringSoon(expiration, this.timeProvider.GetUtcNow()))
         {
             this.LogServerCertificateExpiringSoon(profileName, expiration);
 

--- a/src/Host/Security/ServerCertificateExpiry.cs
+++ b/src/Host/Security/ServerCertificateExpiry.cs
@@ -1,0 +1,39 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace MailFathom.Host.Security;
+
+/// <summary>Decides when a server certificate is close enough to expiry for startup to say so.</summary>
+/// <remarks>
+/// The window is one rule for every listener MailFathom presents a certificate on. Each holder writes its own record —
+/// one names the HTTPS profile, the other has no profile to name — but when to write the warning rather than the
+/// ordinary notice is not a per-endpoint decision, and two copies of it would let one listener start warning a month
+/// before the other.
+/// </remarks>
+internal static class ServerCertificateExpiry
+{
+    /// <summary>How close to expiry a certificate has to be before startup reports it as something to act on.</summary>
+    /// <remarks>Thirty days is the window in which a renewal is still routine rather than urgent, and it is long enough that an operator reading the log on a Monday has not already lost the weekend.</remarks>
+    private static readonly TimeSpan NoticeWindow = TimeSpan.FromDays(30);
+
+    /// <summary>Reads the instant a certificate stops being usable.</summary>
+    /// <param name="leaf">The certificate a listener presents.</param>
+    /// <returns>The expiry instant in UTC, which is what a record states and what an operator renews against.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="leaf" /> is <see langword="null" />.</exception>
+    internal static DateTimeOffset ExpirationOf(X509Certificate2 leaf)
+    {
+        ArgumentNullException.ThrowIfNull(leaf);
+
+        return leaf.NotAfter.ToUniversalTime();
+    }
+
+    /// <summary>Reports whether an expiry is near enough to warn about.</summary>
+    /// <param name="expiration">The instant the certificate stops being usable.</param>
+    /// <param name="readAt">The instant the question is asked, which startup takes from the injected clock.</param>
+    /// <returns><see langword="true" /> when the certificate expires inside the notice window or has expired already.</returns>
+    /// <remarks>An already-expired certificate answers <see langword="true" /> as well, though nothing reaches this with one: the loader refuses it before a holder publishes it.</remarks>
+    internal static bool IsExpiringSoon(DateTimeOffset expiration, DateTimeOffset readAt) =>
+        expiration - readAt <= NoticeWindow;
+}

--- a/src/Host/ServiceDefaultsExtensions.cs
+++ b/src/Host/ServiceDefaultsExtensions.cs
@@ -1,7 +1,7 @@
 // Copyright © 2026 Krzysztof Kasprowicz
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using MailFathom.Host.Hosting;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -15,15 +15,6 @@ namespace MailFathom.Host;
 /// </summary>
 internal static class ServiceDefaultsExtensions
 {
-    /// <summary>The readiness path, which reports every registered health check.</summary>
-    internal const string HealthEndpointPath = "/health";
-
-    /// <summary>The liveness path, which reports only the checks that say the process itself is running.</summary>
-    internal const string AlivenessEndpointPath = "/alive";
-
-    /// <summary>The tag that marks a health check as answering the liveness question rather than the readiness one.</summary>
-    internal const string LivenessCheckTag = "live";
-
     /// <summary>The meter Polly's telemetry publishes every resilience event to.</summary>
     private const string PollyMeterName = "Polly";
 
@@ -79,10 +70,10 @@ internal static class ServiceDefaultsExtensions
             .WithTracing(tracing =>
             {
                 tracing.AddSource(builder.Environment.ApplicationName)
+                    // A probe arrives every few seconds for the lifetime of the process and says the same thing every
+                    // time, so tracing it would fill a trace store with the polling rather than with the work.
                     .AddAspNetCoreInstrumentation(tracingOptions =>
-                        tracingOptions.Filter = context =>
-                            !context.Request.Path.StartsWithSegments(HealthEndpointPath)
-                            && !context.Request.Path.StartsWithSegments(AlivenessEndpointPath))
+                        tracingOptions.Filter = context => !HealthProbe.IsProbePath(context.Request.Path))
                     .AddHttpClientInstrumentation();
             });
 
@@ -105,54 +96,23 @@ internal static class ServiceDefaultsExtensions
     }
 
     /// <summary>
-    /// Adds the default liveness health check that <see cref="MapDefaultEndpoints"/> exposes.
+    /// Adds the check that reports the process itself, which is what the liveness probe consults.
     /// </summary>
     /// <typeparam name="TBuilder">The host application builder type.</typeparam>
     /// <param name="builder">The host application builder to configure.</param>
     /// <returns>The same builder instance for chaining.</returns>
+    /// <remarks>
+    /// It carries the liveness tag alone. Answering means the process is running its own request pipeline, which is the
+    /// whole of the liveness question; adding it to readiness would say nothing a readiness probe acts on, and adding a
+    /// dependency to liveness would let an outage elsewhere restart a process that is working.
+    /// </remarks>
     public static TBuilder AddDefaultHealthChecks<TBuilder>(this TBuilder builder)
         where TBuilder : IHostApplicationBuilder
     {
         builder.Services.AddHealthChecks()
-            .AddCheck("self", () => HealthCheckResult.Healthy(), [LivenessCheckTag]);
+            .AddCheck("self", static () => HealthCheckResult.Healthy(), [HealthProbe.Liveness.Tag]);
 
         return builder;
     }
 
-    /// <summary>
-    /// Maps the readiness and liveness endpoints an orchestrator probes.
-    /// </summary>
-    /// <param name="app">The web application to configure.</param>
-    /// <returns>The same application instance for chaining.</returns>
-    /// <remarks>
-    /// <para>
-    /// Both endpoints are mapped in every environment, because a container platform decides whether to route traffic to
-    /// this process and whether to restart it by probing them, and a deployment shape MailFathom supports must not depend
-    /// on the environment name it was started under. The scaffold this file came from restricted them to Development,
-    /// which would have left every probe in <c>deploy/</c> with nothing to ask.
-    /// </para>
-    /// <para>
-    /// They are deliberately left unauthenticated. Neither carries mailbox data — the response body is the single word
-    /// the framework's default writer emits — and a probe has no credential to present. That is the same split
-    /// <c>docs/operations/mcp-endpoint.md</c> already describes: the authorization requirement sits on the MCP route
-    /// rather than on the pipeline, so these two stay reachable while everything serving mail does not.
-    /// </para>
-    /// <para>
-    /// The two differ in what they consult, and the difference is what makes them safe to wire to different probes.
-    /// <c>/health</c> runs every registered check, the database among them, so a readiness probe stops routing to a
-    /// process that cannot serve. <c>/alive</c> runs only the checks tagged <c>live</c>, so a database outage never
-    /// reaches a liveness probe and never turns into a restart loop that cannot fix what is actually broken.
-    /// </para>
-    /// </remarks>
-    public static WebApplication MapDefaultEndpoints(this WebApplication app)
-    {
-        app.MapHealthChecks(HealthEndpointPath);
-
-        app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
-        {
-            Predicate = registration => registration.Tags.Contains(LivenessCheckTag)
-        });
-
-        return app;
-    }
 }

--- a/src/Infrastructure/Certificates/TlsServerCertificateOptions.cs
+++ b/src/Infrastructure/Certificates/TlsServerCertificateOptions.cs
@@ -32,4 +32,63 @@ public sealed class TlsServerCertificateOptions
 
     /// <summary>Gets or sets the PEM private key belonging to the leaf, whose nested password block decrypts it when it is encrypted.</summary>
     public ConfiguredSecret? PrivateKey { get; set; }
+
+    /// <summary>Gets whether any material is configured at all.</summary>
+    /// <remarks>It answers "did the operator provision an identity here", which is what a listener serving no TLS asks before refusing material nothing would present.</remarks>
+    public bool IsConfigured => IsBlockConfigured(this.Bundle)
+        || IsBlockConfigured(this.CertificateChain)
+        || IsBlockConfigured(this.PrivateKey);
+
+    /// <summary>Finds everything an operator must fix before this material can be loaded.</summary>
+    /// <param name="configurationPath">The configuration path of this block, which prefixes every reported error.</param>
+    /// <returns>One message per faulty setting, empty when the block names material that could be loaded.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurationPath" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Only the shape is decided here: which of the two provisioning kinds the block names, and whether it names one of
+    /// them completely. Whether the referenced material resolves, parses, carries a matching private key, is currently
+    /// valid, and covers the domain is <see cref="TlsServerCertificateLoader" />'s question, answered against real
+    /// material before any listener is opened.
+    /// </para>
+    /// <para>
+    /// The rule lives with the type it constrains rather than with either endpoint that binds it, because it is a
+    /// property of the material contract: every listener MailFathom terminates TLS on provisions its identity the same
+    /// way, and a second copy of these four rules would be a second place for them to drift.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<string> FindConfigurationErrors(string configurationPath)
+    {
+        ArgumentNullException.ThrowIfNull(configurationPath);
+
+        var bundleConfigured = IsBlockConfigured(this.Bundle);
+        var chainConfigured = IsBlockConfigured(this.CertificateChain);
+        var privateKeyConfigured = IsBlockConfigured(this.PrivateKey);
+
+        if (bundleConfigured && (chainConfigured || privateKeyConfigured))
+        {
+            return [$"{configurationPath} — a PKCS#12 bundle and separate PEM material are both configured; state one or the other, because which of them supplies the identity would otherwise be decided by nothing an operator wrote."];
+        }
+
+        if (bundleConfigured)
+        {
+            return [];
+        }
+
+        if (!chainConfigured && !privateKeyConfigured)
+        {
+            return [$"{configurationPath} — a TLS listener must state where its certificate comes from: a '{nameof(this.Bundle)}' holding a PKCS#12 bundle, or a '{nameof(this.CertificateChain)}' beside its '{nameof(this.PrivateKey)}'. There is no development-certificate fallback and no self-signed one, because a listener answering on a port an operator believed was TLS is worse than one that does not answer."];
+        }
+
+        if (!chainConfigured)
+        {
+            return [$"{configurationPath}:{nameof(this.CertificateChain)} — a private key is configured with no certificate to pair it with."];
+        }
+
+        return privateKeyConfigured
+            ? []
+            : [$"{configurationPath}:{nameof(this.PrivateKey)} — a certificate is configured with no private key, so the listener could name the domain but not prove it is the domain."];
+    }
+
+    private static bool IsBlockConfigured(ConfiguredSecret? block) =>
+        block is not null && !string.IsNullOrWhiteSpace(block.SecretReference);
 }

--- a/src/Infrastructure/HostApplicationBuilderExtensions.cs
+++ b/src/Infrastructure/HostApplicationBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using MailFathom.CodeCoverage;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 
 namespace MailFathom.Infrastructure;
@@ -15,11 +16,16 @@ public static class HostApplicationBuilderExtensions
     /// <summary>The seconds a database command may run before it is cancelled, when no deployment configures another value.</summary>
     public const int DefaultDatabaseCommandTimeoutSeconds = 30;
 
+    /// <summary>The name the database health check is registered under, which is the context type's own name.</summary>
+    /// <remarks>The enrichment names it, so this restates that name rather than choosing one. It is the registration the configured probe tags are applied to.</remarks>
+    private const string DatabaseHealthCheckName = nameof(MailFathomDbContext);
+
     /// <summary>Makes the EF Core context report its health and publish database traces and metrics.</summary>
     /// <param name="builder">The host application builder the context is already registered on.</param>
     /// <param name="commandTimeout">How long a single database command may run before it is cancelled.</param>
+    /// <param name="probeTags">The health-check tags that decide which probes consult the database, stated by the composition root that owns the probes.</param>
     /// <returns>The builder, for chaining.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="builder" /> or <paramref name="probeTags" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="commandTimeout" /> is not a positive duration.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the context has not been registered yet.</exception>
     /// <remarks>
@@ -43,9 +49,11 @@ public static class HostApplicationBuilderExtensions
     /// </remarks>
     public static IHostApplicationBuilder AddDatabaseHealthAndTelemetry(
         this IHostApplicationBuilder builder,
-        TimeSpan commandTimeout)
+        TimeSpan commandTimeout,
+        IReadOnlyCollection<string> probeTags)
     {
         ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(probeTags);
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(commandTimeout, TimeSpan.Zero);
 
         // Published so a reloaded candidate can be compared against the value the context was actually built with. It
@@ -60,6 +68,23 @@ public static class HostApplicationBuilderExtensions
             settings.DisableTracing = false;
             settings.DisableMetrics = false;
             settings.CommandTimeout = (int)commandTimeout.TotalSeconds;
+        });
+
+        // The enrichment registers the check without tags, and a probe selects its checks by tag, so an untagged check
+        // reaches no probe. Which probes the database belongs to is not this layer's decision — it is the composition
+        // root's — but the registration is here, which is where the answer has to be applied.
+        builder.Services.Configure<HealthCheckServiceOptions>(healthCheckOptions =>
+        {
+            var databaseRegistrations = healthCheckOptions.Registrations
+                .Where(static registration => string.Equals(registration.Name, DatabaseHealthCheckName, StringComparison.Ordinal));
+
+            foreach (var registration in databaseRegistrations)
+            {
+                foreach (var tag in probeTags)
+                {
+                    registration.Tags.Add(tag);
+                }
+            }
         });
 
         return builder;

--- a/tests/Host.UnitTests/ConfiguredApplicationListenersTests.cs
+++ b/tests/Host.UnitTests/ConfiguredApplicationListenersTests.cs
@@ -1,0 +1,140 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using MailFathom.Host.Configuration;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers the addresses the application listener would bind, and how they survive a second listener being opened.</summary>
+/// <remarks>
+/// Kestrel ignores the URL-shaped addresses as soon as any listener is bound in code, so opening the probe listener
+/// would silently take the application listener away from a deployment that states its port through
+/// <c>ASPNETCORE_HTTP_PORTS</c>. Restating the same strings as Kestrel endpoints is what keeps the socket, and reading
+/// their ports is what lets the probe port be refused before it collides with one.
+/// </remarks>
+public sealed class ConfiguredApplicationListenersTests
+{
+    [Fact]
+    public void ResolveUrls_AConfiguredUrlList_ReadsEveryAddress()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["urls"] = "http://0.0.0.0:8080;https://0.0.0.0:8443",
+        });
+
+        // Act
+        var urls = ConfiguredApplicationListeners.ResolveUrls(configuration);
+
+        // Assert
+        Assert.Equal(["http://0.0.0.0:8080", "https://0.0.0.0:8443"], urls);
+    }
+
+    [Fact]
+    public void ResolveUrls_ConfiguredPorts_ExpandsThemOntoEveryInterface()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["http_ports"] = "8080;8081",
+            ["https_ports"] = "8443",
+        });
+
+        // Act
+        var urls = ConfiguredApplicationListeners.ResolveUrls(configuration);
+
+        // Assert
+        Assert.Equal(["http://*:8080", "http://*:8081", "https://*:8443"], urls);
+    }
+
+    /// <summary>
+    /// An explicit URL list is what the host itself prefers over the port lists, and restating a different precedence
+    /// would bind a socket the deployment had already replaced.
+    /// </summary>
+    [Fact]
+    public void ResolveUrls_BothAUrlListAndPorts_KeepsTheUrlList()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["urls"] = "http://127.0.0.1:5000",
+            ["http_ports"] = "8080",
+        });
+
+        // Act
+        var urls = ConfiguredApplicationListeners.ResolveUrls(configuration);
+
+        // Assert
+        Assert.Equal(["http://127.0.0.1:5000"], urls);
+    }
+
+    /// <summary>
+    /// The framework's own fallback adds an HTTPS address whenever a development certificate happens to be installed on
+    /// the machine. MailFathom never serves a listener out of one, so what is restated is the clear-text half alone.
+    /// </summary>
+    [Fact]
+    public void ResolveUrls_NothingConfigured_RestatesTheClearTextDefaultAlone()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom([]);
+
+        // Act
+        var urls = ConfiguredApplicationListeners.ResolveUrls(configuration);
+
+        // Assert
+        Assert.Equal(["http://localhost:5000"], urls);
+    }
+
+    [Fact]
+    public void AsKestrelEndpointConfiguration_TheResolvedAddresses_HandsEachOneBackToKestrelsOwnParser()
+    {
+        // Arrange
+        string[] urls = ["http://*:8080", "https://*:8443"];
+
+        // Act
+        var endpoints = ConfiguredApplicationListeners.AsKestrelEndpointConfiguration(urls);
+
+        // Assert
+        Assert.Equal(
+            [
+                KeyValuePair.Create<string, string?>("Kestrel:Endpoints:MailFathomApplication0:Url", "http://*:8080"),
+                KeyValuePair.Create<string, string?>("Kestrel:Endpoints:MailFathomApplication1:Url", "https://*:8443"),
+            ],
+            endpoints);
+    }
+
+    [Fact]
+    public void ListenerPorts_TheResolvedAddresses_ReadsThePortsAProbeListenerMustNotTake()
+    {
+        // Arrange
+        string[] urls = ["http://*:8080", "https://0.0.0.0:8443", "http://[::]:8080"];
+
+        // Act
+        var ports = ConfiguredApplicationListeners.ListenerPorts(urls);
+
+        // Assert
+        Assert.Equal([8080, 8443], ports);
+    }
+
+    /// <summary>
+    /// Kestrel parses the same value moments later and reports it against the key an operator wrote. A second message
+    /// here would describe the same mistake in this product's words and hide which setting the framework refused.
+    /// </summary>
+    [Fact]
+    public void ListenerPorts_AnAddressThatIsNotOne_ContributesNoPortRatherThanAFailure()
+    {
+        // Arrange
+        string[] urls = ["not-an-address", "http://*:8080"];
+
+        // Act
+        var ports = ConfiguredApplicationListeners.ListenerPorts(urls);
+
+        // Assert
+        Assert.Equal([8080], ports);
+    }
+
+    private static IConfiguration ConfigurationFrom(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+}

--- a/tests/Host.UnitTests/ConfiguredDnsNameTests.cs
+++ b/tests/Host.UnitTests/ConfiguredDnsNameTests.cs
@@ -1,0 +1,78 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using MailFathom.Host.Configuration;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers what a TLS listener may claim as its name, which is the same question for every one of them.</summary>
+/// <remarks>
+/// The certificate is matched against DNS subject alternative names either way, so a name that could not appear in one
+/// is refused during composition rather than becoming a failed load an operator reads as a provisioning mistake.
+/// </remarks>
+public sealed class ConfiguredDnsNameTests
+{
+    private const string SettingPath = "HealthEndpoints:Domain";
+
+    [Theory]
+    [InlineData("probe.example.test")]
+    [InlineData("mail.example.com")]
+    [InlineData("localhost")]
+    [InlineData("  probe.example.test  ")]
+    public void FindErrors_ADnsName_ReportsNothing(string configuredName)
+    {
+        // Act, Assert
+        Assert.Empty(ConfiguredDnsName.FindErrors(configuredName, SettingPath));
+    }
+
+    /// <summary>Emptiness belongs to each caller, because a missing name means something different to each of them.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FindErrors_NoNameAtAll_ReportsNothingAndLeavesItToTheCaller(string? configuredName)
+    {
+        // Act, Assert
+        Assert.Empty(ConfiguredDnsName.FindErrors(configuredName, SettingPath));
+    }
+
+    /// <summary>
+    /// An orchestrator dials a probe listener by address, so an IP address is the plausible mistake — and a
+    /// certificate's DNS names never carry one, so it could never be matched.
+    /// </summary>
+    [Theory]
+    [InlineData("10.0.0.5")]
+    [InlineData("::1")]
+    public void FindErrors_AnIpAddress_IsRefusedAndPointsAtTheBindAddress(string configuredName)
+    {
+        // Act
+        var error = Assert.Single(ConfiguredDnsName.FindErrors(configuredName, SettingPath));
+
+        // Assert
+        Assert.StartsWith(SettingPath, error, StringComparison.Ordinal);
+        Assert.Contains("BindAddress", error, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("*.example.test")]
+    [InlineData("not a name")]
+    public void FindErrors_ANameThatIsNotDns_IsRefused(string configuredName)
+    {
+        // Act
+        var error = Assert.Single(ConfiguredDnsName.FindErrors(configuredName, SettingPath));
+
+        // Assert
+        Assert.Contains("is not a DNS name", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindErrors_AnInternationalizedName_AsksForItsPunycodeForm()
+    {
+        // Act
+        var error = Assert.Single(ConfiguredDnsName.FindErrors("poczta.example.test".Replace('o', 'ó'), SettingPath));
+
+        // Assert
+        Assert.Contains("punycode", error, StringComparison.Ordinal);
+    }
+}

--- a/tests/Host.UnitTests/ConfiguredKestrelEndpointsTests.cs
+++ b/tests/Host.UnitTests/ConfiguredKestrelEndpointsTests.cs
@@ -84,6 +84,40 @@ public sealed class ConfiguredKestrelEndpointsTests
         Assert.Empty(ConfiguredKestrelEndpoints.FindHttpsProfileConflicts(configuration, HttpsProfiles()));
     }
 
+    /// <summary>
+    /// A deployment naming its own endpoints is one whose URL-shaped addresses Kestrel already ignores, which is what
+    /// the health-endpoint listener must not undo by restating them beside the endpoints an operator wrote.
+    /// </summary>
+    [Fact]
+    public void AnyConfigured_AConfiguredEndpoint_ReportsThatTheDeploymentNamesItsOwnListeners()
+    {
+        // Arrange
+        var configuration = ConfigurationWith(("Kestrel:Endpoints:Http:Url", "http://0.0.0.0:8080"));
+
+        // Act, Assert
+        Assert.True(ConfiguredKestrelEndpoints.AnyConfigured(configuration));
+    }
+
+    [Fact]
+    public void AnyConfigured_AnEndpointWithoutAUrl_ReportsNoConfiguredListener()
+    {
+        // Arrange
+        var configuration = ConfigurationWith(("Kestrel:Endpoints:Http:Protocols", "Http1AndHttp2"));
+
+        // Act, Assert
+        Assert.False(ConfiguredKestrelEndpoints.AnyConfigured(configuration));
+    }
+
+    [Fact]
+    public void AnyConfigured_NoKestrelSectionAtAll_ReportsNoConfiguredListener()
+    {
+        // Arrange
+        var configuration = ConfigurationWith(("Logging:LogLevel:Default", "Information"));
+
+        // Act, Assert
+        Assert.False(ConfiguredKestrelEndpoints.AnyConfigured(configuration));
+    }
+
     private static IConfiguration ConfigurationWith(params (string Key, string Value)[] settings) =>
         new ConfigurationBuilder()
             .AddInMemoryCollection(settings.Select(static setting =>

--- a/tests/Host.UnitTests/ConfiguredKestrelEndpointsTests.cs
+++ b/tests/Host.UnitTests/ConfiguredKestrelEndpointsTests.cs
@@ -118,6 +118,37 @@ public sealed class ConfiguredKestrelEndpointsTests
         Assert.False(ConfiguredKestrelEndpoints.AnyConfigured(configuration));
     }
 
+    /// <summary>
+    /// These are the application listener's ports whenever the section is populated, because the URL-shaped addresses
+    /// stop binding as soon as it is. A second listener that has to avoid the application's reads them from here, or
+    /// its collision check compares against sockets nothing opens.
+    /// </summary>
+    [Fact]
+    public void ListenerPorts_ConfiguredEndpoints_ReadsThePortsTheyBind()
+    {
+        // Arrange
+        var configuration = ConfigurationWith(
+            ("Kestrel:Endpoints:Http:Url", "http://127.0.0.1:8081"),
+            ("Kestrel:Endpoints:Https:Url", "https://0.0.0.0:8443"),
+            ("Kestrel:Endpoints:Defaults:Protocols", "Http1AndHttp2"));
+
+        // Act
+        var ports = ConfiguredKestrelEndpoints.ListenerPorts(configuration);
+
+        // Assert
+        Assert.Equal([8081, 8443], ports);
+    }
+
+    [Fact]
+    public void ListenerPorts_NoConfiguredEndpoint_ReadsNoPort()
+    {
+        // Arrange
+        var configuration = ConfigurationWith(("Logging:LogLevel:Default", "Information"));
+
+        // Act, Assert
+        Assert.Empty(ConfiguredKestrelEndpoints.ListenerPorts(configuration));
+    }
+
     private static IConfiguration ConfigurationWith(params (string Key, string Value)[] settings) =>
         new ConfigurationBuilder()
             .AddInMemoryCollection(settings.Select(static setting =>

--- a/tests/Host.UnitTests/DatabaseSchemaStartupGateTests.cs
+++ b/tests/Host.UnitTests/DatabaseSchemaStartupGateTests.cs
@@ -26,6 +26,40 @@ public sealed class DatabaseSchemaStartupGateTests
     }
 
     [Fact]
+    public async Task StartAsync_EveryMigrationApplied_ReportsTheSchemaGateToTheStartupProbe()
+    {
+        // Arrange
+        var startupGates = new HostStartupGates(HostStartupGate.DatabaseSchema);
+
+        // Act
+        await CreateGate(CreateCurrentSchemaInspector(), startupGates: startupGates).StartAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(startupGates.Completed);
+    }
+
+    /// <summary>
+    /// A gate that failed took the host down with it, so it never reports itself; what the startup probe must not do is
+    /// report a host as having come up on the strength of a step that raised.
+    /// </summary>
+    [Fact]
+    public async Task StartAsync_MigrationsPending_LeavesTheSchemaGateOutstanding()
+    {
+        // Arrange
+        var startupGates = new HostStartupGates(HostStartupGate.DatabaseSchema);
+        var inspector = Substitute.For<IDatabaseSchemaInspector>();
+        inspector.ReadPendingMigrationIdentifiersAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<string>>(["20260729_Initial"]));
+
+        // Act
+        await Assert.ThrowsAsync<DatabaseSchemaOutOfDateException>(() =>
+            CreateGate(inspector, startupGates: startupGates).StartAsync(CancellationToken.None));
+
+        // Assert
+        Assert.False(startupGates.Completed);
+    }
+
+    [Fact]
     public async Task StartAsync_MigrationsPending_FailsStartupNamingThemInsteadOfApplyingThem()
     {
         // Arrange
@@ -141,7 +175,8 @@ public sealed class DatabaseSchemaStartupGateTests
 
     private static DatabaseSchemaStartupGate CreateGate(
         IDatabaseSchemaInspector inspector,
-        PostgresTextSearchConfiguration? textSearchConfiguration = null)
+        PostgresTextSearchConfiguration? textSearchConfiguration = null,
+        HostStartupGates? startupGates = null)
     {
         var services = new ServiceCollection();
         services.AddScoped(_ => inspector);
@@ -149,6 +184,7 @@ public sealed class DatabaseSchemaStartupGateTests
         return new DatabaseSchemaStartupGate(
             services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
             textSearchConfiguration ?? PostgresTextSearchConfiguration.Default,
+            startupGates ?? new HostStartupGates(HostStartupGate.DatabaseSchema),
             NullLogger<DatabaseSchemaStartupGate>.Instance);
     }
 }

--- a/tests/Host.UnitTests/HealthEndpointCertificateTests.cs
+++ b/tests/Host.UnitTests/HealthEndpointCertificateTests.cs
@@ -1,0 +1,151 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+using MailFathom.Host.Configuration;
+using MailFathom.Host.Security;
+using MailFathom.Infrastructure.Certificates;
+using MailFathom.Infrastructure.Secrets;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers the identity the probe listener presents, and what happens when the deployment provisioned none.</summary>
+/// <remarks>
+/// A TLS transport never downgrades. Material that is missing, unresolvable, expired, or unusable fails startup with
+/// nothing listening, because a probe answering on a port an operator believed was TLS is worse than one that does not
+/// answer at all.
+/// </remarks>
+public sealed class HealthEndpointCertificateTests
+{
+    private const string Domain = "probe.example.test";
+
+    private static readonly DateTimeOffset Now = new(2026, 7, 31, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task LoadAsync_MaterialCoveringTheDomain_PresentsAnIdentityCarryingItsPrivateKey()
+    {
+        // Arrange
+        using var identity = TestCertificates.CreateServerIdentity(
+            [Domain],
+            Now.AddDays(-1),
+            Now.AddDays(200));
+
+        using var certificate = CertificateFor(TlsOptions(identity));
+
+        // Act
+        await certificate.LoadAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(certificate.Leaf.HasPrivateKey);
+        Assert.Empty(certificate.Chain);
+    }
+
+    [Fact]
+    public async Task LoadAsync_MaterialThatIsNotUsable_FailsStartupRatherThanServingClearText()
+    {
+        // Arrange
+        var settings = new HealthEndpointOptions
+        {
+            Transport = HealthEndpointTransport.HttpsOnly,
+            Domain = Domain,
+            ServerCertificate = new TlsServerCertificateOptions
+            {
+                Bundle = new ConfiguredSecret { Name = "probe-bundle", SecretReference = "file:/run/secrets/probe.pfx" },
+            },
+        };
+
+        using var certificate = CertificateFor(settings);
+
+        // Act
+        var loading = async () => await certificate.LoadAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var failure = await Assert.ThrowsAsync<OptionsValidationException>(loading);
+
+        Assert.Contains(failure.Failures, message => message.Contains("HealthEndpoints:ServerCertificate", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A certificate outside its validity period is refused by the loader rather than presented, which is what makes an
+    /// expired one a startup failure instead of a handshake every orchestrator meets afterwards.
+    /// </summary>
+    [Fact]
+    public async Task LoadAsync_ExpiredMaterial_FailsStartup()
+    {
+        // Arrange
+        using var identity = TestCertificates.CreateServerIdentity(
+            [Domain],
+            Now.AddDays(-400),
+            Now.AddDays(-1));
+
+        using var certificate = CertificateFor(TlsOptions(identity));
+
+        // Act
+        var loading = async () => await certificate.LoadAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<OptionsValidationException>(loading);
+    }
+
+    [Fact]
+    public async Task LoadAsync_AClearTextTransport_LoadsNothing()
+    {
+        // Arrange
+        using var certificate = CertificateFor(new HealthEndpointOptions());
+
+        // Act
+        await certificate.LoadAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(() => certificate.Leaf);
+    }
+
+    [Fact]
+    public async Task LoadAsync_DisabledProbes_LoadNothingEvenUnderATlsTransport()
+    {
+        // Arrange
+        using var identity = TestCertificates.CreateServerIdentity([Domain], Now.AddDays(-1), Now.AddDays(200));
+        var settings = TlsOptions(identity);
+        settings.Enabled = false;
+
+        using var certificate = CertificateFor(settings);
+
+        // Act
+        await certificate.LoadAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(() => certificate.Leaf);
+    }
+
+    private static HealthEndpointOptions TlsOptions(X509Certificate2 identity) =>
+        new()
+        {
+            Transport = HealthEndpointTransport.HttpsOnly,
+            Domain = Domain,
+            ServerCertificate = new TlsServerCertificateOptions
+            {
+                CertificateChain = new ConfiguredSecret
+                {
+                    Name = "probe-chain",
+                    SecretReference = $"plaintext:{TestCertificates.ToCertificateChainPem(identity)}",
+                },
+                PrivateKey = new ConfiguredSecret
+                {
+                    Name = "probe-key",
+                    SecretReference = $"plaintext:{TestCertificates.ToPrivateKeyPem(identity)}",
+                },
+            },
+        };
+
+    private static HealthEndpointCertificate CertificateFor(HealthEndpointOptions settings) =>
+        new(
+            Options.Create(settings),
+            new TlsServerCertificateLoader(new PlaintextOnlySecretReferenceResolver(), new FakeTimeProvider(Now)),
+            new FakeTimeProvider(Now),
+            NullLogger<HealthEndpointCertificate>.Instance);
+}

--- a/tests/Host.UnitTests/HealthEndpointIsolationTests.cs
+++ b/tests/Host.UnitTests/HealthEndpointIsolationTests.cs
@@ -1,0 +1,156 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using MailFathom.Host.Hosting;
+using MailFathom.Mcp;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers the separation between the listener MCP clients reach and the listener an orchestrator probes.</summary>
+/// <remarks>
+/// Both directions are asserted, because the isolation is the security control this section delivers rather than a
+/// tidiness rule. A probe answered on the application port reports dependency state without a credential to whoever can
+/// reach the mailbox; the protocol surface answered on the probe port would be reachable from a network that was
+/// published to an orchestrator precisely because nothing sensitive was expected to answer there.
+/// </remarks>
+public sealed class HealthEndpointIsolationTests
+{
+    private static readonly IReadOnlySet<int> ProbeListenerPorts = new HashSet<int> { 8081 };
+
+    [Theory]
+    [InlineData("/health")]
+    [InlineData("/alive")]
+    [InlineData("/started")]
+    public void ListenerServesPath_AProbePathOnTheApplicationPort_IsNotServed(string path)
+    {
+        // Arrange
+        var requestPath = new PathString(path);
+
+        // Act
+        var served = HealthEndpointIsolation.ListenerServesPath(8080, requestPath, ProbeListenerPorts);
+
+        // Assert
+        Assert.False(served);
+    }
+
+    [Theory]
+    [InlineData("/health")]
+    [InlineData("/alive")]
+    [InlineData("/started")]
+    public void ListenerServesPath_AProbePathOnTheProbePort_IsServed(string path)
+    {
+        // Arrange
+        var requestPath = new PathString(path);
+
+        // Act
+        var served = HealthEndpointIsolation.ListenerServesPath(8081, requestPath, ProbeListenerPorts);
+
+        // Assert
+        Assert.True(served);
+    }
+
+    [Theory]
+    [InlineData(McpEndpointRoute.Path)]
+    [InlineData("/")]
+    public void ListenerServesPath_AnApplicationPathOnTheProbePort_IsNotServed(string path)
+    {
+        // Arrange
+        var requestPath = new PathString(path);
+
+        // Act
+        var served = HealthEndpointIsolation.ListenerServesPath(8081, requestPath, ProbeListenerPorts);
+
+        // Assert
+        Assert.False(served);
+    }
+
+    [Theory]
+    [InlineData(McpEndpointRoute.Path)]
+    [InlineData("/")]
+    public void ListenerServesPath_AnApplicationPathOnTheApplicationPort_IsServed(string path)
+    {
+        // Arrange
+        var requestPath = new PathString(path);
+
+        // Act
+        var served = HealthEndpointIsolation.ListenerServesPath(8080, requestPath, ProbeListenerPorts);
+
+        // Assert
+        Assert.True(served);
+    }
+
+    /// <summary>
+    /// Serving both schemes means two probe listeners, and an operator publishing either of them expects the probes to
+    /// answer on it.
+    /// </summary>
+    [Fact]
+    public void ListenerServesPath_AProbePathOnTheSecondProbePort_IsServed()
+    {
+        // Arrange
+        IReadOnlySet<int> bothProbePorts = new HashSet<int> { 8081, 8443 };
+
+        // Act
+        var served = HealthEndpointIsolation.ListenerServesPath(8443, new PathString("/health"), bothProbePorts);
+
+        // Assert
+        Assert.True(served);
+    }
+
+    [Fact]
+    public async Task UseHealthEndpointIsolation_ARequestTheListenerDoesNotServe_IsRefusedBeforeAnythingElseRuns()
+    {
+        // Arrange
+        var context = RequestOn(port: 8080, path: "/health");
+        var reachedTheRestOfThePipeline = false;
+
+        // Act
+        await IsolationMiddleware(ProbeListenerPorts, () => reachedTheRestOfThePipeline = true)(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, context.Response.StatusCode);
+        Assert.False(reachedTheRestOfThePipeline);
+    }
+
+    [Fact]
+    public async Task UseHealthEndpointIsolation_ARequestTheListenerServes_ReachesTheRestOfThePipeline()
+    {
+        // Arrange
+        var context = RequestOn(port: 8081, path: "/health");
+        var reachedTheRestOfThePipeline = false;
+
+        // Act
+        await IsolationMiddleware(ProbeListenerPorts, () => reachedTheRestOfThePipeline = true)(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.True(reachedTheRestOfThePipeline);
+    }
+
+    private static RequestDelegate IsolationMiddleware(IReadOnlySet<int> probeListenerPorts, Action onReached)
+    {
+        var pipeline = new ApplicationBuilder(new ServiceCollection().BuildServiceProvider());
+
+        pipeline.UseHealthEndpointIsolation(probeListenerPorts);
+        pipeline.Run(_ =>
+        {
+            onReached();
+
+            return Task.CompletedTask;
+        });
+
+        return pipeline.Build();
+    }
+
+    private static DefaultHttpContext RequestOn(int port, string path)
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.LocalPort = port;
+        context.Request.Path = new PathString(path);
+
+        return context;
+    }
+}

--- a/tests/Host.UnitTests/HealthEndpointIsolationTests.cs
+++ b/tests/Host.UnitTests/HealthEndpointIsolationTests.cs
@@ -21,10 +21,18 @@ public sealed class HealthEndpointIsolationTests
 {
     private static readonly IReadOnlySet<int> ProbeListenerPorts = new HashSet<int> { 8081 };
 
+    /// <summary>
+    /// The trailing-slash forms are here because routing answers them: it ignores a trailing slash, so a rule that
+    /// compared for exact equality would read <c>/health/</c> as an application path, let it through, and serve the
+    /// aggregate dependency status unauthenticated on the listener MCP clients reach.
+    /// </summary>
     [Theory]
     [InlineData("/health")]
     [InlineData("/alive")]
     [InlineData("/started")]
+    [InlineData("/health/")]
+    [InlineData("/alive/")]
+    [InlineData("/started/")]
     public void ListenerServesPath_AProbePathOnTheApplicationPort_IsNotServed(string path)
     {
         // Arrange
@@ -41,6 +49,9 @@ public sealed class HealthEndpointIsolationTests
     [InlineData("/health")]
     [InlineData("/alive")]
     [InlineData("/started")]
+    [InlineData("/health/")]
+    [InlineData("/alive/")]
+    [InlineData("/started/")]
     public void ListenerServesPath_AProbePathOnTheProbePort_IsServed(string path)
     {
         // Arrange

--- a/tests/Host.UnitTests/HealthEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/HealthEndpointOptionsBindingTests.cs
@@ -1,0 +1,101 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using MailFathom.Host.Configuration;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers that the health-endpoint section binds from configuration the way composition reads it.</summary>
+/// <remarks>
+/// The section decides which sockets a deployment opens and whether they carry TLS, so the difference between a key
+/// that bound and a key that was ignored is the difference between the posture an operator wrote and one nobody chose.
+/// Strict binding is what turns a misspelling into a startup failure, and that is asserted here rather than assumed.
+/// </remarks>
+public sealed class HealthEndpointOptionsBindingTests
+{
+    [Fact]
+    public void ReadFrom_AnEmptyConfiguration_ServesTheProbesOnTheDefaultPort()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom([]);
+
+        // Act
+        var options = HealthEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.True(options.Enabled);
+        Assert.Equal(8081, options.Port);
+        Assert.Equal(HealthEndpointTransport.Http, options.Transport);
+    }
+
+    [Fact]
+    public void ReadFrom_AConfiguredSection_ReadsEveryDecisionCompositionActsOn()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["HealthEndpoints:Enabled"] = "true",
+            ["HealthEndpoints:BindAddress"] = "127.0.0.1",
+            ["HealthEndpoints:Port"] = "9090",
+            ["HealthEndpoints:HttpsPort"] = "9443",
+            ["HealthEndpoints:Transport"] = "HttpAndHttps",
+            ["HealthEndpoints:Domain"] = "probe.example.test",
+            ["HealthEndpoints:ServerCertificate:Bundle:Name"] = "probe-bundle",
+            ["HealthEndpoints:ServerCertificate:Bundle:SecretReference"] = "file:/run/secrets/probe.pfx",
+        });
+
+        // Act
+        var options = HealthEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Equal("127.0.0.1", options.BindAddress);
+        Assert.Equal(9090, options.Port);
+        Assert.Equal(9443, options.HttpsPort);
+        Assert.Equal(HealthEndpointTransport.HttpAndHttps, options.Transport);
+        Assert.Equal("probe.example.test", options.Domain);
+        Assert.Equal("file:/run/secrets/probe.pfx", options.ServerCertificate.Bundle?.SecretReference);
+        Assert.Empty(options.FindConfigurationErrors([8080]));
+    }
+
+    [Fact]
+    public void ReadFrom_ADisabledSection_TurnsTheProbesOff()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["HealthEndpoints:Enabled"] = "false",
+        });
+
+        // Act
+        var options = HealthEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.False(options.Enabled);
+        Assert.Empty(options.ListenerPorts);
+    }
+
+    /// <summary>
+    /// A misspelled key that bound quietly would leave the probes on a port an operator believed they had moved, which
+    /// is a listener published to the wrong network rather than a setting that failed to apply.
+    /// </summary>
+    [Fact]
+    public void ReadFrom_AMisspelledKey_FailsRatherThanBindingTheRest()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["HealthEndpoints:Prot"] = "9090",
+        });
+
+        // Act
+        var readingTheSection = () => HealthEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(readingTheSection);
+    }
+
+    private static IConfiguration ConfigurationFrom(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+}

--- a/tests/Host.UnitTests/HealthEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/HealthEndpointOptionsTests.cs
@@ -1,0 +1,348 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using MailFathom.Host.Configuration;
+using MailFathom.Infrastructure.Certificates;
+using MailFathom.Infrastructure.Secrets;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers what an operator may configure about the probe listener, and what fails startup instead of binding.</summary>
+/// <remarks>
+/// Every rule here refuses a configuration that would otherwise produce a listener nobody asked for: a probe port
+/// serving the mailbox's clients, a TLS mode with nothing to present, or a value the binder accepted and no member
+/// declares. A socket bound under any of those is one an operator believes is something it is not.
+/// </remarks>
+public sealed class HealthEndpointOptionsTests
+{
+    private static readonly int[] ApplicationPorts = [8080];
+
+    [Fact]
+    public void Defaults_AnUnconfiguredSection_ServesThreeProbesOnItsOwnClearTextPort()
+    {
+        // Arrange
+        var options = new HealthEndpointOptions();
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.True(options.Enabled);
+        Assert.Equal(8081, options.Port);
+        Assert.Equal("0.0.0.0", options.BindAddress);
+        Assert.Equal(HealthEndpointTransport.Http, options.Transport);
+        Assert.Null(options.HttpsPort);
+        Assert.Equal([8081], options.ListenerPorts);
+        Assert.Empty(errors);
+    }
+
+    /// <summary>
+    /// The disabled state is the one in which nothing about the probes exists: no route to reach, no socket to publish,
+    /// and no configuration left to be wrong.
+    /// </summary>
+    [Fact]
+    public void ListenerPorts_ADisabledSection_OpensNoListenerAndRefusesNothing()
+    {
+        // Arrange
+        var options = new HealthEndpointOptions
+        {
+            Enabled = false,
+            Port = 8080,
+            Transport = HealthEndpointTransport.HttpsOnly,
+        };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Empty(options.ListenerPorts);
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void ListenerPorts_ServingBothSchemes_AnswersOnBothPorts()
+    {
+        // Arrange
+        var options = TlsOptions(HealthEndpointTransport.HttpAndHttps);
+        options.HttpsPort = 8443;
+
+        // Act
+        var listenerPorts = options.ListenerPorts;
+
+        // Assert
+        Assert.Equal([8081, 8443], listenerPorts.Order());
+        Assert.Empty(options.FindConfigurationErrors(ApplicationPorts));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_TlsOnly_OpensNoClearTextListener()
+    {
+        // Arrange
+        var options = TlsOptions(HealthEndpointTransport.HttpsOnly);
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.False(options.ServesClearText);
+        Assert.True(options.TerminatesTls);
+        Assert.Equal([8081], options.ListenerPorts);
+        Assert.Equal(8081, options.TlsListenerPort);
+        Assert.Empty(errors);
+    }
+
+    /// <summary>
+    /// One socket serves one scheme, so which port carries TLS is what the transport decides: the configured port under
+    /// the mode that opens no clear-text listener, and the second one under the mode that opens both.
+    /// </summary>
+    [Fact]
+    public void TlsListenerPort_EachTransport_NamesTheSocketTlsIsServedOn()
+    {
+        // Arrange
+        var clearText = new HealthEndpointOptions();
+        var tlsOnly = TlsOptions(HealthEndpointTransport.HttpsOnly);
+        var bothSchemes = TlsOptions(HealthEndpointTransport.HttpAndHttps);
+        bothSchemes.HttpsPort = 8443;
+
+        // Act
+        var tlsPorts = new[] { clearText, tlsOnly, bothSchemes }.Select(options => options.TlsListenerPort);
+
+        // Assert
+        Assert.Equal([null, 8081, 8443], tlsPorts);
+    }
+
+    /// <summary>
+    /// A port an operator published and nothing binds is a deployment believing its probes answer somewhere they do
+    /// not, which is the same failure a certificate nothing presents produces.
+    /// </summary>
+    [Fact]
+    public void FindConfigurationErrors_ASecondPortUnderAClearTextTransport_IsRefused()
+    {
+        // Arrange
+        var options = new HealthEndpointOptions { HttpsPort = 8443 };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("nothing binds it", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_ASecondPortUnderTlsOnly_IsRefused()
+    {
+        // Arrange
+        var options = TlsOptions(HealthEndpointTransport.HttpsOnly);
+        options.HttpsPort = 8443;
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("nothing binds it", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(65536)]
+    public void FindConfigurationErrors_APortOutsideTheRange_IsRefused(int port)
+    {
+        // Arrange
+        var options = new HealthEndpointOptions { Port = port };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("HealthEndpoints:Port", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_APortTheApplicationListenerBinds_IsRefused()
+    {
+        // Arrange
+        var options = new HealthEndpointOptions { Port = 8080 };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("already the application listener's", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_TheTwoProbePortsColliding_IsRefused()
+    {
+        // Arrange
+        var options = TlsOptions(HealthEndpointTransport.HttpAndHttps);
+        options.HttpsPort = options.Port;
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("one socket cannot serve both schemes", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_BothSchemesWithNoTlsPort_IsRefused()
+    {
+        // Arrange
+        var options = TlsOptions(HealthEndpointTransport.HttpAndHttps);
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("HealthEndpoints:HttpsPort", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The binder accepts any number for an enum, so a value naming no transport would otherwise decide the posture by
+    /// falling through every check that asks which one it is.
+    /// </summary>
+    [Fact]
+    public void FindConfigurationErrors_ATransportNoMemberDeclares_IsRefused()
+    {
+        // Arrange
+        var options = new HealthEndpointOptions { Transport = (HealthEndpointTransport)7 };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("names no transport", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_ABindAddressThatIsNotAnIpAddress_IsRefused()
+    {
+        // Arrange
+        var options = new HealthEndpointOptions { BindAddress = "probe.example.test" };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("HealthEndpoints:BindAddress", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_ALoopbackBindAddress_IsAccepted()
+    {
+        // Arrange
+        var options = new HealthEndpointOptions { BindAddress = "127.0.0.1" };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_ATlsTransportWithNoCertificate_IsRefused()
+    {
+        // Arrange
+        var options = new HealthEndpointOptions
+        {
+            Transport = HealthEndpointTransport.HttpsOnly,
+            Domain = "probe.example.test",
+        };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("no development-certificate fallback", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_ATlsTransportWithNoDomain_IsRefused()
+    {
+        // Arrange
+        var options = TlsOptions(HealthEndpointTransport.HttpsOnly);
+        options.Domain = "   ";
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("HealthEndpoints:Domain", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_APrivateKeyWithNoCertificate_IsRefused()
+    {
+        // Arrange
+        var options = new HealthEndpointOptions
+        {
+            Transport = HealthEndpointTransport.HttpsOnly,
+            Domain = "probe.example.test",
+            ServerCertificate = new TlsServerCertificateOptions
+            {
+                PrivateKey = new ConfiguredSecret { Name = "probe-key", SecretReference = "file:/run/secrets/probe-key" },
+            },
+        };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("CertificateChain", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Material nothing presents is a deployment believing it configured TLS, which is worse than one that knows it did
+    /// not.
+    /// </summary>
+    [Fact]
+    public void FindConfigurationErrors_ACertificateUnderAClearTextTransport_IsRefused()
+    {
+        // Arrange
+        var options = new HealthEndpointOptions
+        {
+            ServerCertificate = new TlsServerCertificateOptions
+            {
+                Bundle = new ConfiguredSecret { Name = "probe-bundle", SecretReference = "file:/run/secrets/probe.pfx" },
+            },
+        };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("opens no TLS listener", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_BothKindsOfMaterial_IsRefused()
+    {
+        // Arrange
+        var options = TlsOptions(HealthEndpointTransport.HttpsOnly);
+        options.ServerCertificate.PrivateKey = new ConfiguredSecret
+        {
+            Name = "probe-key",
+            SecretReference = "file:/run/secrets/probe-key",
+        };
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("state one or the other", StringComparison.Ordinal));
+    }
+
+    private static HealthEndpointOptions TlsOptions(HealthEndpointTransport transport) =>
+        new()
+        {
+            Transport = transport,
+            Domain = "probe.example.test",
+            ServerCertificate = new TlsServerCertificateOptions
+            {
+                Bundle = new ConfiguredSecret { Name = "probe-bundle", SecretReference = "file:/run/secrets/probe.pfx" },
+            },
+        };
+}

--- a/tests/Host.UnitTests/HealthEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/HealthEndpointOptionsTests.cs
@@ -273,6 +273,26 @@ public sealed class HealthEndpointOptionsTests
         Assert.Contains(errors, error => error.Contains("HealthEndpoints:Domain", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// An orchestrator dials this listener by address, so an IP address is the mistake an operator is most likely to
+    /// make here — and a certificate is matched against DNS subject alternative names, which never carry one.
+    /// </summary>
+    [Theory]
+    [InlineData("10.0.0.5")]
+    [InlineData("*.example.test")]
+    public void FindConfigurationErrors_ADomainThatIsNotADnsName_IsRefused(string domain)
+    {
+        // Arrange
+        var options = TlsOptions(HealthEndpointTransport.HttpsOnly);
+        options.Domain = domain;
+
+        // Act
+        var errors = options.FindConfigurationErrors(ApplicationPorts);
+
+        // Assert
+        Assert.Contains(errors, error => error.StartsWith("HealthEndpoints:Domain", StringComparison.Ordinal));
+    }
+
     [Fact]
     public void FindConfigurationErrors_APrivateKeyWithNoCertificate_IsRefused()
     {

--- a/tests/Host.UnitTests/HealthProbeCompositionTests.cs
+++ b/tests/Host.UnitTests/HealthProbeCompositionTests.cs
@@ -1,0 +1,139 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using MailFathom.Host.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers which checks each probe reports, against the health-check service the host composes.</summary>
+/// <remarks>
+/// The predicates are asserted through a real <see cref="HealthCheckService" /> rather than by inspecting the
+/// registrations, because what the three probes have to be safe about is the answer: liveness must stay healthy while a
+/// dependency is not, or a database outage restarts every replica of a process that is working.
+/// </remarks>
+public sealed class HealthProbeCompositionTests
+{
+    [Fact]
+    public async Task CheckHealthAsync_WithTheDatabaseUnreachable_LeavesLivenessHealthy()
+    {
+        // Arrange
+        var healthChecks = HealthChecksWithAnUnreachableDatabase();
+
+        // Act
+        var report = await healthChecks.CheckHealthAsync(
+            HealthProbe.Liveness.Selects,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HealthStatus.Healthy, report.Status);
+        Assert.Equal(["self"], report.Entries.Keys);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WithTheDatabaseUnreachable_TurnsReadinessUnhealthy()
+    {
+        // Arrange
+        var healthChecks = HealthChecksWithAnUnreachableDatabase();
+
+        // Act
+        var report = await healthChecks.CheckHealthAsync(
+            HealthProbe.Readiness.Selects,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HealthStatus.Unhealthy, report.Status);
+        Assert.Equal(["database"], report.Entries.Keys);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WithTheStartupGatesOutstanding_ReportsOnlyTheGates()
+    {
+        // Arrange
+        var healthChecks = HealthChecksWithAnUnreachableDatabase();
+
+        // Act
+        var report = await healthChecks.CheckHealthAsync(
+            HealthProbe.Startup.Selects,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HealthStatus.Unhealthy, report.Status);
+        Assert.Equal([HostStartupGatesHealthCheck.Name], report.Entries.Keys);
+    }
+
+    /// <summary>
+    /// A check that states no probe membership reaches none of them. Landing in all three by default is how a
+    /// dependency check ends up able to restart the process.
+    /// </summary>
+    [Fact]
+    public async Task CheckHealthAsync_AnUntaggedCheck_ReachesNoProbe()
+    {
+        // Arrange
+        var healthChecks = HealthChecksWithAnUnreachableDatabase();
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        // Act
+        var reports = await Task.WhenAll(HealthProbe.All.Select(probe =>
+            healthChecks.CheckHealthAsync(probe.Selects, cancellationToken)));
+
+        // Assert
+        Assert.All(reports, report => Assert.DoesNotContain("unclassified", report.Entries.Keys));
+    }
+
+    [Fact]
+    public void FindUnansweredProbes_TheChecksTheHostRegisters_LeavesNoProbeUnanswered()
+    {
+        // Arrange
+        HealthCheckRegistration[] registrations =
+        [
+            StubHealthCheck.Registration("self", HealthStatus.Healthy, HealthProbe.Liveness.Tag),
+            StubHealthCheck.Registration("database", HealthStatus.Healthy, HealthProbe.Readiness.Tag),
+            StubHealthCheck.Registration(HostStartupGatesHealthCheck.Name, HealthStatus.Healthy, HealthProbe.Startup.Tag),
+        ];
+
+        // Act
+        var unanswered = HealthProbeEndpoints.FindUnansweredProbes(registrations);
+
+        // Assert
+        Assert.Empty(unanswered);
+    }
+
+    /// <summary>
+    /// The aggregate of no checks is healthy, so a readiness probe whose tag stopped matching would keep an instance in
+    /// traffic while reporting itself fit. Composition asserts the composed result rather than the wiring for exactly
+    /// that reason.
+    /// </summary>
+    [Fact]
+    public void FindUnansweredProbes_AProbeNoCheckCarriesTheTagOf_IsReported()
+    {
+        // Arrange
+        HealthCheckRegistration[] registrations =
+        [
+            StubHealthCheck.Registration("self", HealthStatus.Healthy, HealthProbe.Liveness.Tag),
+            StubHealthCheck.Registration(HostStartupGatesHealthCheck.Name, HealthStatus.Healthy, HealthProbe.Startup.Tag),
+        ];
+
+        // Act
+        var unanswered = HealthProbeEndpoints.FindUnansweredProbes(registrations);
+
+        // Assert
+        Assert.Contains(unanswered, message => message.Contains(HealthProbe.Readiness.Path, StringComparison.Ordinal));
+    }
+
+    private static HealthCheckService HealthChecksWithAnUnreachableDatabase()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOptions();
+        services.AddHealthChecks()
+            .Add(StubHealthCheck.Registration("self", HealthStatus.Healthy, HealthProbe.Liveness.Tag))
+            .Add(StubHealthCheck.Registration("database", HealthStatus.Unhealthy, HealthProbe.Readiness.Tag))
+            .Add(StubHealthCheck.Registration(HostStartupGatesHealthCheck.Name, HealthStatus.Unhealthy, HealthProbe.Startup.Tag))
+            .Add(StubHealthCheck.Registration("unclassified", HealthStatus.Unhealthy));
+
+        return services.BuildServiceProvider().GetRequiredService<HealthCheckService>();
+    }
+}

--- a/tests/Host.UnitTests/HealthProbeResponseTests.cs
+++ b/tests/Host.UnitTests/HealthProbeResponseTests.cs
@@ -1,0 +1,68 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Text;
+using MailFathom.Host.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers what a probe response carries, which is the aggregate status and nothing else.</summary>
+/// <remarks>
+/// The endpoint is unauthenticated by design, so everything the body carries is disclosed to whoever can reach the
+/// port. A check name says which dependencies exist, a description or an exception message says what went wrong with
+/// one, and a duration says how a deployment is performing; none of them is something an orchestrator compares.
+/// </remarks>
+public sealed class HealthProbeResponseTests
+{
+    [Fact]
+    public async Task WriteAggregateStatusAsync_AnUnhealthyReport_WritesTheStatusAndNothingAboutTheChecks()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        var body = new MemoryStream();
+        context.Response.Body = body;
+
+        var report = new HealthReport(
+            new Dictionary<string, HealthReportEntry>(StringComparer.Ordinal)
+            {
+                ["database"] = new(
+                    HealthStatus.Unhealthy,
+                    description: "Connection refused to postgres.internal:5432",
+                    duration: TimeSpan.FromMilliseconds(1234),
+                    exception: new InvalidOperationException("Npgsql could not open a connection"),
+                    data: null),
+            },
+            TimeSpan.FromMilliseconds(1234));
+
+        // Act
+        await HealthProbeEndpoints.WriteAggregateStatusAsync(context, report);
+
+        // Assert
+        var written = Encoding.UTF8.GetString(body.ToArray());
+
+        Assert.Equal("Unhealthy", written);
+        Assert.Equal("text/plain", context.Response.ContentType);
+    }
+
+    [Fact]
+    public async Task WriteAggregateStatusAsync_AHealthyReport_WritesTheAggregateStatus()
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        var body = new MemoryStream();
+        context.Response.Body = body;
+
+        var report = new HealthReport(
+            new Dictionary<string, HealthReportEntry>(StringComparer.Ordinal),
+            TimeSpan.Zero);
+
+        // Act
+        await HealthProbeEndpoints.WriteAggregateStatusAsync(context, report);
+
+        // Assert
+        Assert.Equal("Healthy", Encoding.UTF8.GetString(body.ToArray()));
+    }
+}

--- a/tests/Host.UnitTests/HealthProbeTests.cs
+++ b/tests/Host.UnitTests/HealthProbeTests.cs
@@ -75,6 +75,31 @@ public sealed class HealthProbeTests
         Assert.False(isProbePath);
     }
 
+    /// <summary>
+    /// The set is closed, so the struct default is the one value that is not a probe. C# gives no way to forbid it, so
+    /// it reports itself instead of answering for a path or a tag it does not have.
+    /// </summary>
+    [Fact]
+    public void IsSpecified_TheStructDefault_ReportsItselfAndRefusesToAnswer()
+    {
+        // Arrange
+        var unspecified = default(HealthProbe);
+
+        // Act, Assert
+        Assert.False(unspecified.IsSpecified);
+        Assert.Throws<InvalidOperationException>(() => unspecified.Path);
+        Assert.Throws<InvalidOperationException>(() => unspecified.Tag);
+        Assert.Equal("(unspecified)", unspecified.ToString());
+    }
+
+    [Fact]
+    public void IsSpecified_EveryDeclaredProbe_NamesAPathAndATag()
+    {
+        // Act, Assert
+        Assert.All(HealthProbe.All, probe => Assert.True(probe.IsSpecified));
+        Assert.Equal(HealthProbe.All.Select(probe => probe.Path), HealthProbe.All.Select(probe => probe.ToString()));
+    }
+
     [Fact]
     public void Selects_ARegistration_ReadsTheProbeMembershipItStated()
     {

--- a/tests/Host.UnitTests/HealthProbeTests.cs
+++ b/tests/Host.UnitTests/HealthProbeTests.cs
@@ -1,0 +1,85 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using MailFathom.Host.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers the three questions an orchestrator asks and how each one selects the checks that answer it.</summary>
+/// <remarks>
+/// Both the path and the tag are published identities — a deployment writes the path into a probe specification and a
+/// registration writes the tag — so what is asserted here is the identities themselves rather than a lookup that could
+/// be renamed and re-derived without anything failing.
+/// </remarks>
+public sealed class HealthProbeTests
+{
+    [Fact]
+    public void All_TheProbesTheListenerServes_AnswerThreeDistinctQuestionsOnThreeDistinctPaths()
+    {
+        // Arrange
+        var probes = HealthProbe.All;
+
+        // Act
+        var paths = probes.Select(probe => probe.Path).ToArray();
+        var tags = probes.Select(probe => probe.Tag).ToArray();
+
+        // Assert
+        Assert.Equal(["/started", "/health", "/alive"], paths);
+        Assert.Equal(["startup", "ready", "live"], tags);
+    }
+
+    [Theory]
+    [InlineData("/started", true)]
+    [InlineData("/health", true)]
+    [InlineData("/alive", true)]
+    [InlineData("/HEALTH", true)]
+    [InlineData("/mcp", false)]
+    [InlineData("/", false)]
+    public void IsProbePath_APath_ReportsWhetherAProbeAnswersIt(string path, bool expected)
+    {
+        // Arrange
+        var requestPath = new PathString(path);
+
+        // Act
+        var isProbePath = HealthProbe.IsProbePath(requestPath);
+
+        // Assert
+        Assert.Equal(expected, isProbePath);
+    }
+
+    /// <summary>
+    /// A probe answers one path. Treating everything beneath it as a probe path would keep requests off the application
+    /// listener that no probe was ever going to answer, which is a silent way to lose a route.
+    /// </summary>
+    [Fact]
+    public void IsProbePath_APathBeneathAProbe_IsNotAProbePath()
+    {
+        // Arrange
+        var requestPath = new PathString("/health/details");
+
+        // Act
+        var isProbePath = HealthProbe.IsProbePath(requestPath);
+
+        // Assert
+        Assert.False(isProbePath);
+    }
+
+    [Fact]
+    public void Selects_ARegistration_ReadsTheProbeMembershipItStated()
+    {
+        // Arrange
+        var readinessCheck = StubHealthCheck.Registration("database", HealthStatus.Healthy, HealthProbe.Readiness.Tag);
+        var untaggedCheck = StubHealthCheck.Registration("unclassified", HealthStatus.Healthy);
+
+        // Act
+        var selected = HealthProbe.All.Where(probe => probe.Selects(readinessCheck)).ToArray();
+        var selectedForUntagged = HealthProbe.All.Where(probe => probe.Selects(untaggedCheck)).ToArray();
+
+        // Assert
+        Assert.Equal([HealthProbe.Readiness], selected);
+        Assert.Empty(selectedForUntagged);
+    }
+}

--- a/tests/Host.UnitTests/HealthProbeTests.cs
+++ b/tests/Host.UnitTests/HealthProbeTests.cs
@@ -36,6 +36,12 @@ public sealed class HealthProbeTests
     [InlineData("/health", true)]
     [InlineData("/alive", true)]
     [InlineData("/HEALTH", true)]
+    // Routing ignores a trailing slash, so a probe endpoint answers these. Reading them as application paths is what
+    // would let the readiness answer past the listener isolation and onto the port MCP clients reach.
+    [InlineData("/health/", true)]
+    [InlineData("/alive/", true)]
+    [InlineData("/started/", true)]
+    [InlineData("/HEALTH/", true)]
     [InlineData("/mcp", false)]
     [InlineData("/", false)]
     public void IsProbePath_APath_ReportsWhetherAProbeAnswersIt(string path, bool expected)
@@ -54,11 +60,13 @@ public sealed class HealthProbeTests
     /// A probe answers one path. Treating everything beneath it as a probe path would keep requests off the application
     /// listener that no probe was ever going to answer, which is a silent way to lose a route.
     /// </summary>
-    [Fact]
-    public void IsProbePath_APathBeneathAProbe_IsNotAProbePath()
+    [Theory]
+    [InlineData("/health/details")]
+    [InlineData("/healthz")]
+    public void IsProbePath_APathNoProbeAnswers_IsNotAProbePath(string path)
     {
         // Arrange
-        var requestPath = new PathString("/health/details");
+        var requestPath = new PathString(path);
 
         // Act
         var isProbePath = HealthProbe.IsProbePath(requestPath);

--- a/tests/Host.UnitTests/HostStartupGatesTests.cs
+++ b/tests/Host.UnitTests/HostStartupGatesTests.cs
@@ -1,0 +1,89 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using MailFathom.Host.Hosting;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers what the startup probe reports while the host is still coming up.</summary>
+public sealed class HostStartupGatesTests
+{
+    [Fact]
+    public void Completed_WithAGateOutstanding_ReportsTheHostStillComingUp()
+    {
+        // Arrange
+        var gates = new HostStartupGates(HostStartupGate.SecretConfiguration, HostStartupGate.DatabaseSchema);
+
+        // Act
+        gates.MarkCompleted(HostStartupGate.SecretConfiguration);
+
+        // Assert
+        Assert.False(gates.Completed);
+    }
+
+    [Fact]
+    public void Completed_WithEveryGateReported_ReportsTheHostFinishedComingUp()
+    {
+        // Arrange
+        var gates = new HostStartupGates(HostStartupGate.SecretConfiguration, HostStartupGate.DatabaseSchema);
+
+        // Act
+        gates.MarkCompleted(HostStartupGate.SecretConfiguration);
+        gates.MarkCompleted(HostStartupGate.DatabaseSchema);
+
+        // Assert
+        Assert.True(gates.Completed);
+    }
+
+    /// <summary>
+    /// A gate runs once and nothing sets it back, so an orchestrator that has seen a healthy startup probe hands the
+    /// process over to the liveness and readiness probes and never returns to this one.
+    /// </summary>
+    [Fact]
+    public void Completed_AfterCompletion_StaysCompletedWhateverIsReportedAfterwards()
+    {
+        // Arrange
+        var gates = new HostStartupGates(HostStartupGate.DatabaseSchema);
+        gates.MarkCompleted(HostStartupGate.DatabaseSchema);
+
+        // Act
+        gates.MarkCompleted(HostStartupGate.DatabaseSchema);
+        gates.MarkCompleted(HostStartupGate.SecretConfiguration);
+
+        // Assert
+        Assert.True(gates.Completed);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WithAGateOutstanding_ReportsUnhealthy()
+    {
+        // Arrange
+        var check = new HostStartupGatesHealthCheck(new HostStartupGates(HostStartupGate.DatabaseSchema));
+
+        // Act
+        var result = await check.CheckHealthAsync(
+            new HealthCheckContext(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HealthStatus.Unhealthy, result.Status);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_WithEveryGateCompleted_ReportsHealthy()
+    {
+        // Arrange
+        var gates = new HostStartupGates(HostStartupGate.DatabaseSchema);
+        gates.MarkCompleted(HostStartupGate.DatabaseSchema);
+
+        // Act
+        var result = await new HostStartupGatesHealthCheck(gates).CheckHealthAsync(
+            new HealthCheckContext(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+}

--- a/tests/Host.UnitTests/McpRateLimitingTests.cs
+++ b/tests/Host.UnitTests/McpRateLimitingTests.cs
@@ -78,19 +78,23 @@ public sealed class McpRateLimitingTests
         Assert.True(limiterOptions.AutoReplenishment);
     }
 
-    [Fact]
-    public void PartitionForProcess_ForARequestOutsideTheEndpoint_AppliesNoLimit()
+    [Theory]
+    [InlineData("/started")]
+    [InlineData("/health")]
+    [InlineData("/alive")]
+    public void PartitionForProcess_ForAProbeRequest_AppliesNoLimit(string probePath)
     {
         // Arrange
         var limits = Limits(maxConcurrentRequests: 1);
         using var limiter = ProcessLimiter(limits);
 
         // Act
-        var leases = AcquireAll(limiter, () => RequestTo("/health"), attempts: 5);
+        var leases = AcquireAll(limiter, () => RequestTo(probePath), attempts: 5);
 
         // Assert
-        // Readiness and liveness have to keep answering while the endpoint is refusing, so the process-wide limiter
-        // excludes every route that is not the MCP endpoint rather than counting them against the same permits.
+        // A throttled probe fails, and a failed liveness probe restarts a process that was answering correctly, so a
+        // limiter on the probe listener would turn a burst of polling into an outage. The process-wide limiter excludes
+        // every route that is not the MCP endpoint rather than counting them against the same permits.
         Assert.All(leases, lease => Assert.True(lease.IsAcquired));
 
         DisposeAll(leases);

--- a/tests/Host.UnitTests/SecretConfigurationStartupValidatorTests.cs
+++ b/tests/Host.UnitTests/SecretConfigurationStartupValidatorTests.cs
@@ -41,6 +41,40 @@ public sealed class SecretConfigurationStartupValidatorTests
     }
 
     [Fact]
+    public async Task StartingAsync_EveryReferenceResolvable_ReportsTheSecretGateToTheStartupProbe()
+    {
+        // Arrange
+        var harness = CreateHarness(
+            ConfiguredAccounts.WithPasswordReferences(("primary", "plaintext:dev-password")),
+            new PersistenceOptions());
+
+        // Act
+        await harness.Validator.StartingAsync(CancellationToken.None);
+
+        // Assert
+        Assert.True(harness.StartupGates.Completed);
+    }
+
+    /// <summary>
+    /// A host whose secrets are unusable never comes up, so the gate stays outstanding rather than reporting a step
+    /// that raised.
+    /// </summary>
+    [Fact]
+    public async Task StartingAsync_UnresolvableReference_LeavesTheSecretGateOutstanding()
+    {
+        // Arrange
+        var harness = CreateHarness(
+            ConfiguredAccounts.WithPasswordReferences(("primary", "file:/run/secrets/absent")),
+            new PersistenceOptions());
+
+        // Act
+        await Assert.ThrowsAsync<OptionsValidationException>(() => harness.Validator.StartingAsync(CancellationToken.None));
+
+        // Assert
+        Assert.False(harness.StartupGates.Completed);
+    }
+
+    [Fact]
     public async Task StartingAsync_NoSecretConfigured_CompletesBecauseNothingWasDiscovered()
     {
         // Arrange
@@ -609,6 +643,7 @@ public sealed class SecretConfigurationStartupValidatorTests
         var connectionSettingsValidator = databaseConnectionSettings ?? new StubDatabaseConnectionSettingsValidator();
         var validationLogger = new RecordingLogger<SecretConfigurationValidator>();
         var startupLogger = new RecordingLogger<SecretConfigurationStartupValidator>();
+        var startupGates = new HostStartupGates(HostStartupGate.SecretConfiguration);
 
         var validator = new SecretConfigurationStartupValidator(
             new StubSettingsSnapshot<MailSynchronizationOptions>(synchronizationOptions),
@@ -624,13 +659,15 @@ public sealed class SecretConfigurationStartupValidatorTests
                 new FakeTimeProvider(ValidatedAt),
                 validationLogger),
             new SecretResolutionOptions(interpretation),
+            startupGates,
             startupLogger);
 
-        return new ValidatorHarness(validator, startupLogger, validationLogger);
+        return new ValidatorHarness(validator, startupGates, startupLogger, validationLogger);
     }
 
     private sealed record ValidatorHarness(
         SecretConfigurationStartupValidator Validator,
+        HostStartupGates StartupGates,
         RecordingLogger<SecretConfigurationStartupValidator> StartupLogger,
         RecordingLogger<SecretConfigurationValidator> ValidationLogger)
     {

--- a/tests/Host.UnitTests/ServerCertificateExpiryTests.cs
+++ b/tests/Host.UnitTests/ServerCertificateExpiryTests.cs
@@ -1,0 +1,67 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using MailFathom.Host.Security;
+using MailFathom.TestSupport;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers when startup reports a certificate as something to renew rather than as something it loaded.</summary>
+/// <remarks>
+/// The window is one rule for every listener that presents a certificate. Two copies of it would let one listener start
+/// warning a month before the other, which an operator would read as one of them being wrong.
+/// </remarks>
+public sealed class ServerCertificateExpiryTests
+{
+    private static readonly DateTimeOffset ReadAt = new(2026, 7, 31, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void ExpirationOf_ACertificate_ReadsTheInstantItStopsBeingUsable()
+    {
+        // Arrange
+        using var identity = TestCertificates.CreateServerIdentity(
+            ["probe.example.test"],
+            ReadAt.AddDays(-1),
+            ReadAt.AddDays(90));
+
+        // Act
+        var expiration = ServerCertificateExpiry.ExpirationOf(identity);
+
+        // Assert
+        Assert.Equal(TimeSpan.Zero, expiration.Offset);
+        Assert.Equal(identity.NotAfter.ToUniversalTime(), expiration);
+    }
+
+    [Theory]
+    [InlineData(31, false)]
+    [InlineData(30, true)]
+    [InlineData(1, true)]
+    public void IsExpiringSoon_ACertificateExpiringInSoManyDays_IsReportedAgainstTheNoticeWindow(
+        int daysUntilExpiry,
+        bool expected)
+    {
+        // Arrange
+        var expiration = ReadAt.AddDays(daysUntilExpiry);
+
+        // Act
+        var expiringSoon = ServerCertificateExpiry.IsExpiringSoon(expiration, ReadAt);
+
+        // Assert
+        Assert.Equal(expected, expiringSoon);
+    }
+
+    /// <summary>
+    /// Nothing reaches this with an expired certificate — the loader refuses one before a holder publishes it — but the
+    /// window has to answer for it rather than reporting an ordinary load.
+    /// </summary>
+    [Fact]
+    public void IsExpiringSoon_ACertificateThatHasAlreadyExpired_IsReportedAsExpiringSoon()
+    {
+        // Act
+        var expiringSoon = ServerCertificateExpiry.IsExpiringSoon(ReadAt.AddDays(-1), ReadAt);
+
+        // Assert
+        Assert.True(expiringSoon);
+    }
+}

--- a/tests/Host.UnitTests/StubHealthCheck.cs
+++ b/tests/Host.UnitTests/StubHealthCheck.cs
@@ -1,0 +1,28 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>A health check that reports the status it was created with.</summary>
+/// <remarks>
+/// The probes select checks by tag and report what those checks answered, so what a test needs from a check is a status
+/// it decides and a registration it can tag. Substituting the interface would say the same thing through a mock's
+/// configuration, and the real registration type is what the probe predicates read.
+/// </remarks>
+internal sealed class StubHealthCheck : IHealthCheck
+{
+    private readonly HealthStatus status;
+
+    internal StubHealthCheck(HealthStatus status) => this.status = status;
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(new HealthCheckResult(this.status));
+
+    /// <summary>Registers a check under a name, a status, and the probe tags it belongs to.</summary>
+    internal static HealthCheckRegistration Registration(string name, HealthStatus status, params string[] tags) =>
+        new(name, new StubHealthCheck(status), failureStatus: null, tags);
+}

--- a/tests/Infrastructure.UnitTests/TlsServerCertificateOptionsTests.cs
+++ b/tests/Infrastructure.UnitTests/TlsServerCertificateOptionsTests.cs
@@ -1,0 +1,127 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using MailFathom.Infrastructure.Certificates;
+using MailFathom.Infrastructure.Secrets;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests;
+
+/// <summary>Covers the shape a certificate block must have before anything tries to load what it names.</summary>
+/// <remarks>
+/// Every listener MailFathom terminates TLS on provisions its identity through this block, so the rule lives with the
+/// type rather than with either endpoint that binds it. The loader answers the same question against real material and
+/// reports it as <see cref="CertificateMaterialFailure" />; what this adds is the configuration path, reported during
+/// composition before a secret is fetched.
+/// </remarks>
+public sealed class TlsServerCertificateOptionsTests
+{
+    private const string SectionPath = "McpEndpoint:Https:Endpoints:0:ServerCertificate";
+
+    [Fact]
+    public void FindConfigurationErrors_ABundle_IsComplete()
+    {
+        // Arrange
+        var material = new TlsServerCertificateOptions { Bundle = Reference("bundle") };
+
+        // Act
+        var errors = material.FindConfigurationErrors(SectionPath);
+
+        // Assert
+        Assert.Empty(errors);
+        Assert.True(material.IsConfigured);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_AChainBesideItsPrivateKey_IsComplete()
+    {
+        // Arrange
+        var material = new TlsServerCertificateOptions
+        {
+            CertificateChain = Reference("chain"),
+            PrivateKey = Reference("key"),
+        };
+
+        // Act, Assert
+        Assert.Empty(material.FindConfigurationErrors(SectionPath));
+    }
+
+    /// <summary>
+    /// Which of the two states the identity would otherwise be decided by a precedence rule nobody would remember, so
+    /// both kinds together is a refusal rather than a resolution.
+    /// </summary>
+    [Fact]
+    public void FindConfigurationErrors_ABundleBesidePemMaterial_IsRefusedAsAmbiguous()
+    {
+        // Arrange
+        var material = new TlsServerCertificateOptions
+        {
+            Bundle = Reference("bundle"),
+            PrivateKey = Reference("key"),
+        };
+
+        // Act
+        var error = Assert.Single(material.FindConfigurationErrors(SectionPath));
+
+        // Assert
+        Assert.StartsWith(SectionPath, error, StringComparison.Ordinal);
+        Assert.Contains("state one or the other", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_NoMaterialAtAll_IsRefusedWithoutOfferingAFallback()
+    {
+        // Arrange
+        var material = new TlsServerCertificateOptions();
+
+        // Act
+        var error = Assert.Single(material.FindConfigurationErrors(SectionPath));
+
+        // Assert
+        Assert.Contains("no development-certificate fallback", error, StringComparison.Ordinal);
+        Assert.False(material.IsConfigured);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_APrivateKeyWithNoChain_NamesTheMissingChain()
+    {
+        // Arrange
+        var material = new TlsServerCertificateOptions { PrivateKey = Reference("key") };
+
+        // Act
+        var error = Assert.Single(material.FindConfigurationErrors(SectionPath));
+
+        // Assert
+        Assert.StartsWith($"{SectionPath}:{nameof(TlsServerCertificateOptions.CertificateChain)}", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_AChainWithNoPrivateKey_NamesTheMissingKey()
+    {
+        // Arrange
+        var material = new TlsServerCertificateOptions { CertificateChain = Reference("chain") };
+
+        // Act
+        var error = Assert.Single(material.FindConfigurationErrors(SectionPath));
+
+        // Assert
+        Assert.StartsWith($"{SectionPath}:{nameof(TlsServerCertificateOptions.PrivateKey)}", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>A block whose parts are declared without a reference names nothing, which is what an operator who deleted a value leaves behind.</summary>
+    [Fact]
+    public void IsConfigured_BlocksWithoutAReference_NameNoMaterial()
+    {
+        // Arrange
+        var material = new TlsServerCertificateOptions
+        {
+            Bundle = new ConfiguredSecret { Name = "bundle", SecretReference = "   " },
+        };
+
+        // Act, Assert
+        Assert.False(material.IsConfigured);
+    }
+
+    private static ConfiguredSecret Reference(string name) =>
+        new() { Name = name, SecretReference = $"file:/etc/mailfathom/tls/{name}" };
+}

--- a/tests/IntegrationTests/Hosting/OrchestratedDatabaseHealthTests.cs
+++ b/tests/IntegrationTests/Hosting/OrchestratedDatabaseHealthTests.cs
@@ -12,16 +12,28 @@ using Xunit;
 
 namespace MailFathom.IntegrationTests.Hosting;
 
-/// <summary>Proves the database health check the enrichment layers on reports the orchestrated database healthy.</summary>
+/// <summary>Proves the database health check the enrichment layers on reports the orchestrated database healthy, under the tag that reaches the readiness probe.</summary>
 /// <remarks>
+/// <para>
 /// The registration is deliberately the enrichment half of the Aspire PostgreSQL EF Core integration rather than its
 /// context-building half, because MailFathom composes its own connection string asynchronously during startup and supplies
 /// the password per physical connection. Whether that arrangement still yields a working health check is a claim about
 /// two libraries meeting a real server: a unit test can assert the settings the callback sets and nothing beyond them.
+/// </para>
+/// <para>
+/// The tag is asserted here for the same reason. The enrichment registers the check under a name it chooses, and the
+/// readiness probe finds it by the tag MailFathom adds to that registration; a rename upstream would silently leave
+/// readiness answering without consulting the database, which is exactly the failure a composed run catches and a
+/// substitute cannot.
+/// </para>
 /// </remarks>
 [Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
 public sealed class OrchestratedDatabaseHealthTests(MailFathomOrchestrationFixture orchestration)
 {
+    /// <summary>The tag the readiness probe selects its checks by, written out rather than referenced.</summary>
+    /// <remarks>It is a published identity: a deployment reads it in the host's own composition and an operator never types it, but renaming it changes which checks a probe consults. Spelling it here is what makes this test fail on that rename instead of following it.</remarks>
+    private const string ReadinessProbeTag = "ready";
+
     [Fact]
     public async Task CheckHealthAsync_ForTheEnrichedContext_ReportsTheOrchestratedDatabaseHealthy()
     {
@@ -34,20 +46,24 @@ public sealed class OrchestratedDatabaseHealthTests(MailFathomOrchestrationFixtu
             _ => new PostgresConnectionSettings(orchestration.DatabaseConnectionString, null, null),
             PostgresTextSearchConfiguration.Default);
         builder.AddDatabaseHealthAndTelemetry(
-            TimeSpan.FromSeconds(HostApplicationBuilderExtensions.DefaultDatabaseCommandTimeoutSeconds));
+            TimeSpan.FromSeconds(HostApplicationBuilderExtensions.DefaultDatabaseCommandTimeoutSeconds),
+            probeTags: [ReadinessProbeTag]);
 
         using var host = builder.Build();
         await host.StartAsync(cancellationToken);
 
         // Act
-        var report = await host.Services.GetRequiredService<HealthCheckService>().CheckHealthAsync(cancellationToken);
+        var report = await host.Services.GetRequiredService<HealthCheckService>().CheckHealthAsync(
+            registration => registration.Tags.Contains(ReadinessProbeTag),
+            cancellationToken);
 
         await host.StopAsync(cancellationToken);
 
         // Assert
         Assert.Equal(HealthStatus.Healthy, report.Status);
 
-        // A healthy report over no checks at all would say nothing about the database, so the entry itself is asserted.
+        // A healthy report over no checks at all would say nothing about the database, and selecting by tag is exactly
+        // how the readiness probe would end up over none, so the entry itself is asserted.
         Assert.NotEmpty(report.Entries);
         Assert.All(report.Entries, entry => Assert.Equal(HealthStatus.Healthy, entry.Value.Status));
     }


### PR DESCRIPTION
Closes #179

The host serves three probes — `/started`, `/health`, and `/alive` — on a listener the new `HealthEndpoints` section owns, identically in every environment. Nothing reads `IHostEnvironment` any more, so the exposure decision moves from the environment name to which network the probe port is published on.

## What changed

**A listener of its own.** `HealthEndpoints` decides whether the probes are served (`Enabled`, `true` by default), on which address and port (`0.0.0.0:8081`), and under which transport. Disabling it maps no route and opens no listener, and changes nothing else.

**Isolation in both directions.** A probe path asked on the application port is answered with `404`, and `/mcp` asked on the probe port is too. The decision is taken from the connection's local port — a property of the socket, not a header the caller writes — and the middleware runs ahead of everything the MCP endpoint adds.

**Three probes, selected by tag.** A check states which probes it belongs to once, where it is registered; a check with no tag reaches none. Liveness consults process-local state alone, readiness consults the database check `AddDatabaseHealthAndTelemetry` registers, and startup reports the host's own gates — the secret validator and the schema gate. A probe over no checks reports healthy, so composition refuses to start when any of the three would answer without consulting anything.

**Transports.** `Http` (the default), `HttpAndHttps`, and `HttpsOnly`. The TLS modes resolve their certificate through the loader #142 established and never downgrade: material that is missing, unresolvable, expired, or unusable fails startup with nothing listening. Validation refuses a port outside 1–65535, a probe port that collides with the application listener, two probe ports that collide, `HttpAndHttps` with no second port, and a second port or a certificate no transport binds.

**The application listener is preserved.** Binding any listener in code makes Kestrel ignore `ASPNETCORE_URLS` and `ASPNETCORE_HTTP_PORTS`, which would have taken the application listener away from every deployment that states its port that way — the Compose deployment and the chart both do. The host restates those addresses as `Kestrel:Endpoints` entries before opening the probe listener, handing the same strings back to the framework's own parser, and restates nothing where they were already being ignored (an operator's own `Kestrel:Endpoints`, or MCP HTTPS profiles binding in code).

**The response, and what is not on this listener.** A probe response carries the aggregate status and nothing else — no check name, description, exception, or duration. The endpoints carry no authentication, no origin gate, and no rate limiting, deliberately: an orchestrator holds no credential, and a throttled liveness probe restarts a process that was answering correctly.

## Verification

- `scripts/verify-full.sh` — passed. 1973 unit tests, 96.90% aggregate line coverage, formatting clean, workflow contract suite 18/18.
- `scripts/verify-deployment-assets.sh` — passed, including two new rejections: a startup probe pointed at `/alive`, and a probe port colliding with 8080.
- The Kestrel mechanics behind the design were confirmed against a real host outside the repository: a code-bound listener suppresses the URL-shaped addresses, a configuration-backed endpoint coexists with it, and the isolation, the tag predicates, and the minimal body behave as described on real sockets.

## Deployment assets

The chart gains a `health` container port driven by `probes.port`, which also sets `HealthEndpoints__Port` so the two cannot drift; the startup probe moves to `/started`; the values schema pins each path and refuses 8080 for the probe port. Compose publishes the probe port to loopback. `docs/operations/health-endpoints.md` is the new operator page, and the container, Compose, Kubernetes, MCP-endpoint, and scope pages follow it.
