### PR TITLE
[#330] Provision the data-encryption key through Compose, Kubernetes, and systemd

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -11,6 +11,20 @@
 #   openssl rand -base64 33 | tr -d '\n' > secrets/mailfathom-database-password
 #   chmod 444 secrets/postgres-superuser-password secrets/mailfathom-database-password
 #
+# A mailbox that authenticates with OAuth needs one file more: the data-encryption key its refresh token is sealed
+# under. It belongs under ./secrets/mailfathom/, the directory MailFathom reads its own credentials from, rather than
+# beside the two above, which are Compose secrets and arrive at /run/secrets instead:
+#
+#   openssl rand -base64 32 | tr -d '\n' > secrets/mailfathom/mailfathom-data-key
+#   chmod 444 secrets/mailfathom/mailfathom-data-key
+#
+# That is `-base64 32`, never the `-base64 33` on the two lines above it. The material has to decode to exactly 32
+# bytes, which is what AES-256 takes, and startup refuses any other length rather than accepting a weaker key — so the
+# neighbouring command is the one thing never to copy here. Generate it once and back it up with the database: nothing
+# in MailFathom regenerates it, and a database restored without its key restores nothing that was sealed. A deployment
+# whose mailboxes all authenticate with a password needs no key and starts without one. See
+# docs/operations/secret-provisioning.md for the whole contract.
+#
 # The directory restricts access and the files are readable, not the other way round: MailFathom runs as an unprivileged
 # account that is nobody's host user, and Compose bind-mounts a secret with the host's own permissions rather than
 # applying `mode`. A 0600 file reads to MailFathom as an unresolvable secret reference.

--- a/deploy/compose/config/10-mailfathom.json.example
+++ b/deploy/compose/config/10-mailfathom.json.example
@@ -11,6 +11,32 @@
 // The database is configured by compose.yaml through the environment block, which outranks this file, so it is
 // deliberately absent here.
 {
+  // Uncomment this block when an account below authenticates with OAuth rather than with a password. MailFathom seals
+  // the refresh token that account's authorization server rotates, and the key it seals under is provisioned like any
+  // other credential — a file in ./secrets/mailfathom/, named by a reference. The mailbox configured below uses a
+  // password, so a deployment copied from this file seals nothing and needs no key at all: an absent section is a valid
+  // configuration rather than an omission, and MailFathom starts without one. An OAuth account without a key still
+  // authenticates from its configured reference; what needs the key is the moment its authorization server rotates the
+  // refresh token, and without one that rotation is logged as an error instead of being stored.
+  //
+  // The material is base64 decoding to exactly 32 bytes — `openssl rand -base64 32`, never the `-base64 33` that
+  // generates the database passwords. `KeyId` is written beside every value this key seals, so it is chosen once and
+  // never edited afterwards; a date reads well because it says when the key entered service, which is the question a
+  // rotation asks.
+  //
+  // "DataEncryption": {
+  //   "ActiveKeyId": "2026-08",
+  //   "Keys": [
+  //     {
+  //       "KeyId": "2026-08",
+  //       "Material": {
+  //         "Name": "mailfathom-data-key",
+  //         "SecretReference": "file:/etc/mailfathom/secrets/mailfathom-data-key"
+  //       }
+  //     }
+  //   ]
+  // },
+
   "MailSynchronization": {
     "Enabled": true,
     "Interval": "00:05:00",

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -51,6 +51,8 @@ into `secrets/mailfathom/`, which is mounted read-only at `/etc/mailfathom/secre
 ```bash
 printf '%s' 'the-mailbox-password' > secrets/mailfathom/imap-primary-password
 openssl rand -base64 33 | tr -d '\n'  > secrets/mailfathom/mcp-workstation-key
+openssl rand -base64 32 | tr -d '\n'  > secrets/mailfathom/mailfathom-data-key   # only for an OAuth mailbox
+chmod 444 secrets/mailfathom/*
 ```
 
 ```json
@@ -70,6 +72,18 @@ configuration file does and does not expose.
 
 The two database credentials are Compose secrets rather than files in that directory, so the database superuser
 password is never on a path the service can read.
+
+**The data-encryption key is `-base64 32`, not the `-base64 33` on every other line here.** It is the one credential
+generated to a length rather than to a strength: the material has to decode to exactly 32 bytes, and startup refuses
+anything else naming the setting instead of accepting a weaker key. It is needed only when an account authenticates
+with OAuth, because the refresh token its authorization server rotates is the one value MailFathom seals today; a
+deployment whose mailboxes all use a password needs no key and starts without one. `10-mailfathom.json.example` carries
+the `DataEncryption` block commented out for exactly that reason — uncomment it when you configure an OAuth account.
+
+Generate it once and **back it up with the database, not beside it**. The key is not in the database, nothing in
+MailFathom regenerates it in any channel, and a database restored without it restores no sealed value — the failure
+appears at the next read rather than at the moment of loss.
+[The data-encryption key](secret-provisioning.md#the-data-encryption-key) covers rotation and what the ring is for.
 
 ## Starting
 

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -31,11 +31,21 @@ kubectl create namespace mailfathom
 kubectl --namespace mailfathom create secret generic mailfathom-secrets \
   --from-literal=mailfathom-database-password='…' \
   --from-file=imap-primary-password=./imap-primary-password \
-  --from-file=mcp-workstation-key=./mcp-workstation-key
+  --from-file=mcp-workstation-key=./mcp-workstation-key \
+  --from-file=mailfathom-data-key=./mailfathom-data-key
 ```
 
 It is mounted read-only at `/etc/mailfathom/secrets`, one file per key, so every credential is a `file:` reference — the
 same path and the same references the Compose deployment uses.
+
+The last entry is the data-encryption key, and it belongs in this Secret rather than in a chart value: the chart creates
+no Secret and generates nothing, deliberately, because a Helm-generated key would be replaced on any upgrade that did
+not guard it with `lookup` — and `lookup` returns nothing during `helm template`, during a dry run, and under Argo CD.
+Every value already sealed would stop opening. Generate it once with `openssl rand -base64 32`; the material decodes to
+exactly 32 bytes and startup refuses any other length. Drop the line when no account authenticates with OAuth, since a
+deployment that seals nothing needs no key.
+[The data-encryption key](secret-provisioning.md#the-data-encryption-key) states the rest, including why it is backed
+up with the database and never regenerated.
 
 A Secrets Store CSI driver works, with one step this chart does not take for you. The pod mounts a Kubernetes `secret`
 volume and exposes no CSI volume of its own, so configure the driver's `secretObjects` to **synchronize** into the

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -23,7 +23,10 @@ You need two pieces of material before anything is configured:
 - **The mailbox password** or app password of the IMAP account to synchronize. A mailbox whose provider no longer
   accepts one — a Google Workspace or Exchange Online account — is authenticated with an OAuth refresh token instead;
   obtain it first with [mailbox OAuth](../operations/mailbox-oauth.md) and substitute that block for the password
-  below.
+  below. That account needs a third piece of material as well, the **data-encryption key** the rotated refresh token is
+  sealed under: `openssl rand -base64 32`, generated once and never regenerated, provisioned as a reference like
+  everything else here. [The data-encryption key](../operations/secret-provisioning.md#the-data-encryption-key) is the
+  whole of it.
 - **An MCP API key** for the client that will connect. Generate it rather than inventing it:
 
 ```bash

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -108,7 +108,33 @@ Build with the SDK pinned in `global.json`. The process is then an ordinary ASP.
   environment variables.
 - Credentials arrive as systemd credentials: `LoadCredential=` in the unit, `systemd-credential:` references in the
   configuration. [Secret provisioning](../operations/secret-provisioning.md#native-systemd-service) shows the unit
-  fragment, including the encrypted-at-rest variant and the core-dump limit worth setting alongside it.
+  fragment, including the encrypted-at-rest variant and the core-dump limit worth setting alongside it. The
+  data-encryption key is one of them, provisioned no differently from a mailbox password:
+
+  ```ini
+  [Service]
+  LoadCredentialEncrypted=mailfathom-data-key:/etc/mailfathom/mailfathom-data-key.cred
+  ```
+
+  ```json
+  {
+    "DataEncryption": {
+      "ActiveKeyId": "2026-08",
+      "Keys": [
+        {
+          "KeyId": "2026-08",
+          "Material": {
+            "Name": "mailfathom-data-key",
+            "SecretReference": "systemd-credential:mailfathom-data-key"
+          }
+        }
+      ]
+    }
+  }
+  ```
+
+  `KeyId` is stored beside every value the key seals, so it is chosen once and never edited afterwards. Leave both out
+  when no account authenticates with OAuth.
 - [The application listener](../operations/configuration-reference.md#the-application-listener) binds the address
   `ASPNETCORE_URLS`, `ASPNETCORE_HTTP_PORTS`, or your Kestrel configuration names, and `http://localhost:5000` when you
   name none — loopback, so a service you never gave an address to is not reachable from another machine. It is clear


### PR DESCRIPTION
The key ring #329 introduced was reachable only by an operator who already knew the section existed: none of the three deployment channels mentioned it in its own instructions or examples. This adds the key's arrival in each of them, and touches no template — the chart and Compose already mount the directory the key is a file in, so a value for it would be a knob for something the mount does.

## What changed

| Where | What |
| --- | --- |
| `deploy/compose/.env.example` | The generating command beside the two database passwords, with the permission notes those carry |
| `deploy/compose/config/10-mailfathom.json.example` | A commented `DataEncryption` block referencing `file:/etc/mailfathom/secrets/mailfathom-data-key` |
| `docs/operations/deployment-compose.md` | The key in the credential provisioning steps, and why it is backed up with the database |
| `docs/operations/deployment-kubernetes.md` | One more `--from-file=`, and why the chart still creates no Secret and generates nothing |
| `docs/users/installation.md` | The native path's `LoadCredential=` line and the `systemd-credential:` reference it produces |
| `docs/users/getting-started.md` | One clause on the OAuth branch — see below |

## Two decisions worth reviewing

**The example block is commented, and placed first.** The mailbox that example configures authenticates with a password, so an uncommented block would make every Compose install provision a key for a feature it is not using. It sits above `MailSynchronization` rather than below `McpEndpoint` so that uncommenting it yields valid JSON on its own: the trailing comma is inside the comment, and no line above it has to be edited. Both forms were parsed to confirm it.

**`docs/users/getting-started.md` is a sixth file the issue did not list.** Its "provision the secrets" step says two pieces of material are needed and sends a reader whose provider refuses passwords off to `mailbox-oauth.md` for a refresh token — without saying that token needs a key. That is the refusal the issue's acceptance criteria are written against, reached by the sibling path, so it gets one clause pointing at the owning reference page.

## Correctness

Three claims drafted here were wrong and were corrected against the code before this was pushed:

- A missing key is **not** a startup failure. `DataEncryptionKeyRing.ResolveKeyAsync` throws when a value is sealed, and nothing cross-validates an OAuth account against the ring, so the behaviour is what `mailbox-oauth.md#rotation` already documents: the account authenticates from its configured reference, and a rotation that arrives without a key is logged as an error rather than stored. The example's prose says that now. Note this differs from the issue's fourth acceptance bullet, which describes a startup refusal that #329 did not implement — the docs follow the code.
- `mailfathom-database-password` **is** mounted into the `mailfathom` service (`compose.yaml:105`), so a draft sentence calling the two database secrets unreachable by it was replaced. The real distinction is Compose secrets at `/run/secrets` versus the bind-mounted credential directory.
- What startup *does* refuse is configured material of the wrong length, in `SecretConfigurationValidator`; that claim is kept and is the one the `-base64 32` warning rests on.

## Verification

`scripts/verify-full.sh` — exit 0, including `test-agent-workflow.sh`, locked-mode restore, Release build, coverage collection, and `dotnet format --verify-no-changes` (0 of 864 files). `scripts/verify-fast.sh` ran green earlier at 2532 tests, 0 failed; no production code changed. `scripts/review-obligations.sh` reports no test obligation and every describing page in the change.

Helm was not run: no chart file is touched.

Closes #330