### PR TITLE
[#414] Withdraw the icon links' auto margin at the specificity `modern` declares it

### DIFF
--- a/docfx/template/public/main.css
+++ b/docfx/template/public/main.css
@@ -36,9 +36,14 @@
    leave the picker stranded mid-header with the icons half a gap further on. Withdrawing the template's
    margin leaves the picker's as the only claim on that space, so it travels to that end and the icon
    links follow immediately. Below the navbar's breakpoint `modern` replaces that margin with
-   `margin: 1rem 0`, whose left margin is this same zero, so the collapsed panel is unaffected. */
-#navbar form.icons {
-  margin-inline-start: 0;
+   `margin: 1rem 0`, whose left margin is this same zero, so the collapsed panel is unaffected.
+
+   The selector is the template's own, `.navbar` and all, because a declaration is only withdrawn by one
+   that matches its specificity — `#navbar form.icons` carries one class fewer and loses however late it
+   is read. `margin-left` for the same reason: it is the property `modern` declares, so cancelling it
+   takes nothing on trust about how a logical property reaches a physical one through the cascade. */
+.navbar #navbar form.icons {
+  margin-left: 0;
 }
 
 /* Below the navbar's breakpoint `#navbar` becomes a column and the auto margin above would push the


### PR DESCRIPTION
Closes #414

#416 shipped the right diagnosis and a rule that never applied. `modern` declares the margin as `.navbar #navbar form.icons` — one id, two classes, one element — and the withdrawal was written as `#navbar form.icons`, which carries one class fewer. Being later in the cascade cannot rescue a lower specificity, so both auto margins stayed in play and the header rendered exactly as before the merge.

This mirrors the template's own selector, and cancels `margin-left`, the property `modern` actually declares, rather than reaching it through a logical one. That leaves nothing about the fix resting on how logical and physical properties meet in the cascade.

## Measured, not reasoned

The last two attempts were argued from the stylesheet rather than from a rendered page, and one of them was wrong about the stylesheet. So this one was driven in a browser: the site built locally with `dotnet docfx build`, composed under a `versions.json` so the selector renders, served over HTTP, and measured in headless Chrome 151 over the DevTools protocol with the HTTP cache disabled — the same page under the merged stylesheet and under this one.

At a 1900px viewport:

| | merged (`main`) | this branch |
|---|---|---|
| computed `margin-left` on `form.icons` | `226.281px` | `0px` |
| computed `margin-left` on the selector | `226.281px` | `452.562px` |
| gap, section links → selector | 226px | 453px |
| gap, selector → icon links | 234px | 8px |
| gap, icon links → search box | 0px | 0px |

The two equal 226px margins are the defect itself: a flex row dividing its free space between the two auto margins rather than spending it at the first.

Also checked on the same harness:

- **After a theme change**, which is the event that rewrites the whole navigation bar: geometry identical, selector still adjacent to the icon links.
- **Collapsed navbar at 480px**, panel expanded: section links, then the selector spanning the panel at `order: 20` with `margin: 16px 0 0`, then the search box, then the centred icon links at `margin: 16px 0`. Unchanged — the template already zeroes that margin below the breakpoint, so this rule states there what was already computed.

## Verification

`scripts/verify-full.sh` passed on this branch: 108 workflow contracts, 2713 unit tests, 0 failures, whole-solution format check clean.
