### PR TITLE
[#384] Render the version selector on a page at the root of a version

### DIFF
--- a/docfx/template/public/main.js
+++ b/docfx/template/public/main.js
@@ -44,11 +44,16 @@ export default {
 // depth of the page this runs on never has to be guessed.
 function resolveSiteLayout() {
   const relativeRoot = document.querySelector('meta[name="docfx:rel"]')?.getAttribute('content')
-  if (!relativeRoot) {
+
+  // A page *at* that root carries the empty string, which is the correct answer rather than a missing
+  // one — and is why the two pages served from a version's own directory, the landing page and the
+  // changelog, are exactly the ones a falsy test would drop. Only an absent tag means the layout
+  // cannot be resolved; an empty one resolves to the directory the page is in.
+  if (relativeRoot === null || relativeRoot === undefined) {
     return null
   }
 
-  const versionUrl = new URL(relativeRoot, window.location.href)
+  const versionUrl = new URL(relativeRoot || './', window.location.href)
   const siteUrl = new URL('../', versionUrl)
   const segments = versionUrl.pathname.split('/').filter(segment => segment.length > 0)
 

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -115,8 +115,14 @@ above it.
 what is added is behavior the pages need. The one appearance rule is the header logo, which `modern` does not size at
 all: its own logo is an SVG whose intrinsic size already fits a header, so a raster file arrives at whatever size it
 was saved at. Nothing in the build can see that — docfx renders a page without laying it out, so a logo that fits and
-one that covers the page produce the same output — which makes the site's appearance the one part of it that is
-verified by looking at it.
+one that covers the page produce the same output.
+
+That is the general shape of what this template can get wrong. Everything it adds happens in the browser, after the
+build has finished and against files the build never reads, so a page that renders the selector and one that silently
+does not are the same output as far as every gate here is concerned. **The site's appearance and its run-time
+behaviour are the parts of it verified by looking at the deployed site**, and both defects found that way so far — a
+logo at its natural size, and a selector missing from the two pages served from a version's own directory — were
+invisible to a green build.
 
 What the template adds beyond that:
 


### PR DESCRIPTION
Closes #384

The version selector and the out-of-date banner did not render on the site's landing page or on the changelog. It was not a viewport effect — the element was never created.

`docfx:rel` is the relative path from a page back to its own build root. A page one directory down carries `content="../"`; a page *at* that root carries `content=""`, which is the correct answer spelled as the empty string. `resolveSiteLayout` rejected it with `if (!relativeRoot)`, which cannot tell an empty attribute from an absent one — so the two pages served from a version's own directory were exactly the two that lost the selector.

Only an absent tag now means the layout cannot be resolved. An empty one resolves to the directory the page is in, which is what every other depth already resolved to.

## Verification

- The layout arithmetic run over every depth the site produces: the landing page, the changelog, a version directory with no file name, a nested page, a twice-nested page in a released version, and a page carrying no `docfx:rel` at all. The first five now resolve to the same site root and the correct version — `latest`, `latest`, `latest`, `latest`, `v0.3.0` — and the sixth still resolves to nothing.
- `scripts/verify-full.sh` — pass, 104 workflow contracts.
- `node --check` on the module.
- **No automated regression guard.** Everything this template adds happens in the browser, after the build, against files the build never reads — a page that renders the selector and one that silently does not are identical output to every gate here, and a JavaScript test harness for one function would be more machinery than the thing it guards. `docs/operations/documentation-site.md` now states that plainly, along with the two defects found this way so far, rather than leaving the gap implied.