### PR TITLE
[#255] Publish the image under its GHCR reference rather than under an unqualified name

### DIFF
--- a/.github/workflows/publish-container-image.yml
+++ b/.github/workflows/publish-container-image.yml
@@ -4,8 +4,9 @@ name: Publish container image
 # schedule — and neither builds anything of its own, so a change to how MailFathom is built, gated, scanned, or attested
 # is one edit rather than two that can drift apart.
 #
-# The build happens once and the push is the only per-registry part, which is what leaves #235 a login and a tag list to
-# add rather than a second pipeline. Until it lands, GHCR is the only registry a MailFathom image reaches.
+# The build happens once and the push is the only per-registry part, which is what leaves #235 a login and a second
+# repository to qualify the tags against rather than a second pipeline. Until it lands, GHCR is the only registry a
+# MailFathom image reaches.
 #
 # Every action here is pinned to an immutable commit SHA, which the read-only workflows in this repository deliberately
 # do not do. The difference is the privilege: these jobs hold a token that can write to a registry and sign an
@@ -31,7 +32,7 @@ on:
         type: string
         default: ''
       tags:
-        description: 'Newline-separated image tags. The first is the immutable one this version owns; the rest are the moving tags it takes over.'
+        description: 'Newline-separated image tags, without a repository: this workflow resolves that and qualifies each one. The first is the immutable tag this version owns; the rest are the moving tags it takes over.'
         required: true
         type: string
       block-on-vulnerabilities:
@@ -117,6 +118,12 @@ jobs:
 
       # An OCI repository name is lowercase, and this owner's login is not, so the reference is folded once here rather
       # than written as a literal that a rename would leave pointing at nothing.
+      #
+      # Qualifying the caller's tags is part of the same resolution, because a tag on its own is not a tag to a registry
+      # client: an unqualified name is an image on the default registry, so pushing a bare `nightly` would reach
+      # `docker.io/library/nightly` rather than this repository. The callers therefore pass tags and every reference is
+      # composed here, which is also what keeps a second registry one more repository to qualify against rather than a
+      # rule each caller has to repeat.
       - name: Resolve the image reference
         id: reference
         env:
@@ -126,12 +133,21 @@ jobs:
           set -euo pipefail
 
           image="ghcr.io/$(printf '%s' "$REPOSITORY" | tr '[:upper:]' '[:lower:]')"
-          primary_tag="$(printf '%s\n' "$IMAGE_TAGS" | sed '/^[[:space:]]*$/d' | head -n 1)"
+          tags="$(printf '%s\n' "$IMAGE_TAGS" | sed '/^[[:space:]]*$/d')"
+          primary_tag="$(printf '%s\n' "$tags" | head -n 1)"
+
+          if [[ -z "$primary_tag" ]]; then
+            echo "::error::No image tag was supplied, so there is nothing to publish this version as."
+            exit 1
+          fi
 
           {
             printf 'image=%s\n' "$image"
             printf 'primary-tag=%s\n' "$primary_tag"
             printf 'primary-reference=%s:%s\n' "$image" "$primary_tag"
+            printf 'references<<REFERENCES\n'
+            printf '%s\n' "$tags" | sed "s|^|${image}:|"
+            printf 'REFERENCES\n'
           } >> "$GITHUB_OUTPUT"
 
           # `created` names the instant the source was committed rather than the instant a runner happened to start.
@@ -312,7 +328,7 @@ jobs:
           target: runtime
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ${{ inputs.tags }}
+          tags: ${{ steps.reference.outputs.references }}
           build-args: |
             IMAGE_VERSION=${{ inputs.version }}
             IMAGE_REVISION=${{ inputs.ref }}

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -1026,6 +1026,112 @@ fathom_review_reads_the_newest_comment_whatever_the_order() {
   assert_seconds_elapsed_at_least 4 "$started_at"
 }
 
+# `Publish container image` resolves the repository an image belongs to, and both callers hand it tags alone.
+# Qualifying those tags is therefore part of the same step, and nightly run 30725904948 is what leaving them bare
+# costs: an unqualified name is not a tag to a registry client but an image on the default registry, so the push asked
+# `auth.docker.io` for a token instead of writing to GHCR and every gate before it passed. The block is extracted the
+# way the ones above are, because it is a step inside YAML rather than a script the job could call.
+extract_publish_reference_step() {
+  local step_script="$1"
+
+  awk '
+    $0 == "        id: reference" { found = 1; next }
+    found && !extracting && /^        run: \|$/ { extracting = 1; next }
+    extracting {
+      if ($0 != "" && $0 !~ /^          /) { exit }
+      sub(/^          /, "")
+      print
+    }
+  ' "$source_repository_root/.github/workflows/publish-container-image.yml" > "$step_script"
+
+  [[ -s "$step_script" ]]
+  bash -n "$step_script"
+}
+
+# The step reads the committed timestamp of the checkout it runs in, so it runs inside the fixture
+# repository rather than in the temporary directory beside it.
+run_publish_reference_step() {
+  local image_tags="$1"
+  local output_file="$2"
+  local step_output_file="$3"
+  local step_script="$test_directory/publish-reference-step.sh"
+
+  extract_publish_reference_step "$step_script"
+  : > "$step_output_file"
+
+  (
+    export REPOSITORY='Krzysztof318/MailFathom'
+    export IMAGE_TAGS="$image_tags"
+    export GITHUB_OUTPUT="$step_output_file"
+    cd "$repository_root"
+    bash "$step_script"
+  ) > "$output_file" 2>&1
+}
+
+# What the pushing step is handed, read out of the multi-line output the way the runner reads it, so
+# the assertion is about every reference rather than about one line that happens to be present.
+read_published_references() {
+  awk '
+    /^references<<REFERENCES$/ { inside = 1; next }
+    $0 == "REFERENCES" { inside = 0 }
+    inside { print }
+  ' "$1"
+}
+
+publish_qualifies_every_nightly_tag_with_the_repository_it_resolves() {
+  local output_file="$test_directory/publish-reference-nightly-output"
+  local step_output_file="$test_directory/publish-reference-nightly-step-output"
+  local references_file="$test_directory/publish-reference-nightly-references"
+
+  if ! run_publish_reference_step $'0.1.0-nightly.12-616d0a6\nnightly\n' "$output_file" "$step_output_file"; then
+    printf 'The publish workflow failed to resolve a nightly tag list\n' >&2
+    return 1
+  fi
+
+  read_published_references "$step_output_file" > "$references_file"
+
+  assert_contains 'image=ghcr.io/krzysztof318/mailfathom' "$step_output_file"
+  assert_contains 'primary-reference=ghcr.io/krzysztof318/mailfathom:0.1.0-nightly.12-616d0a6' "$step_output_file"
+  assert_file_content \
+    $'ghcr.io/krzysztof318/mailfathom:0.1.0-nightly.12-616d0a6\nghcr.io/krzysztof318/mailfathom:nightly' \
+    "$references_file"
+}
+
+# The release channel's own tag list, and the blank line a heredoc-built list carries. `latest` is the
+# tag that made the defect cheap to miss: it looks like a tag everywhere else and resolves to
+# `docker.io/library/latest` here.
+publish_qualifies_the_release_tags_and_ignores_a_blank_line() {
+  local output_file="$test_directory/publish-reference-release-output"
+  local step_output_file="$test_directory/publish-reference-release-step-output"
+  local references_file="$test_directory/publish-reference-release-references"
+
+  if ! run_publish_reference_step $'0.1.0\n\nlatest\n' "$output_file" "$step_output_file"; then
+    printf 'The publish workflow failed to resolve a release tag list\n' >&2
+    return 1
+  fi
+
+  read_published_references "$step_output_file" > "$references_file"
+
+  assert_file_content \
+    $'ghcr.io/krzysztof318/mailfathom:0.1.0\nghcr.io/krzysztof318/mailfathom:latest' \
+    "$references_file"
+}
+
+# A tag list that is empty once blank lines are dropped would otherwise push `ghcr.io/<repository>:`,
+# which the registry answers for reasons that say nothing about the missing tag.
+publish_refuses_a_tag_list_with_nothing_to_publish() {
+  local output_file="$test_directory/publish-reference-empty-output"
+  local step_output_file="$test_directory/publish-reference-empty-step-output"
+
+  if run_publish_reference_step $'\n   \n' "$output_file" "$step_output_file"; then
+    printf 'The publish workflow resolved a reference from an empty tag list\n' >&2
+    return 1
+  fi
+
+  assert_contains 'No image tag was supplied' "$output_file"
+  assert_file_content '' "$step_output_file"
+}
+
 # The release gate is a script rather than a step inside `release.yml`, so the contracts below run it directly instead
 # of extracting it from YAML. Everything it decides — what a release tag may look like, which history it may come from,
 # and what the tagged tree has to say about itself — is decided once here, before a workflow builds anything, because
@@ -1293,6 +1399,9 @@ run_test fathom_review_collects_at_once_when_nobody_has_commented
 run_test fathom_review_waits_before_freezing_a_quiet_conversation
 run_test fathom_review_stops_waiting_at_the_ceiling
 run_test fathom_review_reads_the_newest_comment_whatever_the_order
+run_test publish_qualifies_every_nightly_tag_with_the_repository_it_resolves
+run_test publish_qualifies_the_release_tags_and_ignores_a_blank_line
+run_test publish_refuses_a_tag_list_with_nothing_to_publish
 run_test release_tag_assertion_accepts_a_tag_that_matches_its_commit
 run_test release_tag_assertion_refuses_a_prerelease_tag
 run_test release_tag_assertion_refuses_a_lightweight_tag


### PR DESCRIPTION
Closes #255

## What was wrong

`Publish container image` handed the caller's tag list straight to `docker/build-push-action`:

```yaml
tags: ${{ inputs.tags }}
```

That input takes full image references. Both channels pass tags alone — `Nightly` emits `0.1.0-nightly.<n>-<short revision>` and `nightly`, `Release` emits `<x.y.z>` and `latest` — so BuildKit read each one as an image *name* on the default registry and resolved it to `docker.io/library/<name>:latest`. The nightly run [30725904948](https://github.com/Krzysztof318/MailFathom/actions/runs/30725904948) failed asking Docker Hub for a token nothing had granted it:

```
failed to fetch oauth token: … https://auth.docker.io/token?scope=repository%3Alibrary%2F0.1.0-nightly.1-616d0a6%3Apull%2Cpush
… 401 Unauthorized: access token has insufficient scopes
```

Every gate before it passed, because nothing else consumes the raw input: `Resolve the image reference` composes the GHCR reference correctly but only for the idempotency check and the digest read-back, and the gating build tags locally as `mailfathom:gate`. Both channels carry the defect, so no image has ever been published and the first release tag would have failed the same way.

## What changed

- `Resolve the image reference` now also emits `references`, every supplied tag prefixed with the repository it already resolves, and the pushing step consumes that instead of the raw input. Qualifying belongs to the step that knows the repository, which keeps a second registry (#235) a login and one more prefix rather than a rule each caller repeats.
- A tag list that is empty once blank lines are dropped fails there with a named error, rather than pushing `ghcr.io/<repository>:` and reading the registry's answer for a cause it does not state.
- The `tags` input description says the callers pass tags without a repository, so the next caller does not repeat the mistake.
- Three contracts in `scripts/test-agent-workflow.sh` run the committed block the way the existing protected-paths, typo-check, and fathom-review contracts do: the nightly tag list, the release tag list including a blank line, and the empty list. They assert the whole `references` block rather than one line of it, so an unqualified tag cannot pass again.

`Release` and `Nightly` are unchanged: they still emit tags, which is what their outputs already documented.

## Verification

- `scripts/verify-full.sh` — passed, workflow contracts 47/47.
- Documentation needed no change: `docs/operations/container-image.md#published-images` and `docs/operations/release-procedure.md` already describe the registry and both channels' tags, which is the behaviour this restores.


## Verified on a real run

`Nightly` dispatched on this branch — [run 30739413168](https://github.com/Krzysztof318/MailFathom/actions/runs/30739413168) — so the workflow definitions came from this commit while the image was built from `main` (2d58ce8), which is what the `decide` job's reachability guard requires.

`Build and push the multi-architecture image` **passed**, and the registry holds what it should:

```
ghcr.io/krzysztof318/mailfathom:nightly              sha256:6fa0f272…
ghcr.io/krzysztof318/mailfathom:0.1.0-nightly.2-2d58ce8  sha256:6fa0f272…   (same digest)
linux/amd64, linux/arm64, plus both attestation manifests
org.opencontainers.image.version=0.1.0-nightly.2-2d58ce8
org.opencontainers.image.revision=2d58ce8d7f421b0e4380e2f68b7c8d7dff1ca455
io.mailfathom.release-channel=nightly
```

The run then failed at `Attest the published image`, for a reason this change does not touch and cannot fix:

```
Failed to persist attestation: Feature not available for user-owned private repositories.
To enable this feature, please make this repository public.
```

That is a GitHub limitation on the attestation store rather than a defect in the workflow, and it resolves itself when the repository is published. It is deliberately left alone — the owner's call — so the step stays as written and starts working at publication. The steps it blocked (`Verify the published image`, `Summarize the publication`, and the pruning job) were run by hand against the registry above and agree with what they would have asserted.