### PR TITLE
[#284] Restore the annotated tag the checkout overwrites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # The checkout above brings the annotated tag object down and then destroys it: having resolved the ref, it
+      # force-fetches the *commit* into the same ref name — `+<sha>:refs/tags/<tag>` — so `refs/tags/<tag>` ends up
+      # pointing straight at the commit, which is what a lightweight tag is. The assertion below requires an annotated
+      # tag, per ADR 0004, and would therefore reject every correctly pushed release tag there is.
+      #
+      # This restores what the tag actually is on the remote. `fetch-tags: true` does not do it: the tags are already
+      # fetched by then and the overwrite happens after. Do not remove this as redundant with `fetch-depth: 0`.
+      - name: Restore the annotated tag the checkout overwrote
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+
       - name: Assert the tag against the commit it names
         id: assert
         env:

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -2256,6 +2256,35 @@ every_checkout_refuses_to_persist_credentials() {
   fi
 }
 
+# `actions/checkout` resolves a tag ref and then force-fetches the commit into that same ref name, so
+# `refs/tags/<tag>` is left pointing straight at a commit — which is what a lightweight tag is.
+# `assert-release-tag.sh` requires an annotated tag, so without the restoring fetch every correctly
+# pushed release tag is rejected and nothing can publish at all. The contracts above run that script
+# directly and cannot see this: a local annotated tag stays annotated, so they pass either way, which
+# is why the guard has to be asserted here against the workflow instead.
+the_release_restores_the_annotated_tag_before_asserting_it() {
+  local workflow="$source_repository_root/.github/workflows/release.yml"
+  local restore_line
+  local assert_line
+
+  restore_line="$(grep -nF 'git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"' \
+    "$workflow" | head -n 1 | cut -d: -f1)"
+  assert_line="$(grep -nF 'bash scripts/assert-release-tag.sh' "$workflow" | head -n 1 | cut -d: -f1)"
+
+  if [[ -z "$restore_line" || -z "$assert_line" ]]; then
+    printf 'release.yml restores the tag at line %s and asserts it at line %s; both are required.\n' \
+      "${restore_line:-<missing>}" "${assert_line:-<missing>}" >&2
+    return 1
+  fi
+
+  # Order is the whole point. A restoration after the assertion repairs a ref nothing reads again.
+  if ((restore_line >= assert_line)); then
+    printf 'release.yml restores the tag at line %s, which is not before the assertion at line %s.\n' \
+      "$restore_line" "$assert_line" >&2
+    return 1
+  fi
+}
+
 # `pull_request_target` runs the base branch's workflow with the repository's secrets against a
 # contribution nobody has reviewed. `fathom-review.yml` uses it deliberately, #189 decided so, and
 # `docs/operations/agent-workflow.md` records why the purpose of the rule is still met there — it
@@ -2370,6 +2399,7 @@ run_test every_external_action_names_an_approved_owner
 run_test every_workflow_job_declares_its_permissions
 run_test every_write_scope_is_one_the_policy_records
 run_test every_checkout_refuses_to_persist_credentials
+run_test the_release_restores_the_annotated_tag_before_asserting_it
 run_test only_the_reviewer_workflow_uses_pull_request_target
 run_test workflow_scripts_use_flat_manual_layout
 


### PR DESCRIPTION
Closes #284.

The `v0.1.0` tag push failed at the first assertion and published nothing. The tag was annotated; the assertion still reported it lightweight, and it was right about the checkout it was given.

## What happens

`actions/checkout` resolves the ref and then force-fetches the **commit** into the same ref name. From the failed run's own log:

```
git fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
git tag --list v0.1.0
git rev-parse refs/tags/v0.1.0
git fetch --no-tags --prune --no-recurse-submodules origin +a5c77b8…:refs/tags/v0.1.0
```

The first fetch brings the annotated tag object down correctly. The last one leaves `refs/tags/v0.1.0` pointing straight at the commit — which is precisely what a lightweight tag is — so `git cat-file -t` answers `commit` and `scripts/assert-release-tag.sh` refuses it.

**This was never specific to one tag.** No annotated tag survives that checkout, so the pipeline as it stood could not have published any release.

## The fix

One step between the checkout and the assertion, restoring what the tag actually is on the remote:

```yaml
- name: Restore the annotated tag the checkout overwrote
  env:
    RELEASE_TAG: ${{ github.ref_name }}
  run: git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
```

It carries a comment saying why it is there, because it reads like something redundant with `fetch-depth: 0` and is not. The repository is public, so the anonymous fetch works under `persist-credentials: false`.

- **`fetch-tags: true` would not have worked.** The tags are already fetched by that point; the overwrite happens after.
- **`scripts/assert-release-tag.sh` is untouched.** It reported the truth, and a release tag stays required to be annotated — ADR 0004 makes the tagger, date, and message part of what a release tag is.

## Why the contract suite missed it, and what now catches it

`scripts/test-agent-workflow.sh` runs the gate script directly against fixtures, and says so where it does. A local annotated tag stays annotated, so all of those contracts passed and always would: the defect lived in the workflow's checkout, not in the script.

`the_release_restores_the_annotated_tag_before_asserting_it` asserts it at the YAML level instead, in the shape the neighbouring workflow-wide contracts use. It checks both that the step exists and that it comes **before** the assertion — a restoration afterwards would repair a ref nothing reads again. Restore is line 52, the assertion line 61.

## Verification

- `scripts/test-agent-workflow.sh` — 84 passed, 0 failed, including the new contract.
- `scripts/review-obligations.sh` — three pages carry a `describes:` marker over `release.yml`; each was read and none states a contract count or a procedure step this changes, so none owes an edit.
- The full gate was deliberately skipped: the diff is a workflow YAML and a bash test script, and nothing under `src/` or `tests/` moved.

## After this merges

`v0.1.0` has been deleted locally and on `origin`. It published nothing — every job after the assertion was skipped, and no image, chart, or GitHub release exists — so the number is unused and is the one to tag again, on the commit this pull request produces rather than burning a version on a CI defect.
