### PR TITLE
Point the contributor's first links at the repository's current path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,9 +14,9 @@ body:
 
 
         **Do not report a security vulnerability here.**
-        [SECURITY.md](https://github.com/Krzysztof318/MailMcp/blob/main/SECURITY.md) has the private
-        channel. Anything touching credentials, tokens, certificates, or unauthorized access to mail
-        goes there instead.
+        [SECURITY.md](https://github.com/Krzysztof318/MailFathom/blob/main/SECURITY.md) has the
+        private channel. Anything touching credentials, tokens, certificates, or unauthorized
+        access to mail goes there instead.
 
 
         **Send no real mail data.** Redact addresses, subjects, and message content in every log,

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,19 +5,19 @@ blank_issues_enabled: true
 
 contact_links:
   - name: Question or idea
-    url: https://github.com/Krzysztof318/MailMcp/discussions
+    url: https://github.com/Krzysztof318/MailFathom/discussions
     about: >-
       Ask in Discussions instead. A question is not a unit of work and does not become one by
       arriving as an issue; one that turns out to be work gets converted into a tracked issue.
 
   - name: Security vulnerability
-    url: https://github.com/Krzysztof318/MailMcp/security/policy
+    url: https://github.com/Krzysztof318/MailFathom/security/policy
     about: >-
       Never report a vulnerability in a public issue. MailFathom holds mailbox credentials and mail
       content; SECURITY.md has the private channel and what to expect.
 
   - name: How to contribute
-    url: https://github.com/Krzysztof318/MailMcp/blob/main/CONTRIBUTING.md
+    url: https://github.com/Krzysztof318/MailFathom/blob/main/CONTRIBUTING.md
     about: >-
       Setup, the verification loop, branch and pull-request rules, and how contributions are
       licensed. Read this before your first change.

--- a/.github/ISSUE_TEMPLATE/work_item.yml
+++ b/.github/ISSUE_TEMPLATE/work_item.yml
@@ -17,8 +17,8 @@ body:
 
 
         Proposing an idea rather than scope? [Discussions →
-        Ideas](https://github.com/Krzysztof318/MailMcp/discussions) is the cheaper place to start,
-        and a discussion that turns out to be work gets converted into an issue.
+        Ideas](https://github.com/Krzysztof318/MailFathom/discussions) is the cheaper place to
+        start, and a discussion that turns out to be work gets converted into an issue.
 
   - type: textarea
     id: context

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ MailFathom is developed and run on Linux.
 ## From a clone to a green run
 
 ```bash
-git clone https://github.com/Krzysztof318/MailMcp.git
-cd MailMcp
+git clone https://github.com/Krzysztof318/MailFathom.git
+cd MailFathom
 dotnet restore MailFathom.slnx
 dotnet build MailFathom.slnx --no-restore
 dotnet test MailFathom.slnx --no-build
@@ -130,4 +130,4 @@ Those files are written for the autonomous agents that do most of the work here,
 
 ## Questions
 
-Use [Discussions](https://github.com/Krzysztof318/MailMcp/discussions) — `Q&A` for questions, `Ideas` for proposals that are not yet scope. A question is not a unit of work and does not become one by arriving as an issue; one that turns out to be work gets converted.
+Use [Discussions](https://github.com/Krzysztof318/MailFathom/discussions) — `Q&A` for questions, `Ideas` for proposals that are not yet scope. A question is not a unit of work and does not become one by arriving as an issue; one that turns out to be work gets converted.

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -547,7 +547,7 @@ run_protected_paths_step() {
   (
     export PATH="$protected_paths_bin_directory:$PATH"
     export GH_TOKEN='fake-token'
-    export REPOSITORY='Krzysztof318/MailMcp'
+    export REPOSITORY='Krzysztof318/MailFathom'
     export REPOSITORY_OWNER='Krzysztof318'
     export PULL_REQUEST_NUMBER='1'
     export PULL_REQUEST_AUTHOR="$pull_request_author"


### PR DESCRIPTION
Closes #220

## What changes

#121 renamed the repository to `Krzysztof318/MailFathom` in place and #139 renamed the product in the tree, but nine references to the old path stayed behind — all of them in the files someone reads before they have read anything else.

- **`CONTRIBUTING.md`** — the clone-to-green-run block now clones `MailFathom` and changes into `MailFathom`, matching `docs/users/installation.md` character for character, and the Discussions link at the end addresses the repository directly.
- **`.github/ISSUE_TEMPLATE/config.yml`** — the three contact links: Discussions, the security policy, and the contribution guide.
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** and **`work_item.yml`** — the `SECURITY.md` and Discussions links inside the form prose. Both folded scalars are rewrapped so no changed line exceeds the 100 columns the rest of those files keep; the text a reporter sees is unchanged, asserted by parsing both files before and after and comparing the folded result.
- **`scripts/test-agent-workflow.sh`** — the `REPOSITORY` fixture the protected-paths tests export.

The roadmap board's README heading was corrected to `MailFathom roadmap` outside this diff, since the board is not a repository file.

## Why now

GitHub redirects the old path, so nothing is broken today. A redirect is not a contract: it holds only until someone creates a repository under the vacated name, and until then it quietly teaches every reader a name the project no longer uses. Correcting it costs this diff; discovering it after publication costs a contributor their first five minutes.

Issues and pull requests that mention the old name are deliberately left alone. They record what was written at the time.

## Verification

- `scripts/verify-full.sh` — green.
- `scripts/test-agent-workflow.sh` — 24 passed, 0 failed, which covers the changed fixture.
- `git grep -iE 'mail[ _-]?mcp'` over the tracked tree returns nothing.
- Both issue-template files parse as YAML, and their folded text differs from `HEAD` only in the URL.

No production code, dependency, service, or container image is touched, so the third-party license register is unaffected.
