### PR TITLE
[#407][#409] Publish the documentation site on the release tag, and fix the version selector

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -30,11 +30,18 @@ on:
   # A tag is pushed before the publication it starts has finished, so the site can briefly carry a version whose image
   # and release do not exist yet. That resolves itself rather than needing handling: every run rebuilds the whole site
   # from the tags it can see, so a tag deleted after a failed publication is gone from the selector on the next one.
+  #
+  # The tag filter is narrowed to a leading `v` followed by three dot-separated groups each opening with a digit, rather
+  # than to `v*`, which would also start a publish for `vnext` or any other tag somebody spells with a leading v. A
+  # filter pattern is a glob and not a regular expression, so the exact `v<major>.<minor>.<patch>` shape is not
+  # expressible here and a prerelease or a fourth group still matches. That costs a rebuild and never a wrong version:
+  # `scripts/list-documented-versions.sh` decides what the site carries, and it does apply that exact expression — so
+  # this filter chooses when a rebuild runs, never what it publishes, and a spurious one rebuilds the same site.
   push:
     branches:
       - main
     tags:
-      - 'v*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
   # The site definition is verified on a pull request that changes it, and deploys nothing. A change under `src/`
   # cannot break this build — an XML comment docfx dislikes is a warning — so the filter deliberately leaves it out
   # rather than adding a multi-minute job to nearly every pull request the repository sees.

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -16,14 +16,25 @@ name: Publish the documentation
 # docs/operations/documentation-site.md is the page a reader reaches for; it records what the site carries, why the
 # architectural decision records are not on it, and what enabling Pages took.
 on:
+  # Two pushes change what the site would carry, and both publish: a merge to the default branch moves `latest`, and a
+  # release tag adds a version to the selector. Without the second, a release's version would first appear on whatever
+  # merged next — which is what `0.3.0` did, reaching the site only because the version-bump pull request happened to
+  # merge a minute after the tag.
+  #
+  # It is the tag rather than the release, and that is not a preference. `scripts/list-documented-versions.sh` answers
+  # from the tags in the checkout rather than from GitHub's releases, so the tag is what the site is a function of — and
+  # a `release: published` trigger could not start this workflow anyway, because `Release` creates the release with
+  # `GITHUB_TOKEN` and GitHub starts no workflow run from an event that token generated. This workflow carried one for
+  # exactly that purpose and it never once fired.
+  #
+  # A tag is pushed before the publication it starts has finished, so the site can briefly carry a version whose image
+  # and release do not exist yet. That resolves itself rather than needing handling: every run rebuilds the whole site
+  # from the tags it can see, so a tag deleted after a failed publication is gone from the selector on the next one.
   push:
     branches:
       - main
-  # A release adds its tag to the selector, and nothing else changes on the default branch when one is cut. Without
-  # this the new version would first appear on whatever merged next.
-  release:
-    types:
-      - published
+    tags:
+      - 'v*'
   # The site definition is verified on a pull request that changes it, and deploys nothing. A change under `src/`
   # cannot break this build — an XML comment docfx dislikes is a warning — so the filter deliberately leaves it out
   # rather than adding a multi-minute job to nearly every pull request the repository sees.

--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -18,8 +18,8 @@ name: Publish the documentation
 on:
   # Two pushes change what the site would carry, and both publish: a merge to the default branch moves `latest`, and a
   # release tag adds a version to the selector. Without the second, a release's version would first appear on whatever
-  # merged next — which is what `0.3.0` did, reaching the site only because the version-bump pull request happened to
-  # merge a minute after the tag.
+  # merged next — which is what the release that found this did, reaching the site only because the version-bump pull
+  # request happened to merge a minute after the tag. #407 records it.
   #
   # It is the tag rather than the release, and that is not a preference. `scripts/list-documented-versions.sh` answers
   # from the tags in the checkout rather than from GitHub's releases, so the tag is what the site is a function of — and

--- a/docfx/template/public/main.css
+++ b/docfx/template/public/main.css
@@ -24,7 +24,24 @@
      to its container reads as a sliver rather than as a control. */
   flex: 0 0 auto;
   width: auto;
-  margin-inline-start: 0.75rem;
+
+  /* The picker sits in `#navbar`, in front of the icon links, and this is what puts it at that end of
+     the header rather than against the section links: the free space is spent here, so `form.icons`
+     — which carries `margin-left: auto` of its own — has none left to spend and follows immediately. */
+  margin-inline-start: auto;
+  margin-inline-end: 0.5rem;
+}
+
+/* Below the navbar's breakpoint `#navbar` becomes a column and the auto margin above would push the
+   picker against the right edge of an otherwise left-aligned panel. `order` places it after the section
+   links and ahead of the search box, which `modern` orders at 30 and the icon links at 40. */
+@media (max-width: 767.98px) {
+  .mf-version-picker {
+    order: 20;
+    align-self: stretch;
+    margin-inline: 0;
+    margin-block-start: 1rem;
+  }
 }
 
 .mf-version-notice {

--- a/docfx/template/public/main.js
+++ b/docfx/template/public/main.js
@@ -8,10 +8,10 @@
 //
 // Both are written against the DOM the `modern` template produces and nothing else, because that
 // template re-renders parts of the page after this module runs — the navigation bar when it loads
-// the table of contents, and every Mermaid diagram again whenever the theme changes or a tab is
-// selected. So the selector is placed in the one header element `modern` never rewrites, and the
-// viewer is opened from a single delegated listener on the document rather than from handlers bound
-// to elements that are about to be replaced.
+// the table of contents and again whenever the theme is changed, and every Mermaid diagram again
+// whenever the theme changes or a tab is selected. So the selector is re-placed by an observer
+// rather than inserted once, and the viewer is opened from a single delegated listener on the
+// document rather than from handlers bound to elements that are about to be replaced.
 
 const versionsFileName = 'versions.json'
 const zoomStep = 1.2
@@ -38,7 +38,7 @@ export default {
   }
 }
 
-// The directory the current documentation build was published into — `.../latest/` or `.../v0.3.0/`
+// The directory the current documentation build was published into — `.../latest/` or `.../v<version>/`
 // — and the site root above it, which is where `versions.json` and the redirecting landing page
 // live. `docfx:rel` is the relative path from the current page back to its own build root, so the
 // depth of the page this runs on never has to be guessed.
@@ -53,13 +53,24 @@ function resolveSiteLayout() {
     return null
   }
 
-  const versionUrl = new URL(relativeRoot || './', window.location.href)
+  // GitHub Pages serves a version's landing page at `.../v<version>` as readily as at `.../v<version>/`,
+  // and the two resolve `./` differently: the address without the trailing slash names the site root
+  // rather than the version's own directory, which leaves everything below looking for a version named
+  // after the repository and finding none. Every page docfx writes is a `.html` file, so a path ending in
+  // neither a slash nor `.html` is a directory served without its slash, and gets one here.
+  const pageUrl = new URL(window.location.href)
+  if (!pageUrl.pathname.endsWith('/') && !pageUrl.pathname.endsWith('.html')) {
+    pageUrl.pathname += '/'
+  }
+
+  const versionUrl = new URL(relativeRoot || './', pageUrl)
   const siteUrl = new URL('../', versionUrl)
   const segments = versionUrl.pathname.split('/').filter(segment => segment.length > 0)
 
   return {
     siteUrl,
     versionUrl,
+    pageUrl,
     currentVersion: segments.length > 0 ? segments[segments.length - 1] : null
   }
 }
@@ -90,11 +101,6 @@ async function renderVersionPicker() {
     return
   }
 
-  const brand = document.querySelector('header .navbar-brand')
-  if (!brand) {
-    return
-  }
-
   const picker = document.createElement('select')
   picker.className = 'form-select form-select-sm mf-version-picker'
   picker.setAttribute('aria-label', 'Documentation version')
@@ -112,11 +118,56 @@ async function renderVersionPicker() {
     void navigateToVersion(layout, picker.value)
   })
 
-  brand.insertAdjacentElement('afterend', picker)
+  if (!placeVersionPicker(picker)) {
+    return
+  }
 
   if (manifest.default && manifest.default !== layout.currentVersion) {
     renderVersionNotice(layout, manifest, current)
   }
+}
+
+// The picker reads as one of the header's controls rather than as part of the wordmark, so it belongs at
+// the right-hand end beside the icon links. That end is inside `#navbar`, which is the element `modern`
+// renders itself: it writes the section links and the icon links there after this module has run, and
+// writes them again every time the theme picker inside it is used. An insertion done once therefore
+// survives until the reader changes the theme and then silently does not.
+//
+// So this places the picker and keeps placing it. The observer re-runs the same placement whenever
+// `#navbar` changes, and the placement returns without touching the DOM when the picker is already where
+// it belongs — which is what stops an observer that reacts to its own insertion from looping.
+function placeVersionPicker(picker) {
+  const navbar = document.getElementById('navbar')
+
+  if (!navbar) {
+    // A page rendered with the navbar disabled has no such element and no icon links to sit beside. The
+    // brand is still there, and beside it is better than nowhere.
+    const brand = document.querySelector('header .navbar-brand')
+    brand?.insertAdjacentElement('afterend', picker)
+    return brand !== null
+  }
+
+  const place = () => {
+    const icons = navbar.querySelector('form.icons')
+
+    if (icons) {
+      if (picker.nextElementSibling !== icons) {
+        icons.insertAdjacentElement('beforebegin', picker)
+      }
+      return
+    }
+
+    // Before `modern` has rendered the icon links there is nothing to sit in front of, so the picker
+    // waits at the end of the navbar and the observer moves it once they arrive.
+    if (picker.parentElement !== navbar) {
+      navbar.appendChild(picker)
+    }
+  }
+
+  place()
+  new MutationObserver(place).observe(navbar, { childList: true, subtree: true })
+
+  return true
 }
 
 // The same page under another version when that version still has it, and that version's front page
@@ -124,7 +175,11 @@ async function renderVersionPicker() {
 // path blindly is how a version switch turns into a 404 on the release they were trying to reach.
 async function navigateToVersion(layout, selectedVersion) {
   const targetVersionUrl = new URL(`${selectedVersion}/`, layout.siteUrl)
-  const relativePagePath = window.location.href.slice(layout.versionUrl.href.length)
+  // The same normalized address the version directory was resolved from, because this subtracts one from
+  // the other: taking the browser's own would subtract a prefix the address may not carry, and produce a
+  // path that resolves against the wrong directory. A version's landing page yields the empty string
+  // either way, which is right — the reader is at the root, and so is where they are going.
+  const relativePagePath = layout.pageUrl.href.slice(layout.versionUrl.href.length)
   const candidate = new URL(relativePagePath, targetVersionUrl)
 
   try {

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -170,7 +170,7 @@ the viewer opens from a single delegated listener rather than from handlers boun
 
 ## Publishing
 
-`.github/workflows/publish-documentation.yml` runs on every push to `main`, on a published release, and on demand. It
+`.github/workflows/publish-documentation.yml` runs on every push to `main`, on a pushed release tag, and on demand. It
 resolves the version list, builds each version in parallel, composes them into one tree, and deploys that tree with
 the repository's own Pages deployment — `actions/deploy-pages`, not a bot pushing to a branch. It needs no secret: the
 `pages: write` and `id-token: write` scopes on the deploying job are all it holds, and nothing in it writes to the

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -4,7 +4,11 @@
 
 The pages under `docs/` are published as a browsable site at
 <https://krzysztof318.github.io/MailFathom/>. The site is generated from this repository by
-[docfx](https://dotnet.github.io/docfx/), deployed by GitHub Pages, and rebuilt in full on every merge to `main`.
+[docfx](https://dotnet.github.io/docfx/), deployed by GitHub Pages, and rebuilt in full by two pushes: a merge to
+`main`, which moves `latest`, and a release tag, which adds that release's version to the selector. It is the tag
+rather than the release, because the version list below is read from the tags in the checkout rather than from GitHub's
+releases — and because a `release: published` trigger cannot start a run at all, the release being created by `Release`
+with `GITHUB_TOKEN` and GitHub starting no workflow from an event that token generated.
 
 Nothing is authored on the site. A page is written here, reviewed in the same pull request as the behavior it
 describes, and published by the merge — which is the whole reason the site is generated from `docs/` rather than kept

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -165,8 +165,9 @@ What the template adds beyond that:
   how much detail it holds, and this is what makes the detail reachable.
 
 Both are written against the DOM the `modern` template produces, which re-renders the navigation bar and every Mermaid
-diagram after the page loads. The selector is therefore placed in the one header element that is never rewritten, and
-the viewer opens from a single delegated listener rather than from handlers bound to elements about to be replaced.
+diagram after the page loads. The selector is therefore re-placed by an observer whenever the navigation bar is written
+again, and the viewer opens from a single delegated listener rather than from handlers bound to elements about to be
+replaced.
 
 ## Publishing
 

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -142,12 +142,17 @@ all: its own logo is an SVG whose intrinsic size already fits a header, so a ras
 was saved at. Nothing in the build can see that — docfx renders a page without laying it out, so a logo that fits and
 one that covers the page produce the same output.
 
+The selector itself sits at the right-hand end of the header, in front of the icon links. That is inside the element
+`modern` renders and re-renders — it writes the section links and the icon links there after the template's own module
+has run, and writes them again whenever the theme picker among them is used — so the selector is placed and then kept
+placed, from an observer that puts it back rather than from an insertion that happens once.
+
 That is the general shape of what this template can get wrong. Everything it adds happens in the browser, after the
 build has finished and against files the build never reads, so a page that renders the selector and one that silently
 does not are the same output as far as every gate here is concerned. **The site's appearance and its run-time
-behaviour are the parts of it verified by looking at the deployed site**, and both defects found that way so far — a
-logo at its natural size, and a selector missing from the two pages served from a version's own directory — were
-invisible to a green build.
+behaviour are the parts of it verified by looking at the deployed site**, and every defect found that way so far — a
+logo at its natural size, a selector missing from the two pages served from a version's own directory, and the same
+selector missing again when that directory was addressed without its trailing slash — was invisible to a green build.
 
 What the template adds beyond that:
 


### PR DESCRIPTION
Closes #407

`publish-documentation.yml` carried this, and it never once fired:

```yaml
  # A release adds its tag to the selector, and nothing else changes on the default branch when one is cut. Without
  # this the new version would first appear on whatever merged next.
  release:
    types:
      - published
```

**The release is created by `release.yml` with `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}`, and GitHub starts no workflow run from an event that token generated.** Across 30 runs of this workflow the event has been `push` or `pull_request` every time, and `v0.3.0` published at `21:01:26Z` with no run behind it. The comment described the exact failure mode the trigger was written to prevent, and the trigger had never prevented it.

`0.3.0` reached the selector only because #400 merged a minute after the tag, and the `push` to `main` that followed rebuilt the site with the tag already in the checkout.

## The change

```yaml
  push:
    branches:
      - main
    tags:
      - 'v*'
```

The tag rather than the release, because that is what the site is actually a function of: `scripts/list-documented-versions.sh` answers from the tags in the checkout, not from GitHub's releases. A tag push is a human act with a credential of its own, so it starts runs normally.

A tag is pushed before the publication it starts has finished, so the site can briefly carry a version whose image and release do not exist yet — the deleted first `v0.3.0` tag is the worked example. That resolves itself rather than needing handling: every run rebuilds the whole site from the tags it can see, so a deleted tag is gone from the selector on the next one.

`docs/operations/documentation-site.md` now states what starts a publish, instead of leaving it to be inferred from the workflow.

## Considered and not taken

Calling `publish-documentation.yml` from `release.yml` as a `workflow_call` job, so a version appears only after a *successful* publication. Its concurrency group reads `${{ github.workflow }}`, which resolves to the caller's workflow name — a called run and a `push`-triggered run would sit in different groups and could race two deploys onto GitHub Pages. That is a real hazard bought to avoid a self-healing cosmetic one.

## Verification

`scripts/test-agent-workflow.sh` passes, 108 tests. The `on:` block parses to `{'push': {'branches': ['main'], 'tags': ['v*']}, 'pull_request': …, 'workflow_dispatch': None}` — a push to `main` and a matching tag push are alternatives rather than a conjunction. `scripts/verify-full.sh` is running against this branch; the pull-request checks run it too.

**This workflow cannot be exercised before it merges**: `workflow_dispatch` resolves the definition against the default branch, and no tag will be pushed until the next release. The next release tag is what proves it.

---

# Also on this branch: the version selector (#409)

Closes #409

Two defects in `docfx/template/public/`, kept on this branch at the owner's request rather than split off.

## It vanished without a trailing slash

`.../v<version>/` rendered the selector; `.../v<version>` — the same page, typed without the slash — rendered none, and no out-of-date notice either. `resolveSiteLayout()` resolved `./` against the current address, and `./` names the last `/` in it: the version's directory when the slash is there, the **site** root when it is not. So `currentVersion` came out as the repository name, the lookup in `versions.json` missed, and the function returned before building anything.

The page URL is normalized first now — a path ending in neither `/` nor `.html` is a directory served without its slash, and every page docfx writes is a `.html` file, which is what makes that test safe. `navigateToVersion()` reads the same normalized address, because it subtracts the version directory from it.

Verified as pure `URL` arithmetic, outside the DOM, across six address forms: a version landing page with and without the slash, its `index.html`, a nested page, the changelog served from the version root, and `latest` without a slash. All six resolve to the right version, the right site root, and the right relative path.

## It sat beside the wordmark rather than on the right

It now goes immediately in front of `form.icons`, at the right-hand end of the header.

That position is inside `#navbar`, which `modern` renders itself — the section links and the icon links are written there after this module's `start()`, and written again every time the theme picker among them is used. An insertion done once survives until the reader changes the theme and then silently does not, which is why the previous position was beside the brand. So the placement repeats from a `MutationObserver` on `#navbar`, and does nothing when the picker is already in place; that early return is what stops an observer reacting to its own insertion from looping.

`.mf-version-picker` takes the free space with `margin-inline-start: auto`, so `form.icons` — which carries `margin-left: auto` of its own — has none left to spend and follows immediately. Below the navbar's `767.98px` breakpoint `#navbar` becomes a column, where an auto margin would push the picker against the right edge of a left-aligned panel, so `order: 20` places it after the section links and ahead of the search box instead.

## What is not verified here

**How it looks.** There is no headless browser on this machine, and a static build cannot show it: the header is assembled at run time, so a page that renders the selector and one that silently does not are the same build output. The pull-request run of this workflow builds the site, because the change touches `docfx/**`, which proves the build and nothing about the placement. `docs/operations/documentation-site.md` already says the template's appearance and run-time behaviour are the parts verified by looking at the deployed site; this change adds the third such defect to the list it keeps.

Two file comments are corrected as part of this: the module header claimed the selector went into the one header element `modern` never rewrites, which this change makes false, and the workflow comment above named a release number.
