### PR TITLE
[#262] Give each orchestrated host its own probe port, so the second one still starts

### DIFF
--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -156,6 +156,15 @@ if (runsIntegrationTests)
     // them, once nothing else is asserting on the infrastructure it would touch.
     mailFathomHost
         .WithExplicitStart()
+        // The probe listener, on a port the orchestration allocates rather than on the one the host defaults to. This
+        // topology runs two MailFathom processes on one machine and a default is the same number in both, so the second
+        // to start would fail to bind and exit — which reaches a test as a request that never answers rather than as a
+        // host that never started. Allocated for the reason every other port here is: nothing this suite opens may
+        // depend on a number another run, or another host, already holds.
+        //
+        // Its scheme is tcp rather than http, for the reason the pinned topology's is: an http endpoint would join
+        // ASPNETCORE_URLS and make the probe port an application listener, which the host refuses.
+        .WithEndpoint(name: "health", scheme: "tcp", env: "HealthEndpoints__Port")
         // Stated here rather than left to appsettings.json, because the isolation above is a promise this app model
         // makes: a default edited elsewhere must not be able to turn the started host into a synchronizing one.
         .WithEnvironment("MailSynchronization__Enabled", "false")
@@ -282,6 +291,9 @@ if (runsIntegrationTests)
     var mutualTlsHost = builder
         .AddProject<Projects.Host>(OrchestrationContract.MutualTlsHostResourceName, launchProfileName: null)
         .WithHttpsEndpoint(name: OrchestrationContract.MutualTlsHostHttpsEndpointName)
+        // Its own probe listener, allocated for the reason the host above allocates one: both processes run at once
+        // under this topology, and the port a host defaults to is the same number in each.
+        .WithEndpoint(name: "health", scheme: "tcp", env: "HealthEndpoints__Port")
         .WithReference(database)
         .WaitFor(database)
         .WithExplicitStart()

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -292,8 +292,12 @@ if (runsIntegrationTests)
         .AddProject<Projects.Host>(OrchestrationContract.MutualTlsHostResourceName, launchProfileName: null)
         .WithHttpsEndpoint(name: OrchestrationContract.MutualTlsHostHttpsEndpointName)
         // Its own probe listener, allocated for the reason the host above allocates one: both processes run at once
-        // under this topology, and the port a host defaults to is the same number in each.
+        // under this topology, and the port a host defaults to is the same number in each. On loopback for that host's
+        // reason as well — the probes answer without a credential, and the machine a suite runs on is a developer's as
+        // often as it is a runner's. The binding is restated rather than inherited: it is set on the resource above,
+        // and this is a second resource that shares nothing but the project it is built from.
         .WithEndpoint(name: "health", scheme: "tcp", env: "HealthEndpoints__Port")
+        .WithEnvironment("HealthEndpoints__BindAddress", "127.0.0.1")
         .WithReference(database)
         .WaitFor(database)
         .WithExplicitStart()


### PR DESCRIPTION
Closes #262

The integration suite has failed on `ComposedMcpClientCertificateHandshakeTests` on every run since the probes were given a listener of their own. Two MailFathom processes run under that topology — `mailfathom-host` and `mailfathom-mtls-host` — and neither declared a probe port, so both fell back to the host's default `8081`. The first to start bound it and the second exited:

```
System.IO.IOException: Failed to bind to address http://0.0.0.0:8081: address already in use.
```

That never reached a test as a host which failed to start. The resource reaches `Running` before Kestrel binds, so the fixture returned an address for a process that was already leaving, and each of the three mutual-TLS tests spent 100 seconds waiting for an answer that had nobody to come from. Reproduced locally against `686cde5` before the change, with the same three failures and the same bind error underneath them.

Each host now declares a probe endpoint of its own, on a port the orchestration allocates. That is what the rest of this topology already does and for the stated reason — a fixed port lets one run refuse to bind because another still holds it — and the probe listener was the one port left to a default, which is the same number in every process. The scheme is `tcp` rather than `http` for the reason the pinned topology's is: an `http` endpoint would join `ASPNETCORE_URLS` and make the probe port an application listener, which the host refuses outright. Aspire allocates a target port when none is stated and injects it into the named variable, so the number is written once.

No production behavior changes: the endpoints are declared inside the `IntegrationTesting` branch of the app model, and a developer's `aspire run` keeps the pinned `8080`, `8081`, and `8443` it publishes today.

## Verification

- `scripts/verify-full.sh` — passed, 0 failed, aggregate line coverage 96.92%.
- `scripts/run-integration-tests.sh --filter-class "*ComposedMcp*"` on the unfixed tree — the three failures this closes, with the bind error in the host's own output.
- The `Integration tests` workflow is dispatched against this branch; the suite is the only test that can speak to an app-model topology, so its result is the acceptance evidence.

No unit test accompanies this. `AppHost.UnitTests` reaches the app model through a `Compile Include` of the files that depend on nothing but the base class library, which is what keeps it free of the Aspire SDK's runtime-identifier-specific packages; the endpoint declarations are not reachable from it.
