### PR TITLE
Continue the release-notes printf with one backslash, not an escaped one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,7 +270,7 @@ jobs:
             printf 'Download the binary for the machine you administer from, not for the machine the service runs on: '
             printf '`mfctl` reaches a deployment over HTTP and runs on Linux and Windows alike. Verify it against '
             printf '`mfctl-%s.sha256`, make it executable, and run `mfctl login --endpoint https://host:port`. ' "$VERSION"
-            printf '[Administering a deployment](https://github.com/%s/blob/%s/docs/operations/admin-endpoint.md)' \\
+            printf '[Administering a deployment](https://github.com/%s/blob/%s/docs/operations/admin-endpoint.md)' \
               "$REPOSITORY" "$RELEASE_TAG"
             printf ' states what the service has to have enabled before it will answer.\n'
           } > "$notes_file"


### PR DESCRIPTION
The `v0.2.0` run failed on its last job, `Publish the GitHub release`, with exit code 127 and
`Krzysztof318/MailFathom: No such file or directory`.

The line building the `mfctl` paragraph ended with `\\`. In a YAML block scalar that reaches bash as
a literal backslash followed by a newline, not as a line continuation, so `printf` ran without its
two arguments and the following line — `"$REPOSITORY" "$RELEASE_TAG"` — was executed as a command.
Under `set -e` the whole heredoc group died before `gh release create` was ever reached, which is why
the image, the chart, and the schema artifact all published while the release itself does not exist.

One character: `\\` becomes `\`.

Verified by extracting the `run:` block and running `bash -n` over it, then generating the notes
locally against the same environment the failed job printed. The `mfctl` paragraph now renders with
both links resolved and the script exits 0.

`grep -rn '\\\\$' .github/workflows/ scripts/` finds no second occurrence, so `nightly.yml` and the
rest of the pipeline are unaffected.

The `v0.2.0` tag is being deleted so it can be pushed again on top of this fix.