### PR TITLE
[#535] Keep the changelog from announcing a feature the release only partly delivered

### DIFF
--- a/.agents/skills/prepare-release/SKILL.md
+++ b/.agents/skills/prepare-release/SKILL.md
@@ -105,6 +105,54 @@ thing they update rather than as what changed internally.
 An entry that resists this is usually an entry that should not exist. A change with nothing to say to that reader is a
 change they cannot observe, and the correct entry for one is none.
 
+#### A feature the release delivers only part of
+
+That last sentence deletes the entry for a change too small to be noticed. This is the case it does not reach: a change
+large enough to matter that is one part of a feature still being assembled. `docs/operations/issue-tracking.md` splits
+such a feature across a parent issue's children, so it arrives here as several closed issues whose own titles name
+pieces — and the instruction to drop the mechanism and state the capability then has exactly one capability-shaped
+sentence within reach, which is the parent's. That sentence is a claim about the whole feature, and the release
+delivered part of it. Nothing in a pull request says which case it is in, which is why the parents are read rather than
+inferred.
+
+Resolve each issue the merged pull requests closed against its parent. The sub-issue links are the source of truth for
+the hierarchy — the `parent` label mirrors them for the board and can be stale — so the lookup follows the link, and
+only GraphQL exposes it:
+
+```bash
+for issue in <the numbers closingIssuesReferences returned above>; do
+  gh api graphql -f query="{ repository(owner: \"Krzysztof318\", name: \"MailFathom\") {
+    issue(number: $issue) { number parent { number title state subIssuesSummary { total completed } } } } }" \
+    --jq '.data.repository.issue | select(.parent != null)
+          | "#\(.number)\t#\(.parent.number) \(.parent.state) \(.parent.subIssuesSummary.completed)/\(.parent.subIssuesSummary.total)\t\(.parent.title)"'
+done
+```
+
+Read each closed issue against what that returns. Two cases decide how far the entry may reach:
+
+- **It has no parent, or its parent has no child left open.** The feature is whole, and the entry names the capability
+  exactly as everything above describes. Ask the same question of the level above when that parent is a sub-parent: the
+  hierarchy is two deep at most, and a finished part of an unfinished feature is still a part.
+- **Its parent still holds open children.** The release carries a part of the feature. The entry states what the reader
+  can do *now* and nothing past it, and where nothing they can do moved, the entry is none — the same answer the
+  paragraph above gives, arrived at for a different reason. **The parent's capability is never written as an entry**, in
+  any tense: a sentence about what a release lays the ground for is read as a sentence about what it ships.
+
+**A third case cuts across both rather than standing beside them: the issue carries an action for the operator.** A
+break, a migration, a new required configuration key, a default that moved. That entry follows from the action alone
+and is written whether or not anything can yet use the feature around it — which is what keeps this from being a rule
+that only deletes, because the groundwork for a capability nobody can invoke is still a table somebody has to migrate
+onto. Write the action, and no more of the feature than the case above allows.
+
+**A parent left open is the expected shape here rather than a fault to correct.** A release never waits for one to
+close, and `cross-milestone` beside `Queue: Parent` says that feature was always going to arrive in stages. Nothing in
+this reading blocks the release or moves an issue either: step 3 is what carries whatever is still open into the next
+milestone, and it does so for every open item rather than for a parent's children in particular.
+
+**The withheld sentence is not lost, it is early.** The release that closes the last child is where the capability is
+named, in the reader's terms and truthfully, and that is the release they would act on anyway. Writing it sooner buys
+them nothing and costs the file the only thing it has, which is that an entry in it can be believed.
+
 **The increment follows from what this reading found**, not the other way round: the highest increment any of the four
 surfaces requires is the release's own. Raise the question with the owner when the entries and the version already
 declared disagree — an unnecessary major costs one careful upgrade, an unmarked break costs an outage.
@@ -218,7 +266,9 @@ On a branch off the release branch, and touching nothing else:
   grouped into the six Keep a Changelog categories and each referencing the pull request or issue that carried it;
 - open the section with a short paragraph in the reader's own terms: what this release is for, whether the database
   schema moves, and whether anything the previous release promised is withdrawn. That is what somebody deciding whether
-  to upgrade reads, and it is the one part no list of entries can state;
+  to upgrade reads, and it is the one part no list of entries can state. It names no capability the parent reading in
+  step 2 found still being assembled — a summarizing paragraph is where a half-delivered feature is easiest to promise
+  and where the qualification reads worst;
 - **add no `Unreleased` section.** The file carries none by design: it says what released versions shipped, and a
   heading standing above the newest one either says nothing or claims something about a release nobody has cut. What
   has merged since the newest section is what a nightly build carries, and the file's own preamble says so;

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -283,19 +283,23 @@ The canonical skills are:
   `Closes #<issue>`, and then moves that issue to `Queue: Next` so the board
   shows the work as in flight;
 - `prepare-release` opens the two pull requests a release consists of and prints
-  the order they and the tag between them have to land in. Its changelog pull
-  request also carries the files that name a version in prose and a sweep for
-  prose describing the release state without naming one, because both go stale
-  at the tag and neither is reached by `<VersionPrefix>`. Before either pull
-  request it settles the milestones — creating the next one if it does not
-  exist, opening the issue that tracks that release in it, moving what is still
-  open into it, and closing the one being released — which is the only place a
-  milestone is opened, and the reason a milestone never stands without the issue
-  that closes it. Both of its pull requests name the tracking issue for the
-  release being cut, and the version-bump one closes it, because a release is
-  finished when `main` names the next version rather than when the changelog
-  merged. It is one of the two skills an agent cannot invoke — its frontmatter
-  sets `disable-model-invocation`, so only the owner reaches it, because when a
+  the order they and the tag between them have to land in. It composes the
+  changelog section from what merged since the previous tag, reading each closed
+  issue against its parent, so a feature the release delivers only part of is
+  written as what the reader can do now rather than as the capability its parent
+  names. Its changelog pull request also carries the files that name a version
+  in prose and a sweep for prose describing the release state without naming
+  one, because both go stale at the tag and neither is reached by
+  `<VersionPrefix>`. Before either pull request it settles the milestones —
+  creating the next one if it does not exist, opening the issue that tracks that
+  release in it, moving what is still open into it, and closing the one being
+  released — which is the only place a milestone is opened, and the reason a
+  milestone never stands without the issue that closes it. Both of its pull
+  requests name the tracking issue for the release being cut, and the
+  version-bump one closes it, because a release is finished when `main` names
+  the next version rather than when the changelog merged. It is one of the two
+  skills an agent cannot invoke — its frontmatter sets
+  `disable-model-invocation`, so only the owner reaches it, because when a
   version becomes real is their decision. It pushes no tag and merges nothing;
   `docs/operations/release-procedure.md` records the same sequence for a reader
   without the skill.

--- a/docs/operations/release-procedure.md
+++ b/docs/operations/release-procedure.md
@@ -113,6 +113,12 @@ question per surface and settles the recurring ambiguous cases.
 The reading that answers it happens at release time, from what merged since the previous tag, and it is the same
 reading that produces the changelog section.
 
+**The increment is judged on what those four surfaces actually moved, whether or not the feature a change belongs to is
+finished.** A release delivering three of a feature's ten parts still moves the database schema when one of the three
+added a table, and an increment lowered because the capability is not usable yet would understate an upgrade the
+operator has to plan for. Incompleteness governs how the changelog *describes* a release, which `$prepare-release`
+holds; it never governs the number.
+
 **`CHANGELOG.md` is written by the release pull request and by nothing else.** Ordinary work never touches it: a
 changelog is a statement about a release, and until someone decides to cut one there is no release for a line to belong
 to. The file is a protected path, so an edit arriving through ordinary work is visible as the exception it is, and


### PR DESCRIPTION
Closes #535

## What changes

`$prepare-release` § *Read what merged since the previous tag* gains a reading of the sub-issue links, and the three
files that describe the release follow it.

The defect it closes is in the step's own translation rule. It tells the writer to drop the mechanism and state the
capability, which is right for a change that stands alone and wrong for one that is a piece of a feature split across a
parent issue's children: the child issue's title *is* the mechanism, so the only capability-shaped sentence within reach
is the parent's, and the parent's is a claim the release has not earned. `0.4.0` is the live case — `#452` at 4 of 10
children, `#436` at 4 of 12, `#85` at 2 of 7, with nine of this release's issues sitting under them. Written the way the
step asked, those nine become three sentences announcing remote mailbox writes, semantic search, and full request-path
instrumentation, none of which an operator could use after the upgrade.

- **`.agents/skills/prepare-release/SKILL.md`** adds `#### A feature the release delivers only part of` to step 2. It
  resolves each closed issue against its parent, follows the sub-issue link rather than the `parent` label — the label
  is the mirror `docs/operations/issue-tracking.md` says can go stale — and splits the outcome into two cases that
  decide how far an entry may reach, plus a third that cuts across both. The third is the one that keeps this from
  being a rule that only deletes: a break, a migration, or a new required key earns its entry from the operator's
  action however little of the surrounding feature exists, which is exactly `#448`'s table in this release. Two
  paragraphs then say why an open parent is the expected shape rather than a fault — `cross-milestone` beside
  `Queue: Parent` says the feature was always going to arrive in stages — and where the withheld sentence goes, since
  "the work would otherwise go unrecorded" is the argument that would push somebody into writing the false entry.
  Step 4's opening-paragraph bullet gains a pointer back, because a summarizing paragraph is where a half-delivered
  feature is easiest to promise.
- **`docs/operations/release-procedure.md`** § *What earns which increment* states the other half, which is not the
  changelog's: the increment follows what the four surfaces actually moved, whether or not the feature is finished. A
  release that adds a table for a capability nobody can invoke still moved the database schema.
- **`docs/operations/agent-workflow.md`** names the reading in its summary of the skill, since it carries
  `describes: .agents/skills/**`.

Decided rather than derived: the two rules live in one file each rather than being cross-stated, per root `AGENTS.md`;
the lookup is GraphQL because REST does not expose `parent` on an issue; and the sub-parent case is answered by asking
the same question one level up rather than by a separate rule, since `issue-tracking.md` caps the hierarchy at two.

## How it was verified

- `bash scripts/verify-full.sh` — exit `0` on this branch rebased onto `5bf2871`: workflow contracts 118 passed /
  0 failed, unit tests `failed: 0`, aggregate line coverage 94.44% against a required 85%, `Formatted 0 of 1062 files`.
  The workflow-contract suite is the part of that gate which reads `.agents/skills/**`, the licensing header on every
  `SKILL.md`, and the `describes:` marker on every page under `docs/`.
- `bash scripts/review-obligations.sh` — Documentation reports `.agents/skills/prepare-release/SKILL.md` as *covered:
  every page describing it is in this change*. No production file under `src/` changed, and no register trigger moved.
- The documented `gh api graphql` loop was run verbatim against `#449`, `#467`, and `#500`. It printed
  `#449  #452 OPEN 4/10` and `#500  #85 OPEN 2/7`, and stayed silent on `#467`, which has no parent.
- No C# changed, so nothing is added to the test suite; the workflow-contract suite is what covers this half of the
  repository. `typos` is not installed on this machine, so the `Typos` job is the first run of that check.

## Checklist

- [x] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [x] Behavior changes are covered by unit tests, and the coverage gate passes. No C# changed, so nothing was added; the coverage gate passed unchanged under `verify-full.sh`.
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail.
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. No dependency, service, image, model, or externally sourced sample is introduced, so `THIRD_PARTY_LICENSES.md` takes no row.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.
