### PR TITLE
[#401] Gate every published artifact on the verification that precedes it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,9 @@ on:
   # `main` itself, once a merge has landed there: the build, the unit tests, the coverage gate, the
   # pending-model-changes check, and the workflow contracts. The `main` ruleset requires a branch to be
   # current with `main` before it merges, so a pull request is normally verified against the state its
-  # merge produces — but the repository admin role bypasses the ruleset when merging, `Nightly` and
-  # `Release` both build from `main` without verifying it first, and *is `main` green right now* is
+  # merge produces — but the repository admin role bypasses the ruleset when merging, a break that
+  # reached `main` would otherwise first be reported by that night's publication failing its own gate,
+  # which names a run at 02:00 rather than the merge that caused it, and *is `main` green right now* is
   # otherwise not a fact that exists anywhere, only one inferred from the last pull request that closed.
   # `CodeQL` watches the branch this way for its own reasons already.
   #

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,8 +10,10 @@ name: Integration tests
 # a run when the change is one this suite can speak to.
 #
 # It is reachable two ways, and both are deliberate acts rather than a schedule: a manual dispatch,
-# and the `Release` workflow, which will not publish an image until this suite has passed on the
-# commit it is about to release. A nightly does not call it — see `publish-container-image.yml`.
+# and the `Release` workflow, which builds nothing at all from the commit it is about to release —
+# not the image, not the schema script, not the command binaries — until this suite has passed on it.
+# A nightly does not call it, which is the difference between the channels rather than an omission;
+# `Nightly` says why.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -144,6 +144,30 @@ jobs:
             printf 'Nothing was built.\n'
           } | tee -a "$GITHUB_STEP_SUMMARY"
 
+  # Everything a nightly builds waits behind this, for the reason `Release` states at greater length: a gate belonging
+  # to the image would gate the image, leaving the schema script and the command binaries to be built beside it from a
+  # commit whose unit tests had not run. It is the same definition a pull request is verified by, against the revision
+  # being previewed rather than against a branch, with every switch at its default — `CI` skips work a pull request's
+  # changed files cannot affect, and a publication skips nothing.
+  #
+  # The migration check is the half worth naming on this channel: a nightly is installable long before any tag, so an
+  # image whose committed model snapshot describes a schema no migration produces would be discovered by whoever
+  # deployed it.
+  #
+  # The integration suite is not here, and that is the channels' difference rather than an omission. It is minutes of
+  # container time on something published every night whose whole value is being current, and `Release` is where the
+  # answer is worth waiting for.
+  verify:
+    name: Build, test, format, and migrations
+    needs:
+      - decide
+    if: needs.decide.outputs.publish == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-test-format-and-migrations.yml
+    with:
+      ref: ${{ needs.decide.outputs.revision }}
+
   # A nightly needs its schema script more than a release does, not less: its schema can be ahead of every published
   # migration, so no release's artifact covers it and there is nothing else to reach for. It is left on the run rather
   # than attached to anything, because a nightly is not a release and has nothing to attach to.
@@ -157,6 +181,7 @@ jobs:
     name: Schema artifact
     needs:
       - decide
+      - verify
     if: needs.decide.outputs.publish == 'true'
     permissions:
       contents: read
@@ -175,6 +200,7 @@ jobs:
     name: CLI binaries
     needs:
       - decide
+      - verify
     if: needs.decide.outputs.publish == 'true'
     permissions:
       contents: read
@@ -187,6 +213,7 @@ jobs:
     name: Publish
     needs:
       - decide
+      - verify
     if: needs.decide.outputs.publish == 'true'
     permissions:
       contents: read

--- a/.github/workflows/publish-container-image.yml
+++ b/.github/workflows/publish-container-image.yml
@@ -5,8 +5,9 @@
 name: Publish container image
 
 # The one place an image is built and pushed. Both channels call it — `Release` on an annotated tag, `Nightly` on a
-# schedule — and neither builds anything of its own, so a change to how MailFathom is built, gated, scanned, or attested
-# is one edit rather than two that can drift apart.
+# schedule — and neither builds an image of its own, so a change to how MailFathom is packaged, smoke-tested, scanned,
+# or attested is one edit rather than two that can drift apart. What the callers do own is the verification the whole
+# publication waits on, for the reason the first job below gives.
 #
 # The build happens once and the push is the only per-registry part, which is what keeps two registries one login and one
 # more repository to qualify the tags against rather than a second pipeline. GHCR and Docker Hub receive the same
@@ -71,46 +72,16 @@ env:
   TRIVY_SEVERITY: 'HIGH,CRITICAL'
 
 jobs:
-  # The same build, unit-test and coverage gate, `dotnet format`, and pending-model-changes check a pull request runs,
-  # from the same definition, against the commit being published rather than against a branch. Every switch stays at
-  # its default: `CI` skips work a pull request's changed files cannot affect, and a publication skips nothing.
-  build-test-format-and-migrations:
-    name: Build, test, format, and migrations
-    permissions:
-      contents: read
-    uses: ./.github/workflows/build-test-format-and-migrations.yml
-    with:
-      ref: ${{ inputs.ref }}
-
-  # A release additionally runs the suite that starts PostgreSQL, applies the baseline migration, and asserts against
-  # the result — and it runs *after* CI rather than beside it, so minutes of container time are never spent on a commit
-  # a unit test would have rejected in seconds.
+  # **The gates this publication stands on are the caller's, and none of them is here.** `Release` and `Nightly` each
+  # run `build-test-format-and-migrations.yml` against the commit being published — and a release additionally runs the
+  # integration suite — before any of the three jobs that build something from that commit starts. They sit there
+  # rather than here because the image is one of those three: a gate inside this workflow would gate the image alone
+  # while the schema script and the command binaries were built beside it from a commit whose unit tests had not run.
   #
-  # A nightly does not run it. A nightly is published every night, its whole value is being current, and the gate it is
-  # worth waiting for is the one above.
-  integration-tests:
-    name: Integration tests
-    needs:
-      - build-test-format-and-migrations
-    if: inputs.channel == 'release'
-    permissions:
-      contents: read
-    uses: ./.github/workflows/integration-tests.yml
-    with:
-      ref: ${{ inputs.ref }}
-
+  # What that leaves here is everything that is about the artifact itself: the image is built for one architecture and
+  # required to start and describe itself, scanned, and only then built for both and pushed.
   publish:
     name: Publish ${{ inputs.channel }} ${{ inputs.version }}
-    needs:
-      - build-test-format-and-migrations
-      - integration-tests
-    # `!cancelled()` is what lets a nightly publish at all: its integration-test job is skipped, and a skipped
-    # dependency would otherwise skip this job with it. Every other outcome still has to be `success`, so nothing
-    # weaker than a passing gate reaches a registry, and a cancelled run publishes nothing at all.
-    if: >-
-      !cancelled()
-      && needs.build-test-format-and-migrations.result == 'success'
-      && (needs.integration-tests.result == 'success' || needs.integration-tests.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,12 +90,47 @@ jobs:
             printf 'tags<<TAGS\n%s\nTAGS\n' "$image_tags"
           } >> "$GITHUB_OUTPUT"
 
+  # Everything this release publishes waits behind these two, and they are jobs here rather than steps inside the
+  # workflow that pushes the image because more than the image is built from this commit. A gate belonging to the image
+  # would gate the image: the schema script and the command binaries would start beside it, so a commit a unit test
+  # rejects would still spend four `dotnet publish` invocations and a schema generation before the failure was legible,
+  # and would start them minutes before the integration suite had said anything at all. Declared here, the dependency
+  # is what a fourth artifact inherits by being added rather than by being reviewed.
+  #
+  # The same definition a pull request is verified by, against the tagged commit rather than against a branch, with
+  # every switch at its default: `CI` skips work a pull request's changed files cannot affect, and a release skips
+  # nothing.
+  verify:
+    name: Build, test, format, and migrations
+    needs:
+      - assert
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-test-format-and-migrations.yml
+    with:
+      ref: ${{ needs.assert.outputs.revision }}
+
+  # The suite that starts PostgreSQL, applies the baseline migration, and asserts against the result. A release is the
+  # one channel that runs it, and it runs *after* the gate above rather than beside it, so minutes of container time are
+  # never spent on a commit a unit test would have rejected in seconds.
+  integration-tests:
+    name: Integration tests
+    needs:
+      - assert
+      - verify
+    permissions:
+      contents: read
+    uses: ./.github/workflows/integration-tests.yml
+    with:
+      ref: ${{ needs.assert.outputs.revision }}
+
   # The artifact a released installation applies, built from the definition both channels share. A release blocks its
   # image push on it; docs/operations/database-schema.md is what an operator then does with the file.
   schema-artifact:
     name: Schema artifact
     needs:
       - assert
+      - integration-tests
     permissions:
       contents: read
     uses: ./.github/workflows/build-schema-artifact.yml
@@ -109,6 +144,7 @@ jobs:
     name: CLI binaries
     needs:
       - assert
+      - integration-tests
     permissions:
       contents: read
     uses: ./.github/workflows/build-cli-binaries.yml
@@ -150,6 +186,9 @@ jobs:
       # A release that cannot produce its schema artifact publishes no image. An operator handed an image and no way to
       # reach the schema it requires has a deployment that starts, fails the startup gate, and stays down.
       - schema-artifact
+      # Reached through `schema-artifact` already, and named anyway: what gates a publication is the sort of thing that
+      # has to be readable off the job that publishes rather than followed through another job's dependencies.
+      - integration-tests
     permissions:
       contents: read
       packages: write

--- a/docs/operations/container-image.md
+++ b/docs/operations/container-image.md
@@ -280,6 +280,14 @@ Publication runs the gates instead, in an order that spends the cheap ones first
    it, which refuses to publish a release carrying a fixable `HIGH` or `CRITICAL` finding and only reports one on a
    nightly.
 
+**Nothing is built from the commit until the first two have passed** — not the image, not the schema script, and not
+the command binaries. They are jobs in `Release` and `Nightly` themselves rather than steps inside the workflow that
+pushes the image, because the image is one of three things a channel builds and a gate inside it would gate only that
+one. Everything above is therefore the order of a whole publication rather than of the image alone: what a red run
+costs is the gate that refused it, not four `dotnet publish` invocations and a schema generation beside a failing
+build. `scripts/test-agent-workflow.sh` reads both workflows' job graphs and fails one whose publishing job does not
+wait for the gate, so a fifth artifact is gated by being added rather than by being reviewed.
+
 Both channels also build the schema artifact, from one shared definition, and differ only in what they do with it. A
 release **waits** on it and refuses to push when it cannot be produced: an operator handed an image and no way to reach
 the schema it requires has a deployment that starts, fails the startup gate, and stays down. A nightly builds it beside

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -94,7 +94,9 @@ dispatch only, like the integration suite, and it publishes nothing.
 
 What does publish is `Release`, on an annotated version tag, and `Nightly`, on its schedule. Neither is something to
 start as part of a task, and neither has a local equivalent: they run `Build, test, format, and migrations` — the same
-workflow `CI` calls for a pull request — then, for a release, the integration suite, and only then build and push. [The container image](container-image.md#published-images) records
+workflow `CI` calls for a pull request — then, for a release, the integration suite, and build nothing at all until
+both have passed. That covers everything a channel produces rather than the image alone: the schema script and the
+`mfctl` binaries wait behind the same gate. [The container image](container-image.md#published-images) records
 what they produce and how a published image is verified.
 
 Both scripts stop immediately when `HEAD` resolves to `main` or `master`,
@@ -557,7 +559,7 @@ Each absence has its own reason, and neither of them is cost.
 
 The `push` trigger carries no path filter either, and for a different reason than the `pull_request` one. That reason protects a required check: a run GitHub never instantiated reports no conclusion, so a pull request would wait on it forever. Nothing waits on a push run, so it does not reach here. What does is the contract job, which reads the whole tree and therefore has no path filter of its own: `docs/`, `specs/`, `deploy/`, `scripts/`, `.agents/`, `.claude/`, and the repository-root Markdown files are its subject matter rather than paths it can be told to ignore, so a trigger filter naming them would suppress exactly the run most likely to have something to report. Which part of a merge is worth verifying is decided inside the run instead, by the same `Detect changes` job that decides it for a pull request — so a merge that moved nothing the build reads costs the contract job's twenty seconds rather than a full build and coverage run.
 
-Why run any of it, when the `main` ruleset requires a branch to be current with `main` before it merges and the run therefore normally repeats a verdict. Three things. The repository admin role bypasses the ruleset when merging, for the reason [Code owners](#code-owners) gives. `Nightly` and `Release` both build from `main` without verifying it first, so without this the earliest a broken `main` could be noticed is a publish. And *is `main` green right now* becomes a fact with a run behind it rather than one inferred from whichever pull request closed last.
+Why run any of it, when the `main` ruleset requires a branch to be current with `main` before it merges and the run therefore normally repeats a verdict. Three things. The repository admin role bypasses the ruleset when merging, for the reason [Code owners](#code-owners) gives. `Nightly` and `Release` do gate the commit they publish, so a broken `main` is caught before anything reaches a registry — but without this run the earliest it is *reported* is that night's publication failing its own gate, which names a scheduled run at 02:00 rather than the merge that broke it. And *is `main` green right now* becomes a fact with a run behind it rather than one inferred from whichever pull request closed last.
 
 Concurrency differs by event too. Cancelling a superseded run is a pull-request behavior, because there the run being cancelled is answering about a commit that is no longer the head. A push to `main` is the opposite case: every commit there is a state that was merged and that a nightly can be built from, and a run the next merge cancelled would leave that commit carrying a conclusion which reads as a failure everywhere while having verified nothing. Merges in quick succession queue behind each other instead, and a manual dispatch on `main` — which shares their concurrency group — queues rather than displacing whichever of the two is running.
 

--- a/docs/operations/release-procedure.md
+++ b/docs/operations/release-procedure.md
@@ -154,9 +154,11 @@ unavailable:
 2. **Push the annotated tag `v<x.y.z>` on that merge commit.** This is what makes the release real and what triggers
    the release workflow. Before publishing anything the workflow asserts the tag against the tagged commit's
    `VersionPrefix`, against the highest existing tag on the same `major.minor` line, and against the changelog section
-   for that version — `scripts/assert-release-tag.sh` is that check. It then builds and gates the image, pushes it to
-   both registries under `<x.y.z>`, moves `latest` onto the same digest, attests it, publishes the Helm chart against
-   that digest, and opens the GitHub release with that changelog section as its notes. Under the section it links
+   for that version — `scripts/assert-release-tag.sh` is that check. It then runs the same build, unit-test,
+   formatting, and migration checks a pull request runs, followed by the integration suite, and builds nothing at all
+   until both have passed. Only then does it build and gate the image, push it to
+   both registries under `<x.y.z>`, move `latest` onto the same digest, attest it, publish the Helm chart against
+   that digest, and open the GitHub release with that changelog section as its notes. Under the section it links
    `CHANGELOG.md` at the tag, so a reader of an older release reaches the file as that release shipped it rather than a
    copy already describing versions they have not upgraded to.
 
@@ -186,8 +188,15 @@ Four artifacts leave one run, and a failure in the first three leaves the releas
 | --- | --- | --- |
 | The image | `ghcr.io/krzysztof318/mailfathom` and `docker.io/krzysztof318/mailfathom` | the schema artifact building |
 | The Helm chart | `ghcr.io/krzysztof318/charts/mailfathom` | the image's digest |
-| `mailfathom-schema-<version>.sql` | the GitHub release's assets | nothing |
-| `mfctl-<version>-<rid>` for `linux-x64`, `linux-arm64`, `win-x64`, and `win-arm64`, plus one `.sha256` covering all of them | the GitHub release's assets | nothing, while signing is switched off |
+| `mailfathom-schema-<version>.sql` | the GitHub release's assets | nothing else the release produces |
+| `mfctl-<version>-<rid>` for `linux-x64`, `linux-arm64`, `win-x64`, and `win-arm64`, plus one `.sha256` covering all of them | the GitHub release's assets | nothing else, while signing is switched off |
+
+The column names what each artifact needs from the other three. What all four need is the same and comes before any of
+them: the tag assertion, then the build, unit-test, formatting, and migration checks, then the integration suite. **No
+artifact is built until every one of those has passed**, so a commit a unit test rejects costs the gate that rejected
+it rather than four `dotnet publish` invocations and a schema generation beside a red build.
+[The container image](container-image.md#verification) records the whole gate order, including the two gates that
+belong to the image alone.
 
 The command binaries are the one artifact that gates nothing, and that is deliberate: a release whose image and schema
 are correct is one an operator can deploy, so a build failure in the command is left visible on the run rather than

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -2755,6 +2755,150 @@ the_release_restores_the_annotated_tag_before_asserting_it() {
   fi
 }
 
+# Reads a workflow's job graph as `<job> <the job it waits for>` pairs, one per line. Comment lines
+# inside a `needs:` block are ignored rather than ending it, because both publishing workflows explain
+# individual dependencies where they are declared.
+extract_workflow_job_dependencies() {
+  local workflow_file="$1"
+
+  awk '
+    /^jobs:/ { in_jobs = 1; next }
+    !in_jobs { next }
+    /^[^[:space:]#]/ { in_jobs = 0; next }
+    /^  [a-zA-Z0-9_-]+:[[:space:]]*$/ { job = substr($1, 1, length($1) - 1); in_needs = 0; next }
+    /^    needs:[[:space:]]*$/ { in_needs = 1; next }
+    in_needs && /^      - / { printf "%s %s\n", job, $2; next }
+    /^    [a-zA-Z0-9_-]+:/ { in_needs = 0 }
+  ' "$workflow_file"
+}
+
+# The jobs that build something from the commit being published, read off the workflow rather than
+# listed here: each of them hands the resolved revision down to the workflow it calls, which is what
+# separates a job that consumes this commit from one that only reasons about the run. A fourth
+# artifact is therefore covered by being added rather than by this list being remembered.
+extract_workflow_jobs_consuming_the_commit() {
+  local workflow_file="$1"
+
+  awk '
+    /^jobs:/ { in_jobs = 1; next }
+    !in_jobs { next }
+    /^[^[:space:]#]/ { in_jobs = 0; next }
+    /^  [a-zA-Z0-9_-]+:[[:space:]]*$/ { job = substr($1, 1, length($1) - 1); next }
+    /^      ref:[[:space:]]+\$\{\{[[:space:]]*needs\.[a-zA-Z0-9_-]+\.outputs\.revision[[:space:]]*\}\}$/ { print job }
+  ' "$workflow_file"
+}
+
+# The reusable workflow a job calls, which is what makes the job names below mean something: a `verify`
+# job that stopped calling the verification workflow would satisfy every dependency and gate nothing.
+extract_workflow_job_uses() {
+  local workflow_file="$1"
+  local job="$2"
+
+  awk -v job_header="  ${job}:" '
+    $0 == job_header { in_job = 1; next }
+    in_job && /^  [a-zA-Z0-9_-]+:[[:space:]]*$/ { exit }
+    in_job && /^    uses:[[:space:]]/ { print $2; exit }
+  ' "$workflow_file"
+}
+
+# Whether a job waits for another, directly or through anything in between. Transitive rather than
+# direct, because a publishing job reaching the gate through the artifact it already waits for is
+# gated just as firmly as one naming it.
+workflow_job_waits_for() {
+  local dependencies="$1"
+  local job="$2"
+  local awaited="$3"
+  local reached=" $job "
+  local grew=1
+  local dependent
+  local dependency
+
+  while ((grew)); do
+    grew=0
+
+    while read -r dependent dependency; do
+      [[ -n "$dependent" ]] || continue
+
+      if [[ "$reached" == *" $dependent "* && "$reached" != *" $dependency "* ]]; then
+        reached+="$dependency "
+        grew=1
+      fi
+    done <<< "$dependencies"
+  done
+
+  [[ "$reached" == *" $awaited "* ]]
+}
+
+# Every artifact a channel publishes is built from a commit that has verified, and the dependency
+# saying so lives in the workflow that publishes rather than inside the reusable workflow one of the
+# artifacts happens to call. A gate belonging to the image would gate the image: `Schema artifact` and
+# `CLI binaries` would start beside it from a commit whose unit tests had not run, so a release would
+# spend four `dotnet publish` invocations and a schema generation before the failure was legible and
+# would start them minutes before the integration suite had said anything. A job graph makes none of
+# that visible on a green run, which is why a fourth artifact is gated by this assertion rather than
+# by whoever reviews it.
+no_channel_builds_an_artifact_before_the_commit_has_verified() {
+  local workflow_directory="$source_repository_root/.github/workflows"
+  local release_dependencies
+  local nightly_dependencies
+  local release_consumers
+  local nightly_consumers
+  local job
+  local failures=''
+
+  release_dependencies="$(extract_workflow_job_dependencies "$workflow_directory/release.yml")"
+  nightly_dependencies="$(extract_workflow_job_dependencies "$workflow_directory/nightly.yml")"
+  release_consumers=" $(extract_workflow_jobs_consuming_the_commit "$workflow_directory/release.yml" | tr '\n' ' ')"
+  nightly_consumers=" $(extract_workflow_jobs_consuming_the_commit "$workflow_directory/nightly.yml" | tr '\n' ' ')"
+
+  # The gate is what the rest waits for, so it is what the rest is measured against rather than
+  # something to measure. Everything else that reads the commit is checked below whatever it is named.
+  for job in $release_consumers; do
+    [[ "$job" == 'verify' || "$job" == 'integration-tests' ]] && continue
+
+    workflow_job_waits_for "$release_dependencies" "$job" verify ||
+      failures+="release.yml: ${job} does not wait for verify. "
+    workflow_job_waits_for "$release_dependencies" "$job" integration-tests ||
+      failures+="release.yml: ${job} does not wait for integration-tests. "
+  done
+
+  for job in $nightly_consumers; do
+    [[ "$job" == 'verify' ]] && continue
+
+    workflow_job_waits_for "$nightly_dependencies" "$job" verify ||
+      failures+="nightly.yml: ${job} does not wait for verify. "
+  done
+
+  # A derived list that derives nothing asserts nothing, and it would do so silently: the loops above
+  # are vacuous the moment the `ref:` expression they read is spelled some other way. These three are
+  # the floor rather than the coverage.
+  for job in schema-artifact cli-binaries publish; do
+    [[ "$release_consumers" == *" $job "* ]] ||
+      failures+="release.yml: ${job} was not recognized as building from the released commit. "
+    [[ "$nightly_consumers" == *" $job "* ]] ||
+      failures+="nightly.yml: ${job} was not recognized as building from the previewed commit. "
+  done
+
+  [[ "$(extract_workflow_job_uses "$workflow_directory/release.yml" verify)" == './.github/workflows/build-test-format-and-migrations.yml' ]] ||
+    failures+='release.yml: verify does not call build-test-format-and-migrations.yml. '
+  [[ "$(extract_workflow_job_uses "$workflow_directory/release.yml" integration-tests)" == './.github/workflows/integration-tests.yml' ]] ||
+    failures+='release.yml: integration-tests does not call integration-tests.yml. '
+  [[ "$(extract_workflow_job_uses "$workflow_directory/nightly.yml" verify)" == './.github/workflows/build-test-format-and-migrations.yml' ]] ||
+    failures+='nightly.yml: verify does not call build-test-format-and-migrations.yml. '
+
+  # The gate has one home. A copy of it back inside the publishing workflow would run the whole thing
+  # twice per publication while gating one artifact of the three.
+  if grep -qE '^[[:space:]]+uses:[[:space:]]+\./\.github/workflows/(build-test-format-and-migrations|integration-tests)\.yml$' \
+    "$workflow_directory/publish-container-image.yml"; then
+    failures+='publish-container-image.yml calls a verification workflow its callers already run. '
+  fi
+
+  if [[ -n "$failures" ]]; then
+    printf 'Publication is not gated as recorded: %s\n' "$failures" >&2
+    return 1
+  fi
+}
+
 # `pull_request_target` runs the base branch's workflow with the repository's secrets against a
 # contribution nobody has reviewed. `fathom-review.yml` uses it deliberately, #189 decided so, and
 # `docs/operations/agent-workflow.md` records why the purpose of the rule is still met there — it
@@ -3053,6 +3197,7 @@ run_test every_workflow_job_declares_its_permissions
 run_test every_write_scope_is_one_the_policy_records
 run_test every_checkout_refuses_to_persist_credentials
 run_test the_release_restores_the_annotated_tag_before_asserting_it
+run_test no_channel_builds_an_artifact_before_the_commit_has_verified
 run_test only_the_reviewer_workflow_uses_pull_request_target
 run_test a_comment_never_cancels_a_review_in_flight
 run_test workflow_scripts_use_flat_manual_layout


### PR DESCRIPTION
Closes #401

The build, unit-test, formatting, and migration checks — and, for a release, the integration suite — move out of
`publish-container-image.yml` and into `Release` and `Nightly` themselves. A gate belonging to the image gated the
image: `Schema artifact` and `CLI binaries` started beside it from a commit whose unit tests had not run, so a release
spent four `dotnet publish` invocations across four runtime identifiers and a schema generation before the failure was
legible, and started them minutes before the integration suite had said anything at all.

`publish-container-image.yml` is now one job. What it keeps is everything about the artifact itself — the
single-architecture build, the smoke test, the vulnerability scan, the multi-architecture push, the attestations — and
what it loses is the two verification jobs, which were never the image's to own.

## The graphs

**Release:** `assert` → `verify` → `integration-tests` → `schema-artifact`, `cli-binaries`, `publish` → `publish-chart`
→ `announce`.

**Nightly:** `decide` → `verify` → `schema-artifact`, `cli-binaries`, `publish` → `prune`.

Everything downstream of that is unchanged: the image still waits on the schema artifact, the chart on the image's
digest, and the release on all three. So are the channel differences — the vulnerability scan blocks a release and
reports on a nightly, a nightly still does not run the integration suite, and a failed `CLI binaries` still withholds
nothing but the binaries.

## The contract

`scripts/test-agent-workflow.sh` reads both workflows' job graphs and fails one whose commit-consuming job does not
wait for the gate. The jobs it checks are derived rather than listed: a job qualifies by handing the resolved revision
down to the workflow it calls, which is what makes a fifth artifact covered by being added. The three known artifacts
are asserted as a floor beside that, so the loop cannot go quietly vacuous if the `ref:` expression it reads is ever
spelled another way. Three mutations were run against it — a removed `needs`, a `publish-chart` cut loose from
`publish`, and a renamed revision expression — and each fails the contract.

## What this costs

Both channels get longer in wall-clock: the schema script and the binaries no longer overlap with verification. That is
the trade the change is for. Neither workflow runs on a pull request, so the contract suite is what verifies the shape
here and the next nightly is the first run of the real thing.

## Documentation

`docs/operations/container-image.md` states that nothing is built from the commit until the first two gates have
passed, `docs/operations/release-procedure.md` says the same in the artifact table and in step 2 of the sequence, and
`docs/operations/local-development.md` drops the claim that `Release` and `Nightly` build from `main` without verifying
it — they do verify the commit they publish, and what the push-triggered `CI` run adds is that a break is reported
against the merge that caused it rather than against a scheduled run at 02:00. The same sentence in `ci.yml`'s header
is corrected with it.
