### PR TITLE
Name the language a review is written in, and the hostility that carries no insult

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,6 +8,7 @@ Everyone participating in this repository — through issues, discussions, pull 
 
 - **Assume good faith.** A confusing question, a wrong patch, and a blunt review are ordinarily what they look like: a person working with incomplete information, in a language that may not be their first.
 - **Review the work, not the author.** "This leaks the connection on the failure path" is a review. "This is amateur work" is not, and it says nothing the first sentence did not.
+- **Keep the language plain.** Blunt is welcome here, and a blunt review is usually kinder than a hedged one. Obscenity, sneering, and contempt are not bluntness: they carry nothing the plain sentence did not, and they make every later reader work past the tone to reach the point.
 - **Say why.** A rejected approach costs the contributor the same amount of time whether or not the reason was given, and only the reason lets the next attempt be better.
 - **Accept the answer.** The maintainer decides what this project builds. Argue the technical case as hard as it deserves, then let a settled decision stay settled.
 - **Respect a stated boundary.** When someone asks that a line of discussion stop, it stops.
@@ -15,7 +16,9 @@ Everyone participating in this repository — through issues, discussions, pull 
 ## What is not acceptable
 
 - Harassment, whether directed at someone here or continued from elsewhere.
+- Intimidation and deliberate provocation: needling, following someone from thread to thread, reopening a settled argument to get a reaction, and piling on one person. Sustained hostility needs no insult in it to make someone stop taking part.
 - Insults, demeaning remarks, and comments about a person rather than about their work.
+- Abusive, obscene, or degrading language, and slurs of any kind. This holds whatever it is aimed at — a person, their patch, or nobody in particular — because language aimed at nobody still tells every reader what passes as normal here.
 - Discriminatory or stereotyping remarks, including ones framed as jokes, about race, ethnicity, nationality, religion, age, disability, neurodivergence, sex, gender identity or expression, sexual orientation, appearance, or any comparable characteristic.
 - Sexual attention or imagery. This project has no context in which either belongs.
 - Publishing someone's private information, or the private contents of a conversation, without their permission.


### PR DESCRIPTION
Closes #227.

`CODE_OF_CONDUCT.md` named harassment, insults, discrimination and threats, which left two shapes outside it.

The first is register. Abusive or obscene phrasing directed at a patch was not a comment about a person, and a slur aimed at nobody in particular was not a remark about anyone's characteristics, so neither existing entry reached them. An expectation now states what the project writes in: blunt is welcome and usually kinder than hedging, while obscenity, sneering and contempt carry nothing the plain sentence did not. The matching entry in the unacceptable list holds whatever the language is aimed at, because language aimed at nobody still tells every reader what passes as normal here.

The second is hostility that never becomes an insult. Needling, following someone from thread to thread, reopening a settled argument to get a reaction, and pile-on were reachable only once one of them produced a demeaning remark. They are now their own entry, distinct from insults above it and from threats below it.

Discrimination is untouched. It was already explicit, with the characteristics enumerated and the framed-as-a-joke case closed, and a second statement of it would leave two lists to keep in step.

The text stays MailFathom's own. Nothing is taken from Contributor Covenant or any other externally licensed code of conduct, so the attribution section and `THIRD_PARTY_LICENSES.md` remain correct. `README.md` and `CONTRIBUTING.md` link the document without restating it, which was checked rather than assumed, so neither needs a change.
