### PR TITLE
[#517] Register the clock the self-composed integration builders resolve secrets through

### DIFF
--- a/tests/IntegrationTests/Hosting/OrchestratedDatabaseHealthTests.cs
+++ b/tests/IntegrationTests/Hosting/OrchestratedDatabaseHealthTests.cs
@@ -42,6 +42,7 @@ public sealed class OrchestratedDatabaseHealthTests(MailFathomOrchestrationFixtu
         var cancellationToken = TestContext.Current.CancellationToken;
 
         var builder = new HostApplicationBuilder();
+        builder.Services.AddSingleton(TimeProvider.System);
         builder.Services.AddSecretResolution(SecretValueInterpretation.ReferenceOnly);
         builder.Services.AddInfrastructure(
             _ => new PostgresConnectionSettings(orchestration.DatabaseConnectionString, null, null),

--- a/tests/IntegrationTests/Persistence/OrchestratedDatabaseSchemaTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedDatabaseSchemaTests.cs
@@ -84,6 +84,7 @@ public sealed class OrchestratedDatabaseSchemaTests(MailFathomOrchestrationFixtu
         PostgresTextSearchConfiguration textSearchConfiguration)
     {
         var builder = new HostApplicationBuilder();
+        builder.Services.AddSingleton(TimeProvider.System);
         builder.Services.AddSecretResolution(SecretValueInterpretation.ReferenceOnly);
         builder.Services.AddInfrastructure(
             _ => new PostgresConnectionSettings(orchestration.DatabaseConnectionString, null, null),

--- a/tests/IntegrationTests/Persistence/OrchestratedSchemaArtifactTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedSchemaArtifactTests.cs
@@ -147,6 +147,7 @@ public sealed class OrchestratedSchemaArtifactTests(MailFathomOrchestrationFixtu
     private static IHost ComposeHost(string connectionString)
     {
         var builder = new HostApplicationBuilder();
+        builder.Services.AddSingleton(TimeProvider.System);
         builder.Services.AddSecretResolution(SecretValueInterpretation.ReferenceOnly);
         builder.Services.AddInfrastructure(
             _ => new PostgresConnectionSettings(connectionString, null, null),


### PR DESCRIPTION
The dispatched `Integration tests` run on `main` fails five tests with `Unable to resolve service for type 'System.TimeProvider' while attempting to activate 'MailFathom.Infrastructure.Secrets.Sources.FileSystemSecretFileReader'`. None of the five reaches an assertion; each fails while the host is being built.

`FileSystemSecretFileReader` took a `TimeProvider` constructor parameter in #511, so `AddSecretResolution` now resolves a clock eagerly — the composite reference resolver enumerates the readers during startup. Three integration test classes compose a `HostApplicationBuilder` of their own rather than going through `OrchestratedMailFathomServices`, and none of them registered one.

Each now registers `TimeProvider.System` before `AddSecretResolution`, which is the line the composition root, `OrchestratedMailFathomServices`, and #511's own `ServiceCollectionExtensionsTests` all already carry. The clock stays the caller's to register: having the extension supply its own default would hide the next dependency the same way this one was hidden, and would leave a test unable to substitute the clock without knowing to overwrite a registration it never made.

No production wiring changes.

## Why no check caught it

The suite runs only through the manually dispatched `Integration tests` workflow, so a pull request can be green while the harness cannot start. This is the third time a dependency reached `AddInfrastructure` or `AddSecretResolution` without the harness following; the gap itself is worth an issue of its own, and this pull request only closes the instance.

## Verification

- `scripts/verify-full.sh` — exit 0, 2834 tests, 0 failed, aggregate line coverage 94.72843450479233% (7709/8138), 0 of 935 files reformatted.
- Typo check over the changed files — clean.
- `Integration tests` dispatched on this branch; the result is what actually proves the fix, since no pull-request check reaches the suite.

Closes #517
