### PR TITLE
[#293] Stop spending a Claude review on a Dependabot version bump

### DIFF
--- a/.github/workflows/fathom-review.yml
+++ b/.github/workflows/fathom-review.yml
@@ -120,6 +120,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PULL_REQUEST_DRAFT: ${{ github.event.pull_request.draft }}
+          PULL_REQUEST_AUTHOR: ${{ github.event.pull_request.user.login }}
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           ADDED_LABEL: ${{ github.event.label.name }}
           IS_PULL_REQUEST_COMMENT: ${{ github.event.issue.pull_request.url != '' }}
@@ -132,6 +133,12 @@ jobs:
           # publishes as `fathom-reviewer[bot]` — so anything that touches the App's identity means
           # re-reading this from the API rather than deriving it from the settings page.
           REVIEWER_LOGIN: 'fathom-reviewer[bot]'
+          # The updater whose pull requests the gate below declines to review, named the way it
+          # authors them rather than the way `.github/dependabot.yml` is spelled. It is the only
+          # account here that opens a pull request without a person having written the diff, which
+          # is the whole of why it is singled out; a second bot would earn its own line and its own
+          # argument rather than a widened match on `[bot]`.
+          UPDATER_LOGIN: 'dependabot[bot]'
         run: |
           set -euo pipefail
 
@@ -165,6 +172,18 @@ jobs:
                 else
                   reason="the applied label is '${ADDED_LABEL}'"
                 fi
+              elif [[ "$PULL_REQUEST_AUTHOR" == "$UPDATER_LOGIN" ]]; then
+                # A version bump is not a change this reviewer can advise on. What decides one is
+                # whether the upstream release renamed an input or dropped a runner, and whether
+                # `THIRD_PARTY_LICENSES.md` still names the version the workflow pins — both read
+                # from upstream release notes and from the register, neither of them present in the
+                # diff. The diff itself is a version number in a `uses:` line, and it is reviewed
+                # again on every rebase the updater performs.
+                #
+                # This is the one skip that is about the author rather than about the change's
+                # state, so it is placed with the other checks the label escapes rather than
+                # anywhere earlier: a major bump worth a second opinion is still one label away.
+                reason="the pull request is authored by ${UPDATER_LOGIN}; label it fathom-review or comment fathom-review to review a bump anyway"
               elif [[ "$PULL_REQUEST_DRAFT" == 'true' ]]; then
                 # This is the one check that contains what `synchronize` costs: a draft is pushed
                 # to while it is being written, and none of those pushes is reviewed.

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -251,7 +251,14 @@ A draft is skipped, because a draft is still being written and reviewing it
 spends subscription usage on a moving target. That is also what contains the cost
 of reviewing pushes: a branch still being written is pushed to freely and spends
 nothing, and marking it ready is the deliberate act that opts every later push in.
-Two things ask for a review anyway:
+
+A pull request authored by `dependabot[bot]` is skipped as well, and that one is
+about who opened it rather than about what state it is in: the updater's batch
+arrives published and non-draft, so the check above would let it straight
+through. [Dependency update pull requests](#dependency-update-pull-requests)
+carries the reasoning, next to the questions a bump is actually read against.
+
+Two things ask for a review anyway, whichever skip refused it:
 
 - a comment on the pull request that *begins a line* with `fathom-review` or
   `@fathom-review`, from an author with write access. A draft is reviewed this
@@ -279,7 +286,10 @@ Two things ask for a review anyway:
   instruction. The marker must be followed by whitespace, so the hyphenated
   `-fathom-review` does not count, and neither does `fathom-reviewer`;
 - the `fathom-review` label, which is how a fork's pull request is reviewed at
-  all. A fork's own pushes never start a review, so a maintainer decides.
+  all. A fork's own pushes never start a review, so a maintainer decides. It is
+  also how a dependency bump gets the pass anyway, which is worth doing for a
+  major that touches a workflow's inputs and is not worth doing for the weekly
+  batch.
 
 An automatic review is bounded per pull request: once ten reviews by
 `fathom-reviewer[bot]` stand on it, the gate refuses and says so in the run log
@@ -866,6 +876,16 @@ included.
 `finish-change` writes a board field, and neither has anything to do here: the
 change is already written, it closes no issue, and it belongs to no roadmap
 item. What it needs is a reading, and the reading is the maintainer's.
+
+**`Fathom review` does not run on one either**, and the four questions below are
+why. Three of them are answered somewhere the diff does not reach — the upstream
+release notes, the action's ownership, the register — and the fourth is answered
+by the checks. A reviewer given the diff sees a version number in a `uses:` line
+and can confirm none of them, so a run would spend subscription usage restating
+what the tag already says, again on every rebase the updater performs. The gate
+refuses by author, before the draft and fork checks that would otherwise let a
+published bump straight through; the `fathom-review` label still reaches one,
+which is what a major touching a workflow's inputs is worth.
 
 Four questions answer a Dependabot pull request, and the first is the one an
 automated bump makes easy to skip.

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -651,12 +651,16 @@ one grouped pull request each Monday, a major on its own, at most three open at 
 newer than a week old; the file states why each of those numbers is what it is and why the `nuget`
 ecosystem stays off, with the upstream issue that decides it.
 
-Two things about those pull requests belong here rather than there. They edit `.github/workflows/**`
+Three things about those pull requests belong here rather than there. They edit `.github/workflows/**`
 by definition, so `Protected paths` recognises `dependabot[bot]` for that directory and refuses it
 everywhere else — that workflow carries the argument for why the exception removes a signal rather
-than an approval. And they are not exempt from anything else: the `main` ruleset asks the same
-code-owner review of them as of any other pull request, `Required CI` still has to pass, nothing
-auto-merges, and the updater holds no write-capable token.
+than an approval. `Fathom review` declines them, by author, because what decides a bump is the
+upstream release notes and the register rather than the diff; the `fathom-review` label still
+reaches one, and
+[Dependency update pull requests](agent-workflow.md#dependency-update-pull-requests) carries the
+argument. And they are exempt from nothing else: the `main` ruleset asks the same code-owner review
+of them as of any other pull request, `Required CI` still has to pass, nothing auto-merges, and the
+updater holds no write-capable token.
 
 ## Repository security features
 

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -1170,6 +1170,10 @@ run_fathom_review_gate() {
   local event_action="$1"
   local output_file="$2"
   local step_output_file="$3"
+  # The author and the applied label default to the ordinary case — the owner's own pull request,
+  # and an event carrying no label — so a contract below names only the input it is about.
+  local pull_request_author="${4:-Krzysztof318}"
+  local added_label="${5:-}"
   local step_script="$test_directory/fathom-review-gate.sh"
 
   extract_fathom_review_step 'gate' "$step_script"
@@ -1182,13 +1186,15 @@ run_fathom_review_gate() {
     export REPOSITORY='Krzysztof318/MailFathom'
     export PULL_REQUEST_NUMBER='1'
     export PULL_REQUEST_DRAFT='false'
+    export PULL_REQUEST_AUTHOR="$pull_request_author"
     export HEAD_REPOSITORY='Krzysztof318/MailFathom'
-    export ADDED_LABEL=''
+    export ADDED_LABEL="$added_label"
     export IS_PULL_REQUEST_COMMENT='false'
     export COMMENT_BODY=''
     export COMMENT_ASSOCIATION=''
     export GH_TOKEN='fake-token'
     export REVIEWER_LOGIN='fathom-reviewer[bot]'
+    export UPDATER_LOGIN='dependabot[bot]'
     export GITHUB_OUTPUT="$step_output_file"
     bash "$step_script"
   ) > "$output_file" 2>&1
@@ -1215,6 +1221,32 @@ fathom_review_refuses_a_closed_pull_request() {
 
   assert_contains 'review=false' "$step_output_file"
   assert_contains 'the pull request is closed' "$output_file"
+}
+
+# The updater opens its batch as ordinary published pull requests, so every check that contains this
+# workflow's cost — the draft one especially — lets them straight through. What the reviewer would
+# read is a version number, and what decides a bump is the upstream release notes and the license
+# register instead.
+fathom_review_refuses_a_pull_request_the_updater_opened() {
+  local output_file="$test_directory/fathom-review-updater-output"
+  local step_output_file="$test_directory/fathom-review-updater-step-output"
+
+  run_fathom_review_gate 'opened' "$output_file" "$step_output_file" 'dependabot[bot]'
+
+  assert_contains 'review=false' "$step_output_file"
+  assert_contains 'authored by dependabot[bot]' "$output_file"
+}
+
+# The refusal above is a default and not a wall. A major bump that renames an input is worth the
+# pass, and the maintainer reaches it the same way a draft and a fork are reached.
+fathom_review_reviews_an_updater_pull_request_the_maintainer_labelled() {
+  local output_file="$test_directory/fathom-review-updater-labelled-output"
+  local step_output_file="$test_directory/fathom-review-updater-labelled-step-output"
+
+  run_fathom_review_gate 'labeled' "$output_file" "$step_output_file" 'dependabot[bot]' 'fathom-review'
+
+  assert_contains 'review=true' "$step_output_file"
+  assert_contains 'a maintainer applied the fathom-review label' "$output_file"
 }
 
 # The settle step waits for the pull request's conversation to stop moving before the snapshot is
@@ -2455,6 +2487,8 @@ run_test typo_check_falls_back_to_the_whole_checkout_for_a_path_containing_a_glo
 run_test typo_check_falls_back_to_the_whole_checkout_for_a_pull_request_beyond_the_reportable_limit
 run_test fathom_review_reviews_a_push_to_a_published_pull_request
 run_test fathom_review_refuses_a_closed_pull_request
+run_test fathom_review_refuses_a_pull_request_the_updater_opened
+run_test fathom_review_reviews_an_updater_pull_request_the_maintainer_labelled
 run_test fathom_review_collects_at_once_when_nobody_has_commented
 run_test fathom_review_waits_before_freezing_a_quiet_conversation
 run_test fathom_review_stops_waiting_at_the_ceiling


### PR DESCRIPTION
Closes #293

The weekly Dependabot batch arrives published and non-draft, so every check that contains what `Fathom review` costs — the draft one above all — let it straight through. What the reviewer is given is a version number in a `uses:` line. What actually decides a bump is read where the diff does not reach: the upstream release notes, for an input renamed or a runner dropped, and `THIRD_PARTY_LICENSES.md`, for whether the register still names the version the workflow pins. The updater rebases, so the same three lines were reviewed again on every push.

## What changed

- The `decide` gate reads the pull request's author and refuses when it is `dependabot[bot]`, naming that as the reason in the run log.
- The refusal sits **after** the `labeled` branch, so the `fathom-review` label still starts a review — a major that touches a workflow's inputs is worth one — and **before** the draft and fork checks, which a published bump would sail past. The `issue_comment` path is untouched, so a maintainer's comment still works.
- `docs/operations/agent-workflow.md` carries the argument in **Dependency update pull requests**, beside the four questions a bump is actually read against; the trigger section above it holds a pointer rather than a second copy.
- `docs/operations/local-development.md` said those pull requests "are not exempt from anything else", which stopped being true.

## Verification

- `scripts/verify-full.sh` — green, exit 0.
- `scripts/test-agent-workflow.sh` — 90 passed, 0 failed, including two new contracts: the author is refused on `opened`, and the label still reviews a pull request that author opened.
- Unit suite — 2105 passed, 0 failed.

`pull_request_target` reads this file from `main`, so the behaviour is first observable on the Dependabot batch after this merges rather than on this pull request.
