### PR TITLE
[#331] Send the mailbox refresh token to the deployment instead of printing it

### DIFF
--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -53,8 +53,30 @@ location exactly when the resource names the same one. A deployment whose resour
 document nothing could find, and OAuth sign-in would be unreachable for a reason no refusal would explain. Behind a
 reverse proxy, write the public URL and keep the path: `https://mail.example.test/api/admin`.
 
-> **Every authenticated caller may perform every administrative operation.** There is no permission model yet. The
+> **Every authenticated caller may perform every administrative operation.** There is no permission model. The
 > credential is what bounds access, so provision one per client and rotate it like any other secret.
+>
+> Weigh that against what the operations are. The endpoint serves one read — who a credential makes the caller — and
+> one write, which stores a mailbox refresh token. Any credential that can do the first can therefore do the second, so
+> an administrative key is as sensitive as the mailbox credentials it can place.
+
+## What the endpoint serves
+
+| Route | What it does |
+| --- | --- |
+| `GET /api/admin/session` | Reports the credential that authenticated and the running version. This is what `login` and `status` ask. |
+| `POST /api/admin/mailbox/refresh-token` | Stores a mailbox refresh token for one configured account, sealed under the deployment's data-encryption key. This is what [`mfctl mailbox authorize --account`](mailbox-oauth.md#sending-the-token-to-the-deployment) sends. |
+
+The write route's body carries a long-lived credential for a named mailbox owner, which is what makes the clear-text
+warning below matter more here than it does for a session probe. It refuses, with `400` and a sentence naming what was
+wrong, an account this deployment does not configure and a body missing either field; a second grant for the same
+account replaces the first rather than adding to it. It reads at most 16 KB, which is far more than any authorization
+server's refresh token and far less than the server's own default. It answers with no body at all, so nothing it stores
+can be read back out through it.
+
+Storing seals the token under the deployment's [data-encryption key](secret-provisioning.md). A deployment that
+configures no key ring cannot store one, and the route answers `500` rather than a refusal it can explain, because
+nothing about the request was wrong.
 
 ## Two postures the endpoint warns about
 
@@ -271,7 +293,10 @@ encryption answers the copy. Holding the credential in the platform's own secret
 | `There is no profile named …` | A typo, or a profile that was never created. The message lists the ones that exist. |
 | `Not signed in to https://…` | `--endpoint` named an address no profile serves. Sign in to it, or name a profile instead. |
 | `The deployment refused the credential.` | The key is not one this endpoint is configured with, or its lifetime has ended. Note that an MCP API key is not one of them. |
-| `serves no administrative endpoint at /api/admin/session` | The address answered, but on a listener that serves something else. Check the port, and check that `AdminEndpoint:Enabled` is true. |
+| `serves no administrative endpoint at /api/admin/…` | The address answered, but on a listener that serves something else. Check the port, and check that `AdminEndpoint:Enabled` is true. |
+| `This deployment configures no mail account named …` | `mailbox authorize --account` named an identifier no `MailSynchronization:Accounts` entry carries, or you are signed in to the wrong deployment. Nothing was stored. |
+| `The deployment refused the grant without saying why.` | The request was refused with no reason in the answer, which is what something in front of the endpoint answering `400` looks like. Check that `--endpoint` reaches the deployment itself. |
+| `rather than storing the token` | The endpoint answered with neither an acceptance nor an explained refusal. The token was not stored and the account is unchanged. A `500` here is most often a deployment with no `DataEncryption` key ring, which is what a stored token is sealed under; its own log names the cause. |
 | `did not identify itself as MailFathom` | Something else is answering on that port — a proxy, or another service. |
 | `could not be reached` | Nothing is listening, or a firewall is in the way. The endpoint binds only what `BindAddress` names; `127.0.0.1` is unreachable from another machine by design. |
 | `did not answer in time` | The connection was accepted and no answer arrived within 30 seconds, so the address and the port are right and the deployment is what to look at — an overloaded host, a stalled process, or a firewall that drops rather than refuses. |

--- a/docs/operations/mailbox-oauth.md
+++ b/docs/operations/mailbox-oauth.md
@@ -1,14 +1,15 @@
 # Mailbox OAuth
 
-<!-- describes: src/Infrastructure/Mail/OAuth/**, src/Common/MailboxOAuth/**, src/Common/OAuth/**, src/Cli/**, src/Application/Accounts/**, src/Infrastructure/Persistence/Accounts/** -->
+<!-- describes: src/Infrastructure/Mail/OAuth/**, src/Common/MailboxOAuth/**, src/Common/OAuth/**, src/Cli/**, src/Host/Api/**, src/Application/Accounts/**, src/Infrastructure/Persistence/Accounts/** -->
 
 How a mailbox that no longer accepts a password is authenticated, and what each provider requires before it will
 issue the credential MailFathom runs on.
 
 MailFathom never obtains a refresh token while it is serving. It is a headless service, it ships in a container, and
 it serves no consent page and owns no redirect endpoint — so the sign-in that produces a refresh token is an
-administration act you perform once, with the `mfctl` command, and the result is provisioned as a secret like
-every other credential. The running service only ever exchanges that token for short-lived access tokens.
+administration act you perform once, with the `mfctl` command. The result is then either sent to the deployment to keep
+or provisioned as a secret like every other credential, and the running service only ever exchanges that token for
+short-lived access tokens.
 
 **Run the command on your own computer.** It administers a deployment over HTTP and needs nothing from the machine the
 service runs on, which is what makes the ordinary browser sign-in available: the command listens on a loopback address,
@@ -65,8 +66,12 @@ The authorization-code and device-code grants appear nowhere in the service's co
 
 ## Obtaining the refresh token
 
-The command is in the published container image and in the release archive. It writes nothing: the refresh token goes
-to standard output and everything else to standard error, so redirecting output captures the token alone.
+The command is in the published container image and in the release archive. `--mode` decides how the person signs in,
+and `--account` decides what becomes of the result — [sending it to the deployment](#sending-the-token-to-the-deployment)
+to keep, or printing it for you to provision. The two are independent: every mode below works either way.
+
+Without `--account` the refresh token goes to standard output and everything else to standard error, so redirecting
+output captures the token alone.
 
 Three modes, and the first is the one to reach for:
 
@@ -152,6 +157,48 @@ stays in the address bar and reaches the server only when you paste it. The requ
 
 This is the last resort. The default mode does listen at that address, which removes both pastes.
 
+## Sending the token to the deployment
+
+`--account` names an account in the deployment's own configuration, and the command sends the grant there instead of
+printing it. The deployment seals it under its [data-encryption key](secret-provisioning.md) and stores it, which is the
+same place a rotated token is kept.
+
+```console
+$ mfctl mailbox authorize --provider google --client-id <client-id> --account workspace
+Client secret (leave empty for a public client):
+
+A browser has been opened for you. If it did not appear, open this address yourself:
+
+  https://accounts.google.com/o/oauth2/v2/auth?client_id=…&code_challenge=…
+
+Waiting for the sign-in to come back to http://127.0.0.1:8765/...
+Stored the refresh token for account 'workspace' on 'production'. It was not printed.
+```
+
+Four things about that run are worth stating, because each removes a way the manual step could go wrong:
+
+- **The token reaches one place.** It is not printed, not redirected, not written to a file, and not repeated in the
+  line that confirms the outcome — so it never enters your scrollback, your shell history, or a session log.
+- **The account is checked against configuration.** A deployment that configures no account by that name refuses the
+  grant and names it, rather than storing a credential for a mailbox owner that nothing would ever read.
+- **Storing replaces.** Authorizing the same account again replaces what was stored, which is what re-authorizing after
+  a revocation is. Nothing accumulates.
+- **Being signed in is checked first.** The command resolves the deployment before it prompts or opens a browser, so
+  a missing profile fails at once instead of after somebody has approved access at the provider.
+
+It goes to the deployment you are signed in to — `--endpoint` names a different profile or address for one invocation,
+the same way it does for every other command. [Administering a deployment](admin-endpoint.md) is how you sign in, and
+the write needs the administrative endpoint enabled; a deployment without one still takes a token you provision
+yourself.
+
+> **The route this uses is behind the endpoint's authentication, and behind nothing else.** Every authenticated caller
+> may perform every administrative operation, so an administrative credential that can read a session can write a
+> mailbox credential. Provision one per client and treat it as what it now is.
+
+Sending a grant does **not** change the account's configuration. `OAuth:RefreshToken` stays a secret reference and is
+still what an account is served from until something is stored for it; what changes is that something now is. The
+interaction between the two is [rotation](#rotation).
+
 ## Configuring the account
 
 Provision the refresh token and the client secret through [secret provisioning](secret-provisioning.md), then point
@@ -231,11 +278,15 @@ A refresh token is still a long-lived credential you can rotate deliberately, th
 — **but only while no token has been stored for that account.** Once one has, the stored token wins on every request and
 the reference is never read again.
 
-**Nothing operator-facing replaces a stored token today.** `mfctl mailbox authorize` obtains a refresh token and prints
-it for you to provision; it writes nothing to the deployment, so re-running it does not change what a stored account
-sends. Writing a grant straight to a deployment through the administrative endpoint is [#331](https://github.com/Krzysztof318/MailFathom/issues/331)
-and does not exist yet. Until it does, the only way to make an account fall back to its configured reference is to
-delete its row with any PostgreSQL client:
+**A stored token is replaced by authorizing the account again**, with
+[`--account`](#sending-the-token-to-the-deployment). That is the repair for a stored grant the authorization server no
+longer accepts, and it needs no database access and no restart: the next token request spends what the run just stored.
+
+```console
+$ mfctl mailbox authorize --provider google --client-id <client-id> --account workspace
+```
+
+To make an account fall back to its configured reference instead, delete its row with any PostgreSQL client:
 
 ```sql
 DELETE FROM mailbox_refresh_tokens WHERE "MailboxAccountId" = 'workspace';
@@ -247,15 +298,17 @@ Two failures are worth knowing about, because neither is silent and both end the
 the rotated token — the database is unreachable, the key ring is gone — the token request still succeeds and the
 failure is logged as an error naming the account; the account keeps working until the token it replaced stops being
 accepted. If the process stops between receiving a rotated token and storing it, that rotation is lost. In both cases
-the account eventually answers `invalid_grant`, and the repair is the two steps above: delete the stored row, then
-provision a token from a fresh `mfctl mailbox authorize` at the configured reference.
+the account eventually answers `invalid_grant`, and the repair is to authorize the account again with `--account`.
 
 ## Troubleshooting
 
 | What you see | What it means |
 | --- | --- |
 | `no_refresh_token_issued` | The grant returned an access token only. For Google, consent was not re-prompted; the command already forces it, so check that the client is a Desktop app. For Microsoft, `offline_access` is missing from the scope. |
-| `invalid_grant` at startup or in a run | The refresh token is revoked, expired, or belongs to a different client. Re-run the authorization and provision the result at the configured reference — and if a token has already been stored for that account, delete its row first, because otherwise the reference is not read. [Rotation](#rotation) has the statement. A rotation MailFathom could not store reaches you this way too; the error logged when the store failed says so. |
+| `invalid_grant` at startup or in a run | The refresh token is revoked, expired, or belongs to a different client. Authorize the account again with `--account`, which replaces whatever was stored. [Rotation](#rotation) has the statement, including what to do on a deployment you provision by hand. A rotation MailFathom could not store reaches you this way too; the error logged when the store failed says so. |
+| `This deployment configures no mail account named …` | `--account` named an identifier no `MailSynchronization:Accounts` entry carries, or you are signed in to the wrong deployment. The grant was not stored; nothing was changed. |
+| `The deployment refused the grant without saying why.` | The administrative endpoint refused the request and sent no reason, which is what a proxy answering `400` in front of it looks like. Check that `--endpoint` reaches the deployment rather than something in front of it. |
+| `answered … rather than storing the token` | The endpoint was reached and answered with neither an acceptance nor a refusal it explained. The token was not stored; nothing about the account changed. A `500` is most often a deployment with no key ring, since that is what a stored token seals under — configure `DataEncryption`, or provision the token at the configured reference instead. |
 | `The rotated refresh token … could not be stored` | The database was unreachable, or the key ring the value seals under is not configured. The account keeps working until the previous token stops being accepted, so fix the cause and it recovers on the next rotation. |
 | `The data-encryption key ring configures no key` | A stored token names a key the ring no longer holds. Restore that key entry; a stored value cannot be opened without it. |
 | `invalid_client` | The client ID or client secret does not match the registration, or a confidential client was authorized as a public one. |

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -18,15 +18,12 @@ in [configuration sources](../operations/configuration-sources.md); the command 
 database, and never touches the secret store. Nothing you do with it changes what the service will do on its next
 restart.
 
-> **Today it verifies who you are, and nothing it does changes a running deployment.** The administrative surface
-> publishes one route, and the commands below are the whole of what talks to it: sign in, keep several deployments
-> straight, and ask one whether your credential still works. Operational commands — inspecting synchronization,
-> triggering work, reading accounts — are not there yet. If you are looking for something to *do* to a running
-> deployment, this is not yet the page that has it.
+> **One thing it does changes a running deployment: it can place a mailbox credential.** Everything else below verifies
+> who you are and keeps several deployments straight. Operational commands — inspecting synchronization, triggering
+> work, reading accounts — are not there yet.
 >
-> One command is not a client of that surface at all. `mfctl mailbox authorize` signs you in to a *mail provider* to
-> produce a mailbox credential, which you then provision on the server yourself; it is described under
-> [authorizing a mailbox](#authorizing-a-mailbox) below.
+> The exception is [authorizing a mailbox](#authorizing-a-mailbox), which signs you in to a *mail provider* and can then
+> hand the resulting credential to your deployment to keep.
 
 ## Before it can answer
 
@@ -136,10 +133,25 @@ computer matters. It listens on a loopback address, opens your browser, and catc
 back — so there is nothing to copy, and the authorization code never crosses a network. On a machine with no browser,
 forward the port over SSH, or use `--mode device` for Microsoft and `--mode manual` for Google.
 
-What it produces is a refresh token printed on standard output. **You provision it on the server yourself**, as a
-secret reference like every other credential; the command writes nothing and the service reads it at startup.
+What it produces is a refresh token, and `--account` decides where that token goes:
+
+```console
+$ mfctl mailbox authorize --provider google --client-id <client-id> --account workspace
+…
+Stored the refresh token for account 'workspace' on 'production'. It was not printed.
+```
+
+**Named, the token goes straight to your deployment**, which encrypts it and keeps it. It is never printed, so it never
+reaches your scrollback or a session log, and there is nothing for you to place by hand. The account has to be one your
+deployment configures; a name it does not know is refused and nothing is stored. Re-running it replaces what was
+stored, which is what re-authorizing after a revocation is.
+
+**Omitted, the token is printed on standard output and you provision it on the server yourself**, as a secret reference
+like every other credential. That is what a deployment with no administrative endpoint needs, and it stays the right
+choice if you would rather place credentials yourself.
+
 [Mailbox OAuth](../operations/mailbox-oauth.md) is the whole procedure, including what each provider requires of the
-application you register.
+application you register and how a stored token relates to the reference in your configuration.
 
 ## Where to go next
 

--- a/src/Application/Accounts/MailboxRefreshTokenRecorder.cs
+++ b/src/Application/Accounts/MailboxRefreshTokenRecorder.cs
@@ -1,0 +1,73 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.Accounts;
+
+/// <summary>Takes the refresh token an operator authorized for one mailbox and stores it against that account.</summary>
+/// <remarks>
+/// <para>
+/// This is the use case behind the administrative write route, and the only path by which a grant enters the store from
+/// outside a token request. It exists as a use case rather than as endpoint code for the reason the account check
+/// exists at all: what a grant may be written for is a rule about this deployment's accounts, not about HTTP.
+/// </para>
+/// <para>
+/// The token is checked against the served accounts before anything is written. A grant stored for an account no
+/// configuration names is a credential for a named mailbox owner that nothing will ever read and nobody knows is there,
+/// so it is refused rather than kept — which is also what turns a mistyped account identifier into a failure at the
+/// terminal rather than into an account that silently keeps failing to authenticate.
+/// </para>
+/// <para>
+/// The caller keeps ownership of the token, as <see cref="IMailboxRefreshTokenStore.SaveTokenAsync" /> requires, and
+/// nothing here copies it into a value with a longer life than the request.
+/// </para>
+/// </remarks>
+public sealed class MailboxRefreshTokenRecorder
+{
+    private readonly IMailAccountCatalog accountCatalog;
+    private readonly IMailboxRefreshTokenStore refreshTokenStore;
+
+    /// <summary>Initializes the use case over the accounts this deployment serves and the store that seals a token.</summary>
+    /// <param name="accountCatalog">Names the accounts a grant may be recorded for.</param>
+    /// <param name="refreshTokenStore">Where the token is written.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public MailboxRefreshTokenRecorder(
+        IMailAccountCatalog accountCatalog,
+        IMailboxRefreshTokenStore refreshTokenStore)
+    {
+        ArgumentNullException.ThrowIfNull(accountCatalog);
+        ArgumentNullException.ThrowIfNull(refreshTokenStore);
+
+        this.accountCatalog = accountCatalog;
+        this.refreshTokenStore = refreshTokenStore;
+    }
+
+    /// <summary>Records the refresh token for one served account, replacing whatever was stored for it before.</summary>
+    /// <param name="accountId">The account the grant acts for.</param>
+    /// <param name="refreshToken">The token to record. The caller keeps ownership of it.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>A task that completes after durable storage.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="refreshToken" /> is <see langword="null" />.</exception>
+    /// <exception cref="MailAccountNotAccessibleException">Thrown when this deployment serves no account with that identifier.</exception>
+    /// <remarks>
+    /// Recording is idempotent in the account, because re-authorizing a mailbox is what an operator does after a
+    /// revocation and a second grant beside the first would leave the account holding a credential nothing chose
+    /// between. The store owns that guarantee; this use case adds only the account check in front of it.
+    /// </remarks>
+    public async Task RecordAsync(
+        MailAccountId accountId,
+        MailboxRefreshToken refreshToken,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(refreshToken);
+
+        if (!this.accountCatalog.ServedAccountIds.Contains(accountId))
+        {
+            throw new MailAccountNotAccessibleException(accountId);
+        }
+
+        await this.refreshTokenStore.SaveTokenAsync(accountId, refreshToken, cancellationToken);
+    }
+}

--- a/src/Cli/Administration/AdminApiClient.cs
+++ b/src/Cli/Administration/AdminApiClient.cs
@@ -68,6 +68,64 @@ internal sealed class AdminApiClient
         return await ReadSessionBodyAsync(response, cancellationToken);
     }
 
+    /// <summary>Hands a deployment the refresh token it should keep for one of its mail accounts.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="account">The account the grant acts for, as the deployment's configuration names it.</param>
+    /// <param name="refreshToken">The token the authorization run produced.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>A task that completes once the deployment has stored the token.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the credential or the grant, could not be reached, or answered with anything but an acceptance.</exception>
+    /// <remarks>
+    /// The one request this command sends that carries a credential of somebody else's. It is presented once and never
+    /// echoed: the deployment answers with no body, so a success is the status alone and there is nothing here that
+    /// could report the token back.
+    /// </remarks>
+    internal async Task StoreMailboxRefreshTokenAsync(
+        string token,
+        string account,
+        string refreshToken,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(token);
+        ArgumentNullException.ThrowIfNull(account);
+        ArgumentNullException.ThrowIfNull(refreshToken);
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, AdminEndpointRoutes.MailboxRefreshTokenPath)
+        {
+            Content = JsonContent.Create(
+                new MailboxRefreshTokenRequest(account, refreshToken),
+                CliJsonContext.Default.MailboxRefreshTokenRequest),
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        using var response = await this.SendAsync(request, cancellationToken);
+
+        if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        {
+            throw new CliFailure(
+                "The deployment refused the credential. Check that it is one the administrative endpoint is configured with, and that it has not expired.");
+        }
+
+        if (response.StatusCode is HttpStatusCode.NotFound)
+        {
+            throw new CliFailure(
+                $"The address answered, but serves no administrative endpoint at {AdminEndpointRoutes.MailboxRefreshTokenPath}. Check the port: the administrative endpoint binds a listener of its own, and it is disabled unless the deployment enabled it.");
+        }
+
+        if (response.StatusCode is HttpStatusCode.BadRequest)
+        {
+            throw new CliFailure(
+                await ReadRefusalAsync(response, cancellationToken)
+                ?? "The deployment refused the grant without saying why.");
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new CliFailure($"The deployment answered {(int)response.StatusCode} rather than storing the token.");
+        }
+    }
+
     /// <summary>Turns a transport failure into something the operator can act on.</summary>
     /// <remarks>A cancelled request is left alone: the operator interrupted it, and reporting that as a deployment problem would be wrong.</remarks>
     private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -92,6 +150,31 @@ internal sealed class AdminApiClient
     /// unrelated service can do that. Requiring the body to name the service is what keeps <c>login</c> from reporting
     /// success against something that never saw the credential.
     /// </remarks>
+    /// <summary>Reads the sentence a refusal carries, when it carries one.</summary>
+    /// <remarks>
+    /// A deployment states what was wrong with the request — an account it does not configure, a field the body omitted
+    /// — and repeating that is more use than any wording invented here. Anything that is not a problem document is read
+    /// as no reason rather than as a failure of its own, because the request was already refused and how the refusal
+    /// was phrased is not the operator's problem to solve.
+    /// </remarks>
+    private static async Task<string?> ReadRefusalAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var problem = await response.Content.ReadFromJsonAsync(
+                CliJsonContext.Default.AdminProblem,
+                cancellationToken);
+
+            return problem?.Detail is { Length: > 0 } stated ? stated : null;
+        }
+        catch (Exception failure) when (failure is JsonException or NotSupportedException)
+        {
+            return null;
+        }
+    }
+
     private static async Task<AdminSession> ReadSessionBodyAsync(
         HttpResponseMessage response,
         CancellationToken cancellationToken)

--- a/src/Cli/Administration/AdminApiClient.cs
+++ b/src/Cli/Administration/AdminApiClient.cs
@@ -144,12 +144,6 @@ internal sealed class AdminApiClient
         }
     }
 
-    /// <summary>Reads the body as a session, refusing anything that merely happens to be JSON.</summary>
-    /// <remarks>
-    /// An address that answers with a success status is not yet a MailFathom deployment — a proxy, a login page, or an
-    /// unrelated service can do that. Requiring the body to name the service is what keeps <c>login</c> from reporting
-    /// success against something that never saw the credential.
-    /// </remarks>
     /// <summary>Reads the sentence a refusal carries, when it carries one.</summary>
     /// <remarks>
     /// A deployment states what was wrong with the request — an account it does not configure, a field the body omitted
@@ -175,6 +169,12 @@ internal sealed class AdminApiClient
         }
     }
 
+    /// <summary>Reads the body as a session, refusing anything that merely happens to be JSON.</summary>
+    /// <remarks>
+    /// An address that answers with a success status is not yet a MailFathom deployment — a proxy, a login page, or an
+    /// unrelated service can do that. Requiring the body to name the service is what keeps <c>login</c> from reporting
+    /// success against something that never saw the credential.
+    /// </remarks>
     private static async Task<AdminSession> ReadSessionBodyAsync(
         HttpResponseMessage response,
         CancellationToken cancellationToken)

--- a/src/Cli/Administration/AdminEndpointRoutes.cs
+++ b/src/Cli/Administration/AdminEndpointRoutes.cs
@@ -6,11 +6,11 @@ namespace MailFathom.Cli.Administration;
 
 /// <summary>Where a deployment answers, relative to the address the operator gave.</summary>
 /// <remarks>
-/// The command is configured with a host and a port and appends the rest, so these two paths are the whole of what it
+/// The command is configured with a host and a port and appends the rest, so these paths are the whole of what it
 /// assumes about the other side. Stated together rather than beside the code that calls each, because they are one
-/// agreement with the service: the deployment publishes its administrative routes beneath the first and refuses to
-/// start unless its resource identifier names that same prefix, which is what puts the second exactly where RFC 9728
-/// says to look for it.
+/// agreement with the service: the deployment publishes its administrative routes beneath the prefix and refuses to
+/// start unless its resource identifier names that same prefix, which is what puts the metadata document exactly where
+/// RFC 9728 says to look for it.
 /// </remarks>
 internal static class AdminEndpointRoutes
 {
@@ -19,6 +19,9 @@ internal static class AdminEndpointRoutes
 
     /// <summary>Where a deployment reports who a presented credential makes the caller.</summary>
     internal const string SessionPath = $"{Prefix}/session";
+
+    /// <summary>Where a deployment accepts the refresh token it should keep for one of its mail accounts.</summary>
+    internal const string MailboxRefreshTokenPath = $"{Prefix}/mailbox/refresh-token";
 
     /// <summary>Where a deployment publishes the document naming its authorization servers, resource, and required scopes.</summary>
     /// <remarks>

--- a/src/Cli/Administration/MailboxRefreshTokenRequest.cs
+++ b/src/Cli/Administration/MailboxRefreshTokenRequest.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Cli.Administration;
+
+/// <summary>The grant the command asks a deployment to keep for one of its mail accounts.</summary>
+/// <param name="Account">The account identifier as it appears in the deployment's own configuration.</param>
+/// <param name="RefreshToken">The token the authorization run produced.</param>
+/// <remarks>
+/// The command's own contract rather than the service's record of the same shape, for the reason
+/// <see cref="AdminSession" /> is one: the two sides are separate artifacts that meet over the wire, and sharing a type
+/// would make the published binary depend on the host to state what it sends. <see cref="ToString" /> is redacted, so
+/// no failure message can print the token by rendering the request it travelled in.
+/// </remarks>
+internal sealed record MailboxRefreshTokenRequest(
+    [property: JsonPropertyName("account")] string Account,
+    [property: JsonPropertyName("refreshToken")] string RefreshToken)
+{
+    /// <inheritdoc />
+    public override string ToString() => $"{nameof(MailboxRefreshTokenRequest)} {{ {this.Account} }}";
+}
+
+/// <summary>What a deployment says when it refuses a request, read from the problem document it answers with.</summary>
+/// <param name="Detail">The sentence written for the operator, which is the whole of what the command reports back.</param>
+/// <remarks>
+/// One field of RFC 9457, because one is what the command uses. The rest of the document — the type, the title, the
+/// status — restates either the status line the command already read or a URI it would have nothing to do with, and a
+/// contract that named them would have to keep agreeing with a service that never sends anything else.
+/// </remarks>
+internal sealed record AdminProblem([property: JsonPropertyName("detail")] string? Detail);

--- a/src/Cli/CliJsonContext.cs
+++ b/src/Cli/CliJsonContext.cs
@@ -29,6 +29,8 @@ namespace MailFathom.Cli;
     PropertyNameCaseInsensitive = true,
     WriteIndented = true)]
 [JsonSerializable(typeof(AdminSession))]
+[JsonSerializable(typeof(MailboxRefreshTokenRequest))]
+[JsonSerializable(typeof(AdminProblem))]
 [JsonSerializable(typeof(StoredCredentials))]
 [JsonSerializable(typeof(ProtectedResourceMetadata))]
 [JsonSerializable(typeof(AuthorizationServerMetadata))]

--- a/src/Cli/Commands/AuthorizeMailboxCommand.cs
+++ b/src/Cli/Commands/AuthorizeMailboxCommand.cs
@@ -3,6 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.CommandLine;
+using MailFathom.Cli.Administration;
+using MailFathom.Cli.Credentials;
 using MailFathom.Common.MailboxOAuth;
 using MailFathom.Common.OAuth;
 
@@ -11,9 +13,12 @@ namespace MailFathom.Cli.Commands;
 /// <summary>Builds the command that walks an operator through authorizing one mailbox.</summary>
 /// <remarks>
 /// <para>
-/// The command produces a refresh token and prints it. It writes no configuration file and contacts no mail server:
-/// provisioning the token is the operator's next step, through the same secret-reference mechanism every other
-/// MailFathom credential arrives by, and the service reads it from there.
+/// <c>--account</c> decides what becomes of the refresh token the run produces, and it is the only difference between
+/// the command's two shapes. Named, the token is sent to the deployment the command is signed in to, which seals it
+/// under its own key and keeps it; the token is then never printed, never redirected, and never placed by hand. Omitted,
+/// the token goes to standard output for the operator to provision through the same secret-reference mechanism every
+/// other MailFathom credential arrives by — which is what a deployment with no administrative endpoint, and an operator
+/// who provisions credentials themselves, still need.
 /// </para>
 /// <para>
 /// Three modes exist because the providers and the machines differ, rather than because an operator has a preference.
@@ -89,7 +94,14 @@ internal static class AuthorizeMailboxCommand
             Description = "Skips the client-secret prompt, for an application registered as a public client.",
         };
 
-        Command command = new("authorize", "Obtain a mailbox refresh token to provision as a secret.")
+        Option<string?> accountOption = new("--account")
+        {
+            Description = "Sends the refresh token to the deployment to keep, for the account this configuration identifier names, instead of printing it.",
+        };
+
+        var endpointOption = CliOptions.Endpoint();
+
+        Command command = new("authorize", "Obtain a mailbox refresh token, and store it on the deployment or print it.")
         {
             providerOption,
             clientIdOption,
@@ -97,6 +109,8 @@ internal static class AuthorizeMailboxCommand
             scopeOption,
             redirectUriOption,
             publicClientOption,
+            accountOption,
+            endpointOption,
         };
 
         command.SetAction((parseResult, cancellationToken) => RunAsync(
@@ -107,6 +121,8 @@ internal static class AuthorizeMailboxCommand
             parseResult.GetValue(scopeOption),
             parseResult.GetValue(redirectUriOption),
             parseResult.GetValue(publicClientOption),
+            parseResult.GetValue(accountOption),
+            CliOptions.RequestedDeployment(parseResult.GetValue(endpointOption)),
             cancellationToken));
 
         return command;
@@ -120,6 +136,8 @@ internal static class AuthorizeMailboxCommand
         string? scopeOverride,
         string? redirectAddress,
         bool isPublicClient,
+        string? accountId,
+        string? requestedDeployment,
         CancellationToken cancellationToken)
     {
         var redirectUri = ReadRedirectAddress(redirectAddress);
@@ -145,6 +163,15 @@ internal static class AuthorizeMailboxCommand
                 $"The {preset.PresetName} provider rejects an authorization that carries no client secret, so --public-client cannot be used with it. Register a confidential client and omit the flag.");
         }
 
+        // Resolved before anything is prompted for or opened in a browser, so a command that is not signed in, or that
+        // names a deployment no profile serves, says so at once instead of after somebody has completed a provider
+        // sign-in whose result it then has nowhere to put.
+        var destination = string.IsNullOrWhiteSpace(accountId)
+            ? null
+            : new GrantDestination(
+                accountId.Trim(),
+                await context.Deployment().ReachAsync(requestedDeployment, cancellationToken));
+
         var clientSecret = isPublicClient
             ? null
             : context.Console.ReadSecret("Client secret (leave empty for a public client): ");
@@ -163,18 +190,18 @@ internal static class AuthorizeMailboxCommand
         using var transport = context.OpenTransport(preset.TokenEndpoint);
         var authorizer = new MailboxAuthorizer(transport, TimeProvider.System);
 
+        // The catch translates failures of the exchange with the authorization server, so what the deployment does with
+        // the result is deliberately outside it: a transport failure reaching a deployment would otherwise be reported
+        // as one reaching the provider, naming the wrong machine to go and look at.
+        MailboxAuthorizationGrant grant;
         try
         {
-            var grant = mode switch
+            grant = mode switch
             {
                 AuthorizationMode.Device => await AuthorizeWithDeviceAsync(context, authorizer, request, cancellationToken),
                 AuthorizationMode.Manual => await AuthorizeManuallyAsync(context, authorizer, request, cancellationToken),
                 _ => await AuthorizeInteractivelyAsync(context, authorizer, request, cancellationToken),
             };
-
-            ReportGrant(context, grant);
-
-            return CliExitCode.Success;
         }
         catch (MailboxAuthorizationFailedException failure)
         {
@@ -185,6 +212,17 @@ internal static class AuthorizeMailboxCommand
             // The message is the transport's, not the authorization server's, so it carries no credential.
             throw new CliFailure($"The authorization server could not be reached: {failure.Message}", failure);
         }
+
+        if (destination is null)
+        {
+            ReportGrant(context, grant);
+        }
+        else
+        {
+            await StoreGrantAsync(context, destination, grant, cancellationToken);
+        }
+
+        return CliExitCode.Success;
     }
 
     private static Task<MailboxAuthorizationGrant> AuthorizeWithDeviceAsync(
@@ -327,4 +365,38 @@ internal static class AuthorizeMailboxCommand
 
         context.Console.WriteLine(grant.RefreshToken);
     }
+
+    /// <summary>Hands the refresh token to the deployment, and says so without saying what was sent.</summary>
+    /// <remarks>
+    /// The token reaches one place and stops there: it is not printed, not written to a file, and not repeated in the
+    /// line that confirms the outcome. That line names the account and the profile instead, which is what an operator
+    /// checks and the only part of this they could have got wrong.
+    /// </remarks>
+    private static async Task StoreGrantAsync(
+        CliContext context,
+        GrantDestination destination,
+        MailboxAuthorizationGrant grant,
+        CancellationToken cancellationToken)
+    {
+        using var transport = context.OpenTransport(destination.Deployment.Endpoint);
+
+        await new AdminApiClient(transport).StoreMailboxRefreshTokenAsync(
+            destination.Deployment.Token,
+            destination.AccountId,
+            grant.RefreshToken,
+            cancellationToken);
+
+        context.Console.WriteLine(
+            $"Stored the refresh token for account '{destination.AccountId}' on '{destination.Deployment.Name}'. It was not printed.");
+    }
+
+    /// <summary>Where a run's grant is going, when it is going anywhere but standard output.</summary>
+    /// <param name="AccountId">The account the deployment is asked to keep it for.</param>
+    /// <param name="Deployment">The deployment to send it to, with a credential it will still accept.</param>
+    /// <remarks>
+    /// The two travel together because they are settled together, before the sign-in, and neither is meaningful without
+    /// the other. Holding them as one value is also what keeps the rest of the run free of a pair of nullable locals
+    /// whose combinations the compiler cannot rule out but the code depends on.
+    /// </remarks>
+    private sealed record GrantDestination(string AccountId, SignedInProfile Deployment);
 }

--- a/src/Host/Api/AdminApiEndpoints.cs
+++ b/src/Host/Api/AdminApiEndpoints.cs
@@ -12,14 +12,18 @@ namespace MailFathom.Host.Api;
 /// <summary>Maps the administrative routes the <c>mailfathom</c> command reaches.</summary>
 /// <remarks>
 /// <para>
-/// One route today, and it is the one <c>mailfathom login</c> exists for: a client that has just been handed a
-/// credential needs to know whether this deployment accepts it before it stores it and reports success. Answering that
-/// is what turns a stored credential from something an operator hopes is right into something the service confirmed.
+/// The first is the one <c>mailfathom login</c> exists for: a client that has just been handed a credential needs to
+/// know whether this deployment accepts it before it stores it and reports success. Answering that is what turns a
+/// stored credential from something an operator hopes is right into something the service confirmed.
 /// </para>
 /// <para>
 /// It reports what the deployment knows about the caller and nothing else. There is no configuration, no account list,
 /// and no mailbox here: the response names the credential that authenticated and the product version, which is what a
 /// client needs to tell "signed in" from "reached something else that answers HTTP".
+/// </para>
+/// <para>
+/// The second is the surface's only write, and <see cref="MailboxRefreshTokenEndpoint" /> states what that costs. Both
+/// are mapped into one group so a route cannot be added outside the requirement the endpoint attaches to it.
 /// </para>
 /// </remarks>
 internal static class AdminApiEndpoints
@@ -35,6 +39,7 @@ internal static class AdminApiEndpoints
         var api = endpoints.MapGroup(AdminEndpointOptions.RoutePrefix);
 
         api.MapGet("/session", (ClaimsPrincipal caller) => Results.Ok(AdminSessionResponse.For(caller)));
+        api.MapMailboxRefreshToken();
 
         return api;
     }

--- a/src/Host/Api/MailboxRefreshTokenEndpoint.cs
+++ b/src/Host/Api/MailboxRefreshTokenEndpoint.cs
@@ -1,0 +1,118 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Accounts;
+using MailFathom.Domain.Accounts;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MailFathom.Host.Api;
+
+/// <summary>Takes the refresh token <c>mfctl mailbox authorize</c> produced and hands it to the deployment to keep.</summary>
+/// <remarks>
+/// <para>
+/// The first administrative route that changes anything, and the request body carries a long-lived credential for a
+/// named mailbox owner. That is what makes the endpoint's two startup warnings matter more here than they did for a
+/// session probe: an endpoint served in clear text hands this token to anything on the path, and one with no
+/// authentication method turned on accepts it from anybody who can reach the address.
+/// </para>
+/// <para>
+/// <strong>Every authenticated caller may perform every administrative operation.</strong> The endpoint has no
+/// permission model, so a credential that could previously read a session can now write a mailbox credential. That is
+/// accepted for this route rather than overlooked: the alternative is a permission model invented for one route, and
+/// the credential is already the thing that bounds administrative access. It is stated in the operations documentation
+/// beside the warnings, because it is a fact an operator provisions keys against.
+/// </para>
+/// <para>
+/// Answered with no body at all. There is nothing to report that the caller did not send, and a response echoing any
+/// part of it would be a way to read a stored credential back out of the service.
+/// </para>
+/// </remarks>
+internal static class MailboxRefreshTokenEndpoint
+{
+    /// <summary>The route, relative to the administrative prefix the group is mapped beneath.</summary>
+    internal const string Route = "/mailbox/refresh-token";
+
+    /// <summary>The largest body this route reads, beyond which the request fails before anything is buffered.</summary>
+    /// <remarks>
+    /// The body is one account identifier and one refresh token, and the longest token any supported authorization
+    /// server issues is a few kilobytes. Stated because the server's own default is measured in tens of megabytes,
+    /// which for this route would let an authenticated client make the process buffer a body four orders of magnitude
+    /// larger than anything it could mean.
+    /// </remarks>
+    internal const int MaxRequestBytes = 16 * 1024;
+
+    /// <summary>Maps the write route into the administrative group, so it inherits that group's authorization.</summary>
+    /// <param name="api">The administrative route group.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="api" /> is <see langword="null" />.</exception>
+    internal static void MapMailboxRefreshToken(this RouteGroupBuilder api)
+    {
+        ArgumentNullException.ThrowIfNull(api);
+
+        api.MapPost(Route, StoreAsync)
+            .WithMetadata(new RequestSizeLimitAttribute(MaxRequestBytes));
+    }
+
+    /// <summary>Stores one account's refresh token, or reports why it was not stored.</summary>
+    /// <param name="request">The account and the token, as the client sent them.</param>
+    /// <param name="recorder">The use case that checks the account and writes the token.</param>
+    /// <param name="cancellationToken">Cancels the write when the client disconnects.</param>
+    /// <returns><c>204</c> once the token is stored, or <c>400</c> naming what was wrong with the request.</returns>
+    /// <remarks>
+    /// Every refusal is <c>400</c> and carries a message written here rather than the failure's own. An account this
+    /// deployment does not configure is the caller's mistake in the request they wrote, not a missing resource — and
+    /// answering <c>404</c> would collide with the answer a client already reads as "this port serves no administrative
+    /// endpoint", turning a mistyped account into a report about the wrong thing.
+    /// </remarks>
+    internal static async Task<Results<NoContent, ProblemHttpResult>> StoreAsync(
+        MailboxRefreshTokenRequest? request,
+        MailboxRefreshTokenRecorder recorder,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(recorder);
+
+        if (string.IsNullOrWhiteSpace(request?.Account))
+        {
+            return TypedResults.Problem("The request named no mail account.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (string.IsNullOrWhiteSpace(request.RefreshToken))
+        {
+            return TypedResults.Problem("The request carried no refresh token.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var accountId = MailAccountId.Create(request.Account);
+
+        // Owned here and erased on the way out, because the request body is the one place the material arrives in a
+        // form nothing can wipe; from here on it is only ever the domain value the store seals.
+        using var refreshToken = MailboxRefreshToken.FromText(request.RefreshToken);
+
+        try
+        {
+            await recorder.RecordAsync(accountId, refreshToken, cancellationToken);
+        }
+        catch (MailAccountNotAccessibleException)
+        {
+            return TypedResults.Problem(
+                $"This deployment configures no mail account named '{accountId.Value}'.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        return TypedResults.NoContent();
+    }
+}
+
+/// <summary>The grant a client asks the deployment to keep for one of its accounts.</summary>
+/// <param name="Account">The configured identifier of the account the grant acts for.</param>
+/// <param name="RefreshToken">The refresh token the authorization server issued.</param>
+/// <remarks>
+/// Both fields are nullable so a body that omits one is refused with a message naming what is missing, rather than by
+/// the model binder with one that names a property. <see cref="ToString" /> is redacted, so no diagnostic, log
+/// template, or exception message can print the token by rendering the record it arrived in.
+/// </remarks>
+internal sealed record MailboxRefreshTokenRequest(string? Account, string? RefreshToken)
+{
+    /// <inheritdoc />
+    public override string ToString() => $"{nameof(MailboxRefreshTokenRequest)} {{ {this.Account} }}";
+}

--- a/src/Host/Api/MailboxRefreshTokenEndpoint.cs
+++ b/src/Host/Api/MailboxRefreshTokenEndpoint.cs
@@ -50,6 +50,10 @@ internal static class MailboxRefreshTokenEndpoint
     {
         ArgumentNullException.ThrowIfNull(api);
 
+        // The attribute is reached for its metadata rather than as an MVC filter, and it is worth saying so because the
+        // type's namespace suggests otherwise: it implements IRequestSizeLimitMetadata, which the routing pipeline
+        // reads and applies to the request body feature, so the bound holds on a minimal API route with no MVC in the
+        // process. A body over the limit is answered 413 before the handler is reached.
         api.MapPost(Route, StoreAsync)
             .WithMetadata(new RequestSizeLimitAttribute(MaxRequestBytes));
     }

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -179,6 +179,7 @@ public static class ServiceCollectionExtensions
         // Registered here rather than beside the OAuth client it serves, because what it is is a table: the token
         // source asks for a credential and this is what knows the credential lives in PostgreSQL, sealed.
         services.AddScoped<IMailboxRefreshTokenStore, MailboxRefreshTokenStore>();
+        services.AddScoped<MailboxRefreshTokenRecorder>();
         // MimeKit arrives with MailKit, so message parsing needs no dependency of its own; the adapter keeps its types
         // out of Application the same way the IMAP adapter keeps MailKit's out.
         services.AddScoped<IEmailMimeReader>(provider => new MimeKitEmailMimeReader(

--- a/tests/Application.UnitTests/Accounts/MailboxRefreshTokenRecorderTests.cs
+++ b/tests/Application.UnitTests/Accounts/MailboxRefreshTokenRecorderTests.cs
@@ -1,0 +1,112 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Accounts;
+using MailFathom.Domain.Accounts;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Accounts;
+
+/// <summary>Covers what the deployment decides before a mailbox grant an operator sent is allowed into the store.</summary>
+/// <remarks>
+/// The check in front of the write is the whole of this use case, and it is a security rule rather than a convenience:
+/// a grant accepted for an account no configuration names is a long-lived credential for a real mailbox owner that
+/// nothing reads and nobody knows is stored. Both substitutes stand at architectural boundaries, and what is asserted
+/// on the store is the interaction — that the write happened once with the account and the token given, or that it did
+/// not happen at all.
+/// </remarks>
+public sealed class MailboxRefreshTokenRecorderTests
+{
+    private static readonly MailAccountId Workspace = MailAccountId.Create("workspace");
+
+    private readonly IMailboxRefreshTokenStore store = Substitute.For<IMailboxRefreshTokenStore>();
+
+    [Fact]
+    public async Task RecordAsync_AServedAccount_StoresTheTokenAgainstIt()
+    {
+        // Arrange
+        var recorder = this.RecorderServing(Workspace);
+        using var refreshToken = MailboxRefreshToken.FromText("a-refresh-token");
+
+        // Act
+        await recorder.RecordAsync(Workspace, refreshToken, TestContext.Current.CancellationToken);
+
+        // Assert
+        await this.store.Received(1).SaveTokenAsync(Workspace, refreshToken, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecordAsync_AnAccountThisDeploymentDoesNotServe_IsRefusedWithoutStoringAnything()
+    {
+        // Arrange
+        var recorder = this.RecorderServing(Workspace);
+        var unknown = MailAccountId.Create("archive");
+        using var refreshToken = MailboxRefreshToken.FromText("a-refresh-token");
+
+        // Act
+        var failure = await Assert.ThrowsAsync<MailAccountNotAccessibleException>(
+            () => recorder.RecordAsync(unknown, refreshToken, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(unknown, failure.AccountId);
+        await this.store.DidNotReceive().SaveTokenAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<MailboxRefreshToken>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>An empty account list is a configured state — synchronization switched off — and it serves nobody.</summary>
+    [Fact]
+    public async Task RecordAsync_ADeploymentServingNoAccount_RefusesEveryGrant()
+    {
+        // Arrange
+        var recorder = this.RecorderServing();
+        using var refreshToken = MailboxRefreshToken.FromText("a-refresh-token");
+
+        // Act, Assert
+        await Assert.ThrowsAsync<MailAccountNotAccessibleException>(
+            () => recorder.RecordAsync(Workspace, refreshToken, TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
+    /// Re-authorizing after a revocation is the second write for one account, and it must reach the store as such:
+    /// keeping the first would leave the account holding a credential nothing chose between.
+    /// </summary>
+    [Fact]
+    public async Task RecordAsync_TheSameAccountTwice_WritesBothThroughToTheStoreThatReplaces()
+    {
+        // Arrange
+        var recorder = this.RecorderServing(Workspace);
+        using var first = MailboxRefreshToken.FromText("the-first-token");
+        using var second = MailboxRefreshToken.FromText("the-second-token");
+
+        // Act
+        await recorder.RecordAsync(Workspace, first, TestContext.Current.CancellationToken);
+        await recorder.RecordAsync(Workspace, second, TestContext.Current.CancellationToken);
+
+        // Assert
+        await this.store.Received(1).SaveTokenAsync(Workspace, first, Arg.Any<CancellationToken>());
+        await this.store.Received(1).SaveTokenAsync(Workspace, second, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RecordAsync_NoToken_IsRejectedBeforeTheAccountIsEvenLookedUp()
+    {
+        // Arrange
+        var recorder = this.RecorderServing(Workspace);
+
+        // Act, Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => recorder.RecordAsync(Workspace, refreshToken: null!, TestContext.Current.CancellationToken));
+    }
+
+    private MailboxRefreshTokenRecorder RecorderServing(params MailAccountId[] servedAccountIds)
+    {
+        var catalog = Substitute.For<IMailAccountCatalog>();
+        catalog.ServedAccountIds.Returns(servedAccountIds);
+
+        return new MailboxRefreshTokenRecorder(catalog, this.store);
+    }
+}

--- a/tests/Cli.UnitTests/AuthorizeMailboxCommandTests.cs
+++ b/tests/Cli.UnitTests/AuthorizeMailboxCommandTests.cs
@@ -4,7 +4,9 @@
 
 using System.Net;
 using System.Text;
+using System.Text.Json;
 using System.Web;
+using MailFathom.Cli.Administration;
 using MailFathom.Cli.Authorization;
 using MailFathom.Cli.Credentials;
 using MailFathom.TestSupport;
@@ -200,6 +202,153 @@ public sealed class AuthorizeMailboxCommandTests : IDisposable
         Assert.DoesNotContain(this.console.Errors, line => line.Contains("a-refresh-token", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// The whole point of <c>--account</c>: the token reaches the deployment and no stream. A regression that printed
+    /// it as well would leave it in the scrollback and in any session log, which is the exposure the option removes.
+    /// </summary>
+    [Fact]
+    public async Task Authorize_WithAnAccount_SendsTheTokenToTheDeploymentAndPrintsItNowhere()
+    {
+        // Arrange
+        this.SignInTo("production", "https://mail.example.test:8443", "an-admin-key");
+        using var handler = ProviderIssuingAGrantAndDeploymentAnswering(HttpStatusCode.NoContent);
+
+        // Act
+        var exitCode = await this.RunAsync(
+            handler,
+            FakeMailboxRedirect.ApprovingWhenAsked("an-authorization-code", this.StateTheCommandGenerated),
+            "mailbox", "authorize", "--provider", "google", "--client-id", "app", "--account", "workspace");
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.DoesNotContain(this.console.Lines, line => line.Contains("a-refresh-token", StringComparison.Ordinal));
+        Assert.DoesNotContain(this.console.Errors, line => line.Contains("a-refresh-token", StringComparison.Ordinal));
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("Stored the refresh token for account 'workspace' on 'production'", StringComparison.Ordinal));
+    }
+
+    /// <summary>The request the deployment receives is the other half of the contract: the route, the credential, and the body.</summary>
+    [Fact]
+    public async Task Authorize_WithAnAccount_PostsTheGrantToTheWriteRouteUnderTheStoredCredential()
+    {
+        // Arrange
+        this.SignInTo("production", "https://mail.example.test:8443", "an-admin-key");
+        using var handler = ProviderIssuingAGrantAndDeploymentAnswering(HttpStatusCode.NoContent);
+
+        // Act
+        await this.RunAsync(
+            handler,
+            FakeMailboxRedirect.ApprovingWhenAsked("an-authorization-code", this.StateTheCommandGenerated),
+            "mailbox", "authorize", "--provider", "google", "--client-id", "app", "--account", "workspace");
+
+        // Assert
+        var sent = handler.RecordedRequests.Single(
+            recorded => recorded.RequestUri?.AbsolutePath == AdminEndpointRoutes.MailboxRefreshTokenPath);
+        Assert.Equal(HttpMethod.Post, sent.Method);
+        Assert.Equal("Bearer an-admin-key", sent.Headers["Authorization"][0]);
+
+        using var body = JsonDocument.Parse(sent.ContentAsUtf8String());
+        Assert.Equal("workspace", body.RootElement.GetProperty("account").GetString());
+        Assert.Equal("a-refresh-token", body.RootElement.GetProperty("refreshToken").GetString());
+    }
+
+    /// <summary>
+    /// A sign-in the deployment has nowhere to put is worse than no sign-in at all: somebody has already approved
+    /// access at the provider, and the credential that produced it is then discarded unread.
+    /// </summary>
+    [Fact]
+    public async Task Authorize_WithAnAccountAndNoProfile_FailsBeforeAnybodyIsAskedToApproveAnything()
+    {
+        // Arrange
+        using var handler = TokenEndpointRefusing();
+
+        // Act
+        var exitCode = await this.RunAsync(
+            handler,
+            FakeMailboxRedirect.Silent(),
+            "mailbox", "authorize", "--provider", "google", "--client-id", "app", "--account", "workspace");
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Empty(handler.RecordedRequests);
+        Assert.Null(this.console.LastPrompt);
+    }
+
+    /// <summary>An account the deployment does not configure is refused by it, and its sentence is what the operator needs.</summary>
+    [Fact]
+    public async Task Authorize_AnAccountTheDeploymentDoesNotConfigure_ReportsWhatItSaid()
+    {
+        // Arrange
+        this.SignInTo("production", "https://mail.example.test:8443", "an-admin-key");
+        using var handler = ProviderIssuingAGrantAndDeploymentRefusing(
+            HttpStatusCode.BadRequest,
+            """{"detail":"This deployment configures no mail account named 'archive'."}""");
+
+        // Act
+        var exitCode = await this.RunAsync(
+            handler,
+            FakeMailboxRedirect.ApprovingWhenAsked("an-authorization-code", this.StateTheCommandGenerated),
+            "mailbox", "authorize", "--provider", "google", "--client-id", "app", "--account", "archive");
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains("configures no mail account named 'archive'", StringComparison.Ordinal));
+        Assert.DoesNotContain(this.console.Lines, line => line.Contains("a-refresh-token", StringComparison.Ordinal));
+    }
+
+    /// <summary>A deployment that refuses the administrative credential is reported as that rather than as a stored grant.</summary>
+    [Fact]
+    public async Task Authorize_ADeploymentRefusingTheAdministrativeCredential_SaysSoAndStoresNothing()
+    {
+        // Arrange
+        this.SignInTo("production", "https://mail.example.test:8443", "a-revoked-key");
+        using var handler = ProviderIssuingAGrantAndDeploymentRefusing(HttpStatusCode.Unauthorized, string.Empty);
+
+        // Act
+        var exitCode = await this.RunAsync(
+            handler,
+            FakeMailboxRedirect.ApprovingWhenAsked("an-authorization-code", this.StateTheCommandGenerated),
+            "mailbox", "authorize", "--provider", "google", "--client-id", "app", "--account", "workspace");
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(this.console.Errors, line => line.Contains("refused the credential", StringComparison.Ordinal));
+        Assert.DoesNotContain(this.console.Lines, line => line.Contains("a-refresh-token", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Each of these reaches an operator as a documented sentence, and each names a different thing to go and look at:
+    /// a listener serving something else, a refusal with no reason in it, and an answer that is neither.
+    /// </summary>
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound, "", "serves no administrative endpoint")]
+    [InlineData(HttpStatusCode.BadRequest, "", "refused the grant without saying why")]
+    [InlineData(HttpStatusCode.BadRequest, "<html>refused</html>", "refused the grant without saying why")]
+    [InlineData(HttpStatusCode.InternalServerError, "", "rather than storing the token")]
+    public async Task Authorize_ADeploymentThatDoesNotStoreTheGrant_ReportsWhichKindOfAnswerItGave(
+        HttpStatusCode deploymentStatus,
+        string deploymentBody,
+        string expectedReport)
+    {
+        // Arrange
+        this.SignInTo("production", "https://mail.example.test:8443", "an-admin-key");
+        using var handler = ProviderIssuingAGrantAndDeploymentRefusing(deploymentStatus, deploymentBody);
+
+        // Act
+        var exitCode = await this.RunAsync(
+            handler,
+            FakeMailboxRedirect.ApprovingWhenAsked("an-authorization-code", this.StateTheCommandGenerated),
+            "mailbox", "authorize", "--provider", "google", "--client-id", "app", "--account", "workspace");
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(this.console.Errors, line => line.Contains(expectedReport, StringComparison.Ordinal));
+        Assert.DoesNotContain(this.console.Lines, line => line.Contains("a-refresh-token", StringComparison.Ordinal));
+    }
+
     [Theory]
     [InlineData("code=abc&state=xyz", "abc", "xyz", null)]
     [InlineData("?code=abc&state=xyz", "abc", "xyz", null)]
@@ -265,6 +414,39 @@ public sealed class AuthorizeMailboxCommandTests : IDisposable
         return HttpUtility.ParseQueryString(new Uri(address.Trim()).Query)["state"]
             ?? throw new InvalidOperationException("The printed authorization address carried no state.");
     }
+
+    /// <summary>Remembers a deployment the way <c>login</c> would, so a command has a profile to act through.</summary>
+    private void SignInTo(string name, string endpoint, string token) =>
+        new CredentialStore(
+            Path.Combine(this.storeDirectory, "credentials.json"),
+            new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key")))
+            .Save(name, new Uri(endpoint), token, "workstation");
+
+    /// <summary>Answers as the provider's token endpoint and as the deployment, told apart by the path.</summary>
+    /// <remarks>
+    /// One handler serves every transport a command opens, so a run that sends to both is only meaningful if the two
+    /// answer differently. Routing on the administrative prefix is also what lets a test assert that the grant reached
+    /// the write route rather than merely that two requests happened.
+    /// </remarks>
+    private static FakeHttpMessageHandler ProviderIssuingAGrantAndDeploymentAnswering(HttpStatusCode deploymentStatus) =>
+        ProviderIssuingAGrantAndDeploymentRefusing(deploymentStatus, string.Empty);
+
+    private static FakeHttpMessageHandler ProviderIssuingAGrantAndDeploymentRefusing(
+        HttpStatusCode deploymentStatus,
+        string deploymentBody) =>
+        new((request, _) => Task.FromResult(
+            request.RequestUri?.AbsolutePath.StartsWith(AdminEndpointRoutes.Prefix, StringComparison.Ordinal) == true
+                ? new HttpResponseMessage(deploymentStatus)
+                {
+                    Content = new StringContent(deploymentBody, Encoding.UTF8, "application/problem+json"),
+                }
+                : new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        """{"access_token":"an-access-token","refresh_token":"a-refresh-token","expires_in":3600}""",
+                        Encoding.UTF8,
+                        "application/json"),
+                }));
 
     /// <summary>A token endpoint that refuses everything, so a test reaching it fails loudly rather than passing quietly.</summary>
     private static FakeHttpMessageHandler TokenEndpointRefusing() =>

--- a/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
@@ -1,0 +1,175 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Accounts;
+using MailFathom.Host.Api;
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Security.Transport;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Api;
+
+/// <summary>Covers what admits a caller to the administrative routes, which is the group rather than any route.</summary>
+/// <remarks>
+/// <para>
+/// The surface's protection is structural: <see cref="AdminApiEndpoints.MapAdminApi" /> maps every route into one
+/// group, and the composition root attaches the requirement to that group. A route mapped outside it, or mapped after
+/// the requirement was attached, would be served to anybody who can reach the address — and for the write route that
+/// means placing a mailbox owner's long-lived credential. So what is asserted here is that the routes the mapping
+/// produces are all inside the group, whichever routes those come to be.
+/// </para>
+/// <para>
+/// This builds the route group and reads the metadata the endpoints carry. It starts no server and issues no request,
+/// which is the boundary <c>tests/AGENTS.md</c> draws for this project: whether the authorization middleware then
+/// enforces that metadata is the framework's contract rather than this repository's, and proving it end to end is what
+/// a composed-host test would add.
+/// </para>
+/// </remarks>
+public sealed class AdminApiEndpointsTests
+{
+    /// <summary>
+    /// The regression this exists for: a route added to the file but mapped outside the group would compile, answer,
+    /// and be unauthenticated, and every other test here would still pass.
+    /// </summary>
+    [Fact]
+    public void MapAdminApi_WithTheGroupRequirementAttached_LeavesNoRouteWithoutIt()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+
+        // Act
+        endpoints.MapAdminApi().RequireAuthorization(TransportSurface.Admin.AccessPolicyName);
+
+        // Assert
+        var mapped = MaterializeEndpoints(endpoints);
+        Assert.NotEmpty(mapped);
+        Assert.All(
+            mapped,
+            endpoint => Assert.Contains(
+                endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>(),
+                requirement => requirement.Policy == TransportSurface.Admin.AccessPolicyName));
+    }
+
+    /// <summary>
+    /// The control for the test above. Without it, an assertion that every route carries the requirement would pass
+    /// just as happily against a reader that never finds the metadata at all, and the protection it claims to check
+    /// would be unobserved rather than present.
+    /// </summary>
+    [Fact]
+    public void MapAdminApi_WithNoGroupRequirementAttached_LeavesEveryRouteWithoutOne()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+
+        // Act
+        endpoints.MapAdminApi();
+
+        // Assert
+        var mapped = MaterializeEndpoints(endpoints);
+        Assert.NotEmpty(mapped);
+        Assert.All(mapped, endpoint => Assert.Empty(endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>()));
+    }
+
+    /// <summary>Both routes are the group's, and the write route is the one whose absence from it would matter most.</summary>
+    [Fact]
+    public void MapAdminApi_Always_ServesBothRoutesBeneathTheAdministrativePrefix()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+
+        // Act
+        endpoints.MapAdminApi();
+
+        // Assert
+        var routes = MaterializeEndpoints(endpoints)
+            .OfType<RouteEndpoint>()
+            .Select(endpoint => $"/{endpoint.RoutePattern.RawText?.TrimStart('/')}")
+            .Order(StringComparer.Ordinal);
+
+        Assert.Equal(
+            [
+                $"{AdminEndpointOptions.RoutePrefix}{MailboxRefreshTokenEndpoint.Route}",
+                $"{AdminEndpointOptions.RoutePrefix}/session",
+            ],
+            routes);
+    }
+
+    /// <summary>The write route is a post, because a get carrying a credential reaches every access log on the path.</summary>
+    [Fact]
+    public void MapAdminApi_TheMailboxRefreshTokenRoute_AcceptsOnlyAPost()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+
+        // Act
+        endpoints.MapAdminApi();
+
+        // Assert
+        var writeRoute = MaterializeEndpoints(endpoints)
+            .OfType<RouteEndpoint>()
+            .Single(endpoint => endpoint.RoutePattern.RawText?.EndsWith(MailboxRefreshTokenEndpoint.Route, StringComparison.Ordinal) == true);
+
+        Assert.Equal(
+            ["POST"],
+            writeRoute.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods);
+    }
+
+    /// <summary>The bound on the body, which the route carries as metadata the routing pipeline reads.</summary>
+    [Fact]
+    public void MapAdminApi_TheMailboxRefreshTokenRoute_CarriesTheRequestBodyBound()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+
+        // Act
+        endpoints.MapAdminApi();
+
+        // Assert
+        var writeRoute = MaterializeEndpoints(endpoints)
+            .OfType<RouteEndpoint>()
+            .Single(endpoint => endpoint.RoutePattern.RawText?.EndsWith(MailboxRefreshTokenEndpoint.Route, StringComparison.Ordinal) == true);
+
+        Assert.Equal(
+            MailboxRefreshTokenEndpoint.MaxRequestBytes,
+            writeRoute.Metadata.GetMetadata<Microsoft.AspNetCore.Http.Metadata.IRequestSizeLimitMetadata>()!.MaxRequestBodySize);
+    }
+
+    /// <summary>Builds the routing seam the mapping extends, with the routing services the group needs and nothing else.</summary>
+    /// <remarks>
+    /// The recorder is registered because minimal API parameter inference resolves a handler's non-primitive parameters
+    /// against the container while the endpoint is built, and refuses to build one it cannot place. It is never invoked
+    /// here — no request is made — so a substitute with no behavior configured is the whole of what this needs.
+    /// </remarks>
+    private static TestEndpointRouteBuilder BuildRouteBuilder()
+    {
+        var services = new ServiceCollection();
+        services.AddRouting();
+        services.AddLogging();
+        services.AddScoped(_ => new MailboxRefreshTokenRecorder(
+            Substitute.For<IMailAccountCatalog>(),
+            Substitute.For<IMailboxRefreshTokenStore>()));
+
+        return new TestEndpointRouteBuilder(services.BuildServiceProvider());
+    }
+
+    private static IReadOnlyList<Endpoint> MaterializeEndpoints(IEndpointRouteBuilder endpoints) =>
+        [.. endpoints.DataSources.SelectMany(source => source.Endpoints)];
+
+    /// <summary>The smallest thing the routing builder API accepts, so a mapping can be exercised without a web host.</summary>
+    private sealed class TestEndpointRouteBuilder(IServiceProvider serviceProvider) : IEndpointRouteBuilder
+    {
+        public IServiceProvider ServiceProvider { get; } = serviceProvider;
+
+        public ICollection<EndpointDataSource> DataSources { get; } = [];
+
+        public IApplicationBuilder CreateApplicationBuilder() =>
+            new ApplicationBuilder(this.ServiceProvider);
+    }
+}

--- a/tests/Host.UnitTests/Api/MailboxRefreshTokenEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/MailboxRefreshTokenEndpointTests.cs
@@ -1,0 +1,185 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json;
+using MailFathom.Application.Accounts;
+using MailFathom.Domain.Accounts;
+using MailFathom.Host.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Api;
+
+/// <summary>Covers what the administrative surface's only write route decides about a request before it stores anything.</summary>
+/// <remarks>
+/// The route is reached with a long-lived mailbox credential in the body, so what is asserted here is the shape of
+/// every refusal and the fact that a refusal stores nothing. Authentication is deliberately not among them: the route
+/// carries no requirement of its own and inherits the group's, which is what
+/// <see cref="AdminApiEndpoints.MapAdminApi" /> exists to guarantee and what the composed host proves in the
+/// integration suite.
+/// </remarks>
+public sealed class MailboxRefreshTokenEndpointTests
+{
+    private static readonly MailAccountId Workspace = MailAccountId.Create("workspace");
+
+    private readonly IMailboxRefreshTokenStore store = Substitute.For<IMailboxRefreshTokenStore>();
+
+    [Fact]
+    public async Task StoreAsync_AGrantForAServedAccount_StoresItAndAnswersWithNoBody()
+    {
+        // Arrange
+        var request = new MailboxRefreshTokenRequest("workspace", "a-refresh-token");
+
+        // Act
+        var result = await MailboxRefreshTokenEndpoint.StoreAsync(
+            request,
+            this.RecorderServing(Workspace),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.IsType<NoContent>(result.Result);
+        await this.store.Received(1).SaveTokenAsync(
+            Workspace,
+            Arg.Any<MailboxRefreshToken>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Naming the account is the whole of what makes this actionable: only the caller knows what they meant.</summary>
+    [Fact]
+    public async Task StoreAsync_AnAccountThisDeploymentDoesNotConfigure_IsRefusedNamingIt()
+    {
+        // Arrange
+        var request = new MailboxRefreshTokenRequest("archive", "a-refresh-token");
+
+        // Act
+        var result = await MailboxRefreshTokenEndpoint.StoreAsync(
+            request,
+            this.RecorderServing(Workspace),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        Assert.Contains("'archive'", refusal.ProblemDetails.Detail, StringComparison.Ordinal);
+        await this.store.DidNotReceive().SaveTokenAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<MailboxRefreshToken>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(null, "a-refresh-token")]
+    [InlineData("", "a-refresh-token")]
+    [InlineData("   ", "a-refresh-token")]
+    [InlineData("workspace", null)]
+    [InlineData("workspace", "")]
+    [InlineData("workspace", "   ")]
+    public async Task StoreAsync_ABodyMissingEitherField_IsRefusedWithoutStoringAnything(
+        string? account,
+        string? refreshToken)
+    {
+        // Arrange
+        var request = new MailboxRefreshTokenRequest(account, refreshToken);
+
+        // Act
+        var result = await MailboxRefreshTokenEndpoint.StoreAsync(
+            request,
+            this.RecorderServing(Workspace),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        await this.store.DidNotReceive().SaveTokenAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<MailboxRefreshToken>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>A request that carried no body at all binds as nothing, and is the same refusal rather than a fault.</summary>
+    [Fact]
+    public async Task StoreAsync_NoBodyAtAll_IsRefusedRatherThanFailing()
+    {
+        // Act
+        var result = await MailboxRefreshTokenEndpoint.StoreAsync(
+            request: null,
+            this.RecorderServing(Workspace),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+    }
+
+    /// <summary>
+    /// A refusal is written here rather than taken from the failure, because an administrative endpoint publishes no
+    /// exception message. The two must therefore not coincide, which is what this asserts.
+    /// </summary>
+    [Fact]
+    public async Task StoreAsync_AnUnservedAccount_ReportsItsOwnSentenceRatherThanTheFailuresMessage()
+    {
+        // Arrange
+        var request = new MailboxRefreshTokenRequest("archive", "a-refresh-token");
+        var raised = new MailAccountNotAccessibleException(MailAccountId.Create("archive")).Message;
+
+        // Act
+        var result = await MailboxRefreshTokenEndpoint.StoreAsync(
+            request,
+            this.RecorderServing(Workspace),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.NotEqual(raised, refusal.ProblemDetails.Detail);
+        Assert.Contains("configures no mail account", refusal.ProblemDetails.Detail, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The body is where the token arrives, and a record that rendered it would put a mailbox credential into whatever
+    /// log template, diagnostic, or exception message happened to format the request.
+    /// </summary>
+    [Fact]
+    public void ToString_ARequestCarryingAToken_RedactsIt()
+    {
+        // Arrange
+        var request = new MailboxRefreshTokenRequest("workspace", "a-refresh-token");
+
+        // Act
+        var rendered = request.ToString();
+
+        // Assert
+        Assert.DoesNotContain("a-refresh-token", rendered, StringComparison.Ordinal);
+        Assert.Contains("workspace", rendered, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The field names are the agreement with <c>mfctl</c>, which serializes its own record of this shape through a
+    /// source-generated context. Nothing else compares the two, so a rename on either side would compile, serialize,
+    /// and fail only against a real deployment as a body whose fields all bound to nothing.
+    /// </summary>
+    [Fact]
+    public void Deserialized_TheBodyTheCommandSends_BindsEveryFieldTheRouteReads()
+    {
+        // Arrange
+        const string Body = """{"account":"workspace","refreshToken":"a-refresh-token"}""";
+
+        // Act
+        var request = JsonSerializer.Deserialize<MailboxRefreshTokenRequest>(Body, JsonSerializerOptions.Web);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal("workspace", request.Account);
+        Assert.Equal("a-refresh-token", request.RefreshToken);
+    }
+
+    private MailboxRefreshTokenRecorder RecorderServing(params MailAccountId[] servedAccountIds)
+    {
+        var catalog = Substitute.For<IMailAccountCatalog>();
+        catalog.ServedAccountIds.Returns(servedAccountIds);
+
+        return new MailboxRefreshTokenRecorder(catalog, this.store);
+    }
+}

--- a/tests/Host.UnitTests/Api/MailboxRefreshTokenEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/MailboxRefreshTokenEndpointTests.cs
@@ -17,9 +17,8 @@ namespace MailFathom.Host.UnitTests.Api;
 /// <remarks>
 /// The route is reached with a long-lived mailbox credential in the body, so what is asserted here is the shape of
 /// every refusal and the fact that a refusal stores nothing. Authentication is deliberately not among them: the route
-/// carries no requirement of its own and inherits the group's, which is what
-/// <see cref="AdminApiEndpoints.MapAdminApi" /> exists to guarantee and what the composed host proves in the
-/// integration suite.
+/// carries no requirement of its own and inherits the group's, so it is asserted where that inheritance happens, in
+/// <see cref="AdminApiEndpointsTests" />.
 /// </remarks>
 public sealed class MailboxRefreshTokenEndpointTests
 {


### PR DESCRIPTION
Closes #331

`mfctl mailbox authorize --account <id>` now sends the refresh token to the deployment it is signed in to, which seals it under the data-encryption key and stores it. The token is never printed, never redirected, and never placed by hand.

```console
$ mfctl mailbox authorize --provider google --client-id <client-id> --account workspace
…
Stored the refresh token for account 'workspace' on 'production'. It was not printed.
```

## What this adds

- **`POST /api/admin/mailbox/refresh-token`** — the administrative surface's first write. It inherits the group's authorization rather than carrying its own, answers `204` with no body, and reads at most 16 KB, because the server's own default would let an authenticated client make the process buffer a body four orders of magnitude larger than a refresh token.
- **`MailboxRefreshTokenRecorder`** in `Application/Accounts` — validates the account against `IMailAccountCatalog` before writing through `IMailboxRefreshTokenStore`. A grant for an account no configuration names is a credential nothing reads and nobody knows is there, so it is refused rather than kept.
- **`--account` and `--endpoint`** on the command, reusing the profile resolution and transport every other `mfctl` command goes through. The deployment is resolved *before* the browser opens, so a command that is not signed in fails at once instead of after somebody has approved access at the provider.

Printing stays: without `--account` the command behaves exactly as it did, which is what a deployment with no administrative endpoint and an operator who provisions credentials themselves still need.

## The decision the issue asked to record

**Every authenticated caller may perform every administrative operation.** The endpoint has no permission model, so a credential that could read a session can now write a mailbox credential. That is accepted for this route rather than overlooked — the alternative is a permission model invented for one route, and the credential is already what bounds administrative access. It is stated in `MailboxRefreshTokenEndpoint`'s remarks and in `docs/operations/admin-endpoint.md` beside the two startup warnings, which is where an operator provisioning keys will meet it.

## Refusals

| Case | Answer |
| --- | --- |
| Account the deployment does not configure | `400`, naming the account, nothing stored |
| Body missing either field, or no body | `400` |
| Unauthenticated | refused by the group's requirement, before the handler |
| No data-encryption key ring | `500` — nothing about the request was wrong, and the deployment's own log names the cause |

Every refusal is written at the boundary rather than taken from the failure's own message, so no exception text reaches a client.

## Tests

- `MailboxRefreshTokenRecorderTests` — the served-account check, the empty catalogue, replacement, and the argument guard.
- `MailboxRefreshTokenEndpointTests` — each refusal, that a refusal stores nothing, that the refusal is not the exception's message, that `ToString` redacts the token, and that the body `mfctl` serializes binds to every field the route reads. That last one is the agreement between two records nothing else compares.
- `AuthorizeMailboxCommandTests` — both modes, the request the deployment receives, failing before the sign-in when no profile exists, and each answer a deployment can give that is not an acceptance.

**No integration test is added, deliberately.** The issue scoped the stored round trip there, but `OrchestratedMailboxRefreshTokenStoreTests` already proves the store's round trip against a real database and a real key ring, and what this change adds above it is an in-memory account check and a route — neither of which needs real infrastructure to prove. A composed-host test would also mean enabling the administrative endpoint on the app model's composed host, which is a larger change than what it would establish.

## Documentation

- `docs/operations/mailbox-oauth.md` — a new section for sending the token, and the rotation section now states that authorizing again replaces a stored grant. That page previously said nothing operator-facing could, and pointed at this issue.
- `docs/operations/admin-endpoint.md` — a table of what the endpoint serves, the write route's contract, and the permission-model note above.
- `docs/users/administering.md` — the mailbox section covers both destinations; the guide no longer says nothing the command does changes a running deployment.

## Verification

`scripts/verify-full.sh` passed: 2558 tests, aggregate line coverage 96.47% against the 85% gate, formatting clean over 869 files. The integration suite was not run.
