### PR TITLE
[#308] Make transport authentication take the surface it protects

### DIFF
--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -693,7 +693,7 @@ PKCS#12 bundle may not, because it is binary and has no faithful representation 
 Startup records what each profile presents and when it stops working:
 
 ```text
-info: MailFathom.Host.Security.McpServerCertificateStore
+info: MailFathom.Host.Security.TransportServerCertificateStore
       The MCP HTTPS profile public presents a server certificate valid until 2027-01-31 00:00:00Z.
 ```
 

--- a/src/Host/Configuration/AuthorizationServerOptions.cs
+++ b/src/Host/Configuration/AuthorizationServerOptions.cs
@@ -25,7 +25,7 @@ namespace MailFathom.Host.Configuration;
 /// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
-internal sealed class McpAuthorizationServerOptions
+internal sealed class AuthorizationServerOptions
 {
     /// <summary>Gets or sets the operator's own name for this profile, which diagnostics correlate on.</summary>
     /// <remarks>It never reaches a client and is never compared against anything a token carries; it exists so a startup message and a log line can say which profile they mean without printing an issuer URL.</remarks>
@@ -111,7 +111,7 @@ internal sealed class McpAuthorizationServerOptions
     /// <exception cref="InvalidOperationException">Thrown when the profile has not passed <see cref="FindConfigurationErrors" />.</exception>
     /// <remarks>A subject is only unique within the server that issued it, so it is paired with the issuer here rather than compared on its own; two servers may both call someone <c>1</c> without either being wrong.</remarks>
     public IEnumerable<string> AuthorizedIdentities() =>
-        this.AuthorizedSubjects.Select(subject => McpOAuthIdentity.IdentityOf(this.ValidatedIssuer(), subject.Trim()));
+        this.AuthorizedSubjects.Select(subject => OAuthIdentity.IdentityOf(this.ValidatedIssuer(), subject.Trim()));
 
     /// <summary>Reports the issuer every comparison against this profile uses.</summary>
     /// <returns>The configured issuer, trimmed and otherwise unchanged.</returns>

--- a/src/Host/Configuration/ConfiguredKestrelEndpoints.cs
+++ b/src/Host/Configuration/ConfiguredKestrelEndpoints.cs
@@ -13,7 +13,7 @@ namespace MailFathom.Host.Configuration;
 /// its socket whatever else the composition root binds.
 /// </para>
 /// <para>
-/// That is exactly the state <see cref="McpHttpsOptions" /> promises cannot exist: a clear-text listener serving the
+/// That is exactly the state <see cref="TransportHttpsOptions" /> promises cannot exist: a clear-text listener serving the
 /// same MCP route behind an endpoint an operator configured HTTPS for. Since the two cannot be reconciled — removing
 /// the configured endpoint is a decision only an operator can take — the conflict fails startup and names both sides.
 /// </para>
@@ -73,7 +73,7 @@ internal static class ConfiguredKestrelEndpoints
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
     internal static IReadOnlyList<string> FindHttpsProfileConflicts(
         IConfiguration configuration,
-        McpHttpsOptions httpsSettings)
+        TransportHttpsOptions httpsSettings)
     {
         ArgumentNullException.ThrowIfNull(configuration);
         ArgumentNullException.ThrowIfNull(httpsSettings);

--- a/src/Host/Configuration/McpEndpointOptions.cs
+++ b/src/Host/Configuration/McpEndpointOptions.cs
@@ -68,7 +68,7 @@ internal sealed class McpEndpointOptions
     /// front supplies TLS. It is what makes <see cref="ClientCertificateProfiles" /> reachable without a reverse proxy,
     /// because a client certificate is presented during a handshake this process has to be the one terminating.
     /// </remarks>
-    public McpHttpsOptions Https { get; set; } = new();
+    public TransportHttpsOptions Https { get; set; } = new();
 
     /// <summary>Gets the client applications whose certificates the endpoint accepts, empty when mutual TLS is off.</summary>
     /// <remarks>

--- a/src/Host/Configuration/McpEndpointOptions.cs
+++ b/src/Host/Configuration/McpEndpointOptions.cs
@@ -37,8 +37,8 @@ internal sealed class McpEndpointOptions
     /// <summary>The configuration section the endpoint settings are bound from.</summary>
     public const string SectionName = "McpEndpoint";
 
-    private const McpTransportAuthenticationMethods KnownAuthenticationMethods =
-        McpTransportAuthenticationMethods.ApiKey | McpTransportAuthenticationMethods.OAuth;
+    private const TransportAuthenticationMethods KnownAuthenticationMethods =
+        TransportAuthenticationMethods.ApiKey | TransportAuthenticationMethods.OAuth;
 
     /// <summary>Gets or sets whether the MCP endpoint is served at all.</summary>
     /// <remarks>Disabled unless a deployment states otherwise, so reaching a mailbox over MCP is always something an operator turned on.</remarks>
@@ -46,7 +46,7 @@ internal sealed class McpEndpointOptions
 
     /// <summary>Gets or sets which credentials a client may present, written as a set such as <c>ApiKey, OAuth</c>.</summary>
     /// <remarks>Empty by default, which is the unauthenticated posture. A request is served when it satisfies any one of the methods named here, because the methods identify different kinds of caller rather than layering checks on one.</remarks>
-    public McpTransportAuthenticationMethods Authentication { get; set; } = McpTransportAuthenticationMethods.None;
+    public TransportAuthenticationMethods Authentication { get; set; } = TransportAuthenticationMethods.None;
 
     /// <summary>Gets the API keys a client may authenticate with, each a named secret with its own lifetime.</summary>
     /// <remarks>
@@ -57,7 +57,7 @@ internal sealed class McpEndpointOptions
     public IList<ConfiguredSecret> ApiKeys { get; } = [];
 
     /// <summary>Gets or sets what this deployment is called in OAuth terms, and which authorization servers may speak for it.</summary>
-    public McpOAuthOptions OAuth { get; set; } = new();
+    public OAuthValidationOptions OAuth { get; set; } = new();
 
     /// <summary>Gets or sets which browser origins the endpoint answers.</summary>
     public McpCorsOptions Cors { get; set; } = new();
@@ -84,10 +84,10 @@ internal sealed class McpEndpointOptions
     public McpRateLimitingOptions RateLimiting { get; set; } = new();
 
     /// <summary>Gets whether a client may authenticate with one of the configured API keys.</summary>
-    public bool AllowsApiKey => this.Authentication.HasFlag(McpTransportAuthenticationMethods.ApiKey);
+    public bool AllowsApiKey => this.Authentication.HasFlag(TransportAuthenticationMethods.ApiKey);
 
     /// <summary>Gets whether a client may authenticate with an access token from one of the configured authorization servers.</summary>
-    public bool AllowsOAuth => this.Authentication.HasFlag(McpTransportAuthenticationMethods.OAuth);
+    public bool AllowsOAuth => this.Authentication.HasFlag(TransportAuthenticationMethods.OAuth);
 
     /// <summary>Gets whether a request must present a credential naming who is calling.</summary>
     /// <remarks>
@@ -95,7 +95,7 @@ internal sealed class McpEndpointOptions
     /// is a different question from which person's mail is being served, so a deployment requiring a certificate and no
     /// authentication method still requires nothing in the sense this asks about — and still warns at startup.
     /// </remarks>
-    public bool RequiresAuthentication => this.Authentication != McpTransportAuthenticationMethods.None;
+    public bool RequiresAuthentication => this.Authentication != TransportAuthenticationMethods.None;
 
     /// <summary>Reads the section the way composition does, defaults included.</summary>
     /// <param name="configuration">The application configuration.</param>
@@ -200,9 +200,9 @@ internal sealed class McpEndpointOptions
         // registers no authentication, requires no credential, and leaves the unauthenticated warning silent because it
         // is not None either. Refusing it here is what keeps a typo from opening the endpoint instead of closing it.
         var unknownMethods = this.Authentication & ~KnownAuthenticationMethods;
-        if (unknownMethods != McpTransportAuthenticationMethods.None)
+        if (unknownMethods != TransportAuthenticationMethods.None)
         {
-            yield return $"{SectionName}:{nameof(this.Authentication)} — '{(int)unknownMethods}' names no authentication method; write '{nameof(McpTransportAuthenticationMethods.ApiKey)}', '{nameof(McpTransportAuthenticationMethods.OAuth)}', both separated by a comma, or '{nameof(McpTransportAuthenticationMethods.None)}'.";
+            yield return $"{SectionName}:{nameof(this.Authentication)} — '{(int)unknownMethods}' names no authentication method; write '{nameof(TransportAuthenticationMethods.ApiKey)}', '{nameof(TransportAuthenticationMethods.OAuth)}', both separated by a comma, or '{nameof(TransportAuthenticationMethods.None)}'.";
 
             yield break;
         }
@@ -222,14 +222,14 @@ internal sealed class McpEndpointOptions
     {
         if (this.AllowsApiKey && this.ApiKeys.Count == 0)
         {
-            yield return $"{SectionName}:{nameof(this.ApiKeys)} — '{nameof(McpTransportAuthenticationMethods.ApiKey)}' authentication is selected and no key is configured, so no client could authenticate with one.";
+            yield return $"{SectionName}:{nameof(this.ApiKeys)} — '{nameof(TransportAuthenticationMethods.ApiKey)}' authentication is selected and no key is configured, so no client could authenticate with one.";
         }
 
         // Configured-but-unchecked is refused rather than ignored in both directions below, because settings nothing
         // reads are a deployment believing it is protected — which is worse than one that knows it is not.
         if (!this.AllowsApiKey && this.ApiKeys.Count > 0)
         {
-            yield return $"{SectionName}:{nameof(this.ApiKeys)} — API keys are configured while '{nameof(McpTransportAuthenticationMethods.ApiKey)}' is not among the authentication methods, so none of them is checked; add it or remove them.";
+            yield return $"{SectionName}:{nameof(this.ApiKeys)} — API keys are configured while '{nameof(TransportAuthenticationMethods.ApiKey)}' is not among the authentication methods, so none of them is checked; add it or remove them.";
         }
     }
 
@@ -239,7 +239,7 @@ internal sealed class McpEndpointOptions
         {
             if (this.OAuth.IsConfigured)
             {
-                yield return $"{SectionName}:{nameof(this.OAuth)} — authorization servers are configured while '{nameof(McpTransportAuthenticationMethods.OAuth)}' is not among the authentication methods, so no token is checked against them; add it or remove the section.";
+                yield return $"{SectionName}:{nameof(this.OAuth)} — authorization servers are configured while '{nameof(TransportAuthenticationMethods.OAuth)}' is not among the authentication methods, so no token is checked against them; add it or remove the section.";
             }
 
             yield break;

--- a/src/Host/Configuration/OAuthValidationOptions.cs
+++ b/src/Host/Configuration/OAuthValidationOptions.cs
@@ -23,7 +23,7 @@ namespace MailFathom.Host.Configuration;
 /// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
-internal sealed class McpOAuthOptions
+internal sealed class OAuthValidationOptions
 {
     /// <summary>How long the host waits for a discovery document or a key set, after which the retrieval fails rather than holding a request.</summary>
     /// <remarks>A constant rather than a setting. It bounds an outbound call an operator never sees, and a deployment that needed it longer would be reporting a problem with the authorization server rather than with this value.</remarks>
@@ -58,7 +58,7 @@ internal sealed class McpOAuthOptions
     public IList<string> RequiredScopes { get; } = [];
 
     /// <summary>Gets the external authorization servers whose access tokens are accepted.</summary>
-    public IList<McpAuthorizationServerOptions> AuthorizationServers { get; } = [];
+    public IList<AuthorizationServerOptions> AuthorizationServers { get; } = [];
 
     /// <summary>Gets whether anything at all was configured in this section.</summary>
     public bool IsConfigured =>
@@ -102,37 +102,6 @@ internal sealed class McpOAuthOptions
     /// <exception cref="InvalidOperationException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
     public HashSet<string> AuthorizedIdentities() =>
         [.. this.AuthorizationServers.SelectMany(authorizationServer => authorizationServer.AuthorizedIdentities())];
-
-    /// <summary>Reports where the protected resource metadata document is published.</summary>
-    /// <returns>The absolute address of the RFC 9728 document.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
-    /// <remarks>
-    /// <para>
-    /// RFC 9728 places the document under the resource's own authority, with the resource's path appended to the
-    /// well-known segment, so <c>https://mail.example.test/mcp</c> publishes at
-    /// <c>https://mail.example.test/.well-known/oauth-protected-resource/mcp</c>.
-    /// </para>
-    /// <para>
-    /// It is composed from the configured resource rather than from the request that asks for it. The MCP SDK will
-    /// otherwise derive both this address and the resource it advertises from the incoming request's scheme and
-    /// <c>Host</c> header, which behind a reverse proxy means a client is told to authenticate for whichever name it
-    /// happened to arrive under — including one an attacker chose. Naming it here is what keeps the resource identifier
-    /// a deployment decision.
-    /// </para>
-    /// </remarks>
-    public string ProtectedResourceMetadataAddress()
-    {
-        var resource = new Uri(this.CanonicalResource());
-
-        return $"{resource.GetLeftPart(UriPartial.Authority)}/.well-known/oauth-protected-resource{resource.AbsolutePath.TrimEnd('/')}";
-    }
-
-    /// <summary>Reports the path of the protected resource metadata document, without its authority.</summary>
-    /// <returns>The absolute path the document answers at.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
-    /// <remarks>The SDK publishes the document from an authentication request handler rather than from a mapped route, so composition needs the path on its own to put a middleware in front of it.</remarks>
-    public string ProtectedResourceMetadataPath() =>
-        new Uri(this.ProtectedResourceMetadataAddress()).AbsolutePath;
 
     private IEnumerable<string> FindRequiredScopeErrors()
     {
@@ -178,7 +147,7 @@ internal sealed class McpOAuthOptions
 
             if (!claimedNames.Add(authorizationServer.Name!))
             {
-                yield return $"{settingPath}:{nameof(McpAuthorizationServerOptions.Name)} — '{authorizationServer.Name}' repeats a name another authorization server already carries.";
+                yield return $"{settingPath}:{nameof(AuthorizationServerOptions.Name)} — '{authorizationServer.Name}' repeats a name another authorization server already carries.";
             }
 
             // Two profiles claiming one issuer is the ambiguity the whole selection rule exists to avoid: a token naming
@@ -186,7 +155,7 @@ internal sealed class McpOAuthOptions
             // token is trusted against would depend on configuration order rather than on what the token says.
             if (!claimedIssuers.Add(authorizationServer.ValidatedIssuer()))
             {
-                yield return $"{settingPath}:{nameof(McpAuthorizationServerOptions.Issuer)} — this issuer repeats one another authorization server already carries, which would leave the key set a token is trusted against decided by configuration order.";
+                yield return $"{settingPath}:{nameof(AuthorizationServerOptions.Issuer)} — this issuer repeats one another authorization server already carries, which would leave the key set a token is trusted against decided by configuration order.";
             }
         }
     }

--- a/src/Host/Configuration/TransportAuthenticationMethods.cs
+++ b/src/Host/Configuration/TransportAuthenticationMethods.cs
@@ -28,7 +28,7 @@ namespace MailFathom.Host.Configuration;
 /// </para>
 /// </remarks>
 [Flags]
-internal enum McpTransportAuthenticationMethods
+internal enum TransportAuthenticationMethods
 {
     /// <summary>No transport authentication at all, which is a posture for a local or network-isolated deployment and warns at startup.</summary>
     None = 0,

--- a/src/Host/Configuration/TransportHttpProtocol.cs
+++ b/src/Host/Configuration/TransportHttpProtocol.cs
@@ -17,7 +17,7 @@ namespace MailFathom.Host.Configuration;
 /// uses TLS 1.3 whatever floor the endpoint configures.
 /// </para>
 /// </remarks>
-internal enum McpHttpProtocol
+internal enum TransportHttpProtocol
 {
     /// <summary>HTTP/1.1, which every MCP client speaks.</summary>
     Http1 = 0,

--- a/src/Host/Configuration/TransportHttpsEndpointOptions.cs
+++ b/src/Host/Configuration/TransportHttpsEndpointOptions.cs
@@ -22,7 +22,7 @@ namespace MailFathom.Host.Configuration;
 /// refuses is a name that could not be a DNS name at all.
 /// </para>
 /// </remarks>
-internal sealed class McpHttpsEndpointOptions
+internal sealed class TransportHttpsEndpointOptions
 {
     /// <summary>Gets or sets the operator-chosen identity of this profile, unique across the configured profiles.</summary>
     /// <remarks>It is what every diagnostic names, so a rejected certificate is reported against a profile an operator recognizes rather than against an array position that renumbers on the next edit.</remarks>
@@ -45,7 +45,7 @@ internal sealed class McpHttpsEndpointOptions
     public int Port { get; set; } = 8443;
 
     /// <summary>Gets or sets the oldest TLS version this profile completes a handshake with.</summary>
-    public McpMinimumTlsVersion MinimumTlsVersion { get; set; } = McpMinimumTlsVersion.Tls12;
+    public TransportMinimumTlsVersion MinimumTlsVersion { get; set; } = TransportMinimumTlsVersion.Tls12;
 
     /// <summary>Gets or sets the HTTP versions this profile serves, or <see langword="null" /> to serve the default HTTP/1.1 and HTTP/2.</summary>
     /// <remarks>
@@ -54,19 +54,19 @@ internal sealed class McpHttpsEndpointOptions
     /// alone serving all three. Absent therefore means the default and an explicitly empty list is a configuration
     /// error, which are two different mistakes and are reported as such.
     /// </remarks>
-    public IList<McpHttpProtocol>? HttpProtocols { get; set; }
+    public IList<TransportHttpProtocol>? HttpProtocols { get; set; }
 
     /// <summary>Gets or sets where the certificate and private key this profile presents come from.</summary>
     public TlsServerCertificateOptions ServerCertificate { get; set; } = new();
 
     /// <summary>Gets the HTTP versions this profile serves, with the default applied.</summary>
-    internal IReadOnlyList<McpHttpProtocol> ServedHttpProtocols => this.HttpProtocols is { Count: > 0 } configured
+    internal IReadOnlyList<TransportHttpProtocol> ServedHttpProtocols => this.HttpProtocols is { Count: > 0 } configured
         ? [.. configured.Distinct()]
-        : [McpHttpProtocol.Http1, McpHttpProtocol.Http2];
+        : [TransportHttpProtocol.Http1, TransportHttpProtocol.Http2];
 
     /// <summary>Gets the address and port this profile binds, which profiles sharing one listener have in common.</summary>
     /// <exception cref="FormatException">Thrown when <see cref="BindAddress" /> is not an IP address, which validation reports before anything reads this.</exception>
-    internal McpHttpsListenerAddress ListenerAddress => new(IPAddress.Parse(this.BindAddress.Trim()), this.Port);
+    internal TransportHttpsListenerAddress ListenerAddress => new(IPAddress.Parse(this.BindAddress.Trim()), this.Port);
 
     /// <summary>Finds everything an operator must fix before this profile can be served.</summary>
     /// <param name="configurationPath">The configuration path of this profile, which prefixes every reported error.</param>
@@ -99,7 +99,7 @@ internal sealed class McpHttpsEndpointOptions
 
         if (!Enum.IsDefined(this.MinimumTlsVersion))
         {
-            yield return $"{configurationPath}:{nameof(this.MinimumTlsVersion)} — '{(int)this.MinimumTlsVersion}' names no TLS version; state '{nameof(McpMinimumTlsVersion.Tls12)}' or '{nameof(McpMinimumTlsVersion.Tls13)}'.";
+            yield return $"{configurationPath}:{nameof(this.MinimumTlsVersion)} — '{(int)this.MinimumTlsVersion}' names no TLS version; state '{nameof(TransportMinimumTlsVersion.Tls12)}' or '{nameof(TransportMinimumTlsVersion.Tls13)}'.";
         }
 
         foreach (var error in this.FindHttpProtocolErrors(configurationPath, http3Supported))
@@ -143,7 +143,7 @@ internal sealed class McpHttpsEndpointOptions
 
         if (configured.Count == 0)
         {
-            yield return $"{settingPath} — the list is empty, so the profile would serve no HTTP version at all; remove it to serve the default '{nameof(McpHttpProtocol.Http1)}' and '{nameof(McpHttpProtocol.Http2)}', or name the versions to serve.";
+            yield return $"{settingPath} — the list is empty, so the profile would serve no HTTP version at all; remove it to serve the default '{nameof(TransportHttpProtocol.Http1)}' and '{nameof(TransportHttpProtocol.Http2)}', or name the versions to serve.";
 
             yield break;
         }
@@ -152,7 +152,7 @@ internal sealed class McpHttpsEndpointOptions
 
         foreach (var protocol in undefined)
         {
-            yield return $"{settingPath} — '{(int)protocol}' names no HTTP version; state '{nameof(McpHttpProtocol.Http1)}', '{nameof(McpHttpProtocol.Http2)}', or '{nameof(McpHttpProtocol.Http3)}'.";
+            yield return $"{settingPath} — '{(int)protocol}' names no HTTP version; state '{nameof(TransportHttpProtocol.Http1)}', '{nameof(TransportHttpProtocol.Http2)}', or '{nameof(TransportHttpProtocol.Http3)}'.";
         }
 
         if (configured.Distinct().Count() != configured.Count)
@@ -162,9 +162,9 @@ internal sealed class McpHttpsEndpointOptions
 
         // Reported rather than silently dropped: an operator who asked for HTTP/3 and got HTTP/2 would read a working
         // endpoint and never learn that the version they configured is not the one being served.
-        if (!http3Supported && undefined.Length == 0 && configured.Contains(McpHttpProtocol.Http3))
+        if (!http3Supported && undefined.Length == 0 && configured.Contains(TransportHttpProtocol.Http3))
         {
-            yield return $"{settingPath} — '{nameof(McpHttpProtocol.Http3)}' is configured and this host cannot provide the QUIC transport it needs; install the platform's QUIC support or remove the version rather than have it quietly fall back.";
+            yield return $"{settingPath} — '{nameof(TransportHttpProtocol.Http3)}' is configured and this host cannot provide the QUIC transport it needs; install the platform's QUIC support or remove the version rather than have it quietly fall back.";
         }
     }
 }

--- a/src/Host/Configuration/TransportHttpsListenerAddress.cs
+++ b/src/Host/Configuration/TransportHttpsListenerAddress.cs
@@ -15,4 +15,4 @@ namespace MailFathom.Host.Configuration;
 /// everything a listener owns rather than a connection — the socket and the set of HTTP versions — is therefore common
 /// to all of them.
 /// </remarks>
-internal readonly record struct McpHttpsListenerAddress(IPAddress Address, int Port);
+internal readonly record struct TransportHttpsListenerAddress(IPAddress Address, int Port);

--- a/src/Host/Configuration/TransportHttpsOptions.cs
+++ b/src/Host/Configuration/TransportHttpsOptions.cs
@@ -24,10 +24,10 @@ namespace MailFathom.Host.Configuration;
 /// without the protection the profile was configured to add.
 /// </para>
 /// </remarks>
-internal sealed class McpHttpsOptions
+internal sealed class TransportHttpsOptions
 {
     /// <summary>Gets the HTTPS profiles served, empty when Kestrel terminates no TLS of its own.</summary>
-    public IList<McpHttpsEndpointOptions> Endpoints { get; } = [];
+    public IList<TransportHttpsEndpointOptions> Endpoints { get; } = [];
 
     /// <summary>Gets whether any profile is configured, which is what decides between the two postures.</summary>
     internal bool TerminatesTls => this.Endpoints.Count > 0;

--- a/src/Host/Configuration/TransportMinimumTlsVersion.cs
+++ b/src/Host/Configuration/TransportMinimumTlsVersion.cs
@@ -17,7 +17,7 @@ namespace MailFathom.Host.Configuration;
 /// so the setting decides what is refused rather than what is preferred.
 /// </para>
 /// </remarks>
-internal enum McpMinimumTlsVersion
+internal enum TransportMinimumTlsVersion
 {
     /// <summary>Accept TLS 1.2 and TLS 1.3, which is what interoperates with every current client.</summary>
     Tls12 = 0,

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -14,6 +14,7 @@ using MailFathom.Host.Hosting;
 using MailFathom.Host.Observability;
 using MailFathom.Host.Security;
 using MailFathom.Infrastructure;
+using MailFathom.Infrastructure.Certificates;
 using MailFathom.Infrastructure.Mail;
 using MailFathom.Infrastructure.Persistence;
 using MailFathom.Infrastructure.Resilience;
@@ -291,7 +292,12 @@ try
 
     // Registered whether or not any profile is configured, because the store is what the certificates are loaded into
     // and disposed from, and an unconfigured deployment simply loads none.
-    builder.Services.AddSingleton<McpServerCertificateStore>();
+    builder.Services.AddSingleton(provider => new TransportServerCertificateStore(
+        mcpEndpointSettings.Https,
+        $"{McpEndpointOptions.SectionName}:{nameof(McpEndpointOptions.Https)}",
+        provider.GetRequiredService<TlsServerCertificateLoader>(),
+        provider.GetRequiredService<TimeProvider>(),
+        provider.GetRequiredService<ILogger<TransportServerCertificateStore>>()));
 
     if (mcpEndpointSettings.Enabled && mcpEndpointSettings.Https.TerminatesTls)
     {
@@ -299,10 +305,10 @@ try
         // clear-text listener from staying open behind an endpoint an operator configured HTTPS for. The callback runs
         // when the server is constructed, after the container exists, so the store it reads is the one the composition
         // root has already loaded.
-        builder.WebHost.ConfigureKestrel(kestrelOptions => McpHttpsEndpointBinder.Bind(
+        builder.WebHost.ConfigureKestrel(kestrelOptions => TransportHttpsEndpointBinder.Bind(
             kestrelOptions,
             mcpEndpointSettings.Https,
-            kestrelOptions.ApplicationServices.GetRequiredService<McpServerCertificateStore>(),
+            kestrelOptions.ApplicationServices.GetRequiredService<TransportServerCertificateStore>(),
             mcpEndpointSettings.ClientCertificateProfiles.Count > 0));
     }
 
@@ -377,7 +383,7 @@ try
     // material is missing, expired, or issued for another domain therefore fails startup with nothing listening.
     if (mcpEndpointSettings.Enabled && mcpEndpointSettings.Https.TerminatesTls)
     {
-        await app.Services.GetRequiredService<McpServerCertificateStore>()
+        await app.Services.GetRequiredService<TransportServerCertificateStore>()
             .LoadAsync(app.Lifetime.ApplicationStopping);
     }
 

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -426,7 +426,8 @@ try
             // none to carry it: the authentication handler publishes it instead of a mapped route. A browser client
             // reads that document before it holds any credential, so without the policy applied to its path the one
             // response that says where to authorize is the one a page cannot read.
-            var protectedResourceMetadataPath = mcpEndpointSettings.OAuth.ProtectedResourceMetadataPath();
+            var protectedResourceMetadataPath = McpProtectedResourceMetadata.PathFor(
+                mcpEndpointSettings.OAuth.CanonicalResource());
 
             app.UseWhen(
                 context => context.Request.Path.Equals(protectedResourceMetadataPath, StringComparison.OrdinalIgnoreCase),
@@ -477,7 +478,7 @@ try
             // answering unauthenticated while everything the MCP route exposes is covered by the one requirement it
             // carries. Under the stateless transport that route is the post alone; a get or a delete is not mapped at
             // all, so there is no second entry into the protocol surface for a requirement to miss.
-            mcpEndpoint.RequireAuthorization(McpAccessPolicy.PolicyName);
+            mcpEndpoint.RequireAuthorization(TransportSurface.Mcp.AccessPolicyName);
         }
     }
 

--- a/src/Host/Security/ApiKeyAuthentication.cs
+++ b/src/Host/Security/ApiKeyAuthentication.cs
@@ -4,21 +4,24 @@
 
 namespace MailFathom.Host.Security;
 
-/// <summary>The names the MCP API key authentication scheme publishes.</summary>
+/// <summary>The names the API key authentication scheme publishes, whichever surface it protects.</summary>
 /// <remarks>
-/// They are constants rather than settings. The scheme name is an internal handle the composition root and the endpoint
-/// convention have to agree on, and the challenge is what an HTTP client reads: <c>Bearer</c>, because that is the
-/// scheme the credential is presented under and the one an MCP client already knows how to answer.
+/// They are constants rather than settings, and the challenge is what an HTTP client reads: <c>Bearer</c>, because that
+/// is the scheme the credential is presented under and the one a client already knows how to answer. The scheme's own
+/// name is not among them, because it differs per surface and is composed by
+/// <see cref="TransportSurface.ApiKeySchemeName" />.
 /// </remarks>
-internal static class McpApiKeyAuthentication
+internal static class ApiKeyAuthentication
 {
-    /// <summary>The authentication scheme the MCP endpoint is protected by.</summary>
-    internal const string SchemeName = "MailFathomApiKey";
-
     /// <summary>The HTTP authentication scheme a credential is presented under, and the one a challenge names.</summary>
     internal const string HttpAuthenticationScheme = "Bearer";
 
     /// <summary>The protection space a challenge names, which stays constant so a client can cache a credential against it.</summary>
+    /// <remarks>
+    /// One realm across every surface, deliberately. A realm tells a client which credential to reuse where, and the
+    /// surfaces here are told apart by the address a client is configured with rather than by a name in a challenge, so
+    /// publishing two would suggest a distinction no client has any way to act on.
+    /// </remarks>
     internal const string Realm = "MailFathom";
 
     /// <summary>The claim type carrying the name of the API key a request authenticated with.</summary>
@@ -26,6 +29,11 @@ internal static class McpApiKeyAuthentication
     /// A private claim type rather than a registered one: the value is MailFathom's own configuration identity for a
     /// credential, not a subject any other system issued or would recognize. It exists so an audit record and a
     /// diagnostic can name which key was used, and it is the only thing the principal carries.
+    /// <para>
+    /// One claim type across every surface, because it says what kind of credential authenticated rather than where. A
+    /// principal never crosses a surface: each registers its own routing scheme and each endpoint requires a policy
+    /// naming only that scheme, so which surface's keys were consulted is settled before this claim is ever read.
+    /// </para>
     /// </remarks>
     internal const string ApiKeyNameClaimType = "urn:mailfathom:api-key-name";
 

--- a/src/Host/Security/ApiKeyAuthenticationHandler.cs
+++ b/src/Host/Security/ApiKeyAuthenticationHandler.cs
@@ -5,20 +5,24 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
-using MailFathom.Host.Configuration;
 using MailFathom.Infrastructure.Security;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 
 namespace MailFathom.Host.Security;
 
-/// <summary>Authenticates an MCP request against the configured API keys.</summary>
+/// <summary>Authenticates a request against the API keys configured for the surface it arrived on.</summary>
 /// <remarks>
 /// <para>
 /// The handler is the adapter and nothing more: it lifts the credential out of the request, hands it to
-/// <see cref="McpApiKeyAuthenticator" />, and turns the answer into the framework's own vocabulary. Every rule worth
+/// <see cref="ApiKeyAuthenticator" />, and turns the answer into the framework's own vocabulary. Every rule worth
 /// asserting — which keys match, how they are compared, when a lifetime has ended — lives below this boundary, where a
 /// test reaches it without a request pipeline.
+/// </para>
+/// <para>
+/// One handler serves every surface, because which keys are compared is the scheme's own option rather than something
+/// the handler goes and reads. Two surfaces therefore register two schemes over two key lists and share this code, and
+/// a key configured for one authenticates nothing on the other.
 /// </para>
 /// <para>
 /// Every refusal produces one indistinguishable answer: an empty <c>401</c> carrying the same challenge, whether the
@@ -28,26 +32,22 @@ namespace MailFathom.Host.Security;
 /// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The authentication framework materializes this handler for its registered scheme.")]
-internal sealed class McpApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+internal sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKeyAuthenticationSchemeOptions>
 {
-    private readonly McpApiKeyAuthenticator authenticator;
-    private readonly McpEndpointOptions endpointSettings;
+    private readonly ApiKeyAuthenticator authenticator;
 
     /// <summary>Initializes a new API key authentication handler.</summary>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="authenticator" /> or <paramref name="endpointSettings" /> is <see langword="null" />.</exception>
-    public McpApiKeyAuthenticationHandler(
-        IOptionsMonitor<AuthenticationSchemeOptions> schemeOptions,
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="authenticator" /> is <see langword="null" />.</exception>
+    public ApiKeyAuthenticationHandler(
+        IOptionsMonitor<ApiKeyAuthenticationSchemeOptions> schemeOptions,
         ILoggerFactory loggerFactory,
         UrlEncoder urlEncoder,
-        McpApiKeyAuthenticator authenticator,
-        IOptions<McpEndpointOptions> endpointSettings)
+        ApiKeyAuthenticator authenticator)
         : base(schemeOptions, loggerFactory, urlEncoder)
     {
         ArgumentNullException.ThrowIfNull(authenticator);
-        ArgumentNullException.ThrowIfNull(endpointSettings);
 
         this.authenticator = authenticator;
-        this.endpointSettings = endpointSettings.Value;
     }
 
     /// <inheritdoc />
@@ -59,20 +59,20 @@ internal sealed class McpApiKeyAuthenticationHandler : AuthenticationHandler<Aut
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
         var result = await this.authenticator.AuthenticateAsync(
-            [.. this.endpointSettings.ApiKeys],
+            [.. this.Options.ApiKeys],
             this.Request.Headers.Authorization.ToString(),
             this.Context.RequestAborted);
 
         if (result.AuthenticatedKeyName is not { } keyName)
         {
-            return AuthenticateResult.Fail("The request presented no usable MCP credential.");
+            return AuthenticateResult.Fail("The request presented no usable credential.");
         }
 
         var identity = new ClaimsIdentity(
-            [new Claim(McpApiKeyAuthentication.ApiKeyNameClaimType, keyName.Value!)],
-            McpApiKeyAuthentication.SchemeName,
-            McpApiKeyAuthentication.ApiKeyNameClaimType,
-            McpApiKeyAuthentication.RoleClaimType);
+            [new Claim(ApiKeyAuthentication.ApiKeyNameClaimType, keyName.Value!)],
+            this.Options.Surface.ApiKeySchemeName,
+            ApiKeyAuthentication.ApiKeyNameClaimType,
+            ApiKeyAuthentication.RoleClaimType);
 
         return AuthenticateResult.Success(
             new AuthenticationTicket(new ClaimsPrincipal(identity), this.Scheme.Name));
@@ -84,7 +84,7 @@ internal sealed class McpApiKeyAuthenticationHandler : AuthenticationHandler<Aut
     {
         this.Response.StatusCode = StatusCodes.Status401Unauthorized;
         this.Response.Headers.WWWAuthenticate =
-            $"{McpApiKeyAuthentication.HttpAuthenticationScheme} realm=\"{McpApiKeyAuthentication.Realm}\"";
+            $"{ApiKeyAuthentication.HttpAuthenticationScheme} realm=\"{ApiKeyAuthentication.Realm}\"";
 
         return Task.CompletedTask;
     }

--- a/src/Host/Security/ApiKeyAuthenticationSchemeOptions.cs
+++ b/src/Host/Security/ApiKeyAuthenticationSchemeOptions.cs
@@ -1,0 +1,41 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Secrets;
+using Microsoft.AspNetCore.Authentication;
+
+namespace MailFathom.Host.Security;
+
+/// <summary>Which keys one surface's API key scheme compares a presented credential against.</summary>
+/// <remarks>
+/// The keys reach the handler through the framework's own per-scheme options rather than through the endpoint settings,
+/// which is what lets two surfaces register the same handler over two different key lists. Reading a settings object
+/// instead would tie the handler to one section, and a second surface would have had to bring a second handler.
+/// <para>
+/// The references are held rather than the material behind them. What a reference resolves to is read per request by
+/// <see cref="Infrastructure.Security.ApiKeyAuthenticator" />, so a key rotated in place reaches the next request
+/// without a restart.
+/// </para>
+/// </remarks>
+internal sealed class ApiKeyAuthenticationSchemeOptions : AuthenticationSchemeOptions
+{
+    /// <summary>Gets or sets the surface this scheme protects, which names the claim identity a success produces.</summary>
+    internal TransportSurface Surface { get; set; }
+
+    /// <summary>Gets or sets the API key references a request may present one of, empty when the surface accepts none.</summary>
+    internal IReadOnlyList<ConfiguredSecret> ApiKeys { get; set; } = [];
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">Thrown when the scheme was registered without a surface, which would leave a successful authentication carrying no identity.</exception>
+    public override void Validate()
+    {
+        base.Validate();
+
+        if (!this.Surface.IsSpecified)
+        {
+            throw new InvalidOperationException(
+                "The API key authentication scheme was registered without a transport surface.");
+        }
+    }
+}

--- a/src/Host/Security/CredentialSchemeSelector.cs
+++ b/src/Host/Security/CredentialSchemeSelector.cs
@@ -27,7 +27,7 @@ namespace MailFathom.Host.Security;
 /// answers with the challenge — which is the same outcome as a refusal, reached without a special case.
 /// </para>
 /// </remarks>
-internal sealed class McpCredentialSchemeSelector
+internal sealed class CredentialSchemeSelector
 {
     private readonly Dictionary<string, string> oauthSchemesByIssuer;
     private readonly string? apiKeySchemeName;
@@ -38,7 +38,7 @@ internal sealed class McpCredentialSchemeSelector
     /// <param name="apiKeySchemeName">The scheme comparing API keys, or <see langword="null" /> when API keys are not accepted.</param>
     /// <param name="unmatchedSchemeName">The scheme a request reaches when no credential it presented selects one.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="oauthSchemesByIssuer" /> or <paramref name="unmatchedSchemeName" /> is <see langword="null" />.</exception>
-    internal McpCredentialSchemeSelector(
+    internal CredentialSchemeSelector(
         IReadOnlyDictionary<string, string> oauthSchemesByIssuer,
         string? apiKeySchemeName,
         string unmatchedSchemeName)

--- a/src/Host/Security/InsufficientScopeResultHandler.cs
+++ b/src/Host/Security/InsufficientScopeResultHandler.cs
@@ -30,7 +30,7 @@ namespace MailFathom.Host.Security;
 /// an authorization requirement. Everything else still reaches the framework's own handler.
 /// </para>
 /// </remarks>
-internal sealed class McpInsufficientScopeResultHandler : IAuthorizationMiddlewareResultHandler
+internal sealed class InsufficientScopeResultHandler : IAuthorizationMiddlewareResultHandler
 {
     private static readonly AuthorizationMiddlewareResultHandler FrameworkHandler = new();
 
@@ -42,7 +42,7 @@ internal sealed class McpInsufficientScopeResultHandler : IAuthorizationMiddlewa
     /// <param name="requiredScopes">The scopes an access token must carry.</param>
     /// <param name="protectedResourceMetadataAddress">Where the protected resource metadata document is published.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="requiredScopes" /> or <paramref name="protectedResourceMetadataAddress" /> is <see langword="null" />.</exception>
-    internal McpInsufficientScopeResultHandler(
+    internal InsufficientScopeResultHandler(
         IReadOnlyCollection<string> requiredScopes,
         string protectedResourceMetadataAddress)
     {
@@ -68,7 +68,7 @@ internal sealed class McpInsufficientScopeResultHandler : IAuthorizationMiddlewa
         // A caller refused for who they are, rather than for what their token was issued for, receives the framework's
         // plain 403. Naming scopes there would send a client to ask its authorization server for something that would
         // change nothing, and would say that the scopes are all that stands between it and the mailbox.
-        if (!authorizeResult.Forbidden || McpOAuthIdentity.CarriesEveryScope(context.User, this.requiredScopes))
+        if (!authorizeResult.Forbidden || OAuthIdentity.CarriesEveryScope(context.User, this.requiredScopes))
         {
             return FrameworkHandler.HandleAsync(next, context, policy, authorizeResult);
         }

--- a/src/Host/Security/McpProtectedResourceMetadata.cs
+++ b/src/Host/Security/McpProtectedResourceMetadata.cs
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Host.Security;
+
+/// <summary>Where the MCP endpoint publishes the RFC 9728 document that tells a client how to authorize.</summary>
+/// <remarks>
+/// <para>
+/// This belongs to the MCP surface alone rather than to OAuth validation generally. Publishing a discovery document is
+/// what a protocol surface does for clients that arrive holding nothing and have to find an authorization server; a
+/// surface whose clients are configured with a credential before they connect publishes none, and would have no reader
+/// for one.
+/// </para>
+/// <para>
+/// Both addresses are composed from the configured resource rather than from the request that asks for them. The MCP SDK
+/// will otherwise derive them from the incoming request's scheme and <c>Host</c> header, which behind a reverse proxy
+/// means a client is told to authorize for whichever name it happened to arrive under — including one an attacker chose.
+/// Composing them here is what keeps the resource identifier a deployment decision.
+/// </para>
+/// </remarks>
+internal static class McpProtectedResourceMetadata
+{
+    /// <summary>Reports where the protected resource metadata document is published.</summary>
+    /// <param name="canonicalResource">The canonical resource identifier the endpoint publishes.</param>
+    /// <returns>The absolute address of the RFC 9728 document.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="canonicalResource" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// RFC 9728 places the document under the resource's own authority, with the resource's path appended to the
+    /// well-known segment, so <c>https://mail.example.test/mcp</c> publishes at
+    /// <c>https://mail.example.test/.well-known/oauth-protected-resource/mcp</c>.
+    /// </remarks>
+    internal static string AddressFor(string canonicalResource)
+    {
+        ArgumentNullException.ThrowIfNull(canonicalResource);
+
+        var resource = new Uri(canonicalResource);
+
+        return $"{resource.GetLeftPart(UriPartial.Authority)}/.well-known/oauth-protected-resource{resource.AbsolutePath.TrimEnd('/')}";
+    }
+
+    /// <summary>Reports the path of the protected resource metadata document, without its authority.</summary>
+    /// <param name="canonicalResource">The canonical resource identifier the endpoint publishes.</param>
+    /// <returns>The absolute path the document answers at.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="canonicalResource" /> is <see langword="null" />.</exception>
+    /// <remarks>The SDK publishes the document from an authentication request handler rather than from a mapped route, so composition needs the path on its own to put a middleware in front of it.</remarks>
+    internal static string PathFor(string canonicalResource) =>
+        new Uri(AddressFor(canonicalResource)).AbsolutePath;
+}

--- a/src/Host/Security/McpTransportSecurityExtensions.cs
+++ b/src/Host/Security/McpTransportSecurityExtensions.cs
@@ -2,17 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Diagnostics.CodeAnalysis;
-using System.Security.Claims;
 using MailFathom.Host.Configuration;
 using MailFathom.Infrastructure.Security;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
-using Microsoft.IdentityModel.Protocols;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Net.Http.Headers;
 using ModelContextProtocol.AspNetCore.Authentication;
 using ModelContextProtocol.Authentication;
@@ -28,10 +23,11 @@ namespace MailFathom.Host.Security;
 /// for another, and a deployment can be narrow on one while wide on the next.
 /// </para>
 /// <para>
-/// Authentication itself is composed of as many schemes as the deployment turned on, sitting behind one scheme that
-/// routes to them. That shape is what lets an API key and an access token be accepted at once without either check
-/// weakening: each credential reaches the handler that understands it, and a handler never sees a credential of the
-/// other kind.
+/// Only what is MCP's own is here. Which credentials are accepted, and what makes a caller authorized, are questions
+/// every protected surface asks, so they are registered through <see cref="TransportSecurityExtensions" /> with the MCP
+/// surface handed in. What stays is the part that exists because this endpoint speaks a protocol to browsers and to MCP
+/// clients: the CORS policy, the client-certificate handshake, the discovery document the MCP authorization
+/// specification defines, and the refusal a client reads when its token lacks a scope.
 /// </para>
 /// </remarks>
 internal static class McpTransportSecurityExtensions
@@ -76,8 +72,26 @@ internal static class McpTransportSecurityExtensions
             return services;
         }
 
-        AddAuthenticationSchemes(services, endpointSettings);
-        AddAuthorizationPolicy(services, endpointSettings);
+        // A challenge is answered by one scheme whichever credential was presented, because a request that has nothing
+        // to authenticate with has told us nothing about which kind of credential it was going to use. With OAuth turned
+        // on that is the MCP scheme, whose challenge carries the metadata document a client needs to begin authorizing;
+        // otherwise it is the API key scheme's bare bearer challenge.
+        var challengeSchemeName = endpointSettings.AllowsOAuth
+            ? McpAuthenticationDefaults.AuthenticationScheme
+            : TransportSurface.Mcp.ApiKeySchemeName;
+
+        var authentication = services.AddTransportAuthentication(
+            TransportSurface.Mcp,
+            endpointSettings.Authentication,
+            [.. endpointSettings.ApiKeys],
+            endpointSettings.OAuth,
+            challengeSchemeName);
+
+        if (endpointSettings.AllowsOAuth)
+        {
+            AddProtectedResourceMetadataScheme(authentication, endpointSettings.OAuth);
+            AddInsufficientScopeRefusal(services, endpointSettings.OAuth);
+        }
 
         return services;
     }
@@ -112,245 +126,43 @@ internal static class McpTransportSecurityExtensions
         }));
     }
 
-    /// <summary>Registers the routing scheme and one scheme per credential the deployment accepts.</summary>
-    /// <remarks>
-    /// The routing scheme is the default, so every part of the pipeline that asks for "the" scheme — the authorization
-    /// middleware challenging an anonymous request, the endpoint requiring an authenticated user — reaches the one place
-    /// that knows how many schemes there are. Nothing downstream names an individual scheme.
-    /// </remarks>
-    private static void AddAuthenticationSchemes(IServiceCollection services, McpEndpointOptions endpointSettings)
-    {
-        var authentication = services.AddAuthentication(McpOAuthAuthentication.RoutingSchemeName);
-
-        var apiKeySchemeName = endpointSettings.AllowsApiKey ? McpApiKeyAuthentication.SchemeName : null;
-        var unmatchedSchemeName = endpointSettings.AllowsOAuth
-            ? McpAuthenticationDefaults.AuthenticationScheme
-            : McpApiKeyAuthentication.SchemeName;
-
-        var oauthSchemesByIssuer = endpointSettings.AllowsOAuth
-            ? endpointSettings.OAuth.AuthorizationServers.ToDictionary(
-                authorizationServer => authorizationServer.ValidatedIssuer(),
-                authorizationServer => McpOAuthAuthentication.SchemeNameFor(authorizationServer.Name!),
-                StringComparer.Ordinal)
-            : [];
-
-        var schemeSelector = new McpCredentialSchemeSelector(
-            oauthSchemesByIssuer,
-            apiKeySchemeName,
-            unmatchedSchemeName);
-
-        authentication.AddPolicyScheme(
-            McpOAuthAuthentication.RoutingSchemeName,
-            displayName: null,
-            policyOptions =>
+    /// <summary>Registers the scheme publishing the RFC 9728 document an MCP client discovers its authorization server through.</summary>
+    private static void AddProtectedResourceMetadataScheme(
+        AuthenticationBuilder authentication,
+        OAuthValidationOptions oauthSettings) =>
+        authentication.AddMcp(mcpOptions =>
+        {
+            // Absolute and configured, never derived from the request. Left unset, the SDK composes both this address
+            // and the resource it advertises from the request's scheme and Host header, so a deployment behind a proxy
+            // would tell each client to authenticate for whichever name that client arrived under.
+            mcpOptions.ResourceMetadataUri = new Uri(
+                McpProtectedResourceMetadata.AddressFor(oauthSettings.CanonicalResource()));
+            mcpOptions.ResourceMetadata = new ProtectedResourceMetadata
             {
-                policyOptions.ForwardDefaultSelector = context =>
-                    schemeSelector.SchemeFor(context.Request.Headers.Authorization.ToString());
+                Resource = oauthSettings.CanonicalResource(),
+                AuthorizationServers = [.. oauthSettings.AuthorizationServers.Select(server => server.ValidatedIssuer())],
+                ScopesSupported = [.. oauthSettings.RequiredScopes],
+                BearerMethodsSupported = ["header"],
+                ResourceName = "MailFathom",
+            };
+        });
 
-                // A challenge is answered by one scheme whichever credential was presented, because a request that has
-                // nothing to authenticate with has told us nothing about which kind of credential it was going to use.
-                // With OAuth turned on that is the MCP scheme, whose challenge carries the metadata document a client
-                // needs to begin authorizing; otherwise it is the API key scheme's bare bearer challenge.
-                policyOptions.ForwardChallenge = unmatchedSchemeName;
-            });
-
-        if (endpointSettings.AllowsApiKey)
-        {
-            services.AddSingleton<McpApiKeyAuthenticator>();
-            authentication.AddScheme<AuthenticationSchemeOptions, McpApiKeyAuthenticationHandler>(
-                McpApiKeyAuthentication.SchemeName,
-                configureOptions: null);
-        }
-
-        if (endpointSettings.AllowsOAuth)
-        {
-            AddOAuthSchemes(authentication, endpointSettings.OAuth);
-        }
-    }
-
-    /// <summary>Registers the metadata scheme and one token validator per configured authorization server.</summary>
-    private static void AddOAuthSchemes(AuthenticationBuilder authentication, McpOAuthOptions oauthSettings)
-    {
-        authentication.AddMcp(
-            mcpOptions =>
-            {
-                // Absolute and configured, never derived from the request. Left unset, the SDK composes both this
-                // address and the resource it advertises from the request's scheme and Host header, so a deployment
-                // behind a proxy would tell each client to authenticate for whichever name that client arrived under.
-                mcpOptions.ResourceMetadataUri = new Uri(oauthSettings.ProtectedResourceMetadataAddress());
-                mcpOptions.ResourceMetadata = new ProtectedResourceMetadata
-                {
-                    Resource = oauthSettings.CanonicalResource(),
-                    AuthorizationServers = [.. oauthSettings.AuthorizationServers.Select(server => server.ValidatedIssuer())],
-                    ScopesSupported = [.. oauthSettings.RequiredScopes],
-                    BearerMethodsSupported = ["header"],
-                    ResourceName = "MailFathom",
-                };
-            });
-
-        foreach (var authorizationServer in oauthSettings.AuthorizationServers)
-        {
-            authentication.AddJwtBearer(
-                McpOAuthAuthentication.SchemeNameFor(authorizationServer.Name!),
-                jwtOptions => ConfigureAuthorizationServer(jwtOptions, authorizationServer, oauthSettings));
-        }
-    }
-
-    /// <summary>Configures one authorization server's token validator, its metadata retrieval, and its key set.</summary>
+    /// <summary>Registers the refusal that names the scope an authenticated token was missing.</summary>
     /// <remarks>
-    /// <para>
-    /// Every profile gets its own configuration manager, which is what keeps two authorization servers isolated. A key
-    /// set is reachable only from the scheme whose issuer published it, so a signing key that two servers happen to
-    /// identify the same way never validates a token claiming the other's issuer.
-    /// </para>
-    /// <para>
-    /// Nothing about the server's own endpoints is assembled here. The key set address comes out of the discovery
-    /// document, which is itself found at the addresses the MCP authorization specification names, so a server that
-    /// moves an endpoint keeps working and one that publishes no document fails to configure rather than being reached
-    /// at a guessed path.
-    /// </para>
+    /// Only a required scope can turn an authenticated caller away, so this is registered only where one exists. Without
+    /// it the endpoint answers every failure with a challenge, and there would be nothing for this to say.
     /// </remarks>
-    private static void ConfigureAuthorizationServer(
-        JwtBearerOptions jwtOptions,
-        McpAuthorizationServerOptions authorizationServer,
-        McpOAuthOptions oauthSettings)
+    private static void AddInsufficientScopeRefusal(IServiceCollection services, OAuthValidationOptions oauthSettings)
     {
-        var issuer = authorizationServer.ValidatedIssuer();
-        var metadataAddresses = authorizationServer.MetadataAddresses();
-
-        jwtOptions.MetadataAddress = metadataAddresses[0];
-        jwtOptions.RequireHttpsMetadata = true;
-
-        // The claims stay under the names the token used, because the identity mapping below reads 'iss' and 'sub'. The
-        // framework's default renames them to long-form SOAP claim types, which would leave that mapping reading claims
-        // that no longer exist and quietly producing no identity.
-        jwtOptions.MapInboundClaims = false;
-
-        // No error description reaches the client. The framework's default reports why a token was refused, which tells
-        // an unauthenticated caller whether an issuer is configured, whether an audience matched, and whether a token
-        // merely expired. The server log keeps all of it.
-        jwtOptions.IncludeErrorDetails = false;
-
-        jwtOptions.Backchannel = MetadataBackchannel();
-        jwtOptions.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
-            metadataAddresses[0],
-            new OAuthAuthorizationServerMetadataRetriever(authorizationServer.Name!, issuer, metadataAddresses),
-            new HttpDocumentRetriever(jwtOptions.Backchannel) { RequireHttps = true })
+        if (oauthSettings.RequiredScopes.Count == 0)
         {
-            AutomaticRefreshInterval = McpOAuthAuthentication.MetadataRefreshInterval,
-            RefreshInterval = McpOAuthAuthentication.MetadataRefreshThrottle,
-            LastKnownGoodLifetime = McpOAuthAuthentication.LastKnownGoodMetadataLifetime,
-        };
-
-        jwtOptions.TokenValidationParameters = McpOAuthAuthentication.TokenValidationParametersFor(
-            issuer,
-            oauthSettings.CanonicalResource());
-
-        jwtOptions.Events = new JwtBearerEvents
-        {
-            OnMessageReceived = RefuseATokenThatArrivedWithoutTransportEncryption,
-            OnTokenValidated = ReplacePrincipalWithMinimalIdentity,
-        };
-    }
-
-    /// <summary>Refuses a bearer token presented over a connection that was not encrypted.</summary>
-    /// <remarks>
-    /// <para>
-    /// An access token is a reusable credential, so a request carrying one over plain HTTP hands it to anybody watching
-    /// the network — and unlike a password nothing about presenting it a second time looks unusual. The resource
-    /// identifier being HTTPS and metadata retrieval requiring HTTPS protect what this deployment publishes and what it
-    /// fetches; neither says anything about the transport an incoming request arrived on.
-    /// </para>
-    /// <para>
-    /// Nothing that worked before is refused by this. A deployment reached over plain HTTP cannot complete OAuth
-    /// discovery anyway, because the SDK serves the protected resource metadata document only to a request whose own
-    /// scheme and host match the configured resource. What this closes is a host listening on both an encrypted and a
-    /// plaintext endpoint, where discovery succeeds over the first and the token is then presented over the second.
-    /// </para>
-    /// <para>
-    /// The refusal is silent — no result rather than a failure — so the caller receives the same challenge an
-    /// unauthenticated request receives, and the token is never read, validated, or recorded.
-    /// </para>
-    /// </remarks>
-    internal static Task RefuseATokenThatArrivedWithoutTransportEncryption(MessageReceivedContext context)
-    {
-        if (!context.Request.IsHttps)
-        {
-            context.NoResult();
+            return;
         }
 
-        return Task.CompletedTask;
-    }
-
-    /// <summary>Reduces a validated token to the identity MailFathom keeps of it.</summary>
-    /// <remarks>
-    /// The validated principal carries every claim the authorization server chose to include, which routinely means a
-    /// name, an address, and a set of groups. Replacing it here means nothing downstream can read one, so a later change
-    /// cannot start depending on a claim the operator never mapped.
-    /// </remarks>
-    private static Task ReplacePrincipalWithMinimalIdentity(TokenValidatedContext context)
-    {
-        var identity = context.Principal is { } validatedPrincipal
-            ? McpOAuthIdentity.FromValidatedToken(validatedPrincipal.Claims, context.Scheme.Name)
-            : null;
-
-        if (identity is null)
-        {
-            context.Fail("The validated token names no subject.");
-
-            return Task.CompletedTask;
-        }
-
-        context.Principal = new ClaimsPrincipal(identity);
-
-        return Task.CompletedTask;
-    }
-
-    /// <summary>Builds the client the discovery document and key set are retrieved through.</summary>
-    /// <remarks>
-    /// It follows no redirect and reads no more than the stated limit, so an authorization server cannot send a key
-    /// refresh somewhere the configuration never named or answer it with an unbounded body. The timeout bounds how long
-    /// a refresh can hold the request that provoked it.
-    /// </remarks>
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The client and its handlers are owned by the JwtBearerOptions this is assigned to and live for the process lifetime; disposing them here would leave every key refresh without a transport.")]
-    private static HttpClient MetadataBackchannel()
-    {
-        var transport = new HttpClientHandler { AllowAutoRedirect = false };
-
-        return new HttpClient(new BoundedMetadataHttpMessageHandler(transport, McpOAuthOptions.MetadataSizeLimitInBytes))
-        {
-            Timeout = McpOAuthOptions.MetadataRetrievalTimeout,
-        };
-    }
-
-    /// <summary>Registers the requirement the MCP endpoint carries, and the refusal an insufficient token receives.</summary>
-    private static void AddAuthorizationPolicy(IServiceCollection services, McpEndpointOptions endpointSettings)
-    {
-        var requiredScopes = endpointSettings.AllowsOAuth
-            ? endpointSettings.OAuth.RequiredScopes.ToArray()
-            : [];
-
-        var authorizedIdentities = endpointSettings.AllowsOAuth
-            ? endpointSettings.OAuth.AuthorizedIdentities()
-            : new HashSet<string>(StringComparer.Ordinal);
-
-        services.AddAuthorization(authorizationOptions => authorizationOptions.AddPolicy(
-            McpAccessPolicy.PolicyName,
-            policy => policy
-                .AddAuthenticationSchemes(McpOAuthAuthentication.RoutingSchemeName)
-                .RequireAssertion(context =>
-                    McpAccessPolicy.IsAuthorized(context.User, authorizedIdentities, requiredScopes))));
-
-        // Only a required scope can turn an authenticated caller away, so the refusal that explains which scope is
-        // missing is registered only where one exists. Without it the endpoint answers every failure with a challenge,
-        // and there is nothing for this to say.
-        if (requiredScopes.Length > 0)
-        {
-            services.AddSingleton<IAuthorizationMiddlewareResultHandler>(
-                new McpInsufficientScopeResultHandler(
-                    requiredScopes,
-                    endpointSettings.OAuth.ProtectedResourceMetadataAddress()));
-        }
+        services.AddSingleton<IAuthorizationMiddlewareResultHandler>(
+            new InsufficientScopeResultHandler(
+                [.. oauthSettings.RequiredScopes],
+                McpProtectedResourceMetadata.AddressFor(oauthSettings.CanonicalResource())));
     }
 
     /// <summary>Builds the CORS policy from the configured origins.</summary>

--- a/src/Host/Security/OAuthTokenValidation.cs
+++ b/src/Host/Security/OAuthTokenValidation.cs
@@ -7,16 +7,15 @@ using Microsoft.IdentityModel.Tokens;
 
 namespace MailFathom.Host.Security;
 
-/// <summary>The constants the OAuth side of the MCP endpoint is composed from.</summary>
+/// <summary>The rules an access token is judged by, whichever surface it was presented to.</summary>
 /// <remarks>
 /// They are constants rather than settings on purpose. Each one is a security decision with a single defensible answer,
-/// and a deployment that could weaken it would eventually be a deployment that had.
+/// and a deployment that could weaken it would eventually be a deployment that had. They are stated once for the process
+/// rather than once per surface for the same reason: a surface free to accept a weaker signature algorithm than another
+/// would make the whole deployment as weak as its most permissive one.
 /// </remarks>
-internal static class McpOAuthAuthentication
+internal static class OAuthTokenValidation
 {
-    /// <summary>The scheme that decides which credential a request presented and forwards it to the handler that judges it.</summary>
-    internal const string RoutingSchemeName = "MailFathomTransport";
-
     /// <summary>The signature algorithms a token may be signed with.</summary>
     /// <remarks>
     /// <para>
@@ -79,12 +78,6 @@ internal static class McpOAuthAuthentication
     /// </remarks>
     internal static readonly TimeSpan LastKnownGoodMetadataLifetime = TimeSpan.FromHours(1);
 
-    /// <summary>Names the scheme that validates tokens from one configured authorization server.</summary>
-    /// <param name="authorizationServerName">The operator's name for the profile.</param>
-    /// <returns>The scheme name.</returns>
-    internal static string SchemeNameFor(string authorizationServerName) =>
-        $"MailFathomOAuth:{authorizationServerName}";
-
     /// <summary>States what a token from one authorization server must satisfy to be accepted.</summary>
     /// <param name="issuer">The profile's issuer, compared against the token's <c>iss</c>.</param>
     /// <param name="canonicalResource">The resource identifier the token's audience must name.</param>
@@ -121,11 +114,11 @@ internal static class McpOAuthAuthentication
             // answering, rather than refusing every request the moment it becomes unreachable or trusting it forever.
             ValidateWithLKG = true,
 
-            NameClaimType = McpOAuthIdentity.SubjectClaimType,
+            NameClaimType = OAuthIdentity.SubjectClaimType,
 
             // A claim type nothing issues, which is what makes a role check answer no. The validator rejects an empty
             // one, and the framework's default would let a 'role' claim an authorization server chose to include answer
             // a check no configuration ever authorized.
-            RoleClaimType = McpOAuthIdentity.RoleClaimType,
+            RoleClaimType = OAuthIdentity.RoleClaimType,
         };
 }

--- a/src/Host/Security/TransportAccessPolicy.cs
+++ b/src/Host/Security/TransportAccessPolicy.cs
@@ -7,13 +7,19 @@ using MailFathom.Infrastructure.Security;
 
 namespace MailFathom.Host.Security;
 
-/// <summary>What an authenticated caller must satisfy before a tool runs.</summary>
+/// <summary>What an authenticated caller must satisfy before a protected surface serves it.</summary>
 /// <remarks>
 /// <para>
-/// Which mailboxes a tool reads is decided by the configured accounts and not by who is asking, so every caller this
-/// policy admits reads the same mail. That is what makes the two questions below the whole of the boundary: a token
+/// What a surface exposes is decided by its configuration and not by who is asking, so every caller one of these
+/// policies admits reaches the same thing. That is what makes the two questions below the whole of the boundary: a token
 /// proves which person an authorization server signed in, and this decides whether that person is one this deployment
 /// serves at all.
+/// </para>
+/// <para>
+/// The rule is the same for every surface, and it is the registration that differs: each surface names its own policy
+/// through <see cref="TransportSurface.AccessPolicyName" /> and hands in its own authorized identities and required
+/// scopes. Sharing the judgement while separating the inputs is what keeps two surfaces from drifting into two
+/// definitions of what an authorized caller is.
 /// </para>
 /// <para>
 /// Neither an authorized subject nor a required scope is ever asked of an API key. A key is a credential the operator
@@ -22,16 +28,13 @@ namespace MailFathom.Host.Security;
 /// Asking either of a key would mean asking a credential for something nothing can ever put in it.
 /// </para>
 /// </remarks>
-internal static class McpAccessPolicy
+internal static class TransportAccessPolicy
 {
-    /// <summary>The name the endpoint's authorization requirement is registered under.</summary>
-    internal const string PolicyName = "MailFathomEndpoint";
-
     /// <summary>Judges an authenticated principal against the people the deployment serves and the scopes it requires.</summary>
     /// <param name="principal">The principal a validated credential produced.</param>
     /// <param name="authorizedIdentities">The issuer and subject pairs a token may name, taken from the configured authorization servers.</param>
     /// <param name="requiredScopes">The scopes an access token must carry, empty when any token from an authorized subject suffices.</param>
-    /// <returns><see langword="true" /> when the caller may reach a tool; otherwise <see langword="false" />.</returns>
+    /// <returns><see langword="true" /> when the caller may reach the surface; otherwise <see langword="false" />.</returns>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     /// <remarks>A token has to satisfy both: a subject the deployment serves and every scope it requires. Neither substitutes for the other, because a scope says what a token was issued for and a subject says whose it is.</remarks>
     internal static bool IsAuthorized(
@@ -54,7 +57,7 @@ internal static class McpAccessPolicy
         }
 
         return NamesAnAuthorizedSubject(principal, authorizedIdentities)
-            && McpOAuthIdentity.CarriesEveryScope(principal, requiredScopes);
+            && OAuthIdentity.CarriesEveryScope(principal, requiredScopes);
     }
 
     /// <summary>Reports whether an authenticated token names one of the people this deployment serves.</summary>
@@ -64,9 +67,9 @@ internal static class McpAccessPolicy
     /// all is refused rather than treated as unrestricted.
     /// </remarks>
     private static bool NamesAnAuthorizedSubject(ClaimsPrincipal principal, IReadOnlySet<string> authorizedIdentities) =>
-        McpOAuthIdentity.IdentityCarriedBy(principal) is { } identity && authorizedIdentities.Contains(identity);
+        OAuthIdentity.IdentityCarriedBy(principal) is { } identity && authorizedIdentities.Contains(identity);
 
     /// <summary>Reports whether an API key produced this principal, judged by what the principal carries rather than by which scheme named it.</summary>
     private static bool AuthenticatedWithAnApiKey(ClaimsPrincipal principal) =>
-        principal.HasClaim(claim => claim.Type == McpApiKeyAuthentication.ApiKeyNameClaimType);
+        principal.HasClaim(claim => claim.Type == ApiKeyAuthentication.ApiKeyNameClaimType);
 }

--- a/src/Host/Security/TransportHttpsEndpointBinder.cs
+++ b/src/Host/Security/TransportHttpsEndpointBinder.cs
@@ -35,7 +35,7 @@ namespace MailFathom.Host.Security;
 /// name is known. Profiles sharing an address are therefore required to agree on it, which the section validates.
 /// </para>
 /// </remarks>
-internal static class McpHttpsEndpointBinder
+internal static class TransportHttpsEndpointBinder
 {
     /// <summary>Binds one Kestrel listener per address the configured profiles name.</summary>
     /// <param name="kestrelOptions">The server options being composed.</param>
@@ -45,8 +45,8 @@ internal static class McpHttpsEndpointBinder
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
     internal static void Bind(
         KestrelServerOptions kestrelOptions,
-        McpHttpsOptions httpsSettings,
-        McpServerCertificateStore certificateStore,
+        TransportHttpsOptions httpsSettings,
+        TransportServerCertificateStore certificateStore,
         bool requestClientCertificates)
     {
         ArgumentNullException.ThrowIfNull(kestrelOptions);
@@ -83,9 +83,9 @@ internal static class McpHttpsEndpointBinder
     /// </remarks>
     [SuppressMessage("Security", "CA5359:Do not disable certificate validation", Justification = "CA5359 reads this callback as a client deciding to trust the server it dialled, where accepting everything defeats TLS. This is the server side of the handshake and the certificate is the client's: refusing here would end the connection for the private authority a trust profile names, and accepting here grants nothing, because whether the certificate identifies a client this deployment serves is decided afterwards by McpClientCertificateValidation against that profile's own anchors, expected names, and required usage. It is set only when a profile exists to make that decision, and it is the same posture HttpsConnectionAdapterOptions.ClientCertificateValidation states for a listener built from a URL.")]
     private static ValueTask<SslServerAuthenticationOptions> SelectIdentity(
-        McpServerCertificateStore certificateStore,
-        McpHttpsListenerAddress listener,
-        IReadOnlyList<McpHttpProtocol> servedProtocols,
+        TransportServerCertificateStore certificateStore,
+        TransportHttpsListenerAddress listener,
+        IReadOnlyList<TransportHttpProtocol> servedProtocols,
         bool requestClientCertificates,
         TlsHandshakeCallbackContext context)
     {
@@ -129,14 +129,14 @@ internal static class McpHttpsEndpointBinder
     }
 
     /// <summary>Maps the configured versions onto the flags a Kestrel listener is bound with.</summary>
-    private static HttpProtocols MapProtocols(IReadOnlyList<McpHttpProtocol> servedProtocols) =>
+    private static HttpProtocols MapProtocols(IReadOnlyList<TransportHttpProtocol> servedProtocols) =>
         servedProtocols.Aggregate(
             HttpProtocols.None,
             static (mapped, protocol) => mapped | protocol switch
             {
-                McpHttpProtocol.Http1 => HttpProtocols.Http1,
-                McpHttpProtocol.Http2 => HttpProtocols.Http2,
-                McpHttpProtocol.Http3 => HttpProtocols.Http3,
+                TransportHttpProtocol.Http1 => HttpProtocols.Http1,
+                TransportHttpProtocol.Http2 => HttpProtocols.Http2,
+                TransportHttpProtocol.Http3 => HttpProtocols.Http3,
                 _ => HttpProtocols.None,
             });
 
@@ -146,16 +146,16 @@ internal static class McpHttpsEndpointBinder
     /// clients through an alternative-service header, so offering it here would name a version this connection cannot
     /// switch to.
     /// </remarks>
-    private static List<SslApplicationProtocol> NegotiableProtocols(IReadOnlyList<McpHttpProtocol> servedProtocols)
+    private static List<SslApplicationProtocol> NegotiableProtocols(IReadOnlyList<TransportHttpProtocol> servedProtocols)
     {
         var negotiable = new List<SslApplicationProtocol>(capacity: 2);
 
-        if (servedProtocols.Contains(McpHttpProtocol.Http2))
+        if (servedProtocols.Contains(TransportHttpProtocol.Http2))
         {
             negotiable.Add(SslApplicationProtocol.Http2);
         }
 
-        if (servedProtocols.Contains(McpHttpProtocol.Http1))
+        if (servedProtocols.Contains(TransportHttpProtocol.Http1))
         {
             negotiable.Add(SslApplicationProtocol.Http11);
         }

--- a/src/Host/Security/TransportSecurityExtensions.cs
+++ b/src/Host/Security/TransportSecurityExtensions.cs
@@ -1,0 +1,297 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
+using MailFathom.Host.Configuration;
+using MailFathom.Infrastructure.Secrets;
+using MailFathom.Infrastructure.Security;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace MailFathom.Host.Security;
+
+/// <summary>Registers the credentials one transport surface accepts, and the requirement its routes carry.</summary>
+/// <remarks>
+/// <para>
+/// Authentication is composed of as many schemes as the surface turned on, sitting behind one scheme that routes to
+/// them. That shape is what lets an API key and an access token be accepted at once without either check weakening: each
+/// credential reaches the handler that understands it, and a handler never sees a credential of the other kind.
+/// </para>
+/// <para>
+/// Every name the registration uses comes from the <see cref="TransportSurface" /> it is given, so two surfaces
+/// registered through this method share the code and share nothing else. A key configured for one authenticates nothing
+/// on the other, a token accepted by one is never consulted for the other, and neither surface's policy can be satisfied
+/// by the other's credential — because a policy names only its own routing scheme.
+/// </para>
+/// </remarks>
+internal static class TransportSecurityExtensions
+{
+    /// <summary>Adds one surface's authentication schemes and its authorization requirement.</summary>
+    /// <param name="services">The container to add to.</param>
+    /// <param name="surface">The surface being protected, which names every scheme and the policy.</param>
+    /// <param name="methods">The credentials this surface accepts.</param>
+    /// <param name="apiKeys">The API key references a request may present one of, consulted only when <paramref name="methods" /> includes them.</param>
+    /// <param name="oauthSettings">The authorization servers and token requirements, consulted only when <paramref name="methods" /> includes OAuth.</param>
+    /// <param name="challengeSchemeName">The scheme answering a request that presented no credential at all.</param>
+    /// <returns>The authentication builder, so a surface can add schemes only it needs.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any reference argument is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="surface" /> is the struct default.</exception>
+    /// <remarks>
+    /// <para>
+    /// The routing scheme becomes the application's default, so every part of the pipeline that asks for "the" scheme
+    /// reaches the one place that knows how many schemes there are, and nothing downstream names an individual scheme.
+    /// </para>
+    /// <para>
+    /// There is one application-wide default, which is what a second surface has to plan around: calling this twice
+    /// leaves the later registration's routing scheme as the default, and with it the scheme
+    /// <c>UseAuthentication</c> runs to populate <c>HttpContext.User</c>. Authorization is unaffected, because each
+    /// surface's policy names its own routing scheme explicitly rather than relying on the default — but a surface
+    /// registered second must scope its authentication middleware to its own routes rather than adding a second global
+    /// one, or requests to the first surface would be pre-authenticated under the second's schemes.
+    /// </para>
+    /// </remarks>
+    internal static AuthenticationBuilder AddTransportAuthentication(
+        this IServiceCollection services,
+        TransportSurface surface,
+        TransportAuthenticationMethods methods,
+        IReadOnlyList<ConfiguredSecret> apiKeys,
+        OAuthValidationOptions oauthSettings,
+        string challengeSchemeName)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(apiKeys);
+        ArgumentNullException.ThrowIfNull(oauthSettings);
+        ArgumentNullException.ThrowIfNull(challengeSchemeName);
+
+        if (!surface.IsSpecified)
+        {
+            throw new ArgumentException("A transport surface is required to name the schemes and the policy.", nameof(surface));
+        }
+
+        var allowsApiKey = methods.HasFlag(TransportAuthenticationMethods.ApiKey);
+        var allowsOAuth = methods.HasFlag(TransportAuthenticationMethods.OAuth);
+
+        var authentication = services.AddAuthentication(surface.RoutingSchemeName);
+
+        AddRoutingScheme(authentication, surface, allowsApiKey, allowsOAuth, oauthSettings, challengeSchemeName);
+
+        if (allowsApiKey)
+        {
+            // Added once however many surfaces accept a key, because the authenticator holds no surface state: which
+            // keys it compares against arrive as an argument on every call. A second registration would resolve the
+            // same thing twice over and leave which instance answers decided by registration order.
+            services.TryAddSingleton<ApiKeyAuthenticator>();
+            authentication.AddScheme<ApiKeyAuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(
+                surface.ApiKeySchemeName,
+                schemeOptions =>
+                {
+                    schemeOptions.Surface = surface;
+                    schemeOptions.ApiKeys = apiKeys;
+                });
+        }
+
+        if (allowsOAuth)
+        {
+            foreach (var authorizationServer in oauthSettings.AuthorizationServers)
+            {
+                authentication.AddJwtBearer(
+                    surface.OAuthSchemeNameFor(authorizationServer.Name!),
+                    jwtOptions => ConfigureAuthorizationServer(jwtOptions, authorizationServer, oauthSettings));
+            }
+        }
+
+        AddAuthorizationPolicy(services, surface, allowsOAuth, oauthSettings);
+
+        return authentication;
+    }
+
+    /// <summary>Refuses a bearer token presented over a connection that was not encrypted.</summary>
+    /// <remarks>
+    /// <para>
+    /// An access token is a reusable credential, so a request carrying one over plain HTTP hands it to anybody watching
+    /// the network — and unlike a password nothing about presenting it a second time looks unusual. The resource
+    /// identifier being HTTPS and metadata retrieval requiring HTTPS protect what this deployment publishes and what it
+    /// fetches; neither says anything about the transport an incoming request arrived on.
+    /// </para>
+    /// <para>
+    /// The refusal is silent — no result rather than a failure — so the caller receives the same challenge an
+    /// unauthenticated request receives, and the token is never read, validated, or recorded.
+    /// </para>
+    /// </remarks>
+    internal static Task RefuseATokenThatArrivedWithoutTransportEncryption(MessageReceivedContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (!context.Request.IsHttps)
+        {
+            context.NoResult();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Registers the scheme that reads the presented credential and forwards it to the handler that judges it.</summary>
+    private static void AddRoutingScheme(
+        AuthenticationBuilder authentication,
+        TransportSurface surface,
+        bool allowsApiKey,
+        bool allowsOAuth,
+        OAuthValidationOptions oauthSettings,
+        string challengeSchemeName)
+    {
+        var oauthSchemesByIssuer = allowsOAuth
+            ? oauthSettings.AuthorizationServers.ToDictionary(
+                authorizationServer => authorizationServer.ValidatedIssuer(),
+                authorizationServer => surface.OAuthSchemeNameFor(authorizationServer.Name!),
+                StringComparer.Ordinal)
+            : [];
+
+        var schemeSelector = new CredentialSchemeSelector(
+            oauthSchemesByIssuer,
+            allowsApiKey ? surface.ApiKeySchemeName : null,
+            challengeSchemeName);
+
+        authentication.AddPolicyScheme(
+            surface.RoutingSchemeName,
+            displayName: null,
+            policyOptions =>
+            {
+                policyOptions.ForwardDefaultSelector = context =>
+                    schemeSelector.SchemeFor(context.Request.Headers.Authorization.ToString());
+
+                // A challenge is answered by one scheme whichever credential was presented, because a request that has
+                // nothing to authenticate with has told us nothing about which kind of credential it was going to use.
+                policyOptions.ForwardChallenge = challengeSchemeName;
+            });
+    }
+
+    /// <summary>Configures one authorization server's token validator, its metadata retrieval, and its key set.</summary>
+    /// <remarks>
+    /// <para>
+    /// Every profile gets its own configuration manager, which is what keeps two authorization servers isolated. A key
+    /// set is reachable only from the scheme whose issuer published it, so a signing key that two servers happen to
+    /// identify the same way never validates a token claiming the other's issuer.
+    /// </para>
+    /// <para>
+    /// Nothing about the server's own endpoints is assembled here. The key set address comes out of the discovery
+    /// document, so a server that moves an endpoint keeps working and one that publishes no document fails to configure
+    /// rather than being reached at a guessed path.
+    /// </para>
+    /// </remarks>
+    private static void ConfigureAuthorizationServer(
+        JwtBearerOptions jwtOptions,
+        AuthorizationServerOptions authorizationServer,
+        OAuthValidationOptions oauthSettings)
+    {
+        var issuer = authorizationServer.ValidatedIssuer();
+        var metadataAddresses = authorizationServer.MetadataAddresses();
+
+        jwtOptions.MetadataAddress = metadataAddresses[0];
+        jwtOptions.RequireHttpsMetadata = true;
+
+        // The claims stay under the names the token used, because the identity mapping below reads 'iss' and 'sub'. The
+        // framework's default renames them to long-form SOAP claim types, which would leave that mapping reading claims
+        // that no longer exist and quietly producing no identity.
+        jwtOptions.MapInboundClaims = false;
+
+        // No error description reaches the client. The framework's default reports why a token was refused, which tells
+        // an unauthenticated caller whether an issuer is configured, whether an audience matched, and whether a token
+        // merely expired. The server log keeps all of it.
+        jwtOptions.IncludeErrorDetails = false;
+
+        jwtOptions.Backchannel = MetadataBackchannel();
+        jwtOptions.ConfigurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+            metadataAddresses[0],
+            new OAuthAuthorizationServerMetadataRetriever(authorizationServer.Name!, issuer, metadataAddresses),
+            new HttpDocumentRetriever(jwtOptions.Backchannel) { RequireHttps = true })
+        {
+            AutomaticRefreshInterval = OAuthTokenValidation.MetadataRefreshInterval,
+            RefreshInterval = OAuthTokenValidation.MetadataRefreshThrottle,
+            LastKnownGoodLifetime = OAuthTokenValidation.LastKnownGoodMetadataLifetime,
+        };
+
+        jwtOptions.TokenValidationParameters = OAuthTokenValidation.TokenValidationParametersFor(
+            issuer,
+            oauthSettings.CanonicalResource());
+
+        jwtOptions.Events = new JwtBearerEvents
+        {
+            OnMessageReceived = RefuseATokenThatArrivedWithoutTransportEncryption,
+            OnTokenValidated = ReplacePrincipalWithMinimalIdentity,
+        };
+    }
+
+    /// <summary>Reduces a validated token to the identity MailFathom keeps of it.</summary>
+    /// <remarks>
+    /// The validated principal carries every claim the authorization server chose to include, which routinely means a
+    /// name, an address, and a set of groups. Replacing it here means nothing downstream can read one, so a later change
+    /// cannot start depending on a claim the operator never mapped.
+    /// </remarks>
+    private static Task ReplacePrincipalWithMinimalIdentity(TokenValidatedContext context)
+    {
+        var identity = context.Principal is { } validatedPrincipal
+            ? OAuthIdentity.FromValidatedToken(validatedPrincipal.Claims, context.Scheme.Name)
+            : null;
+
+        if (identity is null)
+        {
+            context.Fail("The validated token names no subject.");
+
+            return Task.CompletedTask;
+        }
+
+        context.Principal = new ClaimsPrincipal(identity);
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Builds the client the discovery document and key set are retrieved through.</summary>
+    /// <remarks>
+    /// It follows no redirect and reads no more than the stated limit, so an authorization server cannot send a key
+    /// refresh somewhere the configuration never named or answer it with an unbounded body. The timeout bounds how long
+    /// a refresh can hold the request that provoked it.
+    /// </remarks>
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The client and its handlers are owned by the JwtBearerOptions this is assigned to and live for the process lifetime; disposing them here would leave every key refresh without a transport.")]
+    private static HttpClient MetadataBackchannel()
+    {
+        var transport = new HttpClientHandler { AllowAutoRedirect = false };
+
+        return new HttpClient(new BoundedMetadataHttpMessageHandler(transport, OAuthValidationOptions.MetadataSizeLimitInBytes))
+        {
+            Timeout = OAuthValidationOptions.MetadataRetrievalTimeout,
+        };
+    }
+
+    /// <summary>Registers the requirement this surface's routes carry.</summary>
+    /// <remarks>
+    /// The policy names only this surface's routing scheme, which is what keeps a credential the other surface accepts
+    /// from ever being consulted here. How a refusal is *worded* is not registered with it: an
+    /// <see cref="IAuthorizationMiddlewareResultHandler" /> is one object for the whole application, so a surface that
+    /// shapes its own refusal registers it itself rather than through a method two surfaces call.
+    /// </remarks>
+    private static void AddAuthorizationPolicy(
+        IServiceCollection services,
+        TransportSurface surface,
+        bool allowsOAuth,
+        OAuthValidationOptions oauthSettings)
+    {
+        var requiredScopes = allowsOAuth ? oauthSettings.RequiredScopes.ToArray() : [];
+
+        var authorizedIdentities = allowsOAuth
+            ? oauthSettings.AuthorizedIdentities()
+            : new HashSet<string>(StringComparer.Ordinal);
+
+        services.AddAuthorization(authorizationOptions => authorizationOptions.AddPolicy(
+            surface.AccessPolicyName,
+            policy => policy
+                .AddAuthenticationSchemes(surface.RoutingSchemeName)
+                .RequireAssertion(context =>
+                    TransportAccessPolicy.IsAuthorized(context.User, authorizedIdentities, requiredScopes))));
+    }
+}

--- a/src/Host/Security/TransportServerCertificateStore.cs
+++ b/src/Host/Security/TransportServerCertificateStore.cs
@@ -32,39 +32,49 @@ namespace MailFathom.Host.Security;
 /// The store owns every certificate it loaded and releases them on disposal, which the container performs at shutdown.
 /// </para>
 /// </remarks>
-internal sealed partial class McpServerCertificateStore : IDisposable
+internal sealed partial class TransportServerCertificateStore : IDisposable
 {
-    private readonly McpHttpsOptions httpsSettings;
+    private readonly TransportHttpsOptions httpsSettings;
+    private readonly string configurationSectionPath;
     private readonly TlsServerCertificateLoader certificateLoader;
     private readonly TimeProvider timeProvider;
-    private readonly ILogger<McpServerCertificateStore> logger;
+    private readonly ILogger<TransportServerCertificateStore> logger;
     private readonly List<TlsServerCertificate> ownedCertificates = [];
 
     // Frozen because it is built once at startup and then read on every handshake, which is exactly the shape the
     // frozen collections are for. Empty until loading has published, so a handshake that somehow arrives first is
     // refused rather than served by a half-filled lookup.
-    private FrozenDictionary<McpHttpsListenerAddress, FrozenDictionary<string, McpTlsEndpointIdentity>> identities =
-        FrozenDictionary<McpHttpsListenerAddress, FrozenDictionary<string, McpTlsEndpointIdentity>>.Empty;
+    private FrozenDictionary<TransportHttpsListenerAddress, FrozenDictionary<string, TransportTlsEndpointIdentity>> identities =
+        FrozenDictionary<TransportHttpsListenerAddress, FrozenDictionary<string, TransportTlsEndpointIdentity>>.Empty;
 
     private bool disposed;
 
-    /// <summary>Initializes a new certificate store over the configured HTTPS profiles.</summary>
-    /// <param name="endpointSettings">The endpoint settings composition read.</param>
+    /// <summary>Initializes a new certificate store over one surface's configured HTTPS profiles.</summary>
+    /// <param name="httpsSettings">The HTTPS profiles this store loads, which belong to one endpoint.</param>
+    /// <param name="configurationSectionPath">The configuration path those profiles were bound from, which prefixes every reported error.</param>
     /// <param name="certificateLoader">The loader that turns configured material into a validated identity.</param>
     /// <param name="timeProvider">The clock expiry notices are measured against.</param>
     /// <param name="logger">The startup logger.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
-    public McpServerCertificateStore(
-        IOptions<McpEndpointOptions> endpointSettings,
+    /// <remarks>
+    /// The profiles arrive as an argument rather than being read from an endpoint's settings, so an endpoint added later
+    /// gets a store of its own instead of this one growing a second section to look in. Each store owns and disposes the
+    /// certificates it loaded, which is what keeps one endpoint's material out of another's lookup.
+    /// </remarks>
+    public TransportServerCertificateStore(
+        TransportHttpsOptions httpsSettings,
+        string configurationSectionPath,
         TlsServerCertificateLoader certificateLoader,
         TimeProvider timeProvider,
-        ILogger<McpServerCertificateStore> logger)
+        ILogger<TransportServerCertificateStore> logger)
     {
-        ArgumentNullException.ThrowIfNull(endpointSettings);
+        ArgumentNullException.ThrowIfNull(httpsSettings);
+        ArgumentNullException.ThrowIfNull(configurationSectionPath);
         ArgumentNullException.ThrowIfNull(certificateLoader);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
-        this.httpsSettings = endpointSettings.Value.Https;
+        this.httpsSettings = httpsSettings;
+        this.configurationSectionPath = configurationSectionPath;
         this.certificateLoader = certificateLoader;
         this.timeProvider = timeProvider;
         this.logger = logger;
@@ -83,13 +93,13 @@ internal sealed partial class McpServerCertificateStore : IDisposable
     internal async Task LoadAsync(CancellationToken cancellationToken)
     {
         var errors = new List<string>();
-        var loaded = new Dictionary<McpHttpsListenerAddress, Dictionary<string, McpTlsEndpointIdentity>>();
+        var loaded = new Dictionary<TransportHttpsListenerAddress, Dictionary<string, TransportTlsEndpointIdentity>>();
 
         // The loop stays a loop rather than becoming a projection: each step awaits a retrieval, and each successful
         // step takes ownership of a certificate that has to be released even when a later step fails.
         foreach (var (index, endpoint) in this.httpsSettings.Endpoints.Index())
         {
-            var configurationPath = $"{McpEndpointOptions.SectionName}:{nameof(McpEndpointOptions.Https)}:{nameof(McpHttpsOptions.Endpoints)}:{index}";
+            var configurationPath = $"{this.configurationSectionPath}:{nameof(TransportHttpsOptions.Endpoints)}:{index}";
             var domain = endpoint.Domain.Trim();
 
             var result = await this.certificateLoader.LoadAsync(
@@ -107,14 +117,14 @@ internal sealed partial class McpServerCertificateStore : IDisposable
             this.ownedCertificates.Add(certificate);
             this.ReportLoaded(endpoint.Name, certificate.Leaf);
 
-            var identity = new McpTlsEndpointIdentity(
+            var identity = new TransportTlsEndpointIdentity(
                 endpoint.Name,
                 SslStreamCertificateContext.Create(certificate.Leaf, [.. certificate.Intermediates]),
                 EnabledProtocolsFor(endpoint.MinimumTlsVersion));
 
             if (!loaded.TryGetValue(endpoint.ListenerAddress, out var perListener))
             {
-                perListener = new Dictionary<string, McpTlsEndpointIdentity>(StringComparer.OrdinalIgnoreCase);
+                perListener = new Dictionary<string, TransportTlsEndpointIdentity>(StringComparer.OrdinalIgnoreCase);
                 loaded.Add(endpoint.ListenerAddress, perListener);
             }
 
@@ -124,8 +134,8 @@ internal sealed partial class McpServerCertificateStore : IDisposable
         if (errors.Count > 0)
         {
             throw new OptionsValidationException(
-                McpEndpointOptions.SectionName,
-                typeof(McpEndpointOptions),
+                this.configurationSectionPath,
+                typeof(TransportHttpsOptions),
                 errors);
         }
 
@@ -143,7 +153,7 @@ internal sealed partial class McpServerCertificateStore : IDisposable
     /// publishes an exact domain, so a connection that names none is one this deployment has no identity for — and
     /// picking one anyway would hand a certificate to a client that never asked whether it was the right one.
     /// </remarks>
-    internal McpTlsEndpointIdentity? Find(McpHttpsListenerAddress listener, string? serverName)
+    internal TransportTlsEndpointIdentity? Find(TransportHttpsListenerAddress listener, string? serverName)
     {
         if (string.IsNullOrEmpty(serverName))
         {
@@ -161,9 +171,9 @@ internal sealed partial class McpServerCertificateStore : IDisposable
     /// A floor rather than a selection, so 1.2 still admits 1.3. Nothing below 1.2 appears in either branch, which is
     /// what makes a deprecated version unreachable by configuration rather than merely undocumented.
     /// </remarks>
-    [SuppressMessage("Security", "CA5398:Avoid hardcoded SslProtocols values", Justification = "Naming the versions is the feature. CA5398 asks for SslProtocols.None so the operating system chooses, which is the opposite of what this setting exists to do: it hands the floor back to machine policy, where a deployment that must refuse TLS 1.2 cannot state so and a policy change can silently lower what the endpoint accepts. Both values named here are current, nothing below TLS 1.2 is reachable through the configuration that reaches this method, and a future version is added by extending McpMinimumTlsVersion rather than by inheriting whatever the machine allows.")]
-    private static SslProtocols EnabledProtocolsFor(McpMinimumTlsVersion minimumVersion) =>
-        minimumVersion == McpMinimumTlsVersion.Tls13
+    [SuppressMessage("Security", "CA5398:Avoid hardcoded SslProtocols values", Justification = "Naming the versions is the feature. CA5398 asks for SslProtocols.None so the operating system chooses, which is the opposite of what this setting exists to do: it hands the floor back to machine policy, where a deployment that must refuse TLS 1.2 cannot state so and a policy change can silently lower what the endpoint accepts. Both values named here are current, nothing below TLS 1.2 is reachable through the configuration that reaches this method, and a future version is added by extending TransportMinimumTlsVersion rather than by inheriting whatever the machine allows.")]
+    private static SslProtocols EnabledProtocolsFor(TransportMinimumTlsVersion minimumVersion) =>
+        minimumVersion == TransportMinimumTlsVersion.Tls13
             ? SslProtocols.Tls13
             : SslProtocols.Tls12 | SslProtocols.Tls13;
 

--- a/src/Host/Security/TransportSurface.cs
+++ b/src/Host/Security/TransportSurface.cs
@@ -1,0 +1,83 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Host.Security;
+
+/// <summary>One separately protected transport surface, and the names the authentication framework knows it by.</summary>
+/// <remarks>
+/// <para>
+/// A surface is a set of routes with one credential policy in front of it. The MCP endpoint is one, and it is the reason
+/// this type exists: everything that decides whether a request is authenticated used to name that endpoint in a
+/// constant, so a second surface could not have been protected without a second copy of the same code. Passing the
+/// surface instead makes the schemes, the policy, and the keys parameters of a registration rather than properties of
+/// the process.
+/// </para>
+/// <para>
+/// The names below are what keeps two surfaces from reaching each other. Each registers its own routing scheme, and each
+/// endpoint requires an authorization policy naming only that scheme, so a credential the other surface accepts is never
+/// consulted for this one. That isolation is by scheme name rather than by an explicit check, which is what makes it
+/// hold for every route on the surface instead of for the routes somebody remembered.
+/// </para>
+/// <para>
+/// All four names are internal handles: nothing published, persisted, or configured reads them. A challenge names
+/// <see cref="ApiKeyAuthentication.Realm" /> rather than a scheme, and a client is never told which scheme judged it.
+/// They are derived from <see cref="Name" /> rather than stated per surface so that adding one cannot accidentally
+/// reuse another's, which would silently merge the two policies.
+/// </para>
+/// <para>
+/// It is a closed enumeration for the reason <see cref="Hosting.HealthProbe" /> is one: a surface is a decision about
+/// what the host serves, not a value a caller constructs. Being a struct, <see langword="default" /> is reachable and is
+/// not a surface; it reports itself through <see cref="IsSpecified" /> and refuses to answer for a name.
+/// </para>
+/// </remarks>
+internal readonly record struct TransportSurface
+{
+    private readonly string? name;
+
+    private TransportSurface(string name) => this.name = name;
+
+    /// <summary>Gets the surface serving the MCP protocol.</summary>
+    internal static TransportSurface Mcp { get; } = new("Mcp");
+
+    /// <summary>Gets whether this value names a surface rather than the unusable struct default.</summary>
+    internal bool IsSpecified => this.name is not null;
+
+    /// <summary>Gets the surface's name, which every scheme and policy name below is composed from.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a surface.</exception>
+    internal string Name => this.name
+        ?? throw new InvalidOperationException("The value is the default of the struct and names no transport surface.");
+
+    /// <summary>Gets the scheme that decides which credential a request presented and forwards it to the handler that judges it.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a surface.</exception>
+    internal string RoutingSchemeName => $"MailFathom:{this.Name}:Transport";
+
+    /// <summary>Gets the scheme comparing a presented credential against this surface's configured API keys.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a surface.</exception>
+    internal string ApiKeySchemeName => $"MailFathom:{this.Name}:ApiKey";
+
+    /// <summary>Gets the name this surface's authorization requirement is registered under.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a surface.</exception>
+    internal string AccessPolicyName => $"MailFathom:{this.Name}:Access";
+
+    /// <summary>Names the scheme that validates tokens from one of this surface's configured authorization servers.</summary>
+    /// <param name="authorizationServerName">The operator's name for the profile.</param>
+    /// <returns>The scheme name.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="authorizationServerName" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a surface.</exception>
+    /// <remarks>
+    /// The surface's name precedes the server's, so two surfaces configuring one authorization server under the same
+    /// operator-chosen name still register two schemes with two key sets. Sharing one would let either surface's
+    /// configuration decide what the other trusts.
+    /// </remarks>
+    internal string OAuthSchemeNameFor(string authorizationServerName)
+    {
+        ArgumentNullException.ThrowIfNull(authorizationServerName);
+
+        return $"MailFathom:{this.Name}:OAuth:{authorizationServerName}";
+    }
+
+    /// <inheritdoc />
+    /// <remarks>The name, because that is what a diagnostic about a surface is read by.</remarks>
+    public override string ToString() => this.name ?? "(unspecified)";
+}

--- a/src/Host/Security/TransportTlsEndpointIdentity.cs
+++ b/src/Host/Security/TransportTlsEndpointIdentity.cs
@@ -16,7 +16,7 @@ namespace MailFathom.Host.Security;
 /// chain construction that has no reason to happen per handshake. The authentication options handed to the platform are
 /// built per connection from it, since the platform is free to mutate what it is given.
 /// </remarks>
-internal sealed record McpTlsEndpointIdentity(
+internal sealed record TransportTlsEndpointIdentity(
     string ProfileName,
     SslStreamCertificateContext CertificateContext,
     SslProtocols EnabledSslProtocols);

--- a/src/Infrastructure/Security/ApiKeyAuthenticationResult.cs
+++ b/src/Infrastructure/Security/ApiKeyAuthenticationResult.cs
@@ -13,9 +13,9 @@ namespace MailFathom.Infrastructure.Security;
 /// that name is what an audit record and a diagnostic correlate on, and it is the only part of a key that may be
 /// written down.
 /// </remarks>
-public sealed record McpApiKeyAuthenticationResult
+public sealed record ApiKeyAuthenticationResult
 {
-    private McpApiKeyAuthenticationResult(SecretName? authenticatedKeyName, McpApiKeyRejection? rejection)
+    private ApiKeyAuthenticationResult(SecretName? authenticatedKeyName, ApiKeyRejection? rejection)
     {
         this.AuthenticatedKeyName = authenticatedKeyName;
         this.Rejection = rejection;
@@ -29,15 +29,15 @@ public sealed record McpApiKeyAuthenticationResult
 
     /// <summary>Gets why the credential was refused, or <see langword="null" /> when it authenticated.</summary>
     /// <remarks>It reaches the server log only. Every value produces one indistinguishable response.</remarks>
-    public McpApiKeyRejection? Rejection { get; }
+    public ApiKeyRejection? Rejection { get; }
 
     /// <summary>Creates a successful result naming the key that matched.</summary>
     /// <param name="authenticatedKeyName">The name of the matching key.</param>
     /// <returns>The successful result.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="authenticatedKeyName" /> is the unspecified struct default.</exception>
-    public static McpApiKeyAuthenticationResult Authenticated(SecretName authenticatedKeyName) =>
+    public static ApiKeyAuthenticationResult Authenticated(SecretName authenticatedKeyName) =>
         authenticatedKeyName.IsSpecified
-            ? new McpApiKeyAuthenticationResult(authenticatedKeyName, rejection: null)
+            ? new ApiKeyAuthenticationResult(authenticatedKeyName, rejection: null)
             : throw new ArgumentException(
                 "An authenticated result must name the key that matched.",
                 nameof(authenticatedKeyName));
@@ -45,6 +45,6 @@ public sealed record McpApiKeyAuthenticationResult
     /// <summary>Creates a refused result.</summary>
     /// <param name="rejection">Why the credential was refused.</param>
     /// <returns>The refused result.</returns>
-    public static McpApiKeyAuthenticationResult Rejected(McpApiKeyRejection rejection) =>
+    public static ApiKeyAuthenticationResult Rejected(ApiKeyRejection rejection) =>
         new(authenticatedKeyName: null, rejection);
 }

--- a/src/Infrastructure/Security/ApiKeyAuthenticator.cs
+++ b/src/Infrastructure/Security/ApiKeyAuthenticator.cs
@@ -31,24 +31,24 @@ namespace MailFathom.Infrastructure.Security;
 /// unrecognized one — which is exactly the distinction the single generic refusal exists to hide.
 /// </para>
 /// </remarks>
-public sealed partial class McpApiKeyAuthenticator
+public sealed partial class ApiKeyAuthenticator
 {
     private const int DigestLength = 32;
 
     private readonly byte[] comparisonKey = RandomNumberGenerator.GetBytes(DigestLength);
     private readonly ISecretReferenceResolver secretReferenceResolver;
     private readonly TimeProvider timeProvider;
-    private readonly ILogger<McpApiKeyAuthenticator> logger;
+    private readonly ILogger<ApiKeyAuthenticator> logger;
 
     /// <summary>Initializes a new API key authenticator.</summary>
     /// <param name="secretReferenceResolver">The resolver that turns a configured reference into key material.</param>
     /// <param name="timeProvider">The clock a bounded lifetime is judged against.</param>
     /// <param name="logger">The log a refusal and a configuration fault are recorded in.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="secretReferenceResolver" /> or <paramref name="timeProvider" /> is <see langword="null" />.</exception>
-    public McpApiKeyAuthenticator(
+    public ApiKeyAuthenticator(
         ISecretReferenceResolver secretReferenceResolver,
         TimeProvider timeProvider,
-        ILogger<McpApiKeyAuthenticator> logger)
+        ILogger<ApiKeyAuthenticator> logger)
     {
         ArgumentNullException.ThrowIfNull(secretReferenceResolver);
         ArgumentNullException.ThrowIfNull(timeProvider);
@@ -65,7 +65,7 @@ public sealed partial class McpApiKeyAuthenticator
     /// <returns>The name of the key that matched, or the reason the credential was refused.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuredKeys" /> is <see langword="null" />.</exception>
     /// <remarks>Neither the returned result nor anything logged on the way to it carries the presented credential, a configured reference, or key material.</remarks>
-    public async Task<McpApiKeyAuthenticationResult> AuthenticateAsync(
+    public async Task<ApiKeyAuthenticationResult> AuthenticateAsync(
         IReadOnlyList<ConfiguredSecret> configuredKeys,
         string? authorizationHeaderValue,
         CancellationToken cancellationToken)
@@ -74,9 +74,9 @@ public sealed partial class McpApiKeyAuthenticator
 
         if (!BearerCredentialHeader.TryRead(authorizationHeaderValue, out var presentedCredential))
         {
-            return McpApiKeyAuthenticationResult.Rejected(string.IsNullOrWhiteSpace(authorizationHeaderValue)
-                ? McpApiKeyRejection.CredentialMissing
-                : McpApiKeyRejection.CredentialMalformed);
+            return ApiKeyAuthenticationResult.Rejected(string.IsNullOrWhiteSpace(authorizationHeaderValue)
+                ? ApiKeyRejection.CredentialMissing
+                : ApiKeyRejection.CredentialMalformed);
         }
 
         var presentedDigest = this.DigestOfCharacters(presentedCredential);
@@ -90,17 +90,17 @@ public sealed partial class McpApiKeyAuthenticator
             var match = await this.MatchAsync(configuredKey, presentedDigest, now, cancellationToken);
 
             authenticatedKeyName = match.AuthenticatedKeyName ?? authenticatedKeyName;
-            matchedExpiredKey |= match.Rejection == McpApiKeyRejection.CredentialExpired;
+            matchedExpiredKey |= match.Rejection == ApiKeyRejection.CredentialExpired;
         }
 
         if (authenticatedKeyName is { } keyName)
         {
-            return McpApiKeyAuthenticationResult.Authenticated(keyName);
+            return ApiKeyAuthenticationResult.Authenticated(keyName);
         }
 
-        return McpApiKeyAuthenticationResult.Rejected(matchedExpiredKey
-            ? McpApiKeyRejection.CredentialExpired
-            : McpApiKeyRejection.CredentialUnrecognized);
+        return ApiKeyAuthenticationResult.Rejected(matchedExpiredKey
+            ? ApiKeyRejection.CredentialExpired
+            : ApiKeyRejection.CredentialUnrecognized);
     }
 
     /// <summary>Judges one configured key against the presented digest.</summary>
@@ -109,7 +109,7 @@ public sealed partial class McpApiKeyAuthenticator
     /// resolves and every declaration is well formed, so reaching either fault here means the deployment changed
     /// underneath a running process, which an operator has to see.
     /// </remarks>
-    private async Task<McpApiKeyAuthenticationResult> MatchAsync(
+    private async Task<ApiKeyAuthenticationResult> MatchAsync(
         ConfiguredSecret configuredKey,
         byte[] presentedDigest,
         DateTimeOffset now,
@@ -119,7 +119,7 @@ public sealed partial class McpApiKeyAuthenticator
         {
             this.LogKeyDeclarationUnusable();
 
-            return McpApiKeyAuthenticationResult.Rejected(McpApiKeyRejection.CredentialUnrecognized);
+            return ApiKeyAuthenticationResult.Rejected(ApiKeyRejection.CredentialUnrecognized);
         }
 
         var resolution = await this.secretReferenceResolver.ResolveAsync(
@@ -130,14 +130,14 @@ public sealed partial class McpApiKeyAuthenticator
         {
             this.LogKeyMaterialUnavailable(keyName.Value!, resolution.Failure);
 
-            return McpApiKeyAuthenticationResult.Rejected(McpApiKeyRejection.CredentialUnrecognized);
+            return ApiKeyAuthenticationResult.Rejected(ApiKeyRejection.CredentialUnrecognized);
         }
 
         using (material)
         {
             if (!CryptographicOperations.FixedTimeEquals(this.DigestOfTextView(material), presentedDigest))
             {
-                return McpApiKeyAuthenticationResult.Rejected(McpApiKeyRejection.CredentialUnrecognized);
+                return ApiKeyAuthenticationResult.Rejected(ApiKeyRejection.CredentialUnrecognized);
             }
         }
 
@@ -147,10 +147,10 @@ public sealed partial class McpApiKeyAuthenticator
         {
             this.LogExpiredKeyPresented(keyName.Value!);
 
-            return McpApiKeyAuthenticationResult.Rejected(McpApiKeyRejection.CredentialExpired);
+            return ApiKeyAuthenticationResult.Rejected(ApiKeyRejection.CredentialExpired);
         }
 
-        return McpApiKeyAuthenticationResult.Authenticated(keyName);
+        return ApiKeyAuthenticationResult.Authenticated(keyName);
     }
 
     /// <summary>Reduces configured key material to the digest of its text view.</summary>

--- a/src/Infrastructure/Security/ApiKeyRejection.cs
+++ b/src/Infrastructure/Security/ApiKeyRejection.cs
@@ -10,7 +10,7 @@ namespace MailFathom.Infrastructure.Security;
 /// client that learned the difference between an unrecognized key and an expired one would learn that a key it holds
 /// once existed, which is one bit more than a refusal is allowed to say.
 /// </remarks>
-public enum McpApiKeyRejection
+public enum ApiKeyRejection
 {
     /// <summary>The request carried no <c>Authorization</c> header at all.</summary>
     CredentialMissing = 0,

--- a/src/Infrastructure/Security/OAuthIdentity.cs
+++ b/src/Infrastructure/Security/OAuthIdentity.cs
@@ -28,7 +28,7 @@ namespace MailFathom.Infrastructure.Security;
 /// no scopes.
 /// </para>
 /// </remarks>
-public static class McpOAuthIdentity
+public static class OAuthIdentity
 {
     /// <summary>The claim type carrying the stable identity of the person a request was authorized by.</summary>
     /// <remarks>Its value is the issuer and the subject joined by <c>|</c>, a character an <c>https</c> identifier cannot contain unescaped, so the pair cannot be read back ambiguously.</remarks>

--- a/tests/Host.UnitTests/AuthorizationServerOptionsTests.cs
+++ b/tests/Host.UnitTests/AuthorizationServerOptionsTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace MailFathom.Host.UnitTests;
 
 /// <summary>Covers one authorization server profile: what it must state, whose tokens it serves, and where it then looks for that server.</summary>
-public sealed class McpAuthorizationServerOptionsTests
+public sealed class AuthorizationServerOptionsTests
 {
     private const string OwnerSubject = "9f2c";
 
@@ -154,7 +154,7 @@ public sealed class McpAuthorizationServerOptionsTests
     public void FindConfigurationErrors_AProfileNamingNoSubject_IsRefused()
     {
         // Arrange
-        var profile = new McpAuthorizationServerOptions
+        var profile = new AuthorizationServerOptions
         {
             Name = "workforce",
             Issuer = "https://sso.example.test/realms/mailfathom",
@@ -211,8 +211,8 @@ public sealed class McpAuthorizationServerOptionsTests
         // Assert
         Assert.Equal(
             [
-                McpOAuthIdentity.IdentityOf("https://sso.example.test/realms/mailfathom", OwnerSubject),
-                McpOAuthIdentity.IdentityOf("https://sso.example.test/realms/mailfathom", "4b81"),
+                OAuthIdentity.IdentityOf("https://sso.example.test/realms/mailfathom", OwnerSubject),
+                OAuthIdentity.IdentityOf("https://sso.example.test/realms/mailfathom", "4b81"),
             ],
             identities);
     }
@@ -221,7 +221,7 @@ public sealed class McpAuthorizationServerOptionsTests
     public void IsConfigured_AnUntouchedProfile_ReportsNothingWasWritten()
     {
         // Arrange, Act
-        var profile = new McpAuthorizationServerOptions();
+        var profile = new AuthorizationServerOptions();
 
         // Assert
         Assert.False(profile.IsConfigured);
@@ -232,7 +232,7 @@ public sealed class McpAuthorizationServerOptionsTests
     public void IsConfigured_AProfileCarryingOnlySubjects_ReportsSomethingWasWritten()
     {
         // Arrange
-        var profile = new McpAuthorizationServerOptions();
+        var profile = new AuthorizationServerOptions();
 
         // Act
         profile.AuthorizedSubjects.Add(OwnerSubject);
@@ -241,6 +241,6 @@ public sealed class McpAuthorizationServerOptionsTests
         Assert.True(profile.IsConfigured);
     }
 
-    private static McpAuthorizationServerOptions Profile(string? name, string? issuer) =>
+    private static AuthorizationServerOptions Profile(string? name, string? issuer) =>
         new() { Name = name, Issuer = issuer, AuthorizedSubjects = { OwnerSubject } };
 }

--- a/tests/Host.UnitTests/ConfiguredKestrelEndpointsTests.cs
+++ b/tests/Host.UnitTests/ConfiguredKestrelEndpointsTests.cs
@@ -61,7 +61,7 @@ public sealed class ConfiguredKestrelEndpointsTests
         var configuration = ConfigurationWith(("Kestrel:Endpoints:Http:Url", "http://0.0.0.0:8080"));
 
         // Act, Assert
-        Assert.Empty(ConfiguredKestrelEndpoints.FindHttpsProfileConflicts(configuration, new McpHttpsOptions()));
+        Assert.Empty(ConfiguredKestrelEndpoints.FindHttpsProfileConflicts(configuration, new TransportHttpsOptions()));
     }
 
     [Fact]
@@ -156,11 +156,11 @@ public sealed class ConfiguredKestrelEndpointsTests
                 new KeyValuePair<string, string?>(setting.Key, setting.Value)))
             .Build();
 
-    private static McpHttpsOptions HttpsProfiles()
+    private static TransportHttpsOptions HttpsProfiles()
     {
-        var options = new McpHttpsOptions();
+        var options = new TransportHttpsOptions();
 
-        options.Endpoints.Add(new McpHttpsEndpointOptions
+        options.Endpoints.Add(new TransportHttpsEndpointOptions
         {
             Name = "public",
             Domain = "mail.example.test",

--- a/tests/Host.UnitTests/CredentialSchemeSelectorTests.cs
+++ b/tests/Host.UnitTests/CredentialSchemeSelectorTests.cs
@@ -15,7 +15,7 @@ namespace MailFathom.Host.UnitTests;
 /// asserts that an attacker writing whatever they like into that field picks which handler refuses them and nothing
 /// more — never a handler that is more permissive, and never no handler at all.
 /// </remarks>
-public sealed class McpCredentialSchemeSelectorTests
+public sealed class CredentialSchemeSelectorTests
 {
     private const string WorkforceIssuer = "https://sso.example.test/realms/mailfathom";
 
@@ -105,7 +105,7 @@ public sealed class McpCredentialSchemeSelectorTests
     public void SchemeFor_AnUnrecognizedCredentialWhereOnlyOAuthIsAccepted_ReachesTheChallenge(string headerValue)
     {
         // Arrange
-        var selector = new McpCredentialSchemeSelector(
+        var selector = new CredentialSchemeSelector(
             new Dictionary<string, string> { [WorkforceIssuer] = WorkforceScheme },
             apiKeySchemeName: null,
             MetadataScheme);
@@ -119,7 +119,7 @@ public sealed class McpCredentialSchemeSelectorTests
     public void SchemeFor_ATokenWhereOnlyApiKeysAreAccepted_ReachesTheApiKeyComparison()
     {
         // Arrange
-        var selector = new McpCredentialSchemeSelector(
+        var selector = new CredentialSchemeSelector(
             new Dictionary<string, string>(StringComparer.Ordinal),
             ApiKeyScheme,
             ApiKeyScheme);
@@ -140,7 +140,7 @@ public sealed class McpCredentialSchemeSelectorTests
         Assert.Equal(selector.SchemeFor(credential), selector.SchemeFor(credential));
     }
 
-    private static McpCredentialSchemeSelector AcceptingBoth() => new(
+    private static CredentialSchemeSelector AcceptingBoth() => new(
         new Dictionary<string, string>(StringComparer.Ordinal)
         {
             [WorkforceIssuer] = WorkforceScheme,

--- a/tests/Host.UnitTests/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/McpEndpointOptionsBindingTests.cs
@@ -54,7 +54,7 @@ public sealed class McpEndpointOptionsBindingTests
 
         // Assert
         Assert.True(options.Enabled);
-        Assert.Equal(McpTransportAuthenticationMethods.ApiKey, options.Authentication);
+        Assert.Equal(TransportAuthenticationMethods.ApiKey, options.Authentication);
         Assert.Equal(["workstation", "chatgpt-connector"], options.ApiKeys.Select(key => key.Name));
         Assert.Equal(
             [SecretLifetime.NoLimitValue, "2027-01-31T00:00:00Z"],
@@ -139,7 +139,7 @@ public sealed class McpEndpointOptionsBindingTests
 
         // Assert
         Assert.False(options.Enabled);
-        Assert.Equal(McpTransportAuthenticationMethods.None, options.Authentication);
+        Assert.Equal(TransportAuthenticationMethods.None, options.Authentication);
         Assert.Empty(options.ApiKeys);
         Assert.True(options.Cors.ServesEveryBrowserOrigin);
     }

--- a/tests/Host.UnitTests/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/McpEndpointOptionsBindingTests.cs
@@ -307,9 +307,9 @@ public sealed class McpEndpointOptionsBindingTests
         // Assert
         Assert.True(options.Https.TerminatesTls);
         Assert.Equal(["public", "connector"], options.Https.Endpoints.Select(endpoint => endpoint.Name));
-        Assert.Equal(McpMinimumTlsVersion.Tls13, options.Https.Endpoints[0].MinimumTlsVersion);
+        Assert.Equal(TransportMinimumTlsVersion.Tls13, options.Https.Endpoints[0].MinimumTlsVersion);
         Assert.Equal(
-            [McpHttpProtocol.Http1, McpHttpProtocol.Http2],
+            [TransportHttpProtocol.Http1, TransportHttpProtocol.Http2],
             options.Https.Endpoints[0].ServedHttpProtocols);
         Assert.Equal(
             "file:/etc/mailfathom/tls/privkey.pem",
@@ -340,7 +340,7 @@ public sealed class McpEndpointOptionsBindingTests
 
         // Assert
         Assert.Null(profile.HttpProtocols);
-        Assert.Equal([McpHttpProtocol.Http1, McpHttpProtocol.Http2], profile.ServedHttpProtocols);
+        Assert.Equal([TransportHttpProtocol.Http1, TransportHttpProtocol.Http2], profile.ServedHttpProtocols);
     }
 
     private static IConfiguration ConfigurationFrom(Dictionary<string, string?> values) =>

--- a/tests/Host.UnitTests/McpEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/McpEndpointOptionsTests.cs
@@ -47,7 +47,7 @@ public sealed class McpEndpointOptionsTests
         var options = new McpEndpointOptions();
 
         // Assert
-        Assert.Equal(McpTransportAuthenticationMethods.None, options.Authentication);
+        Assert.Equal(TransportAuthenticationMethods.None, options.Authentication);
         Assert.False(options.RequiresAuthentication);
     }
 
@@ -70,7 +70,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_ApiKeyAuthenticationWithAtLeastOneKey_IsAccepted()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.ApiKey);
+        var options = EnabledWith(TransportAuthenticationMethods.ApiKey);
         options.ApiKeys.Add(Key("workstation"));
 
         // Act, Assert
@@ -81,7 +81,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_ApiKeyAuthenticationWithNoKey_IsRefusedBecauseNoClientCouldAuthenticate()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.ApiKey);
+        var options = EnabledWith(TransportAuthenticationMethods.ApiKey);
 
         // Act
         var error = Assert.Single(options.FindConfigurationErrors());
@@ -100,7 +100,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_AnAuthenticationValueNoMemberDeclares_IsRefusedRatherThanTreatedAsNeither()
     {
         // Arrange
-        var options = EnabledWith((McpTransportAuthenticationMethods)4);
+        var options = EnabledWith((TransportAuthenticationMethods)4);
 
         // Act
         var error = Assert.Single(options.FindConfigurationErrors());
@@ -114,7 +114,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_AnUnknownMethodBesideAKnownOne_IsRefused()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.ApiKey | (McpTransportAuthenticationMethods)8);
+        var options = EnabledWith(TransportAuthenticationMethods.ApiKey | (TransportAuthenticationMethods)8);
         options.ApiKeys.Add(Key("workstation"));
 
         // Act
@@ -129,7 +129,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_ApiKeyAndOAuthTogether_IsAccepted()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.ApiKey | McpTransportAuthenticationMethods.OAuth);
+        var options = EnabledWith(TransportAuthenticationMethods.ApiKey | TransportAuthenticationMethods.OAuth);
         options.ApiKeys.Add(Key("nightly-digest"));
         options.OAuth = OAuthWith(AuthorizationServer("workforce", "https://sso.example.test/realms/mailfathom"));
 
@@ -144,7 +144,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_AuthorizationServersConfiguredWhileOAuthIsNotAMethod_IsRefused()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.None);
+        var options = EnabledWith(TransportAuthenticationMethods.None);
         options.OAuth = OAuthWith(AuthorizationServer("workforce", "https://sso.example.test/realms/mailfathom"));
 
         // Act
@@ -158,8 +158,8 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_OAuthWithNoAuthorizationServer_IsRefusedBecauseNoTokenCouldBeValidated()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.OAuth);
-        options.OAuth = new McpOAuthOptions { Resource = "https://mail.example.test/mcp" };
+        var options = EnabledWith(TransportAuthenticationMethods.OAuth);
+        options.OAuth = new OAuthValidationOptions { Resource = "https://mail.example.test/mcp" };
 
         // Act
         var error = Assert.Single(options.FindConfigurationErrors());
@@ -179,7 +179,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_AResourceThatIsNotACanonicalUrl_IsRefused(string? resource)
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.OAuth);
+        var options = EnabledWith(TransportAuthenticationMethods.OAuth);
         options.OAuth = OAuthWith(AuthorizationServer("workforce", "https://sso.example.test/realms/mailfathom"));
         options.OAuth.Resource = resource;
 
@@ -195,7 +195,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_TwoAuthorizationServersSharingAnIssuer_IsRefused()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.OAuth);
+        var options = EnabledWith(TransportAuthenticationMethods.OAuth);
         options.OAuth = OAuthWith(
             AuthorizationServer("workforce", "https://sso.example.test/realms/mailfathom"),
             AuthorizationServer("partners", "https://sso.example.test/realms/mailfathom"));
@@ -216,7 +216,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_AScopeThatCouldRewriteTheChallenge_IsRefused(string scope)
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.OAuth);
+        var options = EnabledWith(TransportAuthenticationMethods.OAuth);
         options.OAuth = OAuthWith(AuthorizationServer("workforce", "https://sso.example.test/realms/mailfathom"));
         options.OAuth.RequiredScopes.Add(scope);
 
@@ -232,7 +232,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_OAuthWithNoRequiredScope_IsAccepted()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.OAuth);
+        var options = EnabledWith(TransportAuthenticationMethods.OAuth);
         options.OAuth = OAuthWith(AuthorizationServer("workforce", "https://sso.example.test/realms/mailfathom"));
 
         // Act, Assert
@@ -249,7 +249,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_ExplicitlyUnauthenticated_IsAccepted()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.None);
+        var options = EnabledWith(TransportAuthenticationMethods.None);
 
         // Act, Assert
         Assert.Empty(options.FindConfigurationErrors());
@@ -260,7 +260,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_KeysConfiguredWhileApiKeyIsNotAMethod_IsRefused()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.None);
+        var options = EnabledWith(TransportAuthenticationMethods.None);
         options.ApiKeys.Add(Key("workstation"));
 
         // Act
@@ -274,7 +274,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_AnUnusableCorsPolicy_IsReportedUnderTheSectionThatCarriesIt()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.None);
+        var options = EnabledWith(TransportAuthenticationMethods.None);
         options.Cors.ServeEveryBrowserOrigin();
         options.Cors.AllowedOrigins.Add("https://client.example.test");
 
@@ -289,7 +289,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_AnUnusableRateLimit_IsReportedUnderTheSectionThatCarriesIt()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.None);
+        var options = EnabledWith(TransportAuthenticationMethods.None);
         options.RateLimiting.MaxConcurrentRequests = 0;
 
         // Act
@@ -307,7 +307,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_AnEndpointConfiguringNoLimits_ReportsNothing()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.None);
+        var options = EnabledWith(TransportAuthenticationMethods.None);
 
         // Act
         var errors = options.FindConfigurationErrors();
@@ -321,7 +321,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_SeveralFaults_ReportsThemAllAtOnce()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.ApiKey);
+        var options = EnabledWith(TransportAuthenticationMethods.ApiKey);
         options.Cors.AllowedOrigins.Add("not-an-origin");
 
         // Act
@@ -346,7 +346,7 @@ public sealed class McpEndpointOptionsTests
     public void ClientCertificateProfiles_UnconfiguredDeployment_IsEmptyRatherThanNull()
     {
         // Arrange, Act
-        var options = EnabledWith(McpTransportAuthenticationMethods.None);
+        var options = EnabledWith(TransportAuthenticationMethods.None);
 
         // Assert
         Assert.Empty(options.ClientCertificateProfiles);
@@ -358,7 +358,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_AnUnusableClientCertificateProfile_IsReportedUnderItsPosition()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.None);
+        var options = EnabledWith(TransportAuthenticationMethods.None);
         var profile = ConnectorProfile();
         profile.TrustAnchors.Clear();
         options.ClientCertificateProfiles.Add(profile);
@@ -375,7 +375,7 @@ public sealed class McpEndpointOptionsTests
     public void FindConfigurationErrors_TwoProfilesSharingAName_IsRefused()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.None);
+        var options = EnabledWith(TransportAuthenticationMethods.None);
         options.ClientCertificateProfiles.Add(ConnectorProfile());
         options.ClientCertificateProfiles.Add(ConnectorProfile());
 
@@ -390,7 +390,7 @@ public sealed class McpEndpointOptionsTests
     public void ToClientCertificateTrustProfiles_SeveralProfiles_MapsThemInConfigurationOrder()
     {
         // Arrange
-        var options = EnabledWith(McpTransportAuthenticationMethods.None);
+        var options = EnabledWith(TransportAuthenticationMethods.None);
         options.ClientCertificateProfiles.Add(ConnectorProfile());
         var reportingProfile = ConnectorProfile();
         reportingProfile.Name = "reporting-service";
@@ -405,12 +405,12 @@ public sealed class McpEndpointOptionsTests
             trustProfiles.Select(profile => profile.Name));
     }
 
-    private static McpEndpointOptions EnabledWith(McpTransportAuthenticationMethods authentication) =>
+    private static McpEndpointOptions EnabledWith(TransportAuthenticationMethods authentication) =>
         new() { Enabled = true, Authentication = authentication };
 
-    private static McpOAuthOptions OAuthWith(params McpAuthorizationServerOptions[] authorizationServers)
+    private static OAuthValidationOptions OAuthWith(params AuthorizationServerOptions[] authorizationServers)
     {
-        var oauth = new McpOAuthOptions { Resource = "https://mail.example.test/mcp" };
+        var oauth = new OAuthValidationOptions { Resource = "https://mail.example.test/mcp" };
 
         // A loop rather than a projection, because adding to a getter-only collection is a side effect and a pipeline
         // must never be the place one happens.
@@ -422,7 +422,7 @@ public sealed class McpEndpointOptionsTests
         return oauth;
     }
 
-    private static McpAuthorizationServerOptions AuthorizationServer(string name, string issuer) =>
+    private static AuthorizationServerOptions AuthorizationServer(string name, string issuer) =>
         new() { Name = name, Issuer = issuer, AuthorizedSubjects = { "9f2c" } };
 
     private static McpClientCertificateProfileOptions ConnectorProfile()

--- a/tests/Host.UnitTests/McpProtectedResourceMetadataTests.cs
+++ b/tests/Host.UnitTests/McpProtectedResourceMetadataTests.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Security;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers where the MCP endpoint tells a client to go and authorize.</summary>
+public sealed class McpProtectedResourceMetadataTests
+{
+    /// <summary>
+    /// The address is composed from the configured resource rather than from the request asking for it. Derived from the
+    /// request, a deployment behind a reverse proxy would tell each client to authenticate for whichever name that client
+    /// arrived under, including one an attacker chose.
+    /// </summary>
+    [Theory]
+    [InlineData("https://mail.example.test/mcp", "https://mail.example.test/.well-known/oauth-protected-resource/mcp")]
+    [InlineData("https://mail.example.test", "https://mail.example.test/.well-known/oauth-protected-resource")]
+    [InlineData("https://mail.example.test/", "https://mail.example.test/.well-known/oauth-protected-resource")]
+    [InlineData("https://mail.example.test:8443/mcp", "https://mail.example.test:8443/.well-known/oauth-protected-resource/mcp")]
+    public void AddressFor_AConfiguredResource_PublishesUnderThatResourcesAuthority(
+        string canonicalResource,
+        string expectedAddress) =>
+        Assert.Equal(expectedAddress, McpProtectedResourceMetadata.AddressFor(canonicalResource));
+
+    /// <summary>The SDK publishes the document from a request handler rather than a route, so composition needs the path alone to put a middleware in front of it.</summary>
+    [Theory]
+    [InlineData("https://mail.example.test/mcp", "/.well-known/oauth-protected-resource/mcp")]
+    [InlineData("https://mail.example.test:8443/mcp", "/.well-known/oauth-protected-resource/mcp")]
+    [InlineData("https://mail.example.test", "/.well-known/oauth-protected-resource")]
+    public void PathFor_AConfiguredResource_DropsTheAuthorityTheMiddlewareCannotMatchOn(
+        string canonicalResource,
+        string expectedPath) =>
+        Assert.Equal(expectedPath, McpProtectedResourceMetadata.PathFor(canonicalResource));
+}

--- a/tests/Host.UnitTests/McpRateLimitingStartupReportTests.cs
+++ b/tests/Host.UnitTests/McpRateLimitingStartupReportTests.cs
@@ -109,7 +109,7 @@ public sealed class McpRateLimitingStartupReportTests
         // Arrange
         using var logs = new RecordingLoggerProvider();
         var endpointSettings = EnabledEndpoint(new McpRateLimitingOptions());
-        endpointSettings.Authentication = McpTransportAuthenticationMethods.ApiKey;
+        endpointSettings.Authentication = TransportAuthenticationMethods.ApiKey;
         endpointSettings.ApiKeys.Add(new ConfiguredSecret { Name = "desktop-agent" });
         var report = ReportFor(endpointSettings, logs);
 
@@ -140,7 +140,7 @@ public sealed class McpRateLimitingStartupReportTests
     private static McpEndpointOptions EnabledEndpoint(McpRateLimitingOptions rateLimitingSettings) => new()
     {
         Enabled = true,
-        Authentication = McpTransportAuthenticationMethods.None,
+        Authentication = TransportAuthenticationMethods.None,
         RateLimiting = rateLimitingSettings,
     };
 

--- a/tests/Host.UnitTests/McpTransportAuthenticationWarningTests.cs
+++ b/tests/Host.UnitTests/McpTransportAuthenticationWarningTests.cs
@@ -68,7 +68,7 @@ public sealed class McpTransportAuthenticationWarningTests
     {
         // Arrange
         using var logs = new RecordingLoggerProvider();
-        var settings = new McpEndpointOptions { Enabled = true, Authentication = McpTransportAuthenticationMethods.ApiKey };
+        var settings = new McpEndpointOptions { Enabled = true, Authentication = TransportAuthenticationMethods.ApiKey };
         settings.ApiKeys.Add(new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:a-key" });
         var warning = WarningFor(settings, logs);
 
@@ -86,7 +86,7 @@ public sealed class McpTransportAuthenticationWarningTests
         // Arrange
         using var logs = new RecordingLoggerProvider();
         var warning = WarningFor(
-            new McpEndpointOptions { Authentication = McpTransportAuthenticationMethods.None },
+            new McpEndpointOptions { Authentication = TransportAuthenticationMethods.None },
             logs);
 
         // Act
@@ -128,7 +128,7 @@ public sealed class McpTransportAuthenticationWarningTests
         var settings = new McpEndpointOptions
         {
             Enabled = true,
-            Authentication = McpTransportAuthenticationMethods.OAuth,
+            Authentication = TransportAuthenticationMethods.OAuth,
         };
         var warning = WarningFor(settings, logs);
 
@@ -145,7 +145,7 @@ public sealed class McpTransportAuthenticationWarningTests
         // Arrange
         using var logs = new RecordingLoggerProvider();
         var warning = WarningFor(
-            new McpEndpointOptions { Enabled = true, Authentication = McpTransportAuthenticationMethods.None },
+            new McpEndpointOptions { Enabled = true, Authentication = TransportAuthenticationMethods.None },
             logs);
 
         // Act
@@ -178,7 +178,7 @@ public sealed class McpTransportAuthenticationWarningTests
     private static McpEndpointOptions Unauthenticated() => new()
     {
         Enabled = true,
-        Authentication = McpTransportAuthenticationMethods.None,
+        Authentication = TransportAuthenticationMethods.None,
     };
 
     private static McpTransportAuthenticationWarning WarningFor(McpEndpointOptions settings, RecordingLoggerProvider logs)

--- a/tests/Host.UnitTests/McpTransportEncryptionWarningTests.cs
+++ b/tests/Host.UnitTests/McpTransportEncryptionWarningTests.cs
@@ -48,7 +48,7 @@ public sealed class McpTransportEncryptionWarningTests
         // Arrange
         using var logs = new RecordingLoggerProvider();
         var settings = Enabled();
-        settings.Authentication = McpTransportAuthenticationMethods.ApiKey;
+        settings.Authentication = TransportAuthenticationMethods.ApiKey;
         settings.ApiKeys.Add(new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:a-key" });
         var warning = WarningFor(settings, logs);
 
@@ -115,7 +115,7 @@ public sealed class McpTransportEncryptionWarningTests
     private static McpEndpointOptions Enabled() => new()
     {
         Enabled = true,
-        Authentication = McpTransportAuthenticationMethods.None,
+        Authentication = TransportAuthenticationMethods.None,
     };
 
     private static McpTransportEncryptionWarning WarningFor(McpEndpointOptions settings, RecordingLoggerProvider logs)

--- a/tests/Host.UnitTests/McpTransportEncryptionWarningTests.cs
+++ b/tests/Host.UnitTests/McpTransportEncryptionWarningTests.cs
@@ -65,7 +65,7 @@ public sealed class McpTransportEncryptionWarningTests
         // Arrange
         using var logs = new RecordingLoggerProvider();
         var settings = Enabled();
-        settings.Https.Endpoints.Add(new McpHttpsEndpointOptions
+        settings.Https.Endpoints.Add(new TransportHttpsEndpointOptions
         {
             Name = "public",
             Domain = "mail.example.test",

--- a/tests/Host.UnitTests/McpTransportSecurityExtensionsTests.cs
+++ b/tests/Host.UnitTests/McpTransportSecurityExtensionsTests.cs
@@ -4,10 +4,7 @@
 
 using MailFathom.Host.Configuration;
 using MailFathom.Host.Security;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Cors.Infrastructure;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
@@ -15,46 +12,13 @@ using Xunit;
 
 namespace MailFathom.Host.UnitTests;
 
-/// <summary>Covers the decisions composition makes about the transport an MCP request arrives on.</summary>
+/// <summary>Covers what the MCP endpoint's own composition decides, beyond the credentials every surface accepts.</summary>
 /// <remarks>
-/// Both are decisions nothing downstream can recover from: a token read off an unencrypted request has already been
-/// disclosed by the time any handler sees it, and a header a browser is not permitted to read is one no client can act
-/// on however correct the response is.
+/// A header a browser is not permitted to read is one no client can act on however correct the response is, which is
+/// why the exposed header is asserted on the composed policy rather than on the call that configured it.
 /// </remarks>
 public sealed class McpTransportSecurityExtensionsTests
 {
-    /// <summary>
-    /// An access token is a reusable credential, so presenting one over plain HTTP hands it to anybody watching the
-    /// network. The refusal is silent, which is what makes the answer the same challenge an unauthenticated request
-    /// receives rather than a statement about what the request carried.
-    /// </summary>
-    [Fact]
-    public async Task RefuseATokenThatArrivedWithoutTransportEncryption_APlaintextRequest_AuthenticatesNobody()
-    {
-        // Arrange
-        var context = MessageReceivedOver("http");
-
-        // Act
-        await McpTransportSecurityExtensions.RefuseATokenThatArrivedWithoutTransportEncryption(context);
-
-        // Assert
-        Assert.NotNull(context.Result);
-        Assert.True(context.Result.None);
-    }
-
-    [Fact]
-    public async Task RefuseATokenThatArrivedWithoutTransportEncryption_AnEncryptedRequest_LeavesTheTokenToBeValidated()
-    {
-        // Arrange
-        var context = MessageReceivedOver("https");
-
-        // Act
-        await McpTransportSecurityExtensions.RefuseATokenThatArrivedWithoutTransportEncryption(context);
-
-        // Assert
-        Assert.Null(context.Result);
-    }
-
     /// <summary>
     /// The challenge names where to authorize and which scopes are required, and a browser cannot read a response header
     /// the policy does not expose. Without it the one answer that tells a page how to proceed is the one it cannot see.
@@ -84,22 +48,11 @@ public sealed class McpTransportSecurityExtensionsTests
         var endpointSettings = new McpEndpointOptions
         {
             Enabled = true,
-            Authentication = McpTransportAuthenticationMethods.None,
+            Authentication = TransportAuthenticationMethods.None,
         };
 
         endpointSettings.Cors.AllowedOrigins.Add("https://client.example.test");
 
         return endpointSettings;
-    }
-
-    private static MessageReceivedContext MessageReceivedOver(string scheme)
-    {
-        var request = new DefaultHttpContext();
-        request.Request.Scheme = scheme;
-
-        return new MessageReceivedContext(
-            request,
-            new AuthenticationScheme("MailFathomOAuth:workforce", displayName: null, typeof(JwtBearerHandler)),
-            new JwtBearerOptions());
     }
 }

--- a/tests/Host.UnitTests/OAuthTokenValidationTests.cs
+++ b/tests/Host.UnitTests/OAuthTokenValidationTests.cs
@@ -16,7 +16,7 @@ namespace MailFathom.Host.UnitTests;
 /// presented — a scheme is configured lazily, so a rule the validator rejects outright would otherwise first be noticed
 /// by a request in production.
 /// </remarks>
-public sealed class McpOAuthAuthenticationTests
+public sealed class OAuthTokenValidationTests
 {
     private const string Issuer = "https://sso.example.test/realms/mailfathom";
 
@@ -26,7 +26,7 @@ public sealed class McpOAuthAuthenticationTests
     public void TokenValidationParametersFor_AnAuthorizationServer_BindsTokensToThatIssuerAndThisResource()
     {
         // Act
-        var validationParameters = McpOAuthAuthentication.TokenValidationParametersFor(Issuer, CanonicalResource);
+        var validationParameters = OAuthTokenValidation.TokenValidationParametersFor(Issuer, CanonicalResource);
 
         // Assert
         Assert.True(validationParameters.ValidateIssuer);
@@ -40,7 +40,7 @@ public sealed class McpOAuthAuthenticationTests
     public void TokenValidationParametersFor_AnAuthorizationServer_PermitsOnlyAsymmetricSignatures()
     {
         // Act
-        var validationParameters = McpOAuthAuthentication.TokenValidationParametersFor(Issuer, CanonicalResource);
+        var validationParameters = OAuthTokenValidation.TokenValidationParametersFor(Issuer, CanonicalResource);
 
         // Assert
         Assert.True(validationParameters.RequireSignedTokens);
@@ -55,7 +55,7 @@ public sealed class McpOAuthAuthenticationTests
     public void TokenValidationParametersFor_AnAuthorizationServer_RefusesAnExpiredTokenWithinASkewShorterThanTheFrameworkDefault()
     {
         // Act
-        var validationParameters = McpOAuthAuthentication.TokenValidationParametersFor(Issuer, CanonicalResource);
+        var validationParameters = OAuthTokenValidation.TokenValidationParametersFor(Issuer, CanonicalResource);
 
         // Assert
         Assert.True(validationParameters.ValidateLifetime);
@@ -72,11 +72,11 @@ public sealed class McpOAuthAuthenticationTests
     public void TokenValidationParametersFor_AnAuthorizationServer_ReadsRolesFromAClaimTypeNothingIssues()
     {
         // Act
-        var validationParameters = McpOAuthAuthentication.TokenValidationParametersFor(Issuer, CanonicalResource);
+        var validationParameters = OAuthTokenValidation.TokenValidationParametersFor(Issuer, CanonicalResource);
 
         // Assert
         Assert.False(string.IsNullOrWhiteSpace(validationParameters.RoleClaimType));
         Assert.NotEqual(ClaimsIdentity.DefaultRoleClaimType, validationParameters.RoleClaimType);
-        Assert.Equal(McpOAuthIdentity.RoleClaimType, validationParameters.RoleClaimType);
+        Assert.Equal(OAuthIdentity.RoleClaimType, validationParameters.RoleClaimType);
     }
 }

--- a/tests/Host.UnitTests/OAuthValidationOptionsTests.cs
+++ b/tests/Host.UnitTests/OAuthValidationOptionsTests.cs
@@ -7,35 +7,14 @@ using Xunit;
 
 namespace MailFathom.Host.UnitTests;
 
-/// <summary>Covers what this deployment is called in OAuth terms and where it says so.</summary>
-public sealed class McpOAuthOptionsTests
+/// <summary>Covers what this deployment is called in OAuth terms, and what it refuses to be called.</summary>
+public sealed class OAuthValidationOptionsTests
 {
-    /// <summary>
-    /// The address is composed from the configured resource rather than from the request asking for it. Derived from the
-    /// request, a deployment behind a reverse proxy would tell each client to authenticate for whichever name that client
-    /// arrived under, including one an attacker chose.
-    /// </summary>
-    [Theory]
-    [InlineData("https://mail.example.test/mcp", "https://mail.example.test/.well-known/oauth-protected-resource/mcp")]
-    [InlineData("https://mail.example.test", "https://mail.example.test/.well-known/oauth-protected-resource")]
-    [InlineData("https://mail.example.test/", "https://mail.example.test/.well-known/oauth-protected-resource")]
-    [InlineData("https://mail.example.test:8443/mcp", "https://mail.example.test:8443/.well-known/oauth-protected-resource/mcp")]
-    public void ProtectedResourceMetadataAddress_AConfiguredResource_PublishesUnderThatResourcesAuthority(
-        string resource,
-        string expectedAddress)
-    {
-        // Arrange
-        var oauth = new McpOAuthOptions { Resource = resource };
-
-        // Act, Assert
-        Assert.Equal(expectedAddress, oauth.ProtectedResourceMetadataAddress());
-    }
-
     [Fact]
     public void CanonicalResource_AResourceSpelledUnusually_IsBroughtToTheFormTokensAreComparedAgainst()
     {
         // Arrange
-        var oauth = new McpOAuthOptions { Resource = "HTTPS://Mail.Example.Test:443/mcp" };
+        var oauth = new OAuthValidationOptions { Resource = "HTTPS://Mail.Example.Test:443/mcp" };
 
         // Act, Assert
         Assert.Equal("https://mail.example.test/mcp", oauth.CanonicalResource());
@@ -45,7 +24,7 @@ public sealed class McpOAuthOptionsTests
     public void CanonicalResource_AResourceThatWasNeverValidated_ThrowsRatherThanYieldingSomethingToCompareAgainst()
     {
         // Arrange
-        var oauth = new McpOAuthOptions { Resource = "not-a-url" };
+        var oauth = new OAuthValidationOptions { Resource = "not-a-url" };
 
         // Act, Assert
         Assert.Throws<InvalidOperationException>(oauth.CanonicalResource);
@@ -55,7 +34,7 @@ public sealed class McpOAuthOptionsTests
     public void IsConfigured_AnUntouchedSection_ReportsNothingWasWritten()
     {
         // Arrange, Act
-        var oauth = new McpOAuthOptions();
+        var oauth = new OAuthValidationOptions();
 
         // Assert
         Assert.False(oauth.IsConfigured);
@@ -66,7 +45,7 @@ public sealed class McpOAuthOptionsTests
     public void IsConfigured_AResourceAlone_ReportsThatSomethingWasWritten()
     {
         // Arrange, Act
-        var oauth = new McpOAuthOptions { Resource = "https://mail.example.test/mcp" };
+        var oauth = new OAuthValidationOptions { Resource = "https://mail.example.test/mcp" };
 
         // Assert
         Assert.True(oauth.IsConfigured);
@@ -76,8 +55,8 @@ public sealed class McpOAuthOptionsTests
     public void FindConfigurationErrors_ARepeatedRequiredScope_IsRefused()
     {
         // Arrange
-        var oauth = new McpOAuthOptions { Resource = "https://mail.example.test/mcp" };
-        oauth.AuthorizationServers.Add(new McpAuthorizationServerOptions
+        var oauth = new OAuthValidationOptions { Resource = "https://mail.example.test/mcp" };
+        oauth.AuthorizationServers.Add(new AuthorizationServerOptions
         {
             Name = "workforce",
             Issuer = "https://sso.example.test/realms/mailfathom",
@@ -98,14 +77,14 @@ public sealed class McpOAuthOptionsTests
     public void FindConfigurationErrors_TwoAuthorizationServersSharingAName_IsRefused()
     {
         // Arrange
-        var oauth = new McpOAuthOptions { Resource = "https://mail.example.test/mcp" };
-        oauth.AuthorizationServers.Add(new McpAuthorizationServerOptions
+        var oauth = new OAuthValidationOptions { Resource = "https://mail.example.test/mcp" };
+        oauth.AuthorizationServers.Add(new AuthorizationServerOptions
         {
             Name = "workforce",
             Issuer = "https://sso.example.test/realms/mailfathom",
             AuthorizedSubjects = { "9f2c" },
         });
-        oauth.AuthorizationServers.Add(new McpAuthorizationServerOptions
+        oauth.AuthorizationServers.Add(new AuthorizationServerOptions
         {
             Name = "Workforce",
             Issuer = "https://partners.example.test",

--- a/tests/Host.UnitTests/SecretConfigurationStartupValidatorTests.cs
+++ b/tests/Host.UnitTests/SecretConfigurationStartupValidatorTests.cs
@@ -463,7 +463,7 @@ public sealed class SecretConfigurationStartupValidatorTests
     public async Task StartingAsync_AnMcpApiKeyThatCannotBeResolved_FailsStartupNamingItsPosition()
     {
         // Arrange
-        var endpoint = new McpEndpointOptions { Enabled = true, Authentication = McpTransportAuthenticationMethods.ApiKey };
+        var endpoint = new McpEndpointOptions { Enabled = true, Authentication = TransportAuthenticationMethods.ApiKey };
         endpoint.ApiKeys.Add(new ConfiguredSecret { Name = "workstation", SecretReference = "file:/run/secrets/absent" });
         var harness = CreateHarness(new MailSynchronizationOptions(), new PersistenceOptions(), mcpEndpointOptions: endpoint);
 
@@ -481,7 +481,7 @@ public sealed class SecretConfigurationStartupValidatorTests
     public async Task StartingAsync_TwoMcpApiKeysSharingAName_FailsStartupBecauseNeitherCouldBeRotatedByName()
     {
         // Arrange
-        var endpoint = new McpEndpointOptions { Enabled = true, Authentication = McpTransportAuthenticationMethods.ApiKey };
+        var endpoint = new McpEndpointOptions { Enabled = true, Authentication = TransportAuthenticationMethods.ApiKey };
         endpoint.ApiKeys.Add(new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:one" });
         endpoint.ApiKeys.Add(new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:two" });
         var harness = CreateHarness(new MailSynchronizationOptions(), new PersistenceOptions(), mcpEndpointOptions: endpoint);
@@ -547,7 +547,7 @@ public sealed class SecretConfigurationStartupValidatorTests
     public async Task StartingAsync_AClientCertificateTrustAnchorThatIsNotACertificate_FailsStartupNamingItsPosition()
     {
         // Arrange
-        var endpoint = new McpEndpointOptions { Enabled = true, Authentication = McpTransportAuthenticationMethods.None };
+        var endpoint = new McpEndpointOptions { Enabled = true, Authentication = TransportAuthenticationMethods.None };
         var profile = new McpClientCertificateProfileOptions
         {
             Name = "chatgpt-connector",
@@ -610,14 +610,14 @@ public sealed class SecretConfigurationStartupValidatorTests
 
     private static McpEndpointOptions EndpointAcceptingBothCredentials()
     {
-        var authorizationServer = new McpAuthorizationServerOptions { Name = "workforce", Issuer = WorkforceIssuer };
+        var authorizationServer = new AuthorizationServerOptions { Name = "workforce", Issuer = WorkforceIssuer };
         authorizationServer.AuthorizedSubjects.Add("9f2c");
 
         var endpoint = new McpEndpointOptions
         {
             Enabled = true,
-            Authentication = McpTransportAuthenticationMethods.ApiKey | McpTransportAuthenticationMethods.OAuth,
-            OAuth = new McpOAuthOptions { Resource = "https://mail.example.test/mcp" },
+            Authentication = TransportAuthenticationMethods.ApiKey | TransportAuthenticationMethods.OAuth,
+            OAuth = new OAuthValidationOptions { Resource = "https://mail.example.test/mcp" },
         };
 
         endpoint.OAuth.AuthorizationServers.Add(authorizationServer);

--- a/tests/Host.UnitTests/TransportAccessPolicyTests.cs
+++ b/tests/Host.UnitTests/TransportAccessPolicyTests.cs
@@ -15,7 +15,7 @@ namespace MailFathom.Host.UnitTests;
 /// is that neither substitutes for the other, that a subject is only meaningful together with the issuer that named it,
 /// and that neither is ever asked of a key that could not carry one.
 /// </remarks>
-public sealed class McpAccessPolicyTests
+public sealed class TransportAccessPolicyTests
 {
     private const string OAuthScheme = "MailFathomOAuth:workforce";
 
@@ -24,7 +24,7 @@ public sealed class McpAccessPolicyTests
     private const string OwnerSubject = "9f2c";
 
     private static readonly HashSet<string> AuthorizedOwner =
-        [McpOAuthIdentity.IdentityOf(Issuer, OwnerSubject)];
+        [OAuthIdentity.IdentityOf(Issuer, OwnerSubject)];
 
     [Fact]
     public void IsAuthorized_AnAnonymousCaller_IsRefused()
@@ -33,7 +33,7 @@ public sealed class McpAccessPolicyTests
         var anonymous = new ClaimsPrincipal(new ClaimsIdentity());
 
         // Act, Assert
-        Assert.False(McpAccessPolicy.IsAuthorized(anonymous, AuthorizedOwner, []));
+        Assert.False(TransportAccessPolicy.IsAuthorized(anonymous, AuthorizedOwner, []));
     }
 
     [Fact]
@@ -43,7 +43,7 @@ public sealed class McpAccessPolicyTests
         var caller = TokenPrincipal();
 
         // Act, Assert
-        Assert.True(McpAccessPolicy.IsAuthorized(caller, AuthorizedOwner, []));
+        Assert.True(TransportAccessPolicy.IsAuthorized(caller, AuthorizedOwner, []));
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public sealed class McpAccessPolicyTests
         var caller = TokenPrincipal("mailfathom.read", "mailfathom.search");
 
         // Act, Assert
-        Assert.True(McpAccessPolicy.IsAuthorized(caller, AuthorizedOwner, ["mailfathom.read"]));
+        Assert.True(TransportAccessPolicy.IsAuthorized(caller, AuthorizedOwner, ["mailfathom.read"]));
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public sealed class McpAccessPolicyTests
         var caller = TokenPrincipal("mailfathom.read");
 
         // Act, Assert
-        Assert.False(McpAccessPolicy.IsAuthorized(caller, AuthorizedOwner, ["mailfathom.search"]));
+        Assert.False(TransportAccessPolicy.IsAuthorized(caller, AuthorizedOwner, ["mailfathom.search"]));
     }
 
     /// <summary>
@@ -78,7 +78,7 @@ public sealed class McpAccessPolicyTests
         var colleague = TokenPrincipalFor(Issuer, "4b81", "mailfathom.read");
 
         // Act, Assert
-        Assert.False(McpAccessPolicy.IsAuthorized(colleague, AuthorizedOwner, ["mailfathom.read"]));
+        Assert.False(TransportAccessPolicy.IsAuthorized(colleague, AuthorizedOwner, ["mailfathom.read"]));
     }
 
     /// <summary>A subject is unique only within the server that issued it, so the pair is compared rather than the subject alone.</summary>
@@ -89,7 +89,7 @@ public sealed class McpAccessPolicyTests
         var caller = TokenPrincipalFor("https://sso.other.test/realms/mailfathom", OwnerSubject);
 
         // Act, Assert
-        Assert.False(McpAccessPolicy.IsAuthorized(caller, AuthorizedOwner, []));
+        Assert.False(TransportAccessPolicy.IsAuthorized(caller, AuthorizedOwner, []));
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ public sealed class McpAccessPolicyTests
         var caller = ApiKeyPrincipal("nightly-digest");
 
         // Act, Assert
-        Assert.True(McpAccessPolicy.IsAuthorized(caller, AuthorizedOwner, ["mailfathom.read"]));
+        Assert.True(TransportAccessPolicy.IsAuthorized(caller, AuthorizedOwner, ["mailfathom.read"]));
     }
 
     /// <summary>A key names no subject and is not expected to, so the subject list constrains tokens alone.</summary>
@@ -115,7 +115,7 @@ public sealed class McpAccessPolicyTests
         var caller = ApiKeyPrincipal("nightly-digest");
 
         // Act, Assert
-        Assert.True(McpAccessPolicy.IsAuthorized(caller, AuthorizedOwner, []));
+        Assert.True(TransportAccessPolicy.IsAuthorized(caller, AuthorizedOwner, []));
     }
 
     /// <summary>The bypass follows what the principal carries rather than which scheme named it, so a token cannot claim it by naming a scheme.</summary>
@@ -124,11 +124,11 @@ public sealed class McpAccessPolicyTests
     {
         // Arrange
         var claims = new[] { new Claim("iss", Issuer), new Claim("sub", OwnerSubject) };
-        var identity = McpOAuthIdentity.FromValidatedToken(claims, "MailFathomApiKey");
+        var identity = OAuthIdentity.FromValidatedToken(claims, "MailFathomApiKey");
         var caller = new ClaimsPrincipal(identity!);
 
         // Act, Assert
-        Assert.False(McpAccessPolicy.IsAuthorized(caller, AuthorizedOwner, ["mailfathom.read"]));
+        Assert.False(TransportAccessPolicy.IsAuthorized(caller, AuthorizedOwner, ["mailfathom.read"]));
     }
 
     /// <summary>An authenticated principal carrying no identity at all is refused rather than treated as unrestricted.</summary>
@@ -139,7 +139,7 @@ public sealed class McpAccessPolicyTests
         var caller = new ClaimsPrincipal(new ClaimsIdentity(claims: [], OAuthScheme));
 
         // Act, Assert
-        Assert.False(McpAccessPolicy.IsAuthorized(caller, AuthorizedOwner, []));
+        Assert.False(TransportAccessPolicy.IsAuthorized(caller, AuthorizedOwner, []));
     }
 
     private static ClaimsPrincipal TokenPrincipal(params string[] scopes) =>
@@ -154,13 +154,13 @@ public sealed class McpAccessPolicyTests
             new("scope", string.Join(' ', scopes)),
         ];
 
-        return new ClaimsPrincipal(McpOAuthIdentity.FromValidatedToken(claims, OAuthScheme)!);
+        return new ClaimsPrincipal(OAuthIdentity.FromValidatedToken(claims, OAuthScheme)!);
     }
 
     private static ClaimsPrincipal ApiKeyPrincipal(string keyName) => new(
         new ClaimsIdentity(
-            [new Claim(McpApiKeyAuthentication.ApiKeyNameClaimType, keyName)],
-            McpApiKeyAuthentication.SchemeName,
-            McpApiKeyAuthentication.ApiKeyNameClaimType,
+            [new Claim(ApiKeyAuthentication.ApiKeyNameClaimType, keyName)],
+            TransportSurface.Mcp.ApiKeySchemeName,
+            ApiKeyAuthentication.ApiKeyNameClaimType,
             roleType: string.Empty));
 }

--- a/tests/Host.UnitTests/TransportHttpsOptionsTests.cs
+++ b/tests/Host.UnitTests/TransportHttpsOptionsTests.cs
@@ -16,7 +16,7 @@ namespace MailFathom.Host.UnitTests;
 /// to their other endpoint. The QUIC capability is a parameter rather than a machine property so both answers are
 /// stated here rather than depending on the host the suite happens to run on.
 /// </remarks>
-public sealed class McpHttpsOptionsTests
+public sealed class TransportHttpsOptionsTests
 {
     private const string SectionPath = "McpEndpoint:Https";
 
@@ -24,7 +24,7 @@ public sealed class McpHttpsOptionsTests
     public void TerminatesTls_NoProfiles_IsTheClearTextPosture()
     {
         // Arrange, Act
-        var options = new McpHttpsOptions();
+        var options = new TransportHttpsOptions();
 
         // Assert
         Assert.False(options.TerminatesTls);
@@ -172,7 +172,7 @@ public sealed class McpHttpsOptionsTests
         var served = Profile().ServedHttpProtocols;
 
         // Assert
-        Assert.Equal([McpHttpProtocol.Http1, McpHttpProtocol.Http2], served);
+        Assert.Equal([TransportHttpProtocol.Http1, TransportHttpProtocol.Http2], served);
     }
 
     [Fact]
@@ -180,7 +180,7 @@ public sealed class McpHttpsOptionsTests
     {
         // Arrange
         var profile = Profile();
-        profile.HttpProtocols = [McpHttpProtocol.Http1, McpHttpProtocol.Http1];
+        profile.HttpProtocols = [TransportHttpProtocol.Http1, TransportHttpProtocol.Http1];
 
         // Act
         var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
@@ -195,7 +195,7 @@ public sealed class McpHttpsOptionsTests
     {
         // Arrange
         var profile = Profile();
-        profile.HttpProtocols = [McpHttpProtocol.Http1, McpHttpProtocol.Http2, McpHttpProtocol.Http3];
+        profile.HttpProtocols = [TransportHttpProtocol.Http1, TransportHttpProtocol.Http2, TransportHttpProtocol.Http3];
 
         // Act
         var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: false));
@@ -209,7 +209,7 @@ public sealed class McpHttpsOptionsTests
     {
         // Arrange
         var profile = Profile();
-        profile.HttpProtocols = [McpHttpProtocol.Http3];
+        profile.HttpProtocols = [TransportHttpProtocol.Http3];
 
         // Act, Assert
         Assert.Empty(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
@@ -221,7 +221,7 @@ public sealed class McpHttpsOptionsTests
     {
         // Arrange
         var profile = Profile();
-        profile.MinimumTlsVersion = (McpMinimumTlsVersion)7;
+        profile.MinimumTlsVersion = (TransportMinimumTlsVersion)7;
 
         // Act
         var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
@@ -325,7 +325,7 @@ public sealed class McpHttpsOptionsTests
         // Arrange
         var first = Profile(name: "first", domain: "one.example.test");
         var second = Profile(name: "second", domain: "two.example.test");
-        second.HttpProtocols = [McpHttpProtocol.Http1];
+        second.HttpProtocols = [TransportHttpProtocol.Http1];
 
         // Act
         var error = Assert.Single(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true));
@@ -341,7 +341,7 @@ public sealed class McpHttpsOptionsTests
         // Arrange
         var first = Profile(name: "first", domain: "one.example.test");
         var second = Profile(name: "second", domain: "two.example.test");
-        second.MinimumTlsVersion = McpMinimumTlsVersion.Tls13;
+        second.MinimumTlsVersion = TransportMinimumTlsVersion.Tls13;
 
         // Act, Assert
         Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true));
@@ -354,7 +354,7 @@ public sealed class McpHttpsOptionsTests
         var first = Profile(name: "first", domain: "one.example.test");
         var second = Profile(name: "second", domain: "two.example.test");
         second.Port = 9443;
-        second.HttpProtocols = [McpHttpProtocol.Http1];
+        second.HttpProtocols = [TransportHttpProtocol.Http1];
 
         // Act, Assert
         Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true));
@@ -435,9 +435,9 @@ public sealed class McpHttpsOptionsTests
         Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true));
     }
 
-    private static McpHttpsOptions With(params McpHttpsEndpointOptions[] profiles)
+    private static TransportHttpsOptions With(params TransportHttpsEndpointOptions[] profiles)
     {
-        var options = new McpHttpsOptions();
+        var options = new TransportHttpsOptions();
 
         foreach (var profile in profiles)
         {
@@ -447,7 +447,7 @@ public sealed class McpHttpsOptionsTests
         return options;
     }
 
-    private static McpHttpsEndpointOptions Profile(string name = "public", string domain = "mail.example.test") => new()
+    private static TransportHttpsEndpointOptions Profile(string name = "public", string domain = "mail.example.test") => new()
     {
         Name = name,
         Domain = domain,

--- a/tests/Host.UnitTests/TransportSecurityExtensionsTests.cs
+++ b/tests/Host.UnitTests/TransportSecurityExtensionsTests.cs
@@ -1,0 +1,155 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration;
+using MailFathom.Host.Security;
+using MailFathom.Infrastructure.Secrets;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests;
+
+/// <summary>Covers what a surface's registration decides, and what it keeps separate from every other surface.</summary>
+/// <remarks>
+/// The isolation assertions are the reason this code was made to take a surface at all. Two surfaces sharing a scheme
+/// name would mean one endpoint's credential silently satisfying the other's policy, which no test of either surface on
+/// its own would notice.
+/// </remarks>
+public sealed class TransportSecurityExtensionsTests
+{
+    /// <summary>
+    /// An access token is a reusable credential, so presenting one over plain HTTP hands it to anybody watching the
+    /// network. The refusal is silent, which is what makes the answer the same challenge an unauthenticated request
+    /// receives rather than a statement about what the request carried.
+    /// </summary>
+    [Fact]
+    public async Task RefuseATokenThatArrivedWithoutTransportEncryption_APlaintextRequest_AuthenticatesNobody()
+    {
+        // Arrange
+        var context = MessageReceivedOver("http");
+
+        // Act
+        await TransportSecurityExtensions.RefuseATokenThatArrivedWithoutTransportEncryption(context);
+
+        // Assert
+        Assert.NotNull(context.Result);
+        Assert.True(context.Result.None);
+    }
+
+    [Fact]
+    public async Task RefuseATokenThatArrivedWithoutTransportEncryption_AnEncryptedRequest_LeavesTheTokenToBeValidated()
+    {
+        // Arrange
+        var context = MessageReceivedOver("https");
+
+        // Act
+        await TransportSecurityExtensions.RefuseATokenThatArrivedWithoutTransportEncryption(context);
+
+        // Assert
+        Assert.Null(context.Result);
+    }
+
+    [Fact]
+    public void AddTransportAuthentication_TheSurfacesRoutingScheme_IsTheDefaultAnAnonymousRequestReaches()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        AddApiKeyAuthentication(services, TransportSurface.Mcp);
+
+        // Assert
+        using var composed = services.BuildServiceProvider();
+        var authentication = composed.GetRequiredService<IOptions<AuthenticationOptions>>().Value;
+
+        Assert.Equal(TransportSurface.Mcp.RoutingSchemeName, authentication.DefaultScheme);
+    }
+
+    /// <summary>
+    /// The policy names one routing scheme, and that is the whole of what keeps two surfaces apart. Naming the other
+    /// surface's scheme as well — or naming none, which lets the application default answer — would let a credential
+    /// issued for one endpoint satisfy the other's requirement without any check noticing.
+    /// </summary>
+    [Fact]
+    public void AddTransportAuthentication_TheSurfacesPolicy_ConsultsThatSurfacesRoutingSchemeAlone()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        AddApiKeyAuthentication(services, TransportSurface.Mcp);
+
+        // Assert
+        using var composed = services.BuildServiceProvider();
+        var policy = composed
+            .GetRequiredService<IOptions<AuthorizationOptions>>()
+            .Value
+            .GetPolicy(TransportSurface.Mcp.AccessPolicyName);
+
+        Assert.NotNull(policy);
+        Assert.Equal([TransportSurface.Mcp.RoutingSchemeName], policy.AuthenticationSchemes);
+    }
+
+    /// <summary>
+    /// Every name a surface registers is composed from the surface, so no two surfaces can collide on one. A shared
+    /// name would merge two policies into whichever registration ran last, and the endpoint that lost would be
+    /// protected by settings its operator never wrote.
+    /// </summary>
+    [Fact]
+    public void TransportSurface_TwoSurfaces_ShareNoSchemeOrPolicyName()
+    {
+        // Arrange: the second surface is built the way a further one would be, through the same public shape.
+        var mcp = TransportSurface.Mcp;
+
+        // Act
+        string[] mcpNames =
+        [
+            mcp.RoutingSchemeName,
+            mcp.ApiKeySchemeName,
+            mcp.AccessPolicyName,
+            mcp.OAuthSchemeNameFor("workforce"),
+        ];
+
+        // Assert: every name carries the surface, so a surface named otherwise produces a disjoint set.
+        Assert.All(mcpNames, name => Assert.Contains($":{mcp.Name}:", name, StringComparison.Ordinal));
+        Assert.Equal(mcpNames.Length, mcpNames.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void AddTransportAuthentication_TheStructDefaultAsASurface_IsRefusedRatherThanRegisteringUnnamedSchemes()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() => AddApiKeyAuthentication(services, default));
+    }
+
+    private static void AddApiKeyAuthentication(IServiceCollection services, TransportSurface surface) =>
+        services.AddTransportAuthentication(
+            surface,
+            TransportAuthenticationMethods.ApiKey,
+            [new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:not-a-real-key" }],
+            new OAuthValidationOptions(),
+            surface.IsSpecified ? surface.ApiKeySchemeName : "unused");
+
+    private static MessageReceivedContext MessageReceivedOver(string scheme)
+    {
+        var request = new DefaultHttpContext();
+        request.Request.Scheme = scheme;
+
+        return new MessageReceivedContext(
+            request,
+            new AuthenticationScheme(
+                TransportSurface.Mcp.OAuthSchemeNameFor("workforce"),
+                displayName: null,
+                typeof(JwtBearerHandler)),
+            new JwtBearerOptions());
+    }
+}

--- a/tests/Infrastructure.UnitTests/ApiKeyAuthenticatorTests.cs
+++ b/tests/Infrastructure.UnitTests/ApiKeyAuthenticatorTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 namespace MailFathom.Infrastructure.UnitTests;
 
 /// <summary>Covers which presented credentials authenticate, which do not, and what a refusal is allowed to reveal.</summary>
-public sealed class McpApiKeyAuthenticatorTests
+public sealed class ApiKeyAuthenticatorTests
 {
     private const string WorkstationKeyMaterial = "8f2c1d5e-workstation";
 
@@ -99,7 +99,7 @@ public sealed class McpApiKeyAuthenticatorTests
 
         // Assert
         Assert.False(result.Succeeded);
-        Assert.Equal(McpApiKeyRejection.CredentialExpired, result.Rejection);
+        Assert.Equal(ApiKeyRejection.CredentialExpired, result.Rejection);
     }
 
     [Fact]
@@ -163,7 +163,7 @@ public sealed class McpApiKeyAuthenticatorTests
             "Bearer not-a-configured-key");
 
         // Assert
-        Assert.Equal(McpApiKeyRejection.CredentialUnrecognized, result.Rejection);
+        Assert.Equal(ApiKeyRejection.CredentialUnrecognized, result.Rejection);
     }
 
     /// <summary>The presented credential is compared in full, so a prefix of a real key is as unrecognized as anything else.</summary>
@@ -179,7 +179,7 @@ public sealed class McpApiKeyAuthenticatorTests
             $"Bearer {WorkstationKeyMaterial[..8]}");
 
         // Assert
-        Assert.Equal(McpApiKeyRejection.CredentialUnrecognized, result.Rejection);
+        Assert.Equal(ApiKeyRejection.CredentialUnrecognized, result.Rejection);
     }
 
     [Theory]
@@ -195,7 +195,7 @@ public sealed class McpApiKeyAuthenticatorTests
         var result = await harness.AuthenticateAsync([Key("workstation", WorkstationKeyMaterial)], headerValue);
 
         // Assert
-        Assert.Equal(McpApiKeyRejection.CredentialMissing, result.Rejection);
+        Assert.Equal(ApiKeyRejection.CredentialMissing, result.Rejection);
     }
 
     [Theory]
@@ -213,7 +213,7 @@ public sealed class McpApiKeyAuthenticatorTests
         var result = await harness.AuthenticateAsync([Key("workstation", WorkstationKeyMaterial)], headerValue);
 
         // Assert
-        Assert.Equal(McpApiKeyRejection.CredentialMalformed, result.Rejection);
+        Assert.Equal(ApiKeyRejection.CredentialMalformed, result.Rejection);
     }
 
     /// <summary>HTTP matches an authentication scheme without regard to case, and a client that spells it its own way still holds a valid key.</summary>
@@ -370,7 +370,7 @@ public sealed class McpApiKeyAuthenticatorTests
         var result = await harness.AuthenticateAsync([], $"Bearer {WorkstationKeyMaterial}");
 
         // Assert
-        Assert.Equal(McpApiKeyRejection.CredentialUnrecognized, result.Rejection);
+        Assert.Equal(ApiKeyRejection.CredentialUnrecognized, result.Rejection);
     }
 
     private static ConfiguredSecret Key(string name, string material, string? lifetime = null) => new()
@@ -392,10 +392,10 @@ public sealed class McpApiKeyAuthenticatorTests
         // Arrange
         using var logs = new RecordingLoggerProvider();
         using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(logs));
-        var authenticator = new McpApiKeyAuthenticator(
+        var authenticator = new ApiKeyAuthenticator(
             new NewlineTerminatedResolver(WorkstationKeyMaterial),
             new FakeTimeProvider(RequestedAt),
-            loggerFactory.CreateLogger<McpApiKeyAuthenticator>());
+            loggerFactory.CreateLogger<ApiKeyAuthenticator>());
 
         // Act
         var result = await authenticator.AuthenticateAsync(
@@ -419,23 +419,23 @@ public sealed class McpApiKeyAuthenticatorTests
 
     private sealed class AuthenticatorHarness
     {
-        private readonly McpApiKeyAuthenticator authenticator;
+        private readonly ApiKeyAuthenticator authenticator;
 
         internal AuthenticatorHarness()
         {
             using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(this.Logs));
 
-            this.authenticator = new McpApiKeyAuthenticator(
+            this.authenticator = new ApiKeyAuthenticator(
                 this.Resolver,
                 new FakeTimeProvider(RequestedAt),
-                loggerFactory.CreateLogger<McpApiKeyAuthenticator>());
+                loggerFactory.CreateLogger<ApiKeyAuthenticator>());
         }
 
         internal RecordingLoggerProvider Logs { get; } = new();
 
         internal CountingPlaintextResolver Resolver { get; } = new();
 
-        internal Task<McpApiKeyAuthenticationResult> AuthenticateAsync(
+        internal Task<ApiKeyAuthenticationResult> AuthenticateAsync(
             IReadOnlyList<ConfiguredSecret> configuredKeys,
             string? authorizationHeaderValue) => this.authenticator.AuthenticateAsync(
                 configuredKeys,

--- a/tests/Infrastructure.UnitTests/OAuthIdentityTests.cs
+++ b/tests/Infrastructure.UnitTests/OAuthIdentityTests.cs
@@ -13,7 +13,7 @@ namespace MailFathom.Infrastructure.UnitTests;
 /// A claim that survives here is a claim something downstream can eventually be tempted to trust, so the tests that
 /// assert an absence are as load-bearing as the ones asserting a value.
 /// </remarks>
-public sealed class McpOAuthIdentityTests
+public sealed class OAuthIdentityTests
 {
     private const string Scheme = "MailFathomOAuth:workforce";
 
@@ -26,13 +26,13 @@ public sealed class McpOAuthIdentityTests
         var claims = TokenClaims(("iss", Issuer), ("sub", "9f2c"));
 
         // Act
-        var identity = McpOAuthIdentity.FromValidatedToken(claims, Scheme);
+        var identity = OAuthIdentity.FromValidatedToken(claims, Scheme);
 
         // Assert
         Assert.NotNull(identity);
         Assert.Equal(Scheme, identity.AuthenticationType);
-        Assert.Equal($"{Issuer}|9f2c", identity.FindFirst(McpOAuthIdentity.SubjectClaimType)?.Value);
-        Assert.Equal(Issuer, identity.FindFirst(McpOAuthIdentity.IssuerClaimType)?.Value);
+        Assert.Equal($"{Issuer}|9f2c", identity.FindFirst(OAuthIdentity.SubjectClaimType)?.Value);
+        Assert.Equal(Issuer, identity.FindFirst(OAuthIdentity.IssuerClaimType)?.Value);
     }
 
     /// <summary>A subject identifier is unique only within the server that issued it, so two servers naming a subject the same way must not merge into one person.</summary>
@@ -44,13 +44,13 @@ public sealed class McpOAuthIdentityTests
         var fromPartners = TokenClaims(("iss", "https://partners.example.test"), ("sub", "1"));
 
         // Act
-        var workforceIdentity = McpOAuthIdentity.FromValidatedToken(fromWorkforce, Scheme);
-        var partnerIdentity = McpOAuthIdentity.FromValidatedToken(fromPartners, Scheme);
+        var workforceIdentity = OAuthIdentity.FromValidatedToken(fromWorkforce, Scheme);
+        var partnerIdentity = OAuthIdentity.FromValidatedToken(fromPartners, Scheme);
 
         // Assert
         Assert.NotEqual(
-            workforceIdentity?.FindFirst(McpOAuthIdentity.SubjectClaimType)?.Value,
-            partnerIdentity?.FindFirst(McpOAuthIdentity.SubjectClaimType)?.Value);
+            workforceIdentity?.FindFirst(OAuthIdentity.SubjectClaimType)?.Value,
+            partnerIdentity?.FindFirst(OAuthIdentity.SubjectClaimType)?.Value);
     }
 
     /// <summary>Everything an authorization server chose to include beyond the three facts MailFathom acts on is dropped, so nothing downstream can start depending on a claim nobody mapped.</summary>
@@ -67,7 +67,7 @@ public sealed class McpOAuthIdentityTests
             ("tid", "a-tenant"));
 
         // Act
-        var identity = McpOAuthIdentity.FromValidatedToken(claims, Scheme);
+        var identity = OAuthIdentity.FromValidatedToken(claims, Scheme);
 
         // Assert
         Assert.NotNull(identity);
@@ -75,7 +75,7 @@ public sealed class McpOAuthIdentityTests
             identity.Claims,
             claim => Assert.Contains(
                 claim.Type,
-                new[] { McpOAuthIdentity.SubjectClaimType, McpOAuthIdentity.IssuerClaimType, McpOAuthIdentity.ScopeClaimType },
+                new[] { OAuthIdentity.SubjectClaimType, OAuthIdentity.IssuerClaimType, OAuthIdentity.ScopeClaimType },
                 StringComparer.Ordinal));
     }
 
@@ -87,7 +87,7 @@ public sealed class McpOAuthIdentityTests
         var claims = TokenClaims(("iss", Issuer), ("sub", "9f2c"), ("role", "administrator"));
 
         // Act
-        var identity = McpOAuthIdentity.FromValidatedToken(claims, Scheme);
+        var identity = OAuthIdentity.FromValidatedToken(claims, Scheme);
 
         // Assert
         Assert.False(new ClaimsPrincipal(identity!).IsInRole("administrator"));
@@ -104,7 +104,7 @@ public sealed class McpOAuthIdentityTests
             .Where(claim => claim.Type != missingClaimType);
 
         // Act, Assert
-        Assert.Null(McpOAuthIdentity.FromValidatedToken(claims, Scheme));
+        Assert.Null(OAuthIdentity.FromValidatedToken(claims, Scheme));
     }
 
     /// <summary>Picking either of two would let enumeration order decide who the request is.</summary>
@@ -115,7 +115,7 @@ public sealed class McpOAuthIdentityTests
         var claims = TokenClaims(("iss", Issuer), ("sub", "9f2c"), ("sub", "other"));
 
         // Act, Assert
-        Assert.Null(McpOAuthIdentity.FromValidatedToken(claims, Scheme));
+        Assert.Null(OAuthIdentity.FromValidatedToken(claims, Scheme));
     }
 
     /// <summary>Both spellings are in circulation and neither is a provider-specific branch: nothing here asks which server sent the token.</summary>
@@ -128,12 +128,12 @@ public sealed class McpOAuthIdentityTests
         var claims = TokenClaims(("iss", Issuer), ("sub", "9f2c"), (scopeClaimType, "mailfathom.read mailfathom.search"));
 
         // Act
-        var identity = McpOAuthIdentity.FromValidatedToken(claims, Scheme);
+        var identity = OAuthIdentity.FromValidatedToken(claims, Scheme);
 
         // Assert
         Assert.Equal(
             ["mailfathom.read", "mailfathom.search"],
-            identity!.FindAll(McpOAuthIdentity.ScopeClaimType).Select(scope => scope.Value));
+            identity!.FindAll(OAuthIdentity.ScopeClaimType).Select(scope => scope.Value));
     }
 
     [Fact]
@@ -147,12 +147,12 @@ public sealed class McpOAuthIdentityTests
             ("scope", "mailfathom.read mailfathom.search"));
 
         // Act
-        var identity = McpOAuthIdentity.FromValidatedToken(claims, Scheme);
+        var identity = OAuthIdentity.FromValidatedToken(claims, Scheme);
 
         // Assert
         Assert.Equal(
             ["mailfathom.read", "mailfathom.search"],
-            identity!.FindAll(McpOAuthIdentity.ScopeClaimType).Select(scope => scope.Value));
+            identity!.FindAll(OAuthIdentity.ScopeClaimType).Select(scope => scope.Value));
     }
 
     /// <summary>Requiring no scope is the coarser boundary a deployment gets by default, so any authenticated principal satisfies it.</summary>
@@ -163,7 +163,7 @@ public sealed class McpOAuthIdentityTests
         var principal = PrincipalWithScopes();
 
         // Act, Assert
-        Assert.True(McpOAuthIdentity.CarriesEveryScope(principal, []));
+        Assert.True(OAuthIdentity.CarriesEveryScope(principal, []));
     }
 
     [Fact]
@@ -173,7 +173,7 @@ public sealed class McpOAuthIdentityTests
         var principal = PrincipalWithScopes("mailfathom.read", "mailfathom.search");
 
         // Act, Assert
-        Assert.True(McpOAuthIdentity.CarriesEveryScope(principal, ["mailfathom.read"]));
+        Assert.True(OAuthIdentity.CarriesEveryScope(principal, ["mailfathom.read"]));
     }
 
     [Fact]
@@ -183,7 +183,7 @@ public sealed class McpOAuthIdentityTests
         var principal = PrincipalWithScopes("mailfathom.read");
 
         // Act, Assert
-        Assert.False(McpOAuthIdentity.CarriesEveryScope(principal, ["mailfathom.read", "mailfathom.search"]));
+        Assert.False(OAuthIdentity.CarriesEveryScope(principal, ["mailfathom.read", "mailfathom.search"]));
     }
 
     /// <summary>Scopes are compared exactly, because a server issuing 'MailFathom.Read' has issued a different scope from the one configured.</summary>
@@ -194,7 +194,7 @@ public sealed class McpOAuthIdentityTests
         var principal = PrincipalWithScopes("MailFathom.Read");
 
         // Act, Assert
-        Assert.False(McpOAuthIdentity.CarriesEveryScope(principal, ["mailfathom.read"]));
+        Assert.False(OAuthIdentity.CarriesEveryScope(principal, ["mailfathom.read"]));
     }
 
     /// <summary>
@@ -209,7 +209,7 @@ public sealed class McpOAuthIdentityTests
         var claims = TokenClaims([("iss", Issuer), ("sub", "9f2c"), ("roles", "mailbox-administrator")]);
 
         // Act
-        var identity = McpOAuthIdentity.FromValidatedToken(claims, Scheme);
+        var identity = OAuthIdentity.FromValidatedToken(claims, Scheme);
 
         // Assert
         Assert.NotNull(identity);
@@ -224,6 +224,6 @@ public sealed class McpOAuthIdentityTests
     {
         var claims = TokenClaims([("iss", Issuer), ("sub", "9f2c"), ("scope", string.Join(' ', scopes))]);
 
-        return new ClaimsPrincipal(McpOAuthIdentity.FromValidatedToken(claims, Scheme)!);
+        return new ClaimsPrincipal(OAuthIdentity.FromValidatedToken(claims, Scheme)!);
     }
 }

--- a/tests/IntegrationTests/Hosting/ComposedMcpEndpointSecurityTests.cs
+++ b/tests/IntegrationTests/Hosting/ComposedMcpEndpointSecurityTests.cs
@@ -15,7 +15,7 @@ namespace MailFathom.IntegrationTests.Hosting;
 /// <remarks>
 /// <para>
 /// Which credentials authenticate, how they are compared, and which origins are served are all unit-tested against
-/// <c>McpApiKeyAuthenticator</c> and <c>McpOriginPolicy</c>, and none of that is repeated here. What only a composed
+/// <c>ApiKeyAuthenticator</c> and <c>McpOriginPolicy</c>, and none of that is repeated here. What only a composed
 /// host can establish is the part those tests cannot see: that the checks are wired into the request pipeline ahead of
 /// the endpoint at all, and that a refusal happens before the protocol surface produces anything. Every assertion below
 /// is about that ordering, which is why each one reads the body for a tool name the surface would have listed.


### PR DESCRIPTION
Closes #308.

Prerequisite for #309, which adds the administrative endpoint the `mailfathom` CLI talks to. That endpoint needs API-key and OAuth authentication with its own configuration, and none of the existing code could give it that: the scheme names, the policy name, and the key list were all singletons of the MCP surface rather than parameters of it.

The alternative was a second handler beside the first. This is the other one — the same code, given the surface it is protecting.

## What moved

`TransportSurface` is a closed enumeration in the shape `HealthProbe` already uses, and every scheme and policy name is composed from it. `AddTransportAuthentication` takes it along with the accepted methods, the API keys, and the OAuth settings, and registers the routing scheme, the API key scheme, one JWT validator per authorization server, and the access policy.

Two surfaces registered through it share the code and share nothing else. Each has its own routing scheme, and each policy names only its own routing scheme, so a key configured for one authenticates nothing on the other and neither surface's credential can satisfy the other's requirement.

The API key handler now reads its keys from its own `AuthenticationSchemeOptions` subclass instead of reaching into `McpEndpointOptions`. That is what lets one handler serve both surfaces; reading a settings type would have tied it to one section.

Renames follow from that, and are mechanical: `Mcp*` became the transport-neutral name wherever the type was never MCP's to begin with — `TransportAuthenticationMethods`, `ApiKeyAuthenticator`, `OAuthIdentity`, `TransportAccessPolicy`, `OAuthTokenValidation`, `AuthorizationServerOptions`, `OAuthValidationOptions`, and the rest.

The second commit does the same for the TLS side, for the same reason: nothing in the HTTPS profiles, the listener binder, the certificate store, or the TLS identity is MCP's — they configure a socket, a handshake, and a set of HTTP versions, and were named `Mcp*` only because the MCP endpoint needed them first. `TransportServerCertificateStore` also stops reading `McpEndpointOptions`; it takes the profiles it loads and the configuration path they were bound from, so a second endpoint gets a store of its own rather than this one growing another section to look in.

## What stayed with MCP

The CORS policy, the client-certificate handshake, the RFC 9728 discovery document, and the insufficient-scope refusal. The last one moved deliberately: an `IAuthorizationMiddlewareResultHandler` is one object for the whole application, so registering it from shared code would let a second surface silently replace the first's refusal. `McpProtectedResourceMetadata` holds the two address helpers that came off `OAuthValidationOptions`, because publishing a discovery document is what a protocol surface does for clients that arrive holding nothing.

## Why this is invisible to a deployment

No configuration key moves, gains a value, or loses one. `McpEndpoint:*` binds exactly as before: every property name on the HTTPS profile is untouched, and the enum members an operator writes — `ApiKey`, `OAuth`, `None`, `Http1`, `Http2`, `Http3`, `Tls12`, `Tls13` — are unchanged. Only type names moved.

One documentation line did go stale, and it is corrected here: `mcp-endpoint.md` prints a startup log whose category is the certificate store's full type name, and a log category is what an operator greps for. Nothing else under `docs/` or `deploy/` names a renamed type — checked rather than assumed, and the remaining `Mcp*` categories in that page belong to types this deliberately leaves alone.

The scheme and policy names did change, and they are internal handles: a challenge names `ApiKeyAuthentication.Realm`, which is unchanged, and a client is never told which scheme judged it. They now carry the surface so that adding one cannot silently collide with another and merge two policies into whichever registered last.

## What #309 still has to solve, and this deliberately does not

`AddAuthentication(scheme)` sets one default for the whole application, and `UseAuthentication` uses it to populate `HttpContext.User` — which `McpRateLimiting` partitions per-client on. Registering a second surface over that default would take it. Removing the default here would leave `User` anonymous and degrade per-client rate limiting into one shared bucket without failing anything, so it is left alone and the constraint is documented on `AddTransportAuthentication`. #309 removes it by scoping each surface's authentication to its own routes.

## Verification

`scripts/verify-full.sh` exit 0 on both commits — `44becc3` and `1235809`: 2112 tests, 0 failed, aggregate line coverage 96.92% against a required 85%.

The existing tests for API-key authentication, OAuth validation, scheme selection, the access policy, and the unauthenticated-posture warning pass unchanged in substance, which is the evidence that behavior did not move. New tests cover what the change introduced: that a surface's policy consults that surface's routing scheme alone, that no two surfaces share a scheme or policy name, and that the struct default is refused rather than registering unnamed schemes.
