### PR TITLE
[#501] Collect the signals the pinned libraries already emit

### DIFF
--- a/docs/architecture/outbound-resilience.md
+++ b/docs/architecture/outbound-resilience.md
@@ -159,11 +159,12 @@ is the layer rather than something MailFathom re-implements:
 
 Polly's metrics stay on and carry the dependency class as the pipeline name, the remote instance as the pipeline
 instance, the event, the attempt number, the outcome, and the duration. Emitting them is not exporting them: the host
-subscribes OpenTelemetry to Polly's meter in `ServiceDefaultsExtensions`, without which the instruments would exist and
-nothing would collect them. Its *logging* is replaced: Polly renders the outcome exception in full, and a mail server
-puts the rejected recipient into its error text. `OutboundResilienceEvents` therefore records a retry, a circuit
-opening, and a circuit closing with the dependency class, the instance, the operation, the failure's type name, the
-attempt number, and the delay — never a message, an address, an identifier, or a payload.
+subscribes OpenTelemetry to Polly's meter in `TelemetrySubscriptionExtensions`, beside every other meter a library
+publishes under its own name, without which the instruments would exist and nothing would collect them. Its *logging*
+is replaced: Polly renders the outcome exception in full, and a mail server puts the rejected recipient into its error
+text. `OutboundResilienceEvents` therefore records a retry, a circuit opening, and a circuit closing with the dependency
+class, the instance, the operation, the failure's type name, the attempt number, and the delay — never a message, an
+address, an identifier, or a payload.
 
 The instance is the configured account identifier and the operation is the folder alias, or the fixed name
 `folder-discovery` for a connection that pins no folder, both carried into the callbacks by the pipeline key and by

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry and the Aspire dashboard
 
-<!-- describes: src/Common/Observability/**, src/Host/Observability/**, src/Host/ServiceDefaultsExtensions.cs, src/Infrastructure/Observability/**, src/AppHost/** -->
+<!-- describes: src/Common/Observability/**, src/Host/Observability/**, src/Host/ServiceDefaultsExtensions.cs, src/Infrastructure/Observability/**, src/Infrastructure/HostApplicationBuilderExtensions.cs, src/AppHost/** -->
 
 The host instruments itself with OpenTelemetry throughout — logs, metrics, and traces — and exports none of it unless
 the environment names a destination. Today exactly one environment does that out of the box: a local run under the
@@ -15,16 +15,39 @@ credentials, tokens, message bodies, attachment content, or raw MIME; a tool cal
 and a duration, never as what was searched for. [What the endpoint records](mcp-endpoint.md#what-the-endpoint-records)
 states that boundary precisely.
 
-**Metrics** cover the request pipeline (ASP.NET Core), outbound HTTP (`HttpClient`), the .NET runtime, PostgreSQL
-through the Npgsql instrumentation, and the `Polly` meter, which is where every outbound-resilience pipeline reports
-its attempts, outcomes, timeouts, and circuit-breaker state transitions.
-[Outbound resilience](../architecture/outbound-resilience.md#telemetry-and-privacy) records which tags those events
-carry and which they never do.
+**Metrics** cover the request pipeline (ASP.NET Core), outbound HTTP (`HttpClient`), and the .NET runtime through their
+instrumentation packages, and four meters that the libraries publishing them name themselves:
 
-**Traces** cover incoming requests, outbound HTTP, and database commands, correlated end to end: the trace a request
-arrives with is the trace its log records and its failure diagnostics carry. One filter is deliberate: requests to the
-health-probe paths are not traced at all, because a probe arrives every few seconds for the life of the process and
-says the same thing every time — tracing it would fill a trace store with polling instead of work.
+| Meter | What it reports | Subscribed by |
+| --- | --- | --- |
+| `Npgsql` | Connection-pool state, command durations, and command counts against PostgreSQL | The Aspire PostgreSQL enrichment |
+| `Microsoft.EntityFrameworkCore` | Active contexts, queries, save operations, compiled-query cache hits and misses, execution-strategy failures, and optimistic-concurrency failures | The host |
+| `Experimental.ModelContextProtocol` | MCP session duration, and per-operation duration broken down by protocol method and — for a tool call — tool name | The host |
+| `Polly` | Every outbound-resilience pipeline's attempts, outcomes, timeouts, and circuit-breaker state transitions | The host |
+
+The split in the last column is where a meter is registered, not how important it is: the Aspire enrichment that gives
+the EF Core context its health check and its database tracing subscribes `Npgsql` as part of the same call, and the
+host subscribes the three it leaves out. Nothing is subscribed twice.
+[Outbound resilience](../architecture/outbound-resilience.md#telemetry-and-privacy) records which tags the `Polly`
+events carry and which they never do; the optimistic-concurrency counter is the aggregate view of the same conflicts
+that surface individually as a persistence conflict failure.
+
+**Traces** cover incoming requests, outbound HTTP, database commands, and MCP protocol operations, correlated end to
+end: the trace a request arrives with is the trace its log records and its failure diagnostics carry. The MCP spans
+come from the SDK's own `Experimental.ModelContextProtocol` activity source and carry the protocol method, the
+negotiated protocol version, the transport, the session identifier, the JSON-RPC request identifier, and the tool name
+for a tool call — which is what makes a slow call attributable to a tool before anything inside the tool is
+instrumented. Database commands are spanned by the `Npgsql` source rather than by EF Core, which reports through
+`DiagnosticSource` and would need a bridging package to span the same commands a second time.
+
+One filter is deliberate: requests to the health-probe paths are not traced at all, because a probe arrives every few
+seconds for the life of the process and says the same thing every time — tracing it would fill a trace store with
+polling instead of work.
+
+Every tag on the metrics above is a bounded set — a protocol method, a transport kind, a negotiated version, one of the
+three tool names, an outcome — so none of them opens a time series per message or per person. The MCP SDK does tag a
+metric with a resource URI, but only for the protocol's resource methods, and MailFathom's server publishes tools
+alone: no resources and no prompts, so the tag never arises.
 
 ## What MailFathom publishes under its own name
 

--- a/src/Host/Observability/TelemetrySubscriptionExtensions.cs
+++ b/src/Host/Observability/TelemetrySubscriptionExtensions.cs
@@ -8,14 +8,39 @@ using OpenTelemetry.Trace;
 
 namespace MailFathom.Host.Observability;
 
-/// <summary>Subscribes the activity source and meter MailFathom publishes to under its own name.</summary>
+/// <summary>Subscribes the activity sources and meters this process collects, whoever publishes to them.</summary>
 /// <remarks>
+/// <para>
 /// Emitting a signal is not collecting it: an unsubscribed source produces no span however much code publishes to it,
-/// and the failure is silent. Both methods therefore subscribe <see cref="Telemetry.Name" /> from the declaration
-/// rather than repeating the string, so the host and the publishers cannot disagree about it.
+/// and the failure is silent. That is as true of a library paying to record a histogram as it is of MailFathom's own
+/// code, which is why both groups are subscribed here rather than only the first-party one.
+/// </para>
+/// <para>
+/// What separates the two groups is who chose the name. MailFathom's own is taken from <see cref="Telemetry.Name" />
+/// rather than repeated, so the host and the publishers cannot disagree about it. A library's name is the library's to
+/// choose, so it is written out here as the string that library publishes under, and the unit tests assert it against
+/// the library's own declaration so that a rename arriving with a package bump fails the build instead of quietly
+/// emptying a dashboard.
+/// </para>
+/// <para>
+/// Absence from these methods is a decision as much as presence is. A name registered elsewhere is deliberately not
+/// repeated here — <c>Npgsql</c> is subscribed by the Aspire PostgreSQL enrichment in
+/// <c>AddDatabaseHealthAndTelemetry</c>, for both its meter and its activity source — and a library that reports
+/// through <c>DiagnosticSource</c> instead of an <c>ActivitySource</c> cannot be reached by a name at all, since it
+/// needs a bridging instrumentation package rather than a subscription.
+/// </para>
 /// </remarks>
 internal static class TelemetrySubscriptionExtensions
 {
+    /// <summary>The meter Polly's telemetry publishes every resilience event to.</summary>
+    private const string PollyMeterName = "Polly";
+
+    /// <summary>The one name the MCP SDK publishes both its spans and its instruments under.</summary>
+    private const string ModelContextProtocolTelemetryName = "Experimental.ModelContextProtocol";
+
+    /// <summary>The meter EF Core publishes its context, query, and concurrency instruments to.</summary>
+    private const string EntityFrameworkCoreMeterName = "Microsoft.EntityFrameworkCore";
+
     /// <summary>Subscribes the activity source MailFathom publishes spans to.</summary>
     /// <param name="tracing">The tracing pipeline being composed.</param>
     /// <returns>The same builder instance for chaining.</returns>
@@ -36,5 +61,60 @@ internal static class TelemetrySubscriptionExtensions
         ArgumentNullException.ThrowIfNull(metrics);
 
         return metrics.AddMeter(Telemetry.Name);
+    }
+
+    /// <summary>Subscribes the activity sources the pinned libraries publish spans to under their own names.</summary>
+    /// <param name="tracing">The tracing pipeline being composed.</param>
+    /// <returns>The same builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="tracing" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// The MCP SDK spans every JSON-RPC request and every notification other than a logging one, and tags each with the
+    /// protocol method, the negotiated protocol version, the transport, the session identifier, the JSON-RPC request
+    /// identifier, and — for a tool call — the tool's name. Without this subscription an MCP request is a gap in the
+    /// trace between the ASP.NET Core span that carried it and the database commands it issued, which reads as work
+    /// that did not happen rather than as a span nobody collected.
+    /// </para>
+    /// <para>
+    /// EF Core is deliberately absent. It reports through <c>DiagnosticSource</c> rather than an
+    /// <c>ActivitySource</c>, so no name subscribes it; reaching it means adding a bridging instrumentation package,
+    /// which would then span the same database commands the <c>Npgsql</c> source already spans.
+    /// </para>
+    /// </remarks>
+    public static TracerProviderBuilder AddLibraryActivitySources(this TracerProviderBuilder tracing)
+    {
+        ArgumentNullException.ThrowIfNull(tracing);
+
+        return tracing.AddSource(ModelContextProtocolTelemetryName);
+    }
+
+    /// <summary>Subscribes the meters the pinned libraries publish instruments to under their own names.</summary>
+    /// <param name="metrics">The metrics pipeline being composed.</param>
+    /// <returns>The same builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="metrics" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Polly's pipelines report attempts, outcomes, timeouts, and circuit-breaker transitions; the MCP SDK reports
+    /// session and per-operation durations, broken down by protocol method and, for a tool call, by tool name; EF Core
+    /// reports active contexts, queries, save operations, compiled-query cache hits and misses, execution-strategy
+    /// failures, and optimistic-concurrency failures — the last of which is the aggregate behind every
+    /// <c>PersistenceConcurrencyConflictException</c> and is visible nowhere else.
+    /// </para>
+    /// <para>
+    /// Every tag on those instruments is a bounded set: a protocol method, a transport kind, a negotiated version, one
+    /// of MailFathom's three tool names, an outcome. The MCP SDK does tag a metric with a resource URI, which would be
+    /// neither bounded nor free of personal data, but only for the resource methods — and MailFathom publishes tools
+    /// alone, no resources and no prompts, so the tag cannot arise. A resource capability added later brings that
+    /// question with it.
+    /// </para>
+    /// </remarks>
+    public static MeterProviderBuilder AddLibraryMeters(this MeterProviderBuilder metrics)
+    {
+        ArgumentNullException.ThrowIfNull(metrics);
+
+        return metrics.AddMeter(
+            PollyMeterName,
+            ModelContextProtocolTelemetryName,
+            EntityFrameworkCoreMeterName);
     }
 }

--- a/src/Host/ServiceDefaultsExtensions.cs
+++ b/src/Host/ServiceDefaultsExtensions.cs
@@ -17,9 +17,6 @@ namespace MailFathom.Host;
 /// </summary>
 internal static class ServiceDefaultsExtensions
 {
-    /// <summary>The meter Polly's telemetry publishes every resilience event to.</summary>
-    private const string PollyMeterName = "Polly";
-
     /// <summary>
     /// Adds observability, service discovery, HTTP resilience, and health-check defaults.
     /// </summary>
@@ -64,15 +61,13 @@ internal static class ServiceDefaultsExtensions
                 metrics.AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
                     .AddRuntimeInstrumentation()
-                    // The outbound resilience pipelines report attempts, outcomes, and durations to Polly's meter.
-                    // Emitting them is not exporting them: without this subscription the instruments exist and
-                    // nothing collects them.
-                    .AddMeter(PollyMeterName)
+                    .AddLibraryMeters()
                     .AddMailFathomMeters();
             })
             .WithTracing(tracing =>
             {
                 tracing.AddMailFathomActivitySources()
+                    .AddLibraryActivitySources()
                     // A probe arrives every few seconds for the lifetime of the process and says the same thing every
                     // time, so tracing it would fill a trace store with the polling rather than with the work.
                     .AddAspNetCoreInstrumentation(tracingOptions =>

--- a/tests/Host.UnitTests/Observability/TelemetrySubscriptionExtensionsTests.cs
+++ b/tests/Host.UnitTests/Observability/TelemetrySubscriptionExtensionsTests.cs
@@ -2,21 +2,38 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
 using MailFathom.Common.Observability;
 using MailFathom.Host.Observability;
 using MailFathom.Host.UnitTests.TestDoubles;
+using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using ModelContextProtocol.Server;
 using Xunit;
 
 namespace MailFathom.Host.UnitTests.Observability;
 
-/// <summary>Covers that the name MailFathom declares for itself is actually collected.</summary>
+/// <summary>Covers that every name this process is supposed to collect is actually subscribed.</summary>
 /// <remarks>
-/// The failure this guards against is silent in production: a subsystem publishes spans to a source nothing subscribed,
-/// the code looks instrumented, and the trace store holds nothing. Asserting the subscribed name against the
-/// declaration is what makes the host and the publishers disagreeing a failing test rather than a quiet gap.
+/// The failure this guards against is silent in production: something publishes spans to a source nothing subscribed,
+/// the code looks instrumented, and the trace store holds nothing. Asserting the subscribed set is what makes a name
+/// dropped from the registration a failing test rather than a quiet gap — for MailFathom's own declaration, and for the
+/// libraries whose names arrive with a package version and can change under one.
 /// </remarks>
 public sealed class TelemetrySubscriptionExtensionsTests
 {
+    /// <summary>The MCP SDK's internal declaration of the one name it publishes both registries under.</summary>
+    /// <remarks>
+    /// Reflection is used here deliberately and nowhere else: the declaration is internal to the SDK, and the name it
+    /// holds is marked experimental by the package that owns it, so a rename is a realistic outcome of a version bump.
+    /// Reading it makes that rename a compile-or-test failure at the moment the pin moves, instead of an MCP surface
+    /// that silently stops appearing in traces and metrics on the next deployment. A missing type is the same signal:
+    /// the SDK's telemetry has moved and the subscription needs re-verifying against its current source.
+    /// </remarks>
+    private static Type ModelContextProtocolDiagnostics =>
+        typeof(McpServerTool).Assembly.GetType("ModelContextProtocol.Diagnostics", throwOnError: true)!;
+
     [Fact]
     public void AddMailFathomActivitySources_SubscribesTheDeclaredName()
     {
@@ -44,6 +61,94 @@ public sealed class TelemetrySubscriptionExtensionsTests
     }
 
     [Fact]
+    public void AddLibraryActivitySources_SubscribesEveryLibraryThatPublishesSpansUnderItsOwnName()
+    {
+        // Arrange
+        var tracing = new RecordingTracerProviderBuilder();
+
+        // Act
+        tracing.AddLibraryActivitySources();
+
+        // Assert
+        Assert.Equal(["Experimental.ModelContextProtocol"], tracing.SubscribedSources);
+    }
+
+    [Fact]
+    public void AddLibraryMeters_SubscribesEveryLibraryThatPublishesInstrumentsUnderItsOwnName()
+    {
+        // Arrange
+        var metrics = new RecordingMeterProviderBuilder();
+
+        // Act
+        metrics.AddLibraryMeters();
+
+        // Assert
+        Assert.Equal(
+            ["Polly", "Experimental.ModelContextProtocol", "Microsoft.EntityFrameworkCore"],
+            metrics.SubscribedMeters);
+    }
+
+    [Fact]
+    public void AddLibraryMeters_LeavesTheMeterTheDatabaseEnrichmentAlreadySubscribes()
+    {
+        // Arrange
+        var metrics = new RecordingMeterProviderBuilder();
+
+        // Act
+        metrics.AddLibraryMeters();
+
+        // Assert
+        Assert.DoesNotContain("Npgsql", metrics.SubscribedMeters);
+    }
+
+    [Fact]
+    public void AddLibraryActivitySources_SubscribesTheNameTheMcpSdkStartsItsSpansFrom()
+    {
+        // Arrange
+        var tracing = new RecordingTracerProviderBuilder();
+        var declaredName = ReadDeclaredTelemetryName("ActivitySource");
+
+        // Act
+        tracing.AddLibraryActivitySources();
+
+        // Assert
+        Assert.Contains(declaredName, tracing.SubscribedSources);
+    }
+
+    [Fact]
+    public void AddLibraryMeters_SubscribesTheNameTheMcpSdkCreatesItsInstrumentsOn()
+    {
+        // Arrange
+        var metrics = new RecordingMeterProviderBuilder();
+        var declaredName = ReadDeclaredTelemetryName("Meter");
+
+        // Act
+        metrics.AddLibraryMeters();
+
+        // Assert
+        Assert.Contains(declaredName, metrics.SubscribedMeters);
+    }
+
+    [Fact]
+    public void AddLibraryMeters_SubscribesTheNameEntityFrameworkCoreDeclaresForItsMeter()
+    {
+        // Arrange
+        var metrics = new RecordingMeterProviderBuilder();
+
+        // Act
+        metrics.AddLibraryMeters();
+
+        // Assert
+        // EF1001 warns that this declaration may change without notice, which is the hazard being asserted rather than
+        // a reason to look away from it: a meter renamed under a version bump would otherwise leave the subscription
+        // collecting nothing and say so nowhere. Reading the declaration turns that into a failure here, and its
+        // removal into one at compile time. The suppression covers this assertion alone.
+#pragma warning disable EF1001
+        Assert.Contains(EntityFrameworkMetrics.MeterName, metrics.SubscribedMeters);
+#pragma warning restore EF1001
+    }
+
+    [Fact]
     public void AddMailFathomActivitySources_WithNoBuilder_Throws()
     {
         // Act and assert
@@ -55,5 +160,36 @@ public sealed class TelemetrySubscriptionExtensionsTests
     {
         // Act and assert
         Assert.Throws<ArgumentNullException>(() => TelemetrySubscriptionExtensions.AddMailFathomMeters(null!));
+    }
+
+    [Fact]
+    public void AddLibraryActivitySources_WithNoBuilder_Throws()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() => TelemetrySubscriptionExtensions.AddLibraryActivitySources(null!));
+    }
+
+    [Fact]
+    public void AddLibraryMeters_WithNoBuilder_Throws()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() => TelemetrySubscriptionExtensions.AddLibraryMeters(null!));
+    }
+
+    private static string ReadDeclaredTelemetryName(string memberName)
+    {
+        var declaration = ModelContextProtocolDiagnostics.GetProperty(
+            memberName,
+            BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+        Assert.NotNull(declaration);
+
+        return declaration.GetValue(null) switch
+        {
+            ActivitySource source => source.Name,
+            Meter meter => meter.Name,
+            var unexpected => throw new InvalidOperationException(
+                $"The MCP SDK's {memberName} declaration is no longer a telemetry registry but {unexpected?.GetType()}."),
+        };
     }
 }


### PR DESCRIPTION
Closes #501

Sub-issue of #85.

Three of the libraries this repository already pins pay to emit telemetry that nothing collected. The MCP SDK spans every JSON-RPC request and records session and per-operation durations; EF Core publishes a meter carrying active contexts, queries, save operations, compiled-query cache hits and misses, execution-strategy failures, and optimistic-concurrency failures. An unsubscribed signal is not a slow signal — it does not exist, and it says so nowhere. The visible cost was an MCP request reading as a gap in the trace between the ASP.NET Core span that carried it and the database commands it issued, and concurrency conflicts observable only one exception at a time.

## What changed

`TelemetrySubscriptionExtensions` becomes the one place the host states what it collects, first-party and library alike. Polly's meter moves into it from `ServiceDefaultsExtensions`, joined by two names that were not collected before:

| Name | Registry | What it buys |
| --- | --- | --- |
| `Experimental.ModelContextProtocol` | activity source **and** meter | MCP spans tagged with the protocol method, negotiated version, transport, session id, JSON-RPC request id, and tool name; session and per-operation duration histograms |
| `Microsoft.EntityFrameworkCore` | meter | Active contexts, queries, save operations, compiled-query cache hits and misses, execution-strategy failures, optimistic-concurrency failures |

**`Npgsql` stays out deliberately.** The acceptance asked that nothing be subscribed twice, and it settles as an absence rather than an addition: the Aspire PostgreSQL enrichment in `AddDatabaseHealthAndTelemetry` already subscribes both the `Npgsql` meter and the `Npgsql` activity source. Verified against `AspireEFPostgreSqlExtensions.cs` and `NpgsqlCommon.cs` at Aspire `v13.4.6` — `AddNpgsql()` for tracing, `AddMeter("Npgsql")` for metrics, and nothing else. A unit test asserts the absence so it cannot be "helpfully" added back.

**EF Core gets no activity source.** It reports through `DiagnosticSource`, not an `ActivitySource`, so no name reaches it; the only route is `OpenTelemetry.Instrumentation.EntityFrameworkCore`, which is prerelease and would span the same database commands the `Npgsql` source already spans.

## How the names were verified

Read from each library's own source at the pinned version, not from the issue body:

- `ModelContextProtocol.Core` v2.0.0 — `src/ModelContextProtocol.Core/Diagnostics.cs` declares one string, `Experimental.ModelContextProtocol`, for both the `ActivitySource` and the `Meter`.
- EF Core v10.0.10 — `EntityFrameworkMetrics.MeterName` is `Microsoft.EntityFrameworkCore`.

Two of the three names are additionally asserted **against the library's own declaration** in the tests, so a rename arriving with a package bump fails the suite rather than quietly emptying a dashboard. The MCP one goes through reflection because the declaration is internal to the SDK and the name is marked experimental by the package that owns it; the EF Core one reads the declaration directly, under an `EF1001` suppression narrowed to that single assertion, since the warning is precisely the hazard being asserted.

## Cardinality and privacy

Every tag on the new instruments is a bounded set: a protocol method, a transport kind, a negotiated version, one of MailFathom's three tool names, an outcome. The high-cardinality identifiers the SDK records — `mcp.session.id`, `jsonrpc.request.id` — go to `activity.AddTag` only, never into the metric `TagList`. The SDK does tag a metric with `mcp.resource.uri`, which would be neither bounded nor free of personal data, but only for the protocol's resource methods; MailFathom's server publishes tools alone, no resources and no prompts, so the tag cannot arise today. Documented so a later resource capability meets the question.

## What is not in this change

The issue's `Microsoft.Extensions.AI` bullet has no target in the tree. That package publishes nothing under a subscribable name: its signals exist only where a client is decorated with `UseOpenTelemetry`, and `src/AI` composes no client at all — `AiServiceCollectionExtensions` registers the deterministic chunker, `Embeddings/`, `Orchestration/`, `ProviderAdapters/`, and `Retrieval/` hold only a `.gitkeep`, and no `IChatClient` or `IEmbeddingGenerator` is constructed anywhere under `src/`. Applying the decorator would mean writing a composition helper nothing calls; subscribing the name would collect from a publisher that does not exist.

So it moves to #520, linked under #85, with #85's delivery table updated to record the split. It belongs to whichever change first composes a chat client or an embedding generator, and it carries no milestone for that reason.

#501's own body now carries a dated *Scope correction* section as well, with the user story and the acceptance bullet that held this work struck through and pointed at #520 — struck rather than deleted, so what moved stays legible. Every acceptance item still standing on #501 is delivered here, which is what makes `Closes #501` accurate rather than a keyword closing an issue over an outstanding item.

## Contracts

No break. No configuration key, database column, MCP tool argument, or deployment contract moves. No package is added, upgraded, or removed, so no pin moves, no lock file is regenerated, and `THIRD_PARTY_LICENSES.md` is unchanged — every name subscribed comes from a package the repository already pins.

## Verification

- `scripts/verify-full.sh` — green. 2867 unit tests, 0 failed; aggregate line coverage 94.73% against the 85% gate.
- `scripts/test-agent-workflow.sh` — 111 passed, 0 failed.
- 12 tests over `TelemetrySubscriptionExtensions`, including the two that read a library's own declaration and the one that asserts `Npgsql` is not subscribed here.

`docs/operations/telemetry.md` now states which libraries' signals the process collects and which registers each; its `describes:` marker gained `src/Infrastructure/HostApplicationBuilderExtensions.cs`, because the page now describes what that file registers. `docs/architecture/outbound-resilience.md` named `ServiceDefaultsExtensions` as where Polly's meter is subscribed and now names the type that holds it.
