### PR TITLE
[#337] Give the deployment one data-encryption key ring, reached through a secret reference

### DIFF
--- a/docs/decisions/0005-data-encryption-key-ring-and-provisioning.md
+++ b/docs/decisions/0005-data-encryption-key-ring-and-provisioning.md
@@ -95,7 +95,11 @@ The generating command is therefore `openssl rand -base64 32`, and it is documen
 
 **The chart must never generate the key, and neither must a Compose hook.** A Helm-generated value regenerates on every `helm upgrade` unless it is guarded with `lookup`, and `lookup` returns nothing during `helm template`, during a dry run, and under Argo CD. For a password that is a reset an operator notices and repairs. For a data-encryption key it is every sealed row becoming permanently unopenable, discovered at the first read after the upgrade rather than at the upgrade.
 
-**Local development is the one exception, and it is an exception because the conditions that make generation unsafe do not hold there.** The Aspire AppHost generates 32 bytes on first start and stores them in .NET user secrets, the way it already keeps the PostgreSQL password stable across runs. There is one writer, the store persists across runs, it lives on the developer's machine rather than in the deployment, and it never reaches a published artifact. A developer therefore runs nothing by hand and still gets a key that survives a restart, which is what makes the local database's sealed rows keep opening.
+**Local development is the one place where the operator's step is the wrong answer, and how it is answered is deliberately left open.** A developer running the Aspire app host is not provisioning a deployment, and a key they have to generate by hand before the first `dotnet run` is ceremony bought for nothing: the local database holds synthetic mail and the machine is not a deployment.
+
+What that exception must not be is generation into a store that can outlive, or be outlived by, the data it protects. `src/AppHost/Program.cs` states the PostgreSQL password as the fixed constant `postgres` rather than generating one for exactly that reason — a generated password persisted per run diverges from a data volume that survives it, because PostgreSQL applies a password when it initializes an empty data directory and never again. A key is worse under the same failure: a diverged password reports an authentication error, and a diverged key leaves every locally sealed row unopenable.
+
+So the two candidates are a fixed development constant, which cannot diverge from itself and matches what the password already does, or generation into user secrets, which is what the password deliberately does not do. **Neither is implemented.** Nothing in the repository generates or persists a data-encryption key today, and until one exists a developer configures the section themselves or runs without it. Issue 329 carries the mechanism, and this record is `proposed`, so the choice belongs to the review of that change rather than to this text.
 
 ### Consequences
 
@@ -107,7 +111,7 @@ The generating command is therefore `openssl rand -base64 32`, and it is documen
 - Neutral, because MailFathom joins the set of systems whose backup is incomplete without a second artifact. That is true of every encrypted store and it is a documentation obligation rather than a design flaw.
 - Bad, because losing the key loses the sealed data. Today that means re-authorizing every mailbox; once a second column is sealed it will mean more, and the cost of the mistake grows without the mechanism changing.
 - Bad, because the operator has one more step at install. It is one line between two identical lines they already run, and it is the price of the two `Good` entries above.
-- Bad, because a developer's local key lives in user secrets in the clear. That is the same protection the local database password already has, on a machine that is not a deployment, and raising it would mean giving a developer the operator's ceremony back.
+- Bad, because local development is left without an answer for now: until the mechanism above is chosen and built, a developer either configures the section themselves or runs without it, which is the ceremony this decision says they should not need.
 
 ## Validation
 

--- a/docs/decisions/0005-data-encryption-key-ring-and-provisioning.md
+++ b/docs/decisions/0005-data-encryption-key-ring-and-provisioning.md
@@ -1,0 +1,185 @@
+---
+status: proposed
+contact: Krzysztof Kasprowicz
+date: 2026-08-03
+deciders: Krzysztof Kasprowicz
+consulted:
+informed:
+---
+
+# Seal data at rest under one deployment-wide symmetric key ring, provisioned as a secret reference the operator creates
+
+<!-- describes: src/Host/Configuration/DataEncryption/**, src/Infrastructure/DataEncryption/**, src/Common/AesGcmEnvelope.cs, src/AppHost/Program.cs -->
+
+## Context and Problem Statement
+
+MailFathom is about to hold its first credential that the service itself writes. A mailbox refresh token is a long-lived credential acting for a named mailbox owner, and until now it arrived the way every other credential does: as a `SecretReference` the process resolves and never writes back. That read-only path is why a refresh token the authorization server rotates cannot be followed, and `docs/operations/mailbox-oauth.md` documents the consequence as an instruction to the operator — watch for a warning and re-authorize before the configured token stops being accepted. An operator watching a log is a mitigation, not a design.
+
+Giving the service a store it can write moves the credential out of the operator's secret system and into MailFathom's own database, which is the whole reason this decision exists. A credential the service persists is a credential the service is now responsible for protecting, and the database is a place a refresh token has never been before: it is dumped for backups, streamed to replicas, restored onto other machines, and read by anyone who obtains one of those copies.
+
+The decision question has three parts that are usually collapsed into one: **what seals the data**, **where the key comes from**, and **who creates the key in the first place**. The third is the part that decides whether the feature is usable, and it is the one where the obvious courtesy — generate it so nobody has to — is the dangerous answer.
+
+Recorded on issue 329, whose scope this ADR is part of. Issue 330 delivers the provisioning through each deployment channel and issue 331 writes a grant through the administrative endpoint; both depend on what is decided here. No numbered specification under `specs/` backs it, though specification 02a defines the secret-reference grammar this reuses and specification 02b defines the rotation vocabulary.
+
+## Decision Drivers
+
+- The threat is a **copy of the database**, not a compromised host: a backup file, a logical dump, a read replica, a restored volume, a decommissioned disk. A mechanism that only protects the running server answers none of them.
+- Every replica of one deployment must open what any other replica sealed. This is stated as an acceptance criterion on issue 329 and it eliminates every per-machine scheme, including the one `mfctl` already uses for its own workstation store.
+- A key must never be **regenerated**. Losing it is not a reset an operator notices and repairs; it is data that no longer opens, discovered at the first read rather than at the moment of loss.
+- Provisioning must have **one shape across all three deployment channels** — Compose, Kubernetes, and a native systemd unit — because a mechanism per channel is three things to document, three to test, and three to get wrong.
+- MailFathom must start with **no network dependency for the key**. A token refresh that first needs a key service turns one outage into two.
+- The key ring must be **general from the start**. Refresh tokens are the first sealed column and will not be the last; a second one must configure nothing new.
+- Local development must not need the operator's ceremony. A developer running `dotnet run` on the AppHost is not provisioning a deployment.
+
+## Considered Options
+
+The decision has two independent axes, and an option on one does not constrain an option on the other.
+
+**What seals the data:**
+
+1. Application-level AES-256-GCM through the existing `AesGcmEnvelope`, under a key ring the deployment configures.
+2. PostgreSQL `pgcrypto`, sealing in the database with `pgp_sym_encrypt`.
+3. Volume or full-disk encryption alone, with the column left in the clear.
+4. An external key-management service — Vault transit, AWS KMS, Azure Key Vault — invoked per operation.
+
+**Where the key comes from, and who creates it:**
+
+- **A.** The operator generates 32 bytes once at install and provisions them as an ordinary `SecretReference`, identically in every channel.
+- **B.** The host generates the key on first start into a durable state directory, and every channel supplies one.
+- **C.** Each deployment channel's own tooling generates it: a one-shot init service under Compose, a `pre-install` hook Job in the Helm chart, an `ExecStartPre` in the systemd unit.
+- **D.** `mfctl` generates it, either as a local command, as a full installer, or through the administrative endpoint.
+
+## Decision Outcome
+
+Chosen options: **1, application-level AES-256-GCM under a configured key ring**, and **A, an operator-generated key provisioned as a secret reference** — with one deliberate exception for local development, recorded below.
+
+Option 1 wins because it is the only one whose protection survives the copy. The value is already ciphertext before it reaches Npgsql, so it is ciphertext in the write-ahead log, in a `pg_dump`, on a replica, and in a restored volume, and the key is never in the database, never in a SQL statement, and never in a query log.
+
+Option A wins because provisioning a key is a one-line act the operator already performs twice for the two database passwords, and because every alternative buys the removal of that one line by adding a mechanism that can lose the key. That trade is wrong in the direction that cannot be undone.
+
+### What is decided
+
+**The key is a `SecretReference`, like every credential MailFathom already holds.** It adds no provisioning mechanism, no new startup failure mode, and no new supply-chain surface. A `systemd-credential:`, a `file:`, or an `env:` reference resolves it, and a mounted Kubernetes `Secret` gives every replica of a deployment the same bytes.
+
+```jsonc
+{
+  "DataEncryption": {
+    "ActiveKeyId": "2026-08",
+    "Keys": [
+      {
+        "KeyId": "2026-08",
+        "Material": { "Name": "mailfathom-data-key", "SecretReference": "systemd-credential:mailfathom-data-key" }
+      }
+    ]
+  }
+}
+```
+
+**The ring is its own configuration root rather than a section of `Persistence`.** The database is the first thing sealed under it and there is no reason it will be the last — a cached credential, an exported artifact, and a queued outbound payload are all candidates, and none of them is persistence. Nesting the ring under the first consumer would name it after the consumer, and the second one would either move the section or inherit a section whose name says it belongs to something else. `DataEncryption` also becomes its own uniqueness scope for secret names, which is what every configuration root already is, so a key's material cannot collide with a name `Persistence` already uses.
+
+`DataProtection` was the other candidate and is refused: ASP.NET Core publishes a subsystem under exactly that name with a different purpose, key lifetime, and threat model, and a reader who knows it would read this section as that one.
+
+**A key entry is identified twice, and the two identities have different jobs.** `KeyId` is written into every sealed value, so it is an identity the database holds and it can never be changed once a single row references it. `Material.Name` is the operator's own label, required of every secret block by the rules `docs/operations/secret-provisioning.md` already states, and it is what a validation failure, a rotation instruction, and an audit record name this key by — exactly as they do for a mailbox password or a trust anchor.
+
+No third name is added on the key entry itself. A key entry holds exactly one material, so a label there would be a second name for the same object, and the two would disagree the first time somebody edited one of them.
+
+**The material is base64 that decodes to exactly 32 bytes.** Base64 rather than raw bytes because every channel that carries this already carries text: a Compose secret file, a Kubernetes `Secret` value, and a systemd credential are all handled as text by the tools that write them, and a raw 32-byte file acquires a trailing newline the first time anyone edits it. Exactly 32 because that is what AES-256 takes, and the length is validated at startup rather than at the first read — a shorter key is a typo, not a weaker key.
+
+The generating command is therefore `openssl rand -base64 32`, and it is documented as such in one place. The neighbouring database passwords use `-base64 33`, which is correct for them and wrong here, so the two must never be copied from one another.
+
+**Every sealed value is bound to `(subject, purpose, keyId)` as associated data.** Sharing one key ring across future sealed columns is only safe if a value cannot be moved between them, and the binding is what makes it unsafe to try: a sealed refresh token does not open as anything else even under the same key, a row copied between accounts fails to open rather than opening as the wrong owner's credential, and a row from another deployment fails to open at all. `purpose` is what lets the second sealed column arrive without a second key.
+
+**Each sealed value stores the identifier of the key that sealed it.** Without it, replacing a key is a flag day with the service stopped. With it, two keys coexist in the ring, a value is re-sealed under the active key the next time it is written, and a key is retired once nothing references it. That is the whole rotation model, and it is the reason `ActiveKeyId` names a key rather than the ring holding a single one.
+
+**A deployment that seals nothing needs no ring.** An absent `DataEncryption` section is a valid configuration and not an omission to report, because no stored value carries a key identifier until something seals one. The section becomes required by whatever first seals a value, at the point that value is written, rather than by the ring's own existence — otherwise adding the ring would refuse to start every deployment that has no use for it yet, which is a break bought for nothing. What is refused even in an absent ring is an `ActiveKeyId` naming a key nothing configures, because an operator who wrote one meant to provision it.
+
+**The chart must never generate the key, and neither must a Compose hook.** A Helm-generated value regenerates on every `helm upgrade` unless it is guarded with `lookup`, and `lookup` returns nothing during `helm template`, during a dry run, and under Argo CD. For a password that is a reset an operator notices and repairs. For a data-encryption key it is every sealed row becoming permanently unopenable, discovered at the first read after the upgrade rather than at the upgrade.
+
+**Local development is the one exception, and it is an exception because the conditions that make generation unsafe do not hold there.** The Aspire AppHost generates 32 bytes on first start and stores them in .NET user secrets, the way it already keeps the PostgreSQL password stable across runs. There is one writer, the store persists across runs, it lives on the developer's machine rather than in the deployment, and it never reaches a published artifact. A developer therefore runs nothing by hand and still gets a key that survives a restart, which is what makes the local database's sealed rows keep opening.
+
+### Consequences
+
+- Good, because a database copy — a dump, a replica, a restored volume, a stolen disk — discloses no refresh token, which is the only threat any of the four options was asked to answer.
+- Good, because provisioning is one command in one shape, and an operator learns it once for all three channels rather than once per channel.
+- Good, because the key ring is general: a second sealed column configures nothing, migrates nothing, and rotates through the same `ActiveKeyId` move.
+- Good, because rotation needs no downtime and no flag day, and a half-rotated deployment is a valid state rather than an outage.
+- Neutral, because the key protects the database against a copy and not against the running host. Anyone able to read the process's resolved configuration can read the key, and no scheme that starts unattended can prevent that.
+- Neutral, because MailFathom joins the set of systems whose backup is incomplete without a second artifact. That is true of every encrypted store and it is a documentation obligation rather than a design flaw.
+- Bad, because losing the key loses the sealed data. Today that means re-authorizing every mailbox; once a second column is sealed it will mean more, and the cost of the mistake grows without the mechanism changing.
+- Bad, because the operator has one more step at install. It is one line between two identical lines they already run, and it is the price of the two `Good` entries above.
+- Bad, because a developer's local key lives in user secrets in the clear. That is the same protection the local database password already has, on a machine that is not a deployment, and raising it would mean giving a developer the operator's ceremony back.
+
+## Validation
+
+- Startup validation refuses, naming the setting: an `ActiveKeyId` that names no configured key, material that does not decode to exactly 32 bytes, a duplicate `KeyId`, and an empty ring where a sealed column exists. Unit tests cover each refusal.
+- Unit tests cover the associated-data binding by proving a value sealed for one subject or one purpose does not open as another, and cover active-key selection and re-sealing.
+- The integration suite covers the EF mapping, the migration, and the round trip through PostgreSQL.
+- `helm lint` and `helm template` against `deploy/helm/mailfathom/ci/*-values.yaml` prove the chart creates no `Secret` of its own; a template that did would be a review failure against this record.
+- `docs/operations/secret-provisioning.md` holds the generating command once, and the other pages point at it. A second spelling of the command anywhere is a documentation defect.
+
+## Pros and Cons of the Options
+
+### 1. Application-level AES-256-GCM under a configured key ring
+
+Sealing happens in `Infrastructure` before the value reaches the provider, using `AesGcmEnvelope`, which already exists, is already tested, and already holds no key of its own.
+
+- Good, because the ciphertext is what PostgreSQL ever sees, so every copy of the database is covered by the same guarantee.
+- Good, because it reuses a component the repository already ships and trusts, rather than adding a second cryptographic implementation with its own format.
+- Good, because associated data gives the binding that makes one key ring safe across several columns.
+- Neutral, because a sealed column cannot be searched, ordered, or indexed by value. Nothing needs to search a refresh token, and a future column that does would need its own decision.
+- Bad, because MailFathom owns the format. A layout change would have to open values written by an older build, which is why the envelope's layout is fixed rather than configurable.
+
+### 2. PostgreSQL `pgcrypto`
+
+- Good, because it needs no application code and the column is encrypted at rest.
+- Bad, because the key travels to the database in the statement text, so it lands in `pg_stat_statements`, in server logs at a sufficient `log_statement`, and in the memory of the process holding the data. The key and the ciphertext end up in the same trust boundary, which is the boundary this decision exists to separate.
+- Bad, because key rotation becomes a SQL migration over rows rather than a configuration move.
+
+### 3. Volume or full-disk encryption alone
+
+- Good, because it costs nothing to implement and every deployment target offers it.
+- Neutral, because it remains worth doing underneath any of the other options.
+- Bad, because it protects a powered-off disk and nothing else. A dump, a replica, a backup file, and a restored volume are all readable, and those are the copies a credential actually leaks through.
+
+### 4. An external key-management service per operation
+
+- Good, because the key never exists in MailFathom's process and rotation is the service's problem.
+- Bad, because it puts a network dependency in the path of a mailbox token refresh, so one provider's outage becomes two.
+- Bad, because it replaces one credential to provision with another — the KMS credential — and does not remove the first-secret problem, only moves it.
+- Neutral, because a future adapter can supply the key ring's material from such a service without changing anything decided here. The ring resolves a `SecretReference`, and a scheme is where that would land.
+
+### A. The operator generates the key at install
+
+- Good, because it is the same act, in the same place, as the two database passwords the operator already generates, and the Compose `.env.example` already establishes the precedent.
+- Good, because nothing can regenerate what nothing generates.
+- Good, because the operator **knows the key exists**, which is what makes them back it up with the database. No automatic scheme can give this back.
+- Bad, because it is a manual step, and an install that fails because it was skipped is a worse first experience than one that starts.
+- Neutral, because the failure is immediate, named, and at startup rather than at the first token request, which is what keeps the skipped step cheap.
+
+### B. The host generates on first start into a durable state directory
+
+- Good, because Compose and a systemd unit both have exactly one writer and a place that persists, so it would be safe in those two channels.
+- Bad, because Kubernetes has neither, and the answers are a read-write-once volume that forbids a second replica, or an init container writing `Secret`s with a permission the chart has no other reason to hold.
+- Bad, because the container is deliberately `read_only` with only a `tmpfs`, so this buys the one line back by adding a writable mount to a hardened deployment.
+- Bad, because a key nobody chose is a key nobody backs up. The failure surfaces when a database is restored somewhere else, which is the worst moment to learn the design.
+
+### C. Per-channel install tooling
+
+- Good, because the operator does nothing in any of the three channels.
+- Bad, because the MailFathom image is chiseled and has no shell, so a Compose init service needs a second image and the Helm hook needs a third.
+- Bad, because Argo CD maps `pre-install` and `pre-upgrade` alike onto `PreSync`, so the hook that was meant to run once runs on every sync and its own idempotence becomes the only thing standing between an upgrade and unopenable data.
+- Bad, because it is three mechanisms in YAML and shell where option A is one sentence, and none of them is reachable by the test suite.
+
+### D. `mfctl`
+
+- Good, as a local generator, because it would produce exactly 32 bytes in exactly the right encoding, where `openssl rand -base64 33` copied from the line above it would not.
+- Neutral, because that variant is option A with a different command, so it changes the ergonomics and not the decision.
+- Bad, as an installer, because preparing a deployment directory is a deployment script, and issue 119 removed those deliberately; it also has nothing to prepare under Kubernetes, where Helm installs.
+- Bad, through the administrative endpoint, because the service would need somewhere to persist the key before it has one, and the only place it always has is the database — which would put the key protecting the database inside the database.
+
+## More Information
+
+- Issue 329 implements the ring and the first sealed column; issue 330 provisions the key through each channel; issue 331 writes a grant through the administrative endpoint.
+- ADR 0001 governs the port the sealed store is reached through, and ADR 0002 governs where the key ring is bound and mapped.
+- `AesGcmEnvelope` in `src/Common/` is shared with `mfctl`'s own credential store. That store keeps a per-machine key beside its file, which is right for one workstation and is exactly the scheme this decision rejects for a deployment, because a per-machine key gives a replica set as many keys as replicas.
+- Revisit this decision if a sealed column ever has to be searched or joined by value, if a deployment target appears where an operator cannot provision a secret before the first start, or if MailFathom gains a first-class key-management adapter — the third would extend the ring's material resolution rather than replace anything recorded here.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,3 +25,4 @@ For background on ADRs, see <https://adr.github.io/>.
 - [0002: Use an application-owned configuration access layer for reading, mapping, and reloadable business settings](0002-configuration-reading-mapping-and-reload-boundary.md)
 - [0003: Give every first-party failure one base type and a five-digit stable error code](0003-first-party-exception-hierarchy-and-stable-error-codes.md)
 - [0004: Version the four public surfaces with SemVer, stamp builds from one declared prefix, and cut a release with a Git tag](0004-versioning-and-release-policy.md)
+- [0005: Seal data at rest under one deployment-wide symmetric key ring, provisioned as a secret reference the operator creates](0005-data-encryption-key-ring-and-provisioning.md)

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -159,6 +159,29 @@ Repointing a reference or editing the connection string reloads; changing *which
 moving a password out of the connection string into `Persistence:Password`, or back — is refused on reload and needs a
 restart, because the connection pool attaches its password provider once.
 
+## `DataEncryption`
+
+The key ring every value MailFathom seals at rest is sealed under. A configuration root of its own rather than a
+section of `Persistence`, because the database is the first thing sealed under it and there is no reason it is the
+last. [ADR 0005](../decisions/0005-data-encryption-key-ring-and-provisioning.md) records the whole decision, and
+[secret provisioning](secret-provisioning.md) states how the material is generated and referenced.
+
+An absent section is a valid deployment that seals nothing. Configuring the section makes every rule below apply.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `DataEncryption:ActiveKeyId` | string | unset | Must name one of `Keys`; required once any key is configured, and refused when none is | reload |
+| `DataEncryption:Keys:<n>:KeyId` | string | — | Up to 64 letters, digits, dots, dashes, and underscores, beginning with a letter or a digit; unique within the ring | reload |
+| `DataEncryption:Keys:<n>:Material` | secret block | — | Base64 decoding to exactly 32 bytes, generated with `openssl rand -base64 32` | reload; material per operation |
+
+`KeyId` is stored beside every value the key seals, so it is chosen once and never edited — renaming it orphans every
+value already carrying the previous spelling. The operator's own label for a key is its material's `Name`, which every
+secret block requires; there is no second name on the entry.
+
+The ring holds several keys so that rotation needs no downtime: move `ActiveKeyId` to the new key, leave the previous
+key configured, and every value still carrying it keeps opening under it. Removing a key the database still references
+makes those values unopenable, and the failure appears at the next read rather than at the edit.
+
 ## `MailboxSearch`
 
 The deployment-wide privacy bound on what a search result may quote. [Lexical email

--- a/docs/operations/secret-provisioning.md
+++ b/docs/operations/secret-provisioning.md
@@ -197,6 +197,22 @@ A Secrets Store CSI driver — Vault, Azure Key Vault, AWS Secrets Manager — n
 
 `LoadCredential=`, Compose secrets, and Kubernetes Secret files routinely end with a newline, and an untrimmed byte presents as a wrong password. MailFathom therefore strips **one** trailing newline when it decodes material as text. Binary material is never modified: a PKCS#12 bundle or a DER-encoded certificate survives resolution byte for byte.
 
+## The data-encryption key
+
+MailFathom seals values it stores under a key the deployment provisions, and the key arrives as an ordinary secret reference like every other credential. What differs is the material behind it: it is **base64 that decodes to exactly 32 bytes**, and startup refuses anything else naming the setting rather than accepting a weaker key.
+
+Generate one with:
+
+```console
+openssl rand -base64 32
+```
+
+**This is not the command beside it.** The two database passwords in a Compose deployment are generated with `openssl rand -base64 33`, which is right for a password and wrong for a key, so copying the neighbouring line produces material startup rejects. Thirty-two is what AES-256 takes.
+
+The key is generated once and never regenerated. Losing it makes every value sealed under it unopenable, and the failure appears at the next read rather than at the moment of loss, so **back it up with the database rather than beside it** — a database restored without its key restores nothing that was sealed. Nothing in MailFathom generates the key for you, in any deployment channel, for the same reason: a mechanism that can create a key can create a second one. [ADR 0005](../decisions/0005-data-encryption-key-ring-and-provisioning.md) records that decision and what each alternative costs.
+
+`DataEncryption:ActiveKeyId` selects which configured key new values are sealed under, and the ring keeps every key a stored value may still name. Rotating is therefore two steps and no downtime: add the new key, move `ActiveKeyId` to it, and leave the previous key configured until nothing references it. [Configuration reference](configuration-reference.md#dataencryption) states every key of the section.
+
 ## Certificate material
 
 A trust anchor is provisioned like any other secret, but the bytes behind it are loaded as a certificate rather than used as a credential. PEM, DER, and PKCS#12 all load, recognized from the material itself so a mistyped encoding hint cannot exist. Only PEM can be supplied inline, because the other two are binary; an inline block carrying them fails startup naming the encoding. A bundle's password, when it has one, goes in the nested `Password` block.

--- a/src/Host/Configuration/DataEncryption/DataEncryptionKeyOptions.cs
+++ b/src/Host/Configuration/DataEncryption/DataEncryptionKeyOptions.cs
@@ -1,0 +1,42 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Infrastructure.Secrets.Discovery;
+
+namespace MailFathom.Host.Configuration.DataEncryption;
+
+/// <summary>One key of the deployment's data-encryption key ring.</summary>
+/// <remarks>
+/// <para>
+/// A key entry is identified twice, and the two identities do different jobs. <see cref="KeyId" /> is written beside
+/// every value this key seals, so the database holds it and it can never be changed once a single row references it.
+/// The operator's own label is the required <c>Name</c> of <see cref="Material" />, which every secret block carries and
+/// which every diagnostic, rotation instruction, and audit record names the key by. No third name is added here: an
+/// entry holds exactly one material, so a second label would be a second name for the same object.
+/// </para>
+/// <para>
+/// See <see href="../../../../docs/decisions/0005-data-encryption-key-ring-and-provisioning.md">ADR 0005</see> for the
+/// key ring, the provisioning model, and why the material is base64 rather than raw bytes.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed class DataEncryptionKeyOptions
+{
+    /// <summary>Gets or sets the identifier stored beside every value this key seals.</summary>
+    /// <remarks>
+    /// It is persisted, so it is chosen once and never edited: renaming it orphans every value that already carries the
+    /// previous spelling. A date such as <c>2026-08</c> reads well because it says when the key entered service, which
+    /// is the question an operator asks when deciding what to retire.
+    /// </remarks>
+    public string KeyId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the reference to the key material: base64 that decodes to exactly 32 bytes.</summary>
+    /// <remarks>
+    /// Generate it with <c>openssl rand -base64 32</c>. The two database passwords beside it in a Compose deployment are
+    /// generated with <c>-base64 33</c>, which is right for them and wrong here, so the commands must never be copied
+    /// from one another — startup refuses material of any other length rather than silently accepting a weaker key.
+    /// </remarks>
+    public ConfiguredSecret? Material { get; set; }
+}

--- a/src/Host/Configuration/DataEncryption/DataEncryptionKeyRingMapper.cs
+++ b/src/Host/Configuration/DataEncryption/DataEncryptionKeyRingMapper.cs
@@ -1,0 +1,36 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.DataEncryption;
+
+namespace MailFathom.Host.Configuration.DataEncryption;
+
+/// <summary>Maps the bound <c>DataEncryption</c> section onto the settings the encryption adapter reads.</summary>
+/// <remarks>
+/// The adapter depends on a settings record rather than on the host's bindable options, which is what keeps the
+/// configuration binder, its mutability, and its validation attributes out of infrastructure — the same split
+/// <see cref="Persistence.DatabaseConnectionSettingsMapper" /> already applies to the database credential.
+/// </remarks>
+internal static class DataEncryptionKeyRingMapper
+{
+    /// <summary>Maps one bound snapshot.</summary>
+    /// <param name="settings">The bound section.</param>
+    /// <returns>The key ring as the adapter reads it.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="settings" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A key configuring no material is dropped rather than mapped with an absent reference. Startup already refuses
+    /// such a snapshot, so this path is only reached while that refusal is being composed, and carrying a half-built
+    /// key into the ring would replace a named configuration error with a null dereference.
+    /// </remarks>
+    internal static DataEncryptionKeyRingSettings Map(DataEncryptionOptions settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        return new DataEncryptionKeyRingSettings(
+            settings.ActiveKeyId,
+            [.. settings.Keys
+                .Where(key => key.Material is not null)
+                .Select(key => new DataEncryptionKeyReference(key.KeyId, key.Material!))]);
+    }
+}

--- a/src/Host/Configuration/DataEncryption/DataEncryptionOptions.cs
+++ b/src/Host/Configuration/DataEncryption/DataEncryptionOptions.cs
@@ -1,0 +1,136 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+
+namespace MailFathom.Host.Configuration.DataEncryption;
+
+/// <summary>Configures the key ring every value MailFathom seals at rest is sealed under.</summary>
+/// <remarks>
+/// <para>
+/// This is a configuration root of its own rather than a section of <c>Persistence</c>. The database is the first thing
+/// sealed under the ring and there is no reason it is the last, so naming the ring after its first consumer would leave
+/// the second one either moving the section or inheriting a name that says the ring belongs elsewhere. Being a root also
+/// makes it a uniqueness scope for secret names, exactly as <c>MailSynchronization</c> and <c>McpEndpoint</c> are.
+/// </para>
+/// <para>
+/// The ring holds several keys so that rotation is not a flag day. Every sealed value stores the identifier of the key
+/// that sealed it, a value is re-sealed under <see cref="ActiveKeyId" /> the next time it is written, and a key is
+/// retired once nothing references it. A ring that configured one key could only be replaced with the service stopped.
+/// </para>
+/// <para>
+/// Validation here covers what the configuration can be judged on by reading it. Whether the referenced material
+/// resolves, and whether it decodes to a key of the right length, is answered where the references are resolved, so a
+/// mistyped path and a truncated key are reported together with every other unusable secret rather than one restart
+/// apart. See
+/// <see href="../../../../docs/decisions/0005-data-encryption-key-ring-and-provisioning.md">ADR 0005</see>.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed partial class DataEncryptionOptions : IValidatableObject
+{
+    /// <summary>Gets or sets the identifier of the key new values are sealed under.</summary>
+    /// <remarks>
+    /// Moving it to another configured key is the whole of a rotation's first half: from that moment every value
+    /// written is sealed under the new key, while values still carrying the previous identifier keep opening under the
+    /// key that sealed them. The previous key therefore stays configured until nothing references it.
+    /// </remarks>
+    public string ActiveKeyId { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets every key the deployment can open a sealed value with.</summary>
+    /// <remarks>
+    /// Removing a key that sealed values the database still holds makes those values unopenable, and the failure appears
+    /// at the next read rather than at the edit, so a key is removed only once it is known to be unreferenced.
+    /// </remarks>
+    public IList<DataEncryptionKeyOptions> Keys { get; } = [];
+
+    /// <inheritdoc />
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        // An absent section is a deployment that seals nothing, which is a valid deployment: no stored value carries a
+        // key identifier yet, so requiring a key here would refuse to start every deployment that has no use for one.
+        // The section becomes required by whatever first seals a value, at the point that value is written.
+        if (this.Keys.Count == 0)
+        {
+            if (this.ActiveKeyId.Length > 0)
+            {
+                yield return new ValidationResult(
+                    $"DataEncryption:ActiveKeyId is '{this.ActiveKeyId}', but DataEncryption:Keys configures no key at all. Generate 32 bytes with 'openssl rand -base64 32' and provision them as a secret reference, or remove the active key.",
+                    [nameof(this.ActiveKeyId)]);
+            }
+
+            yield break;
+        }
+
+        foreach (var result in this.Keys.SelectMany((key, position) => FindKeyErrors(key, position)))
+        {
+            yield return result;
+        }
+
+        foreach (var result in this.FindDuplicateKeyIdErrors())
+        {
+            yield return result;
+        }
+
+        foreach (var result in this.FindActiveKeyErrors())
+        {
+            yield return result;
+        }
+    }
+
+    private static IEnumerable<ValidationResult> FindKeyErrors(DataEncryptionKeyOptions key, int position)
+    {
+        if (!AcceptedKeyId().IsMatch(key.KeyId))
+        {
+            yield return new ValidationResult(
+                $"DataEncryption:Keys:{position}:KeyId is '{key.KeyId}', which is not an acceptable key identifier. It may carry up to 64 letters, digits, dots, dashes, and underscores, and must begin with a letter or a digit.",
+                [nameof(Keys)]);
+        }
+
+        if (key.Material is null)
+        {
+            yield return new ValidationResult(
+                $"DataEncryption:Keys:{position}:Material configures no reference to the key material.",
+                [nameof(Keys)]);
+        }
+    }
+
+    private IEnumerable<ValidationResult> FindDuplicateKeyIdErrors() =>
+        this.Keys
+            .GroupBy(key => key.KeyId, StringComparer.Ordinal)
+            .Where(sameIdentifier => sameIdentifier.Count() > 1)
+            .Select(sameIdentifier => new ValidationResult(
+                $"DataEncryption:Keys configures the key identifier '{sameIdentifier.Key}' {sameIdentifier.Count()} times. An identifier is what a stored value names its key by, so two keys sharing one would leave which key opens a value undecidable.",
+                [nameof(this.Keys)]));
+
+    private IEnumerable<ValidationResult> FindActiveKeyErrors()
+    {
+        if (this.ActiveKeyId.Length == 0)
+        {
+            yield return new ValidationResult(
+                "DataEncryption:ActiveKeyId names no key. It selects which of the configured keys new values are sealed under, so it is required even where the ring holds exactly one.",
+                [nameof(this.ActiveKeyId)]);
+
+            yield break;
+        }
+
+        if (!this.Keys.Any(key => string.Equals(key.KeyId, this.ActiveKeyId, StringComparison.Ordinal)))
+        {
+            yield return new ValidationResult(
+                $"DataEncryption:ActiveKeyId is '{this.ActiveKeyId}', which no configured key declares. Configured identifiers are: {string.Join(", ", this.Keys.Select(key => $"'{key.KeyId}'"))}.",
+                [nameof(this.ActiveKeyId)]);
+        }
+    }
+
+    /// <remarks>
+    /// The same grammar a secret name takes, and for the same reason: a key identifier is written into log lines, metric
+    /// labels, and audit records without escaping, so one that could carry a newline or a quotation mark would let a
+    /// configuration file decide how a log line parses. It is additionally persisted beside every value it seals, which
+    /// is why the set is narrow rather than merely careful.
+    /// </remarks>
+    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$", RegexOptions.CultureInvariant)]
+    private static partial Regex AcceptedKeyId();
+}

--- a/src/Host/Configuration/DataEncryption/DataEncryptionOptions.cs
+++ b/src/Host/Configuration/DataEncryption/DataEncryptionOptions.cs
@@ -131,6 +131,6 @@ internal sealed partial class DataEncryptionOptions : IValidatableObject
     /// configuration file decide how a log line parses. It is additionally persisted beside every value it seals, which
     /// is why the set is narrow rather than merely careful.
     /// </remarks>
-    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$", RegexOptions.CultureInvariant)]
+    [GeneratedRegex(@"\A[A-Za-z0-9][A-Za-z0-9._-]{0,63}\z", RegexOptions.CultureInvariant)]
     private static partial Regex AcceptedKeyId();
 }

--- a/src/Host/Configuration/SecretConfigurationValidator.cs
+++ b/src/Host/Configuration/SecretConfigurationValidator.cs
@@ -3,10 +3,12 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Host.Configuration.Access;
+using MailFathom.Host.Configuration.DataEncryption;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Configuration.Mail;
 using MailFathom.Host.Configuration.Persistence;
 using MailFathom.Infrastructure.Certificates;
+using MailFathom.Infrastructure.DataEncryption;
 using MailFathom.Infrastructure.Mail;
 using MailFathom.Infrastructure.Persistence.Connections;
 using MailFathom.Infrastructure.Secrets;
@@ -37,6 +39,8 @@ internal sealed partial class SecretConfigurationValidator
     private const string MailSynchronizationConfigurationPath = "MailSynchronization";
 
     private const string PersistenceConfigurationPath = "Persistence";
+
+    private const string DataEncryptionConfigurationPath = "DataEncryption";
 
     private readonly TimeProvider timeProvider;
 
@@ -102,6 +106,76 @@ internal sealed partial class SecretConfigurationValidator
             cancellationToken);
 
         errors.AddRange(connectionFailures.Select(DescribeConnectionFailure));
+
+        return errors;
+    }
+
+    /// <summary>Finds everything an operator must fix before a data-encryption key ring can be used.</summary>
+    /// <param name="candidate">The bound snapshot, which may be the startup one or a reloaded one.</param>
+    /// <param name="cancellationToken">Cancels the resolution.</param>
+    /// <returns>One message per unusable setting, empty when the ring is usable.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="candidate" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Resolving the references is not enough, for the reason a trust anchor is loaded rather than merely resolved:
+    /// material that resolves but is not a key would pass a reference check and then fail every read of a sealed value,
+    /// which is exactly the failure this section exists to move to startup. The structural rules — a duplicate
+    /// identifier, an active key naming nothing — are answered by the options type itself, because they need no
+    /// resolution and reporting them here would leave a malformed ring judged twice.
+    /// </remarks>
+    internal async Task<IReadOnlyList<string>> FindDataEncryptionConfigurationErrorsAsync(
+        DataEncryptionOptions candidate,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        var errors = new List<string>(
+            await this.FindSecretReferenceErrorsAsync(DataEncryptionConfigurationPath, candidate, cancellationToken));
+
+        errors.AddRange(await this.FindKeyMaterialErrorsAsync(candidate, cancellationToken));
+
+        return errors;
+    }
+
+    /// <summary>Decodes every configured key and reports the material that is not one, discarding each key once it has proven usable.</summary>
+    /// <remarks>
+    /// Neither the material nor its length reaches the report. A message naming the length of a rejected key would tell
+    /// anyone reading the log how much of it to guess, which is why the failure vocabulary is closed and the remedy is
+    /// stated instead.
+    /// </remarks>
+    private async Task<IReadOnlyList<string>> FindKeyMaterialErrorsAsync(
+        DataEncryptionOptions candidate,
+        CancellationToken cancellationToken)
+    {
+        var errors = new List<string>();
+
+        // The loop stays because each step awaits a resolution, and the position is part of the reported path.
+        foreach (var (position, configuredKey) in candidate.Keys.Index())
+        {
+            // A key configuring no material at all is reported by the options type, which needs no resolution to see it.
+            if (configuredKey.Material is not { } material)
+            {
+                continue;
+            }
+
+            var resolution = await this.secretReferenceResolver.ResolveAsync(material.SecretReference, cancellationToken);
+
+            // A reference that does not resolve is already reported by the reference check every section runs.
+            if (resolution.Secret is not { } resolvedMaterial)
+            {
+                continue;
+            }
+
+            using (resolvedMaterial)
+            {
+                using var key = DataEncryptionKey.Decode(configuredKey.KeyId, resolvedMaterial, out var failure);
+
+                if (key is null)
+                {
+                    errors.Add(
+                        $"{DataEncryptionConfigurationPath}:{nameof(DataEncryptionOptions.Keys)}:{position}:{nameof(DataEncryptionKeyOptions.Material)} — the material is not an AES-256 key [{failure}]. Generate one with 'openssl rand -base64 32'.");
+                }
+            }
+        }
 
         return errors;
     }

--- a/src/Host/Hosting/Startup/SecretConfigurationStartupValidator.cs
+++ b/src/Host/Hosting/Startup/SecretConfigurationStartupValidator.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Host.Configuration;
+using MailFathom.Host.Configuration.DataEncryption;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Configuration.Mail;
 using MailFathom.Host.Configuration.Persistence;
@@ -33,6 +34,7 @@ internal sealed partial class SecretConfigurationStartupValidator : IHostedLifec
 {
     private readonly ISettingsSnapshot<MailSynchronizationOptions> mailSynchronizationSettings;
     private readonly ISettingsSnapshot<PersistenceOptions> persistenceSettings;
+    private readonly ISettingsSnapshot<DataEncryptionOptions> dataEncryptionSettings;
     private readonly McpEndpointOptions mcpEndpointSettings;
     private readonly SecretConfigurationValidator validator;
     private readonly SecretResolutionOptions resolutionOptions;
@@ -45,6 +47,7 @@ internal sealed partial class SecretConfigurationStartupValidator : IHostedLifec
     public SecretConfigurationStartupValidator(
         ISettingsSnapshot<MailSynchronizationOptions> mailSynchronizationSettings,
         ISettingsSnapshot<PersistenceOptions> persistenceSettings,
+        ISettingsSnapshot<DataEncryptionOptions> dataEncryptionSettings,
         IOptions<McpEndpointOptions> mcpEndpointSettings,
         SecretConfigurationValidator validator,
         SecretResolutionOptions resolutionOptions,
@@ -56,6 +59,7 @@ internal sealed partial class SecretConfigurationStartupValidator : IHostedLifec
 
         this.mailSynchronizationSettings = mailSynchronizationSettings;
         this.persistenceSettings = persistenceSettings;
+        this.dataEncryptionSettings = dataEncryptionSettings;
         this.mcpEndpointSettings = mcpEndpointSettings.Value;
         this.validator = validator;
         this.resolutionOptions = resolutionOptions;
@@ -77,6 +81,11 @@ internal sealed partial class SecretConfigurationStartupValidator : IHostedLifec
         failures.AddRange(
             await this.validator.FindPersistenceConfigurationErrorsAsync(
                 this.persistenceSettings.Current,
+                cancellationToken));
+
+        failures.AddRange(
+            await this.validator.FindDataEncryptionConfigurationErrorsAsync(
+                this.dataEncryptionSettings.Current,
                 cancellationToken));
 
         failures.AddRange(

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -14,6 +14,7 @@ using MailFathom.Application.Synchronization.Reconciliation;
 using MailFathom.Host;
 using MailFathom.Host.Api;
 using MailFathom.Host.Configuration;
+using MailFathom.Host.Configuration.DataEncryption;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Configuration.Mail;
 using MailFathom.Host.Configuration.Persistence;
@@ -28,6 +29,7 @@ using MailFathom.Host.Security.Mcp;
 using MailFathom.Host.Security.Transport;
 using MailFathom.Infrastructure;
 using MailFathom.Infrastructure.Certificates;
+using MailFathom.Infrastructure.DataEncryption;
 using MailFathom.Infrastructure.Mail;
 using MailFathom.Infrastructure.Mail.OAuth;
 using MailFathom.Infrastructure.Persistence.Connections;
@@ -113,6 +115,15 @@ try
             binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
         .ValidateDataAnnotations()
         .ValidateOnStart();
+    // A configuration root of its own rather than a section of Persistence: the database is the first thing sealed
+    // under the ring and there is no reason it is the last, and a root is also what gives the key material its own
+    // secret-name uniqueness scope. ADR 0005 records the whole decision.
+    builder.Services.AddOptions<DataEncryptionOptions>()
+        .Bind(
+            builder.Configuration.GetSection("DataEncryption"),
+            binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
+        .ValidateDataAnnotations()
+        .ValidateOnStart();
     // The published snapshot, not the bound one, is what every consumer reads: a reload whose secret references do not
     // resolve is rejected and leaves the previous configuration active for new operations.
     builder.Services.AddSingleton<DatabaseConnectionSettingsMapper>();
@@ -129,8 +140,19 @@ try
             .FindPersistenceConfigurationErrorsAsync(candidate, cancellationToken),
         "Persistence",
         provider.GetRequiredService<ILogger<ValidatedSettingsSnapshot<PersistenceOptions>>>()));
+    builder.Services.AddSingleton(provider => new ValidatedSettingsSnapshot<DataEncryptionOptions>(
+        provider.GetRequiredService<IOptionsMonitor<DataEncryptionOptions>>(),
+        (candidate, cancellationToken) => provider.GetRequiredService<SecretConfigurationValidator>()
+            .FindDataEncryptionConfigurationErrorsAsync(candidate, cancellationToken),
+        "DataEncryption",
+        provider.GetRequiredService<ILogger<ValidatedSettingsSnapshot<DataEncryptionOptions>>>()));
     builder.Services.AddSingleton<ISettingsSnapshot<MailSynchronizationOptions>>(provider => provider.GetRequiredService<ValidatedSettingsSnapshot<MailSynchronizationOptions>>());
     builder.Services.AddSingleton<ISettingsSnapshot<PersistenceOptions>>(provider => provider.GetRequiredService<ValidatedSettingsSnapshot<PersistenceOptions>>());
+    builder.Services.AddSingleton<ISettingsSnapshot<DataEncryptionOptions>>(provider => provider.GetRequiredService<ValidatedSettingsSnapshot<DataEncryptionOptions>>());
+    // The key ring reads the published snapshot on every operation, so a key an operator adds reaches the next seal or
+    // open without a restart — which is the half of a rotation that must not need one.
+    builder.Services.AddDataEncryption(provider => DataEncryptionKeyRingMapper.Map(
+        provider.GetRequiredService<ISettingsSnapshot<DataEncryptionOptions>>().Current));
     // One work unit runs against one snapshot: the enclosing run hands its own down, and a scope with no enclosing run
     // falls back to the published one. That is what keeps the transport security policy a work unit validates against,
     // the material it connects with, and the account list it was scheduled from all from the same reload.
@@ -208,6 +230,7 @@ try
     // Registered after the startup gate so the first snapshot is proven before either begins accepting reloaded ones.
     builder.Services.AddHostedService(provider => provider.GetRequiredService<ValidatedSettingsSnapshot<MailSynchronizationOptions>>());
     builder.Services.AddHostedService(provider => provider.GetRequiredService<ValidatedSettingsSnapshot<PersistenceOptions>>());
+    builder.Services.AddHostedService(provider => provider.GetRequiredService<ValidatedSettingsSnapshot<DataEncryptionOptions>>());
     // The secret blocks come from the published snapshot on every read, so a reference an operator repoints reaches the
     // next physical connection instead of waiting for a restart.
     // The text search configuration is taken once, from configuration directly, because the EF Core model has to be

--- a/src/Infrastructure/DataEncryption/DataEncryptionBinding.cs
+++ b/src/Infrastructure/DataEncryption/DataEncryptionBinding.cs
@@ -1,0 +1,98 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text;
+
+namespace MailFathom.Infrastructure.DataEncryption;
+
+/// <summary>What a sealed value belongs to, authenticated into the value so that it cannot belong to anything else.</summary>
+/// <remarks>
+/// <para>
+/// A binding is a purpose and a subject: what the value is, and whose it is. Both are authenticated but not encrypted,
+/// which is what makes a sealed value refuse to open anywhere other than where it was written. A row copied between
+/// accounts fails to open rather than opening as the wrong owner's credential, a value moved into a column that means
+/// something else fails the same way, and so does a row restored from another deployment.
+/// </para>
+/// <para>
+/// The identifier of the key that sealed the value joins the binding when the associated data is composed. Binding the
+/// key identifier as well means a value cannot be presented as though another key had sealed it, so an attacker holding
+/// one retired key cannot make a value appear current by rewriting the identifier beside it.
+/// </para>
+/// </remarks>
+public readonly record struct DataEncryptionBinding
+{
+    /// <summary>Separates the parts of the associated data, chosen because no part may contain it.</summary>
+    /// <remarks>
+    /// Without a separator no part could contain, a subject ending where the next part begins would produce the same
+    /// associated data as a different pair, and two values that must not open as one another would. The unit separator
+    /// is a C0 control character that no identifier this system accepts can carry, and <see cref="Create" /> refuses one
+    /// that does rather than escaping it.
+    /// </remarks>
+    private const char PartSeparator = '\u001F';
+
+    private DataEncryptionBinding(DataEncryptionPurpose purpose, string subject)
+    {
+        this.Purpose = purpose;
+        this.Subject = subject;
+    }
+
+    /// <summary>Gets what the sealed value is.</summary>
+    public DataEncryptionPurpose Purpose { get; }
+
+    /// <summary>Gets whose the sealed value is, in MailFathom's own naming rather than the remote system's.</summary>
+    /// <remarks>An account identifier is a configured name the operator chose, so it carries no personal data into the associated data or into any diagnostic that reports a binding.</remarks>
+    public string Subject { get; }
+
+    /// <summary>Creates a binding.</summary>
+    /// <param name="purpose">What the value is.</param>
+    /// <param name="subject">Whose the value is.</param>
+    /// <returns>The binding every seal and open of that value must use.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="subject" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="purpose" /> is the unspecified struct default, when <paramref name="subject" /> is
+    /// empty, or when the subject carries the separator the associated data is composed with. Each is a defect in the
+    /// caller rather than a configuration error: a value bound to nothing meaningful would still seal and would open
+    /// under a binding nobody intended.
+    /// </exception>
+    public static DataEncryptionBinding Create(DataEncryptionPurpose purpose, string subject)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+
+        if (!purpose.IsSpecified)
+        {
+            throw new ArgumentException(
+                "The purpose is the default of the struct and names nothing a sealed value could be bound to.",
+                nameof(purpose));
+        }
+
+        if (subject.Length == 0)
+        {
+            throw new ArgumentException("The subject of a sealed value cannot be empty.", nameof(subject));
+        }
+
+        if (subject.Contains(PartSeparator, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                "The subject carries the separator the associated data is composed with, which would let two different bindings compose the same associated data.",
+                nameof(subject));
+        }
+
+        return new DataEncryptionBinding(purpose, subject);
+    }
+
+    /// <summary>Composes the associated data a value sealed under one key is authenticated against.</summary>
+    /// <param name="keyId">The identifier of the key sealing or opening the value.</param>
+    /// <returns>The authenticated bytes.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="keyId" /> is <see langword="null" />.</exception>
+    /// <remarks>The composition is fixed rather than configurable, because a reader has to authenticate a value written by an older build.</remarks>
+    internal byte[] ComposeAssociatedData(string keyId)
+    {
+        ArgumentNullException.ThrowIfNull(keyId);
+
+        return Encoding.UTF8.GetBytes($"{this.Purpose.Identity}{PartSeparator}{this.Subject}{PartSeparator}{keyId}");
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => $"{this.Purpose}/{this.Subject}";
+}

--- a/src/Infrastructure/DataEncryption/DataEncryptionKey.cs
+++ b/src/Infrastructure/DataEncryption/DataEncryptionKey.cs
@@ -1,0 +1,124 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Buffers;
+using System.Security.Cryptography;
+using MailFathom.Common;
+using MailFathom.Infrastructure.Secrets.Resolution;
+
+namespace MailFathom.Infrastructure.DataEncryption;
+
+/// <summary>Why configured key material could not be turned into a key.</summary>
+/// <remarks>It is the whole permitted vocabulary for reporting a bad key: neither the material nor its length reaches an operator's console, because either would narrow what an attacker reading the log has to guess.</remarks>
+public enum DataEncryptionKeyMaterialFailure
+{
+    /// <summary>The material is not base64.</summary>
+    NotBase64 = 0,
+
+    /// <summary>The material is base64 but does not decode to the length an AES-256 key takes.</summary>
+    WrongLength = 1,
+}
+
+/// <summary>An AES-256 key of the ring, owned by the operation that resolved it and erased when that operation ends.</summary>
+/// <remarks>
+/// <para>
+/// The key exists as decoded bytes for the duration of one seal or open, and the identifier travels with it because the
+/// two are used together: the identifier is stored beside the sealed value and is authenticated into it, so handing them
+/// around separately would make it possible to seal under one key and record another.
+/// </para>
+/// <para>
+/// Configuration carries the material as base64 rather than raw bytes because every channel that delivers it — a Compose
+/// secret file, a Kubernetes <c>Secret</c> value, a systemd credential — is handled as text by the tools that write it,
+/// and a raw 32-byte file acquires a trailing newline the first time anyone edits it. Decoding happens here, once, and
+/// every intermediate buffer is erased rather than left for the collector.
+/// </para>
+/// </remarks>
+public sealed class DataEncryptionKey : IDisposable
+{
+    private readonly ResolvedSecret material;
+
+    private DataEncryptionKey(string keyId, ResolvedSecret material)
+    {
+        this.KeyId = keyId;
+        this.material = material;
+    }
+
+    /// <summary>Gets the identifier stored beside every value this key seals.</summary>
+    public string KeyId { get; }
+
+    /// <summary>Decodes configured material into a key.</summary>
+    /// <param name="keyId">The identifier the material is configured under.</param>
+    /// <param name="material">The resolved material, which stays owned by the caller and is not disposed here.</param>
+    /// <param name="failure">Why the material is unusable when it is; otherwise <see langword="null" />.</param>
+    /// <returns>The decoded key, which the caller owns and must dispose, or <see langword="null" /> when the material is unusable.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The decode buffer holds one byte more than a key, so material that is base64 but too long fails to fit rather
+    /// than being silently truncated to the right length. Startup calls this and disposes the result, which is what
+    /// turns a mistyped key into a refusal to start rather than into a failure at the first stored read.
+    /// </remarks>
+    public static DataEncryptionKey? Decode(
+        string keyId,
+        ResolvedSecret material,
+        out DataEncryptionKeyMaterialFailure? failure)
+    {
+        ArgumentNullException.ThrowIfNull(keyId);
+        ArgumentNullException.ThrowIfNull(material);
+
+        failure = null;
+
+        var encoded = ArrayPool<char>.Shared.Rent(material.TextLength);
+        var decoded = new byte[AesGcmEnvelope.KeySizeInBytes + 1];
+
+        try
+        {
+            material.RevealTextInto(encoded.AsSpan(0, material.TextLength));
+
+            if (!Convert.TryFromBase64Chars(encoded.AsSpan(0, material.TextLength), decoded, out var decodedLength))
+            {
+                failure = DataEncryptionKeyMaterialFailure.NotBase64;
+
+                return null;
+            }
+
+            if (decodedLength != AesGcmEnvelope.KeySizeInBytes)
+            {
+                failure = DataEncryptionKeyMaterialFailure.WrongLength;
+
+                return null;
+            }
+
+            return new DataEncryptionKey(keyId, ResolvedSecret.FromBytes(decoded.AsSpan(0, decodedLength)));
+        }
+        finally
+        {
+            // Both buffers held the key. The pooled one is erased before it is returned, because a pooled buffer handed
+            // back uncleared gives the material to the next unrelated caller.
+            CryptographicOperations.ZeroMemory(decoded);
+            encoded.AsSpan().Clear();
+            ArrayPool<char>.Shared.Return(encoded);
+        }
+    }
+
+    /// <summary>Seals a value bound to this key.</summary>
+    /// <param name="binding">What the value belongs to.</param>
+    /// <param name="plaintext">The value to seal.</param>
+    /// <returns>The sealed value, naming this key.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown when the key has already been erased.</exception>
+    internal SealedValue Seal(DataEncryptionBinding binding, ReadOnlySpan<byte> plaintext) =>
+        new(this.KeyId, AesGcmEnvelope.Seal(this.material.RevealBytes(), plaintext, binding.ComposeAssociatedData(this.KeyId)));
+
+    /// <summary>Opens a value sealed under this key.</summary>
+    /// <param name="binding">What the value belongs to.</param>
+    /// <param name="sealedValue">The sealed value.</param>
+    /// <returns>The value.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown when the key has already been erased.</exception>
+    /// <exception cref="CryptographicException">Thrown when the value was sealed under another key or bound to something else.</exception>
+    internal byte[] Open(DataEncryptionBinding binding, ReadOnlySpan<byte> sealedValue) =>
+        AesGcmEnvelope.Open(this.material.RevealBytes(), sealedValue, binding.ComposeAssociatedData(this.KeyId));
+
+    /// <inheritdoc />
+    /// <remarks>Erases the decoded key. Call it as soon as the operation that needed it finishes, so the window in which a process dump could contain the key is bounded by an operation rather than by uptime.</remarks>
+    public void Dispose() => this.material.Dispose();
+}

--- a/src/Infrastructure/DataEncryption/DataEncryptionKey.cs
+++ b/src/Infrastructure/DataEncryption/DataEncryptionKey.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers;
 using System.Security.Cryptography;
 using MailFathom.Common;
 using MailFathom.Infrastructure.Secrets.Resolution;
@@ -68,14 +67,17 @@ public sealed class DataEncryptionKey : IDisposable
 
         failure = null;
 
-        var encoded = ArrayPool<char>.Shared.Rent(material.TextLength);
-        var decoded = new byte[AesGcmEnvelope.KeySizeInBytes + 1];
+        // Both buffers hold the key, so both are pinned: an unpinned buffer can be relocated by the collector while it
+        // holds live material, which leaves a copy behind that the erasure below never reaches. This is the same
+        // allocation ResolvedSecret and every other reader of revealed material in this system uses, for that reason.
+        var encoded = GC.AllocateArray<char>(material.TextLength, pinned: true);
+        var decoded = GC.AllocateArray<byte>(AesGcmEnvelope.KeySizeInBytes + 1, pinned: true);
 
         try
         {
-            material.RevealTextInto(encoded.AsSpan(0, material.TextLength));
+            material.RevealTextInto(encoded);
 
-            if (!Convert.TryFromBase64Chars(encoded.AsSpan(0, material.TextLength), decoded, out var decodedLength))
+            if (!Convert.TryFromBase64Chars(encoded, decoded, out var decodedLength))
             {
                 failure = DataEncryptionKeyMaterialFailure.NotBase64;
 
@@ -93,11 +95,8 @@ public sealed class DataEncryptionKey : IDisposable
         }
         finally
         {
-            // Both buffers held the key. The pooled one is erased before it is returned, because a pooled buffer handed
-            // back uncleared gives the material to the next unrelated caller.
             CryptographicOperations.ZeroMemory(decoded);
             encoded.AsSpan().Clear();
-            ArrayPool<char>.Shared.Return(encoded);
         }
     }
 

--- a/src/Infrastructure/DataEncryption/DataEncryptionKeyRing.cs
+++ b/src/Infrastructure/DataEncryption/DataEncryptionKeyRing.cs
@@ -1,0 +1,87 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Secrets.References;
+
+namespace MailFathom.Infrastructure.DataEncryption;
+
+/// <summary>Resolves the deployment's data-encryption keys, one operation at a time.</summary>
+/// <remarks>
+/// <para>
+/// Nothing is cached. A key is resolved from its reference for each operation that needs one and erased when that
+/// operation ends, which is the same rule every other credential in this system follows: material rotated behind an
+/// unchanged reference is observed by the next operation, with no cache to invalidate, and the window in which a process
+/// dump could contain a key is bounded by an operation rather than by uptime.
+/// </para>
+/// <para>
+/// The settings arrive through a delegate rather than as a value, so the ring reads the currently published snapshot
+/// each time. A key an operator adds to a running deployment is therefore available to the next operation, which is what
+/// makes the first half of a rotation something that can be done without a restart.
+/// </para>
+/// <para>
+/// Every failure here is a defect or a deployment that changed underneath a running process, never an operator error
+/// waiting to be reported: startup already proved that the active key names a configured key and that every key's
+/// material resolves and decodes. See
+/// <see href="../../../docs/decisions/0005-data-encryption-key-ring-and-provisioning.md">ADR 0005</see>.
+/// </para>
+/// </remarks>
+internal sealed class DataEncryptionKeyRing
+{
+    private readonly Func<DataEncryptionKeyRingSettings> readSettings;
+    private readonly ISecretReferenceResolver secretReferenceResolver;
+
+    /// <summary>Initializes a key ring over the published settings and the secret resolver.</summary>
+    /// <param name="readSettings">Reads the currently published key ring settings.</param>
+    /// <param name="secretReferenceResolver">Turns a key's reference into material.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public DataEncryptionKeyRing(
+        Func<DataEncryptionKeyRingSettings> readSettings,
+        ISecretReferenceResolver secretReferenceResolver)
+    {
+        ArgumentNullException.ThrowIfNull(readSettings);
+        ArgumentNullException.ThrowIfNull(secretReferenceResolver);
+
+        this.readSettings = readSettings;
+        this.secretReferenceResolver = secretReferenceResolver;
+    }
+
+    /// <summary>Resolves the key new values are sealed under.</summary>
+    /// <param name="cancellationToken">Cancels the resolution.</param>
+    /// <returns>The active key, which the caller owns and must dispose.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the active key names no configured key, or its material no longer resolves or decodes.</exception>
+    public Task<DataEncryptionKey> ResolveActiveKeyAsync(CancellationToken cancellationToken) =>
+        this.ResolveKeyAsync(this.readSettings().ActiveKeyId, cancellationToken);
+
+    /// <summary>Resolves the key a stored value names.</summary>
+    /// <param name="keyId">The identifier stored beside the sealed value.</param>
+    /// <param name="cancellationToken">Cancels the resolution.</param>
+    /// <returns>The named key, which the caller owns and must dispose.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="keyId" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the ring configures no such key, or its material no longer resolves or decodes. A stored value naming
+    /// a key the ring no longer holds is what retiring a key too early looks like, and it is deliberately a failure of
+    /// the operation rather than something to work around: opening the value is impossible and pretending otherwise
+    /// would replace a clear failure with a silent one.
+    /// </exception>
+    public async Task<DataEncryptionKey> ResolveKeyAsync(string keyId, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(keyId);
+
+        var settings = this.readSettings();
+
+        var reference = settings.Keys.FirstOrDefault(key => string.Equals(key.KeyId, keyId, StringComparison.Ordinal))
+            ?? throw new InvalidOperationException(
+                $"The data-encryption key ring configures no key '{keyId}'. A stored value names it, so the key was removed while values still referenced it.");
+
+        var resolution = await this.secretReferenceResolver.ResolveAsync(reference.Material.SecretReference, cancellationToken);
+
+        using var material = resolution.Secret
+            ?? throw new InvalidOperationException(
+                $"The material of data-encryption key '{keyId}' could not be resolved [{resolution.Failure}].");
+
+        return DataEncryptionKey.Decode(keyId, material, out var failure)
+            ?? throw new InvalidOperationException(
+                $"The material of data-encryption key '{keyId}' is not usable [{failure}].");
+    }
+}

--- a/src/Infrastructure/DataEncryption/DataEncryptionKeyRingSettings.cs
+++ b/src/Infrastructure/DataEncryption/DataEncryptionKeyRingSettings.cs
@@ -1,0 +1,24 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Secrets.Discovery;
+
+namespace MailFathom.Infrastructure.DataEncryption;
+
+/// <summary>One configured key: the identifier stored beside every value it seals, and where its material comes from.</summary>
+/// <param name="KeyId">The identifier a sealed value names its key by, which is persisted and therefore never changes.</param>
+/// <param name="Material">The reference to base64 material that decodes to an AES-256 key.</param>
+public sealed record DataEncryptionKeyReference(string KeyId, ConfiguredSecret Material);
+
+/// <summary>The deployment's key ring as the encryption adapter reads it, mapped from bound configuration.</summary>
+/// <param name="ActiveKeyId">The identifier of the key new values are sealed under.</param>
+/// <param name="Keys">Every key a stored value may still name, including the active one.</param>
+/// <remarks>
+/// This is the infrastructure-facing shape of the <c>DataEncryption</c> configuration root, so the adapter depends on a
+/// settings record rather than on the host's bindable options — the same split
+/// <see cref="Persistence.Connections.IDatabaseConnectionSettingsValidator" /> already uses for the database
+/// credential. A reloaded snapshot reaches the ring by producing a new instance of this record, so a key an operator
+/// adds is available to the next operation without a restart.
+/// </remarks>
+public sealed record DataEncryptionKeyRingSettings(string ActiveKeyId, IReadOnlyList<DataEncryptionKeyReference> Keys);

--- a/src/Infrastructure/DataEncryption/DataEncryptionPurpose.cs
+++ b/src/Infrastructure/DataEncryption/DataEncryptionPurpose.cs
@@ -1,0 +1,138 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Infrastructure.DataEncryption;
+
+/// <summary>Identifies what a sealed value is, so that one key ring can protect several kinds of value safely.</summary>
+/// <remarks>
+/// <para>
+/// The type is a closed enumeration rather than a C# <see langword="enum" /> because a purpose has a published identity
+/// in the strongest sense this repository has: the identity is authenticated into every value sealed under it, so it is
+/// written into the database and stays there for the life of the row. An enum member's ordinal means nothing outside
+/// the assembly and its name changes with an ordinary rename — either would make every value sealed under the previous
+/// spelling fail to open, and the failure would appear at the next read rather than at the rename.
+/// </para>
+/// <para>
+/// Sharing one key ring across several kinds of value is only safe because this identity is bound in. Two values sealed
+/// under the same key for different purposes do not open as one another, so a stored refresh token cannot be replayed
+/// into a column that means something else, and a future sealed column needs no key of its own.
+/// </para>
+/// <para>
+/// An identity is allocated once and never reused or respelled. Being a struct, <see langword="default" /> is reachable
+/// and names no purpose; <see cref="DataEncryptionBinding" /> is where it is rejected, because that is the last point
+/// before a value is bound to something meaningless. See
+/// <see href="../../../docs/decisions/0005-data-encryption-key-ring-and-provisioning.md">ADR 0005</see>.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(DataEncryptionPurposeJsonConverter))]
+public readonly record struct DataEncryptionPurpose
+{
+    private readonly string? identity;
+
+    private DataEncryptionPurpose(string identity) => this.identity = identity;
+
+    /// <summary>Gets the purpose of the OAuth refresh token MailFathom stores for a mailbox account.</summary>
+    /// <remarks>The subject of a value sealed under this purpose is the account identifier, which is MailFathom's own configured name for the account and carries no personal data.</remarks>
+    public static DataEncryptionPurpose MailboxRefreshToken { get; } = new("mailbox-refresh-token");
+
+    /// <summary>Gets every supported purpose.</summary>
+    /// <remarks>Declared last so the members it lists are already initialized when this initializer runs.</remarks>
+    public static IReadOnlyList<DataEncryptionPurpose> All { get; } = [MailboxRefreshToken];
+
+    /// <summary>Gets whether this value names a supported purpose rather than the unusable struct default.</summary>
+    public bool IsSpecified => this.identity is not null;
+
+    /// <summary>Gets the identity authenticated into every value sealed under this purpose.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a purpose.</exception>
+    public string Identity => this.identity
+        ?? throw new InvalidOperationException("The value is the default of the struct and does not name an encryption purpose.");
+
+    /// <summary>Parses a stored or configured identity.</summary>
+    /// <param name="identity">The identity to match, compared exactly because it is authenticated material rather than operator input.</param>
+    /// <param name="purpose">The parsed purpose when the identity is supported; otherwise the unspecified default.</param>
+    /// <returns><see langword="true" /> when the identity names a supported purpose; otherwise <see langword="false" />.</returns>
+    /// <remarks>An identity nothing declares is unknown rather than new, so no value is ever reconstructed from one.</remarks>
+    public static bool TryParse(string? identity, out DataEncryptionPurpose purpose)
+    {
+        purpose = default;
+        if (string.IsNullOrEmpty(identity))
+        {
+            return false;
+        }
+
+        purpose = All.FirstOrDefault(candidate => string.Equals(candidate.Identity, identity, StringComparison.Ordinal));
+
+        return purpose.IsSpecified;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => this.identity ?? "(unspecified)";
+}
+
+/// <summary>Serializes <see cref="DataEncryptionPurpose" /> as its published identity.</summary>
+/// <remarks>
+/// The type carries this converter through <see cref="JsonConverterAttribute" />, so every serializer that meets the
+/// value uses it without per-call registration. The JSON form is the identity rather than an ordinal for the same
+/// reason the value object exists: the identity is what a sealed value already carries, and an ordinal would change
+/// meaning the moment the supported set were reordered.
+/// </remarks>
+public sealed class DataEncryptionPurposeJsonConverter : JsonConverter<DataEncryptionPurpose>
+{
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the token is not a string or does not name a supported purpose.</exception>
+    public override DataEncryptionPurpose Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException($"An encryption purpose must be a JSON string, but the token was {reader.TokenType}.");
+        }
+
+        return ParseOrThrow(reader.GetString());
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the value is the unspecified struct default.</exception>
+    public override void Write(Utf8JsonWriter writer, DataEncryptionPurpose value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WriteStringValue(IdentityOrThrow(value));
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the property name does not name a supported purpose.</exception>
+    public override DataEncryptionPurpose ReadAsPropertyName(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options) =>
+        ParseOrThrow(reader.GetString());
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the value is the unspecified struct default.</exception>
+    public override void WriteAsPropertyName(
+        Utf8JsonWriter writer,
+        DataEncryptionPurpose value,
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WritePropertyName(IdentityOrThrow(value));
+    }
+
+    private static DataEncryptionPurpose ParseOrThrow(string? identity) =>
+        DataEncryptionPurpose.TryParse(identity, out var purpose)
+            ? purpose
+            : throw new JsonException($"'{identity}' does not name a supported encryption purpose.");
+
+    private static string IdentityOrThrow(DataEncryptionPurpose value) =>
+        value.IsSpecified
+            ? value.Identity
+            : throw new JsonException("The unspecified default of the encryption purpose cannot be serialized.");
+}

--- a/src/Infrastructure/DataEncryption/DataEncryptionServiceCollectionExtensions.cs
+++ b/src/Infrastructure/DataEncryption/DataEncryptionServiceCollectionExtensions.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Secrets.References;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MailFathom.Infrastructure.DataEncryption;
+
+/// <summary>Registers what seals and opens the values MailFathom stores under its own protection.</summary>
+public static class DataEncryptionServiceCollectionExtensions
+{
+    /// <summary>Registers the key ring and the encryptor over it.</summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="readSettings">Reads the currently published key ring settings for a resolved provider.</param>
+    /// <returns>The same collection, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Both are singletons because neither holds anything a scope owns: the ring resolves a key per operation and erases
+    /// it, and the encryptor holds only the ring. The settings arrive through a delegate rather than as a value so a
+    /// reloaded snapshot reaches the next operation, which is what lets an operator add a key to a running deployment.
+    /// </remarks>
+    public static IServiceCollection AddDataEncryption(
+        this IServiceCollection services,
+        Func<IServiceProvider, DataEncryptionKeyRingSettings> readSettings)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(readSettings);
+
+        services.AddSingleton(provider => new DataEncryptionKeyRing(
+            () => readSettings(provider),
+            provider.GetRequiredService<ISecretReferenceResolver>()));
+        services.AddSingleton<FieldEncryptor>();
+
+        return services;
+    }
+}

--- a/src/Infrastructure/DataEncryption/FieldEncryptor.cs
+++ b/src/Infrastructure/DataEncryption/FieldEncryptor.cs
@@ -1,0 +1,98 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Cryptography;
+
+namespace MailFathom.Infrastructure.DataEncryption;
+
+/// <summary>Seals and opens one stored value under the deployment's key ring.</summary>
+/// <remarks>
+/// <para>
+/// This is the reusable half of storing something sealed: it owns key selection and the binding, and knows nothing about
+/// what is being sealed or which table it lives in. A store is its consumer, and a second sealed column later needs a
+/// purpose rather than anything here.
+/// </para>
+/// <para>
+/// Sealing always uses the active key and opening always uses the key the value names, which together are the whole of
+/// the rotation model. A value read under a retired key is reported as needing re-sealing rather than re-sealed here,
+/// because writing is the store's decision and its transaction: an encryptor that wrote would be writing outside any
+/// unit of work the caller opened.
+/// </para>
+/// <para>
+/// No key, plaintext, or ciphertext is ever logged, and this type logs nothing at all — a failure carries the binding,
+/// which names MailFathom's own account identifier and the purpose, and nothing else.
+/// </para>
+/// </remarks>
+internal sealed class FieldEncryptor
+{
+    private readonly DataEncryptionKeyRing keyRing;
+
+    /// <summary>Initializes an encryptor over the deployment's key ring.</summary>
+    /// <param name="keyRing">Resolves the keys values are sealed and opened with.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="keyRing" /> is <see langword="null" />.</exception>
+    public FieldEncryptor(DataEncryptionKeyRing keyRing)
+    {
+        ArgumentNullException.ThrowIfNull(keyRing);
+
+        this.keyRing = keyRing;
+    }
+
+    /// <summary>Seals a value under the active key.</summary>
+    /// <param name="binding">What the value belongs to.</param>
+    /// <param name="plaintext">The value to seal.</param>
+    /// <param name="cancellationToken">Cancels resolving the key.</param>
+    /// <returns>The sealed value and the identifier of the key that sealed it, both of which the store persists.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the active key cannot be resolved.</exception>
+    public async Task<SealedValue> SealAsync(
+        DataEncryptionBinding binding,
+        ReadOnlyMemory<byte> plaintext,
+        CancellationToken cancellationToken)
+    {
+        using var key = await this.keyRing.ResolveActiveKeyAsync(cancellationToken);
+
+        return key.Seal(binding, plaintext.Span);
+    }
+
+    /// <summary>Opens a stored value.</summary>
+    /// <param name="binding">What the value belongs to, which must be exactly what it was sealed with.</param>
+    /// <param name="sealedValue">The stored ciphertext and the key it names.</param>
+    /// <param name="cancellationToken">Cancels resolving the key.</param>
+    /// <returns>The value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sealedValue" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the named key is no longer configured or cannot be resolved.</exception>
+    /// <exception cref="CryptographicException">
+    /// Thrown when the value does not open. A value moved between accounts or purposes, a row restored from another
+    /// deployment, and an altered ciphertext are one outcome on purpose: distinguishing them would tell an attacker
+    /// which part of a forgery was wrong.
+    /// </exception>
+    public async Task<byte[]> OpenAsync(
+        DataEncryptionBinding binding,
+        SealedValue sealedValue,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(sealedValue);
+
+        using var key = await this.keyRing.ResolveKeyAsync(sealedValue.KeyId, cancellationToken);
+
+        return key.Open(binding, sealedValue.Ciphertext.Span);
+    }
+
+    /// <summary>Gets whether a stored value was sealed under a key that is no longer the active one.</summary>
+    /// <param name="sealedValue">The stored value.</param>
+    /// <param name="activeKeyId">The identifier of the key new values are sealed under.</param>
+    /// <returns><see langword="true" /> when the next write should re-seal the value.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// This is what makes a rotation progress without a flag day, and also what makes it incomplete on its own: a value
+    /// nothing writes again keeps its original key indefinitely, so retiring that key needs the deliberate re-sealing
+    /// pass tracked separately.
+    /// </remarks>
+    public static bool NeedsResealing(SealedValue sealedValue, string activeKeyId)
+    {
+        ArgumentNullException.ThrowIfNull(sealedValue);
+        ArgumentNullException.ThrowIfNull(activeKeyId);
+
+        return !string.Equals(sealedValue.KeyId, activeKeyId, StringComparison.Ordinal);
+    }
+}

--- a/src/Infrastructure/DataEncryption/SealedValue.cs
+++ b/src/Infrastructure/DataEncryption/SealedValue.cs
@@ -1,0 +1,23 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Infrastructure.DataEncryption;
+
+/// <summary>A value as it is stored: the ciphertext, and the identifier of the key that sealed it.</summary>
+/// <param name="KeyId">The key the value was sealed under, stored beside it.</param>
+/// <param name="Ciphertext">The sealed bytes, in the layout <see cref="Common.AesGcmEnvelope" /> fixes.</param>
+/// <remarks>
+/// <para>
+/// Storing the key identifier beside the ciphertext is what makes rotation possible at all. Without it, replacing a key
+/// would be a flag day with the service stopped, because nothing could tell which of two keys opens a given row. With
+/// it, two keys coexist, a value is re-sealed under the active key the next time it is written, and a key is retired
+/// once nothing references it.
+/// </para>
+/// <para>
+/// The identifier is not a secret and is not authentication on its own: it is authenticated into the ciphertext through
+/// the binding, so rewriting it in the database makes the value fail to open rather than making it open under another
+/// key.
+/// </para>
+/// </remarks>
+public sealed record SealedValue(string KeyId, ReadOnlyMemory<byte> Ciphertext);

--- a/tests/Host.UnitTests/Configuration/DataEncryption/DataEncryptionKeyRingMapperTests.cs
+++ b/tests/Host.UnitTests/Configuration/DataEncryption/DataEncryptionKeyRingMapperTests.cs
@@ -1,0 +1,71 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.DataEncryption;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.DataEncryption;
+
+/// <summary>Covers the mapping from the bound section onto the settings the encryption adapter reads.</summary>
+public sealed class DataEncryptionKeyRingMapperTests
+{
+    [Fact]
+    public void Map_AConfiguredRing_CarriesEveryKeyAndTheActiveIdentifier()
+    {
+        // Arrange
+        var options = new DataEncryptionOptions { ActiveKeyId = "2026-08" };
+        options.Keys.Add(KeyOf("2026-08", "systemd-credential:mailfathom-data-key"));
+        options.Keys.Add(KeyOf("2026-02", "systemd-credential:mailfathom-data-key-previous"));
+
+        // Act
+        var settings = DataEncryptionKeyRingMapper.Map(options);
+
+        // Assert
+        Assert.Equal("2026-08", settings.ActiveKeyId);
+        Assert.Equal(["2026-08", "2026-02"], settings.Keys.Select(key => key.KeyId));
+        Assert.Equal(
+            ["systemd-credential:mailfathom-data-key", "systemd-credential:mailfathom-data-key-previous"],
+            settings.Keys.Select(key => key.Material.SecretReference));
+    }
+
+    [Fact]
+    public void Map_AKeyConfiguringNoMaterial_OmitsItRatherThanCarryingAnAbsentReference()
+    {
+        // Arrange — startup already refuses such a snapshot, so this path is only reached while that refusal is being
+        // composed. Carrying the half-built key into the ring would replace a named configuration error with a null
+        // dereference at the moment the container resolves the ring.
+        var options = new DataEncryptionOptions { ActiveKeyId = "2026-08" };
+        options.Keys.Add(KeyOf("2026-08", "systemd-credential:mailfathom-data-key"));
+        options.Keys.Add(new DataEncryptionKeyOptions { KeyId = "2026-02" });
+
+        // Act
+        var settings = DataEncryptionKeyRingMapper.Map(options);
+
+        // Assert
+        Assert.Equal(["2026-08"], settings.Keys.Select(key => key.KeyId));
+    }
+
+    [Fact]
+    public void Map_AnAbsentSection_CarriesAnEmptyRing()
+    {
+        // Arrange — a deployment that seals nothing configures no ring, and the mapping has to survive that rather
+        // than being reached only after a key exists.
+        var options = new DataEncryptionOptions();
+
+        // Act
+        var settings = DataEncryptionKeyRingMapper.Map(options);
+
+        // Assert
+        Assert.Empty(settings.Keys);
+        Assert.Empty(settings.ActiveKeyId);
+    }
+
+    private static DataEncryptionKeyOptions KeyOf(string keyId, string secretReference) =>
+        new()
+        {
+            KeyId = keyId,
+            Material = new ConfiguredSecret { Name = $"data-key-{keyId}", SecretReference = secretReference },
+        };
+}

--- a/tests/Host.UnitTests/Configuration/DataEncryption/DataEncryptionOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/DataEncryption/DataEncryptionOptionsTests.cs
@@ -131,10 +131,14 @@ public sealed class DataEncryptionOptionsTests
     [InlineData("2026 08")]
     [InlineData("2026/08")]
     [InlineData("key\nid")]
+    [InlineData("2026-08\n")]
+    [InlineData("2026-08\r\n")]
     public void Validate_AnUnacceptableKeyIdentifier_IsRefused(string keyId)
     {
         // Arrange — the identifier is written into log lines and metric labels without escaping and is persisted beside
-        // every value it seals, so the accepted set is narrow rather than merely careful.
+        // every value it seals, so the accepted set is narrow rather than merely careful. The trailing-newline cases are
+        // why the pattern anchors on \z: `$` also matches immediately before one trailing newline, so it would admit
+        // exactly the character the set exists to keep out.
         var options = RingOf((keyId, "systemd-credential:mailfathom-data-key"));
         options.ActiveKeyId = keyId;
 

--- a/tests/Host.UnitTests/Configuration/DataEncryption/DataEncryptionOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/DataEncryption/DataEncryptionOptionsTests.cs
@@ -1,0 +1,181 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.ComponentModel.DataAnnotations;
+using MailFathom.Host.Configuration.DataEncryption;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.DataEncryption;
+
+/// <summary>Covers the rules a key ring can be judged on by reading it, without resolving anything.</summary>
+/// <remarks>
+/// Each refusal exists to move a mistake to startup. Whether the material behind a reference is actually a key is a
+/// separate check, because it needs resolution, and it is covered where the secret configuration is validated.
+/// </remarks>
+public sealed class DataEncryptionOptionsTests
+{
+    [Fact]
+    public void Validate_AWellFormedRing_ReportsNothing()
+    {
+        // Arrange
+        var options = RingOf(("2026-08", "systemd-credential:mailfathom-data-key"));
+        options.ActiveKeyId = "2026-08";
+
+        // Act
+        var results = Validate(options);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Validate_ARingWithSeveralKeys_ReportsNothing()
+    {
+        // Arrange — the state a deployment is in mid-rotation, which has to be a valid configuration rather than one
+        // that only passes once the previous key is gone.
+        var options = RingOf(
+            ("2026-08", "systemd-credential:mailfathom-data-key"),
+            ("2026-02", "systemd-credential:mailfathom-data-key-previous"));
+        options.ActiveKeyId = "2026-08";
+
+        // Act
+        var results = Validate(options);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Validate_AnAbsentSection_ReportsNothing()
+    {
+        // Arrange — a deployment that seals nothing needs no ring, and no stored value carries a key identifier yet.
+        // Requiring one here would refuse to start every deployment that has no use for a key.
+        var options = new DataEncryptionOptions();
+
+        // Act
+        var results = Validate(options);
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void Validate_AnActiveKeyWithNoRingAtAll_IsRefusedNamingTheGeneratingCommand()
+    {
+        // Arrange — an operator who named an active key meant to provision one, so the silence of an absent ring is a
+        // mistake here rather than the deliberate absence above.
+        var options = new DataEncryptionOptions { ActiveKeyId = "2026-08" };
+
+        // Act
+        var results = Validate(options);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Contains("openssl rand -base64 32", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_AnActiveKeyNoConfiguredKeyDeclares_IsRefusedListingTheConfiguredOnes()
+    {
+        // Arrange — the mistake a half-finished rotation leaves behind: the new identifier is typed into ActiveKeyId
+        // before the key itself is added.
+        var options = RingOf(("2026-02", "systemd-credential:mailfathom-data-key"));
+        options.ActiveKeyId = "2026-08";
+
+        // Act
+        var results = Validate(options);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Contains("'2026-08'", result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains("'2026-02'", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_AnAbsentActiveKey_IsRefusedEvenWhereTheRingHoldsOne()
+    {
+        // Arrange — the ring holding exactly one key does not make the selection implicit, because the value that
+        // selects it is what a rotation later moves.
+        var options = RingOf(("2026-08", "systemd-credential:mailfathom-data-key"));
+
+        // Act
+        var results = Validate(options);
+
+        // Assert
+        Assert.Single(results);
+    }
+
+    [Fact]
+    public void Validate_TwoKeysSharingOneIdentifier_AreRefused()
+    {
+        // Arrange — a stored value names its key by the identifier, so two keys sharing one would leave which key opens
+        // a value undecidable.
+        var options = RingOf(
+            ("2026-08", "systemd-credential:mailfathom-data-key"),
+            ("2026-08", "systemd-credential:mailfathom-data-key-previous"));
+        options.ActiveKeyId = "2026-08";
+
+        // Act
+        var results = Validate(options);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Contains("'2026-08'", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("-2026-08")]
+    [InlineData("2026 08")]
+    [InlineData("2026/08")]
+    [InlineData("key\nid")]
+    public void Validate_AnUnacceptableKeyIdentifier_IsRefused(string keyId)
+    {
+        // Arrange — the identifier is written into log lines and metric labels without escaping and is persisted beside
+        // every value it seals, so the accepted set is narrow rather than merely careful.
+        var options = RingOf((keyId, "systemd-credential:mailfathom-data-key"));
+        options.ActiveKeyId = keyId;
+
+        // Act
+        var results = Validate(options);
+
+        // Assert
+        Assert.NotEmpty(results);
+    }
+
+    [Fact]
+    public void Validate_AKeyConfiguringNoMaterial_IsRefused()
+    {
+        // Arrange
+        var options = new DataEncryptionOptions { ActiveKeyId = "2026-08" };
+        options.Keys.Add(new DataEncryptionKeyOptions { KeyId = "2026-08" });
+
+        // Act
+        var results = Validate(options);
+
+        // Assert
+        var result = Assert.Single(results);
+        Assert.Contains("Material", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    private static DataEncryptionOptions RingOf(params (string KeyId, string SecretReference)[] keys)
+    {
+        var options = new DataEncryptionOptions();
+
+        foreach (var (keyId, secretReference) in keys)
+        {
+            options.Keys.Add(new DataEncryptionKeyOptions
+            {
+                KeyId = keyId,
+                Material = new ConfiguredSecret { Name = $"data-key-{options.Keys.Count}", SecretReference = secretReference },
+            });
+        }
+
+        return options;
+    }
+
+    private static IReadOnlyList<ValidationResult> Validate(DataEncryptionOptions options) =>
+        [.. options.Validate(new ValidationContext(options))];
+}

--- a/tests/Host.UnitTests/Hosting/Startup/SecretConfigurationStartupValidatorTests.cs
+++ b/tests/Host.UnitTests/Hosting/Startup/SecretConfigurationStartupValidatorTests.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers.Text;
 using System.Text;
+using MailFathom.Common;
 using MailFathom.Domain.Transport;
 using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Access;
@@ -15,6 +16,7 @@ using MailFathom.Host.Hosting.Startup;
 using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.Infrastructure;
 using MailFathom.Infrastructure.Certificates;
+using MailFathom.Infrastructure.DataEncryption;
 using MailFathom.Infrastructure.Persistence.Connections;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using MailFathom.Infrastructure.Secrets.Resolution;
@@ -596,6 +598,62 @@ public sealed class SecretConfigurationStartupValidatorTests
         await harness.Validator.StartingAsync(CancellationToken.None);
     }
 
+    [Fact]
+    public async Task StartingAsync_ADataEncryptionKeyOfTheWrongLength_IsRefusedNamingTheMaterial()
+    {
+        // Arrange — material that resolves but is not a key would pass a reference check and then fail every read of a
+        // sealed value, which is the failure this section exists to move to startup. Thirty-three bytes is the mistake
+        // that actually happens: it is what the command beside this one generates for a database password.
+        var harness = CreateHarness(
+            new MailSynchronizationOptions(),
+            new PersistenceOptions(),
+            dataEncryptionOptions: RingOf("2026-08", Convert.ToBase64String(new byte[33])));
+
+        // Act
+        var exception = await Assert.ThrowsAsync<OptionsValidationException>(() =>
+            harness.Validator.StartingAsync(CancellationToken.None));
+
+        // Assert
+        var failure = Assert.Single(exception.Failures);
+        Assert.StartsWith("DataEncryption:Keys:0:Material", failure, StringComparison.Ordinal);
+        Assert.Contains(nameof(DataEncryptionKeyMaterialFailure.WrongLength), failure, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StartingAsync_ADataEncryptionKeyThatIsNotBase64_IsRefusedNamingTheMaterial()
+    {
+        // Arrange
+        var harness = CreateHarness(
+            new MailSynchronizationOptions(),
+            new PersistenceOptions(),
+            dataEncryptionOptions: RingOf("2026-08", "not-base64-material"));
+
+        // Act
+        var exception = await Assert.ThrowsAsync<OptionsValidationException>(() =>
+            harness.Validator.StartingAsync(CancellationToken.None));
+
+        // Assert
+        var failure = Assert.Single(exception.Failures);
+        Assert.StartsWith("DataEncryption:Keys:0:Material", failure, StringComparison.Ordinal);
+        Assert.Contains(nameof(DataEncryptionKeyMaterialFailure.NotBase64), failure, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StartingAsync_ARingWhoseMaterialIsAKey_PassesTheGate()
+    {
+        // Arrange — the counterpart the two refusals need: without it they would pass against a validator that
+        // rejected every ring it was handed.
+        var harness = CreateHarness(
+            new MailSynchronizationOptions(),
+            new PersistenceOptions(),
+            dataEncryptionOptions: RingOf(
+                "2026-08",
+                Convert.ToBase64String(new byte[AesGcmEnvelope.KeySizeInBytes])));
+
+        // Act, Assert
+        await harness.Validator.StartingAsync(CancellationToken.None);
+    }
+
     /// <summary>Every lifecycle stage other than the starting one is deliberately empty, because the check belongs before hosted services start.</summary>
     [Fact]
     public async Task RemainingLifecycleMembers_Always_CompleteWithoutResolvingAnything()
@@ -638,6 +696,18 @@ public sealed class SecretConfigurationStartupValidatorTests
         var payload = Base64Url.EncodeToString(Encoding.UTF8.GetBytes($$"""{"iss":"{{issuer}}","sub":"9f2c"}"""));
 
         return $"header.{payload}.signature";
+    }
+
+    private static DataEncryptionOptions RingOf(string keyId, string material)
+    {
+        var options = new DataEncryptionOptions { ActiveKeyId = keyId };
+        options.Keys.Add(new DataEncryptionKeyOptions
+        {
+            KeyId = keyId,
+            Material = new ConfiguredSecret { Name = "mailfathom-data-key", SecretReference = $"plaintext:{material}" },
+        });
+
+        return options;
     }
 
     private static ValidatorHarness CreateHarness(

--- a/tests/Host.UnitTests/Hosting/Startup/SecretConfigurationStartupValidatorTests.cs
+++ b/tests/Host.UnitTests/Hosting/Startup/SecretConfigurationStartupValidatorTests.cs
@@ -7,6 +7,7 @@ using System.Text;
 using MailFathom.Domain.Transport;
 using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Access;
+using MailFathom.Host.Configuration.DataEncryption;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Configuration.Mail;
 using MailFathom.Host.Configuration.Persistence;
@@ -645,7 +646,8 @@ public sealed class SecretConfigurationStartupValidatorTests
         SecretValueInterpretation interpretation = SecretValueInterpretation.ReferenceOnly,
         SecretMaterialSource source = SecretMaterialSource.SchemeAdapter,
         IDatabaseConnectionSettingsValidator? databaseConnectionSettings = null,
-        McpEndpointOptions? mcpEndpointOptions = null)
+        McpEndpointOptions? mcpEndpointOptions = null,
+        DataEncryptionOptions? dataEncryptionOptions = null)
     {
         var resolver = new PlaintextOnlySecretReferenceResolver { Source = source };
         var connectionSettingsValidator = databaseConnectionSettings ?? new StubDatabaseConnectionSettingsValidator();
@@ -656,6 +658,7 @@ public sealed class SecretConfigurationStartupValidatorTests
         var validator = new SecretConfigurationStartupValidator(
             new StubSettingsSnapshot<MailSynchronizationOptions>(synchronizationOptions),
             new StubSettingsSnapshot<PersistenceOptions>(persistenceOptions),
+            new StubSettingsSnapshot<DataEncryptionOptions>(dataEncryptionOptions ?? new DataEncryptionOptions()),
             Options.Create(mcpEndpointOptions ?? new McpEndpointOptions()),
             new SecretConfigurationValidator(
                 resolver,

--- a/tests/Infrastructure.UnitTests/DataEncryption/DataEncryptionBindingTests.cs
+++ b/tests/Infrastructure.UnitTests/DataEncryption/DataEncryptionBindingTests.cs
@@ -1,0 +1,75 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.DataEncryption;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.DataEncryption;
+
+/// <summary>Covers what a binding refuses to be, and that two different bindings never compose the same associated data.</summary>
+public sealed class DataEncryptionBindingTests
+{
+    [Fact]
+    public void Create_TheUnspecifiedPurpose_IsRefused() =>
+        Assert.Throws<ArgumentException>(() => DataEncryptionBinding.Create(default, "primary"));
+
+    [Fact]
+    public void Create_AnEmptySubject_IsRefused() =>
+        Assert.Throws<ArgumentException>(
+            () => DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, string.Empty));
+
+    [Fact]
+    public void Create_ASubjectCarryingTheSeparator_IsRefused()
+    {
+        // Arrange — a subject able to carry the separator could compose the associated data of a different binding,
+        // which is the one way the authentication could be talked out of its guarantee.
+        var subject = "primary\u001Fmailbox-refresh-token";
+
+        // Assert
+        Assert.Throws<ArgumentException>(
+            () => DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, subject));
+    }
+
+    [Fact]
+    public void ComposeAssociatedData_TheSameBindingAndKey_IsStable()
+    {
+        // Arrange — a value sealed by one build has to open in the next, so the composition is asserted rather than
+        // assumed to stay put.
+        var binding = DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary");
+
+        // Assert
+        Assert.Equal(binding.ComposeAssociatedData("2026-08"), binding.ComposeAssociatedData("2026-08"));
+    }
+
+    [Fact]
+    public void ComposeAssociatedData_ADifferentSubject_ComposesSomethingElse()
+    {
+        // Arrange
+        var primary = DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary");
+        var secondary = DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "secondary");
+
+        // Assert
+        Assert.NotEqual(primary.ComposeAssociatedData("2026-08"), secondary.ComposeAssociatedData("2026-08"));
+    }
+
+    [Fact]
+    public void ComposeAssociatedData_ADifferentKey_ComposesSomethingElse()
+    {
+        // Arrange
+        var binding = DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary");
+
+        // Assert
+        Assert.NotEqual(binding.ComposeAssociatedData("2026-08"), binding.ComposeAssociatedData("2026-02"));
+    }
+
+    [Fact]
+    public void ToString_ABinding_NamesThePurposeAndTheSubjectAndNothingElse()
+    {
+        // Arrange — both parts are MailFathom's own configured names, so a binding is safe to report in a diagnostic.
+        var binding = DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary");
+
+        // Assert
+        Assert.Equal("mailbox-refresh-token/primary", binding.ToString());
+    }
+}

--- a/tests/Infrastructure.UnitTests/DataEncryption/DataEncryptionKeyTests.cs
+++ b/tests/Infrastructure.UnitTests/DataEncryption/DataEncryptionKeyTests.cs
@@ -1,0 +1,110 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text;
+using MailFathom.Common;
+using MailFathom.Infrastructure.DataEncryption;
+using MailFathom.Infrastructure.Secrets.Resolution;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.DataEncryption;
+
+/// <summary>Covers turning what an operator provisioned into a key, and refusing what is not one.</summary>
+/// <remarks>
+/// The refusals are what move a mistyped key from the first read of a sealed value to startup, so each is asserted
+/// against the reason it reports rather than merely against failing.
+/// </remarks>
+public sealed class DataEncryptionKeyTests
+{
+    [Fact]
+    public void Decode_Base64OfThirtyTwoBytes_YieldsAKeyNamedByItsIdentifier()
+    {
+        // Arrange
+        using var material = TextMaterial(Convert.ToBase64String(new byte[AesGcmEnvelope.KeySizeInBytes]));
+
+        // Act
+        using var key = DataEncryptionKey.Decode("2026-08", material, out var failure);
+
+        // Assert
+        Assert.NotNull(key);
+        Assert.Null(failure);
+        Assert.Equal("2026-08", key.KeyId);
+    }
+
+    [Fact]
+    public void Decode_MaterialCarryingATrailingNewline_YieldsAKey()
+    {
+        // Arrange — every channel that delivers the key writes it as a text file, and a text file routinely ends with a
+        // newline. Refusing one would make the documented provisioning steps fail for a reason nobody could see.
+        using var material = TextMaterial(Convert.ToBase64String(new byte[AesGcmEnvelope.KeySizeInBytes]) + "\n");
+
+        // Act
+        using var key = DataEncryptionKey.Decode("2026-08", material, out var failure);
+
+        // Assert
+        Assert.NotNull(key);
+        Assert.Null(failure);
+    }
+
+    [Fact]
+    public void Decode_MaterialThatIsNotBase64_ReportsThat()
+    {
+        // Arrange
+        using var material = TextMaterial("not base64 at all!!");
+
+        // Act
+        using var key = DataEncryptionKey.Decode("2026-08", material, out var failure);
+
+        // Assert
+        Assert.Null(key);
+        Assert.Equal(DataEncryptionKeyMaterialFailure.NotBase64, failure);
+    }
+
+    [Fact]
+    public void Decode_ThirtyThreeBytesOfBase64_ReportsTheWrongLength()
+    {
+        // Arrange — this is the mistake the documentation exists to prevent: `openssl rand -base64 33` is the command
+        // beside this one in a Compose deployment, and it is right for the database passwords and wrong for a key.
+        using var material = TextMaterial(Convert.ToBase64String(new byte[AesGcmEnvelope.KeySizeInBytes + 1]));
+
+        // Act
+        using var key = DataEncryptionKey.Decode("2026-08", material, out var failure);
+
+        // Assert
+        Assert.Null(key);
+        Assert.Equal(DataEncryptionKeyMaterialFailure.WrongLength, failure);
+    }
+
+    [Fact]
+    public void Decode_Base64OfTooFewBytes_ReportsTheWrongLength()
+    {
+        // Arrange
+        using var material = TextMaterial(Convert.ToBase64String(new byte[16]));
+
+        // Act
+        using var key = DataEncryptionKey.Decode("2026-08", material, out var failure);
+
+        // Assert
+        Assert.Null(key);
+        Assert.Equal(DataEncryptionKeyMaterialFailure.WrongLength, failure);
+    }
+
+    [Fact]
+    public void Decode_TheCallerOwnedMaterial_IsLeftUsable()
+    {
+        // Arrange — startup decodes every key and reports on all of them, so decoding one must not erase the material
+        // the caller still owns.
+        using var material = TextMaterial(Convert.ToBase64String(new byte[AesGcmEnvelope.KeySizeInBytes]));
+
+        // Act
+        using var key = DataEncryptionKey.Decode("2026-08", material, out _);
+
+        // Assert
+        Assert.NotNull(key);
+        Assert.NotEmpty(material.RevealBytes().ToArray());
+    }
+
+    private static ResolvedSecret TextMaterial(string material) =>
+        ResolvedSecret.FromBytes(Encoding.UTF8.GetBytes(material));
+}

--- a/tests/Infrastructure.UnitTests/DataEncryption/DataEncryptionPurposeTests.cs
+++ b/tests/Infrastructure.UnitTests/DataEncryption/DataEncryptionPurposeTests.cs
@@ -1,0 +1,116 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json;
+using MailFathom.Infrastructure.DataEncryption;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.DataEncryption;
+
+/// <summary>Covers the identity a sealed value is authenticated against, which the database holds for the life of the row.</summary>
+/// <remarks>
+/// The assertions run against <see cref="DataEncryptionPurpose.All" /> rather than over the type's members by
+/// reflection, so a member added without being listed is a failure here rather than a value nothing can enumerate.
+/// </remarks>
+public sealed class DataEncryptionPurposeTests
+{
+    [Fact]
+    public void All_EveryPurpose_DeclaresADistinctIdentity()
+    {
+        // Arrange
+        var identities = DataEncryptionPurpose.All.Select(purpose => purpose.Identity);
+
+        // Act
+        var distinctIdentities = identities.Distinct(StringComparer.Ordinal);
+
+        // Assert
+        Assert.Equal(DataEncryptionPurpose.All.Count, distinctIdentities.Count());
+    }
+
+    [Fact]
+    public void Identity_MailboxRefreshToken_IsTheIdentityStoredValuesWereSealedUnder()
+    {
+        // Assert — the literal is the point of the test. Changing it makes every sealed value fail to open, so it is
+        // asserted here rather than derived from the member, which a rename would carry along silently.
+        Assert.Equal("mailbox-refresh-token", DataEncryptionPurpose.MailboxRefreshToken.Identity);
+    }
+
+    [Fact]
+    public void TryParse_ADeclaredIdentity_YieldsThatPurpose()
+    {
+        // Act
+        var parsed = DataEncryptionPurpose.TryParse("mailbox-refresh-token", out var purpose);
+
+        // Assert
+        Assert.True(parsed);
+        Assert.Equal(DataEncryptionPurpose.MailboxRefreshToken, purpose);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("mailbox-access-token")]
+    [InlineData("Mailbox-Refresh-Token")]
+    public void TryParse_AnIdentityNothingDeclares_YieldsTheUnspecifiedDefault(string? identity)
+    {
+        // Act
+        var parsed = DataEncryptionPurpose.TryParse(identity, out var purpose);
+
+        // Assert — the comparison is exact because the identity is authenticated material rather than operator input,
+        // so a difference in case is a different identity and not a spelling to forgive.
+        Assert.False(parsed);
+        Assert.False(purpose.IsSpecified);
+    }
+
+    [Fact]
+    public void Identity_TheUnspecifiedDefault_RefusesToNameAPurpose()
+    {
+        // Arrange
+        var unspecified = default(DataEncryptionPurpose);
+
+        // Assert
+        Assert.False(unspecified.IsSpecified);
+        Assert.Throws<InvalidOperationException>(() => unspecified.Identity);
+        Assert.Equal("(unspecified)", unspecified.ToString());
+    }
+
+    [Fact]
+    public void Serialization_ADeclaredPurpose_RoundTripsThroughItsIdentity()
+    {
+        // Act
+        var json = JsonSerializer.Serialize(DataEncryptionPurpose.MailboxRefreshToken);
+
+        // Assert
+        Assert.Equal("\"mailbox-refresh-token\"", json);
+        Assert.Equal(
+            DataEncryptionPurpose.MailboxRefreshToken,
+            JsonSerializer.Deserialize<DataEncryptionPurpose>(json));
+    }
+
+    [Fact]
+    public void Serialization_AsAPropertyName_RoundTripsThroughItsIdentity()
+    {
+        // Arrange
+        var byPurpose = new Dictionary<DataEncryptionPurpose, int> { [DataEncryptionPurpose.MailboxRefreshToken] = 1 };
+
+        // Act
+        var json = JsonSerializer.Serialize(byPurpose);
+
+        // Assert
+        Assert.Equal("{\"mailbox-refresh-token\":1}", json);
+        Assert.Equal(
+            byPurpose,
+            JsonSerializer.Deserialize<Dictionary<DataEncryptionPurpose, int>>(json));
+    }
+
+    [Fact]
+    public void Serialization_TheUnspecifiedDefault_IsRefused() =>
+        Assert.Throws<JsonException>(() => JsonSerializer.Serialize(default(DataEncryptionPurpose)));
+
+    [Theory]
+    [InlineData("\"mailbox-access-token\"")]
+    [InlineData("7")]
+    public void Deserialization_AValueNothingDeclares_IsRefused(string json) =>
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<DataEncryptionPurpose>(json));
+}

--- a/tests/Infrastructure.UnitTests/DataEncryption/FieldEncryptorTests.cs
+++ b/tests/Infrastructure.UnitTests/DataEncryption/FieldEncryptorTests.cs
@@ -1,0 +1,199 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Cryptography;
+using System.Text;
+using MailFathom.Common;
+using MailFathom.Infrastructure.DataEncryption;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using MailFathom.Infrastructure.UnitTests.TestDoubles;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.DataEncryption;
+
+/// <summary>Covers what the key ring guarantees about a value it sealed: who can open it, and under which key.</summary>
+/// <remarks>
+/// Every assertion here is about a value refusing to open somewhere it does not belong, because that refusal is the
+/// whole reason one key ring can protect several kinds of value. A test that only proved a round trip would pass
+/// against an implementation that authenticated nothing.
+/// </remarks>
+public sealed class FieldEncryptorTests
+{
+    private const string ActiveKeyId = "2026-08";
+    private const string RetiredKeyId = "2026-02";
+
+    private static readonly byte[] Plaintext = Encoding.UTF8.GetBytes("1//0eXAMPLErefreshtoken");
+
+    [Fact]
+    public async Task SealAsync_AValue_SealsItUnderTheActiveKey()
+    {
+        // Arrange
+        var encryptor = CreateEncryptor(out _);
+        var binding = DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary");
+
+        // Act
+        var sealedValue = await encryptor.SealAsync(binding, Plaintext, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(ActiveKeyId, sealedValue.KeyId);
+        Assert.NotEqual(Plaintext, sealedValue.Ciphertext.ToArray());
+    }
+
+    [Fact]
+    public async Task OpenAsync_AValueSealedUnderTheSameBinding_YieldsTheValue()
+    {
+        // Arrange
+        var encryptor = CreateEncryptor(out _);
+        var binding = DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary");
+        var sealedValue = await encryptor.SealAsync(binding, Plaintext, TestContext.Current.CancellationToken);
+
+        // Act
+        var opened = await encryptor.OpenAsync(binding, sealedValue, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(Plaintext, opened);
+    }
+
+    [Fact]
+    public async Task OpenAsync_AValueMovedToAnotherSubject_DoesNotOpen()
+    {
+        // Arrange — the case an operator would meet as a row copied between accounts, and an attacker as a row planted
+        // under an account they control.
+        var encryptor = CreateEncryptor(out _);
+        var sealedValue = await encryptor.SealAsync(
+            DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary"),
+            Plaintext,
+            TestContext.Current.CancellationToken);
+
+        // Act
+        var opening = async () => await encryptor.OpenAsync(
+            DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "secondary"),
+            sealedValue,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAnyAsync<CryptographicException>(opening);
+    }
+
+    [Fact]
+    public async Task OpenAsync_AValueWhoseStoredKeyIdentifierWasAltered_DoesNotOpen()
+    {
+        // Arrange — the identifier beside the ciphertext is not a secret, so a database writer can change it. It is
+        // authenticated into the value, which is what makes the change a failure rather than a redirection.
+        var encryptor = CreateEncryptor(out _);
+        var binding = DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary");
+        var sealedValue = await encryptor.SealAsync(binding, Plaintext, TestContext.Current.CancellationToken);
+
+        // Act
+        var opening = async () => await encryptor.OpenAsync(
+            binding,
+            sealedValue with { KeyId = RetiredKeyId },
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAnyAsync<CryptographicException>(opening);
+    }
+
+    [Fact]
+    public async Task OpenAsync_AValueNamingAKeyTheRingNoLongerConfigures_FailsNamingTheKey()
+    {
+        // Arrange — what retiring a key too early looks like from the reader's side.
+        var encryptor = CreateEncryptor(out _);
+        var binding = DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary");
+        var sealedValue = new SealedValue("2025-01", new byte[64]);
+
+        // Act
+        var opening = async () => await encryptor.OpenAsync(binding, sealedValue, TestContext.Current.CancellationToken);
+
+        // Assert
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(opening);
+        Assert.Contains("2025-01", failure.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task OpenAsync_AValueStillUnderARetiredKey_OpensAndReportsThatItNeedsResealing()
+    {
+        // Arrange — the state a deployment is in between moving the active key and re-sealing what nothing has
+        // rewritten since. Both halves have to hold: the value opens, and the store can tell it is behind.
+        var encryptor = CreateEncryptor(out var resolver);
+        var binding = DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary");
+
+        var retiredRing = new DataEncryptionKeyRing(
+            () => CreateSettings(RetiredKeyId),
+            resolver);
+        var sealedUnderRetiredKey = await new FieldEncryptor(retiredRing)
+            .SealAsync(binding, Plaintext, TestContext.Current.CancellationToken);
+
+        // Act
+        var opened = await encryptor.OpenAsync(binding, sealedUnderRetiredKey, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(Plaintext, opened);
+        Assert.True(FieldEncryptor.NeedsResealing(sealedUnderRetiredKey, ActiveKeyId));
+    }
+
+    [Fact]
+    public async Task NeedsResealing_AValueUnderTheActiveKey_ReportsNothingToDo()
+    {
+        // Arrange
+        var encryptor = CreateEncryptor(out _);
+        var sealedValue = await encryptor.SealAsync(
+            DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary"),
+            Plaintext,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(FieldEncryptor.NeedsResealing(sealedValue, ActiveKeyId));
+    }
+
+    [Fact]
+    public async Task SealAsync_EveryResolvedKey_IsErasedWhenTheOperationEnds()
+    {
+        // Arrange
+        var encryptor = CreateEncryptor(out var resolver);
+
+        // Act
+        await encryptor.SealAsync(
+            DataEncryptionBinding.Create(DataEncryptionPurpose.MailboxRefreshToken, "primary"),
+            Plaintext,
+            TestContext.Current.CancellationToken);
+
+        // Assert — the resolver hands out the configured base64, and the ring owns both that and the decoded key. What
+        // is asserted is that nothing it issued survives the operation holding material.
+        Assert.NotEmpty(resolver.IssuedMaterial);
+        Assert.All(resolver.IssuedMaterial, material => Assert.Throws<ObjectDisposedException>(() => material.RevealBytes().Length));
+    }
+
+    private static FieldEncryptor CreateEncryptor(out ProvisionedMaterialResolver resolver)
+    {
+        resolver = CreateResolver();
+
+        return new FieldEncryptor(new DataEncryptionKeyRing(() => CreateSettings(ActiveKeyId), resolver));
+    }
+
+    private static ProvisionedMaterialResolver CreateResolver()
+    {
+        var resolver = new ProvisionedMaterialResolver();
+
+        // A trailing newline is what a Compose secret, a Kubernetes Secret file, and `LoadCredential=` all routinely
+        // carry, so the material is provisioned with one rather than in the tidy form nothing produces.
+        resolver.ProvisionText("plaintext:active", Convert.ToBase64String(KeyOf(0x11)) + "\n");
+        resolver.ProvisionText("plaintext:retired", Convert.ToBase64String(KeyOf(0x22)));
+
+        return resolver;
+    }
+
+    private static DataEncryptionKeyRingSettings CreateSettings(string activeKeyId) =>
+        new(
+            activeKeyId,
+            [
+                new DataEncryptionKeyReference(ActiveKeyId, Reference("active")),
+                new DataEncryptionKeyReference(RetiredKeyId, Reference("retired")),
+            ]);
+
+    private static ConfiguredSecret Reference(string target) =>
+        new() { Name = $"data-key-{target}", SecretReference = $"plaintext:{target}" };
+
+    private static byte[] KeyOf(byte fill) => [.. Enumerable.Repeat(fill, AesGcmEnvelope.KeySizeInBytes)];
+}


### PR DESCRIPTION
Closes #337

MailFathom is about to hold a credential it writes itself. A mailbox refresh token has always arrived as a `SecretReference` the process resolves and never writes back, which is why a token the authorization server rotates cannot be followed — and why `docs/operations/mailbox-oauth.md` currently documents that as an instruction to watch a log. Giving the service a store it can write moves the credential into the database, and a credential the service persists is one the service becomes responsible for protecting.

This is the half that decides where the protection comes from. #329 is the store that consumes it.

## ADR 0005

Raised as `proposed`. It records two independent axes with four options each — what seals the data, and where the key comes from — and the decision on both.

The part worth reading is why nothing generates the key. A Helm-generated value regenerates on every `helm upgrade` unless it is guarded with `lookup`, and `lookup` returns nothing during `helm template`, during a dry run, and under Argo CD. For a password that is a reset an operator repairs; for a data-encryption key it is every sealed row becoming permanently unopenable, discovered at the first read after the upgrade. Every mechanism that saves the operator one `openssl rand` line adds one that can lose the key, and that trade is wrong in the direction that cannot be undone.

Local development is the one exception, and the ADR states why the conditions that make generation unsafe do not hold there.

## `DataEncryption`, a configuration root of its own

Not a section of `Persistence`. The database is the first thing sealed under the ring and there is no reason it is the last, so naming the ring after its first consumer would leave the second one either moving the section or inheriting a name that says the ring belongs elsewhere. A root is also its own uniqueness scope for secret names, exactly as `MailSynchronization` and `McpEndpoint` are.

`DataProtection` was the other candidate and is refused: ASP.NET Core publishes a subsystem under that exact name with a different purpose, key lifetime, and threat model.

```jsonc
{
  "DataEncryption": {
    "ActiveKeyId": "2026-08",
    "Keys": [
      {
        "KeyId": "2026-08",
        "Material": { "Name": "mailfathom-data-key", "SecretReference": "systemd-credential:mailfathom-data-key" }
      }
    ]
  }
}
```

**An absent section is valid and stays valid.** No stored value carries a key identifier yet, so requiring a key here would refuse to start every existing deployment for a feature none of them uses. Whatever first seals a value is what makes the section required, at the point that value is written.

## What startup refuses

An `ActiveKeyId` naming no configured key, an active key with no ring at all, a duplicate `KeyId`, an identifier outside the accepted grammar, a key configuring no material, material that does not resolve, and material that is not an AES-256 key. Neither the material nor its length reaches the report — a message naming the length of a rejected key tells anyone reading the log how much of it to guess.

The structural rules live on the options type and the resolution rules live with the other secret validation, so a malformed ring is judged once rather than twice, and an operator who mistyped several references reads one aggregated report.

## Why the binding matters more than the encryption

Every sealed value authenticates `(subject, purpose, keyId)`. That is what makes one ring safe across several kinds of value: a row copied between accounts fails to open rather than opening as the wrong owner's credential, a value moved into a column that means something else fails the same way, and rewriting the key identifier stored beside the ciphertext makes the value fail rather than redirect. The tests are written about those refusals rather than about the round trip, because a test that only proved a round trip would pass against an implementation that authenticated nothing.

Each sealed value stores the identifier of the key that sealed it, which is what makes rotation an edit — add the key, move `ActiveKeyId`, leave the previous key configured — instead of a flag day with the service stopped. #336 covers the part that makes a retired key actually removable.

## Verification

- `scripts/verify-full.sh` passes.
- 2385 unit tests pass; aggregate line coverage 96.47% against the 85% threshold.
- The integration suite was not run. It needs the owner's say-so, and nothing here touches the schema.

## Follows

- #329 seals mailbox refresh tokens under this ring.
- #330 provisions the key through Compose, Helm, and systemd.
- #336 makes a retired key removable.
