### PR TITLE
[#353] Read an OAuth token response through the contract a trimmed binary can keep

### DIFF
--- a/.config/BannedSymbols.txt
+++ b/.config/BannedSymbols.txt
@@ -16,6 +16,21 @@ P:System.DateTimeOffset.UtcNow;Inject TimeProvider and call GetUtcNow(); see roo
 M:System.Threading.Thread.Sleep(System.Int32);Await TimeProvider.Delay so the wait is cancellable and testable.
 M:System.Threading.Thread.Sleep(System.TimeSpan);Await TimeProvider.Delay so the wait is cancellable and testable.
 
+; Reading an HTTP response body as JSON through reflection. Every overload here that takes neither a
+; JsonTypeInfo nor a JsonSerializerContext carries RequiresUnreferencedCode, which the trimmer reports as
+; IL2026 and TreatWarningsAsErrors turns into a failed publish — so one of these calls breaks the trimmed
+; mfctl binaries and nothing before the nightly says so. This is the mechanism that says so instead: the
+; trim analyzer cannot be enabled at build time, because it puts Microsoft.NET.ILLink.Tasks into the
+; ordinary restore graph and every affected project's lock file then fails --locked-mode with NU1004.
+; The type's whole reflection surface is listed rather than the one overload that broke, so the rule
+; cannot be reintroduced through a sibling signature.
+M:System.Net.Http.Json.HttpContentJsonExtensions.ReadFromJsonAsync``1(System.Net.Http.HttpContent,System.Text.Json.JsonSerializerOptions,System.Threading.CancellationToken);Pass the source-generated JsonTypeInfo overload so the read survives trimming.
+M:System.Net.Http.Json.HttpContentJsonExtensions.ReadFromJsonAsync``1(System.Net.Http.HttpContent,System.Threading.CancellationToken);Pass the source-generated JsonTypeInfo overload so the read survives trimming.
+M:System.Net.Http.Json.HttpContentJsonExtensions.ReadFromJsonAsync(System.Net.Http.HttpContent,System.Type,System.Text.Json.JsonSerializerOptions,System.Threading.CancellationToken);Pass the source-generated JsonSerializerContext overload so the read survives trimming.
+M:System.Net.Http.Json.HttpContentJsonExtensions.ReadFromJsonAsync(System.Net.Http.HttpContent,System.Type,System.Threading.CancellationToken);Pass the source-generated JsonSerializerContext overload so the read survives trimming.
+M:System.Net.Http.Json.HttpContentJsonExtensions.ReadFromJsonAsAsyncEnumerable``1(System.Net.Http.HttpContent,System.Text.Json.JsonSerializerOptions,System.Threading.CancellationToken);Pass the source-generated JsonTypeInfo overload so the read survives trimming.
+M:System.Net.Http.Json.HttpContentJsonExtensions.ReadFromJsonAsAsyncEnumerable``1(System.Net.Http.HttpContent,System.Threading.CancellationToken);Pass the source-generated JsonTypeInfo overload so the read survives trimming.
+
 ; The BCL mail stack. MailFathom speaks IMAP and SMTP through MailKit inside the transport adapter, and
 ; System.Net.Mail.MailMessage is the name collision root AGENTS.md forbids for the mail artifact.
 ; The whole namespace is banned rather than the two obvious types, so MailAddress, Attachment, and

--- a/.github/workflows/build-cli-binaries.yml
+++ b/.github/workflows/build-cli-binaries.yml
@@ -53,9 +53,13 @@ jobs:
         run: dotnet restore src/Cli/Cli.csproj --locked-mode
 
       # The publish-time shape lives here rather than in the project file, because a project marked self-contained
-      # cannot be referenced by the test host. Trimming is safe because src/Cli references no other project in the
-      # solution: there is no EF Core model and no MailKit to keep reflection alive, and serialization goes through a
-      # source-generated context.
+      # cannot be referenced by the test host. Trimming is safe because of how little src/Cli reaches: Common, and
+      # Domain through it, neither of which opens a database or speaks a mail protocol, so no EF Core model and no
+      # MailKit keeps reflection alive and every JSON read goes through a source-generated contract.
+      #
+      # That last condition is the one a change can break without noticing, because this job is the only thing that
+      # evaluates it and the soonest it runs is the next nightly. `.config/BannedSymbols.txt` refuses the
+      # reflection-based read overloads for that reason, so the ordinary build is what says so.
       - name: Publish every platform
         id: publish
         env:

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -11,7 +11,7 @@ Some of the rules below are enforced by the build rather than by a reader. Those
 | Enforced by | Covers |
 |---|---|
 | `.editorconfig` diagnostic severities, with `TreatWarningsAsErrors` | Formatting, unnecessary usings, accessibility modifiers, file-scoped namespaces, sealing internal types, disposal (`CA2000`), and the rest of the configured `CA`/`IDE` set |
-| `.config/BannedSymbols.txt`, through `Microsoft.CodeAnalysis.BannedApiAnalyzers` (`RS0030`) | Ambient clocks (`DateTime.Now`, `DateTimeOffset.UtcNow`, and siblings), `Thread.Sleep`, and the `System.Net.Mail` types |
+| `.config/BannedSymbols.txt`, through `Microsoft.CodeAnalysis.BannedApiAnalyzers` (`RS0030`) | Ambient clocks (`DateTime.Now`, `DateTimeOffset.UtcNow`, and siblings), `Thread.Sleep`, the `System.Net.Mail` types, and the `HttpContent.ReadFromJsonAsync` overloads that deserialize through reflection |
 | `Microsoft.VisualStudio.Threading.Analyzers` | Blocking on tasks and other async hazards |
 | `Roslynator.*` and `xunit.analyzers` | General C# quality and xUnit usage |
 

--- a/src/Cli/Cli.csproj
+++ b/src/Cli/Cli.csproj
@@ -15,7 +15,10 @@
          referenced by a test host, and turning the trim analyzers on at build time puts Microsoft.NET.ILLink.Tasks in
          the ordinary restore graph — a package the SDK ships in its own library-packs directory, whose content hash
          differs from the feed copy, which makes this project's lock file fail everywhere it was not written. The
-         trimmer still runs at publish and its warnings are still read there, which is where a release acts on them. -->
+         trimmer still runs at publish and its warnings are still read there, which is where a release acts on them.
+         No gate a pull request passes through reaches a publish, though, so the reads that would fail one are refused
+         earlier and by a mechanism that costs the restore graph nothing: .config/BannedSymbols.txt bans the
+         reflection-based JSON overloads outright, and the ordinary build rejects the call. -->
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 

--- a/src/Common/MailboxOAuth/MailboxAuthorizer.cs
+++ b/src/Common/MailboxOAuth/MailboxAuthorizer.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Net.Http.Json;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using System.Web;
 using MailFathom.Common.OAuth;
 
@@ -122,7 +123,11 @@ public sealed class MailboxAuthorizer
             form["client_secret"] = clientSecret;
         }
 
-        var response = await this.PostFormAsync<OAuthTokenResponse>(request.TokenEndpoint, form, cancellationToken);
+        var response = await this.PostFormAsync(
+            request.TokenEndpoint,
+            form,
+            OAuthJsonContext.Default.OAuthTokenResponse,
+            cancellationToken);
 
         return this.ToGrant(response);
     }
@@ -173,9 +178,10 @@ public sealed class MailboxAuthorizer
             ["scope"] = request.Scope,
         };
 
-        var response = await this.PostFormAsync<OAuthDeviceAuthorizationResponse>(
+        var response = await this.PostFormAsync(
             deviceAuthorizationEndpoint,
             form,
+            OAuthJsonContext.Default.OAuthDeviceAuthorizationResponse,
             cancellationToken);
 
         if (response.Error is { } error)
@@ -216,7 +222,11 @@ public sealed class MailboxAuthorizer
         {
             await Task.Delay(pollInterval, this.timeProvider, cancellationToken);
 
-            var response = await this.PostFormAsync<OAuthTokenResponse>(request.TokenEndpoint, form, cancellationToken);
+            var response = await this.PostFormAsync(
+                request.TokenEndpoint,
+                form,
+                OAuthJsonContext.Default.OAuthTokenResponse,
+                cancellationToken);
 
             switch (response.Error)
             {
@@ -273,6 +283,7 @@ public sealed class MailboxAuthorizer
     private async Task<TResponse> PostFormAsync<TResponse>(
         Uri endpoint,
         Dictionary<string, string> form,
+        JsonTypeInfo<TResponse> responseContract,
         CancellationToken cancellationToken)
         where TResponse : class
     {
@@ -284,9 +295,7 @@ public sealed class MailboxAuthorizer
         {
             // The status code is not the verdict. RFC 6749 requires a rejected grant to arrive as 400 with a machine
             // readable `error`, so the body is read either way and the status is consulted only when it holds nothing.
-            payload = await response.Content.ReadFromJsonAsync<TResponse>(
-                OAuthJsonContext.Default.Options,
-                cancellationToken);
+            payload = await response.Content.ReadFromJsonAsync(responseContract, cancellationToken);
         }
         catch (JsonException)
         {

--- a/src/Infrastructure/Mail/OAuth/MailOAuthAccessTokenSource.cs
+++ b/src/Infrastructure/Mail/OAuth/MailOAuthAccessTokenSource.cs
@@ -172,8 +172,8 @@ internal sealed class MailOAuthAccessTokenSource : IMailAccessTokenSource
 
             // The status code is not the verdict. RFC 6749 requires a rejected grant to arrive as 400 carrying a
             // machine-readable `error`, which says far more than the status does, so the body is read either way.
-            payload = await response.Content.ReadFromJsonAsync<OAuthTokenResponse>(
-                OAuthJsonContext.Default.Options,
+            payload = await response.Content.ReadFromJsonAsync(
+                OAuthJsonContext.Default.OAuthTokenResponse,
                 cancellationToken);
         }
         catch (Exception failure) when (failure is HttpRequestException or System.Text.Json.JsonException)

--- a/tests/Common.UnitTests/MailboxAuthorizerTests.cs
+++ b/tests/Common.UnitTests/MailboxAuthorizerTests.cs
@@ -93,6 +93,31 @@ public sealed class MailboxAuthorizerTests
         Assert.Equal(Now.AddHours(1), grant.AccessTokenExpiresAt);
     }
 
+    /// <summary>
+    /// The body is read through the source-generated contract rather than through serializer options, because the
+    /// options overload resolves the shape by reflection and the trimmed command cannot carry that. Case-insensitive
+    /// matching is the part of the contract the two ways of writing the read do not obviously share, and a server whose
+    /// casing differs from the specification's must not authorize a mailbox here and fail at <c>login</c>.
+    /// </summary>
+    [Fact]
+    public async Task RedeemAuthorizationCodeAsync_AServerVaryingTheCaseOfTheTokenResponse_ReadsTheGrantTheSameWay()
+    {
+        // Arrange
+        using var transport = new FakeHttpMessageHandler((_, _) => Task.FromResult(
+            JsonResponse("""{"Access_Token":"at","Refresh_Token":"rt","Expires_In":3600}""")));
+        using var httpClient = new HttpClient(transport);
+        var authorizer = new MailboxAuthorizer(httpClient, new FakeTimeProvider(Now));
+        var request = CreateRequest();
+        var pending = authorizer.BuildAuthorization(request);
+
+        // Act
+        var grant = await authorizer.RedeemAuthorizationCodeAsync(request, pending, "code", CancellationToken.None);
+
+        // Assert
+        Assert.Equal("rt", grant.RefreshToken);
+        Assert.Equal(Now.AddHours(1), grant.AccessTokenExpiresAt);
+    }
+
     [Fact]
     public async Task RedeemAuthorizationCodeAsync_ResponseWithoutRefreshToken_FailsRatherThanProvisioningADeadGrant()
     {


### PR DESCRIPTION
Closes #353

## What changes

The nightly's `CLI binaries / Build` job has failed since the mailbox authorization exchange moved into `Common`. `MailboxAuthorizer` read the token endpoint's response through `HttpContent.ReadFromJsonAsync<T>(JsonSerializerOptions, CancellationToken)`, which carries `RequiresUnreferencedCode`, so publishing `mfctl` trimmed raised `IL2026` and `TreatWarningsAsErrors` turned it into a failed build. Every nightly since 2026-08-03 has published an image with no `mfctl` beside it, and a release would have failed the same way.

Both reads now pass the source-generated `JsonTypeInfo` — what `OAuthJsonContext` exists for, and what the CLI's own `DeploymentAuthorizer` already did, so `PostFormAsync` here takes the same `responseContract` parameter in the same position. `MailOAuthAccessTokenSource` reads the same response through the same shape and is fixed with it; nothing trims `Infrastructure`, so it broke no build, but leaving it would leave a second copy of the call that broke this one.

The part I decided rather than derived is where the guard goes. What let this through is that the trimmer runs only at publish, and nothing a pull request passes through publishes. Turning the trim analyzer on at build time would catch it and cannot be done — measured, not assumed: `-p:EnableTrimAnalyzer=true` puts `Microsoft.NET.ILLink.Tasks` into the ordinary restore graph, which rewrote `Domain`, `Common`, and `Cli`'s lock files and then failed `--locked-mode` with `NU1004`, exactly as `Cli.csproj` already records. So the rule goes where this repository already puts a mechanical rule: `.config/BannedSymbols.txt` refuses the reflection-based overloads through `RS0030`, and the ordinary build rejects the call with a message naming the fix. The extension type's whole reflection surface is listed rather than the one overload that broke, so a sibling signature cannot reintroduce it — the same reasoning the `Thread.Sleep` and `System.Net.Mail` entries already carry.

The rationale in `build-cli-binaries.yml` said trimming was safe because `src/Cli` referenced no other project in the solution. That stopped being true when it gained its `Common` reference, and it is the sentence this defect walked through, so it now states what actually holds and names the ban as what keeps the one condition a change can silently break. `Cli.csproj` and the enforcement table in `src/AGENTS.md` follow.

## How it was verified

- `bash scripts/verify-full.sh` — exit 0: 2533 tests, 0 failed; aggregate line coverage 96.47% (6087/6310), required 85%; workflow contracts pass; `dotnet format` reformatted 0 of 864 files.
- The failing publish, run locally exactly as the workflow runs it, for all four published runtime identifiers — `linux-x64`, `linux-arm64`, `win-x64`, `win-arm64` — with `--self-contained`, `PublishSingleFile`, `PublishTrimmed`, and `TrimMode=full`: clean, with no `IL` diagnostic. Before the fix the first of them reproduced the nightly's `IL2026` at the same file and line.
- The published `linux-x64` binary was run: `mfctl --version` reports `0.2.0+5e07579…` and `--help` lists the commands, so trimming left a working command rather than one that fails on first use.
- Each of the six ban entries was proven to bind, by compiling a scratch file calling all six overloads and confirming six distinct `RS0030` errors. A `DocumentationCommentId` that matches no symbol fails silently, so a ban nobody verified is a ban that is not there.
- One regression test: an authorization server that varies the case of the token response is still read. That is the property of the context the two ways of writing this read do not obviously share, and `Cli.UnitTests` already asserts the same thing on the other side of it.
- `bash scripts/review-obligations.sh` — its `MailOAuthAccessTokenSourceTests` row is answered by that file already deserializing token responses through the changed line; each documentation row was read, and none of those pages describes the serialization mechanism.

## Checklist

- [x] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [x] Behavior changes are covered by unit tests, and the coverage gate passes.
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail.
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.
