### PR TITLE
[#260] Link a release page to the full changelog at the tag it shipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,10 @@ jobs:
       # a release cannot be deployed over the previous release's data, which is the most important sentence a MailFathom
       # release note will ever carry.
       #
+      # That section describes one version, so the link under it says where the rest is. It points at the tag rather
+      # than at `main`, because an operator reading an older release wants the file as that release shipped it, not a
+      # copy that has since grown the sections describing everything they have not upgraded to yet.
+      #
       # The schema section beside it is the per-release record the artifact needs to be usable years from now: which
       # migrations it carries, the checksum that identifies the file, and the ordering and backup point applying it
       # assumes. The reasoning behind each of those lives once, in docs/operations/database-schema.md, and the notes link
@@ -157,6 +161,10 @@ jobs:
 
           {
             bash scripts/read-changelog-section.sh "$VERSION"
+            printf '\n[The full changelog at this tag](https://github.com/%s/blob/%s/CHANGELOG.md) ' \
+              "$REPOSITORY" "$RELEASE_TAG"
+            printf 'carries the releases before this one and the surfaces each of them broke.\n'
+
             printf '\n## The published image\n\n```\ndocker pull %s:%s\ndocker pull %s@%s\n```\n' \
               "$IMAGE" "$VERSION" "$IMAGE" "$DIGEST"
 

--- a/docs/operations/release-procedure.md
+++ b/docs/operations/release-procedure.md
@@ -125,7 +125,8 @@ whole procedure, and it is recorded here so it survives the skill being unavaila
    `VersionPrefix`, against the highest existing tag on the same `major.minor` line, and against the changelog section
    for that version — `scripts/assert-release-tag.sh` is that check. It then builds and gates the image, pushes it
    under `<x.y.z>`, moves `latest` onto the same digest, attests it, and opens the GitHub release with that changelog
-   section as its notes.
+   section as its notes. Under the section it links `CHANGELOG.md` at the tag, so a reader of an older release reaches
+   the file as that release shipped it rather than a copy already describing versions they have not upgraded to.
 
    ```bash
    git tag --annotate v0.1.0 --message 'MailFathom 0.1.0'


### PR DESCRIPTION
The release notes already open with the changelog section for the version being released —
`scripts/read-changelog-section.sh` extracts it, and `scripts/assert-release-tag.sh` refuses a release whose section is
missing or empty. What was missing is any statement that the section is an extract, or where the rest of the file is.
A reader on a release page had one version in front of them and no route from there to the ones before it.

The notes now carry a link to `CHANGELOG.md` directly under that section. It points at the released tag rather than at
`main`, built from the same `github.repository` and `github.ref_name` the schema section's documentation link already
uses, so an operator reading an older release reaches the file as that release shipped it instead of a copy that has
since grown the sections for versions they have not upgraded to — and a fork publishes its own.

Rendered against a fixture changelog, the notes now read:

```markdown
### Added

- Something an operator notices.

[The full changelog at this tag](https://github.com/Krzysztof318/MailFathom/blob/v0.2.0/CHANGELOG.md) carries the releases before this one and the surfaces each of them broke.

## The published image
...
```

Nothing else about the release moves: the changelog gate is untouched, the image and schema sections are unchanged, and
re-running a release still replaces its notes rather than failing on them.

`docs/operations/release-procedure.md` states what the notes carry. ADR 0004 needs no change — "GitHub release notes
are generated from the changelog rather than the other way round" is exactly what still happens.

Closes #260
