### PR TITLE
Guide users from installation to first tool call, and gather configuration and telemetry in one place each

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -6,6 +6,7 @@ These instructions apply under `docs/` in addition to the repository root instru
 - Documentation describes verified implemented behavior, not intended implementation. Keep future intent in specifications.
 - Document architecture, feature behavior, configuration, security assumptions, operational procedures, failure modes, and important implementation trade-offs when introduced or changed.
 - Keep documentation discoverable under `architecture/`, `features/`, `operations/`, and `decisions/`; add an index when more than a few pages exist.
+- `users/` is the audience-facing guide layer for people who install, configure, and use MailFathom. Its pages guide and link into the sections above for every contract; a limit, default, or rule stated in full belongs on the owning reference page, never duplicated in a guide where it would go stale silently.
 - Create or modify ADRs under `decisions/` only with explicit owner approval.
 - Update examples, configuration snippets, command names, and diagrams with their corresponding behavior.
 - Check whether `AGENTS.md` files need updates when workflows, structure, tooling, or documentation rules change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,13 @@
 
 This documentation set explains the durable design and operating model for MailFathom.
 
+## For users
+
+[The user guide](users/README.md) is the guided path for people who install, configure, and use MailFathom rather
+than develop it: [choosing an installation](users/installation.md), [getting started](users/getting-started.md) from
+first mailbox to first tool call, and [using the tools](users/usage.md). It links into the sections below for depth
+instead of duplicating them.
+
 ## Sections
 
 - [Architecture](architecture/solution-structure.md) describes the clean-architecture boundaries and project layout.
@@ -9,6 +16,8 @@ This documentation set explains the durable design and operating model for MailF
 - [Features](features/initial-scope.md) summarizes the first scaffolded capability scope.
 - [Operations](operations/local-development.md) covers local .NET and Aspire development commands.
 - [Configuration sources](operations/configuration-sources.md) covers the source precedence, the deployment-provisioned JSON directory and file, and the Kubernetes ConfigMap and Secret mapping.
+- [Configuration reference](operations/configuration-reference.md) lists every user-settable option in one place, with its type, default, constraints, and whether changing it needs a restart.
+- [Telemetry](operations/telemetry.md) records what the host emits over OpenTelemetry, the one environment variable that decides whether it is exported, the Aspire dashboard as the local destination, and why deployments export nothing by default.
 - [Secret provisioning](operations/secret-provisioning.md) covers secret references, the systemd and container provisioning paths, and in-memory exposure.
 - [Host startup telemetry](operations/host-startup-telemetry.md) describes the bootstrap logging pipeline that reports process start, startup failure, and shutdown.
 - [MCP endpoint](operations/mcp-endpoint.md) covers enabling the protocol surface, the API keys and explicit unauthenticated mode that guard it, the origins it answers, and the domains and certificates it terminates TLS for.

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -1,0 +1,314 @@
+# Configuration reference
+
+Every user-settable option, in one place, checked against the options classes that bind it. Each section's table
+states the key, its type, the value a deployment gets by writing nothing, the constraint startup enforces, and what a
+change needs to take effect. The prose around a setting group — what it means, why it is shaped that way, how to
+choose a value — lives on the page each section links; this page is the inventory.
+
+## How to read the tables
+
+**Keys.** Written in configuration-section form. As an environment variable, `:` becomes `__` and a list index is a
+numbered segment: `MailSynchronization:Accounts:0:Host` is `MailSynchronization__Accounts__0__Host`. Where the
+configuration comes from, and which source wins, is [configuration sources](configuration-sources.md).
+
+**Types.** A `TimeSpan` binds from `hh:mm:ss` (`"00:05:00"` is five minutes; a leading `d.` adds days). A date binds
+as `yyyy-MM-dd`, an instant as ISO 8601 with an explicit offset. An enum binds by member name, and a **secret block**
+is the three-field shape [secret provisioning](secret-provisioning.md#the-secret-block) defines:
+
+```json
+{ "Name": "imap-primary-password", "SecretReference": "file:/etc/mailfathom/secrets/imap-primary-password", "Lifetime": "NoLimit" }
+```
+
+`Name` is the identity diagnostics use, `SecretReference` is `<scheme>:<target>` with the schemes
+`systemd-credential:`, `file:`, `env:`, and `plaintext:`, and `Lifetime` is `NoLimit` (the default) or the ISO 8601
+instant the material stops being accepted. Trust-anchor and certificate blocks nest a fourth field, `Password`, itself
+a secret block, for protected PKCS#12 bundles.
+
+**Change.** What ADR 0002 classifies for the group:
+
+- *restart* — the section is read while the host composes itself; edit it, then restart.
+- *reload* — a changed value is validated and, if sound, adopted by the next operation without a restart; a rejected
+  candidate leaves the running configuration in force. Reload of a file-shaped source has caveats of its own under
+  Kubernetes — see [configuration sources](configuration-sources.md#reload).
+
+Whatever the classification, the **material behind a secret reference is read per use**: rotating a password, key, or
+certificate behind an unchanged reference needs no restart and no reload. [Secret rotation](secret-rotation.md) walks
+each case.
+
+**Validation.** Every MailFathom section below is bound strictly: a key the section does not define fails startup
+naming it, so a typo cannot silently leave a default in force. Values are validated on start, and a violated
+constraint fails startup with the configuration path in the message. The two exceptions are the framework-shaped
+entries — `Logging` and `ConnectionStrings` — and the single-key `Secrets:Interpretation`, which is read with a
+default rather than bound as a section.
+
+## `ConfigurationSources`
+
+Names JSON configuration provisioned outside the application — a mounted ConfigMap, a systemd drop-in.
+[Configuration sources](configuration-sources.md) is the page.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `ConfigurationSources:Directory` | string | unset | Must exist when named | restart |
+| `ConfigurationSources:File` | string | unset | Must exist when named | restart |
+
+The *content* of files that existed at startup reloads; adding or removing a file is a restart.
+
+## `Secrets`
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `Secrets:Interpretation` | enum | `ReferenceOnly` | `ReferenceOnly`, `ReferenceOrInline`, `InlineOnly` | restart |
+
+Under the default, a plain-text value where a reference belongs fails startup instead of authenticating.
+[Interpretation modes](secret-provisioning.md#interpretation-modes) records when the other two are appropriate;
+development keeps `ReferenceOrInline` so `plaintext:` references stay convenient.
+
+## `MailSynchronization`
+
+Whether and how mailboxes are synchronized. [IMAP synchronization](../features/imap-synchronization.md#configuration)
+explains the model. The section reloads **per operation** — a run takes one validated snapshot when it begins, so a
+changed account list, bound, or policy is adopted at the next run rather than mid-run — except the four values that
+shape the coordinator loop itself, which are read once at start and marked *restart* below.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `MailSynchronization:Enabled` | bool | `false` | Enabled requires at least one account | restart |
+| `MailSynchronization:Interval` | TimeSpan | `00:05:00` | 10 s – 1 day; measured end-of-run to start-of-run | restart |
+| `MailSynchronization:MaxFailureBackoff` | TimeSpan | `00:30:00` | 10 s – 1 day, and never below `Interval` | reload |
+| `MailSynchronization:MaxConcurrentAccounts` | int | `4` | 1 – 100 | restart |
+| `MailSynchronization:MaxConcurrentFoldersPerAccount` | int | `1` | 1 – 20 | reload |
+| `MailSynchronization:ShutdownDrainTimeout` | TimeSpan | `00:00:10` | 0 – 2 min | restart |
+| `MailSynchronization:MaxMetadataBatchSize` | int | `100` | 1 – 1000 | reload |
+| `MailSynchronization:MaxRawMimeBytes` | long | `26214400` (25 MiB) | 1024 – 104857600; larger messages are stored without content | reload |
+| `MailSynchronization:MaxMetadataBatchesPerRun` | int | `10` | 1 – 1000 | reload |
+| `MailSynchronization:MaxReconciledEmailsPerRun` | int | `500` | 1 – 10000 | reload |
+| `MailSynchronization:MaxMimePartCount` | int | `1000` | 1 – 100000 | reload |
+| `MailSynchronization:MaxMimeNestingDepth` | int | `30` | 1 – 1000 | reload |
+| `MailSynchronization:MaxExtractedTextCharacters` | int | `100000` | 1000 – 200000; the ceiling keeps the search vector inside PostgreSQL's limit | reload |
+
+### One account — `MailSynchronization:Accounts:<n>`
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `…:AccountId` | string | — | Required; unique across accounts after normalization | reload |
+| `…:Host` | string | — | Required when synchronization is enabled | reload |
+| `…:Port` | int | `993` | 1 – 65535 | reload |
+| `…:UserName` | string | — | Required when synchronization is enabled; an identifier, not a secret | reload |
+| `…:Secrets:Password` | secret block | — | Must resolve at startup | reload; material per connection |
+| `…:EarliestEmailReceivedDate` | date | unset (everything) | Not in the future (compared in UTC) | reload |
+| `…:RemotelyDeletedEmailDisposition` | enum | `RetainTombstone` | `RetainTombstone`, `EraseLocalCopy` | reload; governs disappearances observed from then on |
+| `…:Folders` | list | inbox by role | Aliases unique; each entry below | reload |
+
+A folder entry names `Alias` (required — your stable name for the folder) and **exactly one** of `RemotePath` (the
+server's own path) or `SpecialUse` (a role discovery resolves: `Inbox`, `Archive`, `Drafts`, `Sent`, `Junk`, `Trash`,
+`All`, `Flagged`, `Important`). Configuring no folder synchronizes the inbox by role.
+
+### Transport security — `…:TransportSecurity`
+
+[The rules](../features/imap-synchronization.md#transport-security) are the domain's; every weakening is an explicit
+opt-in, and unsafe combinations fail startup.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `…:ConnectionSecurity` | enum | `TlsOnConnect` | `Auto`, `TlsOnConnect`, `StartTlsRequired`, `StartTlsWhenAvailable`, `None`; anything but the two guaranteed-TLS modes requires `AllowInsecureConnection` | reload |
+| `…:PermittedAuthenticationMechanisms` | string list | `PLAIN`, `LOGIN` | Supported SASL names; an unordered allow-list, the client picks the strongest that survives | reload |
+| `…:AllowInsecureConnection` | bool | `false` | Opt-in for modes that can leave the channel unencrypted | reload |
+| `…:AllowClearTextAuthenticationOverUnencryptedConnection` | bool | `false` | Opt-in on top of the above | reload |
+| `…:CertificateTrust` | enum | `SystemTrustStore` | `SystemTrustStore`, `AdditionalTrustedAuthority` | reload |
+| `…:TrustedCertificateAuthority` | secret block | unset | Required by, and only valid with, `AdditionalTrustedAuthority` | reload; material per connection |
+
+Certificate validation itself cannot be disabled; a private server is supported by trusting its authority.
+
+## `Persistence` and the connection string
+
+Where the local copy lives. The connection settings travel through the validated snapshot, so repointing them reaches
+the next physical connection without a restart; the remaining settings are read while the host composes itself.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `ConnectionStrings:mailfathom` | string | `Host=localhost;Database=mailfathom;Username=mailfathom` | Carries no password | reload (new connections) |
+| `Persistence:ConnectionString` | secret block | unset | Replaces `ConnectionStrings:mailfathom` entirely when set | reload (new connections) |
+| `Persistence:Password` | secret block | unset | A present block must carry a reference | reload (new connections); material per connection |
+| `Persistence:MaximumConcurrencyCommitAttempts` | int | `2` | 1 – 10; counts the first attempt | restart |
+| `Persistence:CommandTimeoutSeconds` | int | `30` | 1 – 600; bounds one command, not one unit of work | restart |
+| `Persistence:TextSearchConfiguration` | string | `simple` | A stock PostgreSQL text search configuration (`simple`, `english`, `german`, …) | restart — **and it is part of the schema**: the value is compiled into the index, startup fails with `32003` on a mismatch, and changing it means regenerating the migration and rebuilding the search documents |
+
+Repointing a reference or editing the connection string reloads; changing *which* setting supplies the credential —
+moving a password out of the connection string into `Persistence:Password`, or back — is refused on reload and needs a
+restart, because the connection pool attaches its password provider once.
+
+## `MailboxSearch`
+
+The deployment-wide privacy bound on what a search result may quote. [Lexical email
+search](../features/lexical-email-search.md) records how snippets are cut.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `MailboxSearch:SnippetsPerEmail` | int | `3` | 1 – 10 | restart |
+| `MailboxSearch:WordsPerSnippet` | int | `24` | 4 – 100 | restart |
+
+## `EmailContent`
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `EmailContent:MaxBodyCharacters` | int | `100000` | 1000 – 1000000; each body representation is truncated to it, explicitly | restart |
+
+## `MailExtractionBackfill`
+
+The worker that extracts text for messages stored before extraction existed or before a limit was raised.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `MailExtractionBackfill:Enabled` | bool | `true` | — | restart |
+| `MailExtractionBackfill:Interval` | TimeSpan | `00:00:30` | 1 s – 1 h | restart |
+| `MailExtractionBackfill:BatchSize` | int | `50` | 1 – 500 | restart |
+| `MailExtractionBackfill:MaxBatchesPerRun` | int | `10` | 1 – 1000 | restart |
+
+## `McpEndpoint`
+
+Whether the protocol surface is served and what a client must present. The whole section is **restart** — it decides
+routing and listeners — while key and certificate material is read per request or per handshake.
+[The MCP endpoint](mcp-endpoint.md) is the page, section by section.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `McpEndpoint:Enabled` | bool | `false` | — | restart |
+| `McpEndpoint:Authentication` | flag set | `None` | `ApiKey`, `OAuth`, both comma-separated, or `None`; `None` warns at startup | restart |
+| `McpEndpoint:ApiKeys` | list of secret blocks | empty | Required non-empty when `ApiKey` is named; refused when configured while it is not | restart; material per request |
+
+### OAuth — `McpEndpoint:OAuth`
+
+MailFathom is a protected resource only; an external authorization server signs users in.
+[`OAuth`](mcp-endpoint.md#oauth) records what a token must prove.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `…:Resource` | string | — | Required; the canonical `https` URL clients reach this endpoint at — behind a proxy, the proxy's public URL | restart |
+| `…:RequiredScopes` | string list | empty | Scopes every access token must carry; empty accepts any token the configured servers issued for this resource | restart |
+| `…:AuthorizationServers:<n>:Name` | string | — | Required; the identity diagnostics use | restart |
+| `…:AuthorizationServers:<n>:Issuer` | string | — | Required; a well-formed `https` issuer, compared against `iss` exactly | restart |
+| `…:AuthorizationServers:<n>:MetadataAddress` | string | unset | An absolute `https` URL on the issuer's own host; overrides issuer-derived discovery | restart |
+| `…:AuthorizationServers:<n>:AuthorizedSubjects` | string list | — | At least one; a token whose `sub` is not listed is refused, so every user the server can sign in does not automatically read this mailbox | restart |
+
+### Browser origins — `McpEndpoint:Cors`
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `…:AllowedOrigins` | string list | absent = every origin | `*` for every origin, a list for exactly those, an empty list for none | restart |
+
+The default is deliberately the permissive one — an `Origin` header only exists in browsers, and a native client is
+unaffected — but a deployment reachable from a browser should narrow it.
+[CORS and the `Origin` header](mcp-endpoint.md#cors-and-the-origin-header) explains what the check does and does not
+protect.
+
+### TLS termination — `McpEndpoint:Https:Endpoints:<n>`
+
+Empty by default, which serves the endpoint over the host's ordinary listener. Configuring any profile **takes over
+the host's listeners**: only the profiles' sockets are opened.
+[HTTPS and your own domain](mcp-endpoint.md#https-and-your-own-domain) is the page.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `…:Name` | string | — | Required; unique | restart |
+| `…:Domain` | string | — | Required; the DNS name the certificate is proven to cover | restart |
+| `…:BindAddress` | string | `0.0.0.0` | An IP address | restart |
+| `…:Port` | int | `8443` | 1 – 65535 | restart |
+| `…:MinimumTlsVersion` | enum | `Tls12` | `Tls12`, `Tls13` | restart |
+| `…:HttpProtocols` | enum list | `Http1`, `Http2` | `Http1`, `Http2`, `Http3`; selecting `Http3` where the platform provides no QUIC fails startup rather than falling back | restart |
+| `…:ServerCertificate` | certificate block | — | Required; see below | restart; renewal behind unchanged references — see [secret rotation](secret-rotation.md#renewing-an-mcp-server-certificate) |
+
+A certificate block names either `Bundle` (one PKCS#12 secret block, optionally with a nested `Password`) or the pair
+`CertificateChain` and `PrivateKey` (PEM, as two secret blocks). Startup proves the material loads, covers the stated
+domain, and is not expired — before any listener opens.
+
+### Client certificates — `McpEndpoint:ClientCertificateProfiles:<n>`
+
+Mutual TLS, judged per configured client application. A certificate exists only on a TLS connection this process
+terminates — over the HTTPS profiles above, or over a listener the deployment configured with TLS otherwise — so a
+plain-HTTP deployment presents none, which a `Required` profile refuses.
+[Client certificates](mcp-endpoint.md#client-certificates) records how a presented certificate is judged.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `…:Name` | string | — | Required; unique | restart |
+| `…:Requirement` | enum | — | `Optional`, `Required`; required to be stated | restart |
+| `…:TrustAnchors` | list of secret blocks | — | At least one; the authorities the client's chain must anchor in | restart; material per handshake |
+| `…:SubjectAlternativeNames` | string list | — | At least one; a DNS name the certificate must carry | restart |
+
+### Rate limiting — `McpEndpoint:RateLimiting`
+
+The one MCP subsection where every value has a product default, so an enabled endpoint is bounded whether or not
+anyone wrote a number. [Rate limiting](mcp-endpoint.md#rate-limiting) records whose capacity a request spends.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `…:Enabled` | bool | `true` | Turning it off costs a startup warning | restart |
+| `…:MaxConcurrentRequests` | int | `20` | 1 – 1000; process-wide | restart |
+| `…:ConcurrencyQueueLimit` | int | `0` | 0 – 1000; `0` refuses instead of queueing | restart |
+| `…:TokenCapacity` | int | `60` | 1 – 1000000; the largest burst one client may spend | restart |
+| `…:TokensPerReplenishmentPeriod` | int | `60` | 1 – 1000000, and not above `TokenCapacity` | restart |
+| `…:ReplenishmentPeriod` | TimeSpan | `00:01:00` | 1 s – 1 h | restart |
+| `…:RequestQueueLimit` | int | `0` | 0 – 1000, and below `MaxConcurrentRequests` | restart |
+
+## `HealthEndpoints`
+
+The startup, readiness, and liveness probes and the dedicated listener they answer on.
+[Health endpoints](health-endpoints.md) records why the surface carries no credential and how each transport behaves.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `HealthEndpoints:Enabled` | bool | `true` | Off maps no probe route and opens no listener | restart |
+| `HealthEndpoints:BindAddress` | string | `0.0.0.0` | An IP address; `127.0.0.1` restricts to the machine | restart |
+| `HealthEndpoints:Port` | int | `8081` | 1 – 65535; never a port the application listener binds | restart |
+| `HealthEndpoints:HttpsPort` | int | unset | Required by, and only valid with, `HttpAndHttps` | restart |
+| `HealthEndpoints:Transport` | enum | `Http` | `Http`, `HttpAndHttps`, `HttpsOnly` | restart |
+| `HealthEndpoints:Domain` | string | — | Required by the TLS transports; the name the certificate is proven against | restart |
+| `HealthEndpoints:ServerCertificate` | certificate block | unset | Required by the TLS transports; refused otherwise | restart |
+
+## `Resilience`
+
+Retry, timeout, circuit-breaker, and concurrency budgets for the non-HTTP outbound dependencies, one subsection per
+dependency class: `MailboxSessionEstablishment`, `MailboxDataRetrieval`, `EmailDelivery`, `DatabaseCommandExecution`,
+`AiProviderInvocation`. A subsection naming no class fails startup. Every setting is **restart** by construction, and
+[outbound resilience](../architecture/outbound-resilience.md#configuration) explains each strategy and the
+per-class reasoning.
+
+Settings, per class:
+
+| Key | Type | Constraint |
+| --- | --- | --- |
+| `Resilience:<Class>:MaxAttempts` | int | 1 – 10; counts the first call, so `1` disables retry |
+| `Resilience:<Class>:BaseDelay` / `MaxDelay` | TimeSpan | Jittered exponential backoff between attempts |
+| `Resilience:<Class>:AttemptTimeout` / `TotalTimeout` | TimeSpan | One attempt / the whole operation |
+| `Resilience:<Class>:CircuitBreakerFailureRatio` | double | 0.01 – 1.0 |
+| `Resilience:<Class>:CircuitBreakerMinimumThroughput` | int | 2 – 1000 |
+| `Resilience:<Class>:CircuitBreakerSamplingDuration` / `CircuitBreakerBreakDuration` | TimeSpan | — |
+| `Resilience:<Class>:ConcurrencyLimit` | int | 1 – 1000 |
+
+Defaults, per class:
+
+| Class | Attempts | Base/max delay | Attempt/total timeout | Breaker ratio · min · sampling · break | Concurrency |
+| --- | --- | --- | --- | --- | --- |
+| `MailboxSessionEstablishment` | 3 | 2 s / 30 s | 30 s / 2 min | 0.5 · 5 · 60 s · 30 s | 4 |
+| `MailboxDataRetrieval` | 3 | 1 s / 15 s | 60 s / 3 min | 0.5 · 10 · 30 s · 15 s | 8 |
+| `EmailDelivery` | 2 | 5 s / 60 s | 60 s / 3 min | 0.5 · 5 · 60 s · 60 s | 4 |
+| `DatabaseCommandExecution` | 3 | 200 ms / 2 s | 15 s / 30 s | 0.5 · 20 · 30 s · 5 s | 32 |
+| `AiProviderInvocation` | 3 | 2 s / 30 s | 120 s / 5 min | 0.5 · 5 · 60 s · 30 s | 4 |
+
+## `Logging`
+
+The standard .NET `Logging` section applies unchanged — `Logging:LogLevel:Default` is `Information` out of the box,
+with `Microsoft.AspNetCore` at `Warning`. Log lines are structured and never carry credentials, message content, or
+raw MIME, whatever the level.
+
+## Environment-only settings
+
+A few settings are read from the environment alone, because they configure the process before configuration exists or
+belong to the platform rather than to MailFathom:
+
+| Variable | What it does |
+| --- | --- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Attaches the OTLP exporter for logs, metrics, and traces — startup records included. Unset exports nothing. [Telemetry](telemetry.md) is the page, including the sibling `OTEL_*` variables the exporter reads itself |
+| `ASPNETCORE_URLS` / `ASPNETCORE_HTTP_PORTS` | The application listener's addresses, unless MCP HTTPS profiles or explicit Kestrel endpoints replace them |
+| `DOTNET_ENVIRONMENT` / `ASPNETCORE_ENVIRONMENT` | The environment name; `Development` is what admits user secrets and `appsettings.Development.json` |
+| `DOTNET_USE_POLLING_FILE_WATCHER` | Set to `1` where reload must observe a mounted volume's atomic update — Kubernetes ConfigMaps in particular |

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -84,7 +84,7 @@ Take a backup before you answer.
 
 ```
 MailFathom.Application.Persistence.DatabaseSchemaOutOfDateException: The database has not applied 1 migration(s) this
-build defines: 20260730152610_Initial.
+build defines: 20260731132336_Initial.
 ```
 
 > **The schema artifact does not exist yet.** The reviewed, idempotent artifact a released installation applies — and

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -108,7 +108,7 @@ MailFathom verifies the schema while starting and refuses to serve against one i
 therefore does *not* become ready, and its log says why:
 
 ```
-DatabaseSchemaOutOfDateException: The database has not applied 1 migration(s) this build defines: 20260730152610_Initial.
+DatabaseSchemaOutOfDateException: The database has not applied 1 migration(s) this build defines: 20260731132336_Initial.
 ```
 
 That is the design, and the chart deliberately renders nothing that answers it: a Job carrying a Helm hook would be the

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -68,23 +68,52 @@ is about to touch. Check out the branch that carries the change first. A
 detached `HEAD` and any other branch name are accepted, in the primary checkout
 as well as in a linked worktree.
 
-Run the web host directly:
+Run the web host directly, against a PostgreSQL server you provide yourself:
 
 ```bash
 dotnet run --project src/Host/Host.csproj
 ```
 
-Run the Aspire orchestration host:
+## Running locally with Aspire
+
+The Aspire orchestration is the intended local start: it provisions the database, applies the schema, and starts the
+host in the right order, so a working MailFathom is one command on a machine with the pinned SDK and a running Docker
+daemon:
 
 ```bash
 dotnet run --project src/AppHost/AppHost.csproj
 ```
+
+Three resources come up, in dependency order. The `postgres` container starts first and has to report healthy; the
+`mailfathom-migrations` resource then applies every pending migration to it; and `mailfathom-host` waits for that run
+to complete before starting, which is why the schema gate that fails a fresh deployment on purpose never fires on a
+local run — the explicit schema step the deployments require is performed here by the orchestration, before the host
+looks. The host runs in the `Development` environment with the endpoints its launch profile names, so the application
+listener answers at `http://localhost:5171` and the probes at `http://127.0.0.1:8081`; the AppHost pins the probe
+listener to loopback deliberately, because the probes answer without a credential and nothing on a local network has
+any business asking them.
 
 The AppHost prints the dashboard address, including a one-time login link, as it starts. The dashboard is where a
 local run is observed: per-resource console output, structured logs, traces, and metrics, all delivered over OTLP
 because Aspire injects `OTEL_EXPORTER_OTLP_ENDPOINT` into the resources it starts. That injection is currently the
 only place telemetry export is configured at all — a deployment exports nothing until an operator sets the variable
 themselves. [Telemetry](telemetry.md) records what the host emits and where it goes.
+
+A freshly started host synchronizes nothing and serves no MCP endpoint, because both defaults are the shipped ones.
+Configure a development mailbox through user secrets as [development secrets](#development-secrets) below shows, and
+enable the endpoint the same way when a tool call is what is being tested — in Development the `ReferenceOrInline`
+interpretation keeps the credential a one-liner:
+
+```bash
+dotnet user-secrets --project src/Host/Host.csproj set "McpEndpoint:Enabled" "true"
+dotnet user-secrets --project src/Host/Host.csproj set "McpEndpoint:Authentication" "ApiKey"
+dotnet user-secrets --project src/Host/Host.csproj set "McpEndpoint:ApiKeys:0:Name" "dev"
+dotnet user-secrets --project src/Host/Host.csproj set "McpEndpoint:ApiKeys:0:SecretReference" "plaintext:dev-key"
+```
+
+An MCP client then connects to `http://localhost:5171/mcp` with `Authorization: Bearer dev-key`. Stopping the
+orchestration with `Ctrl+C` — or `aspire stop --apphost src/AppHost/AppHost.csproj --non-interactive` — leaves the
+synchronized mail in place, because the database volume outlives the container.
 
 The AppHost PostgreSQL resource uses the `pgvector/pgvector:0.8.2-pg17` image so local development starts with a PostgreSQL server that can support the `vector` extension required by the RAG and embedding slices. It keeps its data in a named Docker volume, so synchronized mail survives a restart instead of costing a full IMAP synchronization every time the orchestration stops.
 

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -80,6 +80,12 @@ Run the Aspire orchestration host:
 dotnet run --project src/AppHost/AppHost.csproj
 ```
 
+The AppHost prints the dashboard address, including a one-time login link, as it starts. The dashboard is where a
+local run is observed: per-resource console output, structured logs, traces, and metrics, all delivered over OTLP
+because Aspire injects `OTEL_EXPORTER_OTLP_ENDPOINT` into the resources it starts. That injection is currently the
+only place telemetry export is configured at all — a deployment exports nothing until an operator sets the variable
+themselves. [Telemetry](telemetry.md) records what the host emits and where it goes.
+
 The AppHost PostgreSQL resource uses the `pgvector/pgvector:0.8.2-pg17` image so local development starts with a PostgreSQL server that can support the `vector` extension required by the RAG and embedding slices. It keeps its data in a named Docker volume, so synchronized mail survives a restart instead of costing a full IMAP synchronization every time the orchestration stops.
 
 That volume is why `src/AppHost/AppHost.csproj` declares a `UserSecretsId` and `src/AppHost/Properties/launchSettings.json` sets `DOTNET_ENVIRONMENT=Development`. Aspire generates the PostgreSQL password and keeps it stable by writing it to user secrets, which are only loaded in the Development environment. Without both, every run generates a new password while the volume keeps the one it was initialized with, and the container never becomes healthy. If it ever does report `password authentication failed`, the volume and the current password have diverged; remove the volume and start again:

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -71,8 +71,9 @@ The startup records from the bootstrap pipeline arrive in the same dashboard, be
 that pipeline reads — a host that fails while binding its options is therefore diagnosable from the dashboard's
 structured logs, not only from the console.
 
-[Local development](local-development.md) covers the rest of the orchestration: the PostgreSQL resource, the data
-volume, and the migration resource that applies the schema before the host starts.
+[Running locally with Aspire](local-development.md#running-locally-with-aspire) covers the rest of the orchestration:
+the resource start order, the PostgreSQL data volume, and the migration resource that applies the schema before the
+host starts.
 
 ## Deployments export nothing by default
 

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1,0 +1,92 @@
+# Telemetry and the Aspire dashboard
+
+The host instruments itself with OpenTelemetry throughout — logs, metrics, and traces — and exports none of it unless
+the environment names a destination. Today exactly one environment does that out of the box: a local run under the
+Aspire orchestration, whose dashboard is the destination. This page records what is emitted, the one switch that
+decides whether it leaves the process, and why the deployments deliberately ship with that switch off.
+
+## What the process emits
+
+**Logs** go through the OpenTelemetry logging provider with formatted messages and scopes included, beside the console
+output that is always on. Log lines are structured with named properties, and by contract they never carry
+credentials, tokens, message bodies, attachment content, or raw MIME; a tool call is recorded as a name, an outcome,
+and a duration, never as what was searched for. [What the endpoint records](mcp-endpoint.md#what-the-endpoint-records)
+states that boundary precisely.
+
+**Metrics** cover the request pipeline (ASP.NET Core), outbound HTTP (`HttpClient`), the .NET runtime, PostgreSQL
+through the Npgsql instrumentation, and the `Polly` meter, which is where every outbound-resilience pipeline reports
+its attempts, outcomes, timeouts, and circuit-breaker state transitions.
+[Outbound resilience](../architecture/outbound-resilience.md#telemetry-and-privacy) records which tags those events
+carry and which they never do.
+
+**Traces** cover incoming requests, outbound HTTP, and database commands, correlated end to end: the trace a request
+arrives with is the trace its log records and its failure diagnostics carry. One filter is deliberate: requests to the
+health-probe paths are not traced at all, because a probe arrives every few seconds for the life of the process and
+says the same thing every time — tracing it would fill a trace store with polling instead of work.
+
+## The one switch: `OTEL_EXPORTER_OTLP_ENDPOINT`
+
+The OTLP exporter is attached only when the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is non-empty. Unset,
+the instruments still exist and nothing collects them: no telemetry leaves the process, and the console remains the
+only place logs go. There is no MailFathom-specific telemetry key — the exporter reads the standard OpenTelemetry
+variables itself:
+
+| Variable | What it does |
+| --- | --- |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | The OTLP destination; setting it is what attaches the exporter |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (the default) or `http/protobuf` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Headers sent with every export, which is where a collector's credential travels |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | The per-export timeout |
+| `OTEL_SERVICE_NAME`, `OTEL_RESOURCE_ATTRIBUTES` | The resource identity the records carry |
+
+The variable has to be an **environment variable**, not a configuration key. That is deliberate, and
+[host startup telemetry](host-startup-telemetry.md) records why: the bootstrap pipeline that reports startup failures
+is built before configuration exists, reads the same variable, and exports each record synchronously — so the decision
+to export and the destination being exported to can never disagree between the two pipelines, and a start that fails
+while configuration is loading is still reported to the same place as everything else.
+
+## Local development: the Aspire dashboard
+
+The AppHost orchestration is where the switch is flipped for you. When `src/AppHost` starts a project resource, Aspire
+injects `OTEL_EXPORTER_OTLP_ENDPOINT` — together with the authentication header its dashboard expects — pointing at
+the dashboard's own OTLP ingestion endpoint. The host needs no telemetry configuration at all:
+
+```bash
+dotnet run --project src/AppHost/AppHost.csproj
+```
+
+The AppHost prints the dashboard address, including a one-time login link, as it starts. The dashboard then shows, per
+resource: the console output, the structured logs with their named properties, the traces — an MCP request, the
+database commands it issued, the outbound calls beside them — and every metric above, including the `Polly` meter's
+resilience events and the Npgsql instruments.
+
+Two properties keep this arrangement honest:
+
+- **It is per run and in memory.** The dashboard retains nothing across restarts. Telemetry produced from a developer's
+  own synchronized mail never lands in a store that outlives the session.
+- **It is local.** The OTLP endpoint Aspire injects is a loopback address with a per-run key, so nothing is exported
+  off the machine.
+
+The startup records from the bootstrap pipeline arrive in the same dashboard, because Aspire sets the same variable
+that pipeline reads — a host that fails while binding its options is therefore diagnosable from the dashboard's
+structured logs, not only from the console.
+
+[Local development](local-development.md) covers the rest of the orchestration: the PostgreSQL resource, the data
+volume, and the migration resource that applies the schema before the host starts.
+
+## Deployments export nothing by default
+
+Neither the Compose deployment nor the Helm chart sets any `OTEL_*` variable. That is a privacy default, not a gap:
+MailFathom's telemetry describes activity around personal mail — account aliases, folder aliases, tool-call rates,
+failure codes — and even without content, that stream identifies people and habits. Where it flows is therefore a
+decision the operator takes explicitly, never one a deployment asset takes for them.
+
+To export from a deployment, set the standard variables on the MailFathom container or service — an OTLP collector
+address, its credential in `OTEL_EXPORTER_OTLP_HEADERS` — and treat the destination as part of the deployment's trust
+boundary: it stores what the log contract permits, which still includes MailFathom's own names for accounts and
+folders, durations, and error codes. Content never enters telemetry, so a collector never holds mail — but a
+collector outside your control is still the wrong place for a mailbox's activity pattern.
+
+The console log needs none of this. A container's log driver, `journalctl` for a native service, and
+`docker compose logs` all read the stream that is always written, and the startup records land there
+[synchronously](host-startup-telemetry.md) whether or not any exporter is attached.

--- a/docs/users/README.md
+++ b/docs/users/README.md
@@ -1,0 +1,50 @@
+# MailFathom user guide
+
+This is the documentation for people who install, configure, operate, and use MailFathom. It is a guided path rather
+than a second copy of the reference material: each step links into the operations and feature pages where the full
+contract lives, so nothing here goes stale on its own. Contributor and agent documentation is separate, under the
+repository root and [`docs/`](../README.md) generally.
+
+## What MailFathom is
+
+MailFathom is a self-hosted service that synchronizes mail from your IMAP accounts into a local PostgreSQL copy,
+indexes it for search, and serves it to AI agents as read-only tools over the
+[Model Context Protocol](https://modelcontextprotocol.io/). An agent connected to it can list, read, and search your
+mail; it cannot send, delete, move, or mark anything, because no such tool exists on the surface.
+
+Two properties hold everywhere and are worth knowing before anything is installed:
+
+- **Reading is local.** A tool call answers from the local copy and never contacts a mail server, so it is fast, works
+  while the server is down, and cannot change anything remotely. Every result states how fresh the local copy is.
+- **Synchronization is read-only.** Fetching mail never sets the remote `\Seen` flag, so mail MailFathom has copied
+  still shows as unread in your mail client until you read it there.
+
+## The state of the release
+
+MailFathom has not had a first release yet. No container image is published, no versioned artifact exists, and the
+schema-application artifact a released installation will use is still open. Every installation therefore starts from a
+checkout of this repository, and these pages say so where it matters instead of describing a release that does not
+exist. The first release is milestone `0.1.0`.
+
+## The path
+
+1. **[Choose and perform an installation](installation.md)** — which deployment shape fits, what each needs, and where
+   its full guide is.
+2. **[Getting started](getting-started.md)** — from an installed instance to a synchronized mailbox and a first
+   successful tool call, including secrets, the schema step, health verification, and connecting an MCP client.
+3. **[Using the tools](usage.md)** — what `list_emails`, `search_emails`, and `get_email_content` do, what they
+   deliberately bound, and how to read a failure.
+4. **[Configuration reference](../operations/configuration-reference.md)** — every user-settable option in one place,
+   with its type, default, constraints, and whether changing it needs a restart.
+
+## Once it is running
+
+| Question | Page |
+| --- | --- |
+| Is it healthy, and how do I probe it? | [Health endpoints](../operations/health-endpoints.md) |
+| How do I provision and rotate credentials? | [Secret provisioning](../operations/secret-provisioning.md), [secret rotation](../operations/secret-rotation.md) |
+| How do I protect the MCP endpoint — keys, OAuth, TLS, client certificates, rate limits? | [The MCP endpoint](../operations/mcp-endpoint.md) |
+| How do I upgrade, back up, restore, or remove it? | [Docker Compose](../operations/deployment-compose.md), [Kubernetes](../operations/deployment-kubernetes.md) |
+| Where does configuration come from, and what reloads without a restart? | [Configuration sources](../operations/configuration-sources.md), [configuration reference](../operations/configuration-reference.md) |
+| What does it record about itself, and where do the records go? | [Telemetry](../operations/telemetry.md), [host startup telemetry](../operations/host-startup-telemetry.md) |
+| What exactly does synchronization store and reconcile? | [IMAP synchronization](../features/imap-synchronization.md) |

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -1,0 +1,180 @@
+# Getting started
+
+This page walks from an installed MailFathom to a first successful tool call: provision the credentials, configure a
+mailbox, start the service, verify it, connect an MCP client, and read a result correctly. It assumes an installation
+from [installing MailFathom](installation.md); a developer evaluating from the checkout can run the
+[Aspire orchestration](../operations/local-development.md) instead, which provisions PostgreSQL and applies the schema
+on its own.
+
+The examples write configuration as JSON. Every setting can arrive as an environment variable instead — `:` becomes
+`__`, so `MailSynchronization:Enabled` is `MailSynchronization__Enabled` — and the
+[configuration reference](../operations/configuration-reference.md) lists every key used below.
+
+## 1. Provision the secrets
+
+MailFathom's configuration never carries a credential. A secret-bearing setting holds a *reference* — `file:/…`,
+`systemd-credential:…`, `env:…` — and the material lives wherever the deployment provisions it. A configuration file
+is therefore safe to review and back up: leaking it leaks paths, not passwords.
+
+You need two pieces of material before anything is configured:
+
+- **The mailbox password** or app password of the IMAP account to synchronize.
+- **An MCP API key** for the client that will connect. Generate it rather than inventing it:
+
+```bash
+openssl rand -base64 33 | tr -d '\n' > mcp-workstation-key
+```
+
+Where the files go is the deployment's convention: `secrets/mailfathom/` for
+[Compose](../operations/deployment-compose.md#credentials), a Kubernetes `Secret` mounted at
+`/etc/mailfathom/secrets` for [the chart](../operations/deployment-kubernetes.md#what-you-supply), `LoadCredential=`
+for [systemd](../operations/secret-provisioning.md#native-systemd-service). The references below assume the mounted
+directory the Compose and Helm shapes share.
+
+## 2. Configure the mailbox
+
+Synchronization is off until configuration turns it on, and an enabled synchronization requires at least one account:
+
+```json
+{
+  "MailSynchronization": {
+    "Enabled": true,
+    "Accounts": [
+      {
+        "AccountId": "primary",
+        "Host": "imap.example.test",
+        "Port": 993,
+        "UserName": "you@example.test",
+        "Secrets": {
+          "Password": {
+            "Name": "imap-primary-password",
+            "SecretReference": "file:/etc/mailfathom/secrets/imap-primary-password"
+          }
+        },
+        "Folders": [
+          { "Alias": "inbox", "SpecialUse": "Inbox" },
+          { "Alias": "sent", "SpecialUse": "Sent" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Points worth knowing before you adapt it:
+
+- **`AccountId` and `Alias` are your names**, not the server's. They are what every tool argument, log line, and error
+  message uses, so pick names you are happy to see in a diagnostic.
+- **Folders are best named by role.** `SpecialUse` lets discovery find the folder whatever the server calls it —
+  a German server's `Gesendet` is still `Sent` — and configuring no folder at all synchronizes the inbox. Naming an
+  exact server path is the alternative for folders with no role.
+- **The transport is TLS by default.** Port 993 with TLS-on-connect is the default posture, and every weakening —
+  an unencrypted connection, clear-text authentication over one — must be stated explicitly and fails startup
+  otherwise. A server with a private certificate authority is supported by trusting that authority, never by turning
+  validation off; [transport security](../features/imap-synchronization.md#transport-security) records the rules.
+- **How far back to synchronize** is per account: `EarliestEmailReceivedDate` bounds the first synchronization of a
+  large mailbox, and omitting it copies everything the server still holds.
+
+The Compose deployment reads this from `config/10-mailfathom.json`; Kubernetes mounts it as a ConfigMap key; a native
+process names the file through [`ConfigurationSources`](../operations/configuration-sources.md).
+
+## 3. Point it at the database
+
+The Compose deployment wires the connection and its password for you — skip this step there. Elsewhere, the connection
+string carries everything but the password, and the password joins it through a reference:
+
+```json
+{
+  "ConnectionStrings": { "mailfathom": "Host=db.example.test;Database=mailfathom;Username=mailfathom" },
+  "Persistence": {
+    "Password": {
+      "Name": "mailfathom-database-password",
+      "SecretReference": "file:/etc/mailfathom/secrets/mailfathom-database-password"
+    }
+  }
+}
+```
+
+## 4. Start it, and apply the schema
+
+Start the service the way the installation shape does. The first start against an empty database **fails on purpose**,
+naming the migration it expects:
+
+```text
+The database has not applied 1 migration(s) this build defines: 20260730152610_Initial.
+```
+
+That is the explicit schema step described in [installing MailFathom](installation.md#what-every-shape-needs):
+MailFathom verifies the schema and refuses to serve against one it does not recognize, and applying migrations is a
+step you take, with a backup first once there is data to lose. Apply the schema, start again, and the refusal is gone.
+
+## 5. Verify it is healthy
+
+```bash
+curl -fsS http://127.0.0.1:8081/started
+curl -fsS http://127.0.0.1:8081/health
+```
+
+`/started` confirms the startup gates passed — every secret reference resolved, the schema matched. `/health` is
+readiness and includes the database. Both answer on the probe listener, `8081` by default, never on the application
+port; [health endpoints](../operations/health-endpoints.md) explains that separation.
+
+Then let the first synchronization run. Its progress is visible in the log — each folder run reports what it stored —
+and, once you can call a tool, in the `folderFreshness` every result carries. A large mailbox takes a while on the
+first pass; later runs move only what changed, every five minutes by default.
+
+## 6. Enable the MCP endpoint
+
+The endpoint is off by default, and enabling it means stating how it is authenticated:
+
+```json
+{
+  "McpEndpoint": {
+    "Enabled": true,
+    "Authentication": "ApiKey",
+    "ApiKeys": [
+      {
+        "Name": "workstation",
+        "SecretReference": "file:/etc/mailfathom/secrets/mcp-workstation-key"
+      }
+    ]
+  }
+}
+```
+
+`Authentication: "None"` is legal — the reverse-proxy-and-loopback deployment is an ordinary one — but it is announced
+with a startup warning, because an unauthenticated endpoint serves your mailbox to whoever can reach its port. Read
+[the MCP endpoint](../operations/mcp-endpoint.md) before widening anything: it records the OAuth alternative, browser
+origins, serving your own domain over TLS, client certificates, and the rate limits that apply out of the box.
+
+MailFathom itself serves plain HTTP unless its own TLS termination is configured, so keep the application port on
+loopback or behind a TLS-terminating proxy — the Compose deployment's default — and give the proxy the certificate.
+
+## 7. Connect an MCP client
+
+The endpoint speaks the MCP **Streamable HTTP** transport at `/mcp` — the path is fixed — and the key travels as a
+bearer credential. Any client that supports Streamable HTTP connects with two facts:
+
+| The client asks for | The value |
+| --- | --- |
+| Server URL | `http://127.0.0.1:8080/mcp` under the Compose defaults; your proxy's HTTPS address otherwise |
+| Header | `Authorization: Bearer <the key material>` |
+
+A connected client's tool listing should show exactly three tools — `list_emails`, `get_email_content`,
+`search_emails` — each advertising itself as read-only, non-destructive, and idempotent.
+[Verifying an enabled endpoint](../operations/mcp-endpoint.md#verifying-an-enabled-endpoint) is the checklist form of
+this, including what the refusals look like when the key or the origin is wrong.
+
+## 8. Make the first call, and read it correctly
+
+Ask the connected agent to list recent mail, or have the client call `list_emails` with a small page. Two parts of the
+result matter more than the emails on the first day:
+
+- **`folderFreshness`** carries one entry per folder in scope, stating when synchronization last committed progress
+  there. An empty page whose entries report `wasSynchronized: false` means the folder has not synchronized yet — not
+  that the mailbox is empty. This is the field to check before trusting any early result.
+- **`nextCursor`** is how the rest of the timeline is read: pass it back unchanged with the same filters. Results are
+  deliberately bounded — at most 100 summaries per page — so an agent reads pages, not mailboxes.
+
+From here, [using the tools](usage.md) describes the day-to-day surface: what each tool answers, what it bounds, and
+what its errors mean.

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -101,7 +101,7 @@ Start the service the way the installation shape does. The first start against a
 naming the migration it expects:
 
 ```text
-The database has not applied 1 migration(s) this build defines: 20260730152610_Initial.
+The database has not applied 1 migration(s) this build defines: 20260731132336_Initial.
 ```
 
 That is the explicit schema step described in [installing MailFathom](installation.md#what-every-shape-needs):

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -3,8 +3,8 @@
 This page walks from an installed MailFathom to a first successful tool call: provision the credentials, configure a
 mailbox, start the service, verify it, connect an MCP client, and read a result correctly. It assumes an installation
 from [installing MailFathom](installation.md); a developer evaluating from the checkout can run the
-[Aspire orchestration](../operations/local-development.md) instead, which provisions PostgreSQL and applies the schema
-on its own.
+[Aspire orchestration](../operations/local-development.md#running-locally-with-aspire) instead, which provisions
+PostgreSQL and applies the schema on its own.
 
 The examples write configuration as JSON. Every setting can arrive as an environment variable instead — `:` becomes
 `__`, so `MailSynchronization:Enabled` is `MailSynchronization__Enabled` — and the

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -1,0 +1,83 @@
+# Installing MailFathom
+
+MailFathom runs in three shapes, and each has one authoritative guide. This page is the decision: what each shape
+assumes, what it is good for, and what every shape shares. Follow the linked guide for the commands; the guides do not
+repeat each other and neither does this page.
+
+**There is no published release yet.** No image is on any registry and no binary artifact is downloadable, so every
+path below starts from a checkout of this repository. That is a statement about today, not about the design: the
+deployment assets are written for released artifacts and will point at them once `0.1.0` ships. Until then, treat what
+you install as a development build of an unreleased product.
+
+```bash
+git clone https://github.com/Krzysztof318/MailFathom.git
+cd MailFathom
+```
+
+## Choosing a shape
+
+| Shape | Choose it when | Guide |
+| --- | --- | --- |
+| **Docker Compose** | You self-host on one machine and want the database, the network boundary, and the secret mounts arranged for you | [Deploying with Docker Compose](../operations/deployment-compose.md) |
+| **Kubernetes with Helm** | You operate a cluster and bring your own PostgreSQL and Secret management | [Deploying to Kubernetes](../operations/deployment-kubernetes.md) |
+| **Native process** | You run services under systemd without a container runtime, and want secrets delivered as systemd credentials | [Below](#native-process), then [secret provisioning](../operations/secret-provisioning.md#native-systemd-service) |
+
+Docker Compose is the recommended first installation. It is the only shape that provisions PostgreSQL for you —
+`compose.yaml` creates the role, the database, and the `vector` extension on first start — and its defaults publish
+both ports on loopback, so nothing is reachable from another machine until you decide it should be.
+
+The Helm chart deliberately installs neither a database nor a Secret. It needs an image reference, a PostgreSQL server
+with the `vector` extension, and a Secret carrying the credentials; [what you supply](../operations/deployment-kubernetes.md#what-you-supply)
+lists all three before the install command.
+
+## What every shape needs
+
+- **PostgreSQL with the `vector` extension.** The synchronized mail, its indexes, and the raw message content all live
+  there. The Compose deployment brings its own (`pgvector/pgvector`, PostgreSQL 17); the other shapes expect yours.
+- **An IMAP account to synchronize** and its password or app password, provisioned as a
+  [secret reference](../operations/secret-provisioning.md) rather than written into configuration.
+- **An explicit schema step.** MailFathom never applies database migrations while starting: it verifies the schema and
+  refuses to serve against one it does not recognize, so bringing a new build up *tells* you a migration is
+  outstanding rather than silently applying one. The reviewed artifact a released installation will apply is still
+  open — [issue #126](https://github.com/Krzysztof318/MailFathom/issues/126) tracks it — so today the step is your own,
+  performed against the `mailfathom` database as the [Compose guide](../operations/deployment-compose.md#starting)
+  describes.
+
+## Native process
+
+The publish output is self-contained in licensing terms — it carries `LICENSE` and `NOTICE` beside the binaries — but
+there is no packaged unit file or installer yet, so a native installation is assembled by hand:
+
+```bash
+dotnet publish src/Host/Host.csproj --configuration Release --output /opt/mailfathom
+```
+
+Build with the SDK pinned in `global.json`. The process is then an ordinary ASP.NET Core service:
+
+- Configuration arrives through `appsettings.json` beside the binaries, a deployment-provisioned JSON file or
+  directory named by [`ConfigurationSources`](../operations/configuration-sources.md), command-line arguments, or
+  environment variables.
+- Credentials arrive as systemd credentials: `LoadCredential=` in the unit, `systemd-credential:` references in the
+  configuration. [Secret provisioning](../operations/secret-provisioning.md#native-systemd-service) shows the unit
+  fragment, including the encrypted-at-rest variant and the core-dump limit worth setting alongside it.
+- The application listener binds the address `ASPNETCORE_URLS` or your Kestrel configuration names; the health probes
+  answer on their own port, `8081` by default. [Health endpoints](../operations/health-endpoints.md) records how to
+  move or disable that listener.
+- PostgreSQL, the `vector` extension, and the schema step are yours, exactly as they are under Kubernetes.
+
+## Verifying any installation
+
+An installation is done when the probes answer and the log shows a healthy start:
+
+```bash
+curl -fsS http://127.0.0.1:8081/started   # startup gates have passed
+curl -fsS http://127.0.0.1:8081/health    # ready, including the database
+curl -fsS http://127.0.0.1:8081/alive     # the process itself
+```
+
+A refusal at startup is designed to name the setting that caused it — a missing secret reference, a pending migration,
+an unsafe transport combination — so the log is the first place to look, and the message quotes the configuration key
+to fix.
+
+Continue with [getting started](getting-started.md): provisioning the secrets, configuring the first account, and
+connecting an MCP client.

--- a/docs/users/usage.md
+++ b/docs/users/usage.md
@@ -1,0 +1,114 @@
+# Using the tools
+
+MailFathom publishes three MCP tools, and together they are the whole surface: an agent can list mail, read one
+message, and search — nothing else. This page is the user's view of that surface: what each tool answers, what every
+result carries, what the deliberate limits are, and how to read a failure. The full contracts — every argument, every
+field, every bound — live in [MCP tools](../features/mcp-tools.md) and the feature pages it links, and this page does
+not restate them.
+
+## The model behind every call
+
+A tool call reads the **local copy** that synchronization maintains. Nothing in a request reaches a mail server, so a
+call is fast, works while the server is unreachable, and cannot mark anything as read — locally or remotely. The price
+of that model is freshness, which is why every listing and every search carries `folderFreshness`: one entry per
+folder in scope, stating when synchronization last committed progress there, or that it never has. An agent that reads
+mail without reading that field will eventually present an empty folder as an empty mailbox.
+
+Results are bounded by design. A listing serves at most 100 summaries per page, a search at most 50 ranked matches, a
+body at most the configured character bound, a search extract at most a few dozen words. The bounds are the
+deployment's privacy control on how much mail one call can draw out, so they are refused rather than stretched when a
+caller asks for more, and none of them is a client argument to widen.
+
+## `list_emails` — the timeline
+
+Returns a page of summaries, newest received first by default, filtered by any combination of account, folder, sender,
+recipient, subject fragment, received range, seen state, and attachment presence. Every argument is optional; a bare
+call reads every folder of every served account.
+
+A summary is enough to recognize a message — subject, sender, recipients, timestamps, size, attachment counts, remote
+flags — and carries `storedEmailId`, the identifier a content read uses. Two fields prevent common misreadings:
+
+- `attachments` counts real attachments separately from inline images, so a message whose only payload is a logo in
+  its signature does not read as one carrying a document.
+- `contentAvailability` says whether the raw content is stored locally, and why not when it is not — a message that
+  exceeded the configured size limit reports so here, instead of failing a later read unexplained.
+
+Paging is a cursor: pass `nextCursor` back unchanged, with the same filters and direction. A cursor is bound to the
+filters that issued it, so changing a filter mid-walk is refused (`52002`) rather than answered with a page from a
+different question.
+
+## `search_emails` — ranked text search
+
+Takes `queryText` — the words to find — plus the same structured filters a listing has, and returns one window of
+matches ranked by relevance, each carrying the summary a listing would show and short extracts of the body around what
+matched, the matched runs wrapped in `**`.
+
+What it searches is the **lexical index**: subject, normalized participant addresses, and the extracted body text. The
+match is by words, not meaning — a query term that appears nowhere in a message will not find it — and text inside
+attachment payloads is not indexed at all. Encrypted mail has no indexed body either. `subjectFragment` and
+`queryText` are different arguments doing different work: the fragment narrows which emails are eligible, the query
+text is what the eligible ones are ranked against.
+
+There is deliberately no search cursor. Relevance order moves as mail keeps arriving and indexing catches up, so a
+second page could silently skip or repeat matches; ask a narrower question instead of a longer window.
+
+## `get_email_content` — one message
+
+Takes the `storedEmailId` a listing or search returned and returns the message: normalized headers, the plain-text
+body, optionally a sanitized HTML body, and one metadata entry per attachment — name, type, size, **never bytes**.
+Attachment download is out of scope for the first release.
+
+Three parts of the result exist so that an agent does not misreport a message:
+
+- **Truncation is explicit.** Each body representation carries `wasTruncated` and the original character count, so a
+  cut message is never summarized as a whole one.
+- **An absent body has a reason.** `availability` distinguishes a message that displayed nothing from one MailFathom
+  cannot decrypt and from one whose content the size limit deliberately kept out of storage.
+- **File names are sanitized.** An attachment name is untrusted text from the message; what is published is a bare,
+  normalized name, with a flag saying whether it had to be rewritten.
+
+The HTML body, when requested, is aggressively sanitized — no scripts, no styles, no remote loads — and
+[email content](../features/email-content.md) records exactly what survives.
+
+## Reading a failure
+
+An expected failure comes back as a tool error in one shape — a stable five-digit code and one safe sentence:
+
+```text
+MailFathom error 53001: Mail account 'shared-billing' is not accessible.
+```
+
+The codes a user meets in practice:
+
+| Code | What it means | What to do |
+| --- | --- | --- |
+| `51001` / `51003` | A page size or result limit outside the served range | Stay within 1–100 pages, 1–50 search results |
+| `51002` | A filter value the query does not accept — too long, malformed, or a range that ends before it starts | Fix the argument; the message names the filter and its limit, never the value |
+| `52001` / `52002` | A cursor this system did not issue, or one reused after the filters changed | Restart the walk from the first page |
+| `53001` | The named account is not served here | Check `AccountId` spelling against the deployment's configuration |
+| `53002` | No such email in the local copy | The identifier is stale, or the mail was removed; list again |
+| `55001` | The email exists but its stored content is currently unreadable; a repair has been queued | Retry later — this is a local-consistency state, not a mail-server problem |
+| `54001` | Something failed for a reason the boundary deliberately does not describe | The server log has the detail, correlated by the request's trace |
+
+Refusals are deliberately uninformative in one direction: an account that does not exist and an account that is not
+yours are the same answer, so the tool surface cannot be used to discover what a deployment serves.
+
+## What the deployment sees, and what it does not
+
+Every call is logged with the tool name, the outcome, and the duration — never with a filter value, a query text, a
+subject, or any part of a result. What you search your own mail for stays out of the operator's log by contract, and
+[what the endpoint records](../operations/mcp-endpoint.md#what-the-endpoint-records) is the precise statement. The
+flip side is worth stating plainly: snippets and bodies returned to an agent are mail content and travel to wherever
+that agent's model runs. Which model sees your mail is decided by the client you connect, not by MailFathom.
+
+## Expectations worth setting
+
+- **Freshness is the synchronization interval** — five minutes by default, per account, plus the length of the run
+  itself. Mail sent a moment ago is not yet listable.
+- **The remote `\Seen` flag is an observation, not an effect.** Results report the flags the last synchronization run
+  saw, with `wasObserved` saying whether any run has looked; reading through MailFathom never changes them.
+- **Removing an account from configuration makes its stored mail unreachable** through the tools, though the rows
+  remain until removed. Disabling synchronization does not — the copy already stored stays readable.
+- **What happens to locally stored mail the server deleted is per account**: the default keeps a hidden tombstone,
+  and a deployment can choose erasure instead. [IMAP synchronization](../features/imap-synchronization.md) records
+  both dispositions.

--- a/docs/users/usage.md
+++ b/docs/users/usage.md
@@ -84,6 +84,7 @@ The codes a user meets in practice:
 | --- | --- | --- |
 | `51001` / `51003` | A page size or result limit outside the served range | Stay within 1–100 pages, 1–50 search results |
 | `51002` | A filter value the query does not accept — too long, malformed, or a range that ends before it starts | Fix the argument; the message names the filter and its limit, never the value |
+| `51004` | The `storedEmailId` argument is no identifier this system issues — blank, truncated, or invented | Pass the identifier a listing or search actually returned; never construct or guess one |
 | `52001` / `52002` | A cursor this system did not issue, or one reused after the filters changed | Restart the walk from the first page |
 | `53001` | The named account is not served here | Check `AccountId` spelling against the deployment's configuration |
 | `53002` | No such email in the local copy | The identifier is stale, or the mail was removed; list again |


### PR DESCRIPTION
Part of #115 — this lands the user-documentation core; the issue stays open for the remaining acceptance items.

## What this adds

- **`docs/users/`** — the audience-facing home #115 asks for, as a guided path that links into the reference pages instead of duplicating them:
  - `README.md` — who the guide is for, the read-only/local-copy model, the pre-release state, and the navigation;
  - `installation.md` — the decision between Compose, Kubernetes, and a native systemd process, what every shape shares (PostgreSQL + `vector`, secret references, the explicit schema step), and the honest statement that every path currently starts from a checkout;
  - `getting-started.md` — first mailbox to first tool call: secrets, account configuration, the deliberate first-start schema refusal, health verification, enabling the MCP endpoint, connecting a Streamable HTTP client, and reading `folderFreshness` before trusting an early result;
  - `usage.md` — the three tools from the user's side, the deliberate bounds, the error codes a caller actually meets, and what the deployment does and does not see.
- **`docs/operations/configuration-reference.md`** — every user-settable option in one place, checked against the options classes: key, type, default, validation range, and restart-vs-reload per ADR 0002, including the four synchronization values the coordinator reads once at start and the persistence settings that reload per connection.
- **`docs/operations/telemetry.md`** — what the host emits over OpenTelemetry, `OTEL_EXPORTER_OTLP_ENDPOINT` as the single export switch, the Aspire dashboard as the only place export is wired today, and why the deployments deliberately set no `OTEL_*` variable.
- `docs/operations/local-development.md` gains the Aspire dashboard paragraph; `docs/README.md` and `docs/AGENTS.md` register the new section and its no-duplication rule.

## What #115 still owes after this

The factual data-and-security page (GDPR/compliance guidance is out of scope per the issue's 2026-08-01 rescope — the operator is the data controller), symptom-organized troubleshooting, verified client-specific integration guides, the release-version stamping of the docs, and the site/README linking owned by #122/#159. Several of those depend on #156 shipping published artifacts, which is why this PR does not close the issue.

## Verification

`scripts/verify-full.sh` passed (all unit tests, 96.88% aggregate coverage, formatting clean); every relative link and anchor in the changed pages validated mechanically; `$check-docs-licenses`: Docs pass, Licenses n/a (no dependency, tool, image, or service change).

