### PR TITLE
[#414] Seat the version selector beside the header's icon links

### DIFF
--- a/docfx/template/public/main.css
+++ b/docfx/template/public/main.css
@@ -25,11 +25,20 @@
   flex: 0 0 auto;
   width: auto;
 
-  /* The picker sits in `#navbar`, in front of the icon links, and this is what puts it at that end of
-     the header rather than against the section links: the free space is spent here, so `form.icons`
-     — which carries `margin-left: auto` of its own — has none left to spend and follows immediately. */
+  /* The picker sits in `#navbar`, in front of the icon links, and this is what carries it to that end
+     of the header rather than leaving it against the section links. */
   margin-inline-start: auto;
   margin-inline-end: 0.5rem;
+}
+
+/* `modern` pushes the icon links to that same end with an auto margin of its own, and a flex row divides
+   its free space equally among every auto margin on it rather than spending it at the first: two of them
+   leave the picker stranded mid-header with the icons half a gap further on. Withdrawing the template's
+   margin leaves the picker's as the only claim on that space, so it travels to that end and the icon
+   links follow immediately. Below the navbar's breakpoint `modern` replaces that margin with
+   `margin: 1rem 0`, whose left margin is this same zero, so the collapsed panel is unaffected. */
+#navbar form.icons {
+  margin-inline-start: 0;
 }
 
 /* Below the navbar's breakpoint `#navbar` becomes a column and the auto margin above would push the

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -145,14 +145,19 @@ one that covers the page produce the same output.
 The selector itself sits at the right-hand end of the header, in front of the icon links. That is inside the element
 `modern` renders and re-renders — it writes the section links and the icon links there after the template's own module
 has run, and writes them again whenever the theme picker among them is used — so the selector is placed and then kept
-placed, from an observer that puts it back rather than from an insertion that happens once.
+placed, from an observer that puts it back rather than from an insertion that happens once. Reaching that end of the
+header takes one rule as well: `modern` carries the icon links there with an auto margin, a flex row divides its free
+space equally among every auto margin on it rather than spending it at the first, and two of them therefore hold the
+selector halfway across the bar. The template's margin is withdrawn in `main.css` so that the selector's is the only
+claim on that space.
 
 That is the general shape of what this template can get wrong. Everything it adds happens in the browser, after the
 build has finished and against files the build never reads, so a page that renders the selector and one that silently
 does not are the same output as far as every gate here is concerned. **The site's appearance and its run-time
 behaviour are the parts of it verified by looking at the deployed site**, and every defect found that way so far — a
-logo at its natural size, a selector missing from the two pages served from a version's own directory, and the same
-selector missing again when that directory was addressed without its trailing slash — was invisible to a green build.
+logo at its natural size, a selector missing from the two pages served from a version's own directory, the same
+selector missing again when that directory was addressed without its trailing slash, and a selector that reached the
+header but stopped halfway across it — was invisible to a green build.
 
 What the template adds beyond that:
 


### PR DESCRIPTION
Closes #414

The selector reached the right element and stopped halfway to it. `#navbar` is a flex row, and after #408 it carried two auto margins on its main axis: `.mf-version-picker`'s own `margin-inline-start: auto`, and the `margin-left: auto` `modern` gives `#navbar form.icons` to carry the icon links to the right-hand end. A flex row divides its free space **equally** among every auto margin on it rather than spending it at the first, so half landed before the selector and half between the selector and the GitHub icon — which is why the selector floated mid-header with the icons a further half-gap away, and why the comment claiming `form.icons` had nothing left to spend was wrong about the mechanism as well as the result.

`main.css` withdraws the template's margin, leaving the selector's as the only claim on that space. It is loaded after `docfx.min.css` and a logical margin property cascades together with its physical counterpart, so an equal-specificity `#navbar form.icons { margin-inline-start: 0 }` is enough. Below the navbar's breakpoint `modern` already replaces that margin with `margin: 1rem 0`, whose left margin is the same zero, so the collapsed panel and the existing mobile rule for the selector are untouched.

`docs/operations/documentation-site.md` gains the rule that holds the selector at that end of the header, and this joins the defects the page lists as found only by reading the deployed site — the class of defect a green build cannot see, since none of it exists until a browser lays the page out.

## Verification

`scripts/verify-full.sh` passed; 2713 unit tests, 0 failures, whole-solution format check clean, workflow contracts green. The placement itself has no gate here: the site's appearance is verified by looking at the deployed page, which is what `documentation-site.md` says and what this change is another instance of.
