### PR TITLE
Bump main version to 0.3.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
        same assembly identity. InformationalVersion is left to the SDK, which is what composes VersionPrefix,
        VersionSuffix, and SourceRevisionId into the single string the runtime reports. -->
   <PropertyGroup>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
   </PropertyGroup>


### PR DESCRIPTION
**Merge this after the `v0.2.0` tag, not before.** #360 is the changelog pull request whose merge commit gets tagged and published; this one returns `main` to naming the *next* release once that has happened.

`<VersionPrefix>` in `Directory.Build.props` is the only place in the repository where an application version is written, so raising it is the whole diff:

- the image's tags and labels arrive as build arguments read through `scripts/read-declared-version.sh`;
- the chart's `version` and `appVersion` are both supplied at package time from the same declaration, which is why `deploy/helm/mailfathom/Chart.yaml` keeps its `0.0.0` placeholder and declares no `appVersion` — it is deliberately not touched here;
- the assembly, file, and informational versions derive from it in the same property group.

The files that name a version in prose belong to #360 rather than here, for the reason the ordering rests on: they describe the release that has just been published, and this pull request merges *after* the tag, so anything corrected here would have been wrong in the tagged tree.

Closes nothing. Bumping is what follows a release rather than what the release was for.

## Verification

`scripts/verify-full.sh` — exit 0. `scripts/read-declared-version.sh` reports `0.3.0`.
