### PR TITLE
[#375] Announce a forwarded-header trust that covers every address

### DIFF
--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -283,7 +283,7 @@ listener shares, so a proxy named here is trusted on each of them.
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
 | `ReverseProxy:Enabled` | bool | `false` | Off reads neither `X-Forwarded-Proto` nor `X-Forwarded-Host` from anybody | restart |
-| `ReverseProxy:TrustedProxies` | string list | empty | Required non-empty when enabled; refused when configured while it is not. Each entry an IP address or a CIDR network whose host bits are clear — not a DNS name. The framework's loopback default is cleared rather than inherited | restart |
+| `ReverseProxy:TrustedProxies` | string list | empty | Required non-empty when enabled; refused when configured while it is not. Each entry an IP address or a CIDR network whose host bits are clear — not a DNS name. The framework's loopback default is cleared rather than inherited. `0.0.0.0/0` and `::/0` are accepted and trust every peer, which disables the refusal of an OAuth token that arrived without TLS — see [trust is the connection](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) | restart |
 | `ReverseProxy:MaximumForwardedHops` | int | `1` | At least 1; how far right-to-left through each header a value is believed | restart |
 
 `X-Forwarded-For` is never read, so the peer MailFathom observes stays the one that opened the connection, and

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -786,6 +786,29 @@ in a container and every other process on the machine in a native installation. 
 the `10.0.0.0/24` it would otherwise have silently become; write the address or write the network, and the deployment
 gets what it asked for.
 
+> **`0.0.0.0/0` and `::/0` are accepted, and they mean what they say.** Nothing refuses a prefix that covers every
+> address, so a deployment can trust every peer — but it has to write that, which is the difference between a decision
+> and an empty field. Understand the cost before you do. **An OAuth access token is refused outright when the request
+> did not arrive over TLS, and that check reads the scheme after this mode has applied it.** With a real proxy named,
+> that is correct: the hop to the client genuinely was HTTPS. With every peer trusted, anything that can reach the
+> listener sends `X-Forwarded-Proto: https` and the refusal stops working, so a reusable credential crosses a
+> clear-text hop and is accepted. Use a range that covers your proxies and nothing else.
+
+Because it is accepted rather than refused, it is announced. A `/0` in the list produces one startup warning naming
+what the deployment gave up:
+
+```text
+warn: MailFathom.Host.Hosting.Warnings.ReverseProxyTrustWarning
+      ReverseProxy:TrustedProxies names 0.0.0.0/0, which covers every address, so a forwarded scheme and host are read
+      from any peer that can open a connection rather than from a proxy. This also turns off the refusal of an access
+      token that arrived without transport encryption, because that refusal reads the scheme a forwarded header set —
+      so a client can claim its own hop was encrypted and have the token accepted over clear text. Narrow the range to
+      the addresses your proxies actually use unless something other than this setting already closes the network.
+```
+
+A merely wide range — a private `/8` — produces nothing. How wide is too wide inside a network you own is a judgement
+only you can make, and a warning that fired on it would be a line you learn to scroll past before it ever mattered.
+
 **Only the two headers are read.** `X-Forwarded-For` is not, so the peer MailFathom observes stays the one that opened
 the connection. Nothing here partitions, limits, or logs by client address, so adopting one from a header would replace
 an observed fact with a claim and buy nothing. Each header is read right to left, and `MaximumForwardedHops` says how

--- a/src/Host/Configuration/Endpoints/ReverseProxyOptions.cs
+++ b/src/Host/Configuration/Endpoints/ReverseProxyOptions.cs
@@ -128,6 +128,19 @@ internal sealed class ReverseProxyOptions
     public IReadOnlyList<IPNetwork> ToTrustedProxyNetworks() =>
         [.. this.TrustedProxies.Select(Normalize).Where(NamesNetwork).Select(IPNetwork.Parse)];
 
+    /// <summary>Reports the configured ranges that cover every address, and so believe any peer that can open a connection.</summary>
+    /// <returns>The ranges, in configuration order, empty when every entry names a proxy this deployment could have meant.</returns>
+    /// <exception cref="FormatException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
+    /// <remarks>
+    /// Accepted rather than refused, because trusting every peer is a posture an operator can mean — a load balancer
+    /// pool with no stable address, a network already closed by something other than this setting. What it is not is a
+    /// posture anybody should reach without knowing the cost, which is why it is reported at startup: the refusal of an
+    /// access token that arrived without transport encryption decides by reading the scheme this mode applies, so a
+    /// range covering every address is also the deployment where any client can claim its own hop was encrypted.
+    /// </remarks>
+    public IReadOnlyList<IPNetwork> ToTrustedProxyRangesCoveringEveryAddress() =>
+        [.. this.ToTrustedProxyNetworks().Where(static network => network.PrefixLength == 0)];
+
     private static bool NamesNetwork(string entry) => entry.Contains('/', StringComparison.Ordinal);
 
     /// <summary>Refuses a prefix that is not a network, and one that names a host inside a network rather than the network.</summary>

--- a/src/Host/Hosting/Warnings/ReverseProxyTrustWarning.cs
+++ b/src/Host/Hosting/Warnings/ReverseProxyTrustWarning.cs
@@ -1,0 +1,82 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Host.Configuration.Endpoints;
+using Microsoft.Extensions.Options;
+
+namespace MailFathom.Host.Hosting.Warnings;
+
+/// <summary>States at startup that the configured proxy trust covers every address rather than a proxy.</summary>
+/// <remarks>
+/// <para>
+/// A range covering every address is accepted rather than refused, because an operator can mean it: a load balancer
+/// pool with no stable address, or a network already closed by something other than this setting. It is reported for
+/// the reason every other posture here is — only an operator knows which of those they have, and none of it is
+/// something MailFathom can detect.
+/// </para>
+/// <para>
+/// What makes it worth a line of its own is that it does not merely widen who is believed. The refusal of an access
+/// token that arrived without transport encryption decides by reading <c>HttpContext.Request.IsHttps</c>, which is the
+/// scheme this mode has already rewritten, so with every peer trusted any client can assert that its own hop was
+/// encrypted and have a reusable credential accepted over clear text. That is a protection the deployment gave up, and
+/// giving it up silently is what this exists to prevent.
+/// </para>
+/// <para>
+/// Only a prefix covering every address is reported. A merely wide range — a private <c>/8</c> — is a judgement about
+/// somebody's network rather than a fact about it, and a warning that fired on one would be a line an operator learns
+/// to scroll past.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this hosted service.")]
+internal sealed partial class ReverseProxyTrustWarning : IHostedService
+{
+    private readonly ReverseProxyOptions reverseProxySettings;
+    private readonly ILogger<ReverseProxyTrustWarning> logger;
+
+    /// <summary>Initializes a new startup warning.</summary>
+    /// <param name="reverseProxySettings">The reverse-proxy settings startup was composed from.</param>
+    /// <param name="logger">The startup logger.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="reverseProxySettings" /> is <see langword="null" />.</exception>
+    public ReverseProxyTrustWarning(
+        IOptions<ReverseProxyOptions> reverseProxySettings,
+        ILogger<ReverseProxyTrustWarning> logger)
+    {
+        ArgumentNullException.ThrowIfNull(reverseProxySettings);
+
+        this.reverseProxySettings = reverseProxySettings.Value;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!this.reverseProxySettings.Enabled)
+        {
+            return Task.CompletedTask;
+        }
+
+        var rangesCoveringEveryAddress = this.reverseProxySettings.ToTrustedProxyRangesCoveringEveryAddress();
+
+        if (rangesCoveringEveryAddress.Count > 0)
+        {
+            this.LogEveryPeerTrusted(string.Join(", ", rangesCoveringEveryAddress));
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "ReverseProxy:TrustedProxies names {TrustedRanges}, which covers every address, so a forwarded scheme "
+            + "and host are read from any peer that can open a connection rather than from a proxy. This also turns off "
+            + "the refusal of an access token that arrived without transport encryption, because that refusal reads the "
+            + "scheme a forwarded header set — so a client can claim its own hop was encrypted and have the token "
+            + "accepted over clear text. Narrow the range to the addresses your proxies actually use unless something "
+            + "other than this setting already closes the network.")]
+    private partial void LogEveryPeerTrusted(string trustedRanges);
+}

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -266,6 +266,7 @@ try
     // to say. Registering it conditionally would put the same condition in two places.
     builder.Services.AddHostedService<McpTransportAuthenticationWarning>();
     builder.Services.AddHostedService<McpTransportEncryptionWarning>();
+    builder.Services.AddHostedService<ReverseProxyTrustWarning>();
     builder.Services.AddHostedService<TransportRateLimitingStartupReport>();
     // Composed from the environment rather than resolved from the container, because the value it reports is one
     // OpenSSL read while it initialized and no configuration source can influence it afterwards. Registered

--- a/tests/Host.UnitTests/Configuration/Endpoints/ReverseProxyOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/ReverseProxyOptionsTests.cs
@@ -79,6 +79,27 @@ public sealed class ReverseProxyOptionsTests
         Assert.Empty(errors);
     }
 
+    /// <summary>
+    /// A prefix covering every address is accepted, because it is a posture an operator can mean and one they have to
+    /// write. What it costs is documented rather than refused: the refusal of an OAuth token that arrived without TLS
+    /// reads the scheme this mode applies, so trusting every peer is trusting every peer to be honest about it.
+    /// </summary>
+    [Theory]
+    [InlineData("0.0.0.0/0")]
+    [InlineData("::/0")]
+    public void FindConfigurationErrors_APrefixCoveringEveryAddress_IsAcceptedRatherThanRefused(string trustedProxy)
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions { Enabled = true };
+        settings.TrustedProxies.Add(trustedProxy);
+
+        // Act
+        var errors = settings.FindConfigurationErrors();
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
     /// <summary>A DNS name resolves to whatever answers today, and the peer is judged by the address its connection arrives from.</summary>
     [Theory]
     [InlineData("ingress.example.test")]

--- a/tests/Host.UnitTests/Hosting/Warnings/ReverseProxyTrustWarningTests.cs
+++ b/tests/Host.UnitTests/Hosting/Warnings/ReverseProxyTrustWarningTests.cs
@@ -1,0 +1,126 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Hosting.Warnings;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Hosting.Warnings;
+
+/// <summary>Covers what an operator is told when their configured proxy trust covers every address.</summary>
+/// <remarks>
+/// Its silence is as much a contract as its text. A warning that also fired for an ordinary range would be one more
+/// line an operator learns to scroll past, and the posture it exists for would then travel with the noise.
+/// </remarks>
+public sealed class ReverseProxyTrustWarningTests
+{
+    [Theory]
+    [InlineData("0.0.0.0/0")]
+    [InlineData("::/0")]
+    public async Task StartAsync_ARangeCoveringEveryAddress_NamesWhatTheDeploymentGaveUp(string trustedProxy)
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningFor(TrustingProxies(trustedProxy), logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("covers every address", record.Message, StringComparison.Ordinal);
+        Assert.Contains("without transport encryption", record.Message, StringComparison.Ordinal);
+        Assert.Equal(trustedProxy, Assert.Contains("TrustedRanges", record.Properties));
+    }
+
+    /// <summary>Both families named at once are one posture rather than two, so they are reported on one line.</summary>
+    [Fact]
+    public async Task StartAsync_EveryAddressOfBothFamilies_ReportsThemTogether()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningFor(TrustingProxies("0.0.0.0/0", "::/0"), logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal("0.0.0.0/0, ::/0", Assert.Contains("TrustedRanges", record.Properties));
+    }
+
+    /// <summary>A judgement about how wide is too wide belongs to an operator who knows their network, not to a line in a log.</summary>
+    [Theory]
+    [InlineData("10.0.0.5")]
+    [InlineData("10.0.0.0/8")]
+    [InlineData("2001:db8::/32")]
+    public async Task StartAsync_ARangeNamingProxiesThisDeploymentCouldHaveMeant_SaysNothing(string trustedProxy)
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningFor(TrustingProxies(trustedProxy), logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    /// <summary>A section nobody enabled reads no forwarded header from anybody, however its list happens to read.</summary>
+    [Fact]
+    public async Task StartAsync_DisabledSection_SaysNothing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var settings = new ReverseProxyOptions();
+        settings.TrustedProxies.Add("0.0.0.0/0");
+        var warning = WarningFor(settings, logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    [Fact]
+    public async Task StopAsync_AnyPosture_CompletesWithoutSayingAnythingFurther()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningFor(TrustingProxies("0.0.0.0/0"), logs);
+
+        // Act
+        await warning.StopAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    private static ReverseProxyOptions TrustingProxies(params string[] trustedProxies)
+    {
+        var settings = new ReverseProxyOptions { Enabled = true };
+
+        foreach (var trustedProxy in trustedProxies)
+        {
+            settings.TrustedProxies.Add(trustedProxy);
+        }
+
+        return settings;
+    }
+
+    private static ReverseProxyTrustWarning WarningFor(ReverseProxyOptions settings, RecordingLoggerProvider logs)
+    {
+        using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(logs));
+
+        return new ReverseProxyTrustWarning(
+            Options.Create(settings),
+            loggerFactory.CreateLogger<ReverseProxyTrustWarning>());
+    }
+}

--- a/tests/Host.UnitTests/Security/Transport/TrustedReverseProxyExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TrustedReverseProxyExtensionsTests.cs
@@ -78,6 +78,27 @@ public sealed class TrustedReverseProxyExtensionsTests
         Assert.Equal("mail.example.test", request.Request.Host.Value);
     }
 
+    /// <summary>
+    /// The documented escape hatch, asserted so the page describing it describes something real: a prefix covering
+    /// every address believes any peer at all, which is why the page states what that gives up rather than leaving it
+    /// to whoever reads the parser.
+    /// </summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_APrefixCoveringEveryAddress_BelievesAnyPeerAtAll()
+    {
+        // Arrange
+        var request = RequestFrom(IPAddress.Parse("203.0.113.9"));
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+        request.Request.Headers["X-Forwarded-Host"] = "anything.example.test";
+
+        // Act
+        await ForwardThrough(TrustingProxies("0.0.0.0/0", "::/0"), request);
+
+        // Assert
+        Assert.Equal("https", request.Request.Scheme);
+        Assert.Equal("anything.example.test", request.Request.Host.Value);
+    }
+
     /// <summary>The header is a value whoever is upstream wrote, so a peer this deployment did not name writes nothing.</summary>
     [Fact]
     public async Task AddTrustedReverseProxy_RequestFromAnUntrustedPeer_KeepsTheSchemeAndHostItArrivedUnder()


### PR DESCRIPTION
Part of #375

#315 shipped `ReverseProxy` with a refusal: an enabled section must name the proxies it accepts a forwarded scheme and host from. What it did not say is that `TrustedProxies: [ "0.0.0.0/0", "::/0" ]` passes that refusal — `IPNetwork` parses a `/0` prefix, the host bits are clear — so a deployment can already trust every peer, and nothing told it what that gives up.

## What it gives up

`RefuseATokenThatArrivedWithoutTransportEncryption` refuses an OAuth token that did not arrive over TLS, and it decides by reading `HttpContext.Request.IsHttps` — that is `Request.Scheme`, which the forwarded-headers middleware has already rewritten by the time authentication runs.

With a real proxy named, that is correct: the hop to the client genuinely was HTTPS, and the refusal must not fire. With a `/0` in the list, anything that can reach the listener sends `X-Forwarded-Proto: https`, the refusal stops working, and a reusable credential crosses a clear-text hop and is accepted.

## What this change does

- **`ToTrustedProxyRangesCoveringEveryAddress()`** on `ReverseProxyOptions` reports the configured ranges whose prefix covers every address.
- **`ReverseProxyTrustWarning`** announces them at startup, naming the refusal that stopped applying. It is registered unconditionally beside the other startup warnings, because the warning is what decides whether it has anything to say.
- **`mcp-endpoint.md` and `configuration-reference.md`** state that the wide form is accepted, what it costs, and that it is announced.

A merely wide range — a private `/8` — produces nothing. How wide is too wide inside a network the operator owns is a judgement about somebody's topology rather than a fact about it, and a warning that fired on one would be a line an operator learns to scroll past before it ever mattered.

## What this change deliberately does not do

`#375` asks for two decisions that are the owner's, and neither is taken here:

- whether `RefuseATokenThatArrivedWithoutTransportEncryption` should keep reading the forwarded scheme or read the scheme of the connection this process actually accepted;
- whether an **empty** `TrustedProxies` on an enabled section should stop failing startup and become the explicit spelling of this posture.

Both change a security property that #315's acceptance settled the other way, so they need an argument accepted rather than an implementation. This change only makes the posture that already exists visible and announced, which is true under either answer. #375 stays open for the rest.

## Verification

`scripts/verify-full.sh` — exit 0, 2618 tests, aggregate line coverage 94.60% (required 85%), formatting clean.

New tests cover the wide form passing validation, an arbitrary peer being believed once it is configured, the warning firing for each family and for both together, and its silence for an ordinary range, a `/8`, and a disabled section.

No dependency movement; `THIRD_PARTY_LICENSES.md` and `CHANGELOG.md` untouched.

> One note on the first full run: it failed with `mfctl` absent from the merged coverage report — the gate #372 added. That was stale raw artifacts from earlier runs on the previous branch, not a defect. A clean re-collection admits `mfctl` and passes.
