### PR TITLE
[#359] Prepare release 0.2.0

### DIFF
--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -110,15 +110,15 @@ which is what makes an edit to it outside this flow visible.
 
 #### The files that name a version in prose
 
-`<VersionPrefix>` is the only place a version is written for the *build*. Five files additionally name one in prose,
+`<VersionPrefix>` is the only place a version is written for the *build*. Seven files additionally name one in prose,
 where nothing derives it and nothing checks it, so they are read here by name rather than left to be noticed:
 
 | File | What to bring onto `x.y.z` |
 | --- | --- |
-| `README.md` | The **Project status** paragraph — which release is current and what it ships |
-| `docs/users/installation.md` | The image references in the opening paragraph, which quote the version literally |
+| `README.md` | The **Project status** paragraph — which release is current and what it ships — and the **Where the artifacts are published** table whenever a release starts or stops attaching one |
+| `docs/users/installation.md` | The image references in the opening paragraph, which quote the version literally, and the sentence naming what a release publishes |
 | `docs/users/README.md` | The **The state of the release** section — which release is current, and what a page is allowed to describe as already downloadable |
-| `docs/operations/admin-endpoint.md` | The **Getting the command** section, which names the release from which `mfctl` binaries are attached. Drop the threshold entirely once that release has shipped, rather than moving the number |
+| `docs/operations/database-schema.md`, `docs/operations/deployment-compose.md`, `docs/operations/deployment-kubernetes.md` | The `mailfathom-schema-<x.y.z>.sql` filename the apply and verify commands quote literally. An operator copies those lines, so a stale one checksums and applies the previous release's schema |
 | `SECURITY.md` | The **Supported versions** table. `x.y` becomes the supported line and the one it replaces moves down a row, per ADR 0004's rule that only the newest released minor is patched by default |
 
 **They belong in this pull request rather than the bump one, and the reason is what the whole ordering rests on:** this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,133 @@ because they are, by definition, whatever has been merged since the newest secti
 Nothing yet. A section appears here only when a release is prepared, because this file is written by the release pull
 request and by nothing else; what has merged since the newest section below is what a nightly build carries.
 
+## [0.2.0] - 2026-08-04
+
+The second release, and the first that had a previous one to differ from. **Nothing `0.1.0` promised is withdrawn:**
+the MCP tool contract is unchanged, every configuration key `0.1.0` accepted is still accepted and still means the
+same thing, and both schema changes are additive. There is no breaking entry below, so an upgrade is the schema step
+and a new image.
+
+What is new is how a mailbox authenticates, how quickly a change on the mail server reaches the local copy, and a
+second HTTP surface — an administrative endpoint with a command-line client of its own — that an operator reaches
+without going through the MCP surface.
+
+**The database schema.** Two migrations, both additive: one table and one nullable column
+([#343](https://github.com/Krzysztof318/MailFathom/pull/343),
+[#346](https://github.com/Krzysztof318/MailFathom/pull/346)). `0.2.0` refuses to serve until they are applied —
+startup is gated on the migrations the binary carries and will not migrate a database out from under a running
+process — but `0.1.0` neither reads nor writes what they add, so **they can be applied while `0.1.0` is still
+serving**, and the release then deploys over `0.1.0`'s data unchanged. The gate reads only what is *pending*, so a
+database already carrying both migrations still starts `0.1.0`: going back needs no schema step of its own.
+[Applying the database schema](https://github.com/Krzysztof318/MailFathom/blob/main/docs/operations/database-schema.md)
+records the apply path and the ordering a deployment follows.
+
+### Added
+
+**Mailbox authentication.** An IMAP account can present an OAuth token instead of a password.
+
+- `XOAUTH2` and `OAUTHBEARER` are accepted in
+  `MailSynchronization:Accounts:<n>:TransportSecurity:PermittedAuthenticationMechanisms`, and naming either one turns
+  on that account's `…:OAuth` block: the token endpoint, the client, the scope, and the grant — `refresh_token` or
+  `client_credentials` — with the client secret and the refresh token supplied by reference like every other
+  credential. Configuring the block for an account that authenticates with a password fails startup rather than
+  provisioning something nothing can use ([#306](https://github.com/Krzysztof318/MailFathom/pull/306)).
+  [Mailbox OAuth](https://github.com/Krzysztof318/MailFathom/blob/main/docs/operations/mailbox-oauth.md) is the page,
+  including where each value comes from for the providers this was verified against.
+- Calls to an authorization server get a retry, timeout, circuit-breaker, and concurrency budget of their own, as the
+  `Resilience:MailAuthorizationServerInvocation` class, rather than borrowing the mailbox session's
+  ([#306](https://github.com/Krzysztof318/MailFathom/pull/306)).
+
+**Continuous synchronization.** A folder change on the mail server can start a pass, instead of every change waiting
+for the account's next interval.
+
+- `MailSynchronization:Accounts:<n>:Mode` selects `Polling` — `0.1.0`'s behaviour, and still the default — or `Push`
+  ([#339](https://github.com/Krzysztof318/MailFathom/pull/339)).
+- Under `Push`, a server offering `NOTIFY` is watched over **one** connection per account covering every configured
+  folder, and a server offering only `IDLE` over one connection per folder
+  ([#339](https://github.com/Krzysztof318/MailFathom/pull/339),
+  [#346](https://github.com/Krzysztof318/MailFathom/pull/346)). `MaxSubscribedFolders` (default `20`) bounds how many
+  folders one subscription may name; the rest synchronize on the account's interval rather than being dropped.
+- Where the server offers `CONDSTORE` and `QRESYNC`, a pass asks what changed since the modification sequence it last
+  reconciled through instead of re-reading the folder, which is what the new nullable
+  `synchronization_checkpoints.ReconciledThroughModSeq` column records
+  ([#346](https://github.com/Krzysztof318/MailFathom/pull/346)).
+- Push degrades to polling rather than stalling: `MaxConsecutivePushFailures` (default `3`) and
+  `PushDegradationPeriod` (default `15 min`) decide when an account falls back and for how long, and
+  `PushRenewalInterval` (default `20 min`) is the lifetime of one `IDLE` command — RFC 2177's ceiling, not a polling
+  cycle ([#339](https://github.com/Krzysztof318/MailFathom/pull/339),
+  [#341](https://github.com/Krzysztof318/MailFathom/pull/341)). Synchronization stays read-only throughout: a push
+  pass sets the remote `\Seen` flag no more than a polled one does.
+
+**An administrative endpoint, and the `mfctl` command that reaches it.**
+
+- `AdminEndpoint` serves administrative routes beneath `/api/admin` on a listener, a credential set, and a set of
+  authorization servers of its own. It is off by default, and a key or an issuer configured under `McpEndpoint`
+  authenticates nothing here — the two surfaces are protected independently rather than sharing one policy
+  ([#313](https://github.com/Krzysztof318/MailFathom/pull/313),
+  [#317](https://github.com/Krzysztof318/MailFathom/pull/317)).
+- **Each release now attaches `mfctl`**, a self-contained binary per platform — `linux-x64`, `linux-arm64`, `win-x64`,
+  `win-arm64` — plus one checksum file covering all of them. It runs where you administer *from* rather than where the
+  service runs, and needs no .NET installation
+  ([#317](https://github.com/Krzysztof318/MailFathom/pull/317)).
+- `mfctl login` signs in with an API key read from standard input, with a browser redirect caught locally, or with a
+  device code entered elsewhere, and keeps the credential in a profile file of its own with the tokens encrypted at
+  rest — the refresh token included, so a session outlives an access token's expiry rather than sending the operator
+  back through the flow ([#348](https://github.com/Krzysztof318/MailFathom/pull/348)).
+  [Administering your deployment](https://github.com/Krzysztof318/MailFathom/blob/main/docs/users/administering.md)
+  states what that encryption protects and what it does not.
+- `mfctl mailbox authorize` runs a mailbox's own OAuth flow from the operator's machine and **sends the resulting
+  refresh token to the deployment**, which seals and stores it, instead of printing it for the operator to paste into
+  a configuration file ([#356](https://github.com/Krzysztof318/MailFathom/pull/356)).
+- [Administering a deployment](https://github.com/Krzysztof318/MailFathom/blob/main/docs/operations/admin-endpoint.md)
+  is the reference: every route, every `--mode`, the configuration, and what each failure means.
+
+  **One caveat, and it is a defect this release ships with**: a deployment that sets `HealthEndpoints:Enabled` to
+  `false` *and* enables this endpoint loses its application listener, because binding the administrative socket in
+  code makes Kestrel ignore `ASPNETCORE_HTTP_PORTS` and only the probe path restates it. The process starts and serves
+  the administrative port alone, and every MCP client is refused.
+  [#325](https://github.com/Krzysztof318/MailFathom/issues/325) carries the fix. Until it lands, leave the probes
+  enabled — the default — or state the application listener as a `Kestrel:Endpoints` entry.
+
+**Encryption at rest.**
+
+- `DataEncryption` configures a key ring: one active key, any number of retained ones, each 32 bytes of material
+  supplied by reference like every other credential, under which MailFathom seals what it stores. An absent section is
+  a valid deployment that seals nothing, and rotation is moving `ActiveKeyId` while leaving the previous key
+  configured, so nothing already sealed becomes unopenable
+  ([#338](https://github.com/Krzysztof318/MailFathom/pull/338)).
+  [ADR 0005](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0005-data-encryption-key-ring-and-provisioning.md)
+  records the decision.
+- The refresh token an authorization server rotates is followed and stored sealed under that ring, in the new
+  `mailbox_refresh_tokens` table, so a provider that issues a new refresh token on every exchange no longer strands an
+  account at the next restart ([#343](https://github.com/Krzysztof318/MailFathom/pull/343)).
+- Docker Compose, the Helm chart, and the native systemd unit each provision the key by the same mechanism they
+  provision every other secret, and the guides state where the file goes in each
+  ([#354](https://github.com/Krzysztof318/MailFathom/pull/354)).
+  [Secret provisioning](https://github.com/Krzysztof318/MailFathom/blob/main/docs/operations/secret-provisioning.md)
+  is the contract. **Back the key up with the database**: nothing in MailFathom regenerates it, and a database
+  restored without its key restores nothing that was sealed under it.
+
+### Changed
+
+- `MailSynchronization:Accounts:<n>:Secrets:Password` is required only when the account's permitted mechanisms include
+  a password mechanism. It was unconditionally required in `0.1.0`, which every configuration written for `0.1.0`
+  already satisfies; what changes is that an account authenticating with OAuth alone now configures no password at all
+  ([#306](https://github.com/Krzysztof318/MailFathom/pull/306)).
+
+### Security
+
+- A mailbox refresh token is held sealed in the database under the deployment's key ring rather than sitting in a
+  configuration file or a secret file that nothing rotates, and the rotation an authorization server performs is
+  followed rather than lost ([#343](https://github.com/Krzysztof318/MailFathom/pull/343)).
+- The refresh token an authorization flow produces never reaches the operator's terminal: `mfctl mailbox authorize`
+  sends it to the deployment over the administrative endpoint, so it is not in scrollback, in a shell history, or in a
+  file somebody has to remember to delete ([#356](https://github.com/Krzysztof318/MailFathom/pull/356)).
+- The administrative endpoint carries its own credentials, its own authorization servers, and its own TLS profiles, so
+  granting somebody administrative access does not grant them the MCP surface and the reverse holds
+  ([#313](https://github.com/Krzysztof318/MailFathom/pull/313),
+  [#317](https://github.com/Krzysztof318/MailFathom/pull/317)).
+
 ## [0.1.0] - 2026-08-02
 
 The first public release, and the point at which MailFathom's four public surfaces begin to promise anything. There is
@@ -160,5 +287,6 @@ is the whole surface, key by key, including which keys reload and which need a r
   [`THIRD_PARTY_LICENSES.md`](https://github.com/Krzysztof318/MailFathom/blob/main/THIRD_PARTY_LICENSES.md) registers
   every dependency it ships beside ([#173](https://github.com/Krzysztof318/MailFathom/pull/173)).
 
-[Unreleased]: https://github.com/Krzysztof318/MailFathom/compare/v0.1.0...main
+[Unreleased]: https://github.com/Krzysztof318/MailFathom/compare/v0.2.0...main
+[0.2.0]: https://github.com/Krzysztof318/MailFathom/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Krzysztof318/MailFathom/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A connected agent can list, read, and search your mail. It cannot send, delete, 
 
 ## Project status
 
-`0.1.0` is the first release: the read side that makes the product usable — mailbox queries, email content, lexical search, and the three MCP tools — on a settled database schema. It ships as a container image, a Helm chart, and the SQL script that creates the schema it expects — [where the artifacts are published](https://github.com/Krzysztof318/MailFathom#where-the-artifacts-are-published) has the references. There is no binary artifact, so a native installation starts from a checkout of this repository. [The changelog](https://github.com/Krzysztof318/MailFathom/blob/main/CHANGELOG.md) states what the release promises across the MCP tool contract, the configuration schema, the database schema, and the deployment contract.
+`0.2.0` is the current release. It builds on `0.1.0`'s read side — mailbox queries, email content, lexical search, and the three MCP tools — with OAuth mailbox authentication, push synchronization that starts a pass when the mail server says a folder changed, and an administrative endpoint an operator reaches with the `mfctl` command. It ships as a container image, a Helm chart, the SQL script that creates the schema it expects, and an `mfctl` binary per platform — [where the artifacts are published](https://github.com/Krzysztof318/MailFathom#where-the-artifacts-are-published) has the references. There is no binary artifact for the service itself, so a native installation starts from a checkout of this repository. [The changelog](https://github.com/Krzysztof318/MailFathom/blob/main/CHANGELOG.md) states what the release promises across the MCP tool contract, the configuration schema, the database schema, and the deployment contract.
 
 Nightly images are built from `main` and published to both registries alongside the releases. A nightly is not a release: its schema can be ahead of any published migration, it has no upgrade path in either direction, and it is deleted once newer ones accumulate. [What a nightly build risks](https://github.com/Krzysztof318/MailFathom/blob/main/docs/operations/container-image.md#what-a-nightly-build-risks) states the whole of it before you choose one.
 
@@ -88,6 +88,7 @@ To evaluate MailFathom from the checkout instead of deploying it, the local Aspi
 | Container image | `ghcr.io/krzysztof318/mailfathom` and `docker.io/krzysztof318/mailfathom` |
 | Helm chart | `oci://ghcr.io/krzysztof318/charts/mailfathom` |
 | Database schema script | attached to each [release](https://github.com/Krzysztof318/MailFathom/releases) |
+| `mfctl`, the administrative command | attached to each [release](https://github.com/Krzysztof318/MailFathom/releases), one self-contained binary per platform |
 
 Both registries carry the same manifest list under the same digest, so the one to pull from is whichever your environment already reaches. Every published artifact carries a signed provenance statement; [the container image](https://github.com/Krzysztof318/MailFathom/blob/main/docs/operations/container-image.md#published-images) records what each tag means and how to verify one.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,8 @@ A confirmed vulnerability is fixed on `main` and reaches you in a release that c
 
 | Version | Supported |
 |---|---|
-| `0.1.x` | Yes — the newest released minor line |
+| `0.2.x` | Yes — the newest released minor line |
+| `0.1.x` | Only by a decision recorded on the issue asking for it |
 | Any older release line | Only by a decision recorded on the issue asking for it |
 | `main`, and the `-nightly.<n>` builds from it | No. A fix lands here first, but nothing built from `main` carries a release promise |
 

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -93,9 +93,7 @@ listeners and no clear-text one stays open behind them.
 
 ## Getting the command
 
-From **0.2.0** each release attaches a self-contained binary per platform, plus one checksum file covering all of them.
-`0.1.0` predates this endpoint and attaches the schema artifact alone, so until 0.2.0 is cut the command is published
-by `dotnet publish src/Cli/Cli.csproj --configuration Release` from a checkout.
+Each release attaches a self-contained binary per platform, plus one checksum file covering all of them.
 
 Download the one for the machine you administer *from* — the command talks to a deployment over HTTP, so it does not
 have to run where the service runs.

--- a/docs/operations/database-schema.md
+++ b/docs/operations/database-schema.md
@@ -34,8 +34,8 @@ MailFathom can. [Rolling back](#rolling-back) is what that leaves.
 Read it before you run it. That is the whole reason the artifact is a SQL file rather than something that runs itself:
 
 ```bash
-sha256sum --check mailfathom-schema-0.1.0.sql.sha256
-less mailfathom-schema-0.1.0.sql
+sha256sum --check mailfathom-schema-0.2.0.sql.sha256
+less mailfathom-schema-0.2.0.sql
 ```
 
 ## The role that applies it
@@ -79,7 +79,7 @@ next statement.
 ```bash
 psql "postgresql://mailfathom_migrator@db.internal:5432/mailfathom" \
   --set ON_ERROR_STOP=on \
-  --file mailfathom-schema-0.1.0.sql
+  --file mailfathom-schema-0.2.0.sql
 ```
 
 Do not add `--single-transaction`. The script issues its own transaction statements, and psql's would nest around them.
@@ -96,7 +96,7 @@ cd deploy/compose
 docker compose exec --no-TTY postgres sh -c \
   'PGPASSWORD="$(cat /run/secrets/postgres-superuser-password)" exec psql \
      --username postgres --dbname "$MAILFATHOM_DATABASE" --set ON_ERROR_STOP=on' \
-  < mailfathom-schema-0.1.0.sql
+  < mailfathom-schema-0.2.0.sql
 ```
 
 [Deploying with Docker Compose](deployment-compose.md#starting) is where that step sits in the sequence.
@@ -111,7 +111,7 @@ kubectl --namespace databases port-forward service/postgres 5432:5432 &
 
 psql "postgresql://mailfathom_migrator@127.0.0.1:5432/mailfathom" \
   --set ON_ERROR_STOP=on \
-  --file mailfathom-schema-0.1.0.sql
+  --file mailfathom-schema-0.2.0.sql
 ```
 
 The chart renders no Job and no `initContainer` for this, deliberately. [Why the artifact is a SQL
@@ -133,7 +133,7 @@ already serving:
 
   ```bash
   PGOPTIONS='-c lock_timeout=5s' psql "postgresql://mailfathom_migrator@db.internal:5432/mailfathom" \
-    --set ON_ERROR_STOP=on --file mailfathom-schema-0.1.0.sql
+    --set ON_ERROR_STOP=on --file mailfathom-schema-0.2.0.sql
   ```
 
 - **Index creation on a large table takes time proportional to the table.** Stop MailFathom, or accept that its writes

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -111,7 +111,7 @@ and hand it the script on standard input — which also keeps the credential off
 docker compose exec --no-TTY postgres sh -c \
   'PGPASSWORD="$(cat /run/secrets/postgres-superuser-password)" exec psql \
      --username postgres --dbname "$MAILFATHOM_DATABASE" --set ON_ERROR_STOP=on' \
-  < mailfathom-schema-0.1.0.sql
+  < mailfathom-schema-0.2.0.sql
 ```
 
 Read the SQL before applying it, and take a backup first. The script is idempotent, so running it against a database

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -166,7 +166,7 @@ kubectl --namespace databases port-forward service/postgres 5432:5432 &
 
 psql "postgresql://mailfathom_migrator@127.0.0.1:5432/mailfathom" \
   --set ON_ERROR_STOP=on \
-  --file mailfathom-schema-0.1.0.sql
+  --file mailfathom-schema-0.2.0.sql
 ```
 
 The role that applies it needs privileges `database.user` does not — the `vector` extension is one an ordinary role may

--- a/docs/operations/release-procedure.md
+++ b/docs/operations/release-procedure.md
@@ -126,15 +126,16 @@ version becomes real is a decision rather than a consequence of work looking fin
 whole procedure, and it is recorded here so it survives the skill being unavailable:
 
 1. **Merge the changelog pull request.** It adds `## [x.y.z] - YYYY-MM-DD` with the release's entries, composed from
-   what merged since the previous tag, and it brings the five files that name a version in prose onto that version:
-   the **Project status** paragraph in `README.md`, the image references opening `docs/users/installation.md`, the
-   **state of the release** section in `docs/users/README.md`, the **Getting the command** section in
-   `docs/operations/admin-endpoint.md`, and the **Supported versions** table in `SECURITY.md`. It touches nothing else.
-   It merges first because **its merge commit is what gets tagged and published**, so the tagged tree contains the
-   released changelog — and the five files describing the release they ship inside — rather than describing them
-   afterwards.
+   what merged since the previous tag, and it brings the files that name a version in prose onto that version: the
+   **Project status** paragraph and the **Where the artifacts are published** table in `README.md`, the image
+   references opening `docs/users/installation.md`, the **state of the release** section in `docs/users/README.md`,
+   the `mailfathom-schema-<x.y.z>.sql` filename the apply commands quote in `docs/operations/database-schema.md`,
+   `docs/operations/deployment-compose.md`, and `docs/operations/deployment-kubernetes.md`, and the **Supported
+   versions** table in `SECURITY.md`. It touches nothing else. It merges first because **its merge commit is what gets
+   tagged and published**, so the tagged tree contains the released changelog — and the files describing the release
+   they ship inside — rather than describing them afterwards.
 
-   Those five are the whole of what `<VersionPrefix>` does not reach *by name*. Everything a build stamps derives from
+   Those are the whole of what `<VersionPrefix>` does not reach *by name*. Everything a build stamps derives from
    that one declaration; prose does not, and nothing checks it, which is why the list is stated rather than searched
    for. The skill additionally sweeps the tree for prose that describes the release *state* without naming a version —
    "no versioned artifact exists yet", "a release will attach it" — because that kind of sentence goes stale at the

--- a/docs/users/README.md
+++ b/docs/users/README.md
@@ -21,10 +21,10 @@ Two properties hold everywhere and are worth knowing before anything is installe
 
 ## The state of the release
 
-`0.1.0` is the current release. The container image is published to both registries, the Helm chart is published, and
-the schema file you apply is attached to the GitHub release — so an installation starts from a versioned artifact
-rather than from a checkout. Where a page describes something that arrives later than `0.1.0`, it says so and names
-the release, rather than describing it as though you could already download it.
+`0.2.0` is the current release. The container image is published to both registries, the Helm chart is published, and
+the schema file you apply and the `mfctl` binaries are attached to the GitHub release — so an installation starts from
+a versioned artifact rather than from a checkout. Where a page describes something that arrives later than `0.2.0`, it
+says so and names the release, rather than describing it as though you could already download it.
 
 ## The path
 

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -6,15 +6,17 @@ MailFathom runs in three shapes, and each has one authoritative guide. This page
 assumes, what it is good for, and what every shape shares. Follow the linked guide for the commands; the guides do not
 repeat each other and neither does this page.
 
-**A release publishes an image, the chart, and the schema script.** The image is
-`ghcr.io/krzysztof318/mailfathom:0.1.0` and `docker.io/krzysztof318/mailfathom:0.1.0` — one manifest list under one
+**A release publishes an image, the chart, the schema script, and the administrative command.** The image is
+`ghcr.io/krzysztof318/mailfathom:0.2.0` and `docker.io/krzysztof318/mailfathom:0.2.0` — one manifest list under one
 digest, so the registry to pull from is whichever your environment already reaches — with `latest` on that same digest.
 The chart is `oci://ghcr.io/krzysztof318/charts/mailfathom` at the same version. Each release also attaches
-`mailfathom-schema-<version>.sql` and its checksum, which is the schema step below. Both packages are public, so
-pulling one needs no login.
+`mailfathom-schema-<version>.sql` and its checksum, which is the schema step below, and one `mfctl` binary per platform
+with a checksum file covering all of them — [getting the command](../operations/admin-endpoint.md#getting-the-command)
+is where that one is picked up. Both packages are public, so pulling one needs no login.
 
-**There is no binary artifact**, so the native shape below is published from a checkout, and so is the Compose
-deployment, whose `compose.yaml` lives here and is versioned with the code that reads it.
+**There is no binary artifact for the service itself**, so the native shape below is published from a checkout, and so
+is the Compose deployment, whose `compose.yaml` lives here and is versioned with the code that reads it. `mfctl` is the
+exception, and it is a client rather than the service: it runs on the machine you administer *from*.
 
 Beside the release runs the nightly channel: `ghcr.io/krzysztof318/mailfathom:nightly` — or
 `docker.io/krzysztof318/mailfathom:nightly`, which is the same digest in the other registry — and the


### PR DESCRIPTION
Closes #359

**This is the pull request whose merge commit gets tagged `v0.2.0` and published.** It merges first; the tag goes on its merge commit; the version-bump pull request merges after the tag. Nothing here pushes a tag.

## What the release is

Composed from the 33 commits merged since `v0.1.0`, keeping what a consumer of a release would notice and dropping the refactors, tests, workflow adjustments, and documentation edits that earn no entry.

**No breaking entry.** The MCP tool contract is unchanged, every configuration key `0.1.0` accepted is still accepted and still means the same thing, and both schema migrations are additive. An upgrade is the schema step plus a new image.

| Surface | What moved |
| --- | --- |
| MCP tool contract | Nothing. `list_emails`, `get_email_content`, and `search_emails` are unchanged |
| Configuration schema | Additions only — `…:OAuth`, `…:Mode` and the four push settings, `DataEncryption`, `AdminEndpoint`, `Resilience:MailAuthorizationServerInvocation`. One relaxation: `…:Secrets:Password` is required only when a password mechanism is permitted |
| Database schema | Two additive migrations — the `mailbox_refresh_tokens` table and a nullable `synchronization_checkpoints.ReconciledThroughModSeq` column |
| Deployment contract | Each release now attaches `mfctl`, one self-contained binary per platform plus a checksum file. The data-encryption key is provisioned through Compose, Helm, and systemd |

The database paragraph states the three things a schema change owes: the migrations must be applied before `0.2.0` will serve, they can be applied while `0.1.0` is still serving, and the release deploys over `0.1.0`'s data unchanged. The startup gate reads only what is *pending*, so a database already carrying both still starts `0.1.0` — going back needs no schema step of its own. That was verified against `DatabaseSchemaStartupGate` rather than assumed.

## One defect the release ships with, stated in the changelog

#325 — a deployment that disables the probes *and* enables the administrative endpoint loses its application listener, because binding the administrative socket in code makes Kestrel ignore `ASPNETCORE_HTTP_PORTS` and only the probe path restates it. The trigger is narrow and the workaround is a default, so this is not a reason to hold the release, but an operator who hits it gets connection refusals from a host that looks healthy. The changelog names it and states the workaround rather than leaving it to be discovered.

If you would rather not ship a known defect, hold this pull request and fix #325 first — the changelog section is the only thing that would need editing.

## The files brought onto `0.2.0`

`README.md` (**Project status**, and the artifacts table, which gains the `mfctl` row), `docs/users/installation.md` (image references and what a release publishes), `docs/users/README.md` (**The state of the release**), `SECURITY.md` (`0.2.x` becomes the supported line, `0.1.x` moves down), and `docs/operations/admin-endpoint.md`, whose `from 0.2.0` threshold is dropped entirely rather than moved, because `0.2.0` is the release that attaches the binaries.

**Three files joined that list in this change**, and the list itself is edited to say so: `docs/operations/database-schema.md`, `docs/operations/deployment-compose.md`, and `docs/operations/deployment-kubernetes.md` quote `mailfathom-schema-0.1.0.sql` literally in the commands an operator copies, so a stale one checksums and applies the previous release's schema. `.agents/skills/prepare-release/SKILL.md` holds the list and `docs/operations/release-procedure.md` restates it for a reader without the skill; both are updated, which is the whole of the workflow change here.

## The release-state sweep

Seven hits, **none corrected**, which is an ordinary outcome:

| Hit | Disposition |
| --- | --- |
| `CONTRIBUTING.md:26`, `README.md:133` — "MailFathom is pre-release" | Still true. `0.x` carries no compatibility promise, per ADR 0004 |
| `.agents/skills/add-migration/SKILL.md:18`, `docs/operations/container-image.md:241`, `docs/operations/deployment-kubernetes.md:361` | Not about the release state — each states a standing rule the pattern happens to match |
| `docs/operations/release-procedure.md:140` | Quotes the sweep's own example phrases |
| `specs/2026-07-22-mail-fathom-architecture-draft.md:114` | Specification prose about compliance scope, not about a release |

`THIRD_PARTY_LICENSES.md`, `CONTRIBUTING.md`, and the root `README.md` were read with the release in mind as the skill asks. The register is current: the two packages this cycle added were registered by the pull requests that added them, and this diff introduces no dependency.

## Verification

- `scripts/verify-fast.sh` — 2564 tests, 0 failures
- `scripts/verify-full.sh` — exit 0, 871 files formatted clean
- `scripts/review-obligations.sh` — named `docs/operations/agent-workflow.md` and `docs/operations/release-procedure.md` against the skill edit; the procedure page restated the list and is corrected here, the workflow page does not enumerate it and needs nothing
- `$check-docs-licenses` — Docs: pass. Changelog: this **is** the release pull request, which is the one thing permitted to write the file. Licenses: n/a, no dependency introduced

---

**The other half of this release is #361**, which raises `VersionPrefix` to `0.3.0`. It merges *after* the `v0.2.0` tag; this one merges before it. Neither is merged alone.
