### PR TITLE
[#315] Read the public scheme and host from a trusted reverse proxy

### DIFF
--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -91,6 +91,25 @@ Configure `AdminEndpoint:Https:Endpoints` to have Kestrel terminate TLS itself. 
 endpoint's does, including `HttpProtocols`, which defaults to HTTP/1.1 and HTTP/2. Naming any profile binds those
 listeners and no clear-text one stays open behind them.
 
+## Behind a TLS-terminating reverse proxy
+
+If a proxy holds your certificate, `ReverseProxy:TrustedProxies` is what makes the request state the public name it
+arrived under, which is what lets `AdminEndpoint:OAuth` discovery complete over a proxied address.
+[Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) documents the mode in
+full; three things are worth stating from this endpoint's side.
+
+- **It is one process-wide setting, not one per endpoint.** This surface is a separate listener over the same request
+  pipeline, so naming your proxy once covers it along with the MCP and probe listeners. There is no
+  `AdminEndpoint:ReverseProxy`, deliberately.
+- **`AdminEndpoint:OAuth:Resource` is unaffected.** It stays the value you wrote, still ends in `/api/admin`, and is
+  still what a token's audience is compared against. The mode never derives it from a header.
+- **A proxy that authenticates its own callers is not this endpoint's authentication.** `AdminEndpoint:Authentication`
+  still decides who may administer the service, and the clear-text warning above still fires, because the hop between
+  the proxy and this process is still clear text.
+
+Whether the proxy publishes this listener at all is your decision: the administrative port is separate from the
+application port, so a deployment can proxy the MCP surface publicly and keep this one on a network you control.
+
 ## Getting the command
 
 Each release attaches a self-contained binary per platform, plus one checksum file covering all of them.

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -273,6 +273,22 @@ Two rules are MailFathom's rather than Kestrel's:
   when they exist, and the URL-shaped addresses otherwise. A collision is reported against the section that asked for
   it rather than left to fail later as an address-in-use error naming a socket.
 
+## `ReverseProxy`
+
+Which proxy this process accepts a public scheme and host from, when something in front of it terminates TLS. One
+section for the whole process rather than one per surface: it runs at the front of the one request pipeline every
+listener shares, so a proxy named here is trusted on each of them.
+[Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) is the page.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `ReverseProxy:Enabled` | bool | `false` | Off reads neither `X-Forwarded-Proto` nor `X-Forwarded-Host` from anybody | restart |
+| `ReverseProxy:TrustedProxies` | string list | empty | Required non-empty when enabled; refused when configured while it is not. Each entry an IP address or a CIDR network whose host bits are clear — not a DNS name. The framework's loopback default is cleared rather than inherited | restart |
+| `ReverseProxy:MaximumForwardedHops` | int | `1` | At least 1; how far right-to-left through each header a value is believed | restart |
+
+`X-Forwarded-For` is never read, so the peer MailFathom observes stays the one that opened the connection, and
+`McpEndpoint:OAuth:Resource` stays a configured value rather than anything derived from a header.
+
 ## `McpEndpoint`
 
 Whether the protocol surface is served and what a client must present. The whole section is **restart** — it decides

--- a/docs/operations/container-image.md
+++ b/docs/operations/container-image.md
@@ -57,7 +57,9 @@ Linux capability.
 
 **The container speaks plain HTTP and terminates no TLS.** A certificate belongs to the reverse proxy or the ingress in
 front of it, which is also the only place one has to exist. An MCP endpoint reached over plain HTTP hands its API key
-and every message it serves to anything on the network path.
+and every message it serves to anything on the network path. Name that proxy in `ReverseProxy:TrustedProxies` so the
+public scheme and host reach the process — see
+[behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy).
 
 `DOTNET_EnableDiagnostics=0` is set, so no diagnostic IPC socket is created. That socket can request a process dump,
 and a dump is a way to read secret material out of managed memory — the residual exposure

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -157,7 +157,10 @@ no default.
 Both ports are published on **loopback** by default. MailFathom speaks plain HTTP and terminates no TLS, so publishing
 the application port on another interface exposes synchronized mail without transport protection. Change
 `MAILFATHOM_HTTP_BIND` only once a reverse proxy on the `frontend` network is what listens publicly, and give that
-proxy the certificate.
+proxy the certificate. Tell MailFathom which proxy that is — `ReverseProxy:TrustedProxies`, naming the address or the
+`frontend` subnet — so the public scheme and host survive the hop and OAuth discovery answers over your domain rather
+than `404`. [Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) is the
+page.
 
 The probe port is separate and stays loopback unless the machine asking is not this one. It answers without a
 credential, so `MAILFATHOM_HEALTH_BIND` is the whole of its access control; a probe path is never served on the

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -220,9 +220,15 @@ Every one of those is a MailFathom setting rather than a chart value, so turning
 | --- | --- | --- |
 | API keys | `McpEndpoint:Authentication` and `McpEndpoint:ApiKeys` | [Authentication](mcp-endpoint.md#authentication) |
 | An `Origin` gate | `McpEndpoint:Cors` | [CORS and the `Origin` header](mcp-endpoint.md#cors-and-the-origin-header) |
+| Reading the public scheme and host from the ingress | `ReverseProxy:Enabled` and `ReverseProxy:TrustedProxies` | [Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) |
 | TLS terminated by the pod itself | `McpEndpoint:Https:Endpoints` | [HTTPS and your own domain](mcp-endpoint.md#https-and-your-own-domain) |
 | Client certificates | `McpEndpoint:ClientCertificateProfiles` | [Client certificates](mcp-endpoint.md#client-certificates) |
 | Rate limits | `McpEndpoint:RateLimiting` | [Rate limiting](mcp-endpoint.md#rate-limiting) |
+
+The ingress row is the one an OAuth deployment cannot skip. The controller terminates TLS and dials the pod over plain
+HTTP under the Service name, so without it the protected resource metadata document answers `404` and discovery never
+completes. `TrustedProxies` then names the pod CIDR the ingress controller runs in, which
+`kubectl cluster-info dump | grep -m1 cluster-cidr` reports on most distributions.
 
 Configuring `Https:Endpoints` takes over the host's application listener, so the chart's `service.port` and the `http`
 container port have to match what the profiles bind. The probe listener is unaffected and keeps its own transport. That is a deliberate step rather than the default: in a cluster, TLS at the ingress is

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -189,7 +189,9 @@ from the request. It is published in the metadata document, a client copies it i
 a token, and every token's audience is compared against it — which is what stops a token issued for some other service on the
 same authorization server from being replayed here. Behind a reverse proxy, write the proxy's public URL: deriving it from
 the `Host` or `X-Forwarded-Host` header would tell each client to authenticate for whichever name it arrived under, including
-one an attacker chose.
+one an attacker chose. That stays true with
+[a trusted proxy configured](#behind-a-tls-terminating-reverse-proxy) — the mode makes a request state the name it
+arrived under, and leaves the resource identifier a value you wrote.
 
 **`Issuer` is copied verbatim from the authorization server**, trailing slash included where there is one. It is compared
 against a token's `iss` by exact string equality and checked against the `issuer` the discovery document reports. Several
@@ -292,12 +294,12 @@ Neither response says why. An expired token, a wrong audience, an unknown issuer
 the client; the server log is where they differ.
 
 > **The metadata document is served only to a request whose own scheme and host match `Resource`.** That is the MCP SDK's
-> check, and it is what stops the document being served under a name the deployment never claimed. A deployment where
-> MailFathom terminates TLS itself, or one behind a proxy that passes HTTPS through with the `Host` header intact, satisfies
-> it; a proxy that terminates TLS does not, because the request then arrives as `http` and no forwarded header changes
-> that — MailFathom does not process `X-Forwarded-Proto` or `X-Forwarded-Host` today, so nothing on either side configures
-> it away. A `404` on the metadata address with everything else working is this, and OAuth discovery cannot complete
-> until the deployment is one of the two shapes above.
+> check, and it is what stops the document being served under a name the deployment never claimed. Three deployments
+> satisfy it: MailFathom terminating TLS itself, a proxy that passes HTTPS through with the `Host` header intact, and a
+> TLS-terminating proxy that MailFathom has been told to trust — see
+> [behind a TLS-terminating reverse proxy](#behind-a-tls-terminating-reverse-proxy). Without that third setting the
+> request from such a proxy arrives as `http` under an internal name, nothing matches, and a `404` on the metadata
+> address with everything else working is what an operator sees.
 
 #### What the MCP client does, not MailFathom
 
@@ -480,6 +482,22 @@ warn: MailFathom.Host.Hosting.Warnings.McpTransportEncryptionWarning
 
 It fires whatever authentication mode is configured. An API key travels in a request header, so on a clear-text hop the
 credential is as readable as the mail it protects.
+
+Once [a trusted proxy is named](#behind-a-tls-terminating-reverse-proxy), the same warning stops guessing between those
+two deployments and describes the one you configured:
+
+```text
+warn: MailFathom.Host.Hosting.Warnings.McpTransportEncryptionWarning
+      The MCP endpoint is enabled on /mcp behind the 1 trusted reverse proxy source(s) ReverseProxy:TrustedProxies
+      names, so the hop this process serves is the one between that proxy and here and TLS to your clients is the
+      proxy's to terminate. Keep that hop inside a network you control: on it, anything on the path can read the API
+      key a client presents and every message the tools return. A client certificate still never arrives, because the
+      handshake ended at the proxy.
+```
+
+The clear-text hop is still stated, because it is still there. What changes is that the line no longer suggests
+configuring `McpEndpoint:Https:Endpoints`, which is the wrong advice for a deployment whose certificate lives on the
+proxy.
 
 ### One domain
 
@@ -719,6 +737,102 @@ MailFathom. It has no ACME client and issues nothing. Startup only refuses a `Do
 an IP address, a wildcard, a name with characters a DNS name cannot carry, or a name a second profile already publishes.
 An internationalized domain is configured in its punycode A-label form, because that is what a client sends and what a
 certificate's names carry.
+
+## Behind a TLS-terminating reverse proxy
+
+When nginx, Traefik, or an ingress controller holds your certificate, the request that reaches MailFathom arrives as
+`http` under whichever internal name the proxy dialled. Your deployment's public identity survives the hop only in
+`X-Forwarded-Proto` and `X-Forwarded-Host`, and MailFathom reads neither until you say which proxy it may read them
+from:
+
+```json
+{
+  "ReverseProxy": {
+    "Enabled": true,
+    "TrustedProxies": [ "10.4.0.0/16" ]
+  }
+}
+```
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `Enabled` | `false` | Whether a forwarded scheme and host are read at all |
+| `TrustedProxies` | empty | The proxy addresses or CIDR networks they are accepted from; required when enabled |
+| `MaximumForwardedHops` | `1` | How many proxies may have appended a value to either header |
+
+The mode applies the forwarded scheme and host to the request before anything reads it, so OAuth discovery, the `401`
+challenge, and every absolute address MailFathom writes carry your public name. Turning it on is what makes the
+metadata document answer behind such a proxy instead of `404` — see
+[discovery a client uses](#discovery-a-client-uses).
+
+**It is one setting for the whole process, not one per endpoint.** The MCP, administrative, and probe surfaces are
+separate listeners over one request pipeline, and this runs at the front of that pipeline. A trusted proxy is therefore
+trusted on every listener it can reach, which is what a network fact should be: you state where your proxy is once
+rather than restating it beside each surface.
+
+**Trust is the connection, never the header.** A forwarded value is worth exactly what the peer that sent it is worth,
+so a request from any address outside `TrustedProxies` is served under the scheme and host it actually arrived with, and
+its `X-Forwarded-*` headers change nothing. Enabling the mode without naming a proxy fails startup rather than falling
+back to anything:
+
+```text
+ReverseProxy:TrustedProxies — a forwarded scheme and host are worth what the connection that carried them is worth, so
+an enabled section must name the proxy it accepts them from. State one or more IP addresses or CIDR networks, for
+example '10.0.0.5' or '10.0.0.0/24'.
+```
+
+The framework's own default — trusting loopback — is cleared rather than inherited, because loopback is the wrong peer
+in a container and every other process on the machine in a native installation. `10.0.0.5/24` is refused too, naming
+the `10.0.0.0/24` it would otherwise have silently become; write the address or write the network, and the deployment
+gets what it asked for.
+
+**Only the two headers are read.** `X-Forwarded-For` is not, so the peer MailFathom observes stays the one that opened
+the connection. Nothing here partitions, limits, or logs by client address, so adopting one from a header would replace
+an observed fact with a claim and buy nothing. Each header is read right to left, and `MaximumForwardedHops` says how
+far back the chain is believed — raise it only to the number of proxies a request genuinely passes through. A value
+that parses as no scheme or no host is discarded and the request keeps what it arrived with for that component; nothing
+is half-read out of it.
+
+A worked nginx location, with `Host` preserved as well so the deployment works whichever of the two MailFathom ends up
+reading:
+
+```nginx
+location /mcp {
+    proxy_pass         http://10.4.2.11:8080;
+    proxy_http_version 1.1;
+    proxy_set_header   Host              $host;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_set_header   X-Forwarded-Host  $host;
+    proxy_buffering    off;
+}
+```
+
+`proxy_buffering off` is what lets the Streamable HTTP response stream rather than arrive at the end.
+
+### What the proxy owns in this mode
+
+- **TLS and the certificate.** `McpEndpoint:Https:Endpoints` stays empty, because a second TLS layer inside the trust
+  boundary protects nothing. `Domain` on an HTTPS profile selects the certificate *MailFathom* presents, so a
+  deployment in this mode configures none.
+- **Redirecting a clear-text client to HTTPS**, which belongs to whichever side faces the client rather than to both.
+
+### What MailFathom keeps owning
+
+- **Authentication.** A proxy that authenticates its own callers is not this endpoint's authentication. `Authentication`
+  still decides who reads the owner's mail, and `OAuth.AuthorizationServers[n].AuthorizedSubjects` still decides whose
+  tokens are served.
+- **`OAuth.Resource`.** It stays required and stays the identifier a token's audience is compared against. Nothing an
+  upstream writes reaches it, which is the property that keeps a client from ever being told to authorize for a name an
+  attacker chose.
+- **CORS.** The response headers a browser reads are written here, so `Cors.AllowedOrigins` is still what decides them.
+- **Rate limiting**, which keeps reading no address at all — neither forwarded nor remote. See
+  [whose capacity a request spends](#whose-capacity-a-request-spends).
+
+### What becomes unreachable
+
+**Client certificates.** The TLS handshake ended at the proxy, so no certificate reaches this process, and no header is
+read as a substitute. `McpEndpoint:ClientCertificateProfiles` is therefore not a posture a TLS-terminating proxy can be
+combined with — the next section says the same thing from the other side.
 
 ## Client certificates
 

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -177,7 +177,9 @@ with a startup warning, because an unauthenticated endpoint serves your mailbox 
 origins, serving your own domain over TLS, client certificates, and the rate limits that apply out of the box.
 
 MailFathom itself serves plain HTTP unless its own TLS termination is configured, so keep the application port on
-loopback or behind a TLS-terminating proxy — the Compose deployment's default — and give the proxy the certificate.
+loopback or behind a TLS-terminating proxy — the Compose deployment's default — and give the proxy the certificate. If
+you put a proxy in front, name it in `ReverseProxy:TrustedProxies` as well, so the public scheme and host survive the
+hop: [behind a TLS-terminating reverse proxy](../operations/mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy).
 
 ## 7. Connect an MCP client
 

--- a/src/Host/Configuration/Endpoints/ReverseProxyOptions.cs
+++ b/src/Host/Configuration/Endpoints/ReverseProxyOptions.cs
@@ -1,0 +1,189 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+
+namespace MailFathom.Host.Configuration.Endpoints;
+
+/// <summary>Configures which reverse proxy this process accepts a public scheme and host from.</summary>
+/// <remarks>
+/// <para>
+/// Behind a proxy that terminates TLS, the request arrives as <c>http</c> under whichever internal name the proxy
+/// dialled, and the deployment's public identity reaches this process only as <c>X-Forwarded-Proto</c> and
+/// <c>X-Forwarded-Host</c>. Applying those two makes the request true: OAuth discovery, the authentication challenge,
+/// and every address composed from a request agree with the name a client actually used.
+/// </para>
+/// <para>
+/// It changes nothing about who declares the deployment's identity. A resource identifier stays a configured value
+/// compared against a token's audience, never a header, so nothing an upstream writes can decide what a client is told
+/// to authorize for. What a forwarded header settles is which name this request arrived under, which is a fact about
+/// the hop rather than a claim about the deployment.
+/// </para>
+/// <para>
+/// One section for the whole process rather than one per surface. The MCP, administrative, and probe surfaces are
+/// separate listeners over one request pipeline, and a forwarded header is applied by middleware in that pipeline
+/// before any surface's routing runs — so a per-surface setting would carry three copies of one network fact, which
+/// proxy this deployment sits behind, and leave an operator to keep them in step. Trust here is a property of what
+/// stands in front of the process, so it is stated once and holds on every listener the named proxy can reach.
+/// </para>
+/// <para>
+/// The section is read once, while the host is being composed, because it decides which middleware the pipeline
+/// carries. A change takes effect on restart.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed class ReverseProxyOptions
+{
+    /// <summary>The configuration section the reverse-proxy settings are bound from.</summary>
+    public const string SectionName = "ReverseProxy";
+
+    /// <summary>Gets or sets whether a forwarded scheme and host are read at all.</summary>
+    /// <remarks>
+    /// Off unless a deployment states otherwise, so a process nobody put a proxy in front of ignores both headers
+    /// entirely. A forwarded header is a value whoever is upstream wrote, and a deployment reachable directly has no
+    /// upstream worth believing.
+    /// </remarks>
+    public bool Enabled { get; set; }
+
+    /// <summary>Gets the proxy addresses or CIDR networks a forwarded scheme and host are accepted from.</summary>
+    /// <remarks>
+    /// <para>
+    /// One list rather than an address list beside a network list, because an operator answering "which proxy do I
+    /// trust" writes <c>10.0.0.5</c> or <c>10.0.0.0/24</c> to the same question. A value carrying <c>/</c> is read as a
+    /// network and everything else as a single address.
+    /// </para>
+    /// <para>
+    /// Empty is not a permitted posture for an enabled section. The framework's own default trusts loopback, which is
+    /// wrong inside a container where the proxy is a peer on the pod or bridge network, and the usual workaround of
+    /// clearing its lists trusts every peer that can open a connection — which is worse than the problem it solves.
+    /// </para>
+    /// </remarks>
+    public IList<string> TrustedProxies { get; } = [];
+
+    /// <summary>Gets or sets how many proxies may have appended a value to the forwarded headers.</summary>
+    /// <remarks>
+    /// One by default, which is the deployment this mode exists for: a single proxy in front of this process. Each
+    /// header is read right to left, so the limit is how far back into a chain a value is believed; raise it only to
+    /// the number of proxies a request genuinely passes through, because every entry beyond the real chain is one an
+    /// earlier hop could have appended.
+    /// </remarks>
+    public int MaximumForwardedHops { get; set; } = 1;
+
+    /// <summary>Reads the section the way composition does, defaults included.</summary>
+    /// <param name="configuration">The application configuration.</param>
+    /// <returns>The bound settings.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
+    /// <remarks>Strict binding is part of the read, like every other security-sensitive section: a misspelled key here would leave a deployment believing it had named its proxy while nothing was trusted, or believing a chain limit applied that never bound.</remarks>
+    public static ReverseProxyOptions ReadFrom(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return configuration.GetSection(SectionName)
+            .Get<ReverseProxyOptions>(binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
+            ?? new ReverseProxyOptions();
+    }
+
+    /// <summary>Finds everything an operator must fix before a forwarded scheme and host can be read.</summary>
+    /// <returns>One message per faulty setting, each naming its configuration path, empty when the settings are usable.</returns>
+    public IReadOnlyList<string> FindConfigurationErrors()
+    {
+        if (!this.Enabled)
+        {
+            // Configured-but-unread is refused rather than ignored, for the reason every other section refuses it: an
+            // operator who named their proxy and left the mode off has a deployment they believe reads a forwarded
+            // header and one that does not.
+            return this.TrustedProxies.Count == 0
+                ? []
+                : [$"{SectionName}:{nameof(this.TrustedProxies)} — proxies are configured while '{nameof(this.Enabled)}' is false, so no forwarded header is read from any of them; enable the section or remove them."];
+        }
+
+        var errors = new List<string>();
+
+        if (this.TrustedProxies.Count == 0)
+        {
+            errors.Add($"{SectionName}:{nameof(this.TrustedProxies)} — a forwarded scheme and host are worth what the connection that carried them is worth, so an enabled section must name the proxy it accepts them from. State one or more IP addresses or CIDR networks, for example '10.0.0.5' or '10.0.0.0/24'.");
+        }
+
+        errors.AddRange(this.FindTrustedProxyErrors());
+
+        if (this.MaximumForwardedHops < 1)
+        {
+            errors.Add($"{SectionName}:{nameof(this.MaximumForwardedHops)} — '{this.MaximumForwardedHops}' reads no forwarded value at all, which is what disabling the section already does. State the number of proxies a request passes through, which is 1 for a single proxy in front of this process.");
+        }
+
+        return errors;
+    }
+
+    /// <summary>Maps the configured entries onto the single proxy addresses among them.</summary>
+    /// <returns>The addresses, in configuration order, empty when every entry names a network.</returns>
+    /// <exception cref="FormatException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
+    public IReadOnlyList<IPAddress> ToTrustedProxyAddresses() =>
+        [.. this.TrustedProxies.Select(Normalize).Where(static entry => !NamesNetwork(entry)).Select(IPAddress.Parse)];
+
+    /// <summary>Maps the configured entries onto the proxy networks among them.</summary>
+    /// <returns>The networks, in configuration order, empty when every entry names a single address.</returns>
+    /// <exception cref="FormatException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
+    public IReadOnlyList<IPNetwork> ToTrustedProxyNetworks() =>
+        [.. this.TrustedProxies.Select(Normalize).Where(NamesNetwork).Select(IPNetwork.Parse)];
+
+    private static bool NamesNetwork(string entry) => entry.Contains('/', StringComparison.Ordinal);
+
+    /// <summary>Refuses a prefix that is not a network, and one that names a host inside a network rather than the network.</summary>
+    /// <remarks>
+    /// The framework's parser accepts a base address whose host bits are set and silently masks them off, so
+    /// <c>10.0.0.5/24</c> would bind as <c>10.0.0.0/24</c>: an operator who meant to trust one proxy would have trusted
+    /// two hundred and fifty-six addresses without being told. The base address is therefore compared against what the
+    /// parse produced, which is the same comparison that catches an IPv6 prefix written one bit too wide.
+    /// </remarks>
+    private static IEnumerable<string> FindNetworkErrors(string entry, string entryPath)
+    {
+        var configuredBaseAddress = entry[..entry.IndexOf('/', StringComparison.Ordinal)];
+
+        if (!IPNetwork.TryParse(entry, out var network) || !IPAddress.TryParse(configuredBaseAddress, out var baseAddress))
+        {
+            yield return $"{entryPath} — '{entry}' is not a CIDR network; state a network address and its prefix length, for example '10.0.0.0/24'.";
+
+            yield break;
+        }
+
+        if (!network.BaseAddress.Equals(baseAddress))
+        {
+            yield return $"{entryPath} — '{entry}' names an address inside '{network}' rather than the network itself. Write '{network}' to trust that whole range, or drop the prefix to trust the one address.";
+        }
+    }
+
+    private static string Normalize(string? entry) => entry?.Trim() ?? string.Empty;
+
+    private IEnumerable<string> FindTrustedProxyErrors()
+    {
+        foreach (var (index, configuredEntry) in this.TrustedProxies.Index())
+        {
+            var entryPath = $"{SectionName}:{nameof(this.TrustedProxies)}:{index}";
+            var entry = Normalize(configuredEntry);
+
+            if (entry.Length == 0)
+            {
+                yield return $"{entryPath} — an empty entry names no proxy; state an IP address such as '10.0.0.5' or a CIDR network such as '10.0.0.0/24', or remove it.";
+
+                continue;
+            }
+
+            if (NamesNetwork(entry))
+            {
+                foreach (var error in FindNetworkErrors(entry, entryPath))
+                {
+                    yield return error;
+                }
+
+                continue;
+            }
+
+            if (!IPAddress.TryParse(entry, out _))
+            {
+                yield return $"{entryPath} — '{entry}' is neither an IP address nor a CIDR network. A proxy is trusted by the address its connection arrives from, so a DNS name cannot stand in for one.";
+            }
+        }
+    }
+}

--- a/src/Host/Hosting/Warnings/McpTransportEncryptionWarning.cs
+++ b/src/Host/Hosting/Warnings/McpTransportEncryptionWarning.cs
@@ -15,8 +15,14 @@ namespace MailFathom.Host.Hosting.Warnings;
 /// Serving the endpoint over clear text is a supported posture rather than a mistake, which is why this reports and
 /// does not refuse. Two deployments run it deliberately: local development, where the endpoint is reachable only from
 /// the machine it runs on, and a deployment behind a TLS-terminating reverse proxy, where the proxy already holds the
-/// operator's certificate and a second TLS layer inside the trust boundary protects nothing. Only an operator knows
-/// which of those they have, and neither is something MailFathom can detect.
+/// operator's certificate and a second TLS layer inside the trust boundary protects nothing.
+/// </para>
+/// <para>
+/// Which of the two is running stopped being something only the operator knows once a trusted proxy could be named. A
+/// configured <see cref="ReverseProxyOptions" /> section is the operator saying what stands in front, so the warning
+/// then describes that deployment — the clear-text hop is the one between the proxy and this process — instead of
+/// listing the postures it would otherwise have to guess between. Nothing is silenced by it: that hop is real, and an
+/// API key crossing it is as readable as it was.
 /// </para>
 /// <para>
 /// What it refuses to let happen is the third case: an endpoint reachable across a network that nobody meant to expose
@@ -34,26 +40,42 @@ namespace MailFathom.Host.Hosting.Warnings;
 internal sealed partial class McpTransportEncryptionWarning : IHostedService
 {
     private readonly McpEndpointOptions endpointSettings;
+    private readonly ReverseProxyOptions reverseProxySettings;
     private readonly ILogger<McpTransportEncryptionWarning> logger;
 
     /// <summary>Initializes a new startup warning.</summary>
     /// <param name="endpointSettings">The endpoint settings startup was composed from.</param>
+    /// <param name="reverseProxySettings">The reverse-proxy settings startup was composed from, which say whether the operator has named what stands in front.</param>
     /// <param name="logger">The startup logger.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpointSettings" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpointSettings" /> or <paramref name="reverseProxySettings" /> is <see langword="null" />.</exception>
     public McpTransportEncryptionWarning(
         IOptions<McpEndpointOptions> endpointSettings,
+        IOptions<ReverseProxyOptions> reverseProxySettings,
         ILogger<McpTransportEncryptionWarning> logger)
     {
         ArgumentNullException.ThrowIfNull(endpointSettings);
+        ArgumentNullException.ThrowIfNull(reverseProxySettings);
 
         this.endpointSettings = endpointSettings.Value;
+        this.reverseProxySettings = reverseProxySettings.Value;
         this.logger = logger;
     }
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        if (this.endpointSettings is { Enabled: true, Https.TerminatesTls: false })
+        if (this.endpointSettings is not { Enabled: true, Https.TerminatesTls: false })
+        {
+            return Task.CompletedTask;
+        }
+
+        if (this.reverseProxySettings.Enabled)
+        {
+            this.LogEndpointServedBehindTrustedReverseProxy(
+                McpEndpointRoute.Path,
+                this.reverseProxySettings.TrustedProxies.Count);
+        }
+        else
         {
             this.LogEndpointServedWithoutTransportEncryption(McpEndpointRoute.Path);
         }
@@ -74,4 +96,13 @@ internal sealed partial class McpTransportEncryptionWarning : IHostedService
             + "anywhere else, configure McpEndpoint:Https:Endpoints so this process presents your domain's certificate "
             + "itself.")]
     private partial void LogEndpointServedWithoutTransportEncryption(string mcpEndpointPath);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The MCP endpoint is enabled on {McpEndpointPath} behind the {TrustedProxyCount} trusted reverse "
+            + "proxy source(s) ReverseProxy:TrustedProxies names, so the hop this process serves is the one between "
+            + "that proxy and here and TLS to your clients is the proxy's to terminate. Keep that hop inside a network "
+            + "you control: on it, anything on the path can read the API key a client presents and every message the "
+            + "tools return. A client certificate still never arrives, because the handshake ended at the proxy.")]
+    private partial void LogEndpointServedBehindTrustedReverseProxy(string mcpEndpointPath, int trustedProxyCount);
 }

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -273,6 +273,27 @@ try
     builder.Services.AddHostedService(provider => OpenSslConfigurationWarning.FromEnvironment(
         provider.GetRequiredService<ILogger<OpenSslConfigurationWarning>>()));
 
+    // Read before the surfaces, because it is the one posture they all sit behind: which proxy, if any, this process
+    // accepts a public scheme and host from. Read once for the same reason every section below is — it decides which
+    // middleware the pipeline carries, and the encryption warning states the posture this settles.
+    var reverseProxySettings = ReverseProxyOptions.ReadFrom(builder.Configuration);
+    builder.Services.AddSingleton(Options.Create(reverseProxySettings));
+
+    var reverseProxyConfigurationErrors = reverseProxySettings.FindConfigurationErrors();
+
+    if (reverseProxyConfigurationErrors.Count > 0)
+    {
+        throw new OptionsValidationException(
+            ReverseProxyOptions.SectionName,
+            typeof(ReverseProxyOptions),
+            reverseProxyConfigurationErrors);
+    }
+
+    if (reverseProxySettings.Enabled)
+    {
+        builder.Services.AddTrustedReverseProxy(reverseProxySettings);
+    }
+
     // Read once and registered, so the value that decides the route is the one every consumer resolves. Whether the
     // endpoint exists is decided while the application is being built, before a container that could resolve a snapshot
     // exists, and a second read of a reloadable source could otherwise map the endpoint from one value while the missing
@@ -498,6 +519,15 @@ try
     // One authorization middleware serves every endpoint that requires it, and either endpoint may be the one that
     // adds it. Adding it twice would run every policy twice.
     var authorizationMiddlewareAdded = false;
+
+    // First, ahead of the exception handler and of every isolation check, so that nothing downstream ever reads a
+    // scheme or host the proxy already corrected. Discovery, the challenge, and any address composed from a request
+    // then agree with the name the client used, and a request from anything but a trusted proxy passes through with
+    // the scheme and host it arrived under.
+    if (reverseProxySettings.Enabled)
+    {
+        app.UseForwardedHeaders();
+    }
 
     app.UseExceptionHandler();
 

--- a/src/Host/Security/Transport/TrustedReverseProxyExtensions.cs
+++ b/src/Host/Security/Transport/TrustedReverseProxyExtensions.cs
@@ -1,0 +1,64 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Endpoints;
+using Microsoft.AspNetCore.HttpOverrides;
+
+namespace MailFathom.Host.Security.Transport;
+
+/// <summary>Composes the rule under which a forwarded scheme and host are applied to a request.</summary>
+/// <remarks>
+/// <para>
+/// The platform's own forwarded-headers middleware does the work, and this states the policy it runs under. Two of
+/// its defaults are deliberately replaced rather than accepted: it trusts loopback, which is the wrong peer inside a
+/// container, and it processes <c>X-Forwarded-For</c> when asked to, which this deployment never asks for.
+/// </para>
+/// <para>
+/// The client address is out of scope on purpose. Nothing here partitions, limits, or logs by remote address, so
+/// rewriting <see cref="ConnectionInfo.RemoteIpAddress" /> from a header would replace the
+/// one address this process observes for itself — the peer that opened the connection — with one an upstream wrote,
+/// and buy nothing for it.
+/// </para>
+/// </remarks>
+internal static class TrustedReverseProxyExtensions
+{
+    /// <summary>Adds the policy under which a trusted proxy's forwarded scheme and host reach the request.</summary>
+    /// <param name="services">The container to add to.</param>
+    /// <param name="reverseProxySettings">The reverse-proxy settings composition read.</param>
+    /// <returns>The container, so composition reads as one sequence.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services" /> or <paramref name="reverseProxySettings" /> is <see langword="null" />.</exception>
+    /// <exception cref="FormatException">Thrown when the settings have not passed <see cref="ReverseProxyOptions.FindConfigurationErrors" />.</exception>
+    internal static IServiceCollection AddTrustedReverseProxy(
+        this IServiceCollection services,
+        ReverseProxyOptions reverseProxySettings)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(reverseProxySettings);
+
+        var trustedAddresses = reverseProxySettings.ToTrustedProxyAddresses();
+        var trustedNetworks = reverseProxySettings.ToTrustedProxyNetworks();
+
+        return services.Configure<ForwardedHeadersOptions>(forwardedHeaders =>
+        {
+            forwardedHeaders.ForwardedHeaders = ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost;
+            forwardedHeaders.ForwardLimit = reverseProxySettings.MaximumForwardedHops;
+
+            // Both lists arrive holding loopback. Left in place, a deployment that named its ingress controller would
+            // also believe anything on the machine, which is the whole of a shared host in a native installation and
+            // every sidecar in a pod.
+            forwardedHeaders.KnownProxies.Clear();
+            forwardedHeaders.KnownIPNetworks.Clear();
+
+            foreach (var address in trustedAddresses)
+            {
+                forwardedHeaders.KnownProxies.Add(address);
+            }
+
+            foreach (var network in trustedNetworks)
+            {
+                forwardedHeaders.KnownIPNetworks.Add(network);
+            }
+        });
+    }
+}

--- a/tests/Host.UnitTests/Configuration/Endpoints/ReverseProxyOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/ReverseProxyOptionsBindingTests.cs
@@ -1,0 +1,80 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Endpoints;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Endpoints;
+
+/// <summary>Covers that the reverse-proxy section binds from configuration the way composition reads it.</summary>
+/// <remarks>
+/// The section decides whose forwarded scheme and host this process believes, so a key that was ignored rather than
+/// bound is a deployment trusting something other than what its operator wrote. Strict binding turns a misspelling
+/// into a startup failure, and that is asserted here rather than assumed.
+/// </remarks>
+public sealed class ReverseProxyOptionsBindingTests
+{
+    [Fact]
+    public void ReadFrom_AnEmptyConfiguration_ReadsNoForwardedHeader()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom([]);
+
+        // Act
+        var options = ReverseProxyOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.False(options.Enabled);
+        Assert.Empty(options.TrustedProxies);
+        Assert.Equal(1, options.MaximumForwardedHops);
+    }
+
+    [Fact]
+    public void ReadFrom_AConfiguredSection_ReadsEveryDecisionCompositionActsOn()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["ReverseProxy:Enabled"] = "true",
+            ["ReverseProxy:TrustedProxies:0"] = "10.4.0.0/16",
+            ["ReverseProxy:TrustedProxies:1"] = "192.168.1.10",
+            ["ReverseProxy:MaximumForwardedHops"] = "2",
+        });
+
+        // Act
+        var options = ReverseProxyOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.True(options.Enabled);
+        Assert.Equal(["10.4.0.0/16", "192.168.1.10"], options.TrustedProxies);
+        Assert.Equal(2, options.MaximumForwardedHops);
+        Assert.Empty(options.FindConfigurationErrors());
+    }
+
+    /// <summary>
+    /// A misspelled key that bound quietly would leave a deployment believing it had named its proxy while nothing was
+    /// trusted, which reads as OAuth discovery still failing behind a proxy that was configured correctly. The singular
+    /// is the plausible mistake, because a deployment with one proxy in front is what this mode is for.
+    /// </summary>
+    [Fact]
+    public void ReadFrom_AMisspelledKey_FailsRatherThanBindingTheRest()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["ReverseProxy:Enabled"] = "true",
+            ["ReverseProxy:TrustedProxy:0"] = "10.0.0.5",
+        });
+
+        // Act
+        var readingTheSection = () => ReverseProxyOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(readingTheSection);
+    }
+
+    private static IConfiguration ConfigurationFrom(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+}

--- a/tests/Host.UnitTests/Configuration/Endpoints/ReverseProxyOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/ReverseProxyOptionsTests.cs
@@ -1,0 +1,228 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using MailFathom.Host.Configuration.Endpoints;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Endpoints;
+
+/// <summary>Covers which reverse-proxy settings an operator is allowed to start the host on.</summary>
+/// <remarks>
+/// A forwarded scheme and host are worth what the connection carrying them is worth, so the refusals here are what
+/// keep the mode from ever running on an unstated trust: enabling it without naming a proxy, and naming one that is
+/// neither an address nor a network.
+/// </remarks>
+public sealed class ReverseProxyOptionsTests
+{
+    [Fact]
+    public void FindConfigurationErrors_DisabledSection_FindsNothing()
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions();
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>An operator who named their proxy and left the mode off has a deployment that reads no forwarded header.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ProxiesConfiguredWhileDisabled_RefusesTheUnreadSetting()
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions();
+        settings.TrustedProxies.Add("10.0.0.5");
+
+        // Act
+        var error = Assert.Single(settings.FindConfigurationErrors());
+
+        // Assert
+        Assert.Contains("ReverseProxy:TrustedProxies", error, StringComparison.Ordinal);
+        Assert.Contains("Enabled", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>The refusal that keeps the framework's loopback default, and a trust-everything workaround, both out of reach.</summary>
+    [Fact]
+    public void FindConfigurationErrors_EnabledWithNoProxyNamed_RefusesStartup()
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions { Enabled = true };
+
+        // Act
+        var error = Assert.Single(settings.FindConfigurationErrors());
+
+        // Assert
+        Assert.Contains("ReverseProxy:TrustedProxies", error, StringComparison.Ordinal);
+        Assert.Contains("CIDR", error, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("10.0.0.5")]
+    [InlineData("  10.0.0.5  ")]
+    [InlineData("10.0.0.0/24")]
+    [InlineData("2001:db8::1")]
+    [InlineData("2001:db8::/32")]
+    public void FindConfigurationErrors_ProxyNamedAsAnAddressOrNetwork_FindsNothing(string trustedProxy)
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions { Enabled = true };
+        settings.TrustedProxies.Add(trustedProxy);
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>A DNS name resolves to whatever answers today, and the peer is judged by the address its connection arrives from.</summary>
+    [Theory]
+    [InlineData("ingress.example.test")]
+    [InlineData("10.0.0.999")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FindConfigurationErrors_ProxyNamingNoAddress_RefusesTheEntryByIndex(string trustedProxy)
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions { Enabled = true };
+        settings.TrustedProxies.Add(trustedProxy);
+
+        // Act
+        var error = Assert.Single(settings.FindConfigurationErrors());
+
+        // Assert
+        Assert.Contains("ReverseProxy:TrustedProxies:0", error, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("10.0.0.0/64")]
+    [InlineData("10.0.0.0/")]
+    [InlineData("ingress.example.test/24")]
+    public void FindConfigurationErrors_MalformedNetwork_RefusesTheEntry(string trustedProxy)
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions { Enabled = true };
+        settings.TrustedProxies.Add(trustedProxy);
+
+        // Act
+        var error = Assert.Single(settings.FindConfigurationErrors());
+
+        // Assert
+        Assert.Contains("ReverseProxy:TrustedProxies:0", error, StringComparison.Ordinal);
+        Assert.Contains("not a CIDR network", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The framework's parser masks host bits off without saying so, which would turn an operator's one proxy into
+    /// every address on its subnet. The refusal names the range they would have got, so the choice stays theirs.
+    /// </summary>
+    [Theory]
+    [InlineData("10.0.0.5/24", "10.0.0.0/24")]
+    [InlineData("2001:db8::1/32", "2001:db8::/32")]
+    public void FindConfigurationErrors_NetworkNamingAHostInsideIt_RefusesTheSilentWidening(
+        string trustedProxy,
+        string widenedNetwork)
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions { Enabled = true };
+        settings.TrustedProxies.Add(trustedProxy);
+
+        // Act
+        var error = Assert.Single(settings.FindConfigurationErrors());
+
+        // Assert
+        Assert.Contains("ReverseProxy:TrustedProxies:0", error, StringComparison.Ordinal);
+        Assert.Contains(widenedNetwork, error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_SeveralFaultyEntries_ReportsEachByItsOwnIndex()
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions { Enabled = true };
+        settings.TrustedProxies.Add("10.0.0.5");
+        settings.TrustedProxies.Add("ingress.example.test");
+        settings.TrustedProxies.Add("10.0.0.5/24");
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        Assert.Equal(2, errors.Count);
+        Assert.Contains(errors, error => error.Contains("TrustedProxies:1", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("TrustedProxies:2", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MaximumForwardedHops_UnconfiguredSection_BelievesOneProxy()
+    {
+        // Arrange
+        // Act
+        var settings = new ReverseProxyOptions();
+
+        // Assert
+        Assert.Equal(1, settings.MaximumForwardedHops);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void FindConfigurationErrors_HopLimitBelowOne_RefusesStartup(int maximumForwardedHops)
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions { Enabled = true, MaximumForwardedHops = maximumForwardedHops };
+        settings.TrustedProxies.Add("10.0.0.5");
+
+        // Act
+        var error = Assert.Single(settings.FindConfigurationErrors());
+
+        // Assert
+        Assert.Contains("ReverseProxy:MaximumForwardedHops", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ToTrustedProxyAddresses_MixedEntries_TakesOnlyTheSingleAddresses()
+    {
+        // Arrange
+        var settings = ProxiesTrusted("10.0.0.5", "10.1.0.0/16", " 2001:db8::1 ");
+
+        // Act
+        var addresses = settings.ToTrustedProxyAddresses();
+
+        // Assert
+        Assert.Equal(
+            [IPAddress.Parse("10.0.0.5"), IPAddress.Parse("2001:db8::1")],
+            addresses);
+    }
+
+    [Fact]
+    public void ToTrustedProxyNetworks_MixedEntries_TakesOnlyTheNetworks()
+    {
+        // Arrange
+        var settings = ProxiesTrusted("10.0.0.5", " 10.1.0.0/16 ", "2001:db8::/32");
+
+        // Act
+        var networks = settings.ToTrustedProxyNetworks();
+
+        // Assert
+        Assert.Equal(
+            [IPNetwork.Parse("10.1.0.0/16"), IPNetwork.Parse("2001:db8::/32")],
+            networks);
+    }
+
+    private static ReverseProxyOptions ProxiesTrusted(params string[] trustedProxies)
+    {
+        var settings = new ReverseProxyOptions { Enabled = true };
+
+        foreach (var trustedProxy in trustedProxies)
+        {
+            settings.TrustedProxies.Add(trustedProxy);
+        }
+
+        return settings;
+    }
+}

--- a/tests/Host.UnitTests/Hosting/Warnings/McpTransportEncryptionWarningTests.cs
+++ b/tests/Host.UnitTests/Hosting/Warnings/McpTransportEncryptionWarningTests.cs
@@ -99,6 +99,51 @@ public sealed class McpTransportEncryptionWarningTests
         Assert.Empty(logs.Records);
     }
 
+    /// <summary>With the proxy named, the posture stops being a guess between two deployments and becomes the one the operator described.</summary>
+    [Fact]
+    public async Task StartAsync_ClearTextEndpointBehindATrustedProxy_NamesTheProxiedHopRatherThanGuessing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningFor(Enabled(), logs, TrustedProxyConfigured());
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("between that proxy and here", record.Message, StringComparison.Ordinal);
+        Assert.Contains("ReverseProxy:TrustedProxies", record.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("McpEndpoint:Https:Endpoints", record.Message, StringComparison.Ordinal);
+        Assert.Equal(1, Assert.Contains("TrustedProxyCount", record.Properties));
+    }
+
+    /// <summary>The proxy stands in front of a process, not in front of a listener it never touches, so a deployment terminating its own TLS is still silent.</summary>
+    [Fact]
+    public async Task StartAsync_EndpointServingItsOwnCertificateBehindATrustedProxy_SaysNothing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var settings = Enabled();
+        settings.Https.Endpoints.Add(new TransportHttpsEndpointOptions
+        {
+            Name = "public",
+            Domain = "mail.example.test",
+            ServerCertificate = new TlsServerCertificateOptions
+            {
+                Bundle = new ConfiguredSecret { Name = "bundle", SecretReference = "file:/etc/mailfathom/tls/bundle.pfx" },
+            },
+        });
+        var warning = WarningFor(settings, logs, TrustedProxyConfigured());
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
     [Fact]
     public async Task StopAsync_AnyPosture_CompletesWithoutSayingAnythingFurther()
     {
@@ -119,12 +164,25 @@ public sealed class McpTransportEncryptionWarningTests
         Authentication = TransportAuthenticationMethods.None,
     };
 
-    private static McpTransportEncryptionWarning WarningFor(McpEndpointOptions settings, RecordingLoggerProvider logs)
+    private static McpTransportEncryptionWarning WarningFor(
+        McpEndpointOptions settings,
+        RecordingLoggerProvider logs,
+        ReverseProxyOptions? reverseProxySettings = null)
     {
         using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(logs));
 
         return new McpTransportEncryptionWarning(
             Options.Create(settings),
+            Options.Create(reverseProxySettings ?? new ReverseProxyOptions()),
             loggerFactory.CreateLogger<McpTransportEncryptionWarning>());
+    }
+
+    private static ReverseProxyOptions TrustedProxyConfigured()
+    {
+        var settings = new ReverseProxyOptions { Enabled = true };
+
+        settings.TrustedProxies.Add("10.0.0.5");
+
+        return settings;
     }
 }

--- a/tests/Host.UnitTests/Security/Transport/TrustedReverseProxyExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TrustedReverseProxyExtensionsTests.cs
@@ -1,0 +1,286 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Security.Transport;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Security.Transport;
+
+/// <summary>Covers which requests are served under a forwarded scheme and host, and which keep their own.</summary>
+/// <remarks>
+/// The policy is asserted by running the platform middleware it configures rather than by reading the options back
+/// alone, because what matters is the request a deployment ends up serving. A composed pipeline is not needed for
+/// that: the middleware takes an <see cref="HttpContext" /> and the options this composition produced, which is
+/// exactly the pair the decision is made from.
+/// </remarks>
+public sealed class TrustedReverseProxyExtensionsTests
+{
+    private const string InternalHost = "mailfathom.internal:8080";
+
+    private static readonly IPAddress ProxyAddress = IPAddress.Parse("10.0.0.5");
+
+    [Fact]
+    public async Task AddTrustedReverseProxy_RequestFromTheNamedProxy_ServesItUnderThePublicSchemeAndHost()
+    {
+        // Arrange
+        var request = RequestFrom(ProxyAddress);
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+        request.Request.Headers["X-Forwarded-Host"] = "mail.example.test";
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.0.0.5"), request);
+
+        // Assert
+        Assert.Equal("https", request.Request.Scheme);
+        Assert.Equal("mail.example.test", request.Request.Host.Value);
+    }
+
+    /// <summary>A container reaches this process as a peer on a bridge or pod network, which is named as a range rather than an address.</summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_RequestFromWithinATrustedNetwork_ServesItUnderThePublicSchemeAndHost()
+    {
+        // Arrange
+        var request = RequestFrom(IPAddress.Parse("10.4.7.19"));
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+        request.Request.Headers["X-Forwarded-Host"] = "mail.example.test";
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.4.0.0/16"), request);
+
+        // Assert
+        Assert.Equal("https", request.Request.Scheme);
+        Assert.Equal("mail.example.test", request.Request.Host.Value);
+    }
+
+    /// <summary>Kestrel reports an IPv4 peer in IPv6 form on a dual-mode socket, which is what a container binds.</summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_TrustedProxyReportedAsAnIPv4MappedAddress_StillServesThePublicOrigin()
+    {
+        // Arrange
+        var request = RequestFrom(ProxyAddress.MapToIPv6());
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+        request.Request.Headers["X-Forwarded-Host"] = "mail.example.test";
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.0.0.5"), request);
+
+        // Assert
+        Assert.Equal("https", request.Request.Scheme);
+        Assert.Equal("mail.example.test", request.Request.Host.Value);
+    }
+
+    /// <summary>The header is a value whoever is upstream wrote, so a peer this deployment did not name writes nothing.</summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_RequestFromAnUntrustedPeer_KeepsTheSchemeAndHostItArrivedUnder()
+    {
+        // Arrange
+        var request = RequestFrom(IPAddress.Parse("203.0.113.9"));
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+        request.Request.Headers["X-Forwarded-Host"] = "attacker.example.test";
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.0.0.5"), request);
+
+        // Assert
+        Assert.Equal("http", request.Request.Scheme);
+        Assert.Equal(InternalHost, request.Request.Host.Value);
+    }
+
+    /// <summary>Loopback is the framework's own default and is cleared, because on a shared host it is every process on the machine.</summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_RequestFromLoopbackWithoutBeingNamed_KeepsTheSchemeAndHostItArrivedUnder()
+    {
+        // Arrange
+        var request = RequestFrom(IPAddress.Loopback);
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+        request.Request.Headers["X-Forwarded-Host"] = "attacker.example.test";
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.0.0.5"), request);
+
+        // Assert
+        Assert.Equal("http", request.Request.Scheme);
+        Assert.Equal(InternalHost, request.Request.Host.Value);
+    }
+
+    [Fact]
+    public async Task AddTrustedReverseProxy_RequestCarryingNoForwardedHeader_IsLeftUnchanged()
+    {
+        // Arrange
+        var request = RequestFrom(ProxyAddress);
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.0.0.5"), request);
+
+        // Assert
+        Assert.Equal("http", request.Request.Scheme);
+        Assert.Equal(InternalHost, request.Request.Host.Value);
+    }
+
+    /// <summary>Each header is read right to left, so one hop believes the value the directly connected proxy appended and nothing an earlier one claimed.</summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_MoreValuesThanHopsConfigured_ReadsOnlyWhatTheNearestProxyAppended()
+    {
+        // Arrange
+        var request = RequestFrom(ProxyAddress);
+        request.Request.Headers["X-Forwarded-Proto"] = "https, https";
+        request.Request.Headers["X-Forwarded-Host"] = "attacker.example.test, mail.example.test";
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.0.0.5"), request);
+
+        // Assert
+        Assert.Equal("https", request.Request.Scheme);
+        Assert.Equal("mail.example.test", request.Request.Host.Value);
+    }
+
+    [Fact]
+    public async Task AddTrustedReverseProxy_ChainAsLongAsTheConfiguredHops_ReadsTheOutermostValue()
+    {
+        // Arrange
+        var settings = TrustingProxies("10.0.0.5");
+        settings.MaximumForwardedHops = 2;
+        var request = RequestFrom(ProxyAddress);
+        request.Request.Headers["X-Forwarded-Proto"] = "https, http";
+        request.Request.Headers["X-Forwarded-Host"] = "mail.example.test, edge.internal";
+
+        // Act
+        await ForwardThrough(settings, request);
+
+        // Assert
+        Assert.Equal("https", request.Request.Scheme);
+        Assert.Equal("mail.example.test", request.Request.Host.Value);
+    }
+
+    /// <summary>A value that parses as no host at all is discarded rather than half-read, so nothing composes an origin out of part of it.</summary>
+    [Theory]
+    [InlineData("mail.example.test:notaport")]
+    [InlineData("mail example.test")]
+    [InlineData("")]
+    public async Task AddTrustedReverseProxy_MalformedForwardedHost_KeepsTheHostTheRequestArrivedUnder(string forwardedHost)
+    {
+        // Arrange
+        var request = RequestFrom(ProxyAddress);
+        request.Request.Headers["X-Forwarded-Host"] = forwardedHost;
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.0.0.5"), request);
+
+        // Assert
+        Assert.Equal(InternalHost, request.Request.Host.Value);
+    }
+
+    [Fact]
+    public async Task AddTrustedReverseProxy_MalformedForwardedScheme_KeepsTheSchemeTheRequestArrivedUnder()
+    {
+        // Arrange
+        var request = RequestFrom(ProxyAddress);
+        request.Request.Headers["X-Forwarded-Proto"] = "ht tps";
+        request.Request.Headers["X-Forwarded-Host"] = "mail.example.test";
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.0.0.5"), request);
+
+        // Assert
+        Assert.Equal("http", request.Request.Scheme);
+        Assert.Equal("mail.example.test", request.Request.Host.Value);
+    }
+
+    /// <summary>The client address is deliberately out of scope: nothing here partitions, limits, or logs by one.</summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_RequestCarryingAForwardedClientAddress_KeepsThePeerItObservedItself()
+    {
+        // Arrange
+        var request = RequestFrom(ProxyAddress);
+        request.Request.Headers["X-Forwarded-For"] = "203.0.113.9";
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.0.0.5"), request);
+
+        // Assert
+        Assert.Equal(ProxyAddress, request.Connection.RemoteIpAddress);
+    }
+
+    [Fact]
+    public void AddTrustedReverseProxy_AnyConfiguration_ConsumesTheSchemeAndHostHeadersAlone()
+    {
+        // Arrange
+        // Act
+        var forwardedHeaders = ComposedOptions(TrustingProxies("10.0.0.5"));
+
+        // Assert
+        Assert.Equal(
+            ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost,
+            forwardedHeaders.ForwardedHeaders);
+    }
+
+    [Fact]
+    public void AddTrustedReverseProxy_ConfiguredProxies_ReplacesTheFrameworkLoopbackDefaults()
+    {
+        // Arrange
+        // Act
+        var forwardedHeaders = ComposedOptions(TrustingProxies("10.0.0.5", "10.4.0.0/16"));
+
+        // Assert
+        Assert.Equal([ProxyAddress], forwardedHeaders.KnownProxies);
+        // Both namespaces imported here publish an IPNetwork, and only the framework's own is meant.
+        Assert.Equal([System.Net.IPNetwork.Parse("10.4.0.0/16")], forwardedHeaders.KnownIPNetworks);
+        Assert.Equal(1, forwardedHeaders.ForwardLimit!.Value);
+    }
+
+    private static ReverseProxyOptions TrustingProxies(params string[] trustedProxies)
+    {
+        var settings = new ReverseProxyOptions { Enabled = true };
+
+        foreach (var trustedProxy in trustedProxies)
+        {
+            settings.TrustedProxies.Add(trustedProxy);
+        }
+
+        return settings;
+    }
+
+    private static ForwardedHeadersOptions ComposedOptions(ReverseProxyOptions settings)
+    {
+        var services = new ServiceCollection();
+
+        services.AddOptions();
+        services.AddTrustedReverseProxy(settings);
+
+        using var provider = services.BuildServiceProvider();
+
+        return provider.GetRequiredService<IOptions<ForwardedHeadersOptions>>().Value;
+    }
+
+    private static DefaultHttpContext RequestFrom(IPAddress remoteAddress)
+    {
+        var context = new DefaultHttpContext();
+
+        context.Connection.RemoteIpAddress = remoteAddress;
+        context.Connection.RemotePort = 51234;
+        context.Request.Scheme = "http";
+        context.Request.Host = new HostString(InternalHost);
+
+        return context;
+    }
+
+    private static Task ForwardThrough(ReverseProxyOptions settings, HttpContext request)
+    {
+        var middleware = new ForwardedHeadersMiddleware(
+            _ => Task.CompletedTask,
+            NullLoggerFactory.Instance,
+            Options.Create(ComposedOptions(settings)));
+
+        return middleware.Invoke(request);
+    }
+}


### PR DESCRIPTION
Closes #315

Behind a proxy that terminates TLS, the request reaches MailFathom as `http` under whichever internal name the proxy dialled. The MCP SDK serves the protected resource metadata document only to a request whose own scheme and host match `OAuth:Resource`, so that deployment answered `404` and OAuth discovery could not complete at all.

## What it adds

A process-wide `ReverseProxy` section, off by default:

```json
{ "ReverseProxy": { "Enabled": true, "TrustedProxies": [ "10.4.0.0/16" ] } }
```

- `Enabled` — whether `X-Forwarded-Proto` and `X-Forwarded-Host` are read at all.
- `TrustedProxies` — the addresses or CIDR networks they are accepted from. Required when enabled.
- `MaximumForwardedHops` — how far right-to-left through each header a value is believed. Defaults to `1`.

The platform's `ForwardedHeadersMiddleware` does the work; this states the policy it runs under and places it at the front of the pipeline, ahead of the exception handler and of both isolation checks.

## The decisions worth arguing

**Trust is settled once for the process, not per surface.** The MCP, administrative, and probe surfaces are separate listeners over one request pipeline, and forwarded headers are applied by middleware in that pipeline before any surface's routing runs. A per-surface setting would carry three copies of one network fact — which proxy this deployment sits behind — and leave an operator to keep them in step. A proxy named here is therefore trusted on every listener it can reach, which is what the documentation says plainly.

**The framework's defaults are replaced, not inherited.** `KnownProxies` and `KnownIPNetworks` both arrive holding loopback, which is the wrong peer inside a container and every other process on the machine in a native installation; both are cleared. Enabling the mode without naming a proxy fails startup rather than falling back to anything.

**`10.0.0.5/24` is refused.** `IPNetwork.TryParse` accepts a base address whose host bits are set and silently masks them off, so an operator who meant to trust one proxy would have trusted 256 addresses without being told. The refusal names the `10.0.0.0/24` they would have got.

**`X-Forwarded-For` is not read.** Nothing here partitions, limits, or logs by client address, so adopting one from a header would replace the one address this process observes for itself with a claim and buy nothing. Out of scope per the issue, and asserted by a test.

**`OAuth:Resource` is untouched.** It stays required, stays the identifier a token's audience is compared against, and is never derived from a header. What the mode settles is which name a request arrived under — a fact about the hop, not a claim about the deployment.

## Two notes on the acceptance list

- **`RequireHeaderSymmetry` is left off**, which is the one place the implementation reads the acceptance more narrowly than its letter. Turning it on would make a malformed value abandon the whole set, but it would also refuse a proxy that forwards only `X-Forwarded-Proto` while passing `Host` through — the most common nginx configuration, and a correct deployment. As shipped, a value that parses as no scheme or no host is discarded and the request keeps what it arrived with for that component; nothing is half-read out of the malformed value itself, and the invariant that matters — nothing an untrusted peer wrote ever reaches the request — is held by the trust gate rather than by symmetry. Both behaviours are covered by tests.
- **The redirect #311 adds needs no work here.** #311 is still open, and because this middleware runs at the front of the pipeline, a redirect added later reads the corrected scheme without knowing this exists.

## `McpTransportEncryptionWarning`

With a proxy named, the warning stops listing the two postures it would otherwise guess between and describes the one the operator configured. It still fires, and still says the hop is clear text, because it is; what it stops doing is advising `McpEndpoint:Https:Endpoints`, which is the wrong advice for a deployment whose certificate lives on the proxy.

## Verification

`scripts/verify-full.sh` — exit 0, 2607 tests, aggregate line coverage 96.47% (required 85%), formatting clean.

New unit tests cover a trusted address, a trusted network, an IPv4-mapped peer, an untrusted peer, unnamed loopback, absent headers, a value list against the configured limit in both directions, a malformed host and a malformed scheme, the ignored client address, every startup refusal, and strict binding.

No new package, no lock-file movement: `Microsoft.AspNetCore.HttpOverrides` is part of the ASP.NET Core shared framework this host already targets. `THIRD_PARTY_LICENSES.md` and `CHANGELOG.md` are untouched.

## Documentation

`mcp-endpoint.md` gains the mode as its own section — the defaults, the refusals, a worked nginx location, and what the proxy owns, what MailFathom keeps owning, and what becomes unreachable — and the note saying discovery cannot complete behind a terminating proxy is retired. `configuration-reference.md` gains the section's table. `admin-endpoint.md`, `deployment-compose.md`, `deployment-kubernetes.md`, `container-image.md`, and `getting-started.md` point at it where each already tells an operator to put a proxy in front.