### PR TITLE
[#410] Stop asking an issue to declare that no specification backs it

### DIFF
--- a/.agents/skills/start-task/SKILL.md
+++ b/.agents/skills/start-task/SKILL.md
@@ -60,9 +60,11 @@ error rather than a partial result.
    - Return `blocked` until every path is inventoried and the user explicitly approves its
      preservation plan, or the changes are moved to a separate worktree. Never assume existing
      changes are unrelated.
-5. Classify the task as a numbered roadmap specification, maintenance outside the roadmap, or
-   documentation-only work.
-6. Read the selected specification, affected implemented-behavior documentation, and relevant ADRs.
+5. Classify the task by what governs it: a numbered roadmap specification, an ADR or an existing
+   issue where no specification does, or documentation-only work. Work no specification backs is an
+   ordinary case and a feature can be one, so never write a specification to supply the
+   classification — say that nothing governs it and let the issue body carry the scope instead.
+6. Read whatever step 5 named, plus affected implemented-behavior documentation and relevant ADRs.
 7. Check the task against the protected paths before planning the work, not after the check refuses
    it. `.github/`, `.config/`, `.agents/`, `.claude/`, and `docs/decisions/`, an `.editorconfig`,
    `.gitattributes`, `.worktreeinclude`, `AGENTS.md`, or `CLAUDE.md` at any depth, and the
@@ -71,9 +73,9 @@ error rather than a partial result.
    of them is a task to raise in an issue instead of to implement; say so now rather than after a
    session spent on a diff that cannot merge.
 8. Identify the GitHub issue that governs the task, reading
-   `docs/operations/issue-tracking.md` first. Create it when none exists; its body draws on the
-   specification read in step 6. A change set that adds a numbered specification also creates that
-   specification's issue.
+   `docs/operations/issue-tracking.md` first. Create it when none exists; its body draws on what
+   step 6 read. A change set that adds a numbered specification also creates that specification's
+   issue.
 9. Place the issue — **owner's checkout only**. It carries exactly one `type:*` label, a `Track` and a
    `Queue` value on the board, a milestone when the milestone rule assigns one, and a `Size` value
    once the work is planned. Decide each from the rules on that page rather than asking. `Queue: Next`
@@ -93,7 +95,7 @@ Return:
 ```text
 Role: <owner's checkout or fork, and what resolved it>
 Workspace: <safe or blocked, branch, base branch>
-Scope: <specification or maintenance classification>
+Scope: <what governs the task, or that nothing does>
 Protected paths: <none reached, or which and what that means for this role>
 Issue: <number and title, or created with reason>
 Placement: <type label, Track, Queue, milestone or none, Size or deferred — or left to triage in the fork role>

--- a/.github/ISSUE_TEMPLATE/work_item.yml
+++ b/.github/ISSUE_TEMPLATE/work_item.yml
@@ -29,10 +29,10 @@ body:
     attributes:
       label: Context
       description: >-
-        What is true today, and why that is a problem or an opportunity. Name the specification under
-        `specs/`, the ADR under `docs/decisions/`, or the issue this follows from; if none backs it,
-        say so plainly. Link a specification rather than copying its text — a copy goes stale in
-        silence.
+        What is true today, and why that is a problem or an opportunity. Name whatever governs this —
+        the specification under `specs/`, the ADR under `docs/decisions/`, or the issue it follows
+        from — and where nothing does, what you write here is it. Link a specification rather than
+        copying its text — a copy goes stale in silence.
     validations:
       required: true
 

--- a/docs/operations/issue-tracking.md
+++ b/docs/operations/issue-tracking.md
@@ -4,7 +4,7 @@
 
 This page is the whole of how work is tracked here. `$start-task` reads it before opening or placing an issue and `$finish-change` before linking a pull request to one, which is every point at which the board is written.
 
-Work is tracked as GitHub issues on the `MailFathom roadmap` project board (project number `4`, owner `Krzysztof318`), which is the owner's view of progress. The board reflects the repository; it never becomes a second source of truth. `specs/` remains authoritative for what a change must do, and an issue links to its specification instead of restating it.
+Work is tracked as GitHub issues on the `MailFathom roadmap` project board (project number `4`, owner `Krzysztof318`), which is the owner's view of progress. The board reflects the repository; it never becomes a second source of truth. Where a specification under `specs/` governs a change, it remains authoritative for what that change must do, and the issue links to it instead of restating it.
 
 **The repository is public and the board is not.** Only the owner can reach project `4`, so every rule below that reads or writes it is a rule for an agent working in the owner's checkout. From a fork, `gh project item-list` and `gh project item-edit` fail on permission rather than degrading, and there is nothing to fall back to — so a fork's agent does not attempt them, and nothing here asks it to. The issues themselves are public and are where a contribution is discussed; what stays private is the owner's ordering of them. No public file links the board, for the same reason: a URL that answers `404` for everyone but one person is worse than no URL.
 
@@ -27,9 +27,9 @@ An open pull request moves both of the bottom two rows, and that is not the dupl
 
 ## The issue that governs a change
 
-- Every change starts from an issue. Identify it during `$start-task`, before editing files, and name it in the task brief. Read the governing specification and ADR context first, because an issue body is written from them.
+- Every change starts from an issue. Identify it during `$start-task`, before editing files, and name it in the task brief. Read whatever governs the change first — a specification, the ADR context, or both — because an issue body is written from it.
 - Each numbered specification under `specs/` has exactly one issue, titled `Spec NN — <specification title>`. Create the issue in the same change set that adds a new specification, so a specification never exists without a tracked unit of work.
-- Work that is not a numbered specification — maintenance, an ADR consequence, a defect — also gets an issue. State in its body that no `specs/` file backs it and name the ADR or the reason instead.
+- An issue names whatever governs it: the specification under `specs/`, the ADR under `docs/decisions/`, or the issue it follows from. A specification is how a large piece of the roadmap is decomposed into reviewable units, not what entitles work to exist, so an issue no specification backs — a feature as readily as maintenance, an ADR consequence, or a defect — is opened on exactly the same terms. Where nothing governs it, its own context is the governing text and there is nothing further to declare: that nothing is linked is already visible to anyone reading it.
 - Do not open a second issue for work an existing issue already covers. Extend the existing issue when scope grows and record why.
 
 ## Issue content


### PR DESCRIPTION
Closes #410

A specification decomposes a large piece of the roadmap into reviewable units. It was never what entitles work to exist, but three places read as though it were, and each closed the assumption differently:

- `docs/operations/issue-tracking.md` required an issue no `specs/` file backs to state that in its body and name an ADR or a reason instead — a line of prose carrying no information, since a reader already sees that nothing is linked.
- `.github/ISSUE_TEMPLATE/work_item.yml` asked a contributor to say so plainly, making the absence the first thing they write about their own contribution.
- `$start-task` offered three scope classifications, one of them a numbered specification and another *maintenance*, so a feature nobody specified had no true answer — it was recorded as maintenance, or read as a specification that had to be written first. Its returned brief said `Scope: <specification or maintenance classification>`, which is the same gap in the shape the next agent copies.

What holds after this change is the part that always carried the information: an issue names whatever governs it — the specification, the ADR, or the issue it follows from — linked rather than restated. Where nothing governs it, the issue's own context is the governing text.

Two neighbouring rules are deliberately untouched. Each numbered specification still has exactly one issue created in the same change set, because that rule is conditional on a specification existing and says nothing about work without one. And the accepted ADRs that used the old formula keep it: an accepted ADR is closed, so it is replaced rather than corrected.

## Verification

`scripts/verify-full.sh` — green: workflow contracts pass, 2713 tests pass, aggregate line coverage 94.60% against the 85% gate. `.github/ISSUE_TEMPLATE/work_item.yml` additionally parsed to confirm the folded scalar still yields the intended sentence.

`scripts/review-obligations.sh` named `docs/operations/agent-workflow.md` as describing `start-task`. Read there: it says the skill "loads the applicable specification, documentation, and ADR context", which is already conditional and remains true, so it owes nothing.
