### PR TITLE
[#311] Redirect a clear-text request to HTTPS on the MCP and administrative endpoints

### DIFF
--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -118,7 +118,34 @@ None is refused, because each is legitimate somewhere and only you know which yo
 
 Configure `AdminEndpoint:Https:Endpoints` to have Kestrel terminate TLS itself. It takes the same profile shape the MCP
 endpoint's does, including `HttpProtocols`, which defaults to HTTP/1.1 and HTTP/2. Naming any profile binds those
-listeners and no clear-text one stays open behind them.
+listeners and no clear-text one stays open behind them serving these routes.
+
+### Redirecting `mfctl` after you configure TLS
+
+A profile also binds one clear-text listener whose only answer is a `308` to the address the profiles are served at, on
+**port 8091** unless you state another. It is what keeps an `mfctl` profile that still holds an `http://` endpoint from
+failing as though the deployment were down:
+
+```console
+$ curl -i http://admin.example.com:8091/api/admin/session
+HTTP/1.1 308 Permanent Redirect
+Location: https://admin.example.com:8543/api/admin/session
+```
+
+**Repoint the profile rather than relying on it.** An administrative API key sent in clear text was on the wire before
+anything answered, and this route stores mailbox credentials — a redirect protects the next request and never the one that
+arrived. `mfctl login --endpoint https://admin.example.com:8543` writes the corrected address; see
+[working with more than one deployment](#working-with-more-than-one-deployment).
+
+That listener maps no route. No administrative operation, no session probe, and no protected-resource metadata document is
+reachable over it, and no credential check runs for a request that arrived on it — every path gets the same redirect, and a
+`Host` header naming no configured domain gets `400`. The port is checked against every other listener in the process, so a
+conflict with the MCP surface, the probes, or the application listener is reported against the section that asked for it.
+
+Turn it off with `AdminEndpoint:Https:Redirect:Enabled` set to `false`, which is what a deployment behind a proxy that
+already answers the clear-text port wants. The setting shape and every refusal are the MCP endpoint's, documented once in
+[redirecting a client still pointed at `http://`](mcp-endpoint.md#redirecting-a-client-still-pointed-at-http); only the
+default port differs, so enabling TLS on both surfaces opens two clear-text ports that do not collide.
 
 ## Behind a TLS-terminating reverse proxy
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -359,7 +359,7 @@ a redirect does and does not protect.
 | --- | --- | --- | --- | --- |
 | `…:Enabled` | bool | `true` | Honored only while an HTTPS profile is configured | restart |
 | `…:BindAddress` | string | `0.0.0.0` | An IP address; `::` binds IPv6 | restart |
-| `…:Port` | int | `8080` | 1 – 65535; bound by no HTTPS profile in this section and by no other listener in the process | restart |
+| `…:Port` | int | `8080` | 1 – 65535; the resulting address and port bound by no HTTPS profile in this section, and the port bound by no other listener in the process | restart |
 
 ### Client certificates — `McpEndpoint:ClientCertificateProfiles:<n>`
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -347,6 +347,20 @@ A certificate block names either `Bundle` (one PKCS#12 secret block, optionally 
 `CertificateChain` and `PrivateKey` (PEM, as two secret blocks). Startup proves the material loads, covers the stated
 domain, and is not expired — before any listener opens.
 
+### Clear-text redirect — `McpEndpoint:Https:Redirect`
+
+One clear-text listener whose only answer is a `308` to the address the profiles above are served at, so enabling TLS does
+not read as an outage to a client nobody repointed yet. It maps no route and runs no credential check, and it exists only
+while `McpEndpoint:Https:Endpoints` names a profile. Writing this section without one fails startup.
+[Redirecting a client still pointed at `http://`](mcp-endpoint.md#redirecting-a-client-still-pointed-at-http) records what
+a redirect does and does not protect.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `…:Enabled` | bool | `true` | Honored only while an HTTPS profile is configured | restart |
+| `…:BindAddress` | string | `0.0.0.0` | An IP address; `::` binds IPv6 | restart |
+| `…:Port` | int | `8080` | 1 – 65535; bound by no HTTPS profile in this section and by no other listener in the process | restart |
+
 ### Client certificates — `McpEndpoint:ClientCertificateProfiles:<n>`
 
 Mutual TLS, judged per configured client application. A certificate exists only on a TLS connection this process
@@ -395,7 +409,8 @@ request or per handshake. [Administering a deployment](admin-endpoint.md) is the
 | `AdminEndpoint:Authentication` | flag set | `None` | `ApiKey`, `OAuth`, both comma-separated, or `None`; `None` warns at startup | restart |
 | `AdminEndpoint:ApiKeys` | list of secret blocks | empty | Required non-empty when `ApiKey` is named; refused when configured while it is not | restart; material per request |
 | `AdminEndpoint:OAuth` | block | empty | Same shape and rules as `McpEndpoint:OAuth`, with one addition: `Resource` must end in `/api/admin`, because that is where these routes answer and what `mfctl` appends to find the metadata document. Refused when configured while `OAuth` is not named | restart |
-| `AdminEndpoint:Https:Endpoints:<n>` | list of profiles | empty | Same shape and rules as `McpEndpoint:Https:Endpoints:<n>`; naming any binds those listeners and no clear-text one | restart; material per handshake |
+| `AdminEndpoint:Https:Endpoints:<n>` | list of profiles | empty | Same shape and rules as `McpEndpoint:Https:Endpoints:<n>`; naming any binds those listeners and no clear-text one serving these routes | restart; material per handshake |
+| `AdminEndpoint:Https:Redirect` | block | on, port `8091` | Same shape and rules as `McpEndpoint:Https:Redirect`; the default port differs so terminating TLS on both surfaces opens two clear-text ports that do not collide | restart |
 | `AdminEndpoint:RateLimiting` | block | bounded | Same shape, defaults, and rules as `McpEndpoint:RateLimiting` above; applied whether or not it is written | restart |
 
 The routes are served beneath `/api/admin`, which is a constant rather than a setting: a client is configured with a

--- a/docs/operations/container-image.md
+++ b/docs/operations/container-image.md
@@ -47,6 +47,7 @@ resolves what the change was reviewed against.
 | --- | --- |
 | User | `1654`, the unprivileged `app` account the .NET base images define |
 | Ports | `8080`, plain HTTP, for `/` and `/mcp`; `8081` for the probes, on a listener of its own |
+| Ports once TLS is configured | The HTTPS profiles' own ports, plus `8080` again — which becomes [a redirect to them](mcp-endpoint.md#redirecting-a-client-still-pointed-at-http) rather than the application listener, so the port this image already publishes keeps answering |
 | Writable paths | `/tmp` only, which a deployment supplies as a tmpfs or an `emptyDir` |
 | Entrypoint | `dotnet /app/MailFathom.Host.dll` |
 | Health check | None. See [the health endpoints](#the-health-endpoints) below. |

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -619,6 +619,13 @@ The [health endpoints](health-endpoints.md) are untouched by this. They keep the
 `HealthEndpoints:Transport`, and no probe is ever asked on this port — which is deliberate, because a probe follows no
 redirect and would read a `308` as a failure.
 
+**If you also run a proxy, point it at a profile's port and never at this one.** The two postures rarely meet — a
+deployment [behind a TLS-terminating proxy](#behind-a-tls-terminating-reverse-proxy) normally configures no profile here,
+and then `8080` is the ordinary application listener rather than a redirect. Where a deployment does both, a proxy
+forwarding to the redirect port would have every request answered with a `308` to the profile it should have been sent to
+in the first place. With [a trusted proxy named](#behind-a-tls-terminating-reverse-proxy) the redirect uses the forwarded
+public host, so the `Location` carries the name your clients use rather than the internal one the proxy dialled.
+
 Four properties are worth knowing:
 
 - **`308`, not `301` or `302`.** The MCP transport is a `POST`; the older codes permit a client to re-send it as a `GET`,

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -1,6 +1,6 @@
 # The MCP endpoint and what protects it
 
-<!-- describes: src/Mcp/**, src/Host/Security/**, src/Infrastructure/Security/**, src/Common/OAuth/** -->
+<!-- describes: src/Mcp/**, src/Host/Security/**, src/Infrastructure/Security/**, src/Common/OAuth/**, src/Host/Configuration/Endpoints/TransportClearTextRedirectOptions.cs, src/Host/Hosting/Startup/ClearTextRedirectToHttps.cs, src/Host/Hosting/Warnings/TransportClearTextRedirectReport.cs -->
 
 The MCP endpoint is how an agent reaches MailFathom. This page records what enabling it means operationally, what a client
 has to present to reach it, which browser origins it answers, which client applications it accepts a certificate from,
@@ -594,6 +594,84 @@ Kestrel:Endpoints:Http — a Kestrel endpoint is configured beside McpEndpoint:H
 listener would stay open alongside the HTTPS profiles and serve the same MCP endpoint without the TLS they were
 configured to add. Remove the endpoint, or remove the HTTPS profiles and let this listener serve the endpoint.
 ```
+
+### Redirecting a client still pointed at `http://`
+
+A client that has not been repointed after you configured a profile meets a refused connection or an unreadable handshake
+error, which is indistinguishable from an outage. So a surface that terminates TLS also binds one clear-text listener
+whose only answer is a redirect, on **port 8080** unless you state another:
+
+```console
+$ curl -i http://mail.example.com:8080/mcp
+HTTP/1.1 308 Permanent Redirect
+Location: https://mail.example.com:8443/mcp
+```
+
+**A redirect protects the next request, never the one that arrived.** An API key sent in clear text was on the wire before
+anything answered, and no redirect recovers it. Treat this as a way to find out that a client needs repointing, not as a
+supported way to reach the endpoint — and repoint the client rather than leaving it following a redirect.
+
+What that listener serves is the redirect and nothing else. It maps no route: `/mcp`, the protected-resource metadata
+document, and an unmapped path are all answered the same way, and no authentication, rate-limiting, CORS, or
+client-certificate handler runs for a request that arrived on it. There is nothing reachable over it to protect.
+
+The [health endpoints](health-endpoints.md) are untouched by this. They keep their own listener and their own
+`HealthEndpoints:Transport`, and no probe is ever asked on this port — which is deliberate, because a probe follows no
+redirect and would read a `308` as a failure.
+
+Four properties are worth knowing:
+
+- **`308`, not `301` or `302`.** The MCP transport is a `POST`; the older codes permit a client to re-send it as a `GET`,
+  which would arrive over TLS as a request nobody made. The path and query are preserved.
+- **The host is redirected to itself.** With [several domains on one address](#several-domains-on-one-address), each
+  redirects to its own profile's port, so no client is sent to a name it did not ask for under a certificate issued for a
+  different one.
+- **A `Host` header naming no configured domain gets `400`.** It is refused rather than rewritten to a domain the
+  deployment does publish.
+- **`:443` is left out of the `Location`**, because it is the scheme's own port and a client appends nothing for it.
+
+Turn it off with one setting, which is what a deployment behind a proxy that already answers the clear-text port wants:
+
+```json
+{
+  "McpEndpoint": {
+    "Https": {
+      "Redirect": { "Enabled": false }
+    }
+  }
+}
+```
+
+| Setting | Default | Meaning |
+|---|---|---|
+| `Enabled` | `true` | Whether the clear-text listener is bound at all |
+| `BindAddress` | `0.0.0.0` | The IP address to bind; `::` binds IPv6 |
+| `Port` | `8080` | The TCP port to bind |
+
+Startup reports the port beside the domains it redirects to, so every socket the process opened is readable from the log:
+
+```text
+info: MailFathom.Host.Hosting.Warnings.TransportClearTextRedirectReport
+      The MCP endpoint redirects clear-text requests on port 8080 to https://mail.example.com:8443. That listener maps
+      no route and answers every path with a 308, so nothing is reachable over it. A redirect protects the next request
+      and not the one that arrived — a credential already sent in clear text is on the wire — so repoint your clients
+      rather than relying on it. Set McpEndpoint:Https:Redirect:Enabled to false to bind no clear-text port at all.
+```
+
+Two configurations are refused before anything binds. Writing a `Redirect` section for a surface that terminates no TLS
+fails startup rather than being ignored, because that surface is already served in clear text and nothing would have bound
+the port:
+
+```text
+McpEndpoint:Https:Redirect — a clear-text redirect is configured while McpEndpoint:Https:Endpoints names no HTTPS
+profile, so there is nothing to redirect to and this surface is already served in clear text. Configure a profile, or
+remove this section.
+```
+
+And the redirect port collides with nothing: a conflict with one of this section's own profiles, with the
+[administrative endpoint](admin-endpoint.md), with the [health listener](health-endpoints.md), or with a
+`Kestrel:Endpoints` entry is reported against the section that asked for it rather than as an address-in-use failure
+naming a socket.
 
 ### Several domains on one address
 

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -675,10 +675,16 @@ profile, so there is nothing to redirect to and this surface is already served i
 remove this section.
 ```
 
-And the redirect port collides with nothing: a conflict with one of this section's own profiles, with the
+And the redirect socket collides with nothing: a conflict with one of this section's own profiles, with the
 [administrative endpoint](admin-endpoint.md), with the [health listener](health-endpoints.md), or with a
 `Kestrel:Endpoints` entry is reported against the section that asked for it rather than as an address-in-use failure
 naming a socket.
+
+Within this section the check is on the socket rather than the port number, the same way it is
+[between two profiles](#several-domains-on-one-address). A profile on `10.0.0.5:9000` and a redirect on `10.0.0.6:9000`
+are two sockets the operating system grants independently, so that deployment is served; a redirect on `0.0.0.0:9000` or
+`::9000` beside that profile is refused, because the wildcard already accepts the connections the profile's address would
+receive and only one of the two could bind.
 
 ### Several domains on one address
 

--- a/src/Host/Configuration/Endpoints/AdminEndpointOptions.cs
+++ b/src/Host/Configuration/Endpoints/AdminEndpointOptions.cs
@@ -58,6 +58,14 @@ internal sealed class AdminEndpointOptions
     /// </remarks>
     public const string RoutePrefix = "/api/admin";
 
+    /// <summary>The port the clear-text redirect binds when a deployment configures HTTPS profiles and states no port for it.</summary>
+    /// <remarks>
+    /// This surface's own default rather than a shared one, because the MCP endpoint redirects to its own profiles: one
+    /// number for both would have the two collide the moment a deployment terminated TLS on each. It sits beside
+    /// <see cref="Port" /> so the two administrative sockets read as a pair, and no other listener here defaults to it.
+    /// </remarks>
+    internal const int DefaultClearTextRedirectPort = 8091;
+
     private const TransportAuthenticationMethods KnownAuthenticationMethods =
         TransportAuthenticationMethods.ApiKey | TransportAuthenticationMethods.OAuth;
 
@@ -121,10 +129,31 @@ internal sealed class AdminEndpointOptions
     /// <summary>Gets whether a request must present a credential naming who is calling.</summary>
     public bool RequiresAuthentication => this.Authentication != TransportAuthenticationMethods.None;
 
+    /// <summary>Gets the port the clear-text redirect listener binds, whether or not this deployment stated one.</summary>
+    /// <remarks>Read whether or not a redirect is served, because a port has to be known before it can be checked against the other listeners in the process; <see cref="TransportHttpsOptions.RedirectsClearText" /> is what decides whether anything binds it.</remarks>
+    public int ClearTextRedirectPort => this.Https.Redirect.Port ?? DefaultClearTextRedirectPort;
+
     /// <summary>Gets the ports this endpoint's listeners bind, which no other listener in the process may claim.</summary>
-    public IReadOnlySet<int> ListenerPorts => this.Https.TerminatesTls
-        ? this.Https.Endpoints.Select(static endpoint => endpoint.Port).ToHashSet()
-        : new HashSet<int> { this.Port };
+    /// <remarks>The redirect's port is one of them, so a deployment cannot give it to the probes, to the application listener, or to the MCP surface and discover the conflict as an address-in-use error naming a socket rather than a section.</remarks>
+    public IReadOnlySet<int> ListenerPorts
+    {
+        get
+        {
+            if (!this.Https.TerminatesTls)
+            {
+                return new HashSet<int> { this.Port };
+            }
+
+            var ports = this.Https.Endpoints.Select(static endpoint => endpoint.Port).ToHashSet();
+
+            if (this.Https.RedirectsClearText)
+            {
+                ports.Add(this.ClearTextRedirectPort);
+            }
+
+            return ports;
+        }
+    }
 
     /// <summary>Reads the section the way composition does, defaults included.</summary>
     /// <param name="configuration">The application configuration.</param>
@@ -135,9 +164,20 @@ internal sealed class AdminEndpointOptions
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
-        return configuration.GetSection(SectionName)
-            .Get<AdminEndpointOptions>(binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
+        var section = configuration.GetSection(SectionName);
+        var settings = section.Get<AdminEndpointOptions>(binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
             ?? new AdminEndpointOptions();
+
+        // Read from configuration rather than from what was bound, because the redirect is on by default: an absent
+        // section and one an operator wrote produce identical values, and only configuration can say which happened. It is
+        // the difference between refusing a redirect configured for a surface that terminates no TLS and staying silent
+        // about a default that surface never asked for.
+        if (section.GetSection($"{nameof(Https)}:{nameof(TransportHttpsOptions.Redirect)}").Exists())
+        {
+            settings.Https.Redirect.MarkStated();
+        }
+
+        return settings;
     }
 
     /// <summary>Finds everything an operator must fix before the endpoint can be served.</summary>
@@ -164,7 +204,8 @@ internal sealed class AdminEndpointOptions
         // property of the machine the process is running on and not a decision composition takes.
         errors.AddRange(this.Https.FindConfigurationErrors(
             $"{SectionName}:{nameof(this.Https)}",
-            QuicListener.IsSupported));
+            QuicListener.IsSupported,
+            DefaultClearTextRedirectPort));
 
         return errors;
     }

--- a/src/Host/Configuration/Endpoints/McpEndpointOptions.cs
+++ b/src/Host/Configuration/Endpoints/McpEndpointOptions.cs
@@ -38,6 +38,14 @@ internal sealed class McpEndpointOptions
     /// <summary>The configuration section the endpoint settings are bound from.</summary>
     public const string SectionName = "McpEndpoint";
 
+    /// <summary>The port the clear-text redirect binds when a deployment configures HTTPS profiles and states no port for it.</summary>
+    /// <remarks>
+    /// This surface's own default rather than a shared one, because the administrative endpoint redirects to its own
+    /// profiles: one number for both would have the two collide the moment a deployment terminated TLS on each. It is
+    /// above 1024 so the process needs no privilege to bind it, and it is not a port any other listener here defaults to.
+    /// </remarks>
+    internal const int DefaultClearTextRedirectPort = 8080;
+
     private const TransportAuthenticationMethods KnownAuthenticationMethods =
         TransportAuthenticationMethods.ApiKey | TransportAuthenticationMethods.OAuth;
 
@@ -98,6 +106,41 @@ internal sealed class McpEndpointOptions
     /// </remarks>
     public bool RequiresAuthentication => this.Authentication != TransportAuthenticationMethods.None;
 
+    /// <summary>Gets the port the clear-text redirect listener binds, whether or not this deployment stated one.</summary>
+    /// <remarks>Read whether or not a redirect is served, because a port has to be known before it can be checked against the other listeners in the process; <see cref="TransportHttpsOptions.RedirectsClearText" /> is what decides whether anything binds it.</remarks>
+    public int ClearTextRedirectPort => this.Https.Redirect.Port ?? DefaultClearTextRedirectPort;
+
+    /// <summary>Gets the ports this endpoint's listeners bind, which no other listener in the process may claim.</summary>
+    /// <remarks>
+    /// The redirect's port is one of them, so a deployment cannot give it to the probes or to the administrative surface
+    /// and discover the conflict as an address-in-use error naming a socket rather than a section.
+    /// <para>
+    /// Empty when this endpoint terminates no TLS, because it then binds no listener of its own at all: it is served over
+    /// whichever listener the host was started with, whose ports belong to that listener rather than to this section. That
+    /// is the one way this differs from <see cref="AdminEndpointOptions.ListenerPorts" />, which reports its own clear-text
+    /// port in the same posture because the administrative surface always has a listener of its own.
+    /// </para>
+    /// </remarks>
+    public IReadOnlySet<int> ListenerPorts
+    {
+        get
+        {
+            if (!this.Https.TerminatesTls)
+            {
+                return new HashSet<int>();
+            }
+
+            var ports = this.Https.Endpoints.Select(static endpoint => endpoint.Port).ToHashSet();
+
+            if (this.Https.RedirectsClearText)
+            {
+                ports.Add(this.ClearTextRedirectPort);
+            }
+
+            return ports;
+        }
+    }
+
     /// <summary>Reads the section the way composition does, defaults included.</summary>
     /// <param name="configuration">The application configuration.</param>
     /// <returns>The bound settings, with the defaults no binder can apply already applied.</returns>
@@ -123,6 +166,15 @@ internal sealed class McpEndpointOptions
         if (!section.GetSection($"{nameof(Cors)}:{nameof(McpCorsOptions.AllowedOrigins)}").Exists())
         {
             settings.Cors.ServeEveryBrowserOrigin();
+        }
+
+        // Read from configuration for the same reason the origin list above is: the redirect is on by default, so an
+        // absent section and one an operator wrote bind to identical values, and only configuration can say which
+        // happened. It is the difference between refusing a redirect configured for a surface that terminates no TLS and
+        // staying silent about a default that surface never asked for.
+        if (section.GetSection($"{nameof(Https)}:{nameof(TransportHttpsOptions.Redirect)}").Exists())
+        {
+            settings.Https.Redirect.MarkStated();
         }
 
         return settings;
@@ -157,7 +209,8 @@ internal sealed class McpEndpointOptions
         // depend on it live in the section itself, where a test can state both answers.
         errors.AddRange(this.Https.FindConfigurationErrors(
             $"{SectionName}:{nameof(this.Https)}",
-            QuicListener.IsSupported));
+            QuicListener.IsSupported,
+            DefaultClearTextRedirectPort));
 
         return errors;
     }

--- a/src/Host/Configuration/Endpoints/TransportClearTextRedirectOptions.cs
+++ b/src/Host/Configuration/Endpoints/TransportClearTextRedirectOptions.cs
@@ -1,0 +1,82 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+
+namespace MailFathom.Host.Configuration.Endpoints;
+
+/// <summary>Configures the clear-text listener that tells a client where a surface's HTTPS profiles moved to.</summary>
+/// <remarks>
+/// <para>
+/// A redirect protects the next request rather than the one that arrived. An API key sent in clear text is already on the
+/// wire by the time a redirect is written, and nothing recovers it. This listener exists so that a client still pointed
+/// at <c>http://</c> is told where the endpoint is instead of failing on a connection refused or an unreadable handshake
+/// error, which is what enabling TLS otherwise looks like from the outside. It is not a supported way to reach the
+/// surface, which is why the listener answers nothing else: no route is mapped on it, and no authentication,
+/// rate-limiting, CORS, or client-certificate handler runs for a request that arrived there.
+/// </para>
+/// <para>
+/// On unless a deployment turns it off, and meaningful only where the surface terminates TLS of its own. A deployment
+/// behind a proxy that already answers on the clear-text port turns it off rather than having MailFathom bind a port it
+/// did not ask for, and one that writes this section for a surface terminating no TLS is refused at startup — the
+/// setting would otherwise read as configured while nothing bound it.
+/// </para>
+/// </remarks>
+internal sealed class TransportClearTextRedirectOptions
+{
+    /// <summary>Gets or sets whether the clear-text listener is bound at all.</summary>
+    /// <remarks>Enabled, so enabling TLS does not read as an outage to a client nobody had repointed yet. It is honored only while the surface terminates TLS; there is no clear-text listener to redirect from otherwise, and the surface is already served over one.</remarks>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>Gets or sets the IP address the clear-text listener binds.</summary>
+    /// <remarks>Separate from the HTTPS profiles' own bind addresses rather than derived from them, because profiles may bind several addresses and a redirect is one socket; a deployment publishing two addresses states which of them answers clear text.</remarks>
+    public string BindAddress { get; set; } = "0.0.0.0";
+
+    /// <summary>Gets or sets the TCP port the clear-text listener binds, or <see langword="null" /> to take the surface's own default.</summary>
+    /// <remarks>
+    /// Nullable rather than carrying a number, because the default belongs to the surface: the MCP endpoint and the
+    /// administrative endpoint each redirect to their own profiles, so one shared default would have the two collide the
+    /// moment a deployment terminated TLS on both. Each surface states its own and documents it.
+    /// </remarks>
+    public int? Port { get; set; }
+
+    /// <summary>Gets whether the deployment wrote this section, as opposed to inheriting every value above.</summary>
+    /// <remarks>
+    /// It is what tells a redirect an operator asked for from the default one, which is the difference between a startup
+    /// error and silence on a surface that terminates no TLS. The binder cannot answer it — an absent section and one
+    /// carrying only defaults bind identically — so it is read from configuration by the surface that owns the section.
+    /// </remarks>
+    internal bool WasStated { get; private set; }
+
+    /// <summary>Records that the deployment wrote this section.</summary>
+    /// <remarks>Called by the surface's own read, which is the only place that holds the configuration section this was bound from.</remarks>
+    internal void MarkStated() => this.WasStated = true;
+
+    /// <summary>Reads the socket the listener binds.</summary>
+    /// <param name="defaultPort">The port the surface serves the redirect on when the deployment states none.</param>
+    /// <returns>The address and port.</returns>
+    /// <exception cref="FormatException">Thrown when <see cref="BindAddress" /> is not an IP address, which validation reports before anything reads this.</exception>
+    internal TransportHttpsListenerAddress ListenerAddress(int defaultPort) =>
+        new(IPAddress.Parse(this.BindAddress.Trim()), this.Port ?? defaultPort);
+
+    /// <summary>Finds everything an operator must fix before the clear-text listener can bind.</summary>
+    /// <param name="configurationPath">The configuration path of this section, which prefixes every reported error.</param>
+    /// <returns>One message per faulty setting, empty when the section is usable.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurationPath" /> is <see langword="null" />.</exception>
+    /// <remarks>Its own two settings only. Whether a redirect belongs on this surface at all, and whether its port is free, are questions about the surface rather than about this section, and <see cref="TransportHttpsOptions" /> answers both.</remarks>
+    internal IEnumerable<string> FindConfigurationErrors(string configurationPath)
+    {
+        ArgumentNullException.ThrowIfNull(configurationPath);
+
+        if (!IPAddress.TryParse(this.BindAddress?.Trim(), out _))
+        {
+            yield return $"{configurationPath}:{nameof(this.BindAddress)} — state the IP address the clear-text listener binds, for example '0.0.0.0' for every IPv4 address or '::' for IPv6.";
+        }
+
+        if (this.Port is { } statedPort && statedPort is < 1 or > 65535)
+        {
+            yield return $"{configurationPath}:{nameof(this.Port)} — '{statedPort}' is not a TCP port; state a value between 1 and 65535, or remove the setting to take this endpoint's default.";
+        }
+    }
+}

--- a/src/Host/Configuration/Endpoints/TransportHttpsOptions.cs
+++ b/src/Host/Configuration/Endpoints/TransportHttpsOptions.cs
@@ -79,9 +79,15 @@ internal sealed class TransportHttpsOptions
     /// <remarks>
     /// A redirect stated for a surface that terminates no TLS is refused rather than ignored, because that surface is
     /// already reachable in clear text: the setting would read as configured while nothing bound it and nothing redirected
-    /// anywhere. The port check is the within-surface half of the collision rule — these profiles are the only listeners
-    /// this section can see, and the surface that owns it compares the same port against every other listener the process
+    /// anywhere. The socket check is the within-surface half of the collision rule — these profiles are the only listeners
+    /// this section can see, and the surface that owns it compares the same socket against every other listener the process
     /// opens.
+    /// <para>
+    /// A socket is an address and a port, so the check is the address-aware one <see cref="FindOverlappingListeners" />
+    /// already applies between two profiles rather than a comparison of port numbers. A port number alone would refuse a
+    /// multi-interface deployment that binds a profile to one address and the redirect to another, which the operating
+    /// system grants as two independent sockets.
+    /// </para>
     /// </remarks>
     private IEnumerable<string> FindRedirectErrors(string configurationPath, int defaultRedirectPort)
     {
@@ -107,13 +113,39 @@ internal sealed class TransportHttpsOptions
             yield break;
         }
 
+        // An address the parser does not recognize was reported just above, and there is no socket to compare against a
+        // profile's until an operator fixes it. Reporting a collision as well would describe a second mistake nobody made.
+        if (!IPAddress.TryParse(this.Redirect.BindAddress?.Trim(), out var redirectAddress))
+        {
+            yield break;
+        }
+
         var redirectPort = this.Redirect.Port ?? defaultRedirectPort;
 
-        if (this.Endpoints.Any(endpoint => endpoint.Port == redirectPort))
+        var collidingProfiles = this.Endpoints
+            .Where(endpoint => endpoint.Port == redirectPort)
+            .Where(endpoint => IPAddress.TryParse(endpoint.BindAddress?.Trim(), out var profileAddress)
+                && Overlaps(redirectAddress, profileAddress))
+            .Select(static endpoint => endpoint.Name)
+            .ToArray();
+
+        if (collidingProfiles.Length > 0)
         {
-            yield return $"{sectionPath}:{nameof(TransportClearTextRedirectOptions.Port)} — port {redirectPort} is bound by an HTTPS profile in this section, and one socket cannot serve both schemes. State a port no profile uses, or turn the redirect off.";
+            yield return $"{sectionPath}:{nameof(TransportClearTextRedirectOptions.Port)} — the clear-text redirect would bind {redirectAddress}:{redirectPort}, which the HTTPS profile {string.Join(" and ", collidingProfiles)} in this section already binds, and one socket cannot serve both schemes. State a port or an address no profile uses, or turn the redirect off.";
         }
     }
+
+    /// <summary>Reports whether two listener addresses on one port would contend for the same socket.</summary>
+    /// <remarks>
+    /// Either one being a wildcard is enough, and the direction matters: the wildcard is the address that accepts the
+    /// connections the other would be bound for, so each is asked whether it covers the other rather than only the first.
+    /// Two specific addresses are two sockets the operating system grants independently, which is the case this exists to
+    /// let through.
+    /// </remarks>
+    private static bool Overlaps(IPAddress left, IPAddress right) =>
+        left.Equals(right)
+        || (IsWildcard(left) && Covers(left, right))
+        || (IsWildcard(right) && Covers(right, left));
 
     /// <summary>Refuses two profiles that cannot be told apart, by the name diagnostics use or by the name a handshake selects on.</summary>
     private IEnumerable<string> FindCollidingIdentities(string configurationPath)

--- a/src/Host/Configuration/Endpoints/TransportHttpsOptions.cs
+++ b/src/Host/Configuration/Endpoints/TransportHttpsOptions.cs
@@ -29,15 +29,35 @@ internal sealed class TransportHttpsOptions
     /// <summary>Gets the HTTPS profiles served, empty when Kestrel terminates no TLS of its own.</summary>
     public IList<TransportHttpsEndpointOptions> Endpoints { get; } = [];
 
+    /// <summary>Gets or sets the clear-text listener that tells a client still pointed at <c>http://</c> where these profiles are.</summary>
+    public TransportClearTextRedirectOptions Redirect { get; set; } = new();
+
     /// <summary>Gets whether any profile is configured, which is what decides between the two postures.</summary>
     internal bool TerminatesTls => this.Endpoints.Count > 0;
+
+    /// <summary>Gets whether a clear-text listener is bound to redirect to these profiles.</summary>
+    /// <remarks>Both halves are required, and the first is what keeps the enabled-by-default setting silent on a surface that terminates no TLS: there is no clear-text listener to redirect away from, because the surface is already served over one.</remarks>
+    internal bool RedirectsClearText => this.TerminatesTls && this.Redirect.Enabled;
+
+    /// <summary>Reads the HTTPS port each configured domain is published on, which is what a redirect resolves against.</summary>
+    /// <returns>One entry per profile, keyed by the domain it publishes, matched without regard to case the way a host name is.</returns>
+    /// <remarks>Every profile carries a domain and no two share one, both of which validation has already proven by the time a composed redirect reads this.</remarks>
+    internal IReadOnlyDictionary<string, int> PublishedDomainPorts() =>
+        this.Endpoints.ToDictionary(
+            static endpoint => endpoint.Domain.Trim(),
+            static endpoint => endpoint.Port,
+            StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Finds everything an operator must fix before the configured profiles can be served.</summary>
     /// <param name="configurationPath">The configuration path of this section, which prefixes every reported error.</param>
     /// <param name="http3Supported">Whether the host platform can provide the QUIC transport HTTP/3 needs.</param>
+    /// <param name="defaultRedirectPort">The port this surface's clear-text redirect binds when the deployment states none.</param>
     /// <returns>One message per faulty setting, empty when the section is usable.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="configurationPath" /> is <see langword="null" />.</exception>
-    internal IReadOnlyList<string> FindConfigurationErrors(string configurationPath, bool http3Supported)
+    internal IReadOnlyList<string> FindConfigurationErrors(
+        string configurationPath,
+        bool http3Supported,
+        int defaultRedirectPort)
     {
         ArgumentNullException.ThrowIfNull(configurationPath);
 
@@ -50,8 +70,49 @@ internal sealed class TransportHttpsOptions
         errors.AddRange(this.FindCollidingIdentities(configurationPath));
         errors.AddRange(this.FindListenerDisagreements(configurationPath));
         errors.AddRange(this.FindOverlappingListeners(configurationPath));
+        errors.AddRange(this.FindRedirectErrors(configurationPath, defaultRedirectPort));
 
         return errors;
+    }
+
+    /// <summary>Refuses a redirect this surface cannot serve, and one whose socket a profile of its own already binds.</summary>
+    /// <remarks>
+    /// A redirect stated for a surface that terminates no TLS is refused rather than ignored, because that surface is
+    /// already reachable in clear text: the setting would read as configured while nothing bound it and nothing redirected
+    /// anywhere. The port check is the within-surface half of the collision rule — these profiles are the only listeners
+    /// this section can see, and the surface that owns it compares the same port against every other listener the process
+    /// opens.
+    /// </remarks>
+    private IEnumerable<string> FindRedirectErrors(string configurationPath, int defaultRedirectPort)
+    {
+        var sectionPath = $"{configurationPath}:{nameof(this.Redirect)}";
+
+        if (!this.TerminatesTls)
+        {
+            if (this.Redirect.WasStated)
+            {
+                yield return $"{sectionPath} — a clear-text redirect is configured while {configurationPath}:{nameof(this.Endpoints)} names no HTTPS profile, so there is nothing to redirect to and this surface is already served in clear text. Configure a profile, or remove this section.";
+            }
+
+            yield break;
+        }
+
+        foreach (var error in this.Redirect.FindConfigurationErrors(sectionPath))
+        {
+            yield return error;
+        }
+
+        if (!this.Redirect.Enabled)
+        {
+            yield break;
+        }
+
+        var redirectPort = this.Redirect.Port ?? defaultRedirectPort;
+
+        if (this.Endpoints.Any(endpoint => endpoint.Port == redirectPort))
+        {
+            yield return $"{sectionPath}:{nameof(TransportClearTextRedirectOptions.Port)} — port {redirectPort} is bound by an HTTPS profile in this section, and one socket cannot serve both schemes. State a port no profile uses, or turn the redirect off.";
+        }
     }
 
     /// <summary>Refuses two profiles that cannot be told apart, by the name diagnostics use or by the name a handshake selects on.</summary>

--- a/src/Host/Hosting/Startup/ClearTextRedirectToHttps.cs
+++ b/src/Host/Hosting/Startup/ClearTextRedirectToHttps.cs
@@ -1,0 +1,121 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Security.Transport;
+using Microsoft.AspNetCore.Http.Extensions;
+
+namespace MailFathom.Host.Hosting.Startup;
+
+/// <summary>Answers a clear-text listener with the address the surface's HTTPS profiles are served at, and with nothing else.</summary>
+/// <remarks>
+/// <para>
+/// A redirect protects the next request, never the one that arrived: a credential sent in clear text is already on the
+/// wire, and nothing here recovers it. What this exists for is the operator who has just configured a certificate, whose
+/// clients would otherwise meet a refused connection or an unreadable handshake error — an outage, as far as anything
+/// looking at it can tell. Telling a client where the endpoint is does not make clear-text access safe, so the listener
+/// serves nothing but this.
+/// </para>
+/// <para>
+/// "Nothing but this" is a property of the ordering as much as of the code. Registered ahead of every other middleware
+/// and every mapped route, so a request that arrived on a redirect listener is answered before it reaches endpoint
+/// isolation, CORS, authentication, the client-certificate check, the rate limiter, or routing. Every path is answered
+/// alike — the MCP route, the administrative routes, the protected-resource metadata document, the probes, and an unmapped
+/// path are indistinguishable here, because none of them is served on this socket.
+/// </para>
+/// <para>
+/// <c>308</c> rather than <c>301</c> or <c>302</c>, because a client must re-send the request it made. The MCP transport
+/// is a <c>POST</c> and the administrative write routes carry bodies; the older codes permit a client to turn either into
+/// a <c>GET</c>, which would arrive over TLS as a request nobody made and fail as a routing error rather than as a
+/// redirect that worked.
+/// </para>
+/// </remarks>
+internal static class ClearTextRedirectToHttps
+{
+    /// <summary>The scheme's own port, which is left out of a redirect rather than written as <c>:443</c>.</summary>
+    private const int DefaultHttpsPort = 443;
+
+    /// <summary>Builds the address a request should have been sent to.</summary>
+    /// <param name="targets">The listeners that redirect, and the domains each publishes.</param>
+    /// <param name="localPort">The TCP port the connection was accepted on.</param>
+    /// <param name="host">The host the request asked for, whose port is the clear-text one the client wrote and is discarded.</param>
+    /// <param name="path">The request path, preserved so the redirect reaches the same resource.</param>
+    /// <param name="query">The request query, preserved for the same reason.</param>
+    /// <returns>The absolute HTTPS address, or <see langword="null" /> when this listener's surface publishes no such domain.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="targets" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The host is redirected to itself rather than to a configured target, so several domains sharing one listener each
+    /// reach their own. A host header naming a domain the surface does not publish resolves to nothing: it is a name the
+    /// client chose, and rewriting it to a domain this deployment does publish would answer a request nobody made with an
+    /// identity nobody asked for.
+    /// </remarks>
+    internal static string? ResolveLocation(
+        ClearTextRedirectTargets targets,
+        int localPort,
+        HostString host,
+        PathString path,
+        QueryString query)
+    {
+        ArgumentNullException.ThrowIfNull(targets);
+
+        if (string.IsNullOrEmpty(host.Host)
+            || targets.PublishedHttpsPortFor(localPort, host.Host) is not { } httpsPort)
+        {
+            return null;
+        }
+
+        // Built through the framework's own composer rather than by concatenation, so the path and query are written back
+        // exactly as they were parsed and an IPv6 literal host keeps its brackets.
+        return UriHelper.BuildAbsolute(
+            Uri.UriSchemeHttps,
+            httpsPort == DefaultHttpsPort ? new HostString(host.Host) : new HostString(host.Host, httpsPort),
+            path: path,
+            query: query);
+    }
+
+    /// <summary>Redirects every request that arrived on a clear-text listener, and lets every other request through.</summary>
+    /// <param name="app">The application pipeline being composed.</param>
+    /// <param name="targets">The listeners that redirect, and the domains each publishes.</param>
+    /// <returns>The same application instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A request whose host names no published domain is answered <c>400</c>. It is the client's own claim about where it
+    /// was connecting that cannot be honored, which is a malformed request rather than a missing resource — and unlike a
+    /// <c>404</c> it does not invite a caller to read the answer as "try another path on this port".
+    /// </remarks>
+    internal static IApplicationBuilder UseClearTextRedirectToHttps(
+        this IApplicationBuilder app,
+        ClearTextRedirectTargets targets)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+        ArgumentNullException.ThrowIfNull(targets);
+
+        return app.Use(async (context, next) =>
+        {
+            if (!targets.RedirectsOnly(context.Connection.LocalPort))
+            {
+                await next(context);
+
+                return;
+            }
+
+            var request = context.Request;
+            var location = ResolveLocation(
+                targets,
+                context.Connection.LocalPort,
+                request.Host,
+                request.Path,
+                request.QueryString);
+
+            if (location is null)
+            {
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+
+                return;
+            }
+
+            context.Response.StatusCode = StatusCodes.Status308PermanentRedirect;
+            context.Response.Headers.Location = location;
+        });
+    }
+}

--- a/src/Host/Hosting/Warnings/TransportClearTextRedirectReport.cs
+++ b/src/Host/Hosting/Warnings/TransportClearTextRedirectReport.cs
@@ -1,0 +1,111 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Host.Configuration.Endpoints;
+using Microsoft.Extensions.Options;
+
+namespace MailFathom.Host.Hosting.Warnings;
+
+/// <summary>States at startup which clear-text port each surface redirects from, and to which domains.</summary>
+/// <remarks>
+/// <para>
+/// A redirect listener is the one socket a deployment can open without having written a port, so it is the one an
+/// operator auditing what the process listens on is most likely to be unable to account for. Reporting it beside the
+/// domains it redirects to is what makes every socket the process opened readable from the startup log.
+/// </para>
+/// <para>
+/// Information rather than a warning, because the posture is the safe one: the surface terminates TLS and the clear-text
+/// socket serves nothing but the address of that TLS. The warnings about a surface that terminates no TLS at all are
+/// separate and unchanged — <see cref="McpTransportEncryptionWarning" /> and
+/// <see cref="AdminTransportSecurityWarning" /> — and neither has anything to say about a deployment this one reports on.
+/// </para>
+/// <para>
+/// One report for both surfaces rather than one per surface, so the sockets are listed together in the order they were
+/// composed. It is registered whether or not either surface redirects, because it is the report that decides whether it
+/// has anything to say.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this hosted service.")]
+internal sealed partial class TransportClearTextRedirectReport : IHostedService
+{
+    private readonly McpEndpointOptions mcpEndpointSettings;
+    private readonly AdminEndpointOptions adminEndpointSettings;
+    private readonly ILogger<TransportClearTextRedirectReport> logger;
+
+    /// <summary>Initializes a new startup report.</summary>
+    /// <param name="mcpEndpointSettings">The MCP endpoint settings startup was composed from.</param>
+    /// <param name="adminEndpointSettings">The administrative endpoint settings startup was composed from.</param>
+    /// <param name="logger">The startup logger.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public TransportClearTextRedirectReport(
+        IOptions<McpEndpointOptions> mcpEndpointSettings,
+        IOptions<AdminEndpointOptions> adminEndpointSettings,
+        ILogger<TransportClearTextRedirectReport> logger)
+    {
+        ArgumentNullException.ThrowIfNull(mcpEndpointSettings);
+        ArgumentNullException.ThrowIfNull(adminEndpointSettings);
+
+        this.mcpEndpointSettings = mcpEndpointSettings.Value;
+        this.adminEndpointSettings = adminEndpointSettings.Value;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        // The description is built into a local rather than passed as a call, so composing it is not an argument the
+        // logging call has to evaluate before it knows the level is enabled. It is paid once, at startup, inside a branch
+        // that has already decided this deployment has a socket to account for.
+        if (this.mcpEndpointSettings is { Enabled: true, Https.RedirectsClearText: true })
+        {
+            var mcpRedirectTargets = DescribeTargets(this.mcpEndpointSettings.Https);
+
+            this.LogMcpEndpointRedirectsClearText(
+                this.mcpEndpointSettings.ClearTextRedirectPort,
+                mcpRedirectTargets);
+        }
+
+        if (this.adminEndpointSettings is { Enabled: true, Https.RedirectsClearText: true })
+        {
+            var adminRedirectTargets = DescribeTargets(this.adminEndpointSettings.Https);
+
+            this.LogAdminEndpointRedirectsClearText(
+                this.adminEndpointSettings.ClearTextRedirectPort,
+                adminRedirectTargets);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>Names each domain a redirect resolves to, beside the port it is served on.</summary>
+    /// <remarks>The configured domains are this deployment's own published names rather than anything a caller supplied, which is what makes them safe to write to a log.</remarks>
+    private static string DescribeTargets(TransportHttpsOptions httpsSettings) =>
+        string.Join(
+            ", ",
+            httpsSettings.PublishedDomainPorts()
+                .OrderBy(static target => target.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(static target => $"https://{target.Key}:{target.Value}"));
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The MCP endpoint redirects clear-text requests on port {ClearTextPort} to {RedirectTargets}. That "
+            + "listener maps no route and answers every path with a 308, so nothing is reachable over it. A redirect "
+            + "protects the next request and not the one that arrived — a credential already sent in clear text is on "
+            + "the wire — so repoint your clients rather than relying on it. Set "
+            + "McpEndpoint:Https:Redirect:Enabled to false to bind no clear-text port at all.")]
+    private partial void LogMcpEndpointRedirectsClearText(int clearTextPort, string redirectTargets);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The administrative endpoint redirects clear-text requests on port {ClearTextPort} to "
+            + "{RedirectTargets}. That listener maps no route and answers every path with a 308, so no administrative "
+            + "operation is reachable over it. A redirect protects the next request and not the one that arrived — a "
+            + "credential already sent in clear text is on the wire — so repoint mfctl rather than relying on it. Set "
+            + "AdminEndpoint:Https:Redirect:Enabled to false to bind no clear-text port at all.")]
+    private partial void LogAdminEndpointRedirectsClearText(int clearTextPort, string redirectTargets);
+}

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -370,7 +370,11 @@ try
             kestrelOptions,
             mcpEndpointSettings.Https,
             kestrelOptions.ApplicationServices.GetRequiredService<TransportServerCertificateStore>(),
-            mcpEndpointSettings.ClientCertificateProfiles.Count > 0));
+            mcpEndpointSettings.ClientCertificateProfiles.Count > 0,
+            mcpEndpointSettings.Https.RedirectsClearText
+                ? mcpEndpointSettings.Https.Redirect.ListenerAddress(
+                    McpEndpointOptions.DefaultClearTextRedirectPort)
+                : null));
     }
 
     // Read once, like the MCP section and for the same reason. Administering this service and reading a mailbox
@@ -383,6 +387,10 @@ try
     // Registered whether or not the endpoint is enabled, because it is the warning that decides whether it has
     // anything to say — the same reason the MCP warnings above are registered unconditionally.
     builder.Services.AddHostedService<AdminTransportSecurityWarning>();
+
+    // Registered here rather than beside the MCP warnings because it reads both surfaces, and unconditionally for the
+    // same reason they are: the report is what decides whether either surface has a clear-text port to account for.
+    builder.Services.AddHostedService<TransportClearTextRedirectReport>();
 
     // Read once, like the MCP section and for the same reason: it decides which sockets are opened and which routes
     // exist, both of which are settled while the application is being built. Bound strictly, so a misspelled key cannot
@@ -401,7 +409,10 @@ try
 
     IReadOnlyCollection<int> applicationListenerPorts = (mcpTerminatesTls, configuredKestrelEndpoints) switch
     {
-        (true, _) => [.. mcpEndpointSettings.Https.Endpoints.Select(static endpoint => endpoint.Port)],
+        // Every socket the MCP surface opens, the clear-text redirect included: it is bound by the same profiles and is
+        // the one a deployment can end up with without having written a port, so leaving it out would let the probes or
+        // the administrative endpoint take it and report the conflict as an address-in-use error naming a socket.
+        (true, _) => [.. mcpEndpointSettings.ListenerPorts],
         (false, true) => ConfiguredKestrelEndpoints.ListenerPorts(builder.Configuration),
         _ => ConfiguredApplicationListeners.ListenerPorts(applicationListenerUrls),
     };
@@ -555,6 +566,34 @@ try
     }
 
     app.UseExceptionHandler();
+
+    // One listener per surface that terminates TLS and redirects, each carrying its own domains: the two surfaces publish
+    // different names on different ports, so a request is redirected to the surface whose clear-text port it arrived on
+    // rather than to whichever set of profiles was composed first.
+    var clearTextRedirectListeners = new List<ClearTextRedirectListener>(capacity: 2);
+
+    if (mcpEndpointSettings is { Enabled: true, Https.RedirectsClearText: true })
+    {
+        clearTextRedirectListeners.Add(new ClearTextRedirectListener(
+            mcpEndpointSettings.ClearTextRedirectPort,
+            mcpEndpointSettings.Https.PublishedDomainPorts()));
+    }
+
+    if (adminEndpointSettings is { Enabled: true, Https.RedirectsClearText: true })
+    {
+        clearTextRedirectListeners.Add(new ClearTextRedirectListener(
+            adminEndpointSettings.ClearTextRedirectPort,
+            adminEndpointSettings.Https.PublishedDomainPorts()));
+    }
+
+    if (clearTextRedirectListeners.Count > 0)
+    {
+        // Ahead of both isolation middlewares and every route, which is what makes the clear-text listener serve nothing
+        // but the redirect. Behind it, an administrative path arriving on a redirect port would be answered by
+        // administrative isolation with a 404 — a listener that is not the administrative one refusing a path that is —
+        // and the client would read the endpoint as gone rather than as moved.
+        app.UseClearTextRedirectToHttps(new ClearTextRedirectTargets(clearTextRedirectListeners));
+    }
 
     if (healthEndpointSettings.Enabled)
     {

--- a/src/Host/Security/Endpoints/AdminEndpointListenerBinder.cs
+++ b/src/Host/Security/Endpoints/AdminEndpointListenerBinder.cs
@@ -24,9 +24,11 @@ internal static class AdminEndpointListenerBinder
     /// <param name="certificateStore">The store holding the TLS identity of each configured profile.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
     /// <remarks>
-    /// Naming any HTTPS profile binds those and nothing else, exactly as the MCP endpoint behaves: there is no mixed
-    /// state in which a clear-text listener stays open behind a profile an operator configured TLS for, because that
-    /// listener would serve the same administrative routes without the protection the profile was added for.
+    /// Naming any HTTPS profile binds those and nothing else that serves a route, exactly as the MCP endpoint behaves:
+    /// there is no mixed state in which a clear-text listener stays open behind a profile an operator configured TLS for,
+    /// because that listener would serve the same administrative routes without the protection the profile was added for.
+    /// The redirect listener is not that state and is the reason the distinction is worth stating — it maps no route and
+    /// answers every request with the address the profiles are served at, so nothing administrative is reachable over it.
     /// </remarks>
     internal static void Bind(
         KestrelServerOptions kestrelOptions,
@@ -43,7 +45,11 @@ internal static class AdminEndpointListenerBinder
                 kestrelOptions,
                 endpointSettings.Https,
                 certificateStore,
-                requestClientCertificates: false);
+                requestClientCertificates: false,
+                endpointSettings.Https.RedirectsClearText
+                    ? endpointSettings.Https.Redirect.ListenerAddress(
+                        AdminEndpointOptions.DefaultClearTextRedirectPort)
+                    : null);
 
             return;
         }

--- a/src/Host/Security/Transport/ClearTextRedirectListener.cs
+++ b/src/Host/Security/Transport/ClearTextRedirectListener.cs
@@ -1,0 +1,16 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Host.Security.Transport;
+
+/// <summary>One clear-text listener, and the HTTPS ports the domains it redirects to are published on.</summary>
+/// <param name="Port">The TCP port the clear-text listener binds.</param>
+/// <param name="PublishedDomainPorts">The HTTPS port each domain this surface publishes is served on, keyed without regard to case.</param>
+/// <remarks>
+/// One surface contributes one of these, because a surface has one clear-text listener and several HTTPS profiles. The
+/// domains are carried rather than a single target, so several domains sharing one listener each redirect to themselves:
+/// resolving one target for the listener would send every client to whichever domain configuration happened to name
+/// first, which is a domain the client never asked for and a certificate it may not accept.
+/// </remarks>
+internal sealed record ClearTextRedirectListener(int Port, IReadOnlyDictionary<string, int> PublishedDomainPorts);

--- a/src/Host/Security/Transport/ClearTextRedirectTargets.cs
+++ b/src/Host/Security/Transport/ClearTextRedirectTargets.cs
@@ -1,0 +1,56 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Host.Security.Transport;
+
+/// <summary>Answers, for the port a connection arrived on, whether that listener only redirects and where a domain moved to.</summary>
+/// <remarks>
+/// <para>
+/// Composed once, from the surfaces that terminate TLS and have a redirect turned on, so the request path resolves a
+/// target by two dictionary lookups and reads no configuration. Both questions are asked of the local port, which is the
+/// socket the operating system accepted the connection on and therefore something a caller cannot state or forward — the
+/// same property the endpoint isolation middlewares decide on.
+/// </para>
+/// </remarks>
+internal sealed class ClearTextRedirectTargets
+{
+    private readonly Dictionary<int, IReadOnlyDictionary<string, int>> publishedPortsByListenerPort;
+
+    /// <summary>Initializes the targets from the listeners the process opens.</summary>
+    /// <param name="listeners">One entry per clear-text listener, each naming the domains it redirects to.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="listeners" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when two listeners claim one port, which the endpoint sections refuse before composition reaches this.</exception>
+    internal ClearTextRedirectTargets(IEnumerable<ClearTextRedirectListener> listeners)
+    {
+        ArgumentNullException.ThrowIfNull(listeners);
+
+        this.publishedPortsByListenerPort = listeners.ToDictionary(
+            static listener => listener.Port,
+            static listener => listener.PublishedDomainPorts);
+    }
+
+    /// <summary>Reports whether a listener exists only to redirect, and therefore serves no route at all.</summary>
+    /// <param name="localPort">The TCP port the connection was accepted on.</param>
+    /// <returns><see langword="true" /> when the listener redirects and nothing else, otherwise <see langword="false" />.</returns>
+    internal bool RedirectsOnly(int localPort) => this.publishedPortsByListenerPort.ContainsKey(localPort);
+
+    /// <summary>Reads the HTTPS port a domain is published on, for the surface whose clear-text listener a request reached.</summary>
+    /// <param name="localPort">The TCP port the connection was accepted on.</param>
+    /// <param name="domain">The host name the request asked for, without its port.</param>
+    /// <returns>The HTTPS port, or <see langword="null" /> when this listener's surface publishes no such domain.</returns>
+    /// <remarks>
+    /// A domain the surface does not publish resolves to nothing rather than to a default. The name came from the client,
+    /// and answering it with a redirect to some other configured domain would send a request to a deployment identity
+    /// nobody asked for; the caller is told its host is not served instead.
+    /// </remarks>
+    internal int? PublishedHttpsPortFor(int localPort, string domain)
+    {
+        ArgumentNullException.ThrowIfNull(domain);
+
+        return this.publishedPortsByListenerPort.TryGetValue(localPort, out var publishedPorts)
+            && publishedPorts.TryGetValue(domain, out var httpsPort)
+                ? httpsPort
+                : null;
+    }
+}

--- a/src/Host/Security/Transport/TransportHttpsEndpointBinder.cs
+++ b/src/Host/Security/Transport/TransportHttpsEndpointBinder.cs
@@ -37,17 +37,19 @@ namespace MailFathom.Host.Security.Transport;
 /// </remarks>
 internal static class TransportHttpsEndpointBinder
 {
-    /// <summary>Binds one Kestrel listener per address the configured profiles name.</summary>
+    /// <summary>Binds one Kestrel listener per address the configured profiles name, and the clear-text redirect beside them.</summary>
     /// <param name="kestrelOptions">The server options being composed.</param>
     /// <param name="httpsSettings">The validated HTTPS profiles.</param>
     /// <param name="certificateStore">The store the handshake reads its identities from.</param>
     /// <param name="requestClientCertificates">Whether the handshake asks the client for a certificate, which it does when any client certificate profile is configured.</param>
-    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <param name="clearTextRedirect">The socket the redirect listener binds, or <see langword="null" /> when this surface serves none.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument other than <paramref name="clearTextRedirect" /> is <see langword="null" />.</exception>
     internal static void Bind(
         KestrelServerOptions kestrelOptions,
         TransportHttpsOptions httpsSettings,
         TransportServerCertificateStore certificateStore,
-        bool requestClientCertificates)
+        bool requestClientCertificates,
+        TransportHttpsListenerAddress? clearTextRedirect)
     {
         ArgumentNullException.ThrowIfNull(kestrelOptions);
         ArgumentNullException.ThrowIfNull(httpsSettings);
@@ -71,6 +73,15 @@ internal static class TransportHttpsEndpointBinder
                         context),
                 });
             });
+        }
+
+        // No UseHttps, because the point of the socket is to accept the clear-text request a client has not been
+        // repointed from, and no protocol selection either: the listener default accepts anything a stray client speaks
+        // over clear text, and every request it accepts is answered by the redirect middleware before routing. Narrowing
+        // it would turn a client this exists to help into a connection failure, which is the outcome it exists to avoid.
+        if (clearTextRedirect is { } redirect)
+        {
+            kestrelOptions.Listen(redirect.Address, redirect.Port);
         }
     }
 

--- a/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
@@ -165,6 +165,7 @@ public sealed class AdminEndpointOptionsTests
             TransportSurface.Admin.RoutingSchemeName,
             TransportSurface.Admin.ApiKeySchemeName,
             TransportSurface.Admin.AccessPolicyName,
+            TransportSurface.Admin.RateLimitingPolicyName,
             TransportSurface.Admin.OAuthSchemeNameFor("workforce"),
         ];
 
@@ -173,6 +174,7 @@ public sealed class AdminEndpointOptionsTests
             TransportSurface.Mcp.RoutingSchemeName,
             TransportSurface.Mcp.ApiKeySchemeName,
             TransportSurface.Mcp.AccessPolicyName,
+            TransportSurface.Mcp.RateLimitingPolicyName,
             TransportSurface.Mcp.OAuthSchemeNameFor("workforce"),
         ];
 

--- a/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Transport;
+using MailFathom.Infrastructure.Certificates;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using MailFathom.Infrastructure.Security.Transport;
 using Microsoft.Extensions.Configuration;
@@ -164,7 +165,6 @@ public sealed class AdminEndpointOptionsTests
             TransportSurface.Admin.RoutingSchemeName,
             TransportSurface.Admin.ApiKeySchemeName,
             TransportSurface.Admin.AccessPolicyName,
-            TransportSurface.Admin.RateLimitingPolicyName,
             TransportSurface.Admin.OAuthSchemeNameFor("workforce"),
         ];
 
@@ -173,7 +173,6 @@ public sealed class AdminEndpointOptionsTests
             TransportSurface.Mcp.RoutingSchemeName,
             TransportSurface.Mcp.ApiKeySchemeName,
             TransportSurface.Mcp.AccessPolicyName,
-            TransportSurface.Mcp.RateLimitingPolicyName,
             TransportSurface.Mcp.OAuthSchemeNameFor("workforce"),
         ];
 
@@ -220,6 +219,103 @@ public sealed class AdminEndpointOptionsTests
         // Assert
         Assert.Contains(errors, error => error.Contains("not a canonical resource URL", StringComparison.Ordinal));
         Assert.DoesNotContain(errors, error => error.Contains("must be '/api/admin'", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The redirect's port is one this endpoint binds, so it is checked against every other listener in the process. Left
+    /// out, a deployment could hand it to the probes or to the MCP surface and meet an address-in-use failure naming a
+    /// socket rather than a section.
+    /// </summary>
+    [Fact]
+    public void ListenerPorts_AnEndpointTerminatingTls_ClaimsTheRedirectPortBesideTheProfiles()
+    {
+        // Arrange
+        var settings = TlsTerminatingEndpoint();
+
+        // Act, Assert
+        Assert.Equal([8091, 8543], settings.ListenerPorts.Order());
+    }
+
+    [Fact]
+    public void ListenerPorts_ARedirectTurnedOff_ClaimsTheProfilePortsAlone()
+    {
+        // Arrange
+        var settings = TlsTerminatingEndpoint();
+        settings.Https.Redirect.Enabled = false;
+
+        // Act, Assert
+        Assert.Equal([8543], settings.ListenerPorts.Order());
+    }
+
+    /// <summary>The clear-text port is what the endpoint binds when it terminates no TLS, and there is nothing to redirect from.</summary>
+    [Fact]
+    public void ListenerPorts_AnEndpointTerminatingNoTls_ClaimsItsClearTextPortAlone() =>
+        Assert.Equal([8090], EnabledEndpoint().ListenerPorts.Order());
+
+    [Fact]
+    public void FindConfigurationErrors_ARedirectPortAnotherListenerBinds_IsRefusedBeforeAnythingBinds()
+    {
+        // Arrange
+        var settings = TlsTerminatingEndpoint();
+
+        // Act, Assert
+        Assert.Contains(
+            settings.FindConfigurationErrors([8091]),
+            error => error.Contains("already bound by another listener", StringComparison.Ordinal));
+    }
+
+    /// <summary>A port nothing binds collides with nothing, so a disabled redirect is not compared against the other listeners.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ADisabledRedirectOnAClaimedPort_ReportsNothing()
+    {
+        // Arrange
+        var settings = TlsTerminatingEndpoint();
+        settings.Https.Redirect.Enabled = false;
+
+        // Act, Assert
+        Assert.Empty(settings.FindConfigurationErrors([8091]));
+    }
+
+    /// <summary>Each surface redirects to its own profiles, so the two defaults have to differ or enabling both would collide.</summary>
+    [Fact]
+    public void ClearTextRedirectPort_TheAdministrativeDefault_IsNotTheMcpEndpointsDefault() =>
+        Assert.NotEqual(
+            McpEndpointOptions.DefaultClearTextRedirectPort,
+            AdminEndpointOptions.DefaultClearTextRedirectPort);
+
+    [Fact]
+    public void ReadFrom_AConfiguredRedirect_BindsItAndRecordsThatItWasStated()
+    {
+        // Arrange
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["AdminEndpoint:Enabled"] = "true",
+            ["AdminEndpoint:Https:Redirect:Port"] = "8092",
+        });
+
+        // Act
+        var settings = AdminEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.True(settings.Https.Redirect.WasStated);
+        Assert.Equal(8092, settings.ClearTextRedirectPort);
+    }
+
+    /// <summary>Stating a redirect for an endpoint that terminates no TLS is refused, because nothing would bind it and the endpoint is already served in clear text.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ARedirectStatedForAnEndpointTerminatingNoTls_IsRefused()
+    {
+        // Arrange
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["AdminEndpoint:Enabled"] = "true",
+            ["AdminEndpoint:Https:Redirect:Port"] = "8092",
+        });
+
+        // Act, Assert
+        Assert.Contains(
+            AdminEndpointOptions.ReadFrom(configuration).FindConfigurationErrors([]),
+            error => error.Contains("nothing to redirect to", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -293,6 +389,23 @@ public sealed class AdminEndpointOptionsTests
     }
 
     private static AdminEndpointOptions EnabledEndpoint() => new() { Enabled = true };
+
+    private static AdminEndpointOptions TlsTerminatingEndpoint()
+    {
+        var settings = EnabledEndpoint();
+        settings.Https.Endpoints.Add(new TransportHttpsEndpointOptions
+        {
+            Name = "admin",
+            Domain = "admin.example.test",
+            Port = 8543,
+            ServerCertificate = new TlsServerCertificateOptions
+            {
+                Bundle = new ConfiguredSecret { Name = "bundle", SecretReference = "file:/etc/mailfathom/tls/admin.pfx" },
+            },
+        });
+
+        return settings;
+    }
 
     private static AdminEndpointOptions OAuthEndpoint(string resource)
     {

--- a/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
@@ -344,6 +344,141 @@ public sealed class McpEndpointOptionsBindingTests
         Assert.Equal([TransportHttpProtocol.Http1, TransportHttpProtocol.Http2], profile.ServedHttpProtocols);
     }
 
+    /// <summary>
+    /// The redirect is on by default, so an absent section and one an operator wrote bind to identical values. Only
+    /// configuration can tell them apart, which is what makes a redirect stated for a surface terminating no TLS a startup
+    /// error rather than a default nobody asked for.
+    /// </summary>
+    [Fact]
+    public void ReadFrom_ASectionWithNoRedirectOfItsOwn_LeavesTheRedirectUnstated()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["McpEndpoint:Enabled"] = "true",
+        });
+
+        // Act
+        var settings = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.False(settings.Https.Redirect.WasStated);
+        Assert.True(settings.Https.Redirect.Enabled);
+        Assert.Null(settings.Https.Redirect.Port);
+    }
+
+    [Fact]
+    public void ReadFrom_AConfiguredRedirect_BindsItAndRecordsThatItWasStated()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["McpEndpoint:Enabled"] = "true",
+            ["McpEndpoint:Https:Redirect:Port"] = "8888",
+            ["McpEndpoint:Https:Redirect:BindAddress"] = "127.0.0.1",
+        });
+
+        // Act
+        var settings = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.True(settings.Https.Redirect.WasStated);
+        Assert.Equal(8888, settings.Https.Redirect.Port);
+        Assert.Equal(8888, settings.ClearTextRedirectPort);
+        Assert.Equal("127.0.0.1", settings.Https.Redirect.BindAddress);
+    }
+
+    /// <summary>Turning it off is stating it, which is what makes the setting readable as a decision rather than as silence.</summary>
+    [Fact]
+    public void ReadFrom_ARedirectTurnedOff_BindsAsStatedAndDisabled()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["McpEndpoint:Enabled"] = "true",
+            ["McpEndpoint:Https:Redirect:Enabled"] = "false",
+        });
+
+        // Act
+        var settings = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.True(settings.Https.Redirect.WasStated);
+        Assert.False(settings.Https.Redirect.Enabled);
+    }
+
+    /// <summary>The default is the surface's own, so a deployment reads a port it never wrote from the same place composition does.</summary>
+    [Fact]
+    public void ClearTextRedirectPort_ADeploymentStatingNoPort_TakesTheEndpointsOwnDefault()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["McpEndpoint:Enabled"] = "true",
+        });
+
+        // Act, Assert
+        Assert.Equal(8080, McpEndpointOptions.ReadFrom(configuration).ClearTextRedirectPort);
+    }
+
+    /// <summary>
+    /// Every socket the surface opens, so the probes and the administrative endpoint are checked against the redirect port
+    /// as well and a conflict is reported against a section rather than as an address already in use.
+    /// </summary>
+    [Fact]
+    public void ListenerPorts_ASurfaceTerminatingTls_ClaimsTheRedirectPortBesideTheProfiles()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(HttpsProfile(new Dictionary<string, string?>
+        {
+            ["McpEndpoint:Https:Endpoints:0:Port"] = "9443",
+        }));
+
+        // Act, Assert
+        Assert.Equal([8080, 9443], McpEndpointOptions.ReadFrom(configuration).ListenerPorts.Order());
+    }
+
+    [Fact]
+    public void ListenerPorts_ARedirectTurnedOff_ClaimsTheProfilePortsAlone()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(HttpsProfile(new Dictionary<string, string?>
+        {
+            ["McpEndpoint:Https:Redirect:Enabled"] = "false",
+        }));
+
+        // Act, Assert
+        Assert.Equal([8443], McpEndpointOptions.ReadFrom(configuration).ListenerPorts.Order());
+    }
+
+    /// <summary>A surface terminating no TLS binds no listener of its own; it is served over whichever one the host was started with.</summary>
+    [Fact]
+    public void ListenerPorts_ASurfaceTerminatingNoTls_ClaimsNothing()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["McpEndpoint:Enabled"] = "true",
+        });
+
+        // Act, Assert
+        Assert.Empty(McpEndpointOptions.ReadFrom(configuration).ListenerPorts);
+    }
+
+    private static Dictionary<string, string?> HttpsProfile(Dictionary<string, string?> extraValues)
+    {
+        var values = new Dictionary<string, string?>(extraValues)
+        {
+            ["McpEndpoint:Enabled"] = "true",
+            ["McpEndpoint:Https:Endpoints:0:Name"] = "public",
+            ["McpEndpoint:Https:Endpoints:0:Domain"] = "mail.example.test",
+            ["McpEndpoint:Https:Endpoints:0:ServerCertificate:Bundle:Name"] = "bundle",
+            ["McpEndpoint:Https:Endpoints:0:ServerCertificate:Bundle:SecretReference"] = "file:/etc/mailfathom/tls/bundle.pfx",
+        };
+
+        return values;
+    }
+
     private static IConfiguration ConfigurationFrom(Dictionary<string, string?> values) =>
         new ConfigurationBuilder()
             .AddInMemoryCollection(values)

--- a/tests/Host.UnitTests/Configuration/Endpoints/TransportHttpsOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/TransportHttpsOptionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Net;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Infrastructure.Certificates;
 using MailFathom.Infrastructure.Secrets.Discovery;
@@ -20,6 +21,10 @@ public sealed class TransportHttpsOptionsTests
 {
     private const string SectionPath = "McpEndpoint:Https";
 
+    /// <summary>The port a surface would redirect on, stated here so no rule below depends on which surface owns the section.</summary>
+    /// <remarks>Deliberately not the port <see cref="Profile" /> binds, so a well-formed profile beside an enabled redirect stays well formed and the collision rule has to be provoked to fire.</remarks>
+    private const int DefaultRedirectPort = 8080;
+
     [Fact]
     public void TerminatesTls_NoProfiles_IsTheClearTextPosture()
     {
@@ -28,7 +33,7 @@ public sealed class TransportHttpsOptionsTests
 
         // Assert
         Assert.False(options.TerminatesTls);
-        Assert.Empty(options.FindConfigurationErrors(SectionPath, http3Supported: true));
+        Assert.Empty(options.FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
     }
 
     [Fact]
@@ -39,7 +44,7 @@ public sealed class TransportHttpsOptionsTests
 
         // Act, Assert
         Assert.True(options.TerminatesTls);
-        Assert.Empty(options.FindConfigurationErrors(SectionPath, http3Supported: true));
+        Assert.Empty(options.FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
     }
 
     [Fact]
@@ -50,7 +55,7 @@ public sealed class TransportHttpsOptionsTests
         profile.Name = "   ";
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:Name", error, StringComparison.Ordinal);
@@ -64,7 +69,7 @@ public sealed class TransportHttpsOptionsTests
         profile.Domain = string.Empty;
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:Domain", error, StringComparison.Ordinal);
@@ -81,7 +86,7 @@ public sealed class TransportHttpsOptionsTests
         profile.Domain = domain;
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.Contains("BindAddress", error, StringComparison.Ordinal);
@@ -99,7 +104,7 @@ public sealed class TransportHttpsOptionsTests
         profile.Domain = domain;
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:Domain", error, StringComparison.Ordinal);
@@ -114,7 +119,7 @@ public sealed class TransportHttpsOptionsTests
         profile.Domain = "poczta.wróbel.test";
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.Contains("punycode", error, StringComparison.Ordinal);
@@ -130,7 +135,7 @@ public sealed class TransportHttpsOptionsTests
         profile.Port = port;
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:Port", error, StringComparison.Ordinal);
@@ -144,7 +149,7 @@ public sealed class TransportHttpsOptionsTests
         profile.BindAddress = "localhost";
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:BindAddress", error, StringComparison.Ordinal);
@@ -159,7 +164,7 @@ public sealed class TransportHttpsOptionsTests
         profile.HttpProtocols = [];
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:HttpProtocols", error, StringComparison.Ordinal);
@@ -183,7 +188,7 @@ public sealed class TransportHttpsOptionsTests
         profile.HttpProtocols = [TransportHttpProtocol.Http1, TransportHttpProtocol.Http1];
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:HttpProtocols", error, StringComparison.Ordinal);
@@ -198,7 +203,7 @@ public sealed class TransportHttpsOptionsTests
         profile.HttpProtocols = [TransportHttpProtocol.Http1, TransportHttpProtocol.Http2, TransportHttpProtocol.Http3];
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: false));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: false, DefaultRedirectPort));
 
         // Assert
         Assert.Contains("Http3", error, StringComparison.Ordinal);
@@ -212,7 +217,7 @@ public sealed class TransportHttpsOptionsTests
         profile.HttpProtocols = [TransportHttpProtocol.Http3];
 
         // Act, Assert
-        Assert.Empty(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        Assert.Empty(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
     }
 
     /// <summary>The binder turns any number into an enum value, and a floor nobody declared would be applied as though it had been chosen.</summary>
@@ -224,7 +229,7 @@ public sealed class TransportHttpsOptionsTests
         profile.MinimumTlsVersion = (TransportMinimumTlsVersion)7;
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:MinimumTlsVersion", error, StringComparison.Ordinal);
@@ -243,7 +248,7 @@ public sealed class TransportHttpsOptionsTests
         };
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:ServerCertificate", error, StringComparison.Ordinal);
@@ -257,7 +262,7 @@ public sealed class TransportHttpsOptionsTests
         profile.ServerCertificate = new TlsServerCertificateOptions();
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:ServerCertificate", error, StringComparison.Ordinal);
@@ -271,7 +276,7 @@ public sealed class TransportHttpsOptionsTests
         profile.ServerCertificate = new TlsServerCertificateOptions { CertificateChain = Block("chain") };
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:ServerCertificate:PrivateKey", error, StringComparison.Ordinal);
@@ -285,7 +290,7 @@ public sealed class TransportHttpsOptionsTests
         profile.ServerCertificate = new TlsServerCertificateOptions { PrivateKey = Block("key") };
 
         // Act
-        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(profile).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.StartsWith($"{SectionPath}:Endpoints:0:ServerCertificate:CertificateChain", error, StringComparison.Ordinal);
@@ -298,7 +303,7 @@ public sealed class TransportHttpsOptionsTests
         var options = With(Profile(name: "public"), Profile(name: "PUBLIC", domain: "other.example.test"));
 
         // Act
-        var error = Assert.Single(options.FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(options.FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.Contains("names more than one HTTPS profile", error, StringComparison.Ordinal);
@@ -312,7 +317,7 @@ public sealed class TransportHttpsOptionsTests
         var options = With(Profile(name: "first"), Profile(name: "second"));
 
         // Act
-        var error = Assert.Single(options.FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(options.FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.Contains("published by more than one HTTPS profile", error, StringComparison.Ordinal);
@@ -328,7 +333,7 @@ public sealed class TransportHttpsOptionsTests
         second.HttpProtocols = [TransportHttpProtocol.Http1];
 
         // Act
-        var error = Assert.Single(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true));
+        var error = Assert.Single(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.Contains("name different HTTP versions", error, StringComparison.Ordinal);
@@ -344,7 +349,7 @@ public sealed class TransportHttpsOptionsTests
         second.MinimumTlsVersion = TransportMinimumTlsVersion.Tls13;
 
         // Act, Assert
-        Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true));
+        Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
     }
 
     [Fact]
@@ -357,7 +362,7 @@ public sealed class TransportHttpsOptionsTests
         second.HttpProtocols = [TransportHttpProtocol.Http1];
 
         // Act, Assert
-        Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true));
+        Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
     }
 
     /// <summary>The wildcard socket already owns the specific address, so the second bind fails with an address-in-use error naming a socket rather than a profile.</summary>
@@ -371,7 +376,7 @@ public sealed class TransportHttpsOptionsTests
 
         // Act
         var error = Assert.Single(With(everyInterface, oneInterface)
-            .FindConfigurationErrors(SectionPath, http3Supported: true));
+            .FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.Contains("already accepts the connections", error, StringComparison.Ordinal);
@@ -390,7 +395,7 @@ public sealed class TransportHttpsOptionsTests
 
         // Act
         var error = Assert.Single(With(everyInterface, oneInterface)
-            .FindConfigurationErrors(SectionPath, http3Supported: true));
+            .FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
 
         // Assert
         Assert.Contains("already accepts the connections", error, StringComparison.Ordinal);
@@ -405,7 +410,7 @@ public sealed class TransportHttpsOptionsTests
         var second = Profile(name: "second", domain: "two.example.test");
 
         // Act, Assert
-        Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true));
+        Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
     }
 
     [Fact]
@@ -418,7 +423,7 @@ public sealed class TransportHttpsOptionsTests
         oneInterface.Port = 9443;
 
         // Act, Assert
-        Assert.Empty(With(everyInterface, oneInterface).FindConfigurationErrors(SectionPath, http3Supported: true));
+        Assert.Empty(With(everyInterface, oneInterface).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
     }
 
     /// <summary>Two specific addresses are two sockets the operating system grants independently.</summary>
@@ -432,8 +437,211 @@ public sealed class TransportHttpsOptionsTests
         second.BindAddress = "10.0.0.5";
 
         // Act, Assert
-        Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true));
+        Assert.Empty(With(first, second).FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
     }
+
+    /// <summary>Enabling TLS should not read as an outage, which is why a deployment gets the redirect without asking.</summary>
+    [Fact]
+    public void RedirectsClearText_ASurfaceTerminatingTlsThatStatedNothing_RedirectsByDefault()
+    {
+        // Arrange
+        var options = With(Profile());
+
+        // Act, Assert
+        Assert.True(options.RedirectsClearText);
+        Assert.Empty(options.FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
+    }
+
+    /// <summary>A deployment behind a proxy that already answers the clear-text port turns it off rather than binding a port it did not ask for.</summary>
+    [Fact]
+    public void RedirectsClearText_ARedirectTurnedOff_BindsNoClearTextListener()
+    {
+        // Arrange
+        var options = With(Profile());
+        options.Redirect.Enabled = false;
+
+        // Act, Assert
+        Assert.False(options.RedirectsClearText);
+        Assert.Empty(options.FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
+    }
+
+    /// <summary>There is no clear-text listener to redirect away from, because the surface is already served over one.</summary>
+    [Fact]
+    public void RedirectsClearText_ASurfaceTerminatingNoTls_RedirectsNothingDespiteTheDefault() =>
+        Assert.False(new TransportHttpsOptions().RedirectsClearText);
+
+    /// <summary>
+    /// The default has to stay silent where it means nothing, or every clear-text deployment would fail startup over a
+    /// section it never wrote.
+    /// </summary>
+    [Fact]
+    public void FindConfigurationErrors_ARedirectLeftAtItsDefaultWithoutAnyProfile_IsNotReported() =>
+        Assert.Empty(new TransportHttpsOptions().FindConfigurationErrors(
+            SectionPath,
+            http3Supported: true,
+            DefaultRedirectPort));
+
+    /// <summary>Configured-but-unbound is refused rather than ignored, the same way every other unread setting here is.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ARedirectStatedWithoutAnyProfile_IsRefused()
+    {
+        // Arrange
+        var options = new TransportHttpsOptions();
+        options.Redirect.MarkStated();
+
+        // Act
+        var error = Assert.Single(options.FindConfigurationErrors(
+            SectionPath,
+            http3Supported: true,
+            DefaultRedirectPort));
+
+        // Assert
+        Assert.StartsWith($"{SectionPath}:Redirect", error, StringComparison.Ordinal);
+        Assert.Contains("nothing to redirect to", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>One socket cannot serve both schemes, and the operating system would report it as an address already in use.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ARedirectPortAProfileAlreadyBinds_IsRefused()
+    {
+        // Arrange
+        var profile = Profile();
+        var options = With(profile);
+        options.Redirect.Port = profile.Port;
+
+        // Act
+        var error = Assert.Single(options.FindConfigurationErrors(
+            SectionPath,
+            http3Supported: true,
+            DefaultRedirectPort));
+
+        // Assert
+        Assert.StartsWith($"{SectionPath}:Redirect:Port", error, StringComparison.Ordinal);
+        Assert.Contains("one socket cannot serve both schemes", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>The same collision, reached through the default rather than through a stated port.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ADefaultRedirectPortAProfileBinds_IsRefused()
+    {
+        // Arrange
+        var profile = Profile();
+        profile.Port = DefaultRedirectPort;
+
+        // Act
+        var error = Assert.Single(With(profile).FindConfigurationErrors(
+            SectionPath,
+            http3Supported: true,
+            DefaultRedirectPort));
+
+        // Assert
+        Assert.StartsWith($"{SectionPath}:Redirect:Port", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>A collision with a port nothing binds is no collision, so a redirect that is off is not checked against the profiles.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ADisabledRedirectSharingAProfilePort_IsNotReported()
+    {
+        // Arrange
+        var profile = Profile();
+        var options = With(profile);
+        options.Redirect.Enabled = false;
+        options.Redirect.Port = profile.Port;
+
+        // Act, Assert
+        Assert.Empty(options.FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_ARedirectBindAddressThatIsNotAnAddress_IsRefused()
+    {
+        // Arrange
+        var options = With(Profile());
+        options.Redirect.BindAddress = "not-an-address";
+
+        // Act
+        var error = Assert.Single(options.FindConfigurationErrors(
+            SectionPath,
+            http3Supported: true,
+            DefaultRedirectPort));
+
+        // Assert
+        Assert.StartsWith($"{SectionPath}:Redirect:BindAddress", error, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(65536)]
+    public void FindConfigurationErrors_ARedirectPortOutsideTheRange_IsRefused(int port)
+    {
+        // Arrange
+        var options = With(Profile());
+        options.Redirect.Port = port;
+
+        // Act
+        var error = Assert.Single(options.FindConfigurationErrors(
+            SectionPath,
+            http3Supported: true,
+            DefaultRedirectPort));
+
+        // Assert
+        Assert.StartsWith($"{SectionPath}:Redirect:Port", error, StringComparison.Ordinal);
+        Assert.Contains("is not a TCP port", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>The socket the binder opens, which is the whole of what it decides from this section.</summary>
+    [Fact]
+    public void ListenerAddress_ARedirectStatingNoPort_BindsEveryIpv4AddressOnTheSurfacesDefault()
+    {
+        // Arrange
+        var options = With(Profile());
+
+        // Act
+        var address = options.Redirect.ListenerAddress(DefaultRedirectPort);
+
+        // Assert
+        Assert.Equal(IPAddress.Any, address.Address);
+        Assert.Equal(DefaultRedirectPort, address.Port);
+    }
+
+    [Fact]
+    public void ListenerAddress_ARedirectStatingBoth_BindsWhatItStated()
+    {
+        // Arrange
+        var options = With(Profile());
+        options.Redirect.BindAddress = "127.0.0.1";
+        options.Redirect.Port = 8888;
+
+        // Act
+        var address = options.Redirect.ListenerAddress(DefaultRedirectPort);
+
+        // Assert
+        Assert.Equal(IPAddress.Loopback, address.Address);
+        Assert.Equal(8888, address.Port);
+    }
+
+    /// <summary>What a composed redirect resolves a client's host against, one entry per profile.</summary>
+    [Fact]
+    public void PublishedDomainPorts_SeveralProfiles_MapEachDomainToItsOwnPort()
+    {
+        // Arrange
+        var standard = Profile(name: "public", domain: "one.example.test");
+        var managed = Profile(name: "managed", domain: "two.example.test");
+        managed.Port = 9443;
+
+        // Act
+        var published = With(standard, managed).PublishedDomainPorts();
+
+        // Assert
+        Assert.Equal(8443, published["one.example.test"]);
+        Assert.Equal(9443, published["two.example.test"]);
+    }
+
+    /// <summary>A client sends a host name without regard to case, so the lookup a redirect performs cannot depend on it.</summary>
+    [Fact]
+    public void PublishedDomainPorts_ADomainInAnotherCase_StillResolves() =>
+        Assert.Equal(8443, With(Profile()).PublishedDomainPorts()["MAIL.EXAMPLE.TEST"]);
 
     private static TransportHttpsOptions With(params TransportHttpsEndpointOptions[] profiles)
     {

--- a/tests/Host.UnitTests/Configuration/Endpoints/TransportHttpsOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/TransportHttpsOptionsTests.cs
@@ -538,6 +538,102 @@ public sealed class TransportHttpsOptionsTests
         Assert.StartsWith($"{SectionPath}:Redirect:Port", error, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Two specific addresses are two sockets the operating system grants independently, which is exactly what
+    /// <c>FindConfigurationErrors_TwoSpecificAddressesOnOnePort_IsAccepted</c> already establishes between two profiles. A
+    /// redirect comparing port numbers alone would block this multi-interface deployment for a collision that does not
+    /// exist.
+    /// </summary>
+    [Fact]
+    public void FindConfigurationErrors_ARedirectOnAnotherSpecificAddressSharingAProfilePort_IsAccepted()
+    {
+        // Arrange
+        var profile = Profile();
+        profile.BindAddress = "10.0.0.5";
+        profile.Port = 9000;
+        var options = With(profile);
+        options.Redirect.BindAddress = "10.0.0.6";
+        options.Redirect.Port = 9000;
+
+        // Act, Assert
+        Assert.Empty(options.FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
+    }
+
+    /// <summary>The wildcard already accepts the connections the profile's address would receive, so only one of the two could bind.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AWildcardRedirectOverAProfilesSpecificAddress_IsRefused()
+    {
+        // Arrange
+        var profile = Profile();
+        profile.BindAddress = "10.0.0.5";
+        profile.Port = 9000;
+        var options = With(profile);
+        options.Redirect.BindAddress = "0.0.0.0";
+        options.Redirect.Port = 9000;
+
+        // Act
+        var error = Assert.Single(options.FindConfigurationErrors(
+            SectionPath,
+            http3Supported: true,
+            DefaultRedirectPort));
+
+        // Assert
+        Assert.StartsWith($"{SectionPath}:Redirect:Port", error, StringComparison.Ordinal);
+        Assert.Contains("public", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>And the reverse direction, because the wildcard is whichever of the two happens to be one.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ASpecificRedirectUnderAProfilesWildcard_IsRefused()
+    {
+        // Arrange
+        var profile = Profile();
+        profile.BindAddress = "0.0.0.0";
+        profile.Port = 9000;
+        var options = With(profile);
+        options.Redirect.BindAddress = "10.0.0.5";
+        options.Redirect.Port = 9000;
+
+        // Act, Assert
+        Assert.Single(options.FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
+    }
+
+    /// <summary>Kestrel binds <c>::</c> as a dual-mode socket, so an IPv6 wildcard accepts the IPv4 connections too.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AnIpv6WildcardRedirectOverAnIpv4Profile_IsRefused()
+    {
+        // Arrange
+        var profile = Profile();
+        profile.BindAddress = "10.0.0.5";
+        profile.Port = 9000;
+        var options = With(profile);
+        options.Redirect.BindAddress = "::";
+        options.Redirect.Port = 9000;
+
+        // Act, Assert
+        Assert.Single(options.FindConfigurationErrors(SectionPath, http3Supported: true, DefaultRedirectPort));
+    }
+
+    /// <summary>Reported once, against the address the operator wrote, rather than a second time as a collision nobody could act on.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ARedirectAddressThatDoesNotParseOnAProfilePort_ReportsOnlyTheAddress()
+    {
+        // Arrange
+        var profile = Profile();
+        var options = With(profile);
+        options.Redirect.BindAddress = "not-an-address";
+        options.Redirect.Port = profile.Port;
+
+        // Act
+        var error = Assert.Single(options.FindConfigurationErrors(
+            SectionPath,
+            http3Supported: true,
+            DefaultRedirectPort));
+
+        // Assert
+        Assert.StartsWith($"{SectionPath}:Redirect:BindAddress", error, StringComparison.Ordinal);
+    }
+
     /// <summary>A collision with a port nothing binds is no collision, so a redirect that is off is not checked against the profiles.</summary>
     [Fact]
     public void FindConfigurationErrors_ADisabledRedirectSharingAProfilePort_IsNotReported()

--- a/tests/Host.UnitTests/Hosting/Startup/ClearTextRedirectToHttpsTests.cs
+++ b/tests/Host.UnitTests/Hosting/Startup/ClearTextRedirectToHttpsTests.cs
@@ -1,0 +1,130 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Hosting.Startup;
+using MailFathom.Host.Security.Transport;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Hosting.Startup;
+
+/// <summary>Covers where a client still pointed at <c>http://</c> is sent, and when it is not sent anywhere.</summary>
+/// <remarks>
+/// The redirect exists so that enabling TLS does not read as an outage, and it is safe only because the listener serves
+/// nothing else. Two rules here carry that weight: the host is redirected to itself rather than to a configured target,
+/// so one listener serving several domains never sends a client to a name it did not ask for; and a host the deployment
+/// does not publish is refused rather than rewritten.
+/// </remarks>
+public sealed class ClearTextRedirectToHttpsTests
+{
+    private const int RedirectListenerPort = 8080;
+
+    private const int OtherSurfaceRedirectPort = 8091;
+
+    private static readonly ClearTextRedirectTargets Targets = new(
+    [
+        new ClearTextRedirectListener(
+            RedirectListenerPort,
+            new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["mail.example.test"] = 8443,
+                ["managed.example.test"] = 9443,
+                ["standard.example.test"] = 443,
+            }),
+        new ClearTextRedirectListener(
+            OtherSurfaceRedirectPort,
+            new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["admin.example.test"] = 8543,
+            }),
+    ]);
+
+    [Fact]
+    public void ResolveLocation_APublishedDomain_RedirectsToItselfOverHttpsOnTheProfilePort() =>
+        Assert.Equal(
+            "https://mail.example.test:8443/mcp",
+            ResolveFor("mail.example.test", "/mcp"));
+
+    /// <summary>Preserved, so the redirect reaches the resource that was asked for rather than the surface's root.</summary>
+    [Fact]
+    public void ResolveLocation_APathAndQuery_AreCarriedThrough() =>
+        Assert.Equal(
+            "https://mail.example.test:8443/mcp/tools?cursor=abc&limit=20",
+            ResolveFor("mail.example.test", "/mcp/tools", "?cursor=abc&limit=20"));
+
+    /// <summary>
+    /// Several domains share one clear-text listener, and each has to reach its own: a single resolved target would send
+    /// every client to whichever profile configuration named first, under a certificate issued for a different name.
+    /// </summary>
+    [Fact]
+    public void ResolveLocation_ASecondDomainOnTheSameListener_RedirectsToItsOwnProfilePort() =>
+        Assert.Equal(
+            "https://managed.example.test:9443/mcp",
+            ResolveFor("managed.example.test", "/mcp"));
+
+    /// <summary>Written without a port, because <c>:443</c> is the scheme's own and a client appends nothing for it.</summary>
+    [Fact]
+    public void ResolveLocation_AProfileOnTheSchemeDefaultPort_OmitsThePort() =>
+        Assert.Equal(
+            "https://standard.example.test/mcp",
+            ResolveFor("standard.example.test", "/mcp"));
+
+    /// <summary>A host name matches the way a client sends it, which is without regard to case.</summary>
+    [Fact]
+    public void ResolveLocation_APublishedDomainInAnotherCase_StillResolves() =>
+        Assert.Equal(
+            "https://Mail.Example.Test:8443/mcp",
+            ResolveFor("Mail.Example.Test", "/mcp"));
+
+    /// <summary>The port the client wrote is the clear-text one it is being moved off, so it never reaches the target.</summary>
+    [Fact]
+    public void ResolveLocation_AHostCarryingTheClearTextPort_RedirectsToTheProfilePortInstead() =>
+        Assert.Equal(
+            "https://mail.example.test:8443/mcp",
+            ClearTextRedirectToHttps.ResolveLocation(
+                Targets,
+                RedirectListenerPort,
+                new HostString("mail.example.test", RedirectListenerPort),
+                "/mcp",
+                QueryString.Empty));
+
+    /// <summary>The name came from the client, and answering it with another configured domain would serve an identity nobody asked for.</summary>
+    [Fact]
+    public void ResolveLocation_AHostTheSurfaceDoesNotPublish_ResolvesToNothing() =>
+        Assert.Null(ResolveFor("someone-elses-domain.test", "/mcp"));
+
+    /// <summary>Each surface's listener publishes its own domains, so the other surface's are not reachable through it.</summary>
+    [Fact]
+    public void ResolveLocation_AnotherSurfacesDomainOnThisListener_ResolvesToNothing() =>
+        Assert.Null(ResolveFor("admin.example.test", "/api/admin/session"));
+
+    [Fact]
+    public void ResolveLocation_ARequestWithoutAHostHeader_ResolvesToNothing() =>
+        Assert.Null(ClearTextRedirectToHttps.ResolveLocation(
+            Targets,
+            RedirectListenerPort,
+            default,
+            "/mcp",
+            QueryString.Empty));
+
+    /// <summary>The administrative surface redirects to its own profiles, on its own listener.</summary>
+    [Fact]
+    public void ResolveLocation_TheOtherSurfacesListener_RedirectsToThatSurfacesProfile() =>
+        Assert.Equal(
+            "https://admin.example.test:8543/api/admin/session",
+            ClearTextRedirectToHttps.ResolveLocation(
+                Targets,
+                OtherSurfaceRedirectPort,
+                new HostString("admin.example.test"),
+                "/api/admin/session",
+                QueryString.Empty));
+
+    private static string? ResolveFor(string host, string path, string query = "") =>
+        ClearTextRedirectToHttps.ResolveLocation(
+            Targets,
+            RedirectListenerPort,
+            new HostString(host),
+            new PathString(path),
+            new QueryString(query));
+}

--- a/tests/Host.UnitTests/Hosting/Startup/ClearTextRedirectToHttpsTests.cs
+++ b/tests/Host.UnitTests/Hosting/Startup/ClearTextRedirectToHttpsTests.cs
@@ -4,7 +4,10 @@
 
 using MailFathom.Host.Hosting.Startup;
 using MailFathom.Host.Security.Transport;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
 using Xunit;
 
 namespace MailFathom.Host.UnitTests.Hosting.Startup;
@@ -120,6 +123,78 @@ public sealed class ClearTextRedirectToHttpsTests
                 "/api/admin/session",
                 QueryString.Empty));
 
+    [Fact]
+    public async Task UseClearTextRedirectToHttps_ARequestOnARedirectListener_IsAnsweredWithoutReachingTheRestOfThePipeline()
+    {
+        // Arrange
+        var context = RequestOn(RedirectListenerPort, "mail.example.test", "/mcp", "?cursor=abc");
+        var reachedTheRestOfThePipeline = false;
+
+        // Act
+        await RedirectMiddleware(() => reachedTheRestOfThePipeline = true)(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status308PermanentRedirect, context.Response.StatusCode);
+        Assert.Equal("https://mail.example.test:8443/mcp?cursor=abc", context.Response.Headers.Location);
+        Assert.False(reachedTheRestOfThePipeline);
+    }
+
+    /// <summary>
+    /// The whole safety property of this listener: nothing behind it runs. Were the refusal to fall through, the request
+    /// would go on to reach routing, authentication, and the rate limiter over a clear-text hop.
+    /// </summary>
+    [Fact]
+    public async Task UseClearTextRedirectToHttps_AnUnrecognizedHostOnARedirectListener_IsRefusedWithoutReachingTheRestOfThePipeline()
+    {
+        // Arrange
+        var context = RequestOn(RedirectListenerPort, "someone-elses-domain.test", "/mcp");
+        var reachedTheRestOfThePipeline = false;
+
+        // Act
+        await RedirectMiddleware(() => reachedTheRestOfThePipeline = true)(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, context.Response.StatusCode);
+        Assert.True(StringValues.IsNullOrEmpty(context.Response.Headers.Location));
+        Assert.False(reachedTheRestOfThePipeline);
+    }
+
+    /// <summary>
+    /// The direction that matters as much: this middleware is registered ahead of every route in the process, so a listener
+    /// it claimed by mistake would take the whole surface down rather than redirect it.
+    /// </summary>
+    [Fact]
+    public async Task UseClearTextRedirectToHttps_ARequestOnAListenerThatServesRoutes_ReachesTheRestOfThePipelineUntouched()
+    {
+        // Arrange
+        var context = RequestOn(8443, "mail.example.test", "/mcp");
+        var reachedTheRestOfThePipeline = false;
+
+        // Act
+        await RedirectMiddleware(() => reachedTheRestOfThePipeline = true)(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.True(StringValues.IsNullOrEmpty(context.Response.Headers.Location));
+        Assert.True(reachedTheRestOfThePipeline);
+    }
+
+    /// <summary>A deployment where no surface redirects leaves every listener alone, which is why the registration can be unconditional.</summary>
+    [Fact]
+    public async Task UseClearTextRedirectToHttps_NoSurfaceRedirecting_LeavesEveryRequestAlone()
+    {
+        // Arrange
+        var context = RequestOn(RedirectListenerPort, "mail.example.test", "/mcp");
+        var reachedTheRestOfThePipeline = false;
+
+        // Act
+        await RedirectMiddleware(() => reachedTheRestOfThePipeline = true, new ClearTextRedirectTargets([]))(context);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
+        Assert.True(reachedTheRestOfThePipeline);
+    }
+
     private static string? ResolveFor(string host, string path, string query = "") =>
         ClearTextRedirectToHttps.ResolveLocation(
             Targets,
@@ -127,4 +202,30 @@ public sealed class ClearTextRedirectToHttpsTests
             new HostString(host),
             new PathString(path),
             new QueryString(query));
+
+    private static RequestDelegate RedirectMiddleware(Action onReached, ClearTextRedirectTargets? targets = null)
+    {
+        var pipeline = new ApplicationBuilder(new ServiceCollection().BuildServiceProvider());
+
+        pipeline.UseClearTextRedirectToHttps(targets ?? Targets);
+        pipeline.Run(_ =>
+        {
+            onReached();
+
+            return Task.CompletedTask;
+        });
+
+        return pipeline.Build();
+    }
+
+    private static DefaultHttpContext RequestOn(int port, string host, string path, string query = "")
+    {
+        var context = new DefaultHttpContext();
+        context.Connection.LocalPort = port;
+        context.Request.Host = new HostString(host);
+        context.Request.Path = new PathString(path);
+        context.Request.QueryString = new QueryString(query);
+
+        return context;
+    }
 }

--- a/tests/Host.UnitTests/Hosting/Warnings/TransportClearTextRedirectReportTests.cs
+++ b/tests/Host.UnitTests/Hosting/Warnings/TransportClearTextRedirectReportTests.cs
@@ -1,0 +1,202 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Hosting.Warnings;
+using MailFathom.Infrastructure.Certificates;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Hosting.Warnings;
+
+/// <summary>Covers what an operator is told about the clear-text port a redirect opens on their behalf.</summary>
+/// <remarks>
+/// This is the one socket a deployment can end up listening on without having written a port, so it is the one an
+/// operator auditing the process cannot otherwise account for. Its silence matters as much as its text: a line for a
+/// deployment that opened no such port would be noise, and a line naming a port nothing bound would send somebody looking
+/// for a listener that is not there.
+/// </remarks>
+public sealed class TransportClearTextRedirectReportTests
+{
+    [Fact]
+    public async Task StartAsync_AnMcpEndpointRedirecting_NamesThePortAndTheDomainsItRedirectsTo()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(McpTerminatingTls(), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.Equal(8080, Assert.Contains("ClearTextPort", record.Properties));
+        Assert.Equal("https://mail.example.test:8443", Assert.Contains("RedirectTargets", record.Properties));
+        Assert.Contains("maps no route", record.Message, StringComparison.Ordinal);
+        Assert.Contains("McpEndpoint:Https:Redirect:Enabled", record.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>Every domain, so an operator reads the whole set of names the one clear-text port answers for.</summary>
+    [Fact]
+    public async Task StartAsync_SeveralProfiles_NamesEveryDomainBesideItsOwnPort()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var settings = McpTerminatingTls();
+        settings.Https.Endpoints.Add(Profile(name: "managed", domain: "managed.example.test", port: 9443));
+        var report = ReportFor(settings, new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(
+            "https://mail.example.test:8443, https://managed.example.test:9443",
+            Assert.Contains("RedirectTargets", record.Properties));
+    }
+
+    /// <summary>Each surface opens its own socket, so each is accounted for separately.</summary>
+    [Fact]
+    public async Task StartAsync_BothSurfacesRedirecting_ReportsOneLinePerSurface()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(McpTerminatingTls(), AdminTerminatingTls(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, logs.Records.Count);
+        Assert.Contains(logs.Records, record => record.Message.Contains("administrative endpoint", StringComparison.Ordinal));
+        Assert.Contains(logs.Records, record => record.Message.Contains("MCP endpoint", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task StartAsync_AnAdministrativeEndpointRedirecting_NamesItsOwnDefaultPort()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(new McpEndpointOptions(), AdminTerminatingTls(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(8091, Assert.Contains("ClearTextPort", record.Properties));
+        Assert.Contains("AdminEndpoint:Https:Redirect:Enabled", record.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>Nothing was bound, so naming a port would send an operator looking for a listener that is not there.</summary>
+    [Fact]
+    public async Task StartAsync_ARedirectTurnedOff_SaysNothing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var settings = McpTerminatingTls();
+        settings.Https.Redirect.Enabled = false;
+        var report = ReportFor(settings, new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    /// <summary>The clear-text posture has its own warning, and it is not this one; nothing here fires for a surface that terminates no TLS.</summary>
+    [Fact]
+    public async Task StartAsync_ASurfaceTerminatingNoTls_SaysNothing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(new McpEndpointOptions { Enabled = true }, new AdminEndpointOptions { Enabled = true }, logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    /// <summary>A surface nobody enabled opens no socket, whatever its profiles say.</summary>
+    [Fact]
+    public async Task StartAsync_ADisabledSurfaceWithProfiles_SaysNothing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var settings = McpTerminatingTls();
+        settings.Enabled = false;
+        var report = ReportFor(settings, new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    [Fact]
+    public async Task StopAsync_AnyPosture_CompletesWithoutSayingAnythingFurther()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(McpTerminatingTls(), AdminTerminatingTls(), logs);
+
+        // Act
+        await report.StopAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    private static McpEndpointOptions McpTerminatingTls()
+    {
+        var settings = new McpEndpointOptions { Enabled = true };
+        settings.Https.Endpoints.Add(Profile());
+
+        return settings;
+    }
+
+    private static AdminEndpointOptions AdminTerminatingTls()
+    {
+        var settings = new AdminEndpointOptions { Enabled = true };
+        settings.Https.Endpoints.Add(Profile(domain: "admin.example.test", port: 8543));
+
+        return settings;
+    }
+
+    private static TransportHttpsEndpointOptions Profile(
+        string name = "public",
+        string domain = "mail.example.test",
+        int port = 8443) => new()
+        {
+            Name = name,
+            Domain = domain,
+            Port = port,
+            ServerCertificate = new TlsServerCertificateOptions
+            {
+                Bundle = new ConfiguredSecret { Name = "bundle", SecretReference = "file:/etc/mailfathom/tls/bundle.pfx" },
+            },
+        };
+
+    private static TransportClearTextRedirectReport ReportFor(
+        McpEndpointOptions mcpEndpointSettings,
+        AdminEndpointOptions adminEndpointSettings,
+        RecordingLoggerProvider logs)
+    {
+        using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(logs));
+
+        return new TransportClearTextRedirectReport(
+            Options.Create(mcpEndpointSettings),
+            Options.Create(adminEndpointSettings),
+            loggerFactory.CreateLogger<TransportClearTextRedirectReport>());
+    }
+}

--- a/tests/Host.UnitTests/Security/Transport/ClearTextRedirectTargetsTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/ClearTextRedirectTargetsTests.cs
@@ -1,0 +1,62 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Security.Transport;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Security.Transport;
+
+/// <summary>Covers which listeners exist only to redirect, decided from the socket a connection arrived on.</summary>
+/// <remarks>
+/// The first question is what makes the clear-text listener serve nothing: a port this answers yes for never reaches a
+/// route, and a port it answers no for is untouched. Getting it wrong in the second direction would put every request the
+/// process serves behind a redirect, so the negative cases here carry as much weight as the positive ones.
+/// </remarks>
+public sealed class ClearTextRedirectTargetsTests
+{
+    private static readonly ClearTextRedirectTargets Targets = new(
+    [
+        new ClearTextRedirectListener(
+            8080,
+            new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase) { ["mail.example.test"] = 8443 }),
+    ]);
+
+    [Fact]
+    public void RedirectsOnly_TheClearTextListener_ServesNothingButTheRedirect() =>
+        Assert.True(Targets.RedirectsOnly(8080));
+
+    /// <summary>The listener the profiles themselves bind carries the surface, so nothing may intercept it.</summary>
+    [Theory]
+    [InlineData(8443)]
+    [InlineData(8081)]
+    [InlineData(8090)]
+    public void RedirectsOnly_AnyOtherListener_IsLeftAlone(int localPort) =>
+        Assert.False(Targets.RedirectsOnly(localPort));
+
+    [Fact]
+    public void RedirectsOnly_ADeploymentWhereNoSurfaceRedirects_LeavesEveryListenerAlone() =>
+        Assert.False(new ClearTextRedirectTargets([]).RedirectsOnly(8080));
+
+    [Fact]
+    public void PublishedHttpsPortFor_APublishedDomain_ReportsTheProfilePort() =>
+        Assert.Equal(8443, Targets.PublishedHttpsPortFor(8080, "mail.example.test"));
+
+    [Fact]
+    public void PublishedHttpsPortFor_ADomainTheSurfaceDoesNotPublish_ReportsNothing() =>
+        Assert.Null(Targets.PublishedHttpsPortFor(8080, "elsewhere.test"));
+
+    /// <summary>A published domain reached through a listener that does not redirect is not a redirect either.</summary>
+    [Fact]
+    public void PublishedHttpsPortFor_APublishedDomainOnAListenerThatServesRoutes_ReportsNothing() =>
+        Assert.Null(Targets.PublishedHttpsPortFor(8443, "mail.example.test"));
+
+    /// <summary>The endpoint sections refuse two listeners on one port, so reaching this state is a composition defect rather than a configuration one.</summary>
+    [Fact]
+    public void Constructor_TwoListenersClaimingOnePort_Throws() =>
+        Assert.Throws<ArgumentException>(() => new ClearTextRedirectTargets(
+        [
+            new ClearTextRedirectListener(8080, new Dictionary<string, int> { ["one.example.test"] = 8443 }),
+            new ClearTextRedirectListener(8080, new Dictionary<string, int> { ["two.example.test"] = 9443 }),
+        ]));
+}


### PR DESCRIPTION
Closes #311

A surface that terminates TLS binds no clear-text listener today, so a client still pointed at `http://` meets a refused connection or an unreadable handshake error — indistinguishable from an outage. Each surface now also binds one clear-text listener whose only answer is a `308` to the address its profiles are served at.

```console
$ curl -i http://mail.example.com:8080/mcp
HTTP/1.1 308 Permanent Redirect
Location: https://mail.example.com:8443/mcp
```

## What it adds

- **`McpEndpoint:Https:Redirect` and `AdminEndpoint:Https:Redirect`** — one shared `TransportClearTextRedirectOptions` bound under each surface's own `Https` section, on by default, with `Enabled`, `BindAddress`, and `Port`.
- **`ClearTextRedirectToHttps`** — the middleware, registered ahead of both endpoint isolation filters and every route. That ordering is the mechanism, not a detail: behind admin isolation, an `/api/admin` path arriving on a redirect port would be answered `404` by a listener that is not the administrative one, and the client would read the endpoint as gone rather than as moved.
- **`ClearTextRedirectTargets`** — composed once from the surfaces that redirect, so the request path resolves a target by two dictionary lookups keyed on `Connection.LocalPort` and reads no configuration.
- **`TransportClearTextRedirectReport`** — one startup line per surface, naming the clear-text port beside the domains it redirects to. This is the one socket a deployment can open without having written a port, so it is the one an operator auditing the process cannot otherwise account for.

## The decisions this settles

The issue left four open. Each is stated in the code it governs.

**Key naming and the default port.** The setting lives on the shared `TransportHttpsOptions`, which already owns every listener decision for its surface. The *default port* is per-surface — `8080` for MCP, `8091` for the administrative endpoint — because one shared number would have the two collide the moment a deployment terminated TLS on both. `8080` is also what the container image already publishes, so a container deployment that configures TLS keeps its exposed port answering.

**"On by default" versus refusing a redirect that binds nothing.** Taken literally these conflict: every clear-text deployment would inherit `Enabled = true` and fail the startup check the issue asks for. So `Enabled` is honored only while the surface terminates TLS, and the refusal fires on a `Redirect` section the deployment actually *wrote*. The binder cannot tell those apart — an absent section and one carrying only defaults bind identically — so `ReadFrom` asks configuration whether the section exists, which is the precedent `McpEndpointOptions.ReadFrom` already set for the CORS origin list.

**An unrecognized `Host` gets `400`.** The request's own claim about where it was connecting cannot be honored, which is malformed rather than missing; unlike a `404` it does not invite a caller to try another path on the port.

**`:443` is omitted from the `Location`**, being the scheme's own port.

## What the listener does not serve

No route is mapped on it. `/mcp`, the protected-resource metadata document, and an unmapped path are answered the same way, and no authentication, rate-limiting, CORS, or client-certificate handler runs. The health endpoints are untouched — they keep their own listener and `HealthEndpoints:Transport`, and no probe is ever asked on this port, which matters because a probe follows no redirect and would read a `308` as a failure.

`308` rather than `301` or `302`, because the MCP transport is a `POST` and the administrative write routes carry bodies; the older codes permit a client to re-send either as a `GET`.

**No open redirect.** The `Location` is built only after the `Host` header is confirmed to name a domain in the surface's own profile set, so a host is redirected to itself and several domains sharing one listener each reach their own under the certificate issued for it. The client-supplied host never reaches a log line, which is the posture `SelectIdentity` already takes for a server name.

## Refusals, before anything binds

| Case | Answer |
| --- | --- |
| `Redirect` written for a surface naming no HTTPS profile | startup error — nothing would bind it and the surface is already clear text |
| Redirect port an HTTPS profile in the same section binds | startup error naming the port |
| Redirect port the probes, the application listener, or the other surface binds | startup error against the section that asked for it |
| Redirect bind address that is not an IP address, or a port outside 1–65535 | startup error naming the setting |

The port reaches the existing cross-listener check by entering `McpEndpointOptions.ListenerPorts` and `AdminEndpointOptions.ListenerPorts`, so a conflict is reported against a configuration section rather than as an address-in-use failure naming a socket.

## Tests

- `ClearTextRedirectToHttpsTests` — status, scheme, host, port, path and query; a second domain on the same listener reaching its own port; the scheme-default port omitted; a host in another case; the clear-text port in the `Host` header discarded; an unpublished host, the other surface's domain, and an absent `Host` header each resolving to nothing.
- `ClearTextRedirectTargetsTests` — which listeners redirect and, as much to the point, which are left alone.
- `TransportHttpsOptionsTests` — every refusal above, the disabled path, the default-port collision reached without stating a port, and the socket the binder opens.
- `McpEndpointOptionsBindingTests` and `AdminEndpointOptionsTests` — the section binding from real configuration, stated versus inherited, both `ListenerPorts` shapes, and that the two surfaces' defaults differ.

No integration test is added. What this change decides is the redirect target and the port set, both unit-testable; binding a Kestrel listener is what `tests/AGENTS.md` keeps out of `Host.UnitTests`, and the two existing listener binders carry no test for the same reason.

## Documentation

`docs/operations/mcp-endpoint.md` documents the behaviour and the limit of what a redirect protects; `docs/operations/admin-endpoint.md` covers its own default port and points there for the shared contract; `docs/operations/configuration-reference.md` adds the key table; `docs/operations/container-image.md` records that `8080` becomes a redirect once TLS is configured. The MCP page's `describes:` marker is widened to the three new files outside `src/Host/Security/**`.

## Verification

`scripts/verify-full.sh` passed: 2622 tests, aggregate line coverage 94.60% against the 85% gate, formatting clean over 880 files. Rebased onto `origin/main` at 63a4be3. The integration suite was not run.