### PR TITLE
[#412] Narrow the release workflow tag filter to version-shaped tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,23 @@ name: Release
 # Everything that could make a release wrong is asserted before anything is built. A tag that disagrees with the version
 # its own commit declares, that repeats or moves backwards on its line, that names a commit which never merged, or whose
 # changelog says nothing, fails here — while deleting the tag is still the whole remedy.
+#
+# The filter is version-shaped rather than `v*`, which would start this workflow for `vnext`, `viewer`, or any other tag
+# somebody spells with a leading v. That matters more here than anywhere else in the repository: these jobs hold write
+# credentials for two container registries, an attestation signing identity, and the token that creates a release, so a
+# tag nobody meant as one is better refused by never starting than by the assertion below.
+#
+# A filter pattern is a glob rather than a regular expression, so the exact shape is not expressible here — the `*`
+# following each `[0-9]` leaves the digits in a group unbounded, which is what admits `v0.15.0` and `v16.34.234`, and
+# also what leaves a prerelease and a fourth group matching. The assertion refuses both, and `$prepare-release` is what
+# a release is cut with in the first place.
+#
+# What this gives up is the one case where a version-shaped typo is not version-shaped enough: `v0.4` for `v0.4.0` used
+# to start a run and fail loudly, and now starts nothing at all. Read the absence of a run as the tag being malformed.
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 # Never cancels a run in progress. Cancelling a publication half-way is exactly the state this pipeline is built to
 # avoid, and two release tags pushed close together are two different versions rather than a race.

--- a/docs/operations/release-procedure.md
+++ b/docs/operations/release-procedure.md
@@ -152,7 +152,9 @@ unavailable:
    moment of the tag and no search for the version number would ever find it. Each hit is read and either corrected in
    this same pull request or left alone; the sweep reports and never gates.
 2. **Push the annotated tag `v<x.y.z>` on that merge commit.** This is what makes the release real and what triggers
-   the release workflow. Before publishing anything the workflow asserts the tag against the tagged commit's
+   the release workflow — which starts only for a version-shaped tag, so a tag that is not one starts nothing at all
+   rather than a run that fails. **Read a pushed tag that produced no run as a malformed tag**, and check its spelling
+   before looking anywhere else. Before publishing anything the workflow asserts the tag against the tagged commit's
    `VersionPrefix`, against the highest existing tag on the same `major.minor` line, and against the changelog section
    for that version — `scripts/assert-release-tag.sh` is that check. It then runs the same build, unit-test,
    formatting, and migration checks a pull request runs, followed by the integration suite, and builds nothing at all


### PR DESCRIPTION
Closes #412

The same narrowing #408 applied to `publish-documentation.yml`, on the workflow where a spurious start costs the most.

```yaml
on:
  push:
    tags:
      - 'v[0-9]*.[0-9]*.[0-9]*'
```

`v*` starts a run for any tag spelled with a leading v. `Release`'s jobs hold write credentials for two container registries, an attestation signing identity, and the token that creates a GitHub release — so a tag nobody meant as a release is better refused by never starting than by the `assert` job that would have stopped it after the run began.

A filter pattern is a glob rather than a regular expression, but it supports `[]` character ranges, and the `*` after each `[0-9]` leaves the digits in a group unbounded. Checked against a glob engine:

| Tag | Matches |
|---|---|
| `v0.3.0`, `v0.15.0`, `v16.34.234`, `v100.200.300` | yes |
| `vnext`, `viewer`, `version`, `v-preview` | no |
| `v1.2`, `v.13.78.322` | no |

A prerelease and a fourth group still match, because `*` absorbs dots. `assert` refuses both, and the contract suite covers the prerelease case — nothing about that job changes here.

## What this gives up, which is the part worth arguing about

**A version-shaped typo that is not version-shaped enough now produces silence.** Push `v0.4` meaning `v0.4.0` today and `Release` starts, `assert` refuses it with a message naming what disagreed, and a red run sits on the commit. After this, that tag matches nothing, no run starts, and the only signal is that nothing happened — which looks exactly like a release still queueing.

That is a real regression in one narrow case, traded for no stray tag reaching a credentialed job at all. The gain is a property of the pipeline and the loss is a property of one typo, so I took the trade — but it is a judgement rather than a fact, and reverting it is one line.

What it costs is mitigated rather than ignored: `docs/operations/release-procedure.md` now says, at the step where the tag is pushed, to read a tag that produced no run as a malformed tag and check its spelling before looking anywhere else. `scripts/assert-release-tag.sh` also keeps its coverage regardless of what the trigger admits, since the contract suite and a by-hand run both call it directly.

## Verification

`scripts/verify-full.sh` passes; the workflow contracts pass at 108. The `on:` block parses to `{'push': {'tags': ['v[0-9]*.[0-9]*.[0-9]*']}}`. The glob table above was checked against a glob engine rather than against GitHub's own — the two agree on `*` and `[]`, and the one documented difference, `*` not crossing `/`, cannot arise in a tag with no slash in it.
