### PR TITLE
[#415] Report the device sign-in prompt on the thread that starts the wait

### DIFF
--- a/src/Cli/Authorization/DeploymentAuthorizer.cs
+++ b/src/Cli/Authorization/DeploymentAuthorizer.cs
@@ -157,7 +157,7 @@ internal sealed class DeploymentAuthorizer
     /// <summary>Requests a device code, reports the prompt, and polls until the person completes the sign-in.</summary>
     /// <param name="authorization">Where to authorize, and for what.</param>
     /// <param name="clientId">The client identifier registered with the authorization server.</param>
-    /// <param name="reportPrompt">Receives the code and address to show the person, once, before polling begins.</param>
+    /// <param name="reportPrompt">Receives the code and address to show the person, once, before polling begins. Invoked on the calling thread, so whatever it writes has been written by the time the wait starts.</param>
     /// <param name="cancellationToken">Cancels the request and the polling.</param>
     /// <returns>The session to store.</returns>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
@@ -166,7 +166,7 @@ internal sealed class DeploymentAuthorizer
     internal async Task<DeploymentGrant> AuthorizeWithDeviceCodeAsync(
         DeploymentAuthorization authorization,
         string clientId,
-        IProgress<DeviceCodePrompt> reportPrompt,
+        Action<DeviceCodePrompt> reportPrompt,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(authorization);
@@ -185,7 +185,7 @@ internal sealed class DeploymentAuthorizer
             clientId,
             cancellationToken);
 
-        reportPrompt.Report(DescribePrompt(deviceAuthorization, this.timeProvider.GetUtcNow()));
+        reportPrompt(DescribePrompt(deviceAuthorization, this.timeProvider.GetUtcNow()));
 
         return await this.PollForDeviceGrantAsync(authorization, clientId, deviceAuthorization, cancellationToken);
     }

--- a/src/Cli/Commands/AuthorizeMailboxCommand.cs
+++ b/src/Cli/Commands/AuthorizeMailboxCommand.cs
@@ -231,7 +231,7 @@ internal static class AuthorizeMailboxCommand
         MailboxAuthorizationRequest request,
         CancellationToken cancellationToken)
     {
-        var reportPrompt = new Progress<DeviceCodePrompt>(prompt =>
+        void ReportPrompt(DeviceCodePrompt prompt)
         {
             context.Console.WriteError(string.Empty);
             context.Console.WriteError("Open this address on any device with a browser:");
@@ -240,9 +240,9 @@ internal static class AuthorizeMailboxCommand
             context.Console.WriteError($"and enter the code: {prompt.UserCode}");
             context.Console.WriteError($"The code expires at {prompt.ExpiresAt:u}. Waiting for the sign-in to complete...");
             context.Console.WriteError(string.Empty);
-        });
+        }
 
-        return authorizer.AuthorizeWithDeviceCodeAsync(request, reportPrompt, cancellationToken);
+        return authorizer.AuthorizeWithDeviceCodeAsync(request, ReportPrompt, cancellationToken);
     }
 
     /// <summary>Reads the address the authorization code comes back to.</summary>

--- a/src/Cli/Commands/LoginCommand.cs
+++ b/src/Cli/Commands/LoginCommand.cs
@@ -263,7 +263,7 @@ internal static class LoginCommand
         string clientId,
         CancellationToken cancellationToken)
     {
-        var reportPrompt = new Progress<DeviceCodePrompt>(prompt =>
+        void ReportPrompt(DeviceCodePrompt prompt)
         {
             context.Console.WriteError(string.Empty);
             context.Console.WriteError("Open this address on any device with a browser:");
@@ -272,9 +272,9 @@ internal static class LoginCommand
             context.Console.WriteError($"and enter the code: {prompt.UserCode}");
             context.Console.WriteError($"The code expires at {prompt.ExpiresAt:u}. Waiting for the sign-in to complete...");
             context.Console.WriteError(string.Empty);
-        });
+        }
 
-        return authorizer.AuthorizeWithDeviceCodeAsync(authorization, clientId, reportPrompt, cancellationToken);
+        return authorizer.AuthorizeWithDeviceCodeAsync(authorization, clientId, ReportPrompt, cancellationToken);
     }
 
     /// <summary>Reads the address the authorization code comes back to.</summary>

--- a/src/Common/MailboxOAuth/MailboxAuthorizer.cs
+++ b/src/Common/MailboxOAuth/MailboxAuthorizer.cs
@@ -134,7 +134,7 @@ public sealed class MailboxAuthorizer
 
     /// <summary>Requests a device code, reports the prompt, and polls until the person completes the sign-in.</summary>
     /// <param name="request">The provider endpoints and registered client.</param>
-    /// <param name="reportPrompt">Receives the code and address to show the person, once, before polling begins.</param>
+    /// <param name="reportPrompt">Receives the code and address to show the person, once, before polling begins. Invoked on the calling thread, so whatever it writes has been written by the time the wait starts.</param>
     /// <param name="cancellationToken">Cancels the request and the polling.</param>
     /// <returns>The grant to provision.</returns>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
@@ -146,7 +146,7 @@ public sealed class MailboxAuthorizer
     /// </remarks>
     public async Task<MailboxAuthorizationGrant> AuthorizeWithDeviceCodeAsync(
         MailboxAuthorizationRequest request,
-        IProgress<DeviceCodePrompt> reportPrompt,
+        Action<DeviceCodePrompt> reportPrompt,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
@@ -162,7 +162,7 @@ public sealed class MailboxAuthorizer
             request,
             cancellationToken);
 
-        reportPrompt.Report(DescribePrompt(deviceAuthorization, this.timeProvider.GetUtcNow()));
+        reportPrompt(DescribePrompt(deviceAuthorization, this.timeProvider.GetUtcNow()));
 
         return await this.PollForDeviceGrantAsync(request, deviceAuthorization, cancellationToken);
     }

--- a/src/Common/OAuth/DeviceCodePrompt.cs
+++ b/src/Common/OAuth/DeviceCodePrompt.cs
@@ -10,9 +10,19 @@ namespace MailFathom.Common.OAuth;
 /// <param name="VerificationUriComplete">The same address with the code already embedded, or <see langword="null" /> when the provider issued none.</param>
 /// <param name="ExpiresAt">When the code stops being redeemable.</param>
 /// <remarks>
+/// <para>
 /// The prompt is reported rather than printed, so the flow stays free of a console it does not own and the command
 /// decides how an operator sees it. Nothing here is a credential: the user code is single-use, bound to one pending
 /// authorization, and useless without the person signing in.
+/// </para>
+/// <para>
+/// It is reported through an <see cref="Action{T}" /> rather than an <see cref="IProgress{T}" />, because what the
+/// report has to guarantee is an ordering: the person cannot act on a code they have not been shown, so it must reach
+/// them before the flow starts waiting on their action. <see cref="IProgress{T}" /> promises the opposite — a report
+/// may be delivered asynchronously — and <see cref="Progress{T}" />, the only implementation the platform ships,
+/// exists to marshal onto a captured <see cref="SynchronizationContext" />. A console process has none, so the report
+/// degrades to a thread-pool work item that races the rest of the sign-in and the writes it makes to the terminal.
+/// </para>
 /// </remarks>
 public sealed record DeviceCodePrompt(
     string UserCode,

--- a/tests/Common.UnitTests/MailboxAuthorizerTests.cs
+++ b/tests/Common.UnitTests/MailboxAuthorizerTests.cs
@@ -182,12 +182,16 @@ public sealed class MailboxAuthorizerTests
         var authorizer = new MailboxAuthorizer(httpClient, timeProvider);
 
         DeviceCodePrompt? reportedPrompt = null;
-        var reportPrompt = new Progress<DeviceCodePrompt>(prompt => reportedPrompt = prompt);
+        var pollsBeforeThePromptWasReported = -1;
 
         // Act
         var authorization = authorizer.AuthorizeWithDeviceCodeAsync(
             CreateRequest(),
-            reportPrompt,
+            prompt =>
+            {
+                reportedPrompt = prompt;
+                pollsBeforeThePromptWasReported = tokenRequestCount;
+            },
             CancellationToken.None);
 
         await AdvanceUntilCompletedAsync(timeProvider, authorization);
@@ -198,6 +202,10 @@ public sealed class MailboxAuthorizerTests
         Assert.Equal(3, tokenRequestCount);
         Assert.Equal("ABCD-EFGH", reportedPrompt?.UserCode);
         Assert.Equal(new Uri("https://authorization.test/activate"), reportedPrompt?.VerificationUri);
+
+        // The person cannot act on a code they have not been shown, so the prompt reaches them before the first poll
+        // rather than whenever a queued callback happens to run.
+        Assert.Equal(0, pollsBeforeThePromptWasReported);
     }
 
     [Fact]
@@ -229,7 +237,7 @@ public sealed class MailboxAuthorizerTests
         // Act
         var authorization = authorizer.AuthorizeWithDeviceCodeAsync(
             CreateRequest(),
-            new Progress<DeviceCodePrompt>(_ => { }),
+            _ => { },
             CancellationToken.None);
 
         await AdvanceUntilCompletedAsync(timeProvider, authorization);
@@ -257,7 +265,7 @@ public sealed class MailboxAuthorizerTests
         // Act, Assert
         await Assert.ThrowsAsync<InvalidOperationException>(() => authorizer.AuthorizeWithDeviceCodeAsync(
             request,
-            new Progress<DeviceCodePrompt>(_ => { }),
+            _ => { },
             CancellationToken.None));
     }
 
@@ -316,7 +324,7 @@ public sealed class MailboxAuthorizerTests
         var failure = await Assert.ThrowsAsync<MailboxAuthorizationFailedException>(
             () => authorizer.AuthorizeWithDeviceCodeAsync(
                 CreateRequest(),
-                new Progress<DeviceCodePrompt>(_ => { }),
+                _ => { },
                 CancellationToken.None));
 
         Assert.Equal("non_json_response_http_502", failure.AuthorizationServerErrorCode);


### PR DESCRIPTION
Closes #415

The nightly run of 2026-08-05 failed on `OAuthSignInTests.Login_ADeviceSignIn_PrintsTheCodeAndStoresTheIssuedSession`: the assertion that the device code was printed found the collection holding the later "access token is renewed" line without it. The test was right and the code under it was wrong.

Both device-code flows handed the prompt to the console through `new Progress<DeviceCodePrompt>(...)`. `Progress<T>` exists to marshal a callback onto a captured `SynchronizationContext`, which is a UI thread; a console process has none, so `Report` degrades to an unordered `ThreadPool` work item. `AuthorizeWithDeviceCodeAsync` called it and moved straight on to polling, so nothing ordered the printing of a code against the wait for the person to type it, and the callback's writes raced the rest of the sign-in's own output.

Measured in `Cli.UnitTests` with a temporary probe: `SynchronizationContext.Current` is `null`, and a `Report` on a freshly constructed `Progress<T>` has not run its callback when the call returns. The window is narrow — 60 isolated runs, 96 concurrent runs, and runs against a starved thread pool all passed locally — and it opens under the contention of a coverage-instrumented run on a shared runner.

Reporting through an `Action<DeviceCodePrompt>` makes the guarantee the parameter documentation already claimed. The delegate cannot dispatch asynchronously, so the wrong shape stops being representable at this seam rather than being caught by a more patient assertion.

`MailboxAuthorizerTests.AuthorizeWithDeviceCodeAsync_PendingThenApproved_...` carried the same race and now states the ordering it depends on. `OAuthSignInTests` needed no change at all.

### The public API break

`MailboxAuthorizer.AuthorizeWithDeviceCodeAsync` is `public`, so this changes a public signature and is argued rather than assumed. `Directory.Build.props` sets `IsPackable=false` for every project, so no assembly here is published as a library — the distributed artifacts are the `mfctl` binary and the service image. The only consumers are `LoginCommand` and `AuthorizeMailboxCommand`, both in this change.

### Verification

- `scripts/verify-full.sh` — exit 0, 2713/2713 passed, 0 warnings, aggregate line coverage 94.62% against the required 85%. Rerun after rebasing onto #416.
- `$check-docs-licenses` — Docs `n/a`, Changelog `n/a`, Licenses `n/a`. No operator-visible behaviour changed: the same seven lines are written by the same command in the same order, and the transcripts in `docs/operations/admin-endpoint.md` and `docs/operations/mailbox-oauth.md` already show the code ahead of "Waiting for the sign-in to complete...", which this change makes guaranteed rather than incidental.
