### PR TITLE
Bump main version to 0.4.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
        same assembly identity. InformationalVersion is left to the SDK, which is what composes VersionPrefix,
        VersionSuffix, and SourceRevisionId into the single string the runtime reports. -->
   <PropertyGroup>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.4.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
   </PropertyGroup>


### PR DESCRIPTION
Raises `<VersionPrefix>` in `Directory.Build.props` from `0.3.0` to `0.4.0`, so `main` names the release being worked rather than the one just published. That property is the only place in the repository where a version number is written for the build: the image's tags and labels arrive as build arguments, and the chart's `version` and `appVersion` are both supplied at package time from this declaration. That is the whole diff.

**Merge this after the `v0.3.0` tag is pushed, never before.** The tag is asserted against the `VersionPrefix` its commit declares, so a `main` already reading `0.4.0` is a tag that cannot be cut.

`deploy/helm/mailfathom/Chart.yaml` is deliberately untouched: its `version` is a `0.0.0` placeholder, it declares no `appVersion`, and the release run supplies both as one number equal to the application's.

This pull request closes no issue. Bumping the version is what follows a release rather than what the release was for.

## Sequence

1. Merge the changelog pull request — the release itself.
2. Push the annotated `v0.3.0` tag on its merge commit.
3. Merge this one.

The release pull request it follows is #399, whose merge commit carries the `v0.3.0` tag.
