### PR TITLE
[#395] Keep the application listener when the administrative endpoint binds and the probes are off

### DIFF
--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -240,9 +240,9 @@ this default is the native-process path's.
 Kestrel's own fallback would add `https://localhost:5001` whenever an ASP.NET Core development certificate happens to
 be installed. MailFathom restates only the clear-text half, so what the process listens on is decided by what was
 configured rather than by what is installed on the machine — it never serves a listener out of a development
-certificate. That restatement happens while the [probe listener](health-endpoints.md#the-application-listener-is-preserved)
-is being opened, which is the default; a deployment that sets `HealthEndpoints:Enabled` to `false` restates nothing and
-is left with Kestrel's own defaults, development certificate included.
+certificate. That [restatement](health-endpoints.md#the-application-listener-is-preserved) happens whenever this process
+binds a listener of its own — the probes, which are the default, or the administrative endpoint; a deployment that
+enables neither restates nothing and is left with Kestrel's own defaults, development certificate included.
 
 ### `Kestrel:Endpoints:<name>`
 

--- a/docs/operations/health-endpoints.md
+++ b/docs/operations/health-endpoints.md
@@ -1,6 +1,6 @@
 # The health endpoints and the listener they are served on
 
-<!-- describes: src/Host/Hosting/** -->
+<!-- describes: src/Host/Hosting/**, src/Host/Configuration/Endpoints/HealthEndpointOptions.cs, src/Host/Configuration/Endpoints/ConfiguredApplicationListeners.cs, src/Host/Configuration/Endpoints/ApplicationListenerRestatement.cs, src/Host/Security/Endpoints/Health* -->
 
 An orchestrator decides three things about a process by asking it: whether it has finished coming up, whether it can
 serve a request right now, and whether it is still running rather than stuck. MailFathom answers those three questions on
@@ -59,20 +59,29 @@ its MCP clients reach.
 ### The application listener is preserved
 
 Kestrel ignores the URL-shaped addresses — `ASPNETCORE_URLS`, `ASPNETCORE_HTTP_PORTS` — as soon as any listener is
-bound in code, and the probe listener is one. MailFathom therefore restates those addresses as `Kestrel:Endpoints`
-entries before opening the probe listener, which hands the same strings back to the framework's own parser and binds
-the same sockets. Nothing is restated where the addresses were already being ignored: a deployment that names its own
-`Kestrel:Endpoints` keeps exactly those, and one whose [MCP HTTPS profiles](mcp-endpoint.md#https-and-your-own-domain) bind their own
-listeners keeps the promise that no clear-text listener stays open behind them.
+bound in code, and the probe listener is one of them. MailFathom therefore restates those addresses as
+`Kestrel:Endpoints` entries before the server is built, which hands the same strings back to the framework's own parser
+and binds the same sockets.
 
-The consequence worth knowing is in the log. A host that opens the probe listener writes Kestrel's
-`Overriding address(es)` warning once at startup and then binds every address the warning named, plus the probe port.
+The question the restating answers is whether anything in this process binds a listener of its own, not whether the
+probes do. The [administrative endpoint](admin-endpoint.md) opens one the same way, so a deployment that sets
+`HealthEndpoints:Enabled` to `false` and `AdminEndpoint:Enabled` to `true` keeps its application address exactly as one
+serving both does.
+
+Nothing is restated where the addresses were already being ignored: a deployment that names its own `Kestrel:Endpoints`
+keeps exactly those, and one whose [MCP HTTPS profiles](mcp-endpoint.md#https-and-your-own-domain) bind their own
+listeners keeps the promise that no clear-text listener stays open behind them. A deployment that enables neither the
+probes nor the administrative endpoint restates nothing either, and hands that decision back to Kestrel, because
+nothing else here opens a socket for the addresses to be taken away by.
+
+The consequence worth knowing is in the log. A host that opens a listener of its own writes Kestrel's
+`Overriding address(es)` warning once at startup and then binds every address the warning named, plus that listener's
+own port.
 
 Restating is also what keeps a deployment that configures no address at all on `http://localhost:5000` alone: the
 clear-text half of Kestrel's own fallback is restated and its `https://localhost:5001` half deliberately is not, so no
-listener is ever served out of an ASP.NET Core development certificate. Turning the probes off restates nothing and
-hands that decision back to Kestrel. [The application listener](configuration-reference.md#the-application-listener)
-records where its address comes from.
+listener is ever served out of an ASP.NET Core development certificate.
+[The application listener](configuration-reference.md#the-application-listener) records where its address comes from.
 
 ## The three probes
 

--- a/src/Host/Configuration/Endpoints/ApplicationListenerRestatement.cs
+++ b/src/Host/Configuration/Endpoints/ApplicationListenerRestatement.cs
@@ -1,0 +1,56 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Host.Configuration.Endpoints;
+
+/// <summary>Decides whether the application's own addresses have to be restated so the listeners composition opens cannot take them away.</summary>
+/// <remarks>
+/// <para>
+/// Kestrel ignores the URL-shaped addresses — <c>ASPNETCORE_URLS</c>, <c>ASPNETCORE_HTTP_PORTS</c>, and everything that
+/// reaches <c>WebApplication.Urls</c> — as soon as any listener is bound in code, so a deployment that states its
+/// application port that way loses it the moment a second endpoint opens a socket beside it.
+/// <see cref="ConfiguredApplicationListeners.AsKestrelEndpointConfiguration" /> is what hands those addresses back to
+/// the framework; this is what decides when it has to.
+/// </para>
+/// <para>
+/// The decision belongs to the whole composition rather than to any one endpoint, which is the defect this closes:
+/// taken inside a single endpoint's branch it is skipped exactly when that endpoint is the one switched off and another
+/// is the one binding, and the process then starts successfully while serving nothing on the address its clients
+/// connect to. Every endpoint that opens a listener of its own is read here, so an endpoint added later is folded into
+/// this one decision rather than restating the addresses from a branch of its own.
+/// </para>
+/// </remarks>
+internal static class ApplicationListenerRestatement
+{
+    /// <summary>Reports whether the application's addresses have to be restated as Kestrel endpoints before the server is built.</summary>
+    /// <param name="configuration">The application configuration, read at the root because the Kestrel section is not nested under this product's own.</param>
+    /// <param name="mcpEndpointSettings">The MCP endpoint's settings, whose HTTPS profiles bind listeners of their own.</param>
+    /// <param name="healthEndpointSettings">The probe endpoint's settings, whose listener is bound in code whenever it is enabled.</param>
+    /// <param name="adminEndpointSettings">The administrative endpoint's settings, whose listener is bound in code whenever it is enabled.</param>
+    /// <returns><see langword="true" /> when the addresses would otherwise be dropped, otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal static bool IsRequired(
+        IConfiguration configuration,
+        McpEndpointOptions mcpEndpointSettings,
+        HealthEndpointOptions healthEndpointSettings,
+        AdminEndpointOptions adminEndpointSettings)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(mcpEndpointSettings);
+        ArgumentNullException.ThrowIfNull(healthEndpointSettings);
+        ArgumentNullException.ThrowIfNull(adminEndpointSettings);
+
+        // The MCP HTTPS profiles bind in code as well and are deliberately not counted here. They replace the
+        // application listener instead of joining it, so restating the addresses beside them would reopen the
+        // clear-text socket those profiles exist to close.
+        var listenerBoundInCode = healthEndpointSettings.Enabled || adminEndpointSettings.Enabled;
+
+        // Where the addresses were already going to be ignored, restating them opens a listener the deployment had
+        // replaced rather than keeping one it still has.
+        var addressesAlreadyReplaced =
+            mcpEndpointSettings.BindsOwnListeners || ConfiguredKestrelEndpoints.AnyConfigured(configuration);
+
+        return listenerBoundInCode && !addressesAlreadyReplaced;
+    }
+}

--- a/src/Host/Configuration/Endpoints/McpEndpointOptions.cs
+++ b/src/Host/Configuration/Endpoints/McpEndpointOptions.cs
@@ -110,6 +110,15 @@ internal sealed class McpEndpointOptions
     /// <remarks>Read whether or not a redirect is served, because a port has to be known before it can be checked against the other listeners in the process; <see cref="TransportHttpsOptions.RedirectsClearText" /> is what decides whether anything binds it.</remarks>
     public int ClearTextRedirectPort => this.Https.Redirect.Port ?? DefaultClearTextRedirectPort;
 
+    /// <summary>Gets whether this endpoint binds listeners of its own instead of being served over the host's.</summary>
+    /// <remarks>
+    /// True only where the HTTPS profiles are bound, which is also what makes Kestrel ignore the URL-shaped addresses.
+    /// This endpoint therefore replaces the application listener rather than joining it, which is the promise that no
+    /// clear-text socket stays open behind the profiles, and <see cref="ApplicationListenerRestatement" /> reads it as
+    /// a reason not to restate those addresses rather than as a reason to.
+    /// </remarks>
+    public bool BindsOwnListeners => this.Enabled && this.Https.TerminatesTls;
+
     /// <summary>Gets the ports this endpoint's listeners bind, which no other listener in the process may claim.</summary>
     /// <remarks>
     /// The redirect's port is one of them, so a deployment cannot give it to the probes or to the administrative surface

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -402,18 +402,34 @@ try
     // when neither exists. Reading the wrong one would leave the collision check comparing the probe port against
     // sockets nothing opens, which is the check passing on the strength of a number nobody binds.
     var applicationListenerUrls = ConfiguredApplicationListeners.ResolveUrls(builder.Configuration);
-    var mcpTerminatesTls = mcpEndpointSettings.Enabled && mcpEndpointSettings.Https.TerminatesTls;
     var configuredKestrelEndpoints = ConfiguredKestrelEndpoints.AnyConfigured(builder.Configuration);
 
-    IReadOnlyCollection<int> applicationListenerPorts = (mcpTerminatesTls, configuredKestrelEndpoints) switch
+    IReadOnlyCollection<int> applicationListenerPorts =
+        (mcpEndpointSettings.BindsOwnListeners, configuredKestrelEndpoints) switch
+        {
+            // Every socket the MCP surface opens, the clear-text redirect included: it is bound by the same profiles and
+            // is the one a deployment can end up with without having written a port, so leaving it out would let the
+            // probes or the administrative endpoint take it and report the conflict as an address-in-use error naming a
+            // socket.
+            (true, _) => [.. mcpEndpointSettings.ListenerPorts],
+            (false, true) => ConfiguredKestrelEndpoints.ListenerPorts(builder.Configuration),
+            _ => ConfiguredApplicationListeners.ListenerPorts(applicationListenerUrls),
+        };
+
+    // Kestrel ignores the URL-shaped addresses as soon as any listener is bound in code, so opening the probe listener
+    // or the administrative one would silently take the application listener away from a deployment that states its
+    // port through ASPNETCORE_HTTP_PORTS or ASPNETCORE_URLS. Restating those addresses as Kestrel endpoints hands the
+    // same strings back to the framework's own parser, which binds the same sockets it would have bound. Asked here,
+    // of every endpoint at once, rather than from inside the branch of whichever one happens to be checked first.
+    if (ApplicationListenerRestatement.IsRequired(
+        builder.Configuration,
+        mcpEndpointSettings,
+        healthEndpointSettings,
+        adminEndpointSettings))
     {
-        // Every socket the MCP surface opens, the clear-text redirect included: it is bound by the same profiles and is
-        // the one a deployment can end up with without having written a port, so leaving it out would let the probes or
-        // the administrative endpoint take it and report the conflict as an address-in-use error naming a socket.
-        (true, _) => [.. mcpEndpointSettings.ListenerPorts],
-        (false, true) => ConfiguredKestrelEndpoints.ListenerPorts(builder.Configuration),
-        _ => ConfiguredApplicationListeners.ListenerPorts(applicationListenerUrls),
-    };
+        builder.Configuration.AddInMemoryCollection(
+            ConfiguredApplicationListeners.AsKestrelEndpointConfiguration(applicationListenerUrls));
+    }
 
     // Against the application listener and the probe listener both, because a port is claimed by whichever binds
     // first and the loser fails with an address-in-use error naming a socket rather than the section that asked for it.
@@ -491,19 +507,6 @@ try
 
     if (healthEndpointSettings.Enabled)
     {
-        // Kestrel ignores the URL-shaped addresses as soon as any listener is bound in code, so opening the probe
-        // listener would silently take the application listener away from a deployment that states its port through
-        // ASPNETCORE_HTTP_PORTS or ASPNETCORE_URLS. Restating those addresses as Kestrel endpoints hands the same
-        // strings back to the framework's own parser, which binds the same sockets it would have bound. Nothing is
-        // restated where the addresses were already being ignored: a deployment that names its own Kestrel endpoints
-        // keeps them, and one whose MCP HTTPS profiles bind in code keeps the promise that no clear-text listener
-        // stays open behind them.
-        if (!mcpTerminatesTls && !configuredKestrelEndpoints)
-        {
-            builder.Configuration.AddInMemoryCollection(
-                ConfiguredApplicationListeners.AsKestrelEndpointConfiguration(applicationListenerUrls));
-        }
-
         // The callback runs when the server is constructed, after the container exists and after the composition root
         // below has loaded the certificate the TLS listener presents.
         builder.WebHost.ConfigureKestrel(kestrelOptions => HealthEndpointListenerBinder.Bind(

--- a/tests/Host.UnitTests/Configuration/Endpoints/ApplicationListenerRestatementTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/ApplicationListenerRestatementTests.cs
@@ -1,0 +1,165 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Infrastructure.Certificates;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Endpoints;
+
+/// <summary>Covers which compositions keep the application's own addresses and which ones would drop them.</summary>
+/// <remarks>
+/// Binding any listener in code makes Kestrel ignore the URL-shaped addresses, so the question is not which endpoint is
+/// being opened but whether any of them is. A composition that answers it from one endpoint's setting serves nothing on
+/// the address its clients connect to whenever that endpoint is the one switched off, and starts successfully doing it.
+/// </remarks>
+public sealed class ApplicationListenerRestatementTests
+{
+    /// <summary>The administrative endpoint binds its listener whether or not the probes are served, so it is what decides here.</summary>
+    [Fact]
+    public void IsRequired_TheAdministrativeEndpointAloneBinding_KeepsTheApplicationAddresses()
+    {
+        // Arrange
+        var healthEndpointSettings = new HealthEndpointOptions { Enabled = false };
+        var adminEndpointSettings = new AdminEndpointOptions { Enabled = true };
+
+        // Act
+        var isRequired = ApplicationListenerRestatement.IsRequired(
+            EmptyConfiguration,
+            ClearTextMcpEndpoint(),
+            healthEndpointSettings,
+            adminEndpointSettings);
+
+        // Assert
+        Assert.True(isRequired);
+    }
+
+    [Fact]
+    public void IsRequired_TheProbeEndpointAloneBinding_KeepsTheApplicationAddresses()
+    {
+        // Arrange
+        var healthEndpointSettings = new HealthEndpointOptions { Enabled = true };
+        var adminEndpointSettings = new AdminEndpointOptions { Enabled = false };
+
+        // Act
+        var isRequired = ApplicationListenerRestatement.IsRequired(
+            EmptyConfiguration,
+            ClearTextMcpEndpoint(),
+            healthEndpointSettings,
+            adminEndpointSettings);
+
+        // Assert
+        Assert.True(isRequired);
+    }
+
+    /// <summary>Nothing opens a socket of its own, so Kestrel binds the addresses itself and restating them would say the same thing twice.</summary>
+    [Fact]
+    public void IsRequired_NoEndpointBindingAListenerOfItsOwn_RestatesNothing()
+    {
+        // Arrange
+        var healthEndpointSettings = new HealthEndpointOptions { Enabled = false };
+        var adminEndpointSettings = new AdminEndpointOptions { Enabled = false };
+
+        // Act
+        var isRequired = ApplicationListenerRestatement.IsRequired(
+            EmptyConfiguration,
+            ClearTextMcpEndpoint(),
+            healthEndpointSettings,
+            adminEndpointSettings);
+
+        // Assert
+        Assert.False(isRequired);
+    }
+
+    /// <summary>
+    /// The HTTPS profiles replace the application listener rather than joining it. Restating the addresses beside them
+    /// would reopen the clear-text socket the profiles exist to close.
+    /// </summary>
+    [Fact]
+    public void IsRequired_TheMcpEndpointTerminatingTls_RestatesNothingEvenWhileAnotherEndpointBinds()
+    {
+        // Arrange
+        var healthEndpointSettings = new HealthEndpointOptions { Enabled = true };
+        var adminEndpointSettings = new AdminEndpointOptions { Enabled = true };
+
+        // Act
+        var isRequired = ApplicationListenerRestatement.IsRequired(
+            EmptyConfiguration,
+            TlsTerminatingMcpEndpoint(enabled: true),
+            healthEndpointSettings,
+            adminEndpointSettings);
+
+        // Assert
+        Assert.False(isRequired);
+    }
+
+    /// <summary>A profile on an endpoint nobody serves binds no listener, so the addresses are still the ones the process answers on.</summary>
+    [Fact]
+    public void IsRequired_HttpsProfilesOnADisabledMcpEndpoint_KeepsTheApplicationAddresses()
+    {
+        // Arrange
+        var healthEndpointSettings = new HealthEndpointOptions { Enabled = false };
+        var adminEndpointSettings = new AdminEndpointOptions { Enabled = true };
+
+        // Act
+        var isRequired = ApplicationListenerRestatement.IsRequired(
+            EmptyConfiguration,
+            TlsTerminatingMcpEndpoint(enabled: false),
+            healthEndpointSettings,
+            adminEndpointSettings);
+
+        // Assert
+        Assert.True(isRequired);
+    }
+
+    /// <summary>A deployment naming its own endpoints is one whose URL-shaped addresses Kestrel was already ignoring, and reinstating them would open a listener the operator had replaced.</summary>
+    [Fact]
+    public void IsRequired_ADeploymentNamingItsOwnKestrelEndpoints_RestatesNothing()
+    {
+        // Arrange
+        var configuration = ConfigurationFrom(new Dictionary<string, string?>
+        {
+            ["Kestrel:Endpoints:Application:Url"] = "http://0.0.0.0:8080",
+        });
+
+        var healthEndpointSettings = new HealthEndpointOptions { Enabled = false };
+        var adminEndpointSettings = new AdminEndpointOptions { Enabled = true };
+
+        // Act
+        var isRequired = ApplicationListenerRestatement.IsRequired(
+            configuration,
+            ClearTextMcpEndpoint(),
+            healthEndpointSettings,
+            adminEndpointSettings);
+
+        // Assert
+        Assert.False(isRequired);
+    }
+
+    private static IConfiguration EmptyConfiguration => new ConfigurationBuilder().Build();
+
+    private static McpEndpointOptions ClearTextMcpEndpoint() => new() { Enabled = true };
+
+    private static McpEndpointOptions TlsTerminatingMcpEndpoint(bool enabled)
+    {
+        var settings = new McpEndpointOptions { Enabled = enabled };
+        settings.Https.Endpoints.Add(new TransportHttpsEndpointOptions
+        {
+            Name = "mcp",
+            Domain = "mcp.example.test",
+            Port = 8443,
+            ServerCertificate = new TlsServerCertificateOptions
+            {
+                Bundle = new ConfiguredSecret { Name = "bundle", SecretReference = "file:/etc/mailfathom/tls/mcp.pfx" },
+            },
+        });
+
+        return settings;
+    }
+
+    private static IConfiguration ConfigurationFrom(Dictionary<string, string?> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+}


### PR DESCRIPTION
Closes #395

## What was wrong

`Program.cs` restated the URL-shaped application addresses as Kestrel endpoint configuration only inside `if (healthEndpointSettings.Enabled)`. Kestrel ignores `ASPNETCORE_URLS` and `ASPNETCORE_HTTP_PORTS` as soon as any listener is bound through `Listen`, so with the probes off and the administrative endpoint on, `AdminEndpointListenerBinder.Bind` opened the administrative socket alone and the MCP endpoint stopped answering — while the process started successfully, leaving only Kestrel's own `Overriding address(es)` warning behind.

## The change

`ApplicationListenerRestatement` takes the decision from whether *anything* in this process binds a listener in code, rather than from one endpoint's `Enabled` flag, and the composition root asks it once for every endpoint instead of from inside the probe branch. `McpEndpointOptions.BindsOwnListeners` names the one endpoint that replaces the application listener rather than joining it, which is the same fact the port-source switch was already reading as a local.

Nothing is restated where the addresses were already being ignored: an MCP endpoint terminating TLS keeps the promise that no clear-text listener stays open behind its profiles, and a deployment naming its own `Kestrel:Endpoints` keeps exactly those. A host that enables neither the probes nor the administrative endpoint binds nothing in code, so the decision is handed back to Kestrel unchanged.

## Verification

- `scripts/verify-full.sh` — exit 0; 2719 tests, 0 failures, formatting and analysis clean.
- Six new `Host.UnitTests` cases cover the mapping from the three sections onto what composition restates, including the administrative endpoint binding alone and HTTPS profiles on a disabled MCP endpoint.
- `docs/operations/health-endpoints.md` and `docs/operations/configuration-reference.md` stated the rule as probe-gated and now state it as belonging to any listener this process binds. The health page's `describes:` marker was too narrow to surface it for this change and now names the files that own the rule.
