### PR TITLE
[#357] Compose the integration suite against the OAuth settings port infrastructure requires

### DIFF
--- a/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
+++ b/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
@@ -12,6 +12,7 @@ using MailFathom.Application.Synchronization.Reconciliation;
 using MailFathom.Infrastructure;
 using MailFathom.Infrastructure.DataEncryption;
 using MailFathom.Infrastructure.Mail;
+using MailFathom.Infrastructure.Mail.OAuth;
 using MailFathom.Infrastructure.Persistence.Connections;
 using MailFathom.Infrastructure.Resilience;
 using MailFathom.Infrastructure.Secrets.Discovery;
@@ -64,6 +65,7 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
         builder.Services.AddSecretResolution(SecretValueInterpretation.ReferenceOnly);
         builder.Services.AddOutboundResiliencePipelines(builder.Configuration.GetSection("Resilience"));
         builder.Services.AddSingleton<IImapAccountSettingsProvider>(account);
+        builder.Services.AddSingleton<IMailOAuthSettingsProvider>(new UnconfiguredMailOAuthSettingsProvider());
         builder.Services.AddSingleton<IMailTransportSecurityPolicyReader>(account);
         builder.Services.AddSingleton<IMailSynchronizationWindowReader>(account);
         builder.Services.AddSingleton<IRemotelyDeletedEmailDispositionReader>(account);

--- a/tests/IntegrationTests/Orchestration/UnconfiguredMailOAuthSettingsProvider.cs
+++ b/tests/IntegrationTests/Orchestration/UnconfiguredMailOAuthSettingsProvider.cs
@@ -1,0 +1,29 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Mail.OAuth;
+
+namespace MailFathom.IntegrationTests.Orchestration;
+
+/// <summary>The token endpoint port for an account that configures no OAuth block, which is every account this suite serves.</summary>
+/// <remarks>
+/// <para>
+/// Infrastructure composes its access token source from this port, so the port has to be present for a mailbox session
+/// factory to resolve at all. It is supplied here for the reason every other composition-root input is: the suite does
+/// not start the host resource, so nothing binds the configuration the real provider reads.
+/// </para>
+/// <para>
+/// Requesting settings throws, which is what a configured provider does for an account with no OAuth block rather than
+/// a refusal invented for the suite. The orchestrated server advertises no token-bearing mechanism and
+/// <see cref="SyntheticMailAccount" /> permits none, so a connection never selects one and never reaches this port; a
+/// change that made it reachable would fail loudly here instead of authenticating against settings nobody configured.
+/// </para>
+/// </remarks>
+internal sealed class UnconfiguredMailOAuthSettingsProvider : IMailOAuthSettingsProvider
+{
+    /// <inheritdoc />
+    public Task<MailOAuthAccountSettings> GetSettingsAsync(string accountId, CancellationToken cancellationToken) =>
+        throw new InvalidOperationException(
+            "The orchestrated account authenticates with clear text and configures no OAuth block.");
+}


### PR DESCRIPTION
Closes #357

The `Integration tests` workflow failed on `main` with 4 of 51 tests ending in `No service for type 'MailFathom.Infrastructure.Mail.OAuth.IMailOAuthSettingsProvider' has been registered` ([run 30909877711](https://github.com/Krzysztof318/MailFathom/actions/runs/30909877711)).

`AddInfrastructure` composes `IMailAccessTokenSource` from that port, and the only implementation of it, `ConfiguredMailOAuthSettingsProvider`, is bound by the host composition root from the `Mail` configuration section. The integration suite deliberately does not start the host resource and supplies the composition-root inputs itself, so `IMailboxSessionFactory`, `IMailboxNotificationSessionFactory`, and `IRemoteFolderCatalog` stopped resolving the moment #78 added the token source. Nothing caught it, because the suite runs only on manual dispatch.

`UnconfiguredMailOAuthSettingsProvider` supplies the port for the orchestrated account. Requesting settings throws, which is what a configured provider does for an account with no OAuth block rather than a refusal invented for the suite, and no connection reaches it: `TrySelectAccessTokenMechanism` picks from the account's permitted mechanisms, `SyntheticMailAccount` permits `PLAIN` and `LOGIN` only, and the orchestrated server advertises no token-bearing mechanism either. A change that made the port reachable therefore fails loudly here instead of authenticating against settings nobody configured.

Production wiring is untouched: the host registers the port, and no file under `src/` changed.

## Verification

- `scripts/verify-full.sh` — green; 2564 unit tests pass, aggregate line coverage 96.47% (6100/6323), format check clean.
- `Integration tests` dispatched on this branch, which is what proves the fix; the suite is not run locally.