### PR TITLE
[#248] Stop the settle-ceiling contract tests turning on a one-second boundary

### DIFF
--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -803,7 +803,12 @@ run_fathom_review_settle() {
     export REPOSITORY='Krzysztof318/MailFathom'
     export PULL_REQUEST_NUMBER='1'
     export SETTLE_MINIMUM_SECONDS='2'
-    export SETTLE_QUIET_SECONDS='1'
+    # Three rather than one, because the fake `gh` reports whole seconds. A conversation it answers
+    # as `now` is already up to a second old by the time the loop reads its own clock, so a quiet
+    # window of one second is decided by which side of a second boundary the two `date` calls fall
+    # on, and the tests that require the ceiling would settle instead. Truncation can cost only one
+    # second, so any window above it leaves the decision to the loop.
+    export SETTLE_QUIET_SECONDS='3'
     export SETTLE_LIMIT_SECONDS='4'
     export SETTLE_POLL_SECONDS='1'
     bash "$step_script"


### PR DESCRIPTION
`fathom_review_stops_waiting_at_the_ceiling` failed once during `scripts/verify-full.sh` on a branch that changed four Markdown files and nothing under `.github/` or `scripts/`. The same suite passed 30/30 on the merge commit before it and on the one after, which is the shape of a test that decides on something other than the code.

It decides on a second boundary. `run_fathom_review_settle` drives the real `settle` step against a fake `gh` that answers `now` with `date -u +%Y-%m-%dT%H:%M:%SZ`, so the timestamp is truncated to whole seconds. The step then reads its own clock as `date -u +%s` and subtracts. With `SETTLE_QUIET_SECONDS='1'`, a conversation the fake reported as current is already "quiet" whenever those two `date` calls land on either side of one boundary — and from the third poll `waited >= SETTLE_MINIMUM_SECONDS` already holds, so the settled branch wins before `waited` ever reaches `SETTLE_LIMIT_SECONDS`. The step prints `Settled` and the test wanted `still moving`.

So the window was set exactly one second wide against a clock whose resolution is one second. `fathom_review_reads_the_newest_comment_whatever_the_order` asserts the same string down the same path and carried the same defect; it happened not to lose the toss in the observed run.

Raising the harness's quiet window to three seconds settles it. Truncation can cost at most one second, so any window above that leaves the decision to the loop rather than to when the run started. The other three values are untouched, all four contracts still hold — a first review collects at once, a quiet conversation still waits out the minimum, a moving one is cut off at the ceiling, and the newest comment decides whatever order the endpoint returned — and the suite's runtime is unchanged, because the ceiling that bounds these tests has not moved.

`.github/workflows/fathom-review.yml` is deliberately not touched. In production the three windows are `60`, `45`, and `300`, where a one-second truncation decides nothing; the defect was in what the harness asked of the loop, not in the loop.

## Verification

`scripts/verify-full.sh` exits `0`: workflow contracts 30 passed / 0 failed, the unit suite with `failed: 0`, and formatting rewrote none of the 708 files. The contract suite was additionally run three times in isolation before the gate, at 15.1s, 15.0s, and 14.0s, passing 30/30 each time.

Closes #248
