### PR TITLE
[#375] Make the forwarded-header posture the trust list alone, and say what an unnamed proxy costs

### DIFF
--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -149,10 +149,11 @@ default port differs, so enabling TLS on both surfaces opens two clear-text port
 
 ## Behind a TLS-terminating reverse proxy
 
-If a proxy holds your certificate, `ReverseProxy:TrustedProxies` is what makes the request state the public name it
-arrived under, which is what lets `AdminEndpoint:OAuth` discovery complete over a proxied address.
-[Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) documents the mode in
-full; three things are worth stating from this endpoint's side.
+If a proxy holds your certificate, the request states the public name it arrived under, which is what lets
+`AdminEndpoint:OAuth` discovery complete over a proxied address. `ReverseProxy:TrustedProxies` is what limits who may
+state it; left empty it is anybody.
+[Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) documents that in
+full, including what the unnamed default gives up; three things are worth stating from this endpoint's side.
 
 - **It is one process-wide setting, not one per endpoint.** This surface is a separate listener over the same request
   pipeline, so naming your proxy once covers it along with the MCP and probe listeners. There is no

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -275,16 +275,22 @@ Two rules are MailFathom's rather than Kestrel's:
 
 ## `ReverseProxy`
 
-Which proxy this process accepts a public scheme and host from, when something in front of it terminates TLS. One
+Which peers this process accepts a public scheme and host from, when something in front of it terminates TLS. One
 section for the whole process rather than one per surface: it runs at the front of the one request pipeline every
 listener shares, so a proxy named here is trusted on each of them.
 [Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) is the page.
 
+`X-Forwarded-Proto` and `X-Forwarded-Host` are always read; there is no key that switches that off. What the section
+carries is who they are believed from, and **an unconfigured section believes every peer.**
+
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
-| `ReverseProxy:Enabled` | bool | `false` | Off reads neither `X-Forwarded-Proto` nor `X-Forwarded-Host` from anybody | restart |
-| `ReverseProxy:TrustedProxies` | string list | empty | Required non-empty when enabled; refused when configured while it is not. Each entry an IP address or a CIDR network whose host bits are clear — not a DNS name. The framework's loopback default is cleared rather than inherited. `0.0.0.0/0` and `::/0` are accepted and trust every peer, which disables the refusal of an OAuth token that arrived without TLS — see [trust is the connection](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) | restart |
+| `ReverseProxy:TrustedProxies` | string list | empty, which trusts `0.0.0.0/0` and `::/0` | Each entry an IP address or a CIDR network whose host bits are clear — not a DNS name. What is named replaces the default rather than adding to it, and the framework's loopback default is cleared rather than inherited. Left empty, or written as `0.0.0.0/0` and `::/0`, it trusts every peer and so disables the refusal of an OAuth token that arrived without TLS — see [what the default costs](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) | restart |
 | `ReverseProxy:MaximumForwardedHops` | int | `1` | At least 1; how far right-to-left through each header a value is believed | restart |
+
+> **`ReverseProxy:Enabled` no longer exists.** A configuration still setting it fails at startup naming the key, because
+> every section here is bound strictly. Delete it: the posture it used to select is now the presence or absence of
+> `TrustedProxies`, and a deployment that had it `true` keeps its behaviour by keeping its list.
 
 `X-Forwarded-For` is never read, so the peer MailFathom observes stays the one that opened the connection, and
 `McpEndpoint:OAuth:Resource` stays a configured value rather than anything derived from a header.

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -288,10 +288,6 @@ carries is who they are believed from, and **an unconfigured section believes ev
 | `ReverseProxy:TrustedProxies` | string list | empty, which trusts `0.0.0.0/0` and `::/0` | Each entry an IP address or a CIDR network whose host bits are clear — not a DNS name. What is named replaces the default rather than adding to it, and the framework's loopback default is cleared rather than inherited. Left empty, or written as `0.0.0.0/0` and `::/0`, it trusts every peer and so disables the refusal of an OAuth token that arrived without TLS — see [what the default costs](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) | restart |
 | `ReverseProxy:MaximumForwardedHops` | int | `1` | At least 1; how far right-to-left through each header a value is believed | restart |
 
-> **`ReverseProxy:Enabled` no longer exists.** A configuration still setting it fails at startup naming the key, because
-> every section here is bound strictly. Delete it: the posture it used to select is now the presence or absence of
-> `TrustedProxies`, and a deployment that had it `true` keeps its behaviour by keeping its list.
-
 `X-Forwarded-For` is never read, so the peer MailFathom observes stays the one that opened the connection, and
 `McpEndpoint:OAuth:Resource` stays a configured value rather than anything derived from a header.
 

--- a/docs/operations/container-image.md
+++ b/docs/operations/container-image.md
@@ -58,8 +58,9 @@ Linux capability.
 
 **The container speaks plain HTTP and terminates no TLS.** A certificate belongs to the reverse proxy or the ingress in
 front of it, which is also the only place one has to exist. An MCP endpoint reached over plain HTTP hands its API key
-and every message it serves to anything on the network path. Name that proxy in `ReverseProxy:TrustedProxies` so the
-public scheme and host reach the process — see
+and every message it serves to anything on the network path. The public scheme and host reach the process from any peer
+until you name that proxy in `ReverseProxy:TrustedProxies`, which is what stops every other container on the bridge
+network from setting them — see
 [behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy).
 
 `DOTNET_EnableDiagnostics=0` is set, so no diagnostic IPC socket is created. That socket can request a process dump,

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -157,10 +157,11 @@ no default.
 Both ports are published on **loopback** by default. MailFathom speaks plain HTTP and terminates no TLS, so publishing
 the application port on another interface exposes synchronized mail without transport protection. Change
 `MAILFATHOM_HTTP_BIND` only once a reverse proxy on the `frontend` network is what listens publicly, and give that
-proxy the certificate. Tell MailFathom which proxy that is — `ReverseProxy:TrustedProxies`, naming the address or the
-`frontend` subnet — so the public scheme and host survive the hop and OAuth discovery answers over your domain rather
-than `404`. [Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) is the
-page.
+proxy the certificate. The public scheme and host survive the hop on their own, because MailFathom reads a forwarded
+header from any peer until told otherwise — so tell it which proxy to believe, `ReverseProxy:TrustedProxies` naming the
+address or the `frontend` subnet, and everything else on that network stops being able to set those headers.
+[Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) is the page, and it
+states what the unnamed default gives up.
 
 The probe port is separate and stays loopback unless the machine asking is not this one. It answers without a
 credential, so `MAILFATHOM_HEALTH_BIND` is the whole of its access control; a probe path is never served on the

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -220,15 +220,17 @@ Every one of those is a MailFathom setting rather than a chart value, so turning
 | --- | --- | --- |
 | API keys | `McpEndpoint:Authentication` and `McpEndpoint:ApiKeys` | [Authentication](mcp-endpoint.md#authentication) |
 | An `Origin` gate | `McpEndpoint:Cors` | [CORS and the `Origin` header](mcp-endpoint.md#cors-and-the-origin-header) |
-| Reading the public scheme and host from the ingress | `ReverseProxy:Enabled` and `ReverseProxy:TrustedProxies` | [Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) |
+| Reading the public scheme and host from the ingress alone | `ReverseProxy:TrustedProxies` | [Behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) |
 | TLS terminated by the pod itself | `McpEndpoint:Https:Endpoints` | [HTTPS and your own domain](mcp-endpoint.md#https-and-your-own-domain) |
 | Client certificates | `McpEndpoint:ClientCertificateProfiles` | [Client certificates](mcp-endpoint.md#client-certificates) |
 | Rate limits | `McpEndpoint:RateLimiting`, and `AdminEndpoint:RateLimiting` for the administrative endpoint | [Rate limiting](mcp-endpoint.md#rate-limiting) |
 
-The ingress row is the one an OAuth deployment cannot skip. The controller terminates TLS and dials the pod over plain
-HTTP under the Service name, so without it the protected resource metadata document answers `404` and discovery never
-completes. `TrustedProxies` then names the pod CIDR the ingress controller runs in, which
-`kubectl cluster-info dump | grep -m1 cluster-cidr` reports on most distributions.
+The ingress row is the one an OAuth deployment should not skip, and it narrows rather than enables. The controller
+terminates TLS and dials the pod over plain HTTP under the Service name, and MailFathom reads the forwarded scheme and
+host from any peer until you say otherwise — so discovery completes out of the box, and until `TrustedProxies` names
+the ingress, anything else that can reach the pod can set those headers too. Name the pod CIDR the ingress controller
+runs in, which `kubectl cluster-info dump | grep -m1 cluster-cidr` reports on most distributions. A `ClusterIP`
+Service is not a substitute: it keeps the pod off the cluster's edge, not away from every other pod.
 
 Configuring `Https:Endpoints` takes over the host's application listener, so the chart's `service.port` and the `http`
 container port have to match what the profiles bind. The probe listener is unaffected and keeps its own transport. That is a deliberate step rather than the default: in a cluster, TLS at the ingress is

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -1,6 +1,6 @@
 # The MCP endpoint and what protects it
 
-<!-- describes: src/Mcp/**, src/Host/Security/**, src/Infrastructure/Security/**, src/Common/OAuth/**, src/Host/Configuration/Endpoints/TransportClearTextRedirectOptions.cs, src/Host/Hosting/Startup/ClearTextRedirectToHttps.cs, src/Host/Hosting/Warnings/TransportClearTextRedirectReport.cs -->
+<!-- describes: src/Mcp/**, src/Host/Security/**, src/Infrastructure/Security/**, src/Common/OAuth/**, src/Host/Configuration/Endpoints/TransportClearTextRedirectOptions.cs, src/Host/Configuration/Endpoints/ReverseProxyOptions.cs, src/Host/Hosting/Startup/ClearTextRedirectToHttps.cs, src/Host/Hosting/Warnings/TransportClearTextRedirectReport.cs, src/Host/Hosting/Warnings/ReverseProxyTrustWarning.cs, src/Host/Hosting/Warnings/McpTransportEncryptionWarning.cs -->
 
 The MCP endpoint is how an agent reaches MailFathom. This page records what enabling it means operationally, what a client
 has to present to reach it, which browser origins it answers, which client applications it accepts a certificate from,
@@ -190,8 +190,8 @@ a token, and every token's audience is compared against it — which is what sto
 same authorization server from being replayed here. Behind a reverse proxy, write the proxy's public URL: deriving it from
 the `Host` or `X-Forwarded-Host` header would tell each client to authenticate for whichever name it arrived under, including
 one an attacker chose. That stays true with
-[a trusted proxy configured](#behind-a-tls-terminating-reverse-proxy) — the mode makes a request state the name it
-arrived under, and leaves the resource identifier a value you wrote.
+[a trusted proxy configured](#behind-a-tls-terminating-reverse-proxy) — a forwarded header makes a request state the
+name it arrived under, and leaves the resource identifier a value you wrote.
 
 **`Issuer` is copied verbatim from the authorization server**, trailing slash included where there is one. It is compared
 against a token's `iss` by exact string equality and checked against the `issuer` the discovery document reports. Several
@@ -296,10 +296,11 @@ the client; the server log is where they differ.
 > **The metadata document is served only to a request whose own scheme and host match `Resource`.** That is the MCP SDK's
 > check, and it is what stops the document being served under a name the deployment never claimed. Three deployments
 > satisfy it: MailFathom terminating TLS itself, a proxy that passes HTTPS through with the `Host` header intact, and a
-> TLS-terminating proxy that MailFathom has been told to trust — see
-> [behind a TLS-terminating reverse proxy](#behind-a-tls-terminating-reverse-proxy). Without that third setting the
-> request from such a proxy arrives as `http` under an internal name, nothing matches, and a `404` on the metadata
-> address with everything else working is what an operator sees.
+> TLS-terminating proxy whose forwarded scheme and host MailFathom believes — see
+> [behind a TLS-terminating reverse proxy](#behind-a-tls-terminating-reverse-proxy). In the third case the proxy has to
+> send both headers and has to fall inside `ReverseProxy:TrustedProxies`; a request that satisfies neither arrives as
+> `http` under an internal name, nothing matches, and a `404` on the metadata address with everything else working is
+> what an operator sees.
 
 #### What the MCP client does, not MailFathom
 
@@ -833,13 +834,12 @@ certificate's names carry.
 
 When nginx, Traefik, or an ingress controller holds your certificate, the request that reaches MailFathom arrives as
 `http` under whichever internal name the proxy dialled. Your deployment's public identity survives the hop only in
-`X-Forwarded-Proto` and `X-Forwarded-Host`, and MailFathom reads neither until you say which proxy it may read them
-from:
+`X-Forwarded-Proto` and `X-Forwarded-Host`. MailFathom always reads both; the one thing you configure is which peers it
+believes them from:
 
 ```json
 {
   "ReverseProxy": {
-    "Enabled": true,
     "TrustedProxies": [ "10.4.0.0/16" ]
   }
 }
@@ -847,13 +847,11 @@ from:
 
 | Setting | Default | Meaning |
 |---|---|---|
-| `Enabled` | `false` | Whether a forwarded scheme and host are read at all |
-| `TrustedProxies` | empty | The proxy addresses or CIDR networks they are accepted from; required when enabled |
+| `TrustedProxies` | empty, which trusts every peer | The proxy addresses or CIDR networks a forwarded scheme and host are accepted from |
 | `MaximumForwardedHops` | `1` | How many proxies may have appended a value to either header |
 
-The mode applies the forwarded scheme and host to the request before anything reads it, so OAuth discovery, the `401`
-challenge, and every absolute address MailFathom writes carry your public name. Turning it on is what makes the
-metadata document answer behind such a proxy instead of `404` — see
+The forwarded scheme and host are applied to the request before anything reads it, so OAuth discovery, the `401`
+challenge, and every absolute address MailFathom writes carry your public name — see
 [discovery a client uses](#discovery-a-client-uses).
 
 **It is one setting for the whole process, not one per endpoint.** The MCP, administrative, and probe surfaces are
@@ -862,31 +860,41 @@ trusted on every listener it can reach, which is what a network fact should be: 
 rather than restating it beside each surface.
 
 **Trust is the connection, never the header.** A forwarded value is worth exactly what the peer that sent it is worth,
-so a request from any address outside `TrustedProxies` is served under the scheme and host it actually arrived with, and
-its `X-Forwarded-*` headers change nothing. Enabling the mode without naming a proxy fails startup rather than falling
-back to anything:
-
-```text
-ReverseProxy:TrustedProxies — a forwarded scheme and host are worth what the connection that carried them is worth, so
-an enabled section must name the proxy it accepts them from. State one or more IP addresses or CIDR networks, for
-example '10.0.0.5' or '10.0.0.0/24'.
-```
+so once you have named a proxy, a request from any address outside `TrustedProxies` is served under the scheme and host
+it actually arrived with, and its `X-Forwarded-*` headers change nothing.
 
 The framework's own default — trusting loopback — is cleared rather than inherited, because loopback is the wrong peer
-in a container and every other process on the machine in a native installation. `10.0.0.5/24` is refused too, naming
-the `10.0.0.0/24` it would otherwise have silently become; write the address or write the network, and the deployment
-gets what it asked for.
+in a container and every other process on the machine in a native installation. What you name replaces the default
+trust rather than adding to it. `10.0.0.5/24` is refused, naming the `10.0.0.0/24` it would otherwise have silently
+become; write the address or write the network, and the deployment gets what it asked for.
 
-> **`0.0.0.0/0` and `::/0` are accepted, and they mean what they say.** Nothing refuses a prefix that covers every
-> address, so a deployment can trust every peer — but it has to write that, which is the difference between a decision
-> and an empty field. Understand the cost before you do. **An OAuth access token is refused outright when the request
-> did not arrive over TLS, and that check reads the scheme after this mode has applied it.** With a real proxy named,
-> that is correct: the hop to the client genuinely was HTTPS. With every peer trusted, anything that can reach the
-> listener sends `X-Forwarded-Proto: https` and the refusal stops working, so a reusable credential crosses a
-> clear-text hop and is accepted. Use a range that covers your proxies and nothing else.
+### What an unconfigured section costs
 
-Because it is accepted rather than refused, it is announced. A `/0` in the list produces one startup warning naming
-what the deployment gave up:
+> **Name your proxies.** With `TrustedProxies` empty, MailFathom trusts `0.0.0.0/0` and `::/0` — every peer that can
+> open a connection. **An OAuth access token is refused outright when the request did not arrive over TLS, and that
+> check reads the scheme after a forwarded header has been applied.** With a real proxy named that is correct: the hop
+> to the client genuinely was HTTPS. With every peer trusted, anything that can reach the listener sends
+> `X-Forwarded-Proto: https` and the refusal stops working, so a reusable credential crosses a clear-text hop and is
+> accepted. `X-Forwarded-Host` is believed on the same terms, so the name your `401` challenge and every absolute
+> address carry is then a client's to choose. Name a range that covers your proxies and nothing else.
+
+Writing `0.0.0.0/0` and `::/0` out is the same posture stated deliberately, and it is a posture an operator can mean: a
+load balancer pool with no stable address, or a network already closed by something other than this setting.
+
+Either way it is announced. Every startup that runs on it logs one line naming what the deployment gave up. A section
+that named no proxy reads:
+
+```text
+warn: MailFathom.Host.Hosting.Warnings.ReverseProxyTrustWarning
+      ReverseProxy:TrustedProxies names no proxy, so this process trusts 0.0.0.0/0, ::/0 — a forwarded scheme and host
+      are read from any peer that can open a connection. This also turns off the refusal of an access token that
+      arrived without transport encryption, because that refusal reads the scheme a forwarded header set, so a client
+      can claim its own hop was encrypted and have the token accepted over clear text. Name the addresses or CIDR
+      networks your proxies actually use, for example '10.0.0.5' or '10.0.0.0/24', to read a forwarded header from them
+      alone; write the ranges above explicitly if trusting every peer is what this deployment means.
+```
+
+and one that wrote the ranges out reads:
 
 ```text
 warn: MailFathom.Host.Hosting.Warnings.ReverseProxyTrustWarning
@@ -897,8 +905,9 @@ warn: MailFathom.Host.Hosting.Warnings.ReverseProxyTrustWarning
       the addresses your proxies actually use unless something other than this setting already closes the network.
 ```
 
-A merely wide range — a private `/8` — produces nothing. How wide is too wide inside a network you own is a judgement
-only you can make, and a warning that fired on it would be a line you learn to scroll past before it ever mattered.
+Both are said once, while the host starts, and never per request. A merely wide range — a private `/8` — produces
+nothing at all. How wide is too wide inside a network you own is a judgement only you can make, and a warning that
+fired on it would be a line you learn to scroll past before it ever mattered.
 
 **Only the two headers are read.** `X-Forwarded-For` is not, so the peer MailFathom observes stays the one that opened
 the connection. Nothing here partitions, limits, or logs by client address, so adopting one from a header would replace

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -178,8 +178,9 @@ origins, serving your own domain over TLS, client certificates, and the rate lim
 
 MailFathom itself serves plain HTTP unless its own TLS termination is configured, so keep the application port on
 loopback or behind a TLS-terminating proxy — the Compose deployment's default — and give the proxy the certificate. If
-you put a proxy in front, name it in `ReverseProxy:TrustedProxies` as well, so the public scheme and host survive the
-hop: [behind a TLS-terminating reverse proxy](../operations/mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy).
+you put a proxy in front, name it in `ReverseProxy:TrustedProxies` as well. The public scheme and host survive the hop
+either way; naming the proxy is what stops anything else that can reach the port from claiming them:
+[behind a TLS-terminating reverse proxy](../operations/mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy).
 
 ## 7. Connect an MCP client
 

--- a/src/Host/Configuration/Endpoints/ReverseProxyOptions.cs
+++ b/src/Host/Configuration/Endpoints/ReverseProxyOptions.cs
@@ -102,10 +102,9 @@ internal sealed class ReverseProxyOptions
     /// <returns>The bound settings.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
     /// <remarks>
-    /// Strict binding is part of the read, like every other security-sensitive section: a misspelled key here would
-    /// leave a deployment believing it had named its proxy while every peer was trusted, or believing a chain limit
-    /// applied that never bound. It is also what makes the removal of the former <c>Enabled</c> key audible — a
-    /// deployment carrying it stops at startup naming the key rather than starting under a posture nobody chose.
+    /// Strict binding is part of the read, like every other security-sensitive section: a key this section does not
+    /// carry would otherwise leave a deployment believing it had named its proxy while every peer was trusted, or
+    /// believing a chain limit applied that never bound.
     /// </remarks>
     public static ReverseProxyOptions ReadFrom(IConfiguration configuration)
     {

--- a/src/Host/Configuration/Endpoints/ReverseProxyOptions.cs
+++ b/src/Host/Configuration/Endpoints/ReverseProxyOptions.cs
@@ -16,6 +16,13 @@ namespace MailFathom.Host.Configuration.Endpoints;
 /// and every address composed from a request agree with the name a client actually used.
 /// </para>
 /// <para>
+/// Reading them is not a mode to switch on. The middleware is always in the pipeline and the section carries one
+/// decision — which peers a forwarded value is believed from — because that is the only question an operator has to
+/// answer. A section that names a proxy believes that proxy and nothing else; a section that names none believes every
+/// peer that can open a connection, which is the default and is announced at startup rather than assumed to be
+/// understood. <see cref="TrustedProxies" /> states what the second posture costs.
+/// </para>
+/// <para>
 /// It changes nothing about who declares the deployment's identity. A resource identifier stays a configured value
 /// compared against a token's audience, never a header, so nothing an upstream writes can decide what a client is told
 /// to authorize for. What a forwarded header settles is which name this request arrived under, which is a fact about
@@ -29,8 +36,8 @@ namespace MailFathom.Host.Configuration.Endpoints;
 /// stands in front of the process, so it is stated once and holds on every listener the named proxy can reach.
 /// </para>
 /// <para>
-/// The section is read once, while the host is being composed, because it decides which middleware the pipeline
-/// carries. A change takes effect on restart.
+/// The section is read once, while the host is being composed, because it decides what the pipeline's forwarded-header
+/// policy is. A change takes effect on restart.
 /// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
@@ -39,13 +46,13 @@ internal sealed class ReverseProxyOptions
     /// <summary>The configuration section the reverse-proxy settings are bound from.</summary>
     public const string SectionName = "ReverseProxy";
 
-    /// <summary>Gets or sets whether a forwarded scheme and host are read at all.</summary>
+    /// <summary>The trust a section that names no proxy resolves to: every address of both families.</summary>
     /// <remarks>
-    /// Off unless a deployment states otherwise, so a process nobody put a proxy in front of ignores both headers
-    /// entirely. A forwarded header is a value whoever is upstream wrote, and a deployment reachable directly has no
-    /// upstream worth believing.
+    /// Held as the configured spelling rather than as parsed networks so that one code path composes trust and one
+    /// reports it. The startup warning names these strings back to the operator, which is the same text they would
+    /// write to state the posture explicitly.
     /// </remarks>
-    public bool Enabled { get; set; }
+    private static readonly string[] EveryAddress = ["0.0.0.0/0", "::/0"];
 
     /// <summary>Gets the proxy addresses or CIDR networks a forwarded scheme and host are accepted from.</summary>
     /// <remarks>
@@ -55,27 +62,51 @@ internal sealed class ReverseProxyOptions
     /// network and everything else as a single address.
     /// </para>
     /// <para>
-    /// Empty is not a permitted posture for an enabled section. The framework's own default trusts loopback, which is
-    /// wrong inside a container where the proxy is a peer on the pod or bridge network, and the usual workaround of
-    /// clearing its lists trusts every peer that can open a connection — which is worse than the problem it solves.
+    /// Empty is the default and means every peer is believed, which is the posture named by <see cref="EveryAddress" />
+    /// written out. It is a real posture — a load balancer pool with no stable address, a network already closed by
+    /// something other than this setting — and it is what an unconfigured deployment gets, so what it costs belongs
+    /// here rather than in a page somebody may not reach. The refusal of an access token that arrived without transport
+    /// encryption decides by reading the scheme this policy has already applied, so with every peer believed any client
+    /// that can reach the listener sends <c>X-Forwarded-Proto: https</c> and has a reusable credential accepted over
+    /// clear text. <see cref="Hosting.Warnings.ReverseProxyTrustWarning" /> says so at every startup
+    /// that runs on it. Naming the addresses your proxies actually use is what turns that refusal back on.
+    /// </para>
+    /// <para>
+    /// The list is deliberately left empty rather than pre-populated with <see cref="EveryAddress" />. The
+    /// configuration binder adds to an existing collection instead of replacing it, so a default written here would
+    /// survive alongside whatever an operator configured and every deployment would trust every peer no matter what it
+    /// wrote.
     /// </para>
     /// </remarks>
     public IList<string> TrustedProxies { get; } = [];
 
     /// <summary>Gets or sets how many proxies may have appended a value to the forwarded headers.</summary>
     /// <remarks>
-    /// One by default, which is the deployment this mode exists for: a single proxy in front of this process. Each
-    /// header is read right to left, so the limit is how far back into a chain a value is believed; raise it only to
-    /// the number of proxies a request genuinely passes through, because every entry beyond the real chain is one an
-    /// earlier hop could have appended.
+    /// One by default, which is the deployment this exists for: a single proxy in front of this process. Each header is
+    /// read right to left, so the limit is how far back into a chain a value is believed; raise it only to the number
+    /// of proxies a request genuinely passes through, because every entry beyond the real chain is one an earlier hop
+    /// could have appended.
     /// </remarks>
     public int MaximumForwardedHops { get; set; } = 1;
+
+    /// <summary>Gets whether the section names a proxy, rather than resolving to trusting every peer.</summary>
+    /// <remarks>
+    /// This is the operator saying what stands in front of the process, which is why it is what the startup warnings
+    /// read: one picks which posture to describe, and the other decides whether a clear-text hop is the one to a proxy
+    /// or the one to a client.
+    /// </remarks>
+    public bool NamesAProxy => this.TrustedProxies.Count > 0;
 
     /// <summary>Reads the section the way composition does, defaults included.</summary>
     /// <param name="configuration">The application configuration.</param>
     /// <returns>The bound settings.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
-    /// <remarks>Strict binding is part of the read, like every other security-sensitive section: a misspelled key here would leave a deployment believing it had named its proxy while nothing was trusted, or believing a chain limit applied that never bound.</remarks>
+    /// <remarks>
+    /// Strict binding is part of the read, like every other security-sensitive section: a misspelled key here would
+    /// leave a deployment believing it had named its proxy while every peer was trusted, or believing a chain limit
+    /// applied that never bound. It is also what makes the removal of the former <c>Enabled</c> key audible — a
+    /// deployment carrying it stops at startup naming the key rather than starting under a posture nobody chose.
+    /// </remarks>
     public static ReverseProxyOptions ReadFrom(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
@@ -87,56 +118,41 @@ internal sealed class ReverseProxyOptions
 
     /// <summary>Finds everything an operator must fix before a forwarded scheme and host can be read.</summary>
     /// <returns>One message per faulty setting, each naming its configuration path, empty when the settings are usable.</returns>
+    /// <remarks>
+    /// An empty list is not among them. It is the default posture rather than a mistake, so it is announced at startup
+    /// instead of refused here; refusing it would make every unconfigured deployment fail to start.
+    /// </remarks>
     public IReadOnlyList<string> FindConfigurationErrors()
     {
-        if (!this.Enabled)
-        {
-            // Configured-but-unread is refused rather than ignored, for the reason every other section refuses it: an
-            // operator who named their proxy and left the mode off has a deployment they believe reads a forwarded
-            // header and one that does not.
-            return this.TrustedProxies.Count == 0
-                ? []
-                : [$"{SectionName}:{nameof(this.TrustedProxies)} — proxies are configured while '{nameof(this.Enabled)}' is false, so no forwarded header is read from any of them; enable the section or remove them."];
-        }
-
-        var errors = new List<string>();
-
-        if (this.TrustedProxies.Count == 0)
-        {
-            errors.Add($"{SectionName}:{nameof(this.TrustedProxies)} — a forwarded scheme and host are worth what the connection that carried them is worth, so an enabled section must name the proxy it accepts them from. State one or more IP addresses or CIDR networks, for example '10.0.0.5' or '10.0.0.0/24'.");
-        }
-
-        errors.AddRange(this.FindTrustedProxyErrors());
+        var errors = new List<string>(this.FindTrustedProxyErrors());
 
         if (this.MaximumForwardedHops < 1)
         {
-            errors.Add($"{SectionName}:{nameof(this.MaximumForwardedHops)} — '{this.MaximumForwardedHops}' reads no forwarded value at all, which is what disabling the section already does. State the number of proxies a request passes through, which is 1 for a single proxy in front of this process.");
+            errors.Add($"{SectionName}:{nameof(this.MaximumForwardedHops)} — '{this.MaximumForwardedHops}' reads no forwarded value at all, so no proxy's scheme or host would reach a request however {nameof(this.TrustedProxies)} is stated. State the number of proxies a request passes through, which is 1 for a single proxy in front of this process.");
         }
 
         return errors;
     }
 
-    /// <summary>Maps the configured entries onto the single proxy addresses among them.</summary>
+    /// <summary>Maps the trusted entries onto the single proxy addresses among them.</summary>
     /// <returns>The addresses, in configuration order, empty when every entry names a network.</returns>
     /// <exception cref="FormatException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
     public IReadOnlyList<IPAddress> ToTrustedProxyAddresses() =>
-        [.. this.TrustedProxies.Select(Normalize).Where(static entry => !NamesNetwork(entry)).Select(IPAddress.Parse)];
+        [.. this.EffectiveTrustedProxies().Where(static entry => !NamesNetwork(entry)).Select(IPAddress.Parse)];
 
-    /// <summary>Maps the configured entries onto the proxy networks among them.</summary>
+    /// <summary>Maps the trusted entries onto the proxy networks among them.</summary>
     /// <returns>The networks, in configuration order, empty when every entry names a single address.</returns>
     /// <exception cref="FormatException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
     public IReadOnlyList<IPNetwork> ToTrustedProxyNetworks() =>
-        [.. this.TrustedProxies.Select(Normalize).Where(NamesNetwork).Select(IPNetwork.Parse)];
+        [.. this.EffectiveTrustedProxies().Where(NamesNetwork).Select(IPNetwork.Parse)];
 
-    /// <summary>Reports the configured ranges that cover every address, and so believe any peer that can open a connection.</summary>
+    /// <summary>Reports the trusted ranges that cover every address, and so believe any peer that can open a connection.</summary>
     /// <returns>The ranges, in configuration order, empty when every entry names a proxy this deployment could have meant.</returns>
     /// <exception cref="FormatException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />.</exception>
     /// <remarks>
-    /// Accepted rather than refused, because trusting every peer is a posture an operator can mean — a load balancer
-    /// pool with no stable address, a network already closed by something other than this setting. What it is not is a
-    /// posture anybody should reach without knowing the cost, which is why it is reported at startup: the refusal of an
-    /// access token that arrived without transport encryption decides by reading the scheme this mode applies, so a
-    /// range covering every address is also the deployment where any client can claim its own hop was encrypted.
+    /// Reached by a section that named such a range and by one that named nothing, because the two produce the same
+    /// trust and give up the same protection. Which of them a deployment is running is <see cref="NamesAProxy" />'s
+    /// question, and only the wording of the warning turns on it.
     /// </remarks>
     public IReadOnlyList<IPNetwork> ToTrustedProxyRangesCoveringEveryAddress() =>
         [.. this.ToTrustedProxyNetworks().Where(static network => network.PrefixLength == 0)];
@@ -168,6 +184,10 @@ internal sealed class ReverseProxyOptions
     }
 
     private static string Normalize(string? entry) => entry?.Trim() ?? string.Empty;
+
+    /// <summary>Produces the entries trust is actually composed from, which is every address when none is named.</summary>
+    private IEnumerable<string> EffectiveTrustedProxies() =>
+        this.NamesAProxy ? this.TrustedProxies.Select(Normalize) : EveryAddress;
 
     private IEnumerable<string> FindTrustedProxyErrors()
     {

--- a/src/Host/Hosting/Warnings/McpTransportEncryptionWarning.cs
+++ b/src/Host/Hosting/Warnings/McpTransportEncryptionWarning.cs
@@ -19,10 +19,11 @@ namespace MailFathom.Host.Hosting.Warnings;
 /// </para>
 /// <para>
 /// Which of the two is running stopped being something only the operator knows once a trusted proxy could be named. A
-/// configured <see cref="ReverseProxyOptions" /> section is the operator saying what stands in front, so the warning
-/// then describes that deployment — the clear-text hop is the one between the proxy and this process — instead of
-/// listing the postures it would otherwise have to guess between. Nothing is silenced by it: that hop is real, and an
-/// API key crossing it is as readable as it was.
+/// <see cref="ReverseProxyOptions" /> section that names one is the operator saying what stands in front, so the
+/// warning then describes that deployment — the clear-text hop is the one between the proxy and this process — instead
+/// of listing the postures it would otherwise have to guess between. Nothing is silenced by it: that hop is real, and
+/// an API key crossing it is as readable as it was. A section naming no proxy says nothing about what stands in front,
+/// which is why it reads as the unqualified posture rather than as the proxied one.
 /// </para>
 /// <para>
 /// What it refuses to let happen is the third case: an endpoint reachable across a network that nobody meant to expose
@@ -69,7 +70,7 @@ internal sealed partial class McpTransportEncryptionWarning : IHostedService
             return Task.CompletedTask;
         }
 
-        if (this.reverseProxySettings.Enabled)
+        if (this.reverseProxySettings.NamesAProxy)
         {
             this.LogEndpointServedBehindTrustedReverseProxy(
                 McpEndpointRoute.Path,

--- a/src/Host/Hosting/Warnings/ReverseProxyTrustWarning.cs
+++ b/src/Host/Hosting/Warnings/ReverseProxyTrustWarning.cs
@@ -8,25 +8,31 @@ using Microsoft.Extensions.Options;
 
 namespace MailFathom.Host.Hosting.Warnings;
 
-/// <summary>States at startup that the configured proxy trust covers every address rather than a proxy.</summary>
+/// <summary>States at startup that the proxy trust in force covers every address rather than a proxy.</summary>
 /// <remarks>
 /// <para>
 /// A range covering every address is accepted rather than refused, because an operator can mean it: a load balancer
-/// pool with no stable address, or a network already closed by something other than this setting. It is reported for
-/// the reason every other posture here is — only an operator knows which of those they have, and none of it is
-/// something MailFathom can detect.
+/// pool with no stable address, or a network already closed by something other than this setting. It is also what a
+/// deployment that configured nothing runs on, which is the case this warning matters most for — nobody chose that
+/// posture, so nobody would otherwise learn they had it.
 /// </para>
 /// <para>
 /// What makes it worth a line of its own is that it does not merely widen who is believed. The refusal of an access
 /// token that arrived without transport encryption decides by reading <c>HttpContext.Request.IsHttps</c>, which is the
-/// scheme this mode has already rewritten, so with every peer trusted any client can assert that its own hop was
-/// encrypted and have a reusable credential accepted over clear text. That is a protection the deployment gave up, and
-/// giving it up silently is what this exists to prevent.
+/// scheme the forwarded-header policy has already rewritten, so with every peer trusted any client can assert that its
+/// own hop was encrypted and have a reusable credential accepted over clear text. That is a protection the deployment
+/// gave up, and giving it up silently is what this exists to prevent.
 /// </para>
 /// <para>
-/// Only a prefix covering every address is reported. A merely wide range — a private <c>/8</c> — is a judgement about
-/// somebody's network rather than a fact about it, and a warning that fired on one would be a line an operator learns
-/// to scroll past.
+/// The two postures are reported separately because the remedy differs: one deployment has to narrow a range it wrote,
+/// the other has to name a proxy it never named. Only the wording turns on that; what was given up is identical, and
+/// both lines say so.
+/// </para>
+/// <para>
+/// Nothing else is reported. A merely wide range — a private <c>/8</c> — is a judgement about somebody's network
+/// rather than a fact about it, and a warning that fired on one would be a line an operator learns to scroll past.
+/// This is said once, while the host starts, and never per request, for the same reason: a line repeated at request
+/// rate is a line nobody reads.
 /// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this hosted service.")]
@@ -52,16 +58,22 @@ internal sealed partial class ReverseProxyTrustWarning : IHostedService
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        if (!this.reverseProxySettings.Enabled)
+        var rangesCoveringEveryAddress = this.reverseProxySettings.ToTrustedProxyRangesCoveringEveryAddress();
+
+        if (rangesCoveringEveryAddress.Count == 0)
         {
             return Task.CompletedTask;
         }
 
-        var rangesCoveringEveryAddress = this.reverseProxySettings.ToTrustedProxyRangesCoveringEveryAddress();
+        var trustedRanges = string.Join(", ", rangesCoveringEveryAddress);
 
-        if (rangesCoveringEveryAddress.Count > 0)
+        if (this.reverseProxySettings.NamesAProxy)
         {
-            this.LogEveryPeerTrusted(string.Join(", ", rangesCoveringEveryAddress));
+            this.LogConfiguredRangeTrustsEveryPeer(trustedRanges);
+        }
+        else
+        {
+            this.LogUnconfiguredSectionTrustsEveryPeer(trustedRanges);
         }
 
         return Task.CompletedTask;
@@ -78,5 +90,16 @@ internal sealed partial class ReverseProxyTrustWarning : IHostedService
             + "scheme a forwarded header set — so a client can claim its own hop was encrypted and have the token "
             + "accepted over clear text. Narrow the range to the addresses your proxies actually use unless something "
             + "other than this setting already closes the network.")]
-    private partial void LogEveryPeerTrusted(string trustedRanges);
+    private partial void LogConfiguredRangeTrustsEveryPeer(string trustedRanges);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "ReverseProxy:TrustedProxies names no proxy, so this process trusts {TrustedRanges} — a forwarded "
+            + "scheme and host are read from any peer that can open a connection. This also turns off the refusal of an "
+            + "access token that arrived without transport encryption, because that refusal reads the scheme a "
+            + "forwarded header set, so a client can claim its own hop was encrypted and have the token accepted over "
+            + "clear text. Name the addresses or CIDR networks your proxies actually use, for example '10.0.0.5' or "
+            + "'10.0.0.0/24', to read a forwarded header from them alone; write the ranges above explicitly if trusting "
+            + "every peer is what this deployment means.")]
+    private partial void LogUnconfiguredSectionTrustsEveryPeer(string trustedRanges);
 }

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -274,9 +274,9 @@ try
     builder.Services.AddHostedService(provider => OpenSslConfigurationWarning.FromEnvironment(
         provider.GetRequiredService<ILogger<OpenSslConfigurationWarning>>()));
 
-    // Read before the surfaces, because it is the one posture they all sit behind: which proxy, if any, this process
-    // accepts a public scheme and host from. Read once for the same reason every section below is — it decides which
-    // middleware the pipeline carries, and the encryption warning states the posture this settles.
+    // Read before the surfaces, because it is the one posture they all sit behind: which peers this process accepts a
+    // public scheme and host from. Read once for the same reason every section below is — the pipeline's
+    // forwarded-header policy is composed from it, and the encryption warning states the posture this settles.
     var reverseProxySettings = ReverseProxyOptions.ReadFrom(builder.Configuration);
     builder.Services.AddSingleton(Options.Create(reverseProxySettings));
 
@@ -290,10 +290,7 @@ try
             reverseProxyConfigurationErrors);
     }
 
-    if (reverseProxySettings.Enabled)
-    {
-        builder.Services.AddTrustedReverseProxy(reverseProxySettings);
-    }
+    builder.Services.AddTrustedReverseProxy(reverseProxySettings);
 
     // Read once and registered, so the value that decides the route is the one every consumer resolves. Whether the
     // endpoint exists is decided while the application is being built, before a container that could resolve a snapshot
@@ -559,12 +556,9 @@ try
 
     // First, ahead of the exception handler and of every isolation check, so that nothing downstream ever reads a
     // scheme or host the proxy already corrected. Discovery, the challenge, and any address composed from a request
-    // then agree with the name the client used, and a request from anything but a trusted proxy passes through with
-    // the scheme and host it arrived under.
-    if (reverseProxySettings.Enabled)
-    {
-        app.UseForwardedHeaders();
-    }
+    // then agree with the name the client used, and a request from a peer this deployment does not trust passes
+    // through with the scheme and host it arrived under.
+    app.UseForwardedHeaders();
 
     app.UseExceptionHandler();
 

--- a/src/Host/Security/Transport/TrustedReverseProxyExtensions.cs
+++ b/src/Host/Security/Transport/TrustedReverseProxyExtensions.cs
@@ -15,6 +15,12 @@ namespace MailFathom.Host.Security.Transport;
 /// container, and it processes <c>X-Forwarded-For</c> when asked to, which this deployment never asks for.
 /// </para>
 /// <para>
+/// A policy is composed on every startup, because there is no posture in which no forwarded header is read. A section
+/// naming no proxy resolves to trusting every address, so the lists cleared below are repopulated with a prefix
+/// covering each family rather than left empty; <see cref="ReverseProxyOptions.TrustedProxies" /> states what that
+/// gives up and the startup warning names it.
+/// </para>
+/// <para>
 /// The client address is out of scope on purpose. Nothing here partitions, limits, or logs by remote address, so
 /// rewriting <see cref="ConnectionInfo.RemoteIpAddress" /> from a header would replace the
 /// one address this process observes for itself — the peer that opened the connection — with one an upstream wrote,

--- a/tests/Host.UnitTests/Configuration/Endpoints/ReverseProxyOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/ReverseProxyOptionsBindingTests.cs
@@ -17,7 +17,7 @@ namespace MailFathom.Host.UnitTests.Configuration.Endpoints;
 public sealed class ReverseProxyOptionsBindingTests
 {
     [Fact]
-    public void ReadFrom_AnEmptyConfiguration_ReadsNoForwardedHeader()
+    public void ReadFrom_AnEmptyConfiguration_NamesNoProxyAndBelievesOneHop()
     {
         // Arrange
         var configuration = ConfigurationFrom([]);
@@ -26,8 +26,8 @@ public sealed class ReverseProxyOptionsBindingTests
         var options = ReverseProxyOptions.ReadFrom(configuration);
 
         // Assert
-        Assert.False(options.Enabled);
         Assert.Empty(options.TrustedProxies);
+        Assert.False(options.NamesAProxy);
         Assert.Equal(1, options.MaximumForwardedHops);
     }
 
@@ -37,7 +37,6 @@ public sealed class ReverseProxyOptionsBindingTests
         // Arrange
         var configuration = ConfigurationFrom(new Dictionary<string, string?>
         {
-            ["ReverseProxy:Enabled"] = "true",
             ["ReverseProxy:TrustedProxies:0"] = "10.4.0.0/16",
             ["ReverseProxy:TrustedProxies:1"] = "192.168.1.10",
             ["ReverseProxy:MaximumForwardedHops"] = "2",
@@ -47,16 +46,36 @@ public sealed class ReverseProxyOptionsBindingTests
         var options = ReverseProxyOptions.ReadFrom(configuration);
 
         // Assert
-        Assert.True(options.Enabled);
         Assert.Equal(["10.4.0.0/16", "192.168.1.10"], options.TrustedProxies);
         Assert.Equal(2, options.MaximumForwardedHops);
         Assert.Empty(options.FindConfigurationErrors());
     }
 
     /// <summary>
-    /// A misspelled key that bound quietly would leave a deployment believing it had named its proxy while nothing was
-    /// trusted, which reads as OAuth discovery still failing behind a proxy that was configured correctly. The singular
-    /// is the plausible mistake, because a deployment with one proxy in front is what this mode is for.
+    /// The configured list replaces the trust an unconfigured section resolves to rather than adding to it, which is
+    /// why the default is not written into the property itself: the binder adds to an existing collection, so a
+    /// pre-populated <c>0.0.0.0/0</c> would survive alongside the proxy an operator named and keep every peer trusted.
+    /// </summary>
+    [Fact]
+    public void ReadFrom_AConfiguredSection_LeavesNoDefaultTrustBesideWhatWasNamed()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["ReverseProxy:TrustedProxies:0"] = "10.4.0.0/16",
+        });
+
+        // Act
+        var options = ReverseProxyOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Empty(options.ToTrustedProxyRangesCoveringEveryAddress());
+    }
+
+    /// <summary>
+    /// A misspelled key that bound quietly would leave a deployment believing it had named its proxy while every peer
+    /// was trusted, which reads as the endpoint working until somebody forges a scheme. The singular is the plausible
+    /// mistake, because a deployment with one proxy in front is what this section is for.
     /// </summary>
     [Fact]
     public void ReadFrom_AMisspelledKey_FailsRatherThanBindingTheRest()
@@ -64,8 +83,31 @@ public sealed class ReverseProxyOptionsBindingTests
         // Arrange
         var configuration = ConfigurationFrom(new Dictionary<string, string?>
         {
-            ["ReverseProxy:Enabled"] = "true",
             ["ReverseProxy:TrustedProxy:0"] = "10.0.0.5",
+        });
+
+        // Act
+        var readingTheSection = () => ReverseProxyOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Throws<InvalidOperationException>(readingTheSection);
+    }
+
+    /// <summary>
+    /// The section carried an <c>Enabled</c> key until the posture became unconditional. A deployment still setting it
+    /// stops at startup rather than starting under a trust nobody chose, which is the whole reason the break is loud
+    /// instead of ignored.
+    /// </summary>
+    [Theory]
+    [InlineData("true")]
+    [InlineData("false")]
+    public void ReadFrom_TheWithdrawnEnabledKey_FailsRatherThanIgnoringIt(string configuredValue)
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["ReverseProxy:Enabled"] = configuredValue,
+            ["ReverseProxy:TrustedProxies:0"] = "10.0.0.5",
         });
 
         // Act

--- a/tests/Host.UnitTests/Configuration/Endpoints/ReverseProxyOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/ReverseProxyOptionsTests.cs
@@ -8,16 +8,18 @@ using Xunit;
 
 namespace MailFathom.Host.UnitTests.Configuration.Endpoints;
 
-/// <summary>Covers which reverse-proxy settings an operator is allowed to start the host on.</summary>
+/// <summary>Covers which reverse-proxy settings an operator is allowed to start the host on, and what an unnamed proxy resolves to.</summary>
 /// <remarks>
-/// A forwarded scheme and host are worth what the connection carrying them is worth, so the refusals here are what
-/// keep the mode from ever running on an unstated trust: enabling it without naming a proxy, and naming one that is
-/// neither an address nor a network.
+/// A forwarded scheme and host are worth what the connection carrying them is worth, so what the trust resolves to is
+/// the contract here: an entry that is neither an address nor a network is refused, and a section that names nothing
+/// trusts every peer rather than nobody. The second is the posture the startup warning exists for, and asserting it
+/// keeps the default from drifting silently.
 /// </remarks>
 public sealed class ReverseProxyOptionsTests
 {
+    /// <summary>An unconfigured section is a supported posture rather than a mistake, so it starts the host.</summary>
     [Fact]
-    public void FindConfigurationErrors_DisabledSection_FindsNothing()
+    public void FindConfigurationErrors_ASectionNamingNoProxy_FindsNothing()
     {
         // Arrange
         var settings = new ReverseProxyOptions();
@@ -29,35 +31,67 @@ public sealed class ReverseProxyOptionsTests
         Assert.Empty(errors);
     }
 
-    /// <summary>An operator who named their proxy and left the mode off has a deployment that reads no forwarded header.</summary>
+    /// <summary>
+    /// The default posture, asserted as trust rather than as an empty list, because that is what the middleware ends up
+    /// running on. An operator who configures nothing has every peer believed, and the refusal of an access token that
+    /// arrived without transport encryption reads a scheme any of them can set.
+    /// </summary>
     [Fact]
-    public void FindConfigurationErrors_ProxiesConfiguredWhileDisabled_RefusesTheUnreadSetting()
+    public void ToTrustedProxyNetworks_ASectionNamingNoProxy_TrustsEveryAddressOfBothFamilies()
     {
         // Arrange
         var settings = new ReverseProxyOptions();
-        settings.TrustedProxies.Add("10.0.0.5");
 
         // Act
-        var error = Assert.Single(settings.FindConfigurationErrors());
+        var networks = settings.ToTrustedProxyNetworks();
 
         // Assert
-        Assert.Contains("ReverseProxy:TrustedProxies", error, StringComparison.Ordinal);
-        Assert.Contains("Enabled", error, StringComparison.Ordinal);
+        Assert.Equal(
+            [IPNetwork.Parse("0.0.0.0/0"), IPNetwork.Parse("::/0")],
+            networks);
+        Assert.Empty(settings.ToTrustedProxyAddresses());
     }
 
-    /// <summary>The refusal that keeps the framework's loopback default, and a trust-everything workaround, both out of reach.</summary>
     [Fact]
-    public void FindConfigurationErrors_EnabledWithNoProxyNamed_RefusesStartup()
+    public void ToTrustedProxyRangesCoveringEveryAddress_ASectionNamingNoProxy_ReportsBothFamilies()
     {
         // Arrange
-        var settings = new ReverseProxyOptions { Enabled = true };
+        var settings = new ReverseProxyOptions();
 
         // Act
-        var error = Assert.Single(settings.FindConfigurationErrors());
+        var ranges = settings.ToTrustedProxyRangesCoveringEveryAddress();
 
         // Assert
-        Assert.Contains("ReverseProxy:TrustedProxies", error, StringComparison.Ordinal);
-        Assert.Contains("CIDR", error, StringComparison.Ordinal);
+        Assert.Equal(
+            [IPNetwork.Parse("0.0.0.0/0"), IPNetwork.Parse("::/0")],
+            ranges);
+    }
+
+    /// <summary>Naming one proxy replaces the default outright, rather than being added to it.</summary>
+    [Fact]
+    public void ToTrustedProxyNetworks_AProxyNamed_TrustsThatProxyAlone()
+    {
+        // Arrange
+        var settings = ProxiesTrusted("10.4.0.0/16");
+
+        // Act
+        var networks = settings.ToTrustedProxyNetworks();
+
+        // Assert
+        Assert.Equal([IPNetwork.Parse("10.4.0.0/16")], networks);
+        Assert.Empty(settings.ToTrustedProxyRangesCoveringEveryAddress());
+    }
+
+    [Fact]
+    public void NamesAProxy_ASectionNamingNoProxy_ReportsThatNothingStandsInFront()
+    {
+        // Arrange
+        var settings = new ReverseProxyOptions();
+
+        // Act
+        // Assert
+        Assert.False(settings.NamesAProxy);
+        Assert.True(ProxiesTrusted("10.0.0.5").NamesAProxy);
     }
 
     [Theory]
@@ -69,8 +103,7 @@ public sealed class ReverseProxyOptionsTests
     public void FindConfigurationErrors_ProxyNamedAsAnAddressOrNetwork_FindsNothing(string trustedProxy)
     {
         // Arrange
-        var settings = new ReverseProxyOptions { Enabled = true };
-        settings.TrustedProxies.Add(trustedProxy);
+        var settings = ProxiesTrusted(trustedProxy);
 
         // Act
         var errors = settings.FindConfigurationErrors();
@@ -80,9 +113,8 @@ public sealed class ReverseProxyOptionsTests
     }
 
     /// <summary>
-    /// A prefix covering every address is accepted, because it is a posture an operator can mean and one they have to
-    /// write. What it costs is documented rather than refused: the refusal of an OAuth token that arrived without TLS
-    /// reads the scheme this mode applies, so trusting every peer is trusting every peer to be honest about it.
+    /// A prefix covering every address is accepted, because it is the same posture the default resolves to and writing
+    /// it out is how an operator states that they meant it. What it costs is announced rather than refused.
     /// </summary>
     [Theory]
     [InlineData("0.0.0.0/0")]
@@ -90,8 +122,7 @@ public sealed class ReverseProxyOptionsTests
     public void FindConfigurationErrors_APrefixCoveringEveryAddress_IsAcceptedRatherThanRefused(string trustedProxy)
     {
         // Arrange
-        var settings = new ReverseProxyOptions { Enabled = true };
-        settings.TrustedProxies.Add(trustedProxy);
+        var settings = ProxiesTrusted(trustedProxy);
 
         // Act
         var errors = settings.FindConfigurationErrors();
@@ -109,8 +140,7 @@ public sealed class ReverseProxyOptionsTests
     public void FindConfigurationErrors_ProxyNamingNoAddress_RefusesTheEntryByIndex(string trustedProxy)
     {
         // Arrange
-        var settings = new ReverseProxyOptions { Enabled = true };
-        settings.TrustedProxies.Add(trustedProxy);
+        var settings = ProxiesTrusted(trustedProxy);
 
         // Act
         var error = Assert.Single(settings.FindConfigurationErrors());
@@ -126,8 +156,7 @@ public sealed class ReverseProxyOptionsTests
     public void FindConfigurationErrors_MalformedNetwork_RefusesTheEntry(string trustedProxy)
     {
         // Arrange
-        var settings = new ReverseProxyOptions { Enabled = true };
-        settings.TrustedProxies.Add(trustedProxy);
+        var settings = ProxiesTrusted(trustedProxy);
 
         // Act
         var error = Assert.Single(settings.FindConfigurationErrors());
@@ -149,8 +178,7 @@ public sealed class ReverseProxyOptionsTests
         string widenedNetwork)
     {
         // Arrange
-        var settings = new ReverseProxyOptions { Enabled = true };
-        settings.TrustedProxies.Add(trustedProxy);
+        var settings = ProxiesTrusted(trustedProxy);
 
         // Act
         var error = Assert.Single(settings.FindConfigurationErrors());
@@ -164,10 +192,7 @@ public sealed class ReverseProxyOptionsTests
     public void FindConfigurationErrors_SeveralFaultyEntries_ReportsEachByItsOwnIndex()
     {
         // Arrange
-        var settings = new ReverseProxyOptions { Enabled = true };
-        settings.TrustedProxies.Add("10.0.0.5");
-        settings.TrustedProxies.Add("ingress.example.test");
-        settings.TrustedProxies.Add("10.0.0.5/24");
+        var settings = ProxiesTrusted("10.0.0.5", "ingress.example.test", "10.0.0.5/24");
 
         // Act
         var errors = settings.FindConfigurationErrors();
@@ -195,8 +220,8 @@ public sealed class ReverseProxyOptionsTests
     public void FindConfigurationErrors_HopLimitBelowOne_RefusesStartup(int maximumForwardedHops)
     {
         // Arrange
-        var settings = new ReverseProxyOptions { Enabled = true, MaximumForwardedHops = maximumForwardedHops };
-        settings.TrustedProxies.Add("10.0.0.5");
+        var settings = ProxiesTrusted("10.0.0.5");
+        settings.MaximumForwardedHops = maximumForwardedHops;
 
         // Act
         var error = Assert.Single(settings.FindConfigurationErrors());
@@ -237,7 +262,7 @@ public sealed class ReverseProxyOptionsTests
 
     private static ReverseProxyOptions ProxiesTrusted(params string[] trustedProxies)
     {
-        var settings = new ReverseProxyOptions { Enabled = true };
+        var settings = new ReverseProxyOptions();
 
         foreach (var trustedProxy in trustedProxies)
         {

--- a/tests/Host.UnitTests/Hosting/Warnings/McpTransportEncryptionWarningTests.cs
+++ b/tests/Host.UnitTests/Hosting/Warnings/McpTransportEncryptionWarningTests.cs
@@ -179,7 +179,7 @@ public sealed class McpTransportEncryptionWarningTests
 
     private static ReverseProxyOptions TrustedProxyConfigured()
     {
-        var settings = new ReverseProxyOptions { Enabled = true };
+        var settings = new ReverseProxyOptions();
 
         settings.TrustedProxies.Add("10.0.0.5");
 

--- a/tests/Host.UnitTests/Hosting/Warnings/ReverseProxyTrustWarningTests.cs
+++ b/tests/Host.UnitTests/Hosting/Warnings/ReverseProxyTrustWarningTests.cs
@@ -11,10 +11,11 @@ using Xunit;
 
 namespace MailFathom.Host.UnitTests.Hosting.Warnings;
 
-/// <summary>Covers what an operator is told when their configured proxy trust covers every address.</summary>
+/// <summary>Covers what an operator is told when the proxy trust in force covers every address.</summary>
 /// <remarks>
 /// Its silence is as much a contract as its text. A warning that also fired for an ordinary range would be one more
-/// line an operator learns to scroll past, and the posture it exists for would then travel with the noise.
+/// line an operator learns to scroll past, and the posture it exists for would then travel with the noise. The
+/// deployment that configured nothing is the one that most needs the line, because nobody chose the trust it runs on.
 /// </remarks>
 public sealed class ReverseProxyTrustWarningTests
 {
@@ -54,6 +55,29 @@ public sealed class ReverseProxyTrustWarningTests
         Assert.Equal("0.0.0.0/0, ::/0", Assert.Contains("TrustedRanges", record.Properties));
     }
 
+    /// <summary>
+    /// The default posture. It gives up exactly what the written-out range gives up, so it is announced in the same
+    /// terms — and it names the remedy this deployment has rather than the one the other has, because an operator who
+    /// configured nothing has no range to narrow.
+    /// </summary>
+    [Fact]
+    public async Task StartAsync_ASectionNamingNoProxy_NamesTheTrustNobodyChose()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningFor(new ReverseProxyOptions(), logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("names no proxy", record.Message, StringComparison.Ordinal);
+        Assert.Contains("without transport encryption", record.Message, StringComparison.Ordinal);
+        Assert.Equal("0.0.0.0/0, ::/0", Assert.Contains("TrustedRanges", record.Properties));
+    }
+
     /// <summary>A judgement about how wide is too wide belongs to an operator who knows their network, not to a line in a log.</summary>
     [Theory]
     [InlineData("10.0.0.5")]
@@ -64,23 +88,6 @@ public sealed class ReverseProxyTrustWarningTests
         // Arrange
         using var logs = new RecordingLoggerProvider();
         var warning = WarningFor(TrustingProxies(trustedProxy), logs);
-
-        // Act
-        await warning.StartAsync(TestContext.Current.CancellationToken);
-
-        // Assert
-        Assert.Empty(logs.Records);
-    }
-
-    /// <summary>A section nobody enabled reads no forwarded header from anybody, however its list happens to read.</summary>
-    [Fact]
-    public async Task StartAsync_DisabledSection_SaysNothing()
-    {
-        // Arrange
-        using var logs = new RecordingLoggerProvider();
-        var settings = new ReverseProxyOptions();
-        settings.TrustedProxies.Add("0.0.0.0/0");
-        var warning = WarningFor(settings, logs);
 
         // Act
         await warning.StartAsync(TestContext.Current.CancellationToken);
@@ -105,7 +112,7 @@ public sealed class ReverseProxyTrustWarningTests
 
     private static ReverseProxyOptions TrustingProxies(params string[] trustedProxies)
     {
-        var settings = new ReverseProxyOptions { Enabled = true };
+        var settings = new ReverseProxyOptions();
 
         foreach (var trustedProxy in trustedProxies)
         {

--- a/tests/Host.UnitTests/Security/Transport/TrustedReverseProxyExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TrustedReverseProxyExtensionsTests.cs
@@ -5,6 +5,8 @@
 using System.Net;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Transport;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -93,6 +95,44 @@ public sealed class TrustedReverseProxyExtensionsTests
 
         // Act
         await ForwardThrough(TrustingProxies("0.0.0.0/0", "::/0"), request);
+
+        // Assert
+        Assert.Equal("https", request.Request.Scheme);
+        Assert.Equal("anything.example.test", request.Request.Host.Value);
+    }
+
+    /// <summary>
+    /// The default posture, asserted through the middleware because that is where it is felt: a deployment that
+    /// configured no proxy serves any peer's forwarded scheme and host. It is the same trust as the written-out prefix
+    /// above and gives up the same refusal, which is why the startup warning names it in the same terms.
+    /// </summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_ASectionNamingNoProxy_BelievesAnyPeerAtAll()
+    {
+        // Arrange
+        var request = RequestFrom(IPAddress.Parse("203.0.113.9"));
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+        request.Request.Headers["X-Forwarded-Host"] = "anything.example.test";
+
+        // Act
+        await ForwardThrough(new ReverseProxyOptions(), request);
+
+        // Assert
+        Assert.Equal("https", request.Request.Scheme);
+        Assert.Equal("anything.example.test", request.Request.Host.Value);
+    }
+
+    /// <summary>An IPv6 peer is believed by the default too, which is what the second prefix is for.</summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_ASectionNamingNoProxyReachedOverIPv6_BelievesThatPeerAsWell()
+    {
+        // Arrange
+        var request = RequestFrom(IPAddress.Parse("2001:db8::99"));
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+        request.Request.Headers["X-Forwarded-Host"] = "anything.example.test";
+
+        // Act
+        await ForwardThrough(new ReverseProxyOptions(), request);
 
         // Assert
         Assert.Equal("https", request.Request.Scheme);
@@ -216,6 +256,50 @@ public sealed class TrustedReverseProxyExtensionsTests
         Assert.Equal("mail.example.test", request.Request.Host.Value);
     }
 
+    /// <summary>
+    /// What the default posture costs, pinned as a test rather than left as prose. The refusal of an access token that
+    /// arrived without transport encryption reads the scheme after this policy applied it, so whoever is trusted here
+    /// decides whether that refusal fires. With every peer trusted, a client asserting that its own hop was encrypted
+    /// has a reusable credential accepted over clear text.
+    /// </summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_ASectionNamingNoProxy_LetsAClientsOwnClaimSatisfyTheTokenTransportRefusal()
+    {
+        // Arrange
+        var request = RequestFrom(IPAddress.Parse("203.0.113.9"));
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+
+        // Act
+        await ForwardThrough(new ReverseProxyOptions(), request);
+        var authentication = MessageReceivedOn(request);
+        await TransportSecurityExtensions.RefuseATokenThatArrivedWithoutTransportEncryption(authentication);
+
+        // Assert
+        Assert.Null(authentication.Result);
+    }
+
+    /// <summary>
+    /// The control the assertion above needs. Naming a proxy makes the same claim from the same peer change nothing,
+    /// so the token is refused — which is what proves the test above observes a real difference rather than a refusal
+    /// that never fires.
+    /// </summary>
+    [Fact]
+    public async Task AddTrustedReverseProxy_AnUntrustedPeerClaimingEncryption_StillHasItsTokenRefused()
+    {
+        // Arrange
+        var request = RequestFrom(IPAddress.Parse("203.0.113.9"));
+        request.Request.Headers["X-Forwarded-Proto"] = "https";
+
+        // Act
+        await ForwardThrough(TrustingProxies("10.0.0.5"), request);
+        var authentication = MessageReceivedOn(request);
+        await TransportSecurityExtensions.RefuseATokenThatArrivedWithoutTransportEncryption(authentication);
+
+        // Assert
+        Assert.NotNull(authentication.Result);
+        Assert.True(authentication.Result.None);
+    }
+
     /// <summary>The client address is deliberately out of scope: nothing here partitions, limits, or logs by one.</summary>
     [Fact]
     public async Task AddTrustedReverseProxy_RequestCarryingAForwardedClientAddress_KeepsThePeerItObservedItself()
@@ -261,7 +345,7 @@ public sealed class TrustedReverseProxyExtensionsTests
 
     private static ReverseProxyOptions TrustingProxies(params string[] trustedProxies)
     {
-        var settings = new ReverseProxyOptions { Enabled = true };
+        var settings = new ReverseProxyOptions();
 
         foreach (var trustedProxy in trustedProxies)
         {
@@ -294,6 +378,16 @@ public sealed class TrustedReverseProxyExtensionsTests
 
         return context;
     }
+
+    /// <summary>Presents the request to the bearer handler at the point the transport refusal reads its scheme.</summary>
+    private static MessageReceivedContext MessageReceivedOn(HttpContext request) =>
+        new(
+            request,
+            new AuthenticationScheme(
+                TransportSurface.Mcp.OAuthSchemeNameFor("workforce"),
+                displayName: null,
+                typeof(JwtBearerHandler)),
+            new JwtBearerOptions());
 
     private static Task ForwardThrough(ReverseProxyOptions settings, HttpContext request)
     {


### PR DESCRIPTION
Closes #375

`ReverseProxy` carried a switch that could never be flipped on its own: an enabled section without a trusted proxy was refused at startup, so `Enabled` and `TrustedProxies` were one decision written twice. The key is gone. The forwarded-headers middleware is composed and mapped unconditionally, at the position it already held — ahead of the exception handler and every isolation check — and the trust list is what the section decides.

## The default posture, and what it costs

An unconfigured section resolves to `0.0.0.0/0` and `::/0` rather than to nobody.

This is a deliberate reversal of #375's acceptance criterion "whatever form the wide posture takes, it is stated rather than defaulted". It is stated here instead of there: the owner decided the wide posture should be the default after the cost below was put in front of them, so this is not that criterion being met — it is that criterion being overridden.

The cost is one named protection. `RefuseATokenThatArrivedWithoutTransportEncryption` decides by reading `HttpContext.Request.IsHttps`, which is the scheme the forwarded-header policy has already rewritten. With every peer trusted, any client that can reach the listener sends `X-Forwarded-Proto: https` and has a reusable credential accepted over clear text. `X-Forwarded-Host` is believed on the same terms, so the name a `401` challenge and every absolute address carry is a client's to choose. `McpEndpoint:OAuth:Resource` is unaffected — it stays a configured value compared against a token's audience, never a header.

Two tests pin that, because an assertion that a refusal did not fire proves nothing without the control where it does:

- an unconfigured section lets a client's own `X-Forwarded-Proto: https` satisfy the refusal;
- a named proxy makes the same claim from the same peer change nothing, and the token is refused.

The refusal keeps reading the forwarded scheme rather than the connection's own. That was #375's first open question; changing it would refuse every OAuth request behind a terminating proxy unless something else told the refusal the client hop was encrypted, which is a larger design than this change.

## The announcement

`ReverseProxyTrustWarning` now carries two messages, both at startup through `IHostedService.StartAsync` and never per request. The remedy differs — one deployment narrows a range it wrote, the other names a proxy it never named — while what was given up is identical and both lines say so. A merely wide range, a private `/8`, still produces nothing.

## Breaking change

`ReverseProxy:Enabled` no longer binds. Because the section binds strictly, a configuration still setting it stops at startup naming the key rather than starting under a trust nobody chose. Tested for both `true` and `false`. A deployment that had it `true` keeps its behaviour by keeping its list and deleting the key.

## One thing worth a reviewer's eye

- **`MaximumForwardedHops` is kept configurable.** The instruction was "only `TrustedProxies` configurable", which I read as the contrast against the on/off switch. `MaximumForwardedHops` is not a switch, and removing it is a second broken key that would leave a two-proxy chain unconfigurable. Say the word and it goes.
## Implementation note

`TrustedProxies` stays empty rather than pre-populated with the two prefixes. The configuration binder adds to an existing collection instead of replacing it, so a default written into the property would survive alongside whatever an operator configured and every deployment would trust every peer regardless. Trust resolves when the policy is composed; a binding test asserts a configured list leaves no default trust beside it.

`mcp-endpoint.md` also gains the `describes:` markers it was missing. It quotes both warning texts verbatim and documents the whole section, while its marker claimed neither `ReverseProxyOptions.cs` nor either warning — so a future change to a message would have been pointed at `health-endpoints.md`, which says nothing about them.

## Verification

- `scripts/verify-full.sh` — pass on head `c7d01d7`.
- 2713 unit tests, 0 failed.
- `$review-change` — no findings. `$check-docs-licenses` — Docs pass, Changelog n/a, Licenses n/a (no dependency, file, or copied-code change).

A review note asked for the withdrawn-key paragraph to go; it is removed from the reference page and from `ReadFrom`'s remarks in `c7d01d7`. `ReadFrom_TheWithdrawnEnabledKey_FailsRatherThanIgnoringIt` stays, because it asserts current behaviour — an unknown key stops startup — rather than history.