### PR TITLE
[#499] Write the changelog for whoever runs MailFathom

### DIFF
--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -80,10 +80,29 @@ gh pr list --state merged --search 'base:main merged:>=<date of previous tag>' -
   --json number,title,url,closingIssuesReferences
 ```
 
+**The reader is somebody who runs MailFathom** — the person installing it and the administrator keeping it running,
+reading before an upgrade to find out what is new for them, what was fixed, what breaks, and what they have to do about
+it. It is not a reader of this repository, and the section is published where that reader is: the release notes are
+this section, and the documentation site carries the file. That settles both halves of this step, what survives the
+reading and how it is written.
+
 Keep what a consumer of a release would notice — anything reaching the MCP tool contract, the configuration schema, the
 database schema, or the deployment contract, plus a defect that was observable from outside and anything with a
 security consequence. Drop the rest. A refactor, a test, a continuous-integration adjustment, a documentation edit, and
-an internal rename earn no entry, and a changelog that lists them stops being read.
+an internal rename earn no entry. Completeness is not the standard and pursuing it is what makes a changelog stop being
+read: forty entries nobody finishes hide the four that decide an upgrade.
+
+**Then write what survives in the reader's terms rather than in the terms it arrived in.** What this step has in front
+of it is a list of pull requests, each titled by the person who made the change and in the vocabulary of the code it
+touched, so an entry is a translation rather than a copy of one. State the behavior that is observable from outside,
+what it means for an installation already running, and the action to take — the configuration key, the tool argument,
+the default that moved, the failure that stops happening. Leave the mechanism out: the type introduced, the layer
+restructured, the abstraction extracted, the package swapped, the test that proved it. Where a name from inside the
+process has to appear because an operator matches on it — a logger category, a metric, a table — it appears as the
+thing they update rather than as what changed internally.
+
+An entry that resists this is usually an entry that should not exist. A change with nothing to say to that reader is a
+change they cannot observe, and the correct entry for one is none.
 
 **The increment follows from what this reading found**, not the other way round: the highest increment any of the four
 surfaces requires is the release's own. Raise the question with the owner when the entries and the version already
@@ -136,6 +155,12 @@ On a branch off the release branch, and touching nothing else:
 
 - add `## [x.y.z] - YYYY-MM-DD` above the previous section, using the release date in UTC, with the entries from step 2
   grouped into the six Keep a Changelog categories and each referencing the pull request or issue that carried it;
+- open the section with a short paragraph in the reader's own terms: what this release is for, whether the database
+  schema moves, and whether anything the previous release promised is withdrawn. That is what somebody deciding whether
+  to upgrade reads, and it is the one part no list of entries can state;
+- **add no `Unreleased` section.** The file carries none by design: it says what released versions shipped, and a
+  heading standing above the newest one either says nothing or claims something about a release nobody has cut. What
+  has merged since the newest section is what a nightly build carries, and the file's own preamble says so;
 - open a breaking entry with `**Breaking (<surface>)**` and state the operator's action, not only the fact;
 - say, when the database schema moved, whether a migration must be applied, whether it applies while the previous
   version still runs, and whether the release deploys over the previous release's data at all;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,29 +6,28 @@ All notable changes to MailFathom are recorded here, in the format of
 [ADR 0004](docs/decisions/0004-versioning-and-release-policy.md) interprets it over MailFathom's four public surfaces:
 the MCP tool contract, the configuration schema, the database schema, and the deployment contract.
 
-**This file is written by the release pull request and by nothing else.** Ordinary work does not touch it — not a
-feature, not a fix, not a refactor — because a changelog is a statement about a *release*, and a release is what the
-tagged and published pull request makes. `$prepare-release` composes each section from the work merged since the
-previous tag, and that same pull request is the one whose merge commit is tagged and published to the container
-registries. `CHANGELOG.md` is a protected path for the same reason: an edit to it outside that flow changes what a
-release claims it shipped.
-
-What earns an entry is what a consumer of a release would notice — anything reaching one of the four surfaces, a fixed
-defect that was observable from outside, and any change with a security consequence. A refactor, a test, a
-continuous-integration adjustment, a documentation edit, and an internal rename earn none.
+**It is written for whoever runs MailFathom** — the person installing it and the administrator keeping it running — and
+every section answers the same question before an upgrade: what is new for you, what was fixed, what breaks, and what
+you have to do about it. So what earns an entry is what you would notice: anything reaching one of the four surfaces, a
+fixed defect that was observable from outside, and any change with a security consequence. A refactor, a test, a
+continuous-integration adjustment, a documentation edit, and an internal rename earn none, and nothing below is written
+in the terms of the code that produced it.
 
 A breaking entry opens with `**Breaking (<surface>)**` and states the operator's action rather than only the fact. A
 release that touches the database schema says whether a migration must be applied, whether it can be applied while the
 previous version is still running, and whether the release can be deployed over the previous release's data at all.
 
 MailFathom is pre-release. Within `0.x` a minor bump may break any of the four surfaces, and every break is named
-below against the surface it breaks; a patch is compatible on all four. Nightly builds get no section of their own,
-because they are, by definition, whatever has been merged since the newest section below.
+below against the surface it breaks; a patch is compatible on all four. There is no `Unreleased` heading, and neither
+nightly nor prerelease builds get a section of their own: what a nightly carries is, by definition, whatever has been
+merged since the newest section below.
 
-## [Unreleased]
-
-Nothing yet. A section appears here only when a release is prepared, because this file is written by the release pull
-request and by nothing else; what has merged since the newest section below is what a nightly build carries.
+**This file is written by the release pull request and by nothing else.** Ordinary work does not touch it — not a
+feature, not a fix, not a refactor — because a changelog is a statement about a *release*, and a release is what the
+tagged and published pull request makes. `$prepare-release` composes each section from the work merged since the
+previous tag, and that same pull request is the one whose merge commit is tagged and published to the container
+registries. `CHANGELOG.md` is a protected path for the same reason: an edit to it outside that flow changes what a
+release claims it shipped.
 
 ## [0.3.0] - 2026-08-04
 
@@ -113,10 +112,10 @@ refused connection indistinguishable from an outage ([#374](https://github.com/K
   holds it, set `…:Https:Redirect:Enabled` to `false`. A conflict with another listener of this process is refused at
   startup naming the section that asked for it rather than failing later as an address-in-use error
   ([#374](https://github.com/Krzysztof318/MailFathom/pull/374)).
-- The startup line stating the rate limits in force comes from
-  `MailFathom.Host.Hosting.Warnings.TransportRateLimitingStartupReport` rather than `…McpRateLimitingStartupReport`,
-  and one line is written per enabled endpoint. A deployment that matches on the logger category updates it
-  ([#373](https://github.com/Krzysztof318/MailFathom/pull/373)).
+- **Startup now reports the rate limits once per enabled endpoint rather than once**, and under a different logger
+  category: `MailFathom.Host.Hosting.Warnings.TransportRateLimitingStartupReport`, where `0.2.0` wrote
+  `…McpRateLimitingStartupReport`. A log pipeline that matches on that category updates it, or it stops seeing the
+  line ([#373](https://github.com/Krzysztof318/MailFathom/pull/373)).
 - The clear-text transport warning describes the deployment you configured once a trusted proxy is named, rather than
   suggesting `McpEndpoint:Https:Endpoints` to a deployment whose certificate lives on the proxy
   ([#378](https://github.com/Krzysztof318/MailFathom/pull/378)).
@@ -290,22 +289,24 @@ records the apply path and the ordering a deployment follows.
   never sets the remote `\Seen` flag, and that invariant is proven against a real IMAP server rather than asserted
   ([#13](https://github.com/Krzysztof318/MailFathom/pull/13),
   [#132](https://github.com/Krzysztof318/MailFathom/pull/132)).
-- A supervisor per configured account, each running on a schedule of its own
-  ([#167](https://github.com/Krzysztof318/MailFathom/pull/167)).
+- Each configured account synchronizes on a schedule of its own, and a failure is isolated to the account and the
+  folder it happened in rather than stopping the rest ([#167](https://github.com/Krzysztof318/MailFathom/pull/167)).
 - Remote deletions and flag changes are reconciled back onto the local copy
   ([#171](https://github.com/Krzysztof318/MailFathom/pull/171)).
 - Synchronization is bounded by a configured earliest received date, so an established mailbox is not backfilled in
   full on first run ([#133](https://github.com/Krzysztof318/MailFathom/pull/133)).
-- Normalized metadata is extracted from stored raw MIME and persisted with the indexes a timeline query reads
-  ([#98](https://github.com/Krzysztof318/MailFathom/pull/98),
+- Senders, recipients, subjects, and dates are read out of each stored message and indexed, so listing a folder by date
+  reads an index rather than re-parsing stored mail ([#98](https://github.com/Krzysztof318/MailFathom/pull/98),
   [#106](https://github.com/Krzysztof318/MailFathom/pull/106)).
-- Searchable text is derived from stored mail and indexed for PostgreSQL full-text search, with a backfill worker for
-  mail stored before extraction existed ([#110](https://github.com/Krzysztof318/MailFathom/pull/110)).
-- Folder aliases resolve to remote folders under a generation of their own, so a renamed or re-created folder is
-  detected rather than silently followed ([#94](https://github.com/Krzysztof318/MailFathom/pull/94)).
-- Each class of outbound dependency runs under one configurable resilience pipeline — timeout, bounded retry with
-  jittered backoff, and a circuit breaker ([#83](https://github.com/Krzysztof318/MailFathom/pull/83)) — and a dropped
-  IMAP session is recovered under it ([#92](https://github.com/Krzysztof318/MailFathom/pull/92)).
+- Message text is indexed for full-text search as mail arrives, and anything already stored before that indexing
+  existed is caught up in the background rather than left unsearchable
+  ([#110](https://github.com/Krzysztof318/MailFathom/pull/110)).
+- A folder renamed or re-created on the mail server is detected rather than silently followed
+  ([#94](https://github.com/Krzysztof318/MailFathom/pull/94)).
+- Everything MailFathom calls out to runs under a configurable timeout, a bounded retry with jittered backoff, and a
+  circuit breaker, set per class of dependency ([#83](https://github.com/Krzysztof318/MailFathom/pull/83)), and a
+  dropped IMAP session is recovered under that same budget
+  ([#92](https://github.com/Krzysztof318/MailFathom/pull/92)).
 
 **The MCP tool contract.** Served over the Streamable HTTP transport
 ([#135](https://github.com/Krzysztof318/MailFathom/pull/135)). Every call reads the local copy only, so no tool
@@ -383,18 +384,17 @@ is the whole surface, key by key, including which keys reload and which need a r
   [#264](https://github.com/Krzysztof318/MailFathom/pull/264)).
 - Each release publishes an idempotent `mailfathom-schema-<version>.sql` artifact naming the migrations it carries and
   the checksum that identifies it ([#258](https://github.com/Krzysztof318/MailFathom/pull/258)).
-- The declared version is written in one place and stamped from there into every assembly, the image's tags and
-  labels, the packaged chart's `appVersion`, the host's startup record, and the server's MCP `initialize` response
-  ([#208](https://github.com/Krzysztof318/MailFathom/pull/208)).
+- One version identifies a deployment wherever you look for it: the assemblies, the image's tags and labels, the
+  packaged chart's `appVersion`, the line the host writes at startup, and the server's MCP `initialize` response all
+  report the same number ([#208](https://github.com/Krzysztof318/MailFathom/pull/208)).
 - OpenTelemetry logs, metrics, and traces export when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, and host start, startup
   failure, and shutdown are reported from a bootstrap logger that exists before configuration does
   ([#89](https://github.com/Krzysztof318/MailFathom/pull/89)).
-- Every published artifact carries `LICENSE` and `NOTICE`, and a publish that would omit either fails
+- Every published artifact carries `LICENSE` and `NOTICE`
   ([#172](https://github.com/Krzysztof318/MailFathom/pull/172)). MailFathom is licensed under Apache-2.0, and
   [`THIRD_PARTY_LICENSES.md`](https://github.com/Krzysztof318/MailFathom/blob/main/THIRD_PARTY_LICENSES.md) registers
   every dependency it ships beside ([#173](https://github.com/Krzysztof318/MailFathom/pull/173)).
 
-[Unreleased]: https://github.com/Krzysztof318/MailFathom/compare/v0.3.0...main
 [0.3.0]: https://github.com/Krzysztof318/MailFathom/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Krzysztof318/MailFathom/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Krzysztof318/MailFathom/releases/tag/v0.1.0


### PR DESCRIPTION
`$prepare-release` composes every `CHANGELOG.md` section, so how an entry is written is decided there. What the skill
recorded was the *selection* rule — what earns an entry and what does not — and nothing about who the section is for or
in whose terms it is phrased. This adds that, and applies it to the file.

## The skill

Step 2 now names the reader before it filters anything: the person installing MailFathom and the administrator keeping
it running, reading before an upgrade to find out what is new for them, what was fixed, what breaks, and what they have
to do about it. The section is published where that reader is — the release notes are this section, and the
documentation site carries the file — so the audience settles both halves of the step.

What follows the selection rule is new: **write what survives in the reader's terms rather than in the terms it arrived
in.** What the step has in front of it is a list of pull requests titled in the vocabulary of the code they touched, so
an entry is a translation rather than a copy. State the observable behavior, what it means for an installation already
running, and the action to take; leave the mechanism out. Where a name from inside the process has to appear because an
operator matches on it — a logger category, a metric — it appears as the thing they update. An entry that resists this
is usually a change nobody outside can observe, and the correct entry for one is none.

Step 4 gains the opening-paragraph rule the released sections already follow, and the rule that no `Unreleased` section
is added.

## The file

The preamble now leads with who the changelog is for; the paragraph about which pull request writes it stays, and moves
to the end where a reader who runs MailFathom needs it least.

Seven entries were rewritten out of the vocabulary of the code and into what the change does to a deployment — a
supervisor per account, extraction from raw MIME, a backfill worker, folder-alias generations, a resilience pipeline,
where the declared version is written, and the startup line whose logger category moved, which now leads with the log
pipeline that has to be updated. **No claim changed**: every fact, date, and pull-request reference is the one that
shipped, and the wording was narrowed wherever the shorter form would have asserted a consequence the original did not.

The `Unreleased` section and its link reference are gone. It stood above the newest release saying "nothing yet",
because this file is written at release time and nothing merges into it in between; what has merged since the newest
section is what a nightly build carries, which the preamble states. Nothing reads that heading —
`scripts/read-changelog-section.sh` resolves a version section, and no workflow, script, or test refers to it.

## The gate this change fails on purpose

`$check-docs-licenses` reports `fail` for any diff that edits `CHANGELOG.md` outside a release, and this one does. The
edit is the owner's explicit instruction and it is in the same change as the rule it applies, so the exception is
recorded here rather than worked around: no released claim moved, and the rule itself is left standing for ordinary
work.

[ADR 0004](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0004-versioning-and-release-policy.md) is
accepted and therefore closed; nothing here edits it, and nothing here restates the selection rule it settles.
`docs/operations/release-procedure.md` and `docs/operations/agent-workflow.md` were both read against this change —
neither carries the composition guidance, so neither goes stale.

## Verification

- `scripts/verify-full.sh` — green, including 108 workflow contract tests.
- `scripts/review-obligations.sh` — two documentation rows, both read and answered above.
- No production code changed.

Closes #499
