### PR TITLE
[#381] Size the site logo, which the modern template leaves at its natural size

### DIFF
--- a/docfx/template/public/main.css
+++ b/docfx/template/public/main.css
@@ -4,11 +4,25 @@
  * Project repository: https://github.com/Krzysztof318/MailFathom
  */
 
-/* Everything here belongs to the two additions `main.js` makes. The rest of the appearance is the
-   `modern` template's, deliberately: a theme of our own would be one more thing to carry forward
+/* Almost everything here belongs to the two additions `main.js` makes. The rest of the appearance is
+   the `modern` template's, deliberately: a theme of our own would be one more thing to carry forward
    across docfx versions, and this site has no design problem that the default one fails to solve. */
 
+/* The exception, and it is the template's gap rather than a preference. `modern` styles
+   `.navbar-brand` and nothing inside it, because its own logo is an SVG whose intrinsic size already
+   fits a header; a raster logo arrives at whatever size the file is, which put a 180-pixel square
+   over the top of every page. The height is stated and the width follows the aspect ratio, so
+   replacing the file with one of different proportions changes nothing here. */
+.navbar-brand > #logo {
+  height: 1.75rem;
+  width: auto;
+  margin-inline-end: 0.5rem;
+}
+
 .mf-version-picker {
+  /* `flex-nowrap` on the header's container makes every child shrinkable, and a select that shrinks
+     to its container reads as a sliver rather than as a control. */
+  flex: 0 0 auto;
   width: auto;
   margin-inline-start: 0.75rem;
 }

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -112,7 +112,13 @@ above it.
 ## What the template adds
 
 `docfx/template/` is a thin layer over docfx's own `modern` template — the appearance is docfx's, deliberately, and
-what is added is behavior the pages need:
+what is added is behavior the pages need. The one appearance rule is the header logo, which `modern` does not size at
+all: its own logo is an SVG whose intrinsic size already fits a header, so a raster file arrives at whatever size it
+was saved at. Nothing in the build can see that — docfx renders a page without laying it out, so a logo that fits and
+one that covers the page produce the same output — which makes the site's appearance the one part of it that is
+verified by looking at it.
+
+What the template adds beyond that:
 
 - **The version selector** in the header, and the banner a page outside the default version carries. Both read
   `versions.json` from the site root at run time, so a version built months ago joins the selector correctly without


### PR DESCRIPTION
Closes #381

The logo in the documentation site's header was drawn at 180 pixels square — the intrinsic size of `assets/icon-180.png` — so it overflowed the header, covered the page title, and overlapped the version selector beside it. Live since #376 merged.

docfx's `modern` template styles `.navbar-brand` and nothing inside it: its own logo is an SVG whose intrinsic size already fits a header, so nothing constrains the element and a raster file arrives at whatever size it was saved at.

The rule states the height and lets the width follow the aspect ratio, so replacing the file with one of different proportions changes nothing. It is written against `#logo` rather than against an `img`, because the default template replaces that element with an inline `<svg>` when the source is one — an SVG logo later would otherwise stop being sized. The version selector beside it also stops being shrinkable, which `flex-nowrap` on the header container would otherwise allow.

`docs/operations/documentation-site.md` now records that the header logo is the one appearance rule the template carries, and why no gate can catch this class of defect: docfx renders a page without laying it out, so a logo that fits and one that covers the page produce identical output. The site's appearance is the part of it verified by looking at it.

## Verification

- `scripts/verify-full.sh` — pass, 104 workflow contracts.
- `docfx build` — the rule reaches `public/main.css` verbatim, and its selector matches the emitted DOM: `<img id="logo">` is a direct child of `<a class="navbar-brand">`.
- **Not verified by running it.** There is no browser in this environment, so the rendered result is checked on the deployed site after merge.