### PR TITLE
[#385] Make the API reference landing page name what the reference carries, and link into it

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,28 +6,37 @@ _disableContribution: true
 
 <!-- describes: none -->
 
-This page introduces the reference the documentation site generates from the source; the reference itself is generated
-at build time and is not in the repository, so nothing under this directory but this page is committed.
-
-This reference is generated from the XML documentation comments in MailFathom's own source, one namespace tree per
-architectural boundary. It documents the code as the release named in the header carries it.
+This reference is generated from the XML documentation comments in MailFathom's own source, and documents the code as
+the release named in the version selector carries it. Only this introduction is in the repository; everything under it
+is produced at build time, so a type that is renamed or removed changes the reference in the same commit.
 
 **None of it is a supported public API.** MailFathom ships as a service and a command-line client rather than as a
 library: nothing here is packed to NuGet, and the four surfaces the versioning policy treats as consumed are the
 configuration keys, the database schema, the MCP tool contracts, and the HTTP endpoints — not these types. Read this
 reference to follow how a contract is implemented, not to take a dependency on it.
 
-The boundaries the namespaces follow are described in
-[the solution structure](../architecture/solution-structure.md):
+## What it covers
 
-- **Domain** — the business concepts and their invariants, with no dependency on any framework.
-- **Application** — the use cases and the ports they are served through.
-- **Infrastructure** — persistence, IMAP and SMTP, content storage, security, and observability.
-- **AI** — retrieval, chunking, and embeddings.
-- **Mcp** — the protocol mapping, and nothing else.
-- **Host** — composition, configuration, endpoints, and process lifetime.
-- **Cli** — the `mfctl` command.
-- **Common** — what more than one boundary needs and none of them owns.
+A namespace appears here when its boundary exposes something publicly. [The solution structure](../architecture/solution-structure.md)
+describes what each of them is for, and why the dependencies between them point the way they do.
 
-The orchestration project that runs the local development topology is left out: it composes a developer's machine
-rather than anything a deployment runs. [Local development](../operations/local-development.md) documents it.
+| Boundary | What you will find |
+| --- | --- |
+| [Domain](xref:MailFathom.Domain) | The business concepts and their invariants, with no dependency on any framework |
+| [Application](xref:MailFathom.Application) | The use cases and the ports they are served through |
+| [Infrastructure](xref:MailFathom.Infrastructure) | Persistence, IMAP and SMTP, content storage, security, and observability |
+| [Mcp](xref:MailFathom.Mcp) | The protocol mapping, and nothing else |
+| [Common](xref:MailFathom.Common) | What more than one boundary needs and none of them owns |
+| [Host](xref:MailFathom.Host.Configuration.Provisioning) | One exception type, which is all of the host that is public |
+
+## What it does not cover, and why that is the point
+
+**`AI` and `Cli` declare no public type at all, and `Host` declares one.** They are not missing from the reference —
+there is nothing in them to document. Each is composition rather than capability: `Host` wires configuration,
+endpoints, and process lifetime together, `Cli` assembles the `mfctl` commands, and `AI` holds the retrieval work that
+has not been built yet. Code like that is `internal` because nothing outside its own assembly calls it, and the
+absence here is the architecture stating that: a boundary with no public surface is a boundary nothing takes a
+dependency on.
+
+The Aspire orchestration project is excluded outright rather than by visibility. It composes a developer's machine
+rather than anything a deployment runs, and [local development](../operations/local-development.md) documents it.

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -80,6 +80,11 @@ Two forms, and which one to use is decided by whether the target is on the site:
 - **A link to anything the site does not carry is written as an absolute `https://github.com/Krzysztof318/MailFathom`
   URL** — an ADR, a specification, a deployment asset, a source file. A relative link to one of those resolves on
   GitHub and reaches a 404 on the site.
+- **A link into the API reference is a `xref:`**, naming the type or namespace rather than the generated file, as
+  `[Domain](xref:MailFathom.Domain)`. It is the one kind of link a refactor breaks without touching the page, so it
+  resolves through docfx's cross-reference map and fails the build when the name stops being generated. On GitHub such
+  a link renders as text rather than as a link, which is why only `docs/api/index.md` uses it: that page exists for
+  the site.
 
 `scripts/build-docs-site.sh` fails when docfx resolves no target for a link, so neither mistake reaches a reader: the
 site build runs on every pull request that changes `docs/` or the site definition, and a broken link is a red check

--- a/scripts/build-docs-site.sh
+++ b/scripts/build-docs-site.sh
@@ -33,7 +33,10 @@ set -euo pipefail
 readonly configuration_file='docfx/docfx.json'
 readonly solution_file='MailFathom.slnx'
 readonly generated_metadata_directory='docfx/api'
-readonly unresolved_link_codes='InvalidFileLink|InvalidBookmark|InvalidExternalBookmark'
+# `UidNotFound` is the same defect reached the other way: a `xref:` naming a type or a namespace the reference no
+# longer generates. A page that links into the API reference is written against names the code owns, so it is the one
+# kind of link here that a refactor breaks without touching the page.
+readonly unresolved_link_codes='InvalidFileLink|InvalidBookmark|InvalidExternalBookmark|UidNotFound'
 # The one published page no change here may correct. `CHANGELOG.md` is written by the release pull request and by
 # nothing else — it is a statement about a release rather than about a change — so a link in it is fixed by the next
 # release rather than by whoever notices it. Failing every documentation build until then would stop the site from


### PR DESCRIPTION
Closes #385

The page listed eight boundaries as namespace trees a reader could follow. Three of them are not in the reference: `src/AI` and `src/Cli` declare no public type at all, and `src/Host` declares one. Each is composition rather than capability — the host wires configuration, endpoints, and process lifetime together, the CLI assembles the `mfctl` commands, and the AI project holds retrieval work that has not been built — so their types are `internal` because nothing outside their own assembly calls them.

Prose promising a namespace tree nobody generated is the "stale guidance is a defect" rule applied to this repository's own page.

The page also carried no link into the reference. Every route in was the sidebar, which a narrow viewport folds behind a button, so the landing page read as a dead end: the reader was told the reference exists and given nothing to click. That is how the gap was found — from the site, on a tablet.

## What changed

The six boundaries the reference actually carries are now a table, each a link written as a `xref:` naming the namespace rather than the generated file. `UidNotFound` joins the codes the link gate refuses, so a namespace that stops being generated fails the build instead of becoming a dead link — this is the one kind of link a refactor breaks without touching the page.

The absence of the other three is stated rather than hidden, because it says something true about the architecture: a boundary with no public surface is a boundary nothing takes a dependency on.

## Verification

- `scripts/build-docs-site.sh` — clean, and all six cross-references render as links to pages that exist: `MailFathom.Domain.html`, `.Application.html`, `.Infrastructure.html`, `.Mcp.html`, `.Common.html`, and `.Host.Configuration.Provisioning.html`.
- The gate observed refusing an unresolved cross-reference: a `xref:` to a namespace that does not exist was reported as `UidNotFound` and failed the build.
- `scripts/verify-full.sh` — pass, 104 workflow contracts.
- The public-type counts behind the claim: `AI` 0, `Cli` 0, `Host` 1.