### PR TITLE
[#210] Return main to naming the next release, and name what the bump does not reach

### DIFF
--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -95,12 +95,33 @@ On a branch off the release branch, and touching nothing else:
 - say, when the database schema moved, whether a migration must be applied, whether it applies while the previous
   version still runs, and whether the release deploys over the previous release's data at all;
 - update the link references at the foot of the file so the new section resolves;
-- leave `VersionPrefix` alone. It already reads `x.y.z`, which is what makes the tagged tree self-consistent.
+- leave `VersionPrefix` alone. It already reads `x.y.z`, which is what makes the tagged tree self-consistent;
+- **bring the three files that name a version in prose onto `x.y.z`**, per the list below.
 
 Nothing else belongs in this diff. **This is the pull request whose merge commit is tagged and published**, so it is
 both the last point at which the release's contents are read as a whole and the thing the published artifact is built
 from; an unrelated change in it is a change nobody reviewed as part of the release. `CHANGELOG.md` is a protected path,
 which is what makes an edit to it outside this flow visible.
+
+#### The files that name a version in prose
+
+`<VersionPrefix>` is the only place a version is written for the *build*. Three files additionally name one in prose,
+where nothing derives it and nothing checks it, so they are read here by name rather than left to be noticed:
+
+| File | What to bring onto `x.y.z` |
+| --- | --- |
+| `README.md` | The **Project status** paragraph — which release is current and what it ships |
+| `docs/users/installation.md` | The image references in the opening paragraph, which quote the version literally |
+| `SECURITY.md` | The **Supported versions** table. `x.y` becomes the supported line and the one it replaces moves down a row, per ADR 0004's rule that only the newest released minor is patched by default |
+
+**They belong in this pull request rather than the bump one, and the reason is what the whole ordering rests on:** this
+diff's merge commit is what gets tagged, so it is the tree an operator reads at `v<x.y.z>`. A `SECURITY.md` corrected
+after the tag names the previous line in the artifact people actually download, and `docs/` at a tag is read far more
+often than `docs/` on `main`. The bump pull request cannot carry them for the same reason it cannot carry the changelog.
+
+Nothing gates this, deliberately: no check can tell prose describing the release from prose quoting a version as an
+example, and one that tried would be satisfied by a search-and-replace through `docs/`. The list above is short and
+fixed instead, and a file joining it is an edit to this table.
 
 ### 4. Open the version-bump pull request
 
@@ -114,6 +135,10 @@ are both supplied at package time from the same declaration.
 edits to the chart directory would need raising on every release anyway — a packaged chart embeds its `appVersion`, so
 each release produces chart content that differs from the last, and a published chart version is immutable — and it
 would leave an operator mapping two numbers onto one artifact.
+
+**Do not bring the three prose files here either.** They name the release that has just been *published*, and this
+pull request merges after the tag — so a `README.md` corrected here is a `README.md` that was wrong in the tagged tree.
+Step 3 owns them.
 
 ### 5. Draft both, and cross-reference them
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
        same assembly identity. InformationalVersion is left to the SDK, which is what composes VersionPrefix,
        VersionSuffix, and SourceRevisionId into the single string the runtime reports. -->
   <PropertyGroup>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
   </PropertyGroup>

--- a/docs/operations/release-procedure.md
+++ b/docs/operations/release-procedure.md
@@ -126,9 +126,14 @@ version becomes real is a decision rather than a consequence of work looking fin
 whole procedure, and it is recorded here so it survives the skill being unavailable:
 
 1. **Merge the changelog pull request.** It adds `## [x.y.z] - YYYY-MM-DD` with the release's entries, composed from
-   what merged since the previous tag, and touches nothing else. It merges first because **its merge commit is what
-   gets tagged and published**, so the tagged tree contains the released changelog rather than describing it
-   afterwards.
+   what merged since the previous tag, and it brings the three files that name a version in prose onto that version:
+   the **Project status** paragraph in `README.md`, the image references opening `docs/users/installation.md`, and the
+   **Supported versions** table in `SECURITY.md`. It touches nothing else. It merges first because **its merge commit
+   is what gets tagged and published**, so the tagged tree contains the released changelog — and the three files
+   describing the release they ship inside — rather than describing them afterwards.
+
+   Those three are the whole of what `<VersionPrefix>` does not reach. Everything a build stamps derives from that one
+   declaration; prose does not, and nothing checks it, which is why the list is stated rather than searched for.
 2. **Push the annotated tag `v<x.y.z>` on that merge commit.** This is what makes the release real and what triggers
    the release workflow. Before publishing anything the workflow asserts the tag against the tagged commit's
    `VersionPrefix`, against the highest existing tag on the same `major.minor` line, and against the changelog section


### PR DESCRIPTION
Follows the merged #282. **This closes no issue** — bumping is what follows a release rather than what the release was for, and #210 was closed by #282.

## The bump

Raises `<VersionPrefix>` in `Directory.Build.props` from `0.1.0` to `0.2.0`, so `main` returns to naming the *next* release. That is the only file in the repository where a version is written for the build: the assemblies derive it centrally, the image's tags and labels arrive as build arguments, and — since #281 — the chart's `version` *and* `appVersion` are both supplied at package time from the same declaration.

- **`deploy/helm/mailfathom/Chart.yaml` is not touched.** Its `version` is a `0.0.0` placeholder and it declares no `appVersion` at all. A chart version counting edits to the chart directory would need raising on every release regardless — a packaged chart embeds `appVersion`, so each release produces chart content that differs from the last, and a published chart version is immutable — while leaving an operator to map two numbers onto one artifact.
- **The next minor, not a patch.** ADR 0004: `main` does not produce patches. A patch is cut from a `release/0.1.x` branch.
- **`CHANGELOG.md` is untouched**, per ADR 0004 step 4 — the next section is written by the next release, not opened in advance.

## The three files `VersionPrefix` does not reach

Answering "is the bump the only place a version is updated?": for the **build**, yes. For **prose**, no — three files name a version where nothing derives it and nothing checks it, and until now nothing said so:

| File | What names a version |
| --- | --- |
| `README.md` | The **Project status** paragraph |
| `docs/users/installation.md` | The image references in the opening paragraph |
| `SECURITY.md` | The **Supported versions** table |

`$prepare-release` and `docs/operations/release-procedure.md` now name all three by file, as an explicit step with the reasoning beside it. Nothing gates it, deliberately: no check can tell prose describing the release from prose quoting a version as an example, and one that tried would be satisfied by a search-and-replace through `docs/`. A short fixed list is honest about that; a file joining it is an edit to the table.

**One deviation from what was asked, and why.** The step is written into the skill's **step 3, the changelog pull request**, not step 4, the bump. That diff's merge commit is what gets tagged, so it is the tree an operator reads at `v<x.y.z>` — a `SECURITY.md` corrected after the tag names the previous supported line in the artifact people actually download, and `docs/` at a tag is read far more often than `docs/` on `main`. Step 4 now says explicitly that the three do not belong there and why, so the placement is visible rather than implied. The change itself lands here, in this pull request, as asked.

The files themselves are **not edited here**: all three already say `0.1.0`, which is correct — #282 brought them onto it, and `0.1.0` is what is published when this merges.

## While this was open

`v0.1.0` was tagged, failed, and was re-cut. `actions/checkout` force-fetches the resolved commit into the tag's own ref name, which turns an annotated tag into a lightweight one and made `scripts/assert-release-tag.sh` reject a correct tag — for every release, not just this one. #284 records it and #285 fixed it; the tag now sits on `ff91615`, which carries the fix.

## Verification

- Rebased onto `ff91615` (#285), cleanly.
- `scripts/read-declared-version.sh` → `0.2.0`.
- `scripts/verify-full.sh` — exit 0. 84 workflow-contract assertions, every unit-test module, `dotnet format` reports 0 of 709 files changed.
- `scripts/review-obligations.sh` — the pages named over the skill and over `Directory.Build.props` were read; `docs/operations/agent-workflow.md` describes `$prepare-release` at a summary level and points at the release procedure for the sequence, so it owes nothing, and ADR 0004 is a closed decision.
- `$check-docs-licenses` — `Docs: pass`, `Changelog: n/a`, `Licenses: n/a`.

## Merge order

**Merge only after the `v0.1.0` tag has published.** Merging before the tag would leave the tagged commit declaring `0.2.0`, which `scripts/assert-release-tag.sh` rejects.
