### PR TITLE
[#340] Say that push keeps the account interval, and that the renewal setting is not a cycle

### DIFF
--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -142,10 +142,23 @@ would be a second implementation of the correctness-critical work, and the one p
 could hold in one path and lapse in the other. The watching session issues `IDLE` and nothing else, and a test asserts
 that it requests no body, no envelope, no flags, and no read-write reselection.
 
-It also changes nothing about the *guaranteed* cadence. The wait a supervisor computes — the interval, or the backoff a
-failing account is under — is still the longest a folder waits; a notification only ends that wait early. A quiet
-mailbox therefore still reconciles on its interval, which is what keeps the backward pass working through a large
-folder's window whether or not any mail is arriving.
+### A folder in push mode still keeps the account's interval
+
+This is a decision rather than a leftover, and it is the one most likely to surprise: **`Interval` is not replaced by
+push, it becomes the ceiling on the wait that a notification cuts short.** The wait a supervisor computes — the
+interval, or the backoff a failing account is under — is still the longest a folder waits; a notification only ends it
+early.
+
+The reason is the backward pass. Reconciliation walks a window bounded by `MaxReconciledEmailsPerRun`, oldest
+observation first, so a folder holding more mail than that window notices a remote deletion or a flag change over
+several runs rather than in one. Those runs have to keep happening while **nothing is arriving**, because a message
+deleted on the server produces no new mail to be notified about — and a folder whose backlog is a hundred thousand
+messages needs two hundred passes at the default window to work through it once. A push mode that removed the interval
+would tie the whole backward pass to inbound traffic: a quiet mailbox would stop reconciling entirely, and the longer it
+stayed quiet the further behind it would fall, silently.
+
+So push buys latency on new mail and gives up nothing. The cost of keeping the interval is one pass per interval on a
+mailbox that had nothing to report, which is exactly what an account not in push mode already pays.
 
 ### Choosing the mode, per folder
 
@@ -182,11 +195,20 @@ connection limit is therefore a configuration to reconsider, and the log says wh
 
 ### Renewal
 
+**`PushRenewalInterval` is not a polling interval, despite its name.** It bounds the lifetime of a *single* `IDLE`
+command, and it schedules nothing whatsoever: it does not decide when a pass runs, it does not shorten or lengthen the
+wait, and lowering it makes MailFathom check nothing more often. Read it as *how long one command may sit before it has
+to be re-issued*.
+
 RFC 2177 requires a client to leave and re-enter `IDLE` at least every 29 minutes, and several servers drop a connection
-that stays in it longer. A wait longer than `PushRenewalInterval` is therefore served by a sequence of `IDLE` commands
-over the same connection rather than by one long one, and the default of twenty minutes keeps nine minutes below the
-mandate as margin for a slow round trip. Renewal reconnects nothing; a change reported during any command in the
-sequence ends the whole wait at once.
+that stays in it longer. A wait longer than this setting is therefore served by a sequence of `IDLE` commands over the
+same connection rather than by one long one, and the default of twenty minutes keeps nine minutes below the mandate as
+margin for a slow round trip. Renewal reconnects nothing and re-authenticates nothing; a change reported during any
+command in the sequence ends the whole wait at once, whichever command of the sequence is in flight.
+
+Lowering it therefore buys nothing but chatter, and raising it past the mandate is refused at startup. The setting an
+operator changes to make a folder synchronize more often is `Interval`, which is the ceiling
+[the section above](#a-folder-in-push-mode-still-keeps-the-accounts-interval) describes.
 
 ### Degradation, and why it expires
 
@@ -801,9 +823,14 @@ polling with nothing reporting the difference, for the same reason the dispositi
 
 The three deployment-wide settings shape how a watched folder behaves and apply to every account that asked for push.
 `PushRenewalInterval` accepts one to twenty-nine minutes, the ceiling being what RFC 2177 mandates, and defaults to
-twenty. `MaxConsecutivePushFailures` accepts 1 to 100 and defaults to three, and `PushDegradationPeriod` accepts ten
-seconds to a day and defaults to fifteen minutes; together they decide when a folder stops retrying push and when it
-starts again.
+twenty; it is the lifetime of one `IDLE` command rather than a cycle, which [Renewal](#renewal) states in full because
+the name reads the other way. `MaxConsecutivePushFailures` accepts 1 to 100 and defaults to three, and
+`PushDegradationPeriod` accepts ten seconds to a day and defaults to fifteen minutes; together they decide when a folder
+stops retrying push and when it starts again.
+
+**How often a push folder synchronizes is still `Interval`.** Push adds no schedule of its own: it ends that wait early
+when the server reports a change, and [A folder in push mode still keeps the account's
+interval](#a-folder-in-push-mode-still-keeps-the-accounts-interval) records why the interval stays.
 
 `ShutdownDrainTimeout` is how long shutdown waits for the work units already under way after it has stopped scheduling
 new ones. It accepts anything from zero to two minutes and defaults to ten seconds. The host's shutdown budget is

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -87,7 +87,7 @@ shape the coordinator loop itself, which are read once at start and marked *rest
 | `MailSynchronization:MaxMimePartCount` | int | `1000` | 1 – 100000 | reload |
 | `MailSynchronization:MaxMimeNestingDepth` | int | `30` | 1 – 1000 | reload |
 | `MailSynchronization:MaxExtractedTextCharacters` | int | `100000` | 1000 – 200000; the ceiling keeps the search vector inside PostgreSQL's limit | reload |
-| `MailSynchronization:PushRenewalInterval` | TimeSpan | `00:20:00` | 1 min – 29 min; the ceiling is what RFC 2177 mandates | reload |
+| `MailSynchronization:PushRenewalInterval` | TimeSpan | `00:20:00` | 1 min – 29 min; the lifetime of one `IDLE` command, **not** a polling cycle — the ceiling is what RFC 2177 mandates | reload |
 | `MailSynchronization:MaxConsecutivePushFailures` | int | `3` | 1 – 100 | reload |
 | `MailSynchronization:PushDegradationPeriod` | TimeSpan | `00:15:00` | 10 s – 1 day | reload |
 

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -86,7 +86,8 @@ Points worth knowing before you adapt it:
 - **New mail arrives on the next run unless you ask for push.** The default reconciles each account every five minutes.
   Setting an account's `"Mode": "Push"` makes MailFathom hold an IMAP `IDLE` session open per folder and synchronize the
   moment the server reports a change, at the cost of one open connection per folder; a server that does not support it
-  is polled instead and says so in the log.
+  is polled instead and says so in the log. Push **adds** to the schedule rather than replacing it — the account still
+  runs on its `Interval`, and a notification only starts the next run sooner.
   [Push synchronization](../features/imap-synchronization.md#push-synchronization) records the whole model.
 
 The Compose deployment reads this from `config/10-mailfathom.json`; Kubernetes mounts it as a ConfigMap key; a native


### PR DESCRIPTION
Closes #340

Documentation only. Follow-up to the review question on #339 that stayed open when that pull request merged.

## The two gaps

**`PushRenewalInterval` reads as a polling cycle and is not one.** It bounds the lifetime of a *single* IMAP `IDLE` command — how long it may sit before the client has to leave it and re-issue it, which RFC 2177 requires at least every 29 minutes because servers drop a connection idle longer than that. It schedules nothing: it does not decide when a pass runs, and lowering it makes MailFathom check nothing more often. The renewal section now opens by saying that outright, and the settings paragraph, the configuration-reference row, and the getting-started note each point at `Interval` as the setting that actually decides how often a push folder synchronizes.

**A folder in push mode still honours the account's `Interval`, and nothing said so.** That is a decision, not a leftover: `Interval` becomes the ceiling on the wait that a notification cuts short. The reason is the backward pass — reconciliation walks a window bounded by `MaxReconciledEmailsPerRun`, oldest observation first, so a folder holding more mail than that window notices a remote deletion or a flag change over several runs rather than in one. Those runs have to keep happening while **nothing is arriving**, because a message deleted on the server produces no new mail to be notified about. A push mode that removed the interval would tie the whole backward pass to inbound traffic: a quiet mailbox would stop reconciling, and the longer it stayed quiet the further behind it would fall, silently. It now has a section of its own instead of a sentence buried in another paragraph.

## What this change does not do

**It does not rename the setting.** The name is the defect that produced the question, and renaming it is a configuration change rather than a documentation one — it moves a key, an options property, and its validation. This pull request was asked for as a documentation fix, so the rename stays the owner's call; the key has no consumer outside the change that introduced it, so it is still free to move if that call is yes.

## Verification

- `scripts/verify-full.sh`: pass — 2366 tests, 0 failed; aggregate line coverage 96.46% (required 85%).
- Diff is three files, all under `docs/`: `features/imap-synchronization.md`, `operations/configuration-reference.md`, `users/getting-started.md`. No code, no dependency, no test moved.
- `$check-docs-licenses`: Docs pass, Changelog n/a, Licenses n/a.