### PR TITLE
[#485] Let a slow Pages queue delay a publish rather than fail it, and say how a failed one is recovered

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -180,6 +180,20 @@ jobs:
           # site were ever served by a Pages build rather than deployed as an artifact.
           include-hidden-files: true
 
+      # A deployment that is merely slow must not fail, because a failed one cannot be re-run: the artifact
+      # `actions/upload-pages-artifact` writes is named `github-pages`, a re-run adds a second under the same run, and
+      # `actions/deploy-pages` refuses when it finds more than one. That asymmetry is what sizes the wait. Waiting
+      # longer costs runner minutes and nothing else; giving up costs a publish, and the recovery is a fresh run
+      # dispatched by hand rather than another attempt at this one.
+      #
+      # So the default of ten minutes is not above what a slow queue reaches — it is inside it. Deployment ordinarily
+      # takes between five and twenty seconds here, and on the day this was raised the queue degraded: one publish
+      # spent four and a half minutes in it, and the two after it were still `deployment_queued` when the default
+      # cancelled them at exactly ten. Thirty minutes is chosen against that rather than against the ordinary case,
+      # which it is roughly two orders of magnitude above.
+      # docs/operations/documentation-site.md records what a run that exhausts even this needs.
       - name: Deploy to Pages
         id: deploy
         uses: actions/deploy-pages@v5
+        with:
+          timeout: 1800000

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -189,3 +189,31 @@ to nearly every pull request the repository sees and catch nothing.
 Pages itself is enabled once, in the repository settings, with **Build and deployment → Source** set to **GitHub
 Actions**. The workflow cannot enable it: the action that would needs a token with administration rights, which is
 exactly the kind of credential this workflow is built not to hold.
+
+### Recovering a failed publish
+
+**A failed publish is recovered by running the workflow again, never by re-running the failed job.** Use the
+`workflow_dispatch` on `main`; the next merge does it as well, since a publish rebuilds the whole site from the
+repository and therefore carries whatever the failed run would have.
+
+Re-running is not merely the slower option — it cannot succeed, and it leaves the run worse than it was.
+`actions/upload-pages-artifact` writes an artifact named `github-pages`, the one from the previous attempt stays
+attached to the same run, and `actions/deploy-pages` refuses to deploy when it finds two:
+
+```text
+Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
+```
+
+Each further attempt adds another, so the count only climbs. The error names an artifact and reads like a defect in
+the workflow, which is what makes this worth stating rather than leaving to be worked out from the message: the run
+that failed is spent, and the fix is a new one.
+
+What fails a publish in the first place is usually the Pages queue rather than anything here — the deployment reports
+`deployment_queued` until `actions/deploy-pages` gives up and cancels it. The step therefore waits thirty minutes
+rather than the action's default of ten, which is enough for every degradation seen so far.
+
+A slow queue is not something the repository can see from the outside, and it is worth knowing that
+[GitHub's status page](https://www.githubstatus.com/) may not show it either: it read *all systems operational*
+throughout the degradation that prompted the thirty minutes, while two consecutive publishes were cancelled at exactly
+the old ten. So the evidence that this is the platform rather than the site is the deployment's own log — a step that
+reports `deployment_queued` on every poll and never advances has not been given anything to fail on.


### PR DESCRIPTION
Closes #485

`Publish the documentation` failed twice in a row this morning without anything in the repository changing. Both runs built every version, composed the site, and uploaded the artifact; both then sat in `deployment_queued` and were cancelled at exactly ten minutes by `actions/deploy-pages`' default `timeout` of `600000` ms. The site did not publish.

## The timeout

Ten minutes is not above what a slow Pages queue reaches — it is inside it. Measured on the `Deploy to Pages` step of the last eight publishes:

| Publish | Duration |
| --- | --- |
| Six of the eight | 5 to 7 seconds |
| One | 17 seconds |
| One, earlier the same morning | 4 minutes 24 seconds |
| The two that failed | cancelled at 10 minutes |

So the queue had already degraded by an order of magnitude before it stalled outright, and the default sits inside the range that degradation covers. Thirty minutes is chosen against that rather than against the ordinary case, which it is roughly two orders of magnitude above.

The asymmetry is what makes a generous value the right call: waiting longer costs runner minutes and nothing else, while giving up costs a publish and cannot be undone cheaply — which is the second half of this change.

## Why a failed publish cannot be re-run

`actions/upload-pages-artifact` writes an artifact named `github-pages`. The one from the previous attempt stays attached to the same run, and `actions/deploy-pages` refuses when it finds more than one:

```
Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.
```

Each further attempt adds another. So re-running the failed job — the obvious thing to reach for, and what was tried on the first failure — leaves the run strictly worse than it was, and the error it produces reads like a defect in the workflow rather than a consequence of the retry. The recovery is a fresh run: `workflow_dispatch`, or the next merge, since a publish rebuilds the whole site from the repository and therefore carries whatever the failed one would have. `docs/operations/documentation-site.md` gains a **Recovering a failed publish** section that says this.

That section also records something worth knowing for the next occurrence: <https://www.githubstatus.com/> reported *all systems operational* throughout, while both publishes were being cancelled. The evidence that a stall is the platform rather than the site is the deployment's own log, not the status page.

## Breaking changes

None. No MCP tool contract, configuration key, database column, or deployment contract is touched.

## Verification

- `scripts/verify-full.sh` — exit 0. 108 workflow-contract tests passed, 0 build errors, 0 test failures, formatting clean at 0 of 890 files rewritten.
- The `timeout` input name and its accepted form are verified against `action.yml` in `actions/deploy-pages`, where it is documented as milliseconds with a default of `600000`.
- The `Deploy` job is skipped on pull requests by design, so this workflow's own check cannot exercise the new value; the first real run of it is the merge to `main`.
