### PR TITLE
[#449] Reconcile a discovered UID against the mutation record instead of guessing

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -169,6 +169,26 @@ process count against `MailSynchronization:MaxMutationAttempts`. Spending that b
 row that is not `Completed` stays in the answer an operator reads — being given up on is what stops a change being
 retried, and it would be worth nothing if it also stopped the change being seen.
 
+`PlacementObservedAt` and `SourceRemovalObservedAt` are what synchronization has since seen come back, and they are
+separate facts from `Stage` because they answer a different question and are written by a different run. The stage says
+what the server acknowledged when the command went out; these say that an ordinary synchronization run has met the
+occurrences the change moved and recognized them as this record's own. A relocation reaching `Completed` still arrives
+in the destination folder later as a discovery something has to join to the email already stored, and its source
+occurrence still vanishes from the folder it left — and left alone, that pair is a new message and a deleted one.
+
+The join is the server's own `COPYUID` answer for the placement and the record's own source occurrence for the
+disappearance. A relocation whose server named no placement matches no discovery at all, and `PlacementObservedAt` stays
+null instead: finding the message by searching the destination folder for something that looks like it would replace a
+fact with a guess, and a header a provider rewrote on copy or a `Message-ID` that legitimately appears twice is wrong in
+both directions. The disappearance needs no `COPYUID`, because the source occurrence was written down before the first
+command was issued.
+
+The source half is settled by carrying the row across where nothing has settled it already, because that is what takes
+the email out of the source folder locally: no later reconciliation window can select it there, so no later run could
+observe the disappearance the record would otherwise keep waiting for. A row whose halves are both accounted for leaves
+the candidates a later discovery is matched against; a relocation still owing one is where an operator looks when a
+message moved and the local mailbox has not caught up.
+
 No mail content is here. A folder path, a UID, a mutation name, and a requester identity are the server's own or
 MailFathom's own names for things, and a failure is kept as its five-digit code rather than as the message text
 assembled at the failure site.
@@ -190,6 +210,7 @@ assembled at the failure site.
 | `ix_email_embeddings_profile` | `(EmbeddingProfileId, Dimension)` | Reading a whole generation, which is how a superseded one is removed |
 | `ix_mailbox_mutations_identity` | `(MailFolderId, UidValidity, Uid, RequesterOrigin, RequesterIdentity, Mutation)`, unique | A mutation's idempotency identity, which is what makes the same request twice perform one change |
 | `ix_mailbox_mutations_outstanding` | `(MailboxAccountId, RecordedAt)` where the stage is not `Completed` | The changes an operator asks about: those in flight and those given up on |
+| `ix_mailbox_mutations_placement` | `(MailboxAccountId, DestinationFolderPath, PlacementUidValidity, PlacementUid)` where `PlacementObservedAt` is null | The question the forward pass asks of every batch it discovers: is one of these UIDs where a relocation put an email |
 
 The recipient and search-vector indexes are GIN rather than B-tree because both serve containment tests. A B-tree over an array column serves only equality against a whole array, and over a `tsvector` it serves nothing search asks for; a GIN index is what turns either into an index scan.
 

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -30,10 +30,11 @@ MailFathom synchronizes mailboxes read-only, on a bounded schedule, and — for 
 - Secrets are re-resolved per operation rather than cached, and the configuration snapshot that names them is republished only after every reference in it has resolved. A rotated credential, trust anchor, or database password therefore reaches the next operation without a restart, and a reload that cannot resolve leaves the previous snapshot active. [Secret rotation](../operations/secret-rotation.md) is the operator procedure.
 - Every message whose raw MIME was stored is also read for normalized metadata — participants by role, sent and received timestamps, subject, thread identifiers, and an attachment summary. The read happens on the payload the run already fetched, so enrichment costs no second IMAP round trip and cannot reach the remote `\Seen` flag. [MIME metadata extraction](#mime-metadata-extraction) describes what is extracted and how each part is classified, and [Stored email schema](../architecture/stored-email-schema.md) describes which of it the row keeps. A message whose MIME no reader could parse is still stored, carrying only what the server's envelope reported; the same holds for one whose payload was never fetched because it exceeded the size limit.
 - The same read also derives the message's searchable text from its body and stores it, together with a bounded copy of the subject and of the normalized participant addresses, in a `email_search_documents` row whose PostgreSQL-generated `tsvector` column carries the GIN index lexical search will query. [Body text and the lexical index](#body-text-and-the-lexical-index) describes which part supplies the text, when a derivation is marked lossy, and what a message with no readable body records instead.
-- Each run ends with a bounded backward pass over mail that is already stored, so a message deleted on the server stops being served locally and a flag changed elsewhere stops being stale. It reuses the run's own read-only session, asks for flags and the UID and nothing that could set `\Seen`, and treats a UID the server declines to answer for as a message that left the folder. What becomes of that message locally is the account's choice between a tombstone every query excludes and erasing the local copy outright; a UIDVALIDITY change selects no window at all and can therefore never delete anything. [Reconciling against the server](#reconciling-against-the-server) describes the window, the ordering that advances it without a cursor, the two dispositions, and the audit lines.
+- Each run ends with a bounded backward pass over mail that is already stored, so a message deleted on the server stops being served locally and a flag changed elsewhere stops being stale. It reuses the run's own read-only session, asks for flags and the UID and nothing that could set `\Seen`, and treats a UID the server declines to answer for as a message that left the folder. What becomes of that message locally is the account's choice between a tombstone every query excludes and erasing the local copy outright — unless the message left because MailFathom itself moved or deleted it, which the bullet below covers and which reaches neither. A UIDVALIDITY change selects no window at all and can therefore never delete anything. [Reconciling against the server](#reconciling-against-the-server) describes the window, the ordering that advances it without a cursor, the two dispositions, and the audit lines.
 - A bounded background backfill re-reads the raw MIME of messages stored before extraction existed, writes the classification markers and the text it finds, and records the position it reached so an interrupted run resumes rather than restarts. It reaches no mail server, and it ends itself once no stored message awaits extraction.
 - `Host` provides typed `MailSynchronization` options, startup validation for enabled account connection settings and their transport security policy, secret resolution and trust anchor loading before any hosted service starts, a validated snapshot every consumer reads instead of the raw bound one, and one supervised synchronization schedule per configured account that isolates failures per account and per folder work unit. [Per-account supervision](#per-account-supervision) describes the coordinator, the two concurrency bounds, the backoff layering, and the shutdown drain. A second worker, configured under `MailExtractionBackfill`, runs the extraction backfill on the same scoped-work-unit terms.
 - An account configured for push keeps its folders watched and starts its next pass as soon as the server reports a change, instead of waiting out the interval. How they are watched is the server's answer: one `NOTIFY` subscription covering the account's folders where the server supports it, one `IDLE` session per folder where it supports only that, and polling where it supports neither. The mode is chosen per folder against what the server advertises, degrades to polling when push keeps failing, and is reported whenever it changes. [Push synchronization](#push-synchronization) describes the fallback matrix, mode selection, renewal, degradation, the rotation boundary a long-lived connection creates, and what an operator can observe.
+- A change MailFathom itself made to the mailbox comes back through an ordinary run, and is recognized rather than reacted to. A message it relocated is discovered in its new folder as the email that was already stored, joined to it by the `COPYUID` the server gave rather than by a guess at a header, and carried across instead of stored a second time; the source occurrence vanishing is that relocation or an authored delete completing rather than a deletion to propagate. A discovery or a disappearance that matches no record is treated exactly as before, so nothing changes for mail a person moved or deleted in their own client. [Changes MailFathom itself made](#changes-mailfathom-itself-made) describes the join, what happens when the server named no placement, and the order the two halves may arrive in.
 - The backward pass asks a capable server only about what changed. Where the server reports modification sequences, the folder's checkpoint records the sequence a completed pass covered it through, and the next pass narrows its flag fetch to what changed since — establishing what still exists from the vanished report `QRESYNC` carries or, without it, from a UID search that returns identifiers and no message data. Every path reaches the same end state; a checkpoint written before sequences were tracked carries none and simply asks about its whole window. [Asking only about what changed](#asking-only-about-what-changed) states the matrix and why a partial pass records nothing.
 
 ## Per-account supervision
@@ -769,9 +770,43 @@ state, so nothing it issues can set the remote `\Seen` flag — and the requeste
 test asserts against, because adding any body or header item to it would silently mark every message the pass inspects
 as read. The pass holds no port that could write a flag back.
 
+### Changes MailFathom itself made
+
+Not every disappearance is somebody else's act, and not every discovery is new mail. MailFathom relocates and deletes
+messages on the server too, and both come back through an ordinary run looking like something to react to: a message
+appears in one folder and vanishes from another. Left alone that is a new message and a deleted one, the history forks,
+and the mailbox holds a duplicate as far as MailFathom is concerned.
+
+The [durable mutation record](https://github.com/Krzysztof318/MailFathom/blob/main/docs/architecture/stored-email-schema.md#recorded-mailbox-mutations)
+is what tells the two apart, and both halves are joined to it by a recorded fact rather than by a guess at a header:
+
+- **A discovered occurrence** is matched against relocations that named this folder as their destination and that the
+  server answered with a `COPYUID` naming this UIDVALIDITY and this UID. A match carries the existing local email onto
+  the new occurrence instead of storing a second one — no fetch, no MIME read, and no new row, because the message is
+  the one already stored and its content, extracted metadata, search document, and passages are all keyed by the local
+  identity being carried across. Only the occurrence identity moves, and the flags become unobserved so the destination
+  folder's own window is what says what holds there now.
+- **A disappearance** is matched against the source occurrence the record names, which was written down before the
+  first IMAP command went out. A match is the relocation or the delete completing, so the disposition below is never
+  reached for it: the row keeps its place and only its position in the reconciliation queue moves.
+
+A relocation whose server named no placement is joined to no discovery at all. Searching the destination folder for
+something that looks like the message would replace a fact the server gave with a guess, and guessing by `Message-ID`
+or a content hash is wrong in both directions — a message legitimately appears twice with one `Message-ID`, and a
+provider may rewrite headers on copy. The record then stays visibly unjoined instead.
+
+The order the two halves arrive in is not fixed, because the destination folder is not necessarily one MailFathom
+synchronizes on the same schedule. A source disappearance seen first settles that half and leaves the row where it is
+until the placement is discovered; a placement discovered first settles both, because carrying the row across is what
+takes the email out of the source folder locally and no later window could observe the disappearance afterwards.
+
+A discovery or a disappearance that matches no record is treated exactly as it is below. Nothing here changes what
+happens to mail a person moved or deleted in their own client.
+
 ### What becomes of a message the server no longer holds
 
-Each account chooses, through `RemotelyDeletedEmailDisposition`:
+This is what happens to a disappearance the previous section did **not** account for — mail that left the folder because
+somebody else removed it. Each account chooses, through `RemotelyDeletedEmailDisposition`:
 
 | Value | What happens locally |
 |---|---|
@@ -803,9 +838,12 @@ this one, and that includes the case where this window would have deleted the em
 
 The counts reach the log and nothing else does. A window that observed something logs how many snapshots it refreshed
 and whether the folder has more to reconcile; a window that found messages gone logs that at warning level, with the
-account, the folder alias, the count, and the disposition that was applied. No subject, address, or fragment of a
-message takes part in deciding whether a message still exists, so none of it is read to decide it and none of it can
-reach an audit line.
+account, the folder alias, the count, and the disposition that was applied. A run that recognized changes of
+MailFathom's own logs them on a line of their own, at information level: how many discoveries carried an existing local
+email across, and how many occurrences left the folder because MailFathom moved or deleted them. Without it an operator
+reading the counts would see mail arriving in one folder and vanishing from another, which is exactly the conclusion the
+join exists to stop the system itself from drawing. No subject, address, or fragment of a message takes part in deciding
+whether a message still exists, so none of it is read to decide it and none of it can reach an audit line.
 
 ## Configuration
 

--- a/src/Application/Mail/Mutations/IMailboxMutationReconciliationStore.cs
+++ b/src/Application/Mail/Mutations/IMailboxMutationReconciliationStore.cs
@@ -1,0 +1,116 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Mail.Mutations;
+
+/// <summary>Reads the mutation records synchronization has to recognize its own work in, and writes down that it did.</summary>
+/// <remarks>
+/// <para>
+/// It is a port of its own rather than more members on <see cref="IMailboxMutationRecordStore" /> because the two answer
+/// to different callers. That one belongs to the act of performing a mutation and is written through the session the
+/// performer already holds; this one belongs to a synchronization run, which reads records it did not create and asks
+/// about them by where the email is rather than by which record it is.
+/// </para>
+/// <para>
+/// Both reads are bounded, and neither returns anything derived from a message. A record names folders, identifiers, and
+/// a requester, which is what lets the join be made without reading mail.
+/// </para>
+/// </remarks>
+public interface IMailboxMutationReconciliationStore
+{
+    /// <summary>Reads the relocations that named one folder as their destination and placed an email at one of these UIDs.</summary>
+    /// <param name="accountId">The account whose mutations are read.</param>
+    /// <param name="destinationPath">The remote folder being synchronized, which is the destination those relocations named.</param>
+    /// <param name="uidValidity">The UIDVALIDITY that folder reports now.</param>
+    /// <param name="uids">The UIDs one batch of the forward pass discovered.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>Every record whose reported placement is one of those occurrences, which may be none.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="uids" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A whole batch of discoveries is asked about at once, so a folder that has no relocation pending — which is nearly
+    /// every folder on nearly every run — costs one query rather than one per message. The batch's own UIDs bound the
+    /// answer, so no limit has to be invented for it and no candidate can be missed by one. Which record a given
+    /// occurrence belongs to is then decided by <see cref="MailboxMutationRecord.IsPlacementOf" />, which restates every
+    /// condition of the read rather than trusting it.
+    /// </remarks>
+    Task<IReadOnlyList<MailboxMutationRecord>> ReadRelocationsPlacedAtAsync(
+        MailAccountId accountId,
+        RemoteFolderPath destinationPath,
+        ImapUidValidity uidValidity,
+        IReadOnlyCollection<ImapUid> uids,
+        CancellationToken cancellationToken);
+
+    /// <summary>Reads the mutations issued against any of the source occurrences a reconciliation window found gone.</summary>
+    /// <param name="accountId">The account whose mutations are read.</param>
+    /// <param name="folderResolutionId">The alias binding the occurrences were stored under.</param>
+    /// <param name="uidValidity">The UIDVALIDITY the window was opened for.</param>
+    /// <param name="uids">The UIDs the folder no longer holds.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>Every record issued against one of those occurrences, which may be none.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="uids" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// The whole window is asked about at once, so attributing a window's disappearances costs one query rather than one
+    /// per email. A record that already carries its observation is part of the answer: it stays the durable reason that
+    /// occurrence is gone, and a window that asks about the same disappearance again must get the same answer rather
+    /// than fall through to the path that handles somebody else's deletion.
+    /// </para>
+    /// <para>
+    /// The answer is bounded by <paramref name="uids" /> and by the schema rather than by a limit of its own, and that is
+    /// deliberate. One occurrence can carry several records — the idempotency identity is the occurrence, the requester,
+    /// and the mutation together — so the rows are the window's occurrences times the requesters that asked something of
+    /// each, which is a handful. A count limit on top would be the wrong shape: it would truncate whichever occurrences
+    /// sorted last, and an occurrence whose record was cut would be attributed to nobody and reach the remote-deletion
+    /// path, which is the one outcome this read exists to prevent.
+    /// </para>
+    /// </remarks>
+    Task<IReadOnlyList<MailboxMutationRecord>> ReadMutationsRemovingAsync(
+        MailAccountId accountId,
+        MailFolderResolutionId folderResolutionId,
+        ImapUidValidity uidValidity,
+        IReadOnlyCollection<ImapUid> uids,
+        CancellationToken cancellationToken);
+
+    /// <summary>Writes down that the occurrence a relocation created has been recognized and the local row carried onto it.</summary>
+    /// <param name="session">The session the write joins, which is the one the row is carried across in.</param>
+    /// <param name="recordId">The record whose placement was recognized.</param>
+    /// <param name="observedAt">When the run recognized it.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>A task that completes when the observation is written.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="session" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when no record carries <paramref name="recordId" />.</exception>
+    /// <remarks>
+    /// It settles the source half as well, where nothing has settled it already. Carrying the row across is what takes
+    /// the email out of the source folder locally, so no later window can select it there and no later run can observe
+    /// the disappearance the record is otherwise still waiting for. The stage this is only ever reached from is
+    /// <see cref="MailboxMutationStage.Completed" />, which is the server's own statement that the source occurrence is
+    /// already gone.
+    /// </remarks>
+    Task RecordPlacementObservedAsync(
+        IPersistenceSession session,
+        MailboxMutationRecordId recordId,
+        DateTimeOffset observedAt,
+        CancellationToken cancellationToken);
+
+    /// <summary>Writes down that the source occurrence a mutation removed has been seen to leave its folder.</summary>
+    /// <param name="session">The session the write joins, which is the one the window's outcome is applied in.</param>
+    /// <param name="recordId">The record the disappearance was attributed to.</param>
+    /// <param name="observedAt">When the window read the folder.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>A task that completes when the observation is written.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="session" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when no record carries <paramref name="recordId" />.</exception>
+    /// <remarks>The first observation is kept, because what it says is when the disappearance was first accounted for.</remarks>
+    Task RecordSourceRemovalObservedAsync(
+        IPersistenceSession session,
+        MailboxMutationRecordId recordId,
+        DateTimeOffset observedAt,
+        CancellationToken cancellationToken);
+}

--- a/src/Application/Synchronization/IEmailMetadataRepository.cs
+++ b/src/Application/Synchronization/IEmailMetadataRepository.cs
@@ -42,4 +42,36 @@ public interface IEmailMetadataRepository
         ExtractedEmailMetadata? extractedMetadata,
         StoredEmailContentAvailability contentAvailability,
         CancellationToken cancellationToken);
+
+    /// <summary>Moves one stored email onto the occurrence a relocation put it at, instead of storing a second email there.</summary>
+    /// <param name="session">The explicit persistence session this write participates in.</param>
+    /// <param name="storedEmailId">The email that was relocated, named by the mutation record.</param>
+    /// <param name="occurrenceId">Where the destination folder now holds it.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns><see langword="true" /> when the row was carried across; <see langword="false" /> when another row already occupies the occurrence.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="occurrenceId" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when no stored email carries <paramref name="storedEmailId" />, or when the occurrence names a folder binding that is not stored.</exception>
+    /// <remarks>
+    /// <para>
+    /// Only the occurrence identity moves. The raw MIME, the extracted metadata, the search document, and the passages
+    /// are all keyed by the local identity and describe a message that a relocation did not change, so re-deriving any
+    /// of them would spend a fetch and a parse to arrive back where they already are.
+    /// </para>
+    /// <para>
+    /// The flags become unobserved rather than being carried over as observed. What is stored still describes the
+    /// message, but it was read in the folder the email has left, and the destination folder's own reconciliation window
+    /// is what says whether it still holds.
+    /// </para>
+    /// <para>
+    /// An occurrence another row already occupies is reported rather than written, because the occurrence identity is
+    /// unique and a caller cannot decide for the mailbox which of two local emails is the one the server holds there.
+    /// The caller then stores the discovery as it would any other, which leaves a duplicate visible instead of failing
+    /// the run.
+    /// </para>
+    /// </remarks>
+    Task<bool> TryCarryToOccurrenceAsync(
+        IPersistenceSession session,
+        StoredEmailId storedEmailId,
+        EmailOccurrenceId occurrenceId,
+        CancellationToken cancellationToken);
 }

--- a/src/Application/Synchronization/MailboxSynchronizer.cs
+++ b/src/Application/Synchronization/MailboxSynchronizer.cs
@@ -6,6 +6,7 @@ using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.Synchronization.Reconciliation;
@@ -13,6 +14,7 @@ using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Synchronization;
 using MailFathom.Domain.Transport;
 
@@ -30,6 +32,7 @@ public sealed class MailboxSynchronizer
     private readonly IEmailMetadataRepository metadataRepository;
     private readonly IEmailContentStore contentStore;
     private readonly IEmailMimeReader mimeReader;
+    private readonly IMailboxMutationReconciliationStore mutationStore;
     private readonly MailboxReconciler reconciler;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
     private readonly TimeProvider timeProvider;
@@ -46,6 +49,7 @@ public sealed class MailboxSynchronizer
         IEmailMetadataRepository metadataRepository,
         IEmailContentStore contentStore,
         IEmailMimeReader mimeReader,
+        IMailboxMutationReconciliationStore mutationStore,
         MailboxReconciler reconciler,
         OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
         TimeProvider timeProvider,
@@ -60,6 +64,7 @@ public sealed class MailboxSynchronizer
         this.metadataRepository = metadataRepository;
         this.contentStore = contentStore;
         this.mimeReader = mimeReader;
+        this.mutationStore = mutationStore;
         this.reconciler = reconciler;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
         this.timeProvider = timeProvider;
@@ -152,6 +157,7 @@ public sealed class MailboxSynchronizer
         var storedCount = 0;
         var skippedOversizedCount = 0;
         var unreadableMimeCount = 0;
+        var relocatedCount = 0;
         var hasMore = true;
         var inspectedBatchCount = 0;
 
@@ -164,8 +170,22 @@ public sealed class MailboxSynchronizer
                 this.options.MaxMetadataBatchSize,
                 synchronizationWindow,
                 cancellationToken);
+            var relocations = await this.ReadRelocationsPlacedInBatchAsync(
+                accountId,
+                folder,
+                uidValidity,
+                batch,
+                cancellationToken);
+
             foreach (var metadata in batch.Emails.OrderBy(email => email.OccurrenceId.Uid.Value))
             {
+                if (await this.TryCarryRelocatedEmailAsync(relocations, folder, metadata, cancellationToken))
+                {
+                    relocatedCount++;
+
+                    continue;
+                }
+
                 var occurrence = await this.StoreOccurrenceAsync(mailboxSession, metadata, cancellationToken);
                 if (occurrence.Availability == StoredEmailContentAvailability.Available)
                 {
@@ -224,9 +244,89 @@ public sealed class MailboxSynchronizer
             storedCount,
             skippedOversizedCount,
             unreadableMimeCount,
+            relocatedCount,
             hasMore,
             checkpoint,
             reconciliation);
+    }
+
+    /// <summary>Reads the relocations whose destination is this folder and whose placement is one of the UIDs this batch discovered.</summary>
+    /// <remarks>
+    /// A batch that discovered nothing asks nothing. The read is otherwise made once for the whole batch, so recognizing
+    /// MailFathom's own work costs one query per batch on a folder nobody relocates into and never one per message.
+    /// </remarks>
+    private async Task<IReadOnlyList<MailboxMutationRecord>> ReadRelocationsPlacedInBatchAsync(
+        MailAccountId accountId,
+        MailFolderResolution folder,
+        ImapUidValidity uidValidity,
+        RemoteEmailMetadataBatch batch,
+        CancellationToken cancellationToken)
+    {
+        if (batch.Emails.Count == 0)
+        {
+            return [];
+        }
+
+        return await this.mutationStore.ReadRelocationsPlacedAtAsync(
+            accountId,
+            folder.RemotePath,
+            uidValidity,
+            [.. batch.Emails.Select(static email => email.OccurrenceId.Uid)],
+            cancellationToken);
+    }
+
+    /// <summary>Carries the local email a relocation moved onto the occurrence it was discovered at, rather than storing a second one.</summary>
+    /// <returns><see langword="true" /> when the discovery was this mutation's own and needs nothing further; otherwise, <see langword="false" />.</returns>
+    /// <remarks>
+    /// <para>
+    /// It runs before the payload is fetched, so recognizing a relocation costs no <c>FETCH</c> and no MIME read: the
+    /// message is the one already stored, and everything derived from it is keyed by the local identity that is being
+    /// carried across rather than by the occurrence it sits at.
+    /// </para>
+    /// <para>
+    /// A discovery that matches nothing, and one whose destination occurrence another row already occupies, both fall
+    /// through to the ordinary path. That is the same treatment mail a person moved in their own client gets, which is
+    /// what keeps this change invisible to every mailbox MailFathom is not writing to.
+    /// </para>
+    /// </remarks>
+    private async Task<bool> TryCarryRelocatedEmailAsync(
+        IReadOnlyList<MailboxMutationRecord> relocations,
+        MailFolderResolution folder,
+        RemoteEmailMetadata metadata,
+        CancellationToken cancellationToken)
+    {
+        var occurrenceId = metadata.OccurrenceId;
+        var record = relocations.FirstOrDefault(candidate =>
+            candidate.IsPlacementOf(folder.RemotePath, occurrenceId.UidValidity, occurrenceId.Uid));
+
+        if (record is null)
+        {
+            return false;
+        }
+
+        var carried = false;
+
+        await this.concurrencyRetryPolicy.CommitAsync(
+            async (persistenceSession, attemptCancellationToken) =>
+            {
+                carried = await this.metadataRepository.TryCarryToOccurrenceAsync(
+                    persistenceSession,
+                    record.Request.StoredEmailId,
+                    occurrenceId,
+                    attemptCancellationToken);
+
+                if (carried)
+                {
+                    await this.mutationStore.RecordPlacementObservedAsync(
+                        persistenceSession,
+                        record.Id,
+                        this.timeProvider.GetUtcNow(),
+                        attemptCancellationToken);
+                }
+            },
+            cancellationToken);
+
+        return carried;
     }
 
     /// <summary>Commits the modification sequence a completed backward pass reached, and leaves the checkpoint alone otherwise.</summary>
@@ -387,6 +487,11 @@ public enum MailboxSynchronizationOutcome
 /// <param name="StoredEmailCount">How many occurrences were stored with their content.</param>
 /// <param name="SkippedOversizedEmailCount">How many occurrences were stored as metadata only.</param>
 /// <param name="UnreadableMimeEmailCount">How many stored occurrences carried MIME that enrichment could not read.</param>
+/// <param name="RelocatedEmailCount">
+/// How many discovered occurrences were an email MailFathom had relocated into this folder, and so carried the existing
+/// local email across instead of storing a second one. They are counted apart from the stored ones because no mail
+/// arrived: the mailbox holds exactly what it held before the run.
+/// </param>
 /// <param name="HasMoreEmails">Whether the folder still held unprocessed emails when the run's batch budget ran out.</param>
 /// <param name="Checkpoint">The progress the run ended on, which is present exactly when <paramref name="Outcome" /> is <see cref="MailboxSynchronizationOutcome.Synchronized" />.</param>
 /// <param name="Reconciliation">What the run's backward pass found among the emails already stored for this folder.</param>
@@ -402,6 +507,7 @@ public sealed record MailboxSynchronizationResult(
     int StoredEmailCount,
     int SkippedOversizedEmailCount,
     int UnreadableMimeEmailCount,
+    int RelocatedEmailCount,
     bool HasMoreEmails,
     SynchronizationCheckpoint? Checkpoint,
     MailboxReconciliationResult Reconciliation)
@@ -411,6 +517,7 @@ public sealed record MailboxSynchronizationResult(
     /// <param name="storedEmailCount">How many occurrences were stored with their content.</param>
     /// <param name="skippedOversizedEmailCount">How many occurrences were stored as metadata only.</param>
     /// <param name="unreadableMimeEmailCount">How many stored occurrences carried unreadable MIME.</param>
+    /// <param name="relocatedEmailCount">How many discovered occurrences carried an existing local email across.</param>
     /// <param name="hasMoreEmails">Whether unprocessed emails remain.</param>
     /// <param name="checkpoint">The progress the run ended on.</param>
     /// <param name="reconciliation">What the run's backward pass found.</param>
@@ -421,6 +528,7 @@ public sealed record MailboxSynchronizationResult(
         int storedEmailCount,
         int skippedOversizedEmailCount,
         int unreadableMimeEmailCount,
+        int relocatedEmailCount,
         bool hasMoreEmails,
         SynchronizationCheckpoint checkpoint,
         MailboxReconciliationResult reconciliation)
@@ -433,6 +541,7 @@ public sealed record MailboxSynchronizationResult(
             storedEmailCount,
             skippedOversizedEmailCount,
             unreadableMimeEmailCount,
+            relocatedEmailCount,
             hasMoreEmails,
             checkpoint,
             reconciliation);
@@ -461,6 +570,7 @@ public sealed record MailboxSynchronizationResult(
         return new MailboxSynchronizationResult(
             outcome,
             Folder: null,
+            0,
             0,
             0,
             0,

--- a/src/Application/Synchronization/Reconciliation/MailboxReconciler.cs
+++ b/src/Application/Synchronization/Reconciliation/MailboxReconciler.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 
 namespace MailFathom.Application.Synchronization.Reconciliation;
 
@@ -28,10 +30,16 @@ namespace MailFathom.Application.Synchronization.Reconciliation;
 /// <c>\Seen</c> flag, and it holds no port that could write one back — which is the structural form of the invariant
 /// this pass is the riskiest place in the system for.
 /// </para>
+/// <para>
+/// A disappearance is not by itself somebody else's act. MailFathom relocates and deletes mail on the server too, and
+/// the occurrence leaving its folder is those changes completing rather than a remote deletion to react to. The durable
+/// mutation record is what tells the two apart, so the pass reads it before the disposition is reached.
+/// </para>
 /// </remarks>
 public sealed class MailboxReconciler
 {
     private readonly IStoredEmailReconciliationStore reconciliationStore;
+    private readonly IMailboxMutationReconciliationStore mutationStore;
     private readonly IRemotelyDeletedEmailDispositionReader dispositionReader;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
     private readonly TimeProvider timeProvider;
@@ -39,6 +47,7 @@ public sealed class MailboxReconciler
 
     /// <summary>Initializes a new mailbox reconciler.</summary>
     /// <param name="reconciliationStore">Chooses the window and records what the server answered.</param>
+    /// <param name="mutationStore">Says which of the disappearances are changes MailFathom itself made.</param>
     /// <param name="dispositionReader">Answers what the account being reconciled does with an email its server no longer holds.</param>
     /// <param name="concurrencyRetryPolicy">Commits one window's outcome, retrying a conflict with a competing writer.</param>
     /// <param name="timeProvider">Stamps the observation, which is what advances the window across runs.</param>
@@ -46,18 +55,21 @@ public sealed class MailboxReconciler
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public MailboxReconciler(
         IStoredEmailReconciliationStore reconciliationStore,
+        IMailboxMutationReconciliationStore mutationStore,
         IRemotelyDeletedEmailDispositionReader dispositionReader,
         OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
         TimeProvider timeProvider,
         MailboxSynchronizationOptions options)
     {
         ArgumentNullException.ThrowIfNull(reconciliationStore);
+        ArgumentNullException.ThrowIfNull(mutationStore);
         ArgumentNullException.ThrowIfNull(dispositionReader);
         ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentNullException.ThrowIfNull(options);
 
         this.reconciliationStore = reconciliationStore;
+        this.mutationStore = mutationStore;
         this.dispositionReader = dispositionReader;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
         this.timeProvider = timeProvider;
@@ -122,18 +134,33 @@ public sealed class MailboxReconciler
             reconciledThroughModSeq,
             cancellationToken);
 
-        var outcome = ClassifyWindow(
-            window,
-            observation,
-            this.dispositionReader.GetDisposition(accountId),
-            this.timeProvider.GetUtcNow());
+        var classification = ClassifyWindow(window, observation);
+        var outcome = await this.AttributeDisappearancesAsync(
+            classification,
+            accountId,
+            folder.Id,
+            uidValidity,
+            cancellationToken);
 
         await this.concurrencyRetryPolicy.CommitAsync(
-            (persistenceSession, attemptCancellationToken) =>
-                this.reconciliationStore.ApplyReconciliationOutcomeAsync(
+            async (persistenceSession, attemptCancellationToken) =>
+            {
+                await this.reconciliationStore.ApplyReconciliationOutcomeAsync(
                     persistenceSession,
                     outcome,
-                    attemptCancellationToken),
+                    attemptCancellationToken);
+
+                // Written in the window's own transaction, so a record can never say a disappearance was accounted for
+                // by a window whose observation of it was rolled back.
+                foreach (var attributed in outcome.RemovedByOwnMutation)
+                {
+                    await this.mutationStore.RecordSourceRemovalObservedAsync(
+                        persistenceSession,
+                        attributed.MutationRecordId,
+                        outcome.ObservedAt,
+                        attemptCancellationToken);
+                }
+            },
             cancellationToken);
 
         var emailsRemain = window.Count == this.options.MaxReconciledEmailsPerRun;
@@ -141,8 +168,84 @@ public sealed class MailboxReconciler
         return new MailboxReconciliationResult(
             outcome.StillPresent.Count + outcome.ConfirmedUnchanged.Count,
             outcome.Disappeared.Count,
+            outcome.RemovedByOwnMutation.Count,
             emailsRemain,
             emailsRemain ? null : observation.FolderHighestModSeq);
+    }
+
+    /// <summary>Separates the disappearances MailFathom caused from the ones the disposition answers for.</summary>
+    /// <remarks>
+    /// <para>
+    /// The whole window's gone UIDs are asked about in one read rather than one per email, and a window that found none
+    /// asks nothing at all — which is every window on a mailbox nobody is changing through MailFathom.
+    /// </para>
+    /// <para>
+    /// An occurrence matched by more than one record is attributed once, to the oldest, because the read is ordered and
+    /// the first match is taken. Which record is credited changes nothing about the local row; what matters is that the
+    /// disappearance does not reach the remote-deletion path.
+    /// </para>
+    /// </remarks>
+    private async Task<ReconciledFolderOutcome> AttributeDisappearancesAsync(
+        ReconciledWindowClassification classification,
+        MailAccountId accountId,
+        MailFolderResolutionId folderResolutionId,
+        ImapUidValidity uidValidity,
+        CancellationToken cancellationToken)
+    {
+        var disposition = this.dispositionReader.GetDisposition(accountId);
+        var observedAt = this.timeProvider.GetUtcNow();
+
+        if (classification.Disappeared.Count == 0)
+        {
+            return new ReconciledFolderOutcome(
+                classification.StillPresent,
+                classification.ConfirmedUnchanged,
+                [],
+                [],
+                disposition,
+                observedAt);
+        }
+
+        var records = await this.mutationStore.ReadMutationsRemovingAsync(
+            accountId,
+            folderResolutionId,
+            uidValidity,
+            [.. classification.Disappeared.Select(static candidate => candidate.Uid)],
+            cancellationToken);
+
+        var attributions = classification.Disappeared
+            .Select(candidate => new
+            {
+                candidate.StoredEmailId,
+                Record = FindRecordRemoving(records, accountId, folderResolutionId, uidValidity, candidate.Uid),
+            })
+            .ToArray();
+
+        return new ReconciledFolderOutcome(
+            classification.StillPresent,
+            classification.ConfirmedUnchanged,
+            [.. attributions.Where(static attribution => attribution.Record is null).Select(static attribution => attribution.StoredEmailId)],
+            [
+                .. attributions
+                    .Where(static attribution => attribution.Record is not null)
+                    .Select(static attribution => new MutationAttributedDisappearance(
+                        attribution.StoredEmailId,
+                        attribution.Record!.Id)),
+            ],
+            disposition,
+            observedAt);
+    }
+
+    private static MailboxMutationRecord? FindRecordRemoving(
+        IReadOnlyList<MailboxMutationRecord> records,
+        MailAccountId accountId,
+        MailFolderResolutionId folderResolutionId,
+        ImapUidValidity uidValidity,
+        ImapUid uid)
+    {
+        var occurrence = EmailOccurrenceId.Create(accountId, folderResolutionId, uidValidity, uid);
+
+        return records.FirstOrDefault(record => record.AccountsForRemovalOf(occurrence));
     }
 
     /// <summary>Sorts the window into the occurrences the server described, the ones it confirmed, and the ones it accounted for in neither.</summary>
@@ -164,11 +267,9 @@ public sealed class MailboxReconciler
     /// that repeats one has said the message exists, which is the only thing this classification reads out of it.
     /// </para>
     /// </remarks>
-    private static ReconciledFolderOutcome ClassifyWindow(
+    private static ReconciledWindowClassification ClassifyWindow(
         IReadOnlyList<StoredEmailAwaitingReconciliation> window,
-        RemoteFolderWindowObservation observation,
-        RemotelyDeletedEmailDisposition disposition,
-        DateTimeOffset observedAt)
+        RemoteFolderWindowObservation observation)
     {
         var snapshotsByUid = observation.Observations
             .DistinctBy(static describedOccurrence => describedOccurrence.Uid)
@@ -187,16 +288,32 @@ public sealed class MailboxReconciler
             .ToArray();
         var disappeared = window
             .Where(candidate => !snapshotsByUid.ContainsKey(candidate.Uid) && !unchangedUids.Contains(candidate.Uid))
-            .Select(static candidate => candidate.StoredEmailId)
             .ToArray();
 
-        return new ReconciledFolderOutcome(stillPresent, confirmedUnchanged, disappeared, disposition, observedAt);
+        return new ReconciledWindowClassification(stillPresent, confirmedUnchanged, disappeared);
     }
+
+    /// <summary>What the server's answer alone says about one window, before anything MailFathom did is taken into account.</summary>
+    /// <param name="StillPresent">The occurrences the server described.</param>
+    /// <param name="ConfirmedUnchanged">The occurrences the server confirmed without describing.</param>
+    /// <param name="Disappeared">
+    /// The occurrences the folder no longer holds, still carrying their UIDs because that is what a mutation record is
+    /// matched against.
+    /// </param>
+    private sealed record ReconciledWindowClassification(
+        IReadOnlyList<ObservedEmailFlags> StillPresent,
+        IReadOnlyList<StoredEmailId> ConfirmedUnchanged,
+        IReadOnlyList<StoredEmailAwaitingReconciliation> Disappeared);
 }
 
 /// <summary>Summarizes one bounded reconciliation window.</summary>
 /// <param name="ObservedEmailCount">How many stored occurrences the server still holds, whether it described them or only confirmed them.</param>
-/// <param name="RemotelyDeletedEmailCount">How many stored occurrences the folder no longer holds.</param>
+/// <param name="RemotelyDeletedEmailCount">How many stored occurrences the folder no longer holds and nothing MailFathom did accounts for.</param>
+/// <param name="OwnMutationCompletedEmailCount">
+/// How many stored occurrences left the folder because MailFathom relocated or deleted them. They are counted apart from
+/// the remotely deleted ones because they are the opposite finding: a change of the owner's own that has come back
+/// through synchronization, rather than one to react to.
+/// </param>
 /// <param name="EmailsRemain">Whether occurrences still await reconciliation after this window.</param>
 /// <param name="ReconciledThroughModSeq">
 /// The folder modification sequence this pass covered the whole folder through, or <see langword="null" /> when the
@@ -209,6 +326,7 @@ public sealed class MailboxReconciler
 public sealed record MailboxReconciliationResult(
     int ObservedEmailCount,
     int RemotelyDeletedEmailCount,
+    int OwnMutationCompletedEmailCount,
     bool EmailsRemain,
     ulong? ReconciledThroughModSeq)
 {
@@ -221,6 +339,7 @@ public sealed record MailboxReconciliationResult(
     public static MailboxReconciliationResult NothingToReconcile { get; } = new(
         ObservedEmailCount: 0,
         RemotelyDeletedEmailCount: 0,
+        OwnMutationCompletedEmailCount: 0,
         EmailsRemain: false,
         ReconciledThroughModSeq: null);
 }

--- a/src/Application/Synchronization/Reconciliation/ReconciledFolderOutcome.cs
+++ b/src/Application/Synchronization/Reconciliation/ReconciledFolderOutcome.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Mutations;
 
 namespace MailFathom.Application.Synchronization.Reconciliation;
 
@@ -11,13 +12,27 @@ namespace MailFathom.Application.Synchronization.Reconciliation;
 /// <param name="Snapshot">What the server reported, and when it was read.</param>
 public sealed record ObservedEmailFlags(StoredEmailId StoredEmailId, RemoteEmailFlagSnapshot Snapshot);
 
+/// <summary>Pairs one occurrence the folder no longer holds with the change MailFathom made that took it out.</summary>
+/// <param name="StoredEmailId">The local identity whose occurrence has gone.</param>
+/// <param name="MutationRecordId">The durable record of the change that removed it.</param>
+public sealed record MutationAttributedDisappearance(
+    StoredEmailId StoredEmailId,
+    MailboxMutationRecordId MutationRecordId);
+
 /// <summary>Everything one reconciliation window learned, as one thing to apply.</summary>
 /// <param name="StillPresent">The emails the folder still holds, with the flags to write onto them.</param>
 /// <param name="ConfirmedUnchanged">
 /// The emails the folder still holds and reported no change to, so the stored flags already describe them and only the
 /// record of when they were last asked about moves.
 /// </param>
-/// <param name="Disappeared">The emails the folder no longer holds.</param>
+/// <param name="Disappeared">The emails the folder no longer holds and nothing MailFathom did accounts for.</param>
+/// <param name="RemovedByOwnMutation">
+/// The emails the folder no longer holds because MailFathom itself relocated or deleted them, each named with the record
+/// that says so. They are separated from <paramref name="Disappeared" /> before the disposition is reached, because the
+/// disposition answers what becomes of mail somebody else deleted and these are not that. Applying one is applying an
+/// observation and nothing else: the queue timestamp moves so the window can reach further into the folder, and the row
+/// itself is left for the relocation to carry across or for the delete action to decide about.
+/// </param>
 /// <param name="Disposition">What becomes of the local copy of each disappeared email.</param>
 /// <param name="ObservedAt">When this window was read, which orders it against what other writers have recorded.</param>
 /// <remarks>
@@ -42,5 +57,6 @@ public sealed record ReconciledFolderOutcome(
     IReadOnlyList<ObservedEmailFlags> StillPresent,
     IReadOnlyList<StoredEmailId> ConfirmedUnchanged,
     IReadOnlyList<StoredEmailId> Disappeared,
+    IReadOnlyList<MutationAttributedDisappearance> RemovedByOwnMutation,
     RemotelyDeletedEmailDisposition Disposition,
     DateTimeOffset ObservedAt);

--- a/src/Domain/Mutations/MailboxMutationRecord.cs
+++ b/src/Domain/Mutations/MailboxMutationRecord.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
 
 namespace MailFathom.Domain.Mutations;
 
@@ -83,6 +85,105 @@ public sealed record MailboxMutationRecord
     /// </remarks>
     public required MailFathomErrorCode? LastFailure { get; init; }
 
+    /// <summary>Gets when synchronization recognized the occurrence this mutation created, or <see langword="null" /> while it has not.</summary>
+    /// <remarks>
+    /// The stage says what the server acknowledged and this says what synchronization has since seen come back, which
+    /// are different questions with different answers. A relocation is acknowledged the moment the server confirms it,
+    /// and the message still arrives in the destination folder later as an ordinary discovery that something has to
+    /// recognize as this mutation's own.
+    /// </remarks>
+    public required DateTimeOffset? PlacementObservedAt { get; init; }
+
+    /// <summary>Gets when synchronization saw the source occurrence leave its folder, or <see langword="null" /> while it has not.</summary>
+    public required DateTimeOffset? SourceRemovalObservedAt { get; init; }
+
     /// <summary>Gets whether the record has reached a stage nothing moves it out of.</summary>
     public bool IsTerminal => this.Stage is MailboxMutationStage.Completed or MailboxMutationStage.Abandoned;
+
+    /// <summary>Gets whether this mutation puts the email somewhere synchronization will later discover it.</summary>
+    /// <remarks>
+    /// A copy places one too, and is deliberately absent: whether a second live occurrence of one message is one local
+    /// row or two is the copy action's decision rather than this join's, so nothing here carries a row across for one.
+    /// </remarks>
+    public bool ExpectsPlacementObservation => this.Request.Mutation == MailboxMutation.Relocate;
+
+    /// <summary>Gets whether this mutation takes the source occurrence out of the folder it was in.</summary>
+    public bool ExpectsSourceRemovalObservation =>
+        this.Request.Mutation == MailboxMutation.Relocate || this.Request.Mutation == MailboxMutation.Delete;
+
+    /// <summary>Gets whether synchronization has accounted for every occurrence this mutation moved.</summary>
+    /// <remarks>
+    /// This is the terminal state of the join rather than of the protocol sequence, and the two are reached at
+    /// different moments. <see cref="MailboxMutationStage.Completed" /> says the server did what was asked; this says
+    /// the local mailbox has stopped owing anything about it, which is what takes the record out of the candidates a
+    /// later discovery is matched against.
+    /// </remarks>
+    public bool IsReconciled =>
+        (!this.ExpectsPlacementObservation || this.PlacementObservedAt is not null)
+        && (!this.ExpectsSourceRemovalObservation || this.SourceRemovalObservedAt is not null);
+
+    /// <summary>Reports whether a newly discovered occurrence is the one this mutation's placement created.</summary>
+    /// <param name="discoveredFolderPath">The remote path of the folder the occurrence was discovered in.</param>
+    /// <param name="discoveredUidValidity">The UIDVALIDITY that folder reports now.</param>
+    /// <param name="discoveredUid">The UID the discovered occurrence carries.</param>
+    /// <returns><see langword="true" /> when the server itself named this occurrence as where it put the email.</returns>
+    /// <remarks>
+    /// <para>
+    /// The join is the server's own <c>COPYUID</c> answer and nothing else. A record that carries no reported placement
+    /// matches nothing here, because the only way to find the message without one is to search the destination folder
+    /// for something that looks like it — which is a guess about identity rather than a fact, and is exactly what
+    /// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md">ADR 0007</see>
+    /// refuses. A relocation whose placement was never reported leaves the record awaiting its observation, which is
+    /// visible rather than guessed at.
+    /// </para>
+    /// <para>
+    /// The UIDVALIDITY is compared as well as the UID, so a destination folder recreated between the placement and the
+    /// discovery matches nothing: the recorded UID names a message in a UID space the folder no longer has.
+    /// </para>
+    /// <para>
+    /// The stage has to be <see cref="MailboxMutationStage.Completed" />. Anything earlier means the sequence still owes
+    /// a command — a fallback relocation stopped after its copy still has the email in both folders — and carrying the
+    /// local row into the destination then would leave the source occurrence with nothing local pointing at it while
+    /// convergence still has to remove it.
+    /// </para>
+    /// </remarks>
+    public bool IsPlacementOf(
+        RemoteFolderPath discoveredFolderPath,
+        ImapUidValidity discoveredUidValidity,
+        ImapUid discoveredUid) =>
+        this.ExpectsPlacementObservation
+        && this.PlacementObservedAt is null
+        && this.Stage == MailboxMutationStage.Completed
+        && this.Request.DestinationPath is { } destinationPath
+        && string.Equals(destinationPath.Value, discoveredFolderPath.Value, StringComparison.Ordinal)
+        && this.Placement is { UidValidity: { } placedUidValidity, Uid: { } placedUid }
+        && placedUidValidity == discoveredUidValidity
+        && placedUid == discoveredUid;
+
+    /// <summary>Reports whether an occurrence that has left its folder left it because of this mutation.</summary>
+    /// <param name="sourceOccurrence">The occurrence the folder no longer holds.</param>
+    /// <returns><see langword="true" /> when this mutation is what took the occurrence out of the folder.</returns>
+    /// <remarks>
+    /// <para>
+    /// This half needs no <c>COPYUID</c>, because the record names the source occurrence exactly: it is the identity an
+    /// IMAP command was issued against, written down before the command went out. All four components are compared, so
+    /// a folder renumbered under a new UIDVALIDITY matches nothing.
+    /// </para>
+    /// <para>
+    /// A record still at <see cref="MailboxMutationStage.Recorded" /> matches nothing, because nothing has reached the
+    /// server for it and a disappearance is therefore somebody else's act. Every later stage matches, including
+    /// <see cref="MailboxMutationStage.Abandoned" />, and that direction is deliberate: an abandoned relocation may
+    /// have placed the email in the destination folder before it ran out of attempts, and treating the vanished source
+    /// as a remote deletion would erase the local copy of mail that still exists. Attributing one manual deletion to
+    /// MailFathom keeps mail nobody asked to keep; the other way round loses mail.
+    /// </para>
+    /// <para>
+    /// It stays true after the observation has been recorded. The record is a durable fact about that occurrence rather
+    /// than a pending item, so a folder asked about the same disappearance twice gets the same answer both times.
+    /// </para>
+    /// </remarks>
+    public bool AccountsForRemovalOf(EmailOccurrenceId sourceOccurrence) =>
+        this.ExpectsSourceRemovalObservation
+        && this.Stage != MailboxMutationStage.Recorded
+        && this.Request.Occurrence == sourceOccurrence;
 }

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -317,6 +317,15 @@ internal sealed partial class AccountSynchronizationSupervisor
             result.UnreadableMimeEmailCount,
             result.HasMoreEmails);
 
+        if (result.RelocatedEmailCount > 0 || result.Reconciliation.OwnMutationCompletedEmailCount > 0)
+        {
+            this.LogOwnMutationsRecognized(
+                this.accountId.Value,
+                folderAlias,
+                result.RelocatedEmailCount,
+                result.Reconciliation.OwnMutationCompletedEmailCount);
+        }
+
         this.ReportReconciliation(folderAlias, remotelyDeletedEmailDisposition, result.Reconciliation);
     }
 
@@ -407,6 +416,21 @@ internal sealed partial class AccountSynchronizationSupervisor
         string folderAlias,
         int observedEmailCount,
         bool emailsRemain);
+
+    /// <summary>Reports the changes MailFathom made to the mailbox arriving back through an ordinary run.</summary>
+    /// <remarks>
+    /// It is the line that says a message which moved is the same message. Without it an operator reading the counts
+    /// would see mail arriving in one folder and vanishing from another, which is exactly what the join exists to stop
+    /// the system itself from concluding. Counts and MailFathom's own configured names only, as everywhere else here.
+    /// </remarks>
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Recognized MailFathom's own changes in {AccountId}/{FolderAlias}; {RelocatedEmailCount} discovered messages kept the local email they were relocated from, and {OwnMutationCompletedEmailCount} source occurrences left the folder because MailFathom moved or deleted them rather than because somebody else did.")]
+    private partial void LogOwnMutationsRecognized(
+        string accountId,
+        string folderAlias,
+        int relocatedEmailCount,
+        int ownMutationCompletedEmailCount);
 
     /// <summary>Records mail leaving the local copy, which is the one reconciliation outcome an operator has to be able to find afterwards.</summary>
     /// <remarks>

--- a/src/Infrastructure/Persistence/Emails/StoredEmailMetadataRepository.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailMetadataRepository.cs
@@ -31,17 +31,7 @@ internal sealed class StoredEmailMetadataRepository(TimeProvider timeProvider, E
 
         var dbContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
         var occurrenceId = metadata.OccurrenceId;
-        var alias = occurrenceId.FolderResolutionId.Alias.Value;
-        var generation = occurrenceId.FolderResolutionId.Generation.Value;
-        var entity = await TrackedEntityLookup.SinglePendingOrPersistedAsync(
-            dbContext.StoredEmails,
-            dbContext.StoredEmails.Include(candidate => candidate.MailFolder),
-            candidate => candidate.MailFolder.MailboxAccountId == occurrenceId.AccountId.Value
-                && candidate.MailFolder.Alias == alias
-                && candidate.MailFolder.ResolutionGeneration == generation
-                && candidate.UidValidity == occurrenceId.UidValidity.Value
-                && candidate.Uid == occurrenceId.Uid.Value,
-            cancellationToken);
+        var entity = await FindByOccurrenceAsync(dbContext, occurrenceId, cancellationToken);
 
         if (entity is null)
         {
@@ -97,5 +87,67 @@ internal sealed class StoredEmailMetadataRepository(TimeProvider timeProvider, E
         }
 
         return StoredEmailId.Create(entity.Id);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> TryCarryToOccurrenceAsync(
+        IPersistenceSession session,
+        StoredEmailId storedEmailId,
+        EmailOccurrenceId occurrenceId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(occurrenceId);
+
+        var dbContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
+        var occupant = await FindByOccurrenceAsync(dbContext, occurrenceId, cancellationToken);
+
+        // A row already sitting on the occurrence is either this same email, which a previous attempt of this commit
+        // already carried, or a different one, which only the mailbox could say is the wrong occupant.
+        if (occupant is not null)
+        {
+            return occupant.Id == storedEmailId.Value;
+        }
+
+        var entity = await dbContext.StoredEmails.FindAsync([storedEmailId.Value], cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"No stored email carries the identifier {storedEmailId}, so no occurrence can be carried onto it.");
+        var folder = await MailFolderEntityResolver.GetRequiredAsync(
+            dbContext,
+            occurrenceId.AccountId,
+            occurrenceId.FolderResolutionId,
+            cancellationToken);
+
+        entity.MailFolder = folder;
+        entity.MailFolderId = folder.Id;
+        entity.UidValidity = occurrenceId.UidValidity.Value;
+        entity.Uid = occurrenceId.Uid.Value;
+
+        // The stored flags were read in the folder the email has left, and the tombstone, if the source disappearance
+        // was seen first, described an occurrence that no longer exists. Both are cleared so the destination folder's
+        // own window is what says what holds there now.
+        entity.RemoteFlagsObservedAt = null;
+        entity.RemoteExpungeObservedAt = null;
+
+        return true;
+    }
+
+    /// <summary>Reads whatever row already occupies one occurrence, including one this session has staged and not committed.</summary>
+    private static Task<StoredEmailEntity?> FindByOccurrenceAsync(
+        MailFathomDbContext dbContext,
+        EmailOccurrenceId occurrenceId,
+        CancellationToken cancellationToken)
+    {
+        var alias = occurrenceId.FolderResolutionId.Alias.Value;
+        var generation = occurrenceId.FolderResolutionId.Generation.Value;
+
+        return TrackedEntityLookup.SinglePendingOrPersistedAsync(
+            dbContext.StoredEmails,
+            dbContext.StoredEmails.Include(candidate => candidate.MailFolder),
+            candidate => candidate.MailFolder.MailboxAccountId == occurrenceId.AccountId.Value
+                && candidate.MailFolder.Alias == alias
+                && candidate.MailFolder.ResolutionGeneration == generation
+                && candidate.UidValidity == occurrenceId.UidValidity.Value
+                && candidate.Uid == occurrenceId.Uid.Value,
+            cancellationToken);
     }
 }

--- a/src/Infrastructure/Persistence/Entities/MailboxMutationEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/MailboxMutationEntity.cs
@@ -79,6 +79,18 @@ internal sealed class MailboxMutationEntity
     /// <summary>Gets or sets the UID a <c>COPYUID</c> response named, where the server supplied one.</summary>
     public uint? PlacementUid { get; set; }
 
+    /// <summary>Gets or sets when synchronization recognized the occurrence this mutation created, and <see langword="null" /> while it has not.</summary>
+    /// <remarks>
+    /// It is a separate fact from <see cref="Stage" /> because the two are recorded by different runs from different
+    /// answers. The stage says what the server acknowledged when the command was issued; this says that an ordinary
+    /// synchronization run has since discovered the message in the destination folder and joined it to the email it
+    /// already had.
+    /// </remarks>
+    public DateTimeOffset? PlacementObservedAt { get; set; }
+
+    /// <summary>Gets or sets when synchronization saw the source occurrence leave its folder, and <see langword="null" /> while it has not.</summary>
+    public DateTimeOffset? SourceRemovalObservedAt { get; set; }
+
     public int AttemptCount { get; set; }
 
     public DateTimeOffset RecordedAt { get; set; }

--- a/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -90,6 +90,8 @@ internal sealed class MailFathomDbContext : DbContext
 
     internal const string MailboxMutationOutstandingIndexName = "ix_mailbox_mutations_outstanding";
 
+    internal const string MailboxMutationPlacementIndexName = "ix_mailbox_mutations_placement";
+
     private readonly PostgresTextSearchConfiguration textSearchConfiguration;
 
     /// <summary>Initializes a new MailFathom EF Core context.</summary>
@@ -405,6 +407,14 @@ internal sealed class MailFathomDbContext : DbContext
     /// stays in, deliberately: giving up on a change is what makes it stop being retried, and it would be worth nothing
     /// if it also made the change stop being seen.
     /// </para>
+    /// <para>
+    /// The third answers the forward pass of synchronization, which asks of every batch it discovers whether any of
+    /// those UIDs is where a relocation put an email. It is filtered to the records that can still answer yes, so it
+    /// holds one row per relocation in flight rather than one per relocation ever made — and on a mailbox nobody
+    /// relocates into it holds nothing at all, which is what makes the question free to ask on every batch. Reading a
+    /// disappearance back needs no index of its own: it is asked by folder, UIDVALIDITY, and UID, which is the prefix
+    /// the identity index already leads with.
+    /// </para>
     /// </remarks>
     private static void ConfigureMailboxMutationIndexes(EntityTypeBuilder<MailboxMutationEntity> entity)
     {
@@ -423,6 +433,16 @@ internal sealed class MailFathomDbContext : DbContext
         entity.HasIndex(mutation => new { mutation.MailboxAccountId, mutation.RecordedAt })
             .HasDatabaseName(MailboxMutationOutstandingIndexName)
             .HasFilter($"\"{nameof(MailboxMutationEntity.Stage)}\" <> '{nameof(MailboxMutationStage.Completed)}'");
+
+        entity.HasIndex(mutation => new
+        {
+            mutation.MailboxAccountId,
+            mutation.DestinationFolderPath,
+            mutation.PlacementUidValidity,
+            mutation.PlacementUid,
+        })
+            .HasDatabaseName(MailboxMutationPlacementIndexName)
+            .HasFilter($"\"{nameof(MailboxMutationEntity.PlacementObservedAt)}\" IS NULL");
     }
 
     /// <summary>Declares the derived search document and the lexical index built over it.</summary>

--- a/src/Infrastructure/Persistence/Migrations/20260807154642_AddMailboxMutationObservations.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260807154642_AddMailboxMutationObservations.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260807154642_AddMailboxMutationObservations")]
+    partial class AddMailboxMutationObservations
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260807154642_AddMailboxMutationObservations.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260807154642_AddMailboxMutationObservations.cs
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMailboxMutationObservations : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "PlacementObservedAt",
+                table: "mailbox_mutations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "SourceRemovalObservedAt",
+                table: "mailbox_mutations",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mailbox_mutations_placement",
+                table: "mailbox_mutations",
+                columns: new[] { "MailboxAccountId", "DestinationFolderPath", "PlacementUidValidity", "PlacementUid" },
+                filter: "\"PlacementObservedAt\" IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_mailbox_mutations_placement",
+                table: "mailbox_mutations");
+
+            migrationBuilder.DropColumn(
+                name: "PlacementObservedAt",
+                table: "mailbox_mutations");
+
+            migrationBuilder.DropColumn(
+                name: "SourceRemovalObservedAt",
+                table: "mailbox_mutations");
+        }
+    }
+}

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationReconciliationStore.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationReconciliationStore.cs
@@ -1,0 +1,155 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Persistence;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Sessions;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailFathom.Infrastructure.Persistence.Mutations;
+
+/// <summary>Answers, in PostgreSQL, whether an occurrence a synchronization run just met is one MailFathom created.</summary>
+/// <remarks>
+/// <para>
+/// The reads use the scoped context because they join no transaction, and the writes use the context enlisted in the
+/// caller's session, so a record only ever says a change was accounted for inside the transaction that accounted for it.
+/// </para>
+/// <para>
+/// Both reads are asked about a whole batch or a whole window at once. A synchronization run meets far more mail than
+/// MailFathom has ever moved, so the question has to cost one query per batch rather than one per message — and on an
+/// installation that has never written to a mailbox, the partial indexes these queries use hold nothing at all.
+/// </para>
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class MailboxMutationReconciliationStore(MailFathomDbContext readContext)
+    : IMailboxMutationReconciliationStore
+{
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailboxMutationRecord>> ReadRelocationsPlacedAtAsync(
+        MailAccountId accountId,
+        RemoteFolderPath destinationPath,
+        ImapUidValidity uidValidity,
+        IReadOnlyCollection<ImapUid> uids,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(uids);
+
+        if (uids.Count == 0)
+        {
+            return [];
+        }
+
+        var accountValue = accountId.Value;
+        var destinationValue = destinationPath.Value;
+        var uidValidityValue = uidValidity.Value;
+        var relocateName = MailboxMutation.Relocate.Name;
+
+        // Nullable so the comparison is against the column as it is stored: a record whose server named no placement
+        // holds null there and must match nothing, rather than being coerced into a UID it never reported.
+        uint?[] placedUids = [.. uids.Select(static uid => (uint?)uid.Value)];
+
+        var entities = await readContext.MailboxMutations
+            .AsNoTracking()
+            .Include(mutation => mutation.MailFolder)
+            .Where(mutation => mutation.MailboxAccountId == accountValue
+                && mutation.Mutation == relocateName
+                && mutation.Stage == MailboxMutationStage.Completed
+                && mutation.PlacementObservedAt == null
+                && mutation.DestinationFolderPath == destinationValue
+                && mutation.PlacementUidValidity == uidValidityValue
+                && placedUids.Contains(mutation.PlacementUid))
+            .OrderBy(mutation => mutation.RecordedAt)
+            .ThenBy(mutation => mutation.Id)
+            .ToArrayAsync(cancellationToken);
+
+        return [.. entities.Select(static entity => MailboxMutationRecordMapping.ToRecord(entity, entity.MailFolder))];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailboxMutationRecord>> ReadMutationsRemovingAsync(
+        MailAccountId accountId,
+        MailFolderResolutionId folderResolutionId,
+        ImapUidValidity uidValidity,
+        IReadOnlyCollection<ImapUid> uids,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(uids);
+
+        if (uids.Count == 0)
+        {
+            return [];
+        }
+
+        var accountValue = accountId.Value;
+        var alias = folderResolutionId.Alias.Value;
+        var generation = folderResolutionId.Generation.Value;
+        var uidValidityValue = uidValidity.Value;
+        string[] removingMutations = [MailboxMutation.Relocate.Name, MailboxMutation.Delete.Name];
+        uint[] sourceUids = [.. uids.Select(static uid => uid.Value)];
+
+        var entities = await readContext.MailboxMutations
+            .AsNoTracking()
+            .Include(mutation => mutation.MailFolder)
+            .Where(mutation => mutation.MailboxAccountId == accountValue
+                && mutation.MailFolder.Alias == alias
+                && mutation.MailFolder.ResolutionGeneration == generation
+                && mutation.UidValidity == uidValidityValue
+                && sourceUids.Contains(mutation.Uid)
+                && removingMutations.Contains(mutation.Mutation))
+            .OrderBy(mutation => mutation.RecordedAt)
+            .ThenBy(mutation => mutation.Id)
+            .ToArrayAsync(cancellationToken);
+
+        return [.. entities.Select(static entity => MailboxMutationRecordMapping.ToRecord(entity, entity.MailFolder))];
+    }
+
+    /// <inheritdoc />
+    public async Task RecordPlacementObservedAsync(
+        IPersistenceSession session,
+        MailboxMutationRecordId recordId,
+        DateTimeOffset observedAt,
+        CancellationToken cancellationToken)
+    {
+        var entity = await RequireEntityAsync(session, recordId, cancellationToken);
+
+        entity.PlacementObservedAt ??= observedAt;
+
+        // The row has just left the source folder, so no later window can select it there and observe the disappearance
+        // this record would otherwise keep waiting for. The stage that got here is the server's own statement that the
+        // source occurrence is already gone.
+        entity.SourceRemovalObservedAt ??= observedAt;
+    }
+
+    /// <inheritdoc />
+    public async Task RecordSourceRemovalObservedAsync(
+        IPersistenceSession session,
+        MailboxMutationRecordId recordId,
+        DateTimeOffset observedAt,
+        CancellationToken cancellationToken)
+    {
+        var entity = await RequireEntityAsync(session, recordId, cancellationToken);
+
+        entity.SourceRemovalObservedAt ??= observedAt;
+    }
+
+    private static async Task<MailboxMutationEntity> RequireEntityAsync(
+        IPersistenceSession session,
+        MailboxMutationRecordId recordId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        var writeContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
+
+        // A primary-key lookup, so FindAsync already resolves a row this session may have loaded or inserted itself.
+        return await writeContext.MailboxMutations.FindAsync([recordId.Value], cancellationToken)
+            ?? throw new InvalidOperationException($"No mailbox mutation record carries the identifier {recordId}.");
+    }
+}

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordMapping.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordMapping.cs
@@ -1,0 +1,106 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Infrastructure.Persistence.Entities;
+
+namespace MailFathom.Infrastructure.Persistence.Mutations;
+
+/// <summary>Rebuilds the domain record one stored mutation row describes.</summary>
+/// <remarks>
+/// It is shared rather than owned by one store because two adapters read the same rows for different questions — the
+/// performer's, which asks what a mutation still owes, and synchronization's, which asks whether an occurrence it just
+/// met is one MailFathom created. A second mapping would be a second reading of the same row, and the two would drift.
+/// </remarks>
+internal static class MailboxMutationRecordMapping
+{
+    /// <summary>Rebuilds the record a row and its folder binding describe.</summary>
+    /// <param name="entity">The stored row.</param>
+    /// <param name="folder">The binding the source occurrence was read under, which turns a folder key back into an alias and generation.</param>
+    /// <returns>The record that row states.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the row names a mutation or a destination folder path that no longer parses.</exception>
+    internal static MailboxMutationRecord ToRecord(MailboxMutationEntity entity, MailFolderEntity folder)
+    {
+        if (!MailboxMutation.TryParseName(entity.Mutation, out var mutation))
+        {
+            throw new InvalidOperationException(
+                $"Mailbox mutation record {entity.Id} names '{entity.Mutation}', which is not a permitted mutation.");
+        }
+
+        var occurrence = EmailOccurrenceId.Create(
+            MailAccountId.Create(entity.MailboxAccountId),
+            new MailFolderResolutionId(
+                MailFolderAlias.Create(folder.Alias),
+                MailFolderResolutionGeneration.Create(folder.ResolutionGeneration)),
+            ImapUidValidity.Create(entity.UidValidity),
+            ImapUid.Create(entity.Uid));
+
+        return new MailboxMutationRecord
+        {
+            Id = MailboxMutationRecordId.Create(entity.Id),
+            Request = MailboxMutationRequest.Create(
+                StoredEmailId.Create(entity.StoredEmailId),
+                occurrence,
+                mutation,
+                MailboxMutationRequester.Create(entity.RequesterOrigin, entity.RequesterIdentity),
+                ToDestinationPath(entity),
+                entity.DesiredSeenState),
+            Stage = entity.Stage,
+            RequiresSourceRemoval = entity.RequiresSourceRemoval,
+            Placement = ToPlacement(entity),
+            AttemptCount = entity.AttemptCount,
+            RecordedAt = entity.RecordedAt,
+            StageChangedAt = entity.StageChangedAt,
+            LastFailure = ToFailure(entity),
+            PlacementObservedAt = entity.PlacementObservedAt,
+            SourceRemovalObservedAt = entity.SourceRemovalObservedAt,
+        };
+    }
+
+    /// <summary>Restores the destination folder a relocation or a copy named, exactly as it was stored.</summary>
+    /// <remarks>
+    /// The text is not trimmed on the way back, for the reason it was not trimmed on the way in: IMAP permits a quoted
+    /// mailbox name bounded by a space, and normalizing one would name a different mailbox or none at all.
+    /// </remarks>
+    private static RemoteFolderPath? ToDestinationPath(MailboxMutationEntity entity)
+    {
+        if (entity.DestinationFolderPath is null)
+        {
+            return null;
+        }
+
+        return RemoteFolderPath.TryCreate(
+            entity.DestinationFolderPath,
+            entity.DestinationHierarchyDelimiter is { Length: > 0 } delimiter ? delimiter[0] : null,
+            out var destinationPath)
+            ? destinationPath
+            : throw new InvalidOperationException(
+                $"Mailbox mutation record {entity.Id} carries a destination folder path that names no folder.");
+    }
+
+    private static RemoteEmailPlacement ToPlacement(MailboxMutationEntity entity) =>
+        entity is { PlacementUidValidity: { } uidValidity, PlacementUid: { } uid }
+            ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(uidValidity), ImapUid.Create(uid))
+            : RemoteEmailPlacement.NotReported();
+
+    /// <summary>Reads back the code of the failure the last attempt ended in.</summary>
+    /// <remarks>
+    /// A number this build does not recognize is a row written by one that allocated a code since. It is diagnostic
+    /// detail rather than something acted on, so it is reported as absent instead of failing the read of every other
+    /// mutation the account has.
+    /// </remarks>
+    private static MailFathomErrorCode? ToFailure(MailboxMutationEntity entity)
+    {
+        if (entity.LastFailureCode is not { } failureCode)
+        {
+            return null;
+        }
+
+        return MailFathomErrorCode.TryParse(failureCode, out var failure) ? failure : null;
+    }
+}

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordStore.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordStore.cs
@@ -6,9 +6,7 @@ using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
-using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
-using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
@@ -53,7 +51,7 @@ internal sealed class MailboxMutationRecordStore(MailFathomDbContext readContext
         var existing = await FindByIdentityAsync(writeContext, request, folder.Id, cancellationToken);
         if (existing is not null)
         {
-            return ToRecord(existing, folder);
+            return MailboxMutationRecordMapping.ToRecord(existing, folder);
         }
 
         var storedEmail = await writeContext.StoredEmails.FindAsync([request.StoredEmailId.Value], cancellationToken)
@@ -86,7 +84,7 @@ internal sealed class MailboxMutationRecordStore(MailFathomDbContext readContext
 
         writeContext.MailboxMutations.Add(entity);
 
-        return ToRecord(entity, folder);
+        return MailboxMutationRecordMapping.ToRecord(entity, folder);
     }
 
     /// <inheritdoc />
@@ -174,7 +172,7 @@ internal sealed class MailboxMutationRecordStore(MailFathomDbContext readContext
             .Take(limit)
             .ToArrayAsync(cancellationToken);
 
-        return [.. entities.Select(entity => ToRecord(entity, entity.MailFolder))];
+        return [.. entities.Select(entity => MailboxMutationRecordMapping.ToRecord(entity, entity.MailFolder))];
     }
 
     /// <summary>Refuses a stage that would pull the record backwards or move it out of a terminal one.</summary>
@@ -218,84 +216,6 @@ internal sealed class MailboxMutationRecordStore(MailFathomDbContext readContext
                 mutation.RequesterIdentity == identity &&
                 mutation.Mutation == mutationName,
             cancellationToken);
-    }
-
-    private static MailboxMutationRecord ToRecord(MailboxMutationEntity entity, MailFolderEntity folder)
-    {
-        if (!MailboxMutation.TryParseName(entity.Mutation, out var mutation))
-        {
-            throw new InvalidOperationException(
-                $"Mailbox mutation record {entity.Id} names '{entity.Mutation}', which is not a permitted mutation.");
-        }
-
-        var occurrence = EmailOccurrenceId.Create(
-            MailAccountId.Create(entity.MailboxAccountId),
-            new MailFolderResolutionId(
-                MailFolderAlias.Create(folder.Alias),
-                MailFolderResolutionGeneration.Create(folder.ResolutionGeneration)),
-            ImapUidValidity.Create(entity.UidValidity),
-            ImapUid.Create(entity.Uid));
-
-        return new MailboxMutationRecord
-        {
-            Id = MailboxMutationRecordId.Create(entity.Id),
-            Request = MailboxMutationRequest.Create(
-                StoredEmailId.Create(entity.StoredEmailId),
-                occurrence,
-                mutation,
-                MailboxMutationRequester.Create(entity.RequesterOrigin, entity.RequesterIdentity),
-                ToDestinationPath(entity),
-                entity.DesiredSeenState),
-            Stage = entity.Stage,
-            RequiresSourceRemoval = entity.RequiresSourceRemoval,
-            Placement = ToPlacement(entity),
-            AttemptCount = entity.AttemptCount,
-            RecordedAt = entity.RecordedAt,
-            StageChangedAt = entity.StageChangedAt,
-            LastFailure = ToFailure(entity),
-        };
-    }
-
-    /// <summary>Restores the destination folder a relocation or a copy named, exactly as it was stored.</summary>
-    /// <remarks>
-    /// The text is not trimmed on the way back, for the reason it was not trimmed on the way in: IMAP permits a quoted
-    /// mailbox name bounded by a space, and normalizing one would name a different mailbox or none at all.
-    /// </remarks>
-    private static RemoteFolderPath? ToDestinationPath(MailboxMutationEntity entity)
-    {
-        if (entity.DestinationFolderPath is null)
-        {
-            return null;
-        }
-
-        return RemoteFolderPath.TryCreate(
-            entity.DestinationFolderPath,
-            entity.DestinationHierarchyDelimiter is { Length: > 0 } delimiter ? delimiter[0] : null,
-            out var destinationPath)
-            ? destinationPath
-            : throw new InvalidOperationException(
-                $"Mailbox mutation record {entity.Id} carries a destination folder path that names no folder.");
-    }
-
-    private static RemoteEmailPlacement ToPlacement(MailboxMutationEntity entity) =>
-        entity is { PlacementUidValidity: { } uidValidity, PlacementUid: { } uid }
-            ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(uidValidity), ImapUid.Create(uid))
-            : RemoteEmailPlacement.NotReported();
-
-    /// <summary>Reads back the code of the failure the last attempt ended in.</summary>
-    /// <remarks>
-    /// A number this build does not recognize is a row written by one that allocated a code since. It is diagnostic
-    /// detail rather than something acted on, so it is reported as absent instead of failing the read of every other
-    /// mutation the account has.
-    /// </remarks>
-    private static MailFathomErrorCode? ToFailure(MailboxMutationEntity entity)
-    {
-        if (entity.LastFailureCode is not { } failureCode)
-        {
-            return null;
-        }
-
-        return MailFathomErrorCode.TryParse(failureCode, out var failure) ? failure : null;
     }
 
     private static async Task<MailboxMutationEntity> RequireEntityAsync(

--- a/src/Infrastructure/Persistence/Synchronization/StoredEmailReconciliationStore.cs
+++ b/src/Infrastructure/Persistence/Synchronization/StoredEmailReconciliationStore.cs
@@ -98,6 +98,18 @@ internal sealed class StoredEmailReconciliationStore(MailFathomDbContext readCon
             }
         }
 
+        // A disappearance MailFathom itself caused moves the queue timestamp and nothing else. The row is on its way
+        // into another folder, or it is the local copy of a message the owner deleted on the server and what becomes of
+        // it is the delete action's own decision; neither is the remote deletion the disposition below answers for.
+        foreach (var attributed in outcome.RemovedByOwnMutation)
+        {
+            if (rowsById.TryGetValue(attributed.StoredEmailId.Value, out var row)
+                && !HasNewerObservationThan(row, outcome.ObservedAt))
+            {
+                row.RemoteFlagsObservedAt = outcome.ObservedAt;
+            }
+        }
+
         var disappeared = outcome.Disappeared
             .Select(storedEmailId => rowsById.GetValueOrDefault(storedEmailId.Value))
             .OfType<StoredEmailEntity>()
@@ -158,6 +170,7 @@ internal sealed class StoredEmailReconciliationStore(MailFathomDbContext readCon
             .Select(static observed => observed.StoredEmailId.Value)
             .Concat(outcome.ConfirmedUnchanged.Select(static storedEmailId => storedEmailId.Value))
             .Concat(outcome.Disappeared.Select(static storedEmailId => storedEmailId.Value))
+            .Concat(outcome.RemovedByOwnMutation.Select(static attributed => attributed.StoredEmailId.Value))
             .ToArray();
 
         var rows = await sessionContext.StoredEmails

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -253,6 +253,9 @@ public static class ServiceCollectionExtensions
         // The record is written before the session that acts on it is opened, so the store is registered beside the
         // other repositories that take a persistence session rather than with the mail adapters above.
         services.AddScoped<IMailboxMutationRecordStore, MailboxMutationRecordStore>();
+        // Read by synchronization rather than by the performer, so that a relocation coming back through an ordinary
+        // run is recognized as MailFathom's own instead of being stored as a second email.
+        services.AddScoped<IMailboxMutationReconciliationStore, MailboxMutationReconciliationStore>();
         services.AddScoped<IMailboxMutationPerformer, MailboxMutationPerformer>();
         services.AddScoped<IRemoteFolderCatalog>(provider => new MailKitRemoteFolderCatalog(
             static () => new ImapClient(),

--- a/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -165,6 +165,71 @@ public sealed class MailboxSynchronizerTests
         Assert.True(observed.IsReconciled);
     }
 
+    /// <summary>An occurrence another local email already occupies is stored rather than carried, because only the mailbox could say which of the two is right.</summary>
+    /// <remarks>
+    /// Falling through is what leaves the duplicate visible instead of failing the run, and the record stays unobserved
+    /// so the relocation is still something an operator can find. The two together are what a regression that quietly
+    /// marked the mutation observed, or threw, would cost.
+    /// </remarks>
+    [Fact]
+    public async Task SynchronizeAsync_DiscoveredPlacementAlreadyOccupiedByAnotherEmail_StoresTheDiscoveryAndLeavesTheRecordUnobserved()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var uid = ImapUid.Create(10);
+        var occurrence = EmailOccurrenceId.Create(accountId, InboxFolder.Id, uidValidity, uid);
+        var relocatedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        var record = RelocationPlacedInInbox(accountId, relocatedEmailId, uidValidity, uid);
+        mutationStore.Add(record);
+        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionScopeFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(persistenceSession);
+        persistenceSession.CommitAsync(Arg.Any<CancellationToken>()).Returns(PersistenceCommitResult.Committed);
+        metadataRepository
+            .TryCarryToOccurrenceAsync(persistenceSession, relocatedEmailId, occurrence, Arg.Any<CancellationToken>())
+            .Returns(false);
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 8, 7, 12, 0, 0, TimeSpan.Zero));
+        await using var session = CreateSessionDiscovering(occurrence, uidValidity);
+        session
+            .FetchEmailContentWithoutSettingSeenAsync(occurrence, Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(RemoteEmailContentFetchResult.Retrieved(
+                new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]))));
+        var synchronizer = CreateSynchronizer(
+            CreateSessionFactoryFor(accountId, session),
+            CreateCheckpointStoreAt(accountId, uidValidity),
+            sessionScopeFactory,
+            metadataRepository,
+            contentStore: Substitute.For<IEmailContentStore>(),
+            clock,
+            new MailboxSynchronizationOptions(),
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, result.RelocatedEmailCount);
+        Assert.Equal(1, result.StoredEmailCount);
+        await metadataRepository.Received(1).TryCarryToOccurrenceAsync(
+            persistenceSession,
+            relocatedEmailId,
+            occurrence,
+            Arg.Any<CancellationToken>());
+        await metadataRepository.Received(1).UpsertMetadataAsync(
+            persistenceSession,
+            Arg.Any<RemoteEmailMetadata>(),
+            Arg.Any<ExtractedEmailMetadata?>(),
+            StoredEmailContentAvailability.Available,
+            Arg.Any<CancellationToken>());
+
+        var unobserved = mutationStore.RecordOf(record.Id);
+        Assert.Null(unobserved.PlacementObservedAt);
+        Assert.Null(unobserved.SourceRemovalObservedAt);
+    }
+
     /// <summary>A server that named no placement is joined to nothing, so the discovery is stored exactly as it is today.</summary>
     [Fact]
     public async Task SynchronizeAsync_RelocationWhoseServerNamedNoPlacement_StoresTheDiscoveryAsAnyOtherNewMessage()

--- a/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -12,9 +12,11 @@ using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.Synchronization.Reconciliation;
 using MailFathom.Application.Synchronization.Sessions;
+using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Synchronization;
 using MailFathom.Domain.Transport;
 using Microsoft.Extensions.Time.Testing;
@@ -95,6 +97,129 @@ public sealed class MailboxSynchronizerTests
         await metadataRepository.Received(1).UpsertMetadataAsync(persistenceSession, metadata, Arg.Any<ExtractedEmailMetadata?>(), StoredEmailContentAvailability.Available, CancellationToken.None);
         await contentStore.Received(1).SaveContentAsync(persistenceSession, storedEmailId, content, CancellationToken.None);
         await checkpointStore.Received(1).SaveCheckpointAsync(persistenceSession, accountId, folder.Id, Arg.Any<SynchronizationCheckpoint?>(), Arg.Is<SynchronizationCheckpoint>(checkpoint => checkpoint!.LastSeenUid == uid), CancellationToken.None);
+    }
+
+    /// <summary>A message MailFathom relocated arrives in its new folder as an ordinary discovery, and is the email it already had.</summary>
+    /// <remarks>
+    /// It costs no fetch and no metadata write, because the message is the one already stored and everything derived
+    /// from it is keyed by the local identity being carried across rather than by the occurrence it sits at.
+    /// </remarks>
+    [Fact]
+    public async Task SynchronizeAsync_DiscoversTheOccurrenceARelocationPlaced_CarriesTheLocalEmailAcrossInsteadOfStoringASecond()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var uid = ImapUid.Create(10);
+        var occurrence = EmailOccurrenceId.Create(accountId, InboxFolder.Id, uidValidity, uid);
+        var relocatedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        var record = RelocationPlacedInInbox(accountId, relocatedEmailId, uidValidity, uid);
+        mutationStore.Add(record);
+        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionScopeFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(persistenceSession);
+        persistenceSession.CommitAsync(Arg.Any<CancellationToken>()).Returns(PersistenceCommitResult.Committed);
+        metadataRepository
+            .TryCarryToOccurrenceAsync(persistenceSession, relocatedEmailId, occurrence, Arg.Any<CancellationToken>())
+            .Returns(true);
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 8, 7, 12, 0, 0, TimeSpan.Zero));
+        await using var session = CreateSessionDiscovering(occurrence, uidValidity);
+        var synchronizer = CreateSynchronizer(
+            CreateSessionFactoryFor(accountId, session),
+            CreateCheckpointStoreAt(accountId, uidValidity),
+            sessionScopeFactory,
+            metadataRepository,
+            contentStore: Substitute.For<IEmailContentStore>(),
+            clock,
+            new MailboxSynchronizationOptions(),
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.RelocatedEmailCount);
+        Assert.Equal(0, result.StoredEmailCount);
+        await metadataRepository.Received(1).TryCarryToOccurrenceAsync(
+            persistenceSession,
+            relocatedEmailId,
+            occurrence,
+            Arg.Any<CancellationToken>());
+        await metadataRepository.DidNotReceiveWithAnyArgs().UpsertMetadataAsync(
+            Arg.Any<IPersistenceSession>(),
+            Arg.Any<RemoteEmailMetadata>(),
+            Arg.Any<ExtractedEmailMetadata?>(),
+            Arg.Any<StoredEmailContentAvailability>(),
+            Arg.Any<CancellationToken>());
+        await session.DidNotReceiveWithAnyArgs().FetchEmailContentWithoutSettingSeenAsync(
+            Arg.Any<EmailOccurrenceId>(),
+            Arg.Any<long>(),
+            Arg.Any<CancellationToken>());
+
+        // Both halves settle here: the row has just left the source folder, so no later window can select it there to
+        // observe the disappearance the record would otherwise still be waiting for.
+        var observed = mutationStore.RecordOf(record.Id);
+        Assert.Equal(clock.GetUtcNow(), observed.PlacementObservedAt);
+        Assert.True(observed.IsReconciled);
+    }
+
+    /// <summary>A server that named no placement is joined to nothing, so the discovery is stored exactly as it is today.</summary>
+    [Fact]
+    public async Task SynchronizeAsync_RelocationWhoseServerNamedNoPlacement_StoresTheDiscoveryAsAnyOtherNewMessage()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var uid = ImapUid.Create(10);
+        var occurrence = EmailOccurrenceId.Create(accountId, InboxFolder.Id, uidValidity, uid);
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        var record = RelocationPlacedInInbox(accountId, StoredEmailId.Create(Guid.CreateVersion7()), uidValidity, uid)
+            with
+        {
+            Placement = RemoteEmailPlacement.NotReported(),
+        };
+        mutationStore.Add(record);
+        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionScopeFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(persistenceSession);
+        persistenceSession.CommitAsync(Arg.Any<CancellationToken>()).Returns(PersistenceCommitResult.Committed);
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 8, 7, 12, 0, 0, TimeSpan.Zero));
+        await using var session = CreateSessionDiscovering(occurrence, uidValidity);
+        session
+            .FetchEmailContentWithoutSettingSeenAsync(occurrence, Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(RemoteEmailContentFetchResult.Retrieved(
+                new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]))));
+        var synchronizer = CreateSynchronizer(
+            CreateSessionFactoryFor(accountId, session),
+            CreateCheckpointStoreAt(accountId, uidValidity),
+            sessionScopeFactory,
+            metadataRepository,
+            contentStore: Substitute.For<IEmailContentStore>(),
+            clock,
+            new MailboxSynchronizationOptions(),
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, result.RelocatedEmailCount);
+        Assert.Equal(1, result.StoredEmailCount);
+        await metadataRepository.DidNotReceiveWithAnyArgs().TryCarryToOccurrenceAsync(
+            Arg.Any<IPersistenceSession>(),
+            Arg.Any<StoredEmailId>(),
+            Arg.Any<EmailOccurrenceId>(),
+            Arg.Any<CancellationToken>());
+        await metadataRepository.Received(1).UpsertMetadataAsync(
+            persistenceSession,
+            Arg.Any<RemoteEmailMetadata>(),
+            Arg.Any<ExtractedEmailMetadata?>(),
+            StoredEmailContentAvailability.Available,
+            Arg.Any<CancellationToken>());
+        Assert.Null(mutationStore.RecordOf(record.Id).PlacementObservedAt);
     }
 
     [Fact]
@@ -1578,6 +1703,89 @@ public sealed class MailboxSynchronizerTests
         return reader;
     }
 
+    /// <summary>Builds the record a relocation into the folder under synchronization would have left, with the placement the server named.</summary>
+    private static MailboxMutationRecord RelocationPlacedInInbox(
+        MailAccountId accountId,
+        StoredEmailId relocatedEmailId,
+        ImapUidValidity placedUidValidity,
+        ImapUid placedUid)
+    {
+        var sourceBinding = new MailFolderResolutionId(
+            MailFolderAlias.Create("later"),
+            MailFolderResolutionGeneration.First);
+        var recordedAt = new DateTimeOffset(2026, 8, 7, 11, 0, 0, TimeSpan.Zero);
+
+        return new MailboxMutationRecord
+        {
+            Id = MailboxMutationRecordId.Create(Guid.CreateVersion7(recordedAt)),
+            Request = MailboxMutationRequest.Relocate(
+                relocatedEmailId,
+                EmailOccurrenceId.Create(accountId, sourceBinding, ImapUidValidity.Create(3), ImapUid.Create(41)),
+                MailboxMutationRequester.Rule("file-newsletters", 1),
+                InboxFolder.RemotePath),
+            Stage = MailboxMutationStage.Completed,
+            RequiresSourceRemoval = true,
+            Placement = RemoteEmailPlacement.Reported(placedUidValidity, placedUid),
+            AttemptCount = 1,
+            RecordedAt = recordedAt,
+            StageChangedAt = recordedAt,
+            LastFailure = null,
+            PlacementObservedAt = null,
+            SourceRemovalObservedAt = null,
+        };
+    }
+
+    /// <summary>Builds a session whose folder holds exactly one newly discovered occurrence and nothing awaiting reconciliation.</summary>
+    private static IMailboxSession CreateSessionDiscovering(EmailOccurrenceId occurrence, ImapUidValidity uidValidity)
+    {
+        var session = Substitute.For<IMailboxSession>();
+        var metadata = new RemoteEmailMetadata(
+            occurrence,
+            "relocated@example.test",
+            "Subject",
+            new DateTimeOffset(2026, 8, 7, 8, 0, 0, TimeSpan.Zero),
+            128);
+
+        session.GetUidValidityAsync(Arg.Any<CancellationToken>()).Returns(uidValidity);
+        session
+            .GetEmailBatchAfterAsync(
+                Arg.Any<ImapUid?>(),
+                Arg.Any<int>(),
+                Arg.Any<MailSynchronizationWindow>(),
+                Arg.Any<CancellationToken>())
+            .Returns(
+                _ => new RemoteEmailMetadataBatch([metadata], occurrence.Uid, HasMore: false),
+                _ => new RemoteEmailMetadataBatch([], InspectedThroughUid: null, HasMore: false));
+
+        return session;
+    }
+
+    private static IMailboxSessionFactory CreateSessionFactoryFor(MailAccountId accountId, IMailboxSession session)
+    {
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        sessionFactory
+            .OpenReadOnlyAsync(
+                accountId,
+                InboxFolder,
+                Arg.Any<MailTransportSecurityPolicy>(),
+                Arg.Any<CancellationToken>())
+            .Returns(session);
+
+        return sessionFactory;
+    }
+
+    private static ISynchronizationCheckpointStore CreateCheckpointStoreAt(
+        MailAccountId accountId,
+        ImapUidValidity uidValidity)
+    {
+        var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
+        checkpointStore
+            .GetCheckpointAsync(accountId, InboxFolder.Id, Arg.Any<CancellationToken>())
+            .Returns(SynchronizationCheckpoint.None(uidValidity));
+
+        return checkpointStore;
+    }
+
     private static MailboxSynchronizer CreateSynchronizer(
         IMailboxSessionFactory mailboxSessionFactory,
         ISynchronizationCheckpointStore checkpointStore,
@@ -1590,12 +1798,14 @@ public sealed class MailboxSynchronizerTests
         MailFolderResolver? folderResolver = null,
         IEmailMimeReader? mimeReader = null,
         MailSynchronizationWindow synchronizationWindow = default,
-        IStoredEmailReconciliationStore? reconciliationStore = null)
+        IStoredEmailReconciliationStore? reconciliationStore = null,
+        InMemoryMailboxMutationReconciliationStore? mutationStore = null)
     {
         var concurrencyRetryPolicy = new OptimisticConcurrencyRetryPolicy(
             persistenceSessionFactory,
             new PersistenceConcurrencyOptions(),
             timeProvider);
+        var mutations = mutationStore ?? new InMemoryMailboxMutationReconciliationStore();
 
         return new MailboxSynchronizer(
             folderResolver ?? CreateFolderResolverBoundToInbox(persistenceSessionFactory, timeProvider),
@@ -1607,8 +1817,10 @@ public sealed class MailboxSynchronizerTests
             metadataRepository,
             contentStore,
             mimeReader ?? CreateMimeReaderThatExtractsEverything(),
+            mutations,
             new MailboxReconciler(
                 reconciliationStore ?? CreateReconciliationStoreWithNothingToDo(),
+                mutations,
                 CreateDispositionReader(RemotelyDeletedEmailDisposition.RetainTombstone),
                 concurrencyRetryPolicy,
                 timeProvider,

--- a/tests/Application.UnitTests/Synchronization/Reconciliation/MailboxReconcilerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/Reconciliation/MailboxReconcilerTests.cs
@@ -6,9 +6,11 @@ using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Reconciliation;
 using MailFathom.Application.Synchronization.Sessions;
+using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -75,6 +77,81 @@ public sealed class MailboxReconcilerTests
         Assert.Equal(1, result.RemotelyDeletedEmailCount);
         Assert.Equal([11U], store.RemovedUids);
         Assert.Empty(store.TombstonedUids);
+    }
+
+    /// <summary>An occurrence MailFathom moved or deleted itself left the folder because of that, not because somebody else deleted it.</summary>
+    /// <remarks>
+    /// The account erases local copies, which is the setting that makes the difference visible: without the record the
+    /// row would be destroyed here, and for a relocation that would erase the local copy of mail that still exists in
+    /// another folder.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ReconcileAsync_OccurrenceRemovedByAMutationMailFathomMade_AttributesItInsteadOfErasingTheLocalCopy(
+        bool isRelocation)
+    {
+        // Arrange
+        var store = new FakeReconciliationStore(StoredOccurrences(10, 11));
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        var record = MutationRemoving(store.StoredEmailIdOf(11), uid: 11, isRelocation);
+        mutationStore.Add(record);
+        await using var mailboxSession = CreateSessionHolding(10);
+        var reconciler = CreateReconciler(
+            store,
+            RemotelyDeletedEmailDisposition.EraseLocalCopy,
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await reconciler.ReconcileAsync(
+            mailboxSession,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, result.RemotelyDeletedEmailCount);
+        Assert.Equal(1, result.OwnMutationCompletedEmailCount);
+        Assert.Empty(store.RemovedUids);
+        Assert.Empty(store.TombstonedUids);
+        Assert.Equal(RunInstant, mutationStore.RecordOf(record.Id).SourceRemovalObservedAt);
+
+        // The observation moves so the window reaches further into the folder on the next run rather than selecting
+        // the same occurrence forever.
+        Assert.Equal(RunInstant, store.RowOf(11).ObservedAt);
+    }
+
+    /// <summary>A disappearance seen before the destination folder is synchronized settles one half and leaves the other owing.</summary>
+    [Fact]
+    public async Task ReconcileAsync_RelocationSourceSeenBeforeItsPlacement_LeavesThePlacementStillAwaited()
+    {
+        // Arrange
+        var store = new FakeReconciliationStore(StoredOccurrences(11));
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        var record = MutationRemoving(store.StoredEmailIdOf(11), uid: 11, isRelocation: true);
+        mutationStore.Add(record);
+        await using var mailboxSession = CreateSessionHolding();
+        var reconciler = CreateReconciler(
+            store,
+            RemotelyDeletedEmailDisposition.RetainTombstone,
+            mutationStore: mutationStore);
+
+        // Act
+        await reconciler.ReconcileAsync(
+            mailboxSession,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        // Assert
+        var observed = mutationStore.RecordOf(record.Id);
+        Assert.Equal(RunInstant, observed.SourceRemovalObservedAt);
+        Assert.Null(observed.PlacementObservedAt);
+        Assert.False(observed.IsReconciled);
     }
 
     /// <summary>A message read on another client changes its flags, and the stored snapshot has to follow.</summary>
@@ -587,7 +664,8 @@ public sealed class MailboxReconcilerTests
         FakeReconciliationStore store,
         RemotelyDeletedEmailDisposition disposition,
         int maxReconciledEmailsPerRun = 100,
-        FakeTimeProvider? timeProvider = null)
+        FakeTimeProvider? timeProvider = null,
+        InMemoryMailboxMutationReconciliationStore? mutationStore = null)
     {
         var clock = timeProvider ?? new FakeTimeProvider(RunInstant);
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
@@ -598,10 +676,41 @@ public sealed class MailboxReconcilerTests
 
         return new MailboxReconciler(
             store,
+            mutationStore ?? new InMemoryMailboxMutationReconciliationStore(),
             dispositionReader,
             new OptimisticConcurrencyRetryPolicy(sessionFactory, new PersistenceConcurrencyOptions(), clock),
             clock,
             new MailboxSynchronizationOptions { MaxReconciledEmailsPerRun = maxReconciledEmailsPerRun });
+    }
+
+    /// <summary>Builds the record a completed relocation or delete of one stored occurrence would have left behind.</summary>
+    private static MailboxMutationRecord MutationRemoving(StoredEmailId storedEmailId, uint uid, bool isRelocation)
+    {
+        var occurrence = EmailOccurrenceId.Create(Account, InboxFolder.Id, SelectedUidValidity, ImapUid.Create(uid));
+        var requester = MailboxMutationRequester.Rule("file-newsletters", 1);
+
+        return new MailboxMutationRecord
+        {
+            Id = MailboxMutationRecordId.Create(Guid.CreateVersion7(RunInstant)),
+            Request = isRelocation
+                ? MailboxMutationRequest.Relocate(
+                    storedEmailId,
+                    occurrence,
+                    requester,
+                    RemoteFolderPath.Create("Archive", '/'))
+                : MailboxMutationRequest.Delete(storedEmailId, occurrence, requester),
+            Stage = MailboxMutationStage.Completed,
+            RequiresSourceRemoval = isRelocation,
+            Placement = isRelocation
+                ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(99), ImapUid.Create(4))
+                : RemoteEmailPlacement.NotReported(),
+            AttemptCount = 1,
+            RecordedAt = RunInstant,
+            StageChangedAt = RunInstant,
+            LastFailure = null,
+            PlacementObservedAt = null,
+            SourceRemovalObservedAt = null,
+        };
     }
 
     private static IReadOnlyList<StoredOccurrence> StoredOccurrences(params uint[] uids) =>
@@ -647,6 +756,9 @@ public sealed class MailboxReconcilerTests
         private readonly List<uint> removedUids = [];
 
         public ReconciledRow RowOf(uint uid) => this.rowsById.Values.Single(row => row.Uid == uid);
+
+        public StoredEmailId StoredEmailIdOf(uint uid) =>
+            this.rowsById.Single(entry => entry.Value.Uid == uid).Key;
 
         public Task<IReadOnlyList<StoredEmailAwaitingReconciliation>> GetReconciliationWindowAsync(
             MailAccountId accountId,
@@ -715,6 +827,15 @@ public sealed class MailboxReconcilerTests
                     && !HasNewerObservationThan(confirmedRow, outcome.ObservedAt))
                 {
                     confirmedRow.ObservedAt = outcome.ObservedAt;
+                }
+            }
+
+            foreach (var attributed in outcome.RemovedByOwnMutation)
+            {
+                if (this.rowsById.TryGetValue(attributed.StoredEmailId, out var attributedRow)
+                    && !HasNewerObservationThan(attributedRow, outcome.ObservedAt))
+                {
+                    attributedRow.ObservedAt = outcome.ObservedAt;
                 }
             }
 

--- a/tests/Application.UnitTests/Synchronization/Reconciliation/MailboxReconcilerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/Reconciliation/MailboxReconcilerTests.cs
@@ -123,6 +123,50 @@ public sealed class MailboxReconcilerTests
         Assert.Equal(RunInstant, store.RowOf(11).ObservedAt);
     }
 
+    /// <summary>One occurrence can carry several records, and the disappearance is credited to the one that has been outstanding longest.</summary>
+    /// <remarks>
+    /// The case is real rather than theoretical: a record matches at every stage past <c>Recorded</c>, abandoned
+    /// included, so a completed relocation and a later mutation that gave up on the same source occurrence both
+    /// qualify. Which one is credited changes nothing about the local row — the point is that the disappearance is
+    /// attributed once, and to the record that describes the change that actually moved the message.
+    /// </remarks>
+    [Fact]
+    public async Task ReconcileAsync_OccurrenceCarryingSeveralRecords_AttributesTheDisappearanceToTheOldestOnlyOnce()
+    {
+        // Arrange
+        var store = new FakeReconciliationStore(StoredOccurrences(11));
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        var storedEmailId = store.StoredEmailIdOf(11);
+        var oldest = MutationRemoving(storedEmailId, uid: 11, isRelocation: true);
+        var later = MutationRemoving(storedEmailId, uid: 11, isRelocation: false, RunInstant.AddMinutes(5))
+            with
+        {
+            Stage = MailboxMutationStage.Abandoned,
+        };
+        mutationStore.Add(oldest);
+        mutationStore.Add(later);
+        await using var mailboxSession = CreateSessionHolding();
+        var reconciler = CreateReconciler(
+            store,
+            RemotelyDeletedEmailDisposition.RetainTombstone,
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await reconciler.ReconcileAsync(
+            mailboxSession,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.OwnMutationCompletedEmailCount);
+        Assert.Equal(0, result.RemotelyDeletedEmailCount);
+        Assert.Equal(RunInstant, mutationStore.RecordOf(oldest.Id).SourceRemovalObservedAt);
+        Assert.Null(mutationStore.RecordOf(later.Id).SourceRemovalObservedAt);
+    }
+
     /// <summary>A disappearance seen before the destination folder is synchronized settles one half and leaves the other owing.</summary>
     [Fact]
     public async Task ReconcileAsync_RelocationSourceSeenBeforeItsPlacement_LeavesThePlacementStillAwaited()
@@ -684,14 +728,19 @@ public sealed class MailboxReconcilerTests
     }
 
     /// <summary>Builds the record a completed relocation or delete of one stored occurrence would have left behind.</summary>
-    private static MailboxMutationRecord MutationRemoving(StoredEmailId storedEmailId, uint uid, bool isRelocation)
+    private static MailboxMutationRecord MutationRemoving(
+        StoredEmailId storedEmailId,
+        uint uid,
+        bool isRelocation,
+        DateTimeOffset? recordedAt = null)
     {
         var occurrence = EmailOccurrenceId.Create(Account, InboxFolder.Id, SelectedUidValidity, ImapUid.Create(uid));
         var requester = MailboxMutationRequester.Rule("file-newsletters", 1);
+        var opened = recordedAt ?? RunInstant;
 
         return new MailboxMutationRecord
         {
-            Id = MailboxMutationRecordId.Create(Guid.CreateVersion7(RunInstant)),
+            Id = MailboxMutationRecordId.Create(Guid.CreateVersion7(opened)),
             Request = isRelocation
                 ? MailboxMutationRequest.Relocate(
                     storedEmailId,
@@ -705,8 +754,8 @@ public sealed class MailboxReconcilerTests
                 ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(99), ImapUid.Create(4))
                 : RemoteEmailPlacement.NotReported(),
             AttemptCount = 1,
-            RecordedAt = RunInstant,
-            StageChangedAt = RunInstant,
+            RecordedAt = opened,
+            StageChangedAt = opened,
             LastFailure = null,
             PlacementObservedAt = null,
             SourceRemovalObservedAt = null,

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationReconciliationStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationReconciliationStore.cs
@@ -13,9 +13,17 @@ namespace MailFathom.Application.UnitTests.TestDoubles;
 
 /// <summary>Holds mutation records in memory and answers the two questions a synchronization run asks of them.</summary>
 /// <remarks>
+/// <para>
 /// The reads reproduce the filters the port documents rather than returning everything and leaving the domain predicate
 /// to sort it out. A fake that answered more broadly than the real query would let a record the database never returns
 /// still decide a test, so the narrowing is part of what is being reproduced.
+/// </para>
+/// <para>
+/// They reproduce its ordering for the same reason. Attributing one disappearance to the oldest of several records is
+/// the first match in that order, so a fake ordering by the timestamp alone would decide a tied-timestamp test on
+/// whatever order the dictionary happened to enumerate — behavior the real store does not have, because it breaks the
+/// tie on the identifier.
+/// </para>
 /// </remarks>
 internal sealed class InMemoryMailboxMutationReconciliationStore : IMailboxMutationReconciliationStore
 {
@@ -48,7 +56,8 @@ internal sealed class InMemoryMailboxMutationReconciliationStore : IMailboxMutat
                     && record.Placement.UidValidity == uidValidity
                     && record.Placement.Uid is { } placedUid
                     && uids.Contains(placedUid))
-                .OrderBy(record => record.RecordedAt),
+                .OrderBy(record => record.RecordedAt)
+                .ThenBy(record => record.Id.Value),
         ];
 
         return Task.FromResult(placed);
@@ -73,7 +82,8 @@ internal sealed class InMemoryMailboxMutationReconciliationStore : IMailboxMutat
                     && uids.Contains(record.Request.Occurrence.Uid)
                     && (record.Request.Mutation == MailboxMutation.Relocate
                         || record.Request.Mutation == MailboxMutation.Delete))
-                .OrderBy(record => record.RecordedAt),
+                .OrderBy(record => record.RecordedAt)
+                .ThenBy(record => record.Id.Value),
         ];
 
         return Task.FromResult(removing);

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationReconciliationStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationReconciliationStore.cs
@@ -1,0 +1,121 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.UnitTests.TestDoubles;
+
+/// <summary>Holds mutation records in memory and answers the two questions a synchronization run asks of them.</summary>
+/// <remarks>
+/// The reads reproduce the filters the port documents rather than returning everything and leaving the domain predicate
+/// to sort it out. A fake that answered more broadly than the real query would let a record the database never returns
+/// still decide a test, so the narrowing is part of what is being reproduced.
+/// </remarks>
+internal sealed class InMemoryMailboxMutationReconciliationStore : IMailboxMutationReconciliationStore
+{
+    private readonly Dictionary<MailboxMutationRecordId, MailboxMutationRecord> recordsById = [];
+
+    /// <summary>Puts a record into the state a completed mutation would have left.</summary>
+    internal void Add(MailboxMutationRecord record) => this.recordsById[record.Id] = record;
+
+    /// <summary>Reads back one record as a test asserts against it.</summary>
+    internal MailboxMutationRecord RecordOf(MailboxMutationRecordId recordId) => this.recordsById[recordId];
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<MailboxMutationRecord>> ReadRelocationsPlacedAtAsync(
+        MailAccountId accountId,
+        RemoteFolderPath destinationPath,
+        ImapUidValidity uidValidity,
+        IReadOnlyCollection<ImapUid> uids,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(uids);
+
+        IReadOnlyList<MailboxMutationRecord> placed =
+        [
+            .. this.recordsById.Values
+                .Where(record => record.Request.Occurrence.AccountId == accountId
+                    && record.Request.Mutation == MailboxMutation.Relocate
+                    && record.Stage == MailboxMutationStage.Completed
+                    && record.PlacementObservedAt is null
+                    && record.Request.DestinationPath?.Value == destinationPath.Value
+                    && record.Placement.UidValidity == uidValidity
+                    && record.Placement.Uid is { } placedUid
+                    && uids.Contains(placedUid))
+                .OrderBy(record => record.RecordedAt),
+        ];
+
+        return Task.FromResult(placed);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<MailboxMutationRecord>> ReadMutationsRemovingAsync(
+        MailAccountId accountId,
+        MailFolderResolutionId folderResolutionId,
+        ImapUidValidity uidValidity,
+        IReadOnlyCollection<ImapUid> uids,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(uids);
+
+        IReadOnlyList<MailboxMutationRecord> removing =
+        [
+            .. this.recordsById.Values
+                .Where(record => record.Request.Occurrence.AccountId == accountId
+                    && record.Request.Occurrence.FolderResolutionId == folderResolutionId
+                    && record.Request.Occurrence.UidValidity == uidValidity
+                    && uids.Contains(record.Request.Occurrence.Uid)
+                    && (record.Request.Mutation == MailboxMutation.Relocate
+                        || record.Request.Mutation == MailboxMutation.Delete))
+                .OrderBy(record => record.RecordedAt),
+        ];
+
+        return Task.FromResult(removing);
+    }
+
+    /// <inheritdoc />
+    public Task RecordPlacementObservedAsync(
+        IPersistenceSession session,
+        MailboxMutationRecordId recordId,
+        DateTimeOffset observedAt,
+        CancellationToken cancellationToken)
+    {
+        var record = this.Require(recordId);
+
+        this.recordsById[recordId] = record with
+        {
+            PlacementObservedAt = record.PlacementObservedAt ?? observedAt,
+            SourceRemovalObservedAt = record.SourceRemovalObservedAt ?? observedAt,
+        };
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task RecordSourceRemovalObservedAsync(
+        IPersistenceSession session,
+        MailboxMutationRecordId recordId,
+        DateTimeOffset observedAt,
+        CancellationToken cancellationToken)
+    {
+        var record = this.Require(recordId);
+
+        this.recordsById[recordId] = record with
+        {
+            SourceRemovalObservedAt = record.SourceRemovalObservedAt ?? observedAt,
+        };
+
+        return Task.CompletedTask;
+    }
+
+    private MailboxMutationRecord Require(MailboxMutationRecordId recordId) =>
+        this.recordsById.TryGetValue(recordId, out var record)
+            ? record
+            : throw new InvalidOperationException($"No mailbox mutation record carries the identifier {recordId}.");
+}

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationRecordStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationRecordStore.cs
@@ -49,6 +49,8 @@ internal sealed class InMemoryMailboxMutationRecordStore : IMailboxMutationRecor
             RecordedAt = this.now,
             StageChangedAt = this.now,
             LastFailure = null,
+            PlacementObservedAt = null,
+            SourceRemovalObservedAt = null,
         };
 
         this.identities[identity] = record.Id;

--- a/tests/Domain.UnitTests/Mutations/MailboxMutationRecordTests.cs
+++ b/tests/Domain.UnitTests/Mutations/MailboxMutationRecordTests.cs
@@ -1,0 +1,281 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Mutations;
+
+/// <summary>Covers the join a synchronization run makes between what it discovered and what MailFathom recorded.</summary>
+public sealed class MailboxMutationRecordTests
+{
+    private static readonly DateTimeOffset RecordedAt = new(2026, 8, 7, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly RemoteFolderPath Inbox = RemoteFolderPath.Create("INBOX");
+
+    private static readonly RemoteFolderPath Archive = RemoteFolderPath.Create("Archive", '/');
+
+    private static readonly StoredEmailId LocalEmail = StoredEmailId.Create(Guid.CreateVersion7(RecordedAt));
+
+    private static readonly MailboxMutationRequester Requester = MailboxMutationRequester.Rule("file-newsletters", 3);
+
+    private static readonly ImapUidValidity DestinationUidValidity = ImapUidValidity.Create(9001);
+
+    private static readonly ImapUid PlacedUid = ImapUid.Create(77);
+
+    /// <summary>A discovered occurrence the server itself named as the destination of a completed relocation is that relocation's own.</summary>
+    [Fact]
+    public void IsPlacementOf_TheOccurrenceCopyUidNamed_IsRecognized()
+    {
+        // Arrange
+        var record = CompletedRelocation();
+
+        // Act
+        var isPlacement = record.IsPlacementOf(Archive, DestinationUidValidity, PlacedUid);
+
+        // Assert
+        Assert.True(isPlacement);
+    }
+
+    /// <summary>A server that named no placement is joined to nothing, because the only alternative is a guess.</summary>
+    [Fact]
+    public void IsPlacementOf_RelocationWhoseServerReportedNoPlacement_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedRelocation() with { Placement = RemoteEmailPlacement.NotReported() };
+
+        // Act
+        var isPlacement = record.IsPlacementOf(Archive, DestinationUidValidity, PlacedUid);
+
+        // Assert
+        Assert.False(isPlacement);
+    }
+
+    /// <summary>A destination folder recreated between the placement and the discovery renumbers its UIDs, so the recorded one names nothing.</summary>
+    [Fact]
+    public void IsPlacementOf_DestinationFolderRenumberedSinceThePlacement_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedRelocation();
+
+        // Act
+        var isPlacement = record.IsPlacementOf(Archive, ImapUidValidity.Create(9002), PlacedUid);
+
+        // Assert
+        Assert.False(isPlacement);
+    }
+
+    /// <summary>The same UID in another folder is another message, so the destination path is part of the join.</summary>
+    [Fact]
+    public void IsPlacementOf_TheRecordedUidInAnotherFolder_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedRelocation();
+
+        // Act
+        var isPlacement = record.IsPlacementOf(RemoteFolderPath.Create("Later", '/'), DestinationUidValidity, PlacedUid);
+
+        // Assert
+        Assert.False(isPlacement);
+    }
+
+    /// <summary>A sequence that still owes a command has the email in both folders, so nothing is carried across yet.</summary>
+    [Theory]
+    [InlineData(MailboxMutationStage.PlacementIssued)]
+    [InlineData(MailboxMutationStage.PlacementConfirmed)]
+    [InlineData(MailboxMutationStage.SourceFlaggedDeleted)]
+    [InlineData(MailboxMutationStage.Abandoned)]
+    public void IsPlacementOf_RelocationThatHasNotCompleted_MatchesNothing(MailboxMutationStage stage)
+    {
+        // Arrange
+        var record = CompletedRelocation() with { Stage = stage };
+
+        // Act
+        var isPlacement = record.IsPlacementOf(Archive, DestinationUidValidity, PlacedUid);
+
+        // Assert
+        Assert.False(isPlacement);
+    }
+
+    /// <summary>A placement already recognized is not offered a second local email to carry.</summary>
+    [Fact]
+    public void IsPlacementOf_PlacementAlreadyObserved_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedRelocation() with { PlacementObservedAt = RecordedAt.AddMinutes(1) };
+
+        // Act
+        var isPlacement = record.IsPlacementOf(Archive, DestinationUidValidity, PlacedUid);
+
+        // Assert
+        Assert.False(isPlacement);
+    }
+
+    /// <summary>A copy places an email too, and whether that is one local email or two is not this join's decision.</summary>
+    [Fact]
+    public void IsPlacementOf_ACopyIntoTheSameFolder_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedRelocation() with
+        {
+            Request = MailboxMutationRequest.Copy(LocalEmail, SourceOccurrence(), Requester, Archive),
+        };
+
+        // Act
+        var isPlacement = record.IsPlacementOf(Archive, DestinationUidValidity, PlacedUid);
+
+        // Assert
+        Assert.False(isPlacement);
+    }
+
+    /// <summary>The source occurrence is written down before any command goes out, so the disappearance needs no COPYUID to be attributed.</summary>
+    [Theory]
+    [InlineData(MailboxMutationStage.PlacementIssued)]
+    [InlineData(MailboxMutationStage.SourceFlaggedDeleted)]
+    [InlineData(MailboxMutationStage.Completed)]
+    [InlineData(MailboxMutationStage.Abandoned)]
+    public void AccountsForRemovalOf_ItsOwnSourceOnceACommandHasGoneOut_IsRecognized(MailboxMutationStage stage)
+    {
+        // Arrange
+        var record = CompletedRelocation() with { Stage = stage };
+
+        // Act
+        var accountsForRemoval = record.AccountsForRemovalOf(SourceOccurrence());
+
+        // Assert
+        Assert.True(accountsForRemoval);
+    }
+
+    /// <summary>Nothing has reached the server yet, so an occurrence vanishing is somebody else's act.</summary>
+    [Fact]
+    public void AccountsForRemovalOf_AMutationNothingHasBeenIssuedFor_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedRelocation() with { Stage = MailboxMutationStage.Recorded };
+
+        // Act
+        var accountsForRemoval = record.AccountsForRemovalOf(SourceOccurrence());
+
+        // Assert
+        Assert.False(accountsForRemoval);
+    }
+
+    /// <summary>A folder renumbered under a new UIDVALIDITY names different messages, so the recorded occurrence matches none of them.</summary>
+    [Fact]
+    public void AccountsForRemovalOf_TheSameUidUnderAnotherUidValidity_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedRelocation();
+        var renumbered = EmailOccurrenceId.Create(
+            MailAccountId.Create("work"),
+            InboxBinding,
+            ImapUidValidity.Create(2),
+            ImapUid.Create(41));
+
+        // Act
+        var accountsForRemoval = record.AccountsForRemovalOf(renumbered);
+
+        // Assert
+        Assert.False(accountsForRemoval);
+    }
+
+    /// <summary>A flag change moves no occurrence, so a disappearance beside one is not it completing.</summary>
+    [Fact]
+    public void AccountsForRemovalOf_ASeenFlagChange_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedRelocation() with
+        {
+            Request = MailboxMutationRequest.SetSeen(LocalEmail, SourceOccurrence(), Requester, isSeen: true),
+        };
+
+        // Act
+        var accountsForRemoval = record.AccountsForRemovalOf(SourceOccurrence());
+
+        // Assert
+        Assert.False(accountsForRemoval);
+    }
+
+    /// <summary>The record stays the reason that occurrence is gone, so a window asking twice is answered twice.</summary>
+    [Fact]
+    public void AccountsForRemovalOf_ARemovalAlreadyObserved_IsStillRecognized()
+    {
+        // Arrange
+        var record = CompletedRelocation() with { SourceRemovalObservedAt = RecordedAt.AddMinutes(1) };
+
+        // Act
+        var accountsForRemoval = record.AccountsForRemovalOf(SourceOccurrence());
+
+        // Assert
+        Assert.True(accountsForRemoval);
+    }
+
+    /// <summary>A relocation owes both halves, so seeing one of them is not the join being done.</summary>
+    [Fact]
+    public void IsReconciled_RelocationWithOnlyOneHalfObserved_IsNotYetSettled()
+    {
+        // Arrange
+        var record = CompletedRelocation();
+
+        // Act
+        var withSourceRemovalOnly = record with { SourceRemovalObservedAt = RecordedAt.AddMinutes(1) };
+        var withBothHalves = withSourceRemovalOnly with { PlacementObservedAt = RecordedAt.AddMinutes(2) };
+
+        // Assert
+        Assert.False(record.IsReconciled);
+        Assert.False(withSourceRemovalOnly.IsReconciled);
+        Assert.True(withBothHalves.IsReconciled);
+    }
+
+    /// <summary>A delete puts the email nowhere and a flag change moves nothing, so neither waits for a placement that will never be discovered.</summary>
+    [Fact]
+    public void IsReconciled_MutationsThatPlaceNothing_WaitForNoPlacement()
+    {
+        // Arrange
+        var delete = CompletedRelocation() with
+        {
+            Request = MailboxMutationRequest.Delete(LocalEmail, SourceOccurrence(), Requester),
+            Placement = RemoteEmailPlacement.NotReported(),
+        };
+        var setSeen = delete with
+        {
+            Request = MailboxMutationRequest.SetSeen(LocalEmail, SourceOccurrence(), Requester, isSeen: true),
+        };
+
+        // Act
+        var deleteObserved = delete with { SourceRemovalObservedAt = RecordedAt.AddMinutes(1) };
+
+        // Assert
+        Assert.False(delete.IsReconciled);
+        Assert.True(deleteObserved.IsReconciled);
+        Assert.True(setSeen.IsReconciled);
+    }
+
+    private static MailFolderResolutionId InboxBinding =>
+        new(MailFolderAlias.Create(Inbox.Value), MailFolderResolutionGeneration.First);
+
+    private static EmailOccurrenceId SourceOccurrence() => EmailOccurrenceId.Create(
+        MailAccountId.Create("work"),
+        InboxBinding,
+        ImapUidValidity.Create(1),
+        ImapUid.Create(41));
+
+    private static MailboxMutationRecord CompletedRelocation() => new()
+    {
+        Id = MailboxMutationRecordId.Create(Guid.CreateVersion7(RecordedAt)),
+        Request = MailboxMutationRequest.Relocate(LocalEmail, SourceOccurrence(), Requester, Archive),
+        Stage = MailboxMutationStage.Completed,
+        RequiresSourceRemoval = true,
+        Placement = RemoteEmailPlacement.Reported(DestinationUidValidity, PlacedUid),
+        AttemptCount = 1,
+        RecordedAt = RecordedAt,
+        StageChangedAt = RecordedAt,
+        LastFailure = null,
+        PlacementObservedAt = null,
+        SourceRemovalObservedAt = null,
+    };
+}

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
@@ -15,6 +16,7 @@ using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Transport;
 using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Mail;
@@ -89,6 +91,7 @@ internal static class SynchronizationTestHost
         services.AddSingleton(Substitute.For<IEmailContentStore>());
         services.AddSingleton(CreateMimeReaderThatExtractsEverything());
         services.AddSingleton(CreateReconciliationStoreWithNothingToDo());
+        services.AddSingleton(CreateMutationStoreWithNothingRecorded());
         services.AddSingleton(new PersistenceConcurrencyOptions());
         services.AddSingleton(new MailboxSynchronizationOptions());
         services.AddSingleton(timeProvider);
@@ -217,6 +220,34 @@ internal static class SynchronizationTestHost
             .Returns(Task.FromResult<IReadOnlyList<StoredEmailAwaitingReconciliation>>([]));
 
         return reconciliationStore;
+    }
+
+    /// <summary>Builds a store holding no mutations, so nothing a run discovers is one MailFathom itself made.</summary>
+    /// <remarks>
+    /// These tests are about how a supervisor schedules and isolates folder work units. An unconfigured substitute would
+    /// answer both reads with a null task the run then faults on, which surfaces as a supervision that never signals.
+    /// </remarks>
+    private static IMailboxMutationReconciliationStore CreateMutationStoreWithNothingRecorded()
+    {
+        var mutationStore = Substitute.For<IMailboxMutationReconciliationStore>();
+        mutationStore
+            .ReadRelocationsPlacedAtAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<RemoteFolderPath>(),
+                Arg.Any<ImapUidValidity>(),
+                Arg.Any<IReadOnlyCollection<ImapUid>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<MailboxMutationRecord>>([]));
+        mutationStore
+            .ReadMutationsRemovingAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailFolderResolutionId>(),
+                Arg.Any<ImapUidValidity>(),
+                Arg.Any<IReadOnlyCollection<ImapUid>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<MailboxMutationRecord>>([]));
+
+        return mutationStore;
     }
 
     /// <summary>Builds a reader whose messages all parse, because these tests are about how a supervisor isolates folders.</summary>

--- a/tests/IntegrationTests/Persistence/OrchestratedStoredEmailReconciliationTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedStoredEmailReconciliationTests.cs
@@ -120,6 +120,7 @@ public sealed class OrchestratedStoredEmailReconciliationTests(MailFathomOrchest
                 ],
                 ConfirmedUnchanged: [],
                 Disappeared: [],
+                RemovedByOwnMutation: [],
                 RemotelyDeletedEmailDisposition.RetainTombstone,
                 EarlierObservation),
             cancellationToken);
@@ -131,6 +132,7 @@ public sealed class OrchestratedStoredEmailReconciliationTests(MailFathomOrchest
                 StillPresent: [],
                 ConfirmedUnchanged: [storedEmailIds[ConfirmedUid]],
                 Disappeared: [storedEmailIds[DisappearedUid]],
+                RemovedByOwnMutation: [],
                 RemotelyDeletedEmailDisposition.RetainTombstone,
                 LaterObservation),
             cancellationToken);
@@ -227,6 +229,7 @@ public sealed class OrchestratedStoredEmailReconciliationTests(MailFathomOrchest
                 StillPresent: [],
                 ConfirmedUnchanged: [],
                 Disappeared: [erasedId, storedEmailIds[SparedUid]],
+                RemovedByOwnMutation: [],
                 RemotelyDeletedEmailDisposition.EraseLocalCopy,
                 EarlierObservation),
             cancellationToken);
@@ -323,6 +326,7 @@ public sealed class OrchestratedStoredEmailReconciliationTests(MailFathomOrchest
                     [new ObservedEmailFlags(StoredEmailId.Create(rows[uid].Id), SeenAt(recordedAt))],
                     ConfirmedUnchanged: [],
                     Disappeared: [],
+                    RemovedByOwnMutation: [],
                     RemotelyDeletedEmailDisposition.RetainTombstone,
                     recordedAt),
                 cancellationToken);

--- a/tests/IntegrationTests/Synchronization/OrchestratedRelocationReconciliationTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedRelocationReconciliationTests.cs
@@ -1,0 +1,227 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.IntegrationTests.Mailbox;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Synchronization;
+
+/// <summary>Proves that a message MailFathom moved stays one local email, against a real server and a real database.</summary>
+/// <remarks>
+/// <para>
+/// Neither substitute can establish this. The join is made from the <c>COPYUID</c> a real server chose to send, against
+/// a UID that server assigned, and what it has to produce is one row where a unique index over folder, UIDVALIDITY, and
+/// UID would otherwise hold two. GreenMail advertises <c>UIDPLUS</c>, so the response the join rests on is really there.
+/// </para>
+/// <para>
+/// Two tests, because the two halves cannot both be observed in one order. Carrying the row into the destination folder
+/// takes it out of the source folder locally, so the source disappearance is only observable when the source folder is
+/// reconciled first — which is the second test, and also the out-of-order case an operator's mailbox will produce
+/// whenever the destination folder is not one MailFathom synchronizes on the same schedule.
+/// </para>
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+[TestCaseOrderer(typeof(MailboxStateSequenceOrderer))]
+public sealed class OrchestratedRelocationReconciliationTests(MailFathomOrchestrationFixture orchestration)
+{
+    private const string SourceFolderName = "RelocationSource";
+
+    private const string TargetFolderName = "RelocationTarget";
+
+    private static readonly MailFolderMapping SourceMapping = MailFolderMapping.ToRemotePath(
+        MailFolderAlias.Create("relocation-source"),
+        RemoteFolderPath.Create(SourceFolderName, hierarchyDelimiter: '.'));
+
+    private static readonly MailFolderMapping TargetMapping = MailFolderMapping.ToRemotePath(
+        MailFolderAlias.Create("relocation-target"),
+        RemoteFolderPath.Create(TargetFolderName, hierarchyDelimiter: '.'));
+
+    private static readonly RemoteFolderPath TargetPath =
+        RemoteFolderPath.Create(TargetFolderName, hierarchyDelimiter: '.');
+
+    private static readonly MailboxMutationRequester Requester =
+        MailboxMutationRequester.Rule("file-to-relocation-target", 1);
+
+    /// <summary>The message arrives in its new folder as an ordinary discovery, and is the email that was already stored.</summary>
+    [Fact]
+    [MailboxStateStep(1)]
+    public async Task SynchronizeAsync_AfterARelocationIntoTheFolder_CarriesTheLocalEmailAcrossInsteadOfStoringASecond()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mailbox = new OrchestratedMailbox(orchestration.MailServer);
+        await mailbox.RecreateFolderAsync(SourceFolderName, cancellationToken);
+        await mailbox.RecreateFolderAsync(TargetFolderName, cancellationToken);
+
+        var subject = $"relocation-carried-{Guid.NewGuid():N}";
+        await mailbox.AppendAsync(SourceFolderName, subject, cancellationToken);
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        Assert.Equal(1, (await SynchronizeAsync(services, SourceMapping, cancellationToken)).StoredEmailCount);
+
+        var stored = await ReadStoredEmailAsync(services, subject, cancellationToken);
+        var outcome = await RelocateToTargetAsync(services, stored, cancellationToken);
+
+        // The arrangement only proves what this test is about once the server really named the destination occurrence,
+        // so the response the join rests on is asserted before the run rather than assumed by it.
+        Assert.Equal(MailboxMutationStatus.Performed, outcome.Status);
+        Assert.True(outcome.Placement.IsReported);
+
+        // Act
+        var result = await SynchronizeAsync(services, TargetMapping, cancellationToken);
+
+        // Assert
+        Assert.Equal(1, result.RelocatedEmailCount);
+        Assert.Equal(0, result.StoredEmailCount);
+
+        var carried = await ReadStoredEmailAsync(services, subject, cancellationToken);
+        Assert.Equal(stored.StoredEmailId, carried.StoredEmailId);
+        Assert.Equal(TargetMapping.Alias.Value, carried.Alias);
+        Assert.Equal(outcome.Placement.Uid, carried.Uid);
+
+        // One row, where a run without the join would have left the source occurrence beside the destination one.
+        Assert.Equal(1, await CountStoredEmailsAsync(services, subject, cancellationToken));
+
+        var record = await ReadRecordAsync(services, outcome.RecordId, cancellationToken);
+        Assert.NotNull(record.PlacementObservedAt);
+        Assert.NotNull(record.SourceRemovalObservedAt);
+    }
+
+    /// <summary>The source occurrence vanishing is the relocation completing, not a deletion somebody else made.</summary>
+    [Fact]
+    [MailboxStateStep(2)]
+    public async Task SynchronizeAsync_AfterARelocationOutOfTheFolder_AttributesTheDisappearanceToTheMutationRatherThanToTheServer()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mailbox = new OrchestratedMailbox(orchestration.MailServer);
+
+        var subject = $"relocation-attributed-{Guid.NewGuid():N}";
+        await mailbox.AppendAsync(SourceFolderName, subject, cancellationToken);
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        Assert.Equal(1, (await SynchronizeAsync(services, SourceMapping, cancellationToken)).StoredEmailCount);
+
+        var stored = await ReadStoredEmailAsync(services, subject, cancellationToken);
+        var outcome = await RelocateToTargetAsync(services, stored, cancellationToken);
+        Assert.Equal(MailboxMutationStatus.Performed, outcome.Status);
+
+        // Act
+        var result = await SynchronizeAsync(services, SourceMapping, cancellationToken);
+
+        // Assert
+        Assert.Equal(0, result.Reconciliation.RemotelyDeletedEmailCount);
+        Assert.Equal(1, result.Reconciliation.OwnMutationCompletedEmailCount);
+
+        // The row stays where it is, waiting for the destination folder to be synchronized. A remote deletion would
+        // have tombstoned it out of every mailbox query instead.
+        var afterReconciliation = await ReadStoredEmailAsync(services, subject, cancellationToken);
+        Assert.Equal(stored.StoredEmailId, afterReconciliation.StoredEmailId);
+        Assert.Null(afterReconciliation.RemoteExpungeObservedAt);
+
+        var record = await ReadRecordAsync(services, outcome.RecordId, cancellationToken);
+        Assert.NotNull(record.SourceRemovalObservedAt);
+        Assert.Null(record.PlacementObservedAt);
+    }
+
+    private static Task<MailboxSynchronizationResult> SynchronizeAsync(
+        OrchestratedMailFathomServices services,
+        MailFolderMapping mapping,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailboxSynchronizer>().SynchronizeAsync(
+                SyntheticMailAccount.AccountId,
+                mapping,
+                token),
+            cancellationToken);
+
+    /// <summary>Relocates one stored email through the production performer, which writes the record the join reads.</summary>
+    private static Task<MailboxMutationOutcome> RelocateToTargetAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailRow stored,
+        CancellationToken cancellationToken)
+    {
+        var folder = MailFolderResolution.FirstBindingOf(SourceMapping.Alias, SourceMapping.RemotePath!.Value);
+        var occurrence = EmailOccurrenceId.Create(
+            SyntheticMailAccount.AccountId,
+            folder.Id,
+            stored.UidValidity,
+            stored.Uid);
+        var request = MailboxMutationRequest.Relocate(stored.StoredEmailId, occurrence, Requester, TargetPath);
+
+        return services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IMailboxMutationPerformer>().PerformAsync(
+                request,
+                folder,
+                scope.GetRequiredService<IMailTransportSecurityPolicyReader>()
+                    .GetPolicy(SyntheticMailAccount.AccountId),
+                token),
+            cancellationToken);
+    }
+
+    /// <summary>Reads the one row stored for a subject, whichever folder binding currently carries it.</summary>
+    private static Task<StoredEmailRow> ReadStoredEmailAsync(
+        OrchestratedMailFathomServices services,
+        string subject,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) => await scope.GetRequiredService<MailFathomDbContext>()
+                .StoredEmails
+                .AsNoTracking()
+                .Where(storedEmail => storedEmail.Subject == subject)
+                .Select(storedEmail => new StoredEmailRow(
+                    StoredEmailId.Create(storedEmail.Id),
+                    storedEmail.MailFolder.Alias,
+                    ImapUidValidity.Create(storedEmail.UidValidity),
+                    ImapUid.Create(storedEmail.Uid),
+                    storedEmail.RemoteExpungeObservedAt))
+                .SingleAsync(token),
+            cancellationToken);
+
+    private static Task<int> CountStoredEmailsAsync(
+        OrchestratedMailFathomServices services,
+        string subject,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailFathomDbContext>()
+                .StoredEmails
+                .AsNoTracking()
+                .CountAsync(storedEmail => storedEmail.Subject == subject, token),
+            cancellationToken);
+
+    /// <summary>Reads the two observations off the record's own row, because a completed mutation is no longer outstanding.</summary>
+    private static Task<MutationObservationRow> ReadRecordAsync(
+        OrchestratedMailFathomServices services,
+        MailboxMutationRecordId recordId,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) => await scope.GetRequiredService<MailFathomDbContext>()
+                .MailboxMutations
+                .AsNoTracking()
+                .Where(mutation => mutation.Id == recordId.Value)
+                .Select(mutation => new MutationObservationRow(
+                    mutation.PlacementObservedAt,
+                    mutation.SourceRemovalObservedAt))
+                .SingleAsync(token),
+            cancellationToken);
+
+    /// <summary>The columns of one stored email this class reads back.</summary>
+    private sealed record StoredEmailRow(
+        StoredEmailId StoredEmailId,
+        string Alias,
+        ImapUidValidity UidValidity,
+        ImapUid Uid,
+        DateTimeOffset? RemoteExpungeObservedAt);
+
+    /// <summary>What one mutation record says synchronization has accounted for.</summary>
+    private sealed record MutationObservationRow(
+        DateTimeOffset? PlacementObservedAt,
+        DateTimeOffset? SourceRemovalObservedAt);
+}


### PR DESCRIPTION
## What this changes

A relocation MailFathom performs comes back through an ordinary synchronization run as two unrelated events: a message appears in one folder and vanishes from another. Left alone that is a new message and a deleted one — the history forks, anything citing the old occurrence points at something marked deleted, and the mailbox holds a duplicate as far as MailFathom is concerned.

The durable mutation record from #448 now joins both halves, without weakening `(account, folder, UIDVALIDITY, UID)` as the occurrence identity. The record is what says two occurrences are one message's history; the occurrences themselves are unchanged.

**The appearance** is joined by the server's own `COPYUID` answer. A discovered occurrence is matched against relocations that named this folder as their destination, completed, and were answered with a placement naming this UIDVALIDITY and this UID. A match carries the existing local email onto the new occurrence instead of storing a second one — no `FETCH`, no MIME read, no new row, because the message is the one already stored and its content, extracted metadata, search document, and passages are all keyed by the local identity being carried across. Only the occurrence identity moves, and the flags become unobserved so the destination folder's own window says what holds there now.

**The disappearance** is joined by the record's own source occurrence, which was written down before the first IMAP command went out and needs no `COPYUID`. A match is the relocation or an authored delete completing, so the account's `RemotelyDeletedEmailDisposition` is never reached for it — which is the case that would otherwise erase the local copy of mail that still exists in another folder.

**Nothing is guessed.** A relocation whose server named no placement is joined to no discovery at all and stays visibly unobserved instead. Searching the destination folder for something that looks like the message would replace a fact the server gave with a guess, which is what [ADR 0007](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md) refuses; matching on `Message-ID` or a content hash is wrong in both directions, since a message legitimately appears twice with one `Message-ID` and a provider may rewrite headers on copy. A discovery or a disappearance that matches no record is treated exactly as it is today.

**The order the two halves arrive in is not fixed**, because the destination folder is not necessarily one MailFathom synchronizes on the same schedule. A source disappearance seen first settles that half and leaves the row where it is until the placement is discovered. A placement discovered first settles both, because carrying the row across is what takes the email out of the source folder locally and no later window could observe the disappearance afterwards.

A copy places an occurrence too and is deliberately not carried across: whether a second live occurrence is one local row or two is #476's decision. What becomes of the local copy after an authored delete stays #474's.

## Breaking change

**The database schema.** `mailbox_mutations` gains `PlacementObservedAt` and `SourceRemovalObservedAt`, plus the partial index `ix_mailbox_mutations_placement` over `(MailboxAccountId, DestinationFolderPath, PlacementUidValidity, PlacementUid)` where the placement is unobserved.

The migration is additive and regenerates no baseline, so this release is deployable over the previous release's data. **No operator action is required** beyond applying the schema artifact as usual.

No configuration key, MCP tool contract, or deployment contract changes.

## Bounds and privacy

Both reads ask about a whole batch or a whole window at once, so recognizing MailFathom's own work costs one query per batch rather than one per message — and on an installation that has never written to a mailbox the partial index holds nothing at all. Nothing derived from a message takes part in the join, and the new log line carries counts and MailFathom's own configured names only.

## Verification

- `scripts/verify-full.sh`: green. 3118 tests, 0 failed; aggregate line coverage 94.42%.
- Unit tests cover the matched appearance, the matched disappearance for both a relocation and a delete, the unmatched path where the server named no placement, a mutation observed out of order, and a UIDVALIDITY change mid-flight.
- The integration suite proves the join end to end against real PostgreSQL and the orchestrated mail server: a relocation performed through the write session is discovered by an ordinary synchronization run and carries the local row across rather than creating a second, and the source disappearance completes the mutation instead of entering the remote-deletion path. It has **not** been run in this session; `Integration tests` needs a manual dispatch.
- The migration was applied to the orchestrated database and `mailfathom-host` reached `Running`/`Healthy` against the resulting schema.

Closes #449

https://claude.ai/code/session_016m6zyzHMeUNaKEncoh4MpV