### PR TITLE
[#307] Carry the reviewer's verdict as structured output

### DIFF
--- a/.github/fathom-review/findings-schema.json
+++ b/.github/fathom-review/findings-schema.json
@@ -1,0 +1,63 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["summary", "findings"],
+  "properties": {
+    "summary": {
+      "type": "string",
+      "description": "What the change does, how much of it was covered, and anything left out. Never a tally by severity and never a restatement of a finding."
+    },
+    "findings": {
+      "type": "array",
+      "description": "Every defect above the bar, and nothing else. Empty when the change has none.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "severity",
+          "path",
+          "start_line",
+          "line",
+          "title",
+          "impact",
+          "correction",
+          "rule"
+        ],
+        "properties": {
+          "severity": {
+            "enum": ["P1", "P2", "P3"],
+            "description": "P1 breaks something, P2 is owed by a rule, P3 is paid for later."
+          },
+          "path": {
+            "anyOf": [{ "type": "string" }, { "type": "null" }],
+            "description": "A key of lines.json, or null for the one finding that has no line."
+          },
+          "start_line": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "description": "The first line of a range, or null when the finding sits on one line."
+          },
+          "line": {
+            "anyOf": [{ "type": "integer" }, { "type": "null" }],
+            "description": "One of the numbers lines.json lists for path, or null when path is null."
+          },
+          "title": {
+            "type": "string",
+            "description": "Imperative, naming the correction in a handful of words."
+          },
+          "impact": {
+            "type": "string",
+            "description": "The input or state that reaches this code, and the wrong result that follows."
+          },
+          "correction": {
+            "type": "string",
+            "description": "The smallest change that fixes it, and nothing else."
+          },
+          "rule": {
+            "type": "string",
+            "description": "The file and its section, or the specification or ADR, that the finding rests on."
+          }
+        }
+      }
+    }
+  }
+}

--- a/.github/fathom-review/reviewer-prompt.md
+++ b/.github/fathom-review/reviewer-prompt.md
@@ -446,12 +446,12 @@ writing because you have only a few.
   exists because the code is wrong, never because a category went unmentioned.
 - Anything that would quote a credential, a token, message content, or raw MIME.
 
-## What to write
+## What to answer
 
-Write your findings to `{{FINDINGS_FILE}}` with the `Write` tool,
-and write nothing else anywhere. The step after you validates this file and submits the
-review; a finding that is not in this file is not delivered, and prose in your final
-message reaches nobody.
+Your findings are your answer. Return this object and nothing else — it is validated
+against a schema, and the step after you renders it into the review. There is no file to
+write and no tool that could write one: a finding that is not in the object is not
+delivered, and prose alongside it reaches nobody.
 
 ```json
 {
@@ -498,8 +498,8 @@ you can say — what you covered, and what you could not. Anything `truncation.t
 the `notes` of `obligations.json` records was not collected belongs there, because a
 section that was cut short still looks complete to everybody but you.
 
-When nothing survives the second pass, write the file with an empty `findings` array and
-a summary that says plainly what you covered and that you found nothing above the bar.
+When nothing survives the second pass, answer with an empty `findings` array and a
+summary that says plainly what you covered and that you found nothing above the bar.
 That is a finished review rather than a failed one, and the step after you turns it into
 an approval whose body is the verdict `APPROVED` followed by your summary. Two or three
 lines under that heading: what you covered, and the state you found it in. Do not write

--- a/.github/workflows/fathom-review.yml
+++ b/.github/workflows/fathom-review.yml
@@ -12,10 +12,10 @@ name: Fathom review
 # The branch under review is never checked out and nothing from it is executed. The workspace holds
 # the base commit, which is code that already merged; the change itself arrives as data through the
 # GitHub API and is written to files the reviewer only reads. Claude runs with no shell, no editor,
-# and no network tool, and it posts nothing: it writes findings to a file, and the deterministic step
-# after it validates every anchor against the frozen diff and submits one review. That split is what
-# keeps a prompt injection in the diff, in a comment, or in the linked issue from reaching an
-# authenticated API call.
+# no writer, and no network tool, and it posts nothing: its findings are the run's own answer, held
+# to a schema, and the deterministic step after it validates every anchor against the frozen diff
+# and submits one review. That split is what keeps a prompt injection in the diff, in a comment, or
+# in the linked issue from reaching an authenticated API call.
 #
 # What that step posts, it posts as the `Fathom reviewer` GitHub App rather than as `github-actions`.
 # The App is the owner's, so the review carries an identity that says what produced it, and the
@@ -465,14 +465,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
           PULL_REQUEST_NUMBER: ${{ needs.decide.outputs.pull_request_number }}
-          # What the reviewer is given, and what it produces, are separate directories on purpose.
-          # The collected inputs are made read-only once they are complete, so the only writable
-          # path the reviewer has is its own output and it cannot rewrite the anchor list that
-          # validates it. Both paths are declared per step rather than once for the job, because
-          # `runner` is not one of the contexts a job-level `env` block may read and a workflow that
-          # names it there fails validation before a job exists.
+          # The collected inputs are made read-only once they are complete, and the reviewer holds
+          # no tool that writes: its findings are the run's own answer rather than a file it
+          # produces, so it cannot rewrite the anchor list that validates them. The path is
+          # declared per step rather than once for the job, because `runner` is not one of the
+          # contexts a job-level `env` block may read and a workflow that names it there fails
+          # validation before a job exists.
           REVIEW_DIRECTORY: ${{ runner.temp }}/review
-          FINDINGS_FILE: ${{ runner.temp }}/findings/findings.json
         run: |
           set -euo pipefail
 
@@ -489,7 +488,7 @@ jobs:
           thread_comment_limit=20
           closing_reference_limit=5
 
-          mkdir -p "$REVIEW_DIRECTORY/head" "$(dirname "$FINDINGS_FILE")"
+          mkdir -p "$REVIEW_DIRECTORY/head"
 
           # Every ceiling in this step appends what it dropped here, so it is created empty before
           # the first one can run rather than written once at the end by whichever ceiling happens
@@ -732,10 +731,15 @@ jobs:
       # expressions in this file, where they are a handful of short lines, and leaves the
       # instructions as prose that no length limit reaches.
       #
-      # The template is read from the workspace, which holds the base commit, so a pull request
-      # cannot supply the prompt that reviews it — the same reason the workflow itself runs from
-      # the base rather than from the branch.
-      - name: Compose the reviewer prompt
+      # The answer's schema lives beside them, in `findings-schema.json`, and is emitted here as a
+      # single line because `--json-schema` takes the schema itself rather than a path to one.
+      # Keeping it a committed file is what makes it readable and reviewable; compacting it here is
+      # what makes it passable.
+      #
+      # Both are read from the workspace, which holds the base commit, so a pull request can supply
+      # neither the prompt that reviews it nor the shape of the verdict — the same reason the
+      # workflow itself runs from the base rather than from the branch.
+      - name: Compose the reviewer prompt and the answer schema
         id: prompt
         shell: bash
         env:
@@ -744,8 +748,8 @@ jobs:
           HEAD_SHA: ${{ steps.collect.outputs.head_sha }}
           SNAPSHOT_TAKEN: ${{ steps.collect.outputs.snapshot_taken }}
           REVIEW_DIRECTORY: ${{ runner.temp }}/review
-          FINDINGS_FILE: ${{ runner.temp }}/findings/findings.json
           TEMPLATE_FILE: ${{ github.workspace }}/.github/fathom-review/reviewer-prompt.md
+          SCHEMA_FILE: ${{ github.workspace }}/.github/fathom-review/findings-schema.json
           PROMPT_FILE: ${{ runner.temp }}/reviewer-prompt.md
         run: |
           set -euo pipefail
@@ -756,7 +760,6 @@ jobs:
             -e "s|{{HEAD_SHA}}|${HEAD_SHA}|g" \
             -e "s|{{SNAPSHOT_TAKEN}}|${SNAPSHOT_TAKEN}|g" \
             -e "s|{{REVIEW_DIRECTORY}}|${REVIEW_DIRECTORY}|g" \
-            -e "s|{{FINDINGS_FILE}}|${FINDINGS_FILE}|g" \
             "$TEMPLATE_FILE" > "$PROMPT_FILE"
 
           # A placeholder that survived substitution reaches the model as literal text, which is a
@@ -766,10 +769,23 @@ jobs:
             exit 1
           fi
 
+          # The schema is quoted with `'` in `claude_args` below, because the action parses that
+          # input with shell-quoting rules and the schema is full of `"`. A `'` inside the schema
+          # would therefore end the quoting and hand the CLI a fragment, so it is refused here
+          # rather than at the far end as an unparseable flag. Nothing else about the schema is
+          # checked by hand: `jq` reads it, so a schema that is not JSON fails on the line above.
+          schema="$(jq -c . "$SCHEMA_FILE")"
+
+          if [[ "$schema" == *"'"* ]]; then
+            echo 'The findings schema contains an apostrophe, which the reviewer flag cannot quote.' >&2
+            exit 1
+          fi
+
           {
             echo 'prompt<<FATHOM_REVIEW_PROMPT'
             cat "$PROMPT_FILE"
             echo 'FATHOM_REVIEW_PROMPT'
+            echo "schema=${schema}"
           } >> "$GITHUB_OUTPUT"
       - name: Review the change
         id: review
@@ -786,9 +802,11 @@ jobs:
           # The buffered inline comments this step would post are the mechanism this workflow
           # replaces with a validated submission of its own.
           classify_inline_comments: 'false'
-          # The reviewer reads and writes one file. It has no shell, no editor, no network tool, and
-          # no MCP tool, so no path exists from the untrusted text it reads to an authenticated call
-          # or to the runner. The deny rules cover the places a credential still sits despite that:
+          # The reviewer only reads. It has no shell, no editor, no writer, no network tool, and no
+          # MCP tool, so no path exists from the untrusted text it reads to an authenticated call,
+          # to the runner, or to the collected inputs the submission step trusts. `Write` is denied
+          # here as well as absent from `--allowedTools` below, so the property survives a later
+          # change to either one. The remaining deny rules cover the places a credential still sits:
           # the workspace git configuration, where the action writes the workflow token for its own
           # use; `/proc`, where a process can read its own environment as a file; and `.claude`,
           # where the CLI keeps its own configuration. This input is written to the user settings
@@ -799,6 +817,7 @@ jobs:
                 "deny": [
                   "Bash",
                   "Edit",
+                  "Write",
                   "WebFetch",
                   "WebSearch",
                   "mcp__*",
@@ -829,22 +848,34 @@ jobs:
           # the extra depth `xhigh` buys has not been measured against that cost here. Raise it if a
           # missed finding ever justifies the measurement.
           #
-          # `--model` and `--effort` are not inputs the action declares. It forwards a flag it does
-          # not recognize to the CLI unchanged, which is the documented way to reach a CLI option
-          # from here.
+          # `--json-schema` is what makes the verdict the run's own answer rather than a side effect
+          # of the session. Under it the model's final message is validated against the schema and
+          # published as this step's `structured_output`, and a run that ends without one fails here
+          # naming that as the cause. The alternative this replaces was an instruction to call
+          # `Write`, which nothing enforced: on #306 the reviewer twice read the whole change, spent
+          # four minutes and 34 turns on it, ended cleanly, and never made the call — a verdict that
+          # existed and reached nobody. The schema takes JSON rather than a path, which is why the
+          # step above compacts the committed file into one line.
+          #
+          # `--model`, `--effort`, and `--json-schema` are not inputs the action declares. It
+          # forwards a flag it does not recognize to the CLI unchanged, which is the documented way
+          # to reach a CLI option from here.
           claude_args: |
             --model ${{ needs.decide.outputs.model }}
             --effort high
-            --allowedTools "Read,Grep,Glob,Write"
+            --allowedTools "Read,Grep,Glob"
             --setting-sources user
+            --json-schema '${{ steps.prompt.outputs.schema }}'
 
       # The action hides everything the reviewer produced, which is right: that output is model
       # text derived from an untrusted diff. It hides the run's own error string with it, and that
       # string is the only place the cause of a failure is written — an expired credential, an
-      # exhausted subscription, a model the plan cannot use. Without it a failed run is a red job
-      # with nothing to act on, and the only alternative the action offers is `show_full_output`,
-      # which would print the whole review into the log to recover one sentence. The saved
-      # execution log holds that sentence, so this reads it and prints nothing else.
+      # exhausted subscription, a model the plan cannot use, or a reviewer that answered without
+      # conforming to the schema, where the last result message holds what it said instead. Without
+      # it a failed run is a red job with nothing to act on, and the only alternative the action
+      # offers is `show_full_output`, which would print the whole review into the log to recover one
+      # sentence. The saved execution log holds that sentence — the action writes it before it
+      # refuses a non-conforming answer — so this reads it and prints nothing else.
       - name: Report why the reviewer stopped
         if: failure() && steps.review.outcome == 'failure'
         shell: bash
@@ -895,12 +926,13 @@ jobs:
           printf '::error::The reviewer stopped: %s\n' "$reason"
 
       # `!cancelled()` rather than `always()`, which GitHub documents as running a step even when the
-      # run was cancelled. This step must still run after a reviewer that failed, because a run that
-      # died holding findings has something worth posting — but a cancelled run has the opposite
-      # property: it was cancelled because the head was superseded or the pull request closed, and
-      # `always()` would let it publish the very verdict the cancellation was meant to prevent. The
-      # `${{ }}` is required, because a YAML scalar may not begin with `!`.
+      # run was cancelled. This step must still run after a reviewer that failed, so that the reason
+      # is reported as a notice rather than as a second red step — but a cancelled run has the
+      # opposite property: it was cancelled because the head was superseded or the pull request
+      # closed, and `always()` would let it publish the very verdict the cancellation was meant to
+      # prevent. The `${{ }}` is required, because a YAML scalar may not begin with `!`.
       - name: Submit the review
+        id: submit
         if: ${{ !cancelled() && steps.collect.outcome == 'success' }}
         shell: bash
         env:
@@ -917,27 +949,42 @@ jobs:
           # credential the reviewer was never able to read still cannot be published if it somehow
           # reaches the findings.
           CLAUDE_CREDENTIAL: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Whether the reviewer got as far as an answer, which decides whether a missing findings
-          # file is this step's failure to report or the previous step's, already reported.
+          # Whether the reviewer got as far as an answer. Two branches consult it: an empty answer
+          # is a failure already reported when the step failed and this workflow's own defect when
+          # it did not, and an empty findings array means one thing from a run that finished and
+          # the opposite from one that died after answering.
           REVIEW_OUTCOME: ${{ steps.review.outcome }}
-          # The two paths the collection step wrote, restated here for the reason given there.
+          # The reviewer's answer, validated against the schema by the action and published as this
+          # output. It is model text derived from an untrusted diff, so it arrives through the
+          # environment rather than through an expression in the script below, and every check this
+          # step makes runs against it before anything is posted.
+          FINDINGS: ${{ steps.review.outputs.structured_output }}
+          # The path the collection step wrote, restated here for the reason given there.
           REVIEW_DIRECTORY: ${{ runner.temp }}/review
-          FINDINGS_FILE: ${{ runner.temp }}/findings/findings.json
         run: |
           set -euo pipefail
 
           payload_file="$(mktemp)"
+          findings_file="$(mktemp)"
 
-          if [[ ! -s "$FINDINGS_FILE" ]] || ! jq -e '.' "$FINDINGS_FILE" > /dev/null 2>&1; then
+          printf '%s' "$FINDINGS" > "$findings_file"
+
+          if [[ ! -s "$findings_file" ]] || ! jq -e '.' "$findings_file" > /dev/null 2>&1; then
             # A reviewer that never answered has already failed and said why, and repeating the
-            # consequence as a second error buries the cause. A reviewer that answered and still
-            # produced nothing valid is this workflow's own defect, and fails here.
+            # consequence as a second error buries the cause. That is the path this takes today for
+            # every empty answer, because the action fails its own step when no structured answer
+            # comes back.
             if [[ "$REVIEW_OUTCOME" != 'success' ]]; then
               echo '::notice::The reviewer did not finish, so there are no findings to submit.'
               exit 0
             fi
 
-            echo "::error::The reviewer finished but produced no valid ${FINDINGS_FILE}, so there is nothing to submit."
+            # A reviewer that finished and still produced nothing is unreachable while the action
+            # keeps that promise, and this is what makes the workflow stop depending on it. If a
+            # later version renames the output or stops failing on a missing one, every review would
+            # otherwise post nothing under a green job — a pipeline that has silently stopped
+            # reviewing, which is the failure this whole change exists to remove.
+            echo '::error::The reviewer finished but returned no valid findings, so there is nothing to submit.'
             exit 1
           fi
 
@@ -962,10 +1009,10 @@ jobs:
           # The App's own token is compared literally as well as by shape. Its `ghs_` prefix already
           # matches the pattern below, but this is the credential the step is about to authenticate
           # with, and a literal comparison does not depend on the pattern continuing to describe it.
-          if grep -qE 'gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{20,}|sk-ant-[A-Za-z0-9_-]{16,}' "$FINDINGS_FILE" \
-            || grep -qF "$WORKFLOW_TOKEN" "$FINDINGS_FILE" \
-            || grep -qF "$REVIEWER_TOKEN" "$FINDINGS_FILE" \
-            || grep -qF "$CLAUDE_CREDENTIAL" "$FINDINGS_FILE"; then
+          if grep -qE 'gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{20,}|sk-ant-[A-Za-z0-9_-]{16,}' "$findings_file" \
+            || grep -qF "$WORKFLOW_TOKEN" "$findings_file" \
+            || grep -qF "$REVIEWER_TOKEN" "$findings_file" \
+            || grep -qF "$CLAUDE_CREDENTIAL" "$findings_file"; then
             echo '::error::The findings contain something shaped like a credential and were not posted.'
             exit 1
           fi
@@ -984,19 +1031,19 @@ jobs:
           # code owner, and a GitHub App cannot be one. `REQUEST_CHANGES` is never used in either
           # branch — a reviewer that gates nothing must not be able to block a merge either.
           # An empty findings array means two different things depending on how the reviewer ended.
-          # From a run that finished, it means nothing was found. From one that died after its
-          # `Write` call — an exhausted subscription, a transport error, a model that stopped — it
-          # means the search never completed, and the file is a snapshot rather than a verdict.
-          # Findings from such a run are still worth posting, because a defect it did name is real;
-          # an approval is not, because it asserts the absence of what the run stopped looking for.
-          # So the affirmative branch is the one gated on the reviewer having succeeded.
-          if [[ "$(jq '(.findings // []) | length' "$FINDINGS_FILE")" == '0' ]] \
+          # From a run that finished, it means nothing was found. From one that answered and then
+          # failed anyway, it means the search never completed and the answer is a snapshot rather
+          # than a verdict. Findings from such a run are still worth posting, because a defect it
+          # did name is real; an approval is not, because it asserts the absence of what the run
+          # stopped looking for. So the affirmative branch is the one gated on the reviewer having
+          # succeeded.
+          if [[ "$(jq '(.findings // []) | length' "$findings_file")" == '0' ]] \
             && [[ "$REVIEW_OUTCOME" != 'success' ]]; then
             echo '::notice::The reviewer did not finish and found nothing before stopping, so no approval was posted.'
             exit 0
           fi
 
-          if [[ "$(jq '(.findings // []) | length' "$FINDINGS_FILE")" == '0' ]]; then
+          if [[ "$(jq '(.findings // []) | length' "$findings_file")" == '0' ]]; then
             jq --arg commit "$HEAD_SHA" \
                --arg truncation "$(cat "$REVIEW_DIRECTORY/truncation.txt")" '
               {
@@ -1008,7 +1055,7 @@ jobs:
                   + (if $truncation == "" then [] else ["", $truncation] end)
                   | join("\n")
                 )
-              }' "$FINDINGS_FILE" > "$payload_file"
+              }' "$findings_file" > "$payload_file"
 
             gh api "repos/${REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/reviews" \
               --method POST --input "$payload_file" --silent
@@ -1097,7 +1144,7 @@ jobs:
                   }
                   + (if .start_line == null then {} else {start_line, start_side: "RIGHT"} end)
                 ))
-              }' "$FINDINGS_FILE" > "$payload_file"
+              }' "$findings_file" > "$payload_file"
 
           gh api "repos/${REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}/reviews" \
             --method POST --input "$payload_file" --silent

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -373,12 +373,12 @@ files or comments; the line list derived from the files would inherit that shape
 and the submission step would then validate every anchor against the first page
 alone and push every other finding into the review body.
 
-Claude then runs with `Read`, `Grep`, `Glob`, and `Write` and nothing else: no
-shell, no editor, no network tool, no MCP tool, and no read access to `.git`,
+Claude then runs with `Read`, `Grep`, and `Glob` and nothing else: no shell, no
+editor, no writer, no network tool, no MCP tool, and no read access to `.git`,
 where the action leaves a token for its own use. It holds no credential it could
-use and posts nothing. It writes findings to one file, and the step after it
-validates them and submits a single review: `event: COMMENT` when the file holds
-findings, `event: APPROVE` when it holds none.
+use and posts nothing. Its findings are the run's own answer, and the step after
+it validates them and submits a single review: `event: COMMENT` when the answer
+holds findings, `event: APPROVE` when it holds none.
 
 The model is named exactly rather than by alias: `claude-sonnet-5` at
 `--effort high`. An alias re-points at whatever ships next, and findings are only
@@ -418,6 +418,38 @@ every trigger included, which stops the pipeline rather than degrading it. The
 expressions stay here, where they are six short lines; the prose sits where no
 length limit reaches it. The template is read from the workspace, which holds the
 base commit, so a pull request cannot supply the prompt that reviews it.
+
+### The verdict is the run's answer, not a file it might not write
+
+`--json-schema` in `claude_args` is what makes it one. Under that flag the
+reviewer's final message is validated against
+`.github/fathom-review/findings-schema.json` and published as the step's
+`structured_output`, so a run either answers in the shape the submission step
+reads or fails naming that as its cause.
+
+The contract it replaces was an instruction to write the findings to a file with
+the `Write` tool, and nothing enforced it. Both reviews of #306 on 2026-08-02
+ended without the call: the reviewer read the whole change, spent four minutes
+and 34 turns on it, and ended cleanly with no permission denial — and the verdict
+it reached went nowhere, leaving a red job whose message named a missing file
+rather than a cause anybody could act on. The same failure had been measured once
+in roughly twenty runs the day before and treated as a flake worth re-running,
+which two failures out of two on one pull request is not.
+
+The schema is a committed file rather than a literal in the workflow, because it
+is a contract somebody reads; the step that composes the prompt compacts it onto
+one line, because `--json-schema` takes the schema itself and not a path to one.
+That step also refuses a schema containing an apostrophe — the flag is
+single-quoted in `claude_args`, which the action parses with shell-quoting rules,
+so an apostrophe would end the quoting and hand the CLI a fragment. Both files
+are read from the workspace, so a pull request can supply neither the prompt that
+reviews it nor the shape of the verdict.
+
+Removing the write removed the reviewer's last reason to hold a tool that writes.
+`Write` is denied in the session settings as well as absent from `--allowedTools`,
+so the session stays read-only whichever of the two a later change touches, and
+the collected inputs the submission step trusts cannot be rewritten by the
+session that reads them.
 
 ### Waiting for the conversation before collecting it
 
@@ -494,17 +526,17 @@ reaches one at all; `pull_request` would give the run neither the secrets it nee
 to publish under the App nor a trigger a maintainer can aim. What makes that safe
 is structural rather than procedural: the workspace holds `base.sha` and never the
 branch, nothing from the contribution is executed, and the reviewer runs with
-`Read`, `Grep`, `Glob`, and `Write` and no shell, network tool, or MCP tool. The
+`Read`, `Grep`, and `Glob` and no shell, writer, network tool, or MCP tool. The
 purpose of the prohibition — untrusted code never runs with a credential — is met
 without avoiding the trigger.
 
 The exception is scoped to this workflow and to that shape. It is revoked by any
 change that checks out, builds, restores, or executes the branch under review,
-that grants the reviewer a shell or a network tool, that adds `workflow_dispatch`
-— a dispatch takes a ref, which would let the branch supply the job that receives
-the Claude credential — or that lets a trigger other than a maintainer's label or
-comment reach a fork. A second workflow wanting the trigger does not inherit this
-reasoning; it argues its own case or uses `pull_request`.
+that grants the reviewer a shell, a writer, or a network tool, that adds
+`workflow_dispatch` — a dispatch takes a ref, which would let the branch supply
+the job that receives the Claude credential — or that lets a trigger other than a
+maintainer's label or comment reach a fork. A second workflow wanting the trigger
+does not inherit this reasoning; it argues its own case or uses `pull_request`.
 
 ### What bounds the cost
 
@@ -701,17 +733,23 @@ edit to discharge it and the only kind of line a review comment can reach.
 `claude-code-action` hides everything the reviewer produced, and rightly so: that output
 is model text derived from an untrusted diff. It hides the run's own error string with
 it, which is the one place a failure says what happened — an expired credential, an
-exhausted subscription, a model the plan cannot use. The action does save every message
-to `$RUNNER_TEMP/claude-execution-output.json`, so a step after it reads the last result
-message's error text and prints that and nothing else, flattened to one line, truncated
+exhausted subscription, a model the plan cannot use, or a reviewer that answered without
+conforming to the schema, where the last result message holds what it said instead. The
+action does save every message to `$RUNNER_TEMP/claude-execution-output.json`, and it
+does so before it refuses a non-conforming answer, so a step after it reads the last
+result message's text and prints that and nothing else, flattened to one line, truncated
 to 500 characters, and withheld if it matches a credential shape or either credential the
 workflow holds. The alternative the action offers is `show_full_output`, which would
 print the entire review into the log to recover one sentence.
 
 The submission step then distinguishes two silences. A reviewer that never answered has
-already failed and said why, so a missing findings file is reported as a notice and the
-run keeps the reviewer's own error as its only cause. A reviewer that answered and still
-produced no valid file is this workflow's defect and fails there.
+already failed and said why, so an empty `structured_output` from a step that failed is
+reported as a notice and the run keeps the reviewer's own error as its only cause. An empty
+one from a step that *succeeded* is unreachable while the action keeps failing on a missing
+structured answer, and it fails there anyway: that branch is what stops the workflow
+depending on a promise it does not own, because a later action version that renamed the
+output or stopped failing on it would otherwise leave every review posting nothing under a
+green job — a pipeline that has silently stopped reviewing.
 
 Both steps refuse to compare against an unset `CLAUDE_CODE_OAUTH_TOKEN` and report the
 missing secret instead, because `grep -F ''` matches every file and an empty pattern
@@ -727,7 +765,7 @@ ranged comment, submits with an explicit `POST`, and refuses to post at all if
 the findings contain any credential this workflow holds or anything shaped like
 one.
 
-It also lays each finding out. The reviewer writes one as separate fields —
+It also lays each finding out. The reviewer answers with separate fields —
 `impact`, what breaks; `correction`, the smallest change that fixes it; `rule`,
 what the finding rests on — and this step renders them under fixed headings, so
 every thread answers the same three questions in the same order. An author
@@ -752,14 +790,13 @@ The alternatives are both worse — `event: COMMENT` with an empty comment list
 records that a review happened without saying what it concluded, and an ordinary
 issue comment says it somewhere nothing reads as a verdict at all.
 
-That branch is the one place the reviewer's own exit status is consulted a second
-time. An empty findings array means two different things: from a run that
-finished it means nothing was found, and from one that died after writing the
-file — an exhausted subscription, a transport error, a model that stopped — it
-means the search never completed. Findings from such a run are still posted,
-because a defect it did name is real. An approval is not, because it asserts the
-absence of what the run stopped looking for, so an unfinished run that found
-nothing reports a notice and publishes no verdict.
+That branch consults the reviewer's own exit status a second time. An empty
+findings array means two different things: from a run that finished it means
+nothing was found, and from one that answered and then failed anyway it means the
+search never completed. Findings from such a run are still posted, because a
+defect it did name is real. An approval is not, because it asserts the absence of
+what the run stopped looking for, so an unfinished run that found nothing reports
+a notice and publishes no verdict.
 
 `commit_id` ties the approval to the head the reviewer actually saw, and the
 `main` ruleset sets `dismiss_stale_reviews_on_push`, so the next push dismisses

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -30,6 +30,7 @@ protected_paths_bin_directory="$test_directory/protected-paths-bin"
 typo_check_bin_directory="$test_directory/typo-check-bin"
 fathom_review_bin_directory="$test_directory/fathom-review-bin"
 settle_bin_directory="$test_directory/fathom-review-settle-bin"
+submit_bin_directory="$test_directory/fathom-review-submit-bin"
 invocation_log="$test_directory/dotnet-invocations.log"
 workflow_invocation_log="$test_directory/workflow-invocations.log"
 fixture_branch='agent/workflow-fixture'
@@ -1357,6 +1358,167 @@ fathom_review_reads_the_newest_comment_whatever_the_order() {
   assert_seconds_elapsed_at_least 4 "$started_at"
 }
 
+# The submission step is where the reviewer's answer becomes a review, and it is the one step whose
+# input is model text. What it decides — which findings can be anchored, which verdict the body
+# carries, whether anything is posted at all — is decided from that text alone, so these contracts
+# hand it an answer and read the payload it would have posted. The fake `gh` below stands in for the
+# one call it makes: it copies the `--input` file rather than sending it, which is what lets a
+# contract assert on a payload that never leaves the machine.
+mkdir -p "$submit_bin_directory"
+cat > "$submit_bin_directory/gh" <<'FAKE_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${FAKE_REVIEW_PAYLOAD:?FAKE_REVIEW_PAYLOAD must identify where the payload is recorded}"
+
+while (($# > 0)); do
+  if [[ "$1" == '--input' ]]; then
+    cp "$2" "$FAKE_REVIEW_PAYLOAD"
+    exit 0
+  fi
+  shift
+done
+
+echo 'The submission step called gh without an --input payload.' >&2
+exit 1
+FAKE_GH
+chmod +x "$submit_bin_directory/gh"
+
+# The collected inputs the step reads: the anchors every finding is validated against, and whatever
+# a ceiling dropped. Both are written by the collection step in the real job, which these contracts
+# do not run — what they exercise is everything the submission step does with them.
+write_fathom_review_collection() {
+  local review_directory="$1"
+
+  mkdir -p "$review_directory"
+  printf '[{"filename":"src/Sample.cs","lines":[12,13,14]}]\n' > "$review_directory/lines.json"
+  : > "$review_directory/truncation.txt"
+}
+
+run_fathom_review_submit() {
+  local findings="$1"
+  local output_file="$2"
+  local payload_file="$3"
+  # A reviewer that finished is the ordinary case; the contract about a run that did not names it.
+  local review_outcome="${4:-success}"
+  local step_script="$test_directory/fathom-review-submit.sh"
+  local review_directory="$test_directory/fathom-review-submit-review"
+
+  extract_fathom_review_step 'submit' "$step_script"
+  write_fathom_review_collection "$review_directory"
+  rm -f "$payload_file"
+
+  set +e
+  (
+    export PATH="$submit_bin_directory:$PATH"
+    export GH_TOKEN='ghs_reviewerapptokenthatisnotreal'
+    export REPOSITORY='Krzysztof318/MailFathom'
+    export PULL_REQUEST_NUMBER='1'
+    export HEAD_SHA='0123456789abcdef0123456789abcdef01234567'
+    export WORKFLOW_TOKEN='ghs_workflowtokenthatisnotreal'
+    export REVIEWER_TOKEN='ghs_reviewerapptokenthatisnotreal'
+    export CLAUDE_CREDENTIAL='sk-ant-oat01-credentialthatisnotreal'
+    export REVIEW_OUTCOME="$review_outcome"
+    export FINDINGS="$findings"
+    export REVIEW_DIRECTORY="$review_directory"
+    export FAKE_REVIEW_PAYLOAD="$payload_file"
+    bash "$step_script"
+  ) > "$output_file" 2>&1
+  submit_status=$?
+  set -e
+}
+
+fathom_review_anchors_a_finding_to_its_line() {
+  local output_file="$test_directory/fathom-review-submit-anchored-output"
+  local payload_file="$test_directory/fathom-review-submit-anchored-payload"
+
+  run_fathom_review_submit \
+    '{"summary":"Read the whole change.","findings":[{"severity":"P1","path":"src/Sample.cs","start_line":null,"line":12,"title":"Refuse the empty case","impact":"An empty list reaches the loop and the guard passes.","correction":"Return early when the list is empty.","rule":"`AGENTS.md`, \"Reliability, security, and performance\""}]}' \
+    "$output_file" "$payload_file"
+
+  ((submit_status == 0))
+  assert_json '"COMMENT"' '.event' "$payload_file"
+  assert_json '["src/Sample.cs"]' '[.comments[].path]' "$payload_file"
+  assert_json '[12]' '[.comments[].line]' "$payload_file"
+  assert_json '["RIGHT"]' '[.comments[].side]' "$payload_file"
+  assert_contains '# NEEDS CHANGES' "$payload_file"
+  assert_contains '**Findings** — P1: 1' "$payload_file"
+}
+
+fathom_review_moves_a_finding_with_no_line_into_the_body() {
+  local output_file="$test_directory/fathom-review-submit-unanchored-output"
+  local payload_file="$test_directory/fathom-review-submit-unanchored-payload"
+
+  # A line the diff does not carry and a finding that never had one: both reach the author through
+  # the body rather than being dropped, which is the property the anchor validation exists for.
+  run_fathom_review_submit \
+    '{"summary":"Read the whole change.","findings":[{"severity":"P2","path":"src/Sample.cs","start_line":null,"line":99,"title":"Name the moved line","impact":"The anchor is not on the diff.","correction":"Anchor it where the change is.","rule":"`AGENTS.md`"},{"severity":"P3","path":null,"start_line":null,"line":null,"title":"Say what the body claims","impact":"The body promises a rename the diff does not make.","correction":"Correct the body.","rule":"`docs/operations/issue-tracking.md`"}]}' \
+    "$output_file" "$payload_file"
+
+  ((submit_status == 0))
+  assert_json '[]' '.comments' "$payload_file"
+  assert_contains '### Findings with no line to sit on' "$payload_file"
+  assert_contains '**P2 — Name the moved line** — `src/Sample.cs`' "$payload_file"
+  assert_contains '**P3 — Say what the body claims**' "$payload_file"
+  assert_contains '**Findings** — P2: 1, P3: 1' "$payload_file"
+}
+
+fathom_review_approves_when_it_finds_nothing() {
+  local output_file="$test_directory/fathom-review-submit-approved-output"
+  local payload_file="$test_directory/fathom-review-submit-approved-payload"
+
+  run_fathom_review_submit \
+    '{"summary":"Read every changed file and found nothing above the bar.","findings":[]}' \
+    "$output_file" "$payload_file"
+
+  ((submit_status == 0))
+  assert_json '"APPROVE"' '.event' "$payload_file"
+  assert_contains '# APPROVED' "$payload_file"
+  assert_contains 'nothing above the bar' "$payload_file"
+}
+
+fathom_review_publishes_nothing_when_the_reviewer_returned_no_answer() {
+  local output_file="$test_directory/fathom-review-submit-silent-output"
+  local payload_file="$test_directory/fathom-review-submit-silent-payload"
+
+  # The action fails its own step when the reviewer returns no structured answer, so this is what
+  # the submission step sees afterwards: an empty output and a step that did not succeed. The cause
+  # was reported there, so this reports a notice and posts nothing rather than failing again.
+  run_fathom_review_submit '' "$output_file" "$payload_file" 'failure'
+
+  ((submit_status == 0))
+  [[ ! -e "$payload_file" ]]
+  assert_contains 'no findings to submit' "$output_file"
+}
+
+fathom_review_fails_when_a_finished_reviewer_returned_no_answer() {
+  local output_file="$test_directory/fathom-review-submit-empty-output"
+  local payload_file="$test_directory/fathom-review-submit-empty-payload"
+
+  # Unreachable while the action fails its own step on a missing structured answer, which is the
+  # point: this is what stops the workflow depending on that promise. A later version that renamed
+  # the output or stopped failing would otherwise leave every review posting nothing under a green
+  # job, so the contract fixes the loud half here rather than trusting the action to stay as it is.
+  run_fathom_review_submit '' "$output_file" "$payload_file" 'success'
+
+  ((submit_status == 1))
+  [[ ! -e "$payload_file" ]]
+  assert_contains 'returned no valid findings' "$output_file"
+}
+
+fathom_review_refuses_findings_that_carry_a_credential() {
+  local output_file="$test_directory/fathom-review-submit-credential-output"
+  local payload_file="$test_directory/fathom-review-submit-credential-payload"
+
+  run_fathom_review_submit \
+    '{"summary":"Read the whole change.","findings":[{"severity":"P1","path":"src/Sample.cs","start_line":null,"line":12,"title":"Quote the token","impact":"The token sk-ant-oat01-credentialthatisnotreal is echoed here.","correction":"Do not.","rule":"`AGENTS.md`"}]}' \
+    "$output_file" "$payload_file"
+
+  ((submit_status == 1))
+  [[ ! -e "$payload_file" ]]
+  assert_contains 'shaped like a credential' "$output_file"
+}
+
 # The `describes:` marker is what tells a reviewer which pages a change to the code obliges, and it is
 # the half of that mapping nothing derives: a page is written about configuration keys and behavior
 # rather than about type names, so no name match finds the edge. The two contracts below are what
@@ -2493,6 +2655,12 @@ run_test fathom_review_collects_at_once_when_nobody_has_commented
 run_test fathom_review_waits_before_freezing_a_quiet_conversation
 run_test fathom_review_stops_waiting_at_the_ceiling
 run_test fathom_review_reads_the_newest_comment_whatever_the_order
+run_test fathom_review_anchors_a_finding_to_its_line
+run_test fathom_review_moves_a_finding_with_no_line_into_the_body
+run_test fathom_review_approves_when_it_finds_nothing
+run_test fathom_review_publishes_nothing_when_the_reviewer_returned_no_answer
+run_test fathom_review_fails_when_a_finished_reviewer_returned_no_answer
+run_test fathom_review_refuses_findings_that_carry_a_credential
 run_test every_documentation_page_declares_what_it_describes
 run_test every_describes_pattern_matches_something_that_exists
 run_test closing_references_collect_every_issue_the_body_closes


### PR DESCRIPTION
Closes #307

## What this changes

`Fathom review` asked the reviewer to write its findings to a file with the `Write` tool, and nothing enforced the call. Both reviews of #306 on 2026-08-02 ended without it — runs `30769580323` and `30771647244`, each reporting `"subtype": "success"`, `is_error: false`, `permission_denials_count: 0`, `num_turns: 34` — so the reviewer read the whole change, worked for four minutes, ended cleanly, and the verdict it reached went nowhere. What the pull request saw was a red job whose message named a missing file rather than a cause.

The findings are now the run's own answer. `--json-schema` in `claude_args` validates the reviewer's final message against `.github/fathom-review/findings-schema.json` and publishes it as the step's `structured_output`, so a run either answers in the shape the submission step reads or fails naming that as its cause. `anthropics/claude-code-action` already exposes both halves of that — the flag is forwarded to the CLI unchanged, and the action fails its own step when no structured answer comes back — so nothing here waits on an upstream change.

## What follows from it

- **The reviewer no longer writes anything.** `Write` is gone from `--allowedTools` and denied in the session settings, so the session stays read-only whichever of the two a later change touches, and the collected inputs the submission step trusts cannot be rewritten by the session that reads them.
- **The schema is a committed file** because it is a contract somebody reads. The step that composes the prompt compacts it onto one line, because `--json-schema` takes a schema rather than a path, and refuses one containing an apostrophe — the flag is single-quoted in `claude_args`, which the action parses with shell-quoting rules.
- **The submission step still distinguishes two silences,** and the second is what stops this workflow depending on a promise it does not own. An empty answer from a reviewer that *succeeded* is unreachable while the action keeps failing on a missing structured answer, and it fails there anyway: a later version that renamed the output or stopped failing on it would otherwise leave every review posting nothing under a green job.
- **A run that answers without conforming is now self-diagnosing.** The reviewer step fails, so `Report why the reviewer stopped` runs and prints what the model said instead — the action writes the execution log before it refuses the answer.

## Verification

- `scripts/verify-full.sh` — green: 2105 unit tests, 96 workflow contracts, formatting clean.
- Six new contracts in `scripts/test-agent-workflow.sh` run the extracted submission step against a reviewer's answer: an anchored finding, findings with no line to sit on, an approval, both empty-answer paths, and a payload carrying something shaped like a credential. They exercise the real step, so the rendering, the anchor validation, and the credential refusal are checked against model-shaped input rather than described.
- The schema itself was run against the API before it was committed: an empty `findings` array and a two-finding answer covering both an anchored finding and one with `path` and `line` null round-tripped intact, which is what proves the nullable unions are accepted.

The workflow file runs from `main`, so the change reviews nothing until it merges; the first run under the new contract is the one after that.
