### PR TITLE
[#450] Withhold a change MailFathom made from the rules that would react to it

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -176,6 +176,16 @@ occurrences the change moved and recognized them as this record's own. A relocat
 in the destination folder later as a discovery something has to join to the email already stored, and its source
 occurrence still vanishes from the folder it left — and left alone, that pair is a new message and a deleted one.
 
+Both are written once and never moved afterwards, and that is what scopes an arrival's provenance to the one change the
+record describes: a record whose placement has been met answers for no later discovery at the same UID.
+
+A `\Seen` store carries no such column and needs none, because it moves no occurrence for a run to come back and meet.
+Its provenance is settled against the stored email's own `remote_flags_observed_at` instead: a store accounts for a flag
+reading only while that column still predates the moment the store completed. Every window advances it for every
+occurrence it asked about, so the first reading after the store is the whole of what the record can answer for. A column
+here would answer only for the readings that happened to *differ* — and an owner who reverted the flag before the first
+reading would leave it unwritten and have their own later change silenced by it.
+
 The join is the server's own `COPYUID` answer for the placement and the record's own source occurrence for the
 disappearance. A relocation whose server named no placement matches no discovery at all, and `PlacementObservedAt` stays
 null instead: finding the message by searching the destination folder for something that looks like it would replace a
@@ -210,7 +220,7 @@ assembled at the failure site.
 | `ix_email_embeddings_profile` | `(EmbeddingProfileId, Dimension)` | Reading a whole generation, which is how a superseded one is removed |
 | `ix_mailbox_mutations_identity` | `(MailFolderId, UidValidity, Uid, RequesterOrigin, RequesterIdentity, Mutation)`, unique | A mutation's idempotency identity, which is what makes the same request twice perform one change |
 | `ix_mailbox_mutations_outstanding` | `(MailboxAccountId, RecordedAt)` where the stage is not `Completed` | The changes an operator asks about: those in flight and those given up on |
-| `ix_mailbox_mutations_placement` | `(MailboxAccountId, DestinationFolderPath, PlacementUidValidity, PlacementUid)` where `PlacementObservedAt` is null | The question the forward pass asks of every batch it discovers: is one of these UIDs where a relocation put an email |
+| `ix_mailbox_mutations_placement` | `(MailboxAccountId, DestinationFolderPath, PlacementUidValidity, PlacementUid)` where `PlacementObservedAt` is null | The question the forward pass asks of every batch it discovers: is one of these UIDs where a relocation or a copy put an email |
 
 The recipient and search-vector indexes are GIN rather than B-tree because both serve containment tests. A B-tree over an array column serves only equality against a whole array, and over a `tsvector` it serves nothing search asks for; a GIN index is what turns either into an index scan.
 

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -780,20 +780,26 @@ and the mailbox holds a duplicate as far as MailFathom is concerned.
 The [durable mutation record](https://github.com/Krzysztof318/MailFathom/blob/main/docs/architecture/stored-email-schema.md#recorded-mailbox-mutations)
 is what tells the two apart, and both halves are joined to it by a recorded fact rather than by a guess at a header:
 
-- **A discovered occurrence** is matched against relocations that named this folder as their destination and that the
-  server answered with a `COPYUID` naming this UIDVALIDITY and this UID. A match carries the existing local email onto
-  the new occurrence instead of storing a second one — no fetch, no MIME read, and no new row, because the message is
-  the one already stored and its content, extracted metadata, search document, and passages are all keyed by the local
-  identity being carried across. Only the occurrence identity moves, and the flags become unobserved so the destination
-  folder's own window is what says what holds there now.
+- **A discovered occurrence** is matched against relocations and copies that named this folder as their destination and
+  that the server answered with a `COPYUID` naming this UIDVALIDITY and this UID. A relocation carries the existing
+  local email onto the new occurrence instead of storing a second one — no fetch, no MIME read, and no new row, because
+  the message is the one already stored and its content, extracted metadata, search document, and passages are all
+  keyed by the local identity being carried across. Only the occurrence identity moves, and the flags become unobserved
+  so the destination folder's own window is what says what holds there now. A copy is stored like any other discovery,
+  because the message it duplicates stayed where it was; what the record settles for it is only whose act the arrival
+  was.
 - **A disappearance** is matched against the source occurrence the record names, which was written down before the
   first IMAP command went out. A match is the relocation or the delete completing, so the disposition below is never
   reached for it: the row keeps its place and only its position in the reconciliation queue moves.
+- **A remote `\Seen` flag standing somewhere new** is matched against the `\Seen` stores issued against that occurrence,
+  and the direction is compared as well: a store that asked for the flag to be set answers for the flag becoming set and
+  never for it becoming clear. The stored snapshot still follows the server either way — what the match decides is whose
+  act it was, not what is recorded.
 
-A relocation whose server named no placement is joined to no discovery at all. Searching the destination folder for
-something that looks like the message would replace a fact the server gave with a guess, and guessing by `Message-ID`
-or a content hash is wrong in both directions — a message legitimately appears twice with one `Message-ID`, and a
-provider may rewrite headers on copy. The record then stays visibly unjoined instead.
+A relocation or a copy whose server named no placement is joined to no discovery at all. Searching the destination
+folder for something that looks like the message would replace a fact the server gave with a guess, and guessing by
+`Message-ID` or a content hash is wrong in both directions — a message legitimately appears twice with one `Message-ID`,
+and a provider may rewrite headers on copy. The record then stays visibly unjoined instead.
 
 The order the two halves arrive in is not fixed, because the destination folder is not necessarily one MailFathom
 synchronizes on the same schedule. A source disappearance seen first settles that half and leaves the row where it is
@@ -802,6 +808,35 @@ takes the email out of the source folder locally and no later window could obser
 
 A discovery or a disappearance that matches no record is treated exactly as it is below. Nothing here changes what
 happens to mail a person moved or deleted in their own client.
+
+#### A change MailFathom made is not a change to react to
+
+The join above is one reader of the record. The other is provenance: a change MailFathom performed must not come back
+as something to act on. Once rules can write to a mailbox, that stops being tidiness. A rule matching on folder would
+file a message, meet it in its new folder, match again, and go round for as long as the folder is watched — an IMAP
+command a lap — and two rules with overlapping conditions would do the same to each other. `\Seen` is the case that
+makes it unavoidable: a flag change reaches synchronization as a changed modification sequence, which is precisely the
+signal a person marking mail read in their own client produces, so a rule conditioned on unread mail that marks mail
+read would re-evaluate everything it had just acted on.
+
+A run therefore **withholds** every change a mutation record accounts for, and raises everything else. There is no
+cycle counter, no depth limit, and no rate limit involved, and that is deliberate: a cycle limit stops a loop only
+after it has already run several times, and a rate limit stops legitimate work at the same threshold. The record
+answers the question exactly.
+
+The suppression is scoped to the one change the record describes and expires with it. A relocation or a copy is written
+down as observed the first time synchronization meets the occurrence it placed, and answers for no discovery afterwards.
+A `\Seen` store moves no occurrence, so it expires against the message's own flag observation instead: it accounts for a
+reading only while the last one predates the moment the store completed, and every window advances that for every
+occurrence it asked about. So the mailbox owner setting by hand the same flag MailFathom set months earlier, or moving
+the message back themselves, reaches rule evaluation as the change it is — including when they reverted the flag before
+any window had seen MailFathom's own change at all.
+
+A withheld change is visible rather than silent, because a rule that appears not to have fired is otherwise
+indistinguishable from a rule that never matched. Each folder's run reports how many changes it withheld at
+`Information`, and names each one at `Debug` with its kind, the mutation, the local email, and the record that
+accounted for it. Nothing derived from a message appears in either line. A folder MailFathom never writes to emits
+neither.
 
 ### What becomes of a message the server no longer holds
 

--- a/src/Application/Mail/Mutations/IMailboxMutationReconciliationStore.cs
+++ b/src/Application/Mail/Mutations/IMailboxMutationReconciliationStore.cs
@@ -25,24 +25,64 @@ namespace MailFathom.Application.Mail.Mutations;
 /// </remarks>
 public interface IMailboxMutationReconciliationStore
 {
-    /// <summary>Reads the relocations that named one folder as their destination and placed an email at one of these UIDs.</summary>
+    /// <summary>Reads the mutations that named one folder as their destination and placed an email at one of these UIDs.</summary>
     /// <param name="accountId">The account whose mutations are read.</param>
-    /// <param name="destinationPath">The remote folder being synchronized, which is the destination those relocations named.</param>
+    /// <param name="destinationPath">The remote folder being synchronized, which is the destination those mutations named.</param>
     /// <param name="uidValidity">The UIDVALIDITY that folder reports now.</param>
     /// <param name="uids">The UIDs one batch of the forward pass discovered.</param>
     /// <param name="cancellationToken">Cancels the read.</param>
     /// <returns>Every record whose reported placement is one of those occurrences, which may be none.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="uids" /> is <see langword="null" />.</exception>
     /// <remarks>
-    /// A whole batch of discoveries is asked about at once, so a folder that has no relocation pending — which is nearly
+    /// <para>
+    /// A whole batch of discoveries is asked about at once, so a folder that has no placement pending — which is nearly
     /// every folder on nearly every run — costs one query rather than one per message. The batch's own UIDs bound the
     /// answer, so no limit has to be invented for it and no candidate can be missed by one. Which record a given
-    /// occurrence belongs to is then decided by <see cref="MailboxMutationRecord.IsPlacementOf" />, which restates every
-    /// condition of the read rather than trusting it.
+    /// occurrence belongs to is then decided by <see cref="MailboxMutationRecord.AccountsForPlacementAt" />, which
+    /// restates every condition of the read rather than trusting it.
+    /// </para>
+    /// <para>
+    /// A relocation and a copy are both read, because both put a message where the forward pass will meet it and the
+    /// discovery is MailFathom's own act either way. What the two then do differs — a relocation carries the local email
+    /// onto the new occurrence and a copy does not — and that is the caller's decision rather than this read's.
+    /// </para>
     /// </remarks>
-    Task<IReadOnlyList<MailboxMutationRecord>> ReadRelocationsPlacedAtAsync(
+    Task<IReadOnlyList<MailboxMutationRecord>> ReadPlacementsAtAsync(
         MailAccountId accountId,
         RemoteFolderPath destinationPath,
+        ImapUidValidity uidValidity,
+        IReadOnlyCollection<ImapUid> uids,
+        CancellationToken cancellationToken);
+
+    /// <summary>Reads the <c>\Seen</c> stores issued against any of the occurrences a reconciliation window read flags for.</summary>
+    /// <param name="accountId">The account whose mutations are read.</param>
+    /// <param name="folderResolutionId">The alias binding the occurrences were stored under.</param>
+    /// <param name="uidValidity">The UIDVALIDITY the window was opened for.</param>
+    /// <param name="uids">The UIDs whose remote <c>\Seen</c> flag the window found standing somewhere new.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>Every <c>\Seen</c> store issued against one of those occurrences, which may be none.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="uids" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// This is the read the whole issue turns on. A flag change reaches synchronization as a changed modification
+    /// sequence, which is exactly what a person marking mail read in their own client produces, so nothing in the
+    /// server's answer distinguishes the two and only the record does. A rule conditioned on unread mail that marks mail
+    /// read would otherwise re-evaluate every message it had just acted on.
+    /// </para>
+    /// <para>
+    /// Only the occurrences whose flag actually moved are asked about, so a window that found the mailbox unchanged —
+    /// which is most windows — asks nothing. The answer is bounded by <paramref name="uids" /> and by the idempotency
+    /// identity, which admits one record per occurrence, requester, and mutation.
+    /// </para>
+    /// <para>
+    /// Every such record is returned, spent or not, because whether one still accounts for anything is settled against
+    /// the occurrence's own last observation rather than against a mark on the row. That comparison belongs to
+    /// <see cref="MailboxMutationRecord.AccountsForSeenStateOf" />, which the caller applies to what this returns.
+    /// </para>
+    /// </remarks>
+    Task<IReadOnlyList<MailboxMutationRecord>> ReadSeenStateChangesOnAsync(
+        MailAccountId accountId,
+        MailFolderResolutionId folderResolutionId,
         ImapUidValidity uidValidity,
         IReadOnlyCollection<ImapUid> uids,
         CancellationToken cancellationToken);
@@ -87,11 +127,18 @@ public interface IMailboxMutationReconciliationStore
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="session" /> is <see langword="null" />.</exception>
     /// <exception cref="InvalidOperationException">Thrown when no record carries <paramref name="recordId" />.</exception>
     /// <remarks>
-    /// It settles the source half as well, where nothing has settled it already. Carrying the row across is what takes
-    /// the email out of the source folder locally, so no later window can select it there and no later run can observe
-    /// the disappearance the record is otherwise still waiting for. The stage this is only ever reached from is
+    /// <para>
+    /// It settles the source half as well, for a mutation that has one. Carrying the row across is what takes the email
+    /// out of the source folder locally, so no later window can select it there and no later run can observe the
+    /// disappearance the record is otherwise still waiting for. The stage this is only ever reached from is
     /// <see cref="MailboxMutationStage.Completed" />, which is the server's own statement that the source occurrence is
-    /// already gone.
+    /// already gone. A copy leaves its source where it was and settles nothing about it.
+    /// </para>
+    /// <para>
+    /// Writing it is also what expires the suppression. A record whose placement has been observed answers for no later
+    /// discovery, which is what keeps a folder recreated under a reused UID from being attributed to a mutation made
+    /// against the previous one.
+    /// </para>
     /// </remarks>
     Task RecordPlacementObservedAsync(
         IPersistenceSession session,

--- a/src/Application/Synchronization/MailboxSynchronizer.cs
+++ b/src/Application/Synchronization/MailboxSynchronizer.cs
@@ -160,6 +160,7 @@ public sealed class MailboxSynchronizer
         var relocatedCount = 0;
         var hasMore = true;
         var inspectedBatchCount = 0;
+        var suppressedChanges = new List<SuppressedMailboxChange>();
 
         while (hasMore && inspectedBatchCount < this.options.MaxMetadataBatchesPerRun)
         {
@@ -170,7 +171,7 @@ public sealed class MailboxSynchronizer
                 this.options.MaxMetadataBatchSize,
                 synchronizationWindow,
                 cancellationToken);
-            var relocations = await this.ReadRelocationsPlacedInBatchAsync(
+            var placements = await this.ReadPlacementsInBatchAsync(
                 accountId,
                 folder,
                 uidValidity,
@@ -179,14 +180,29 @@ public sealed class MailboxSynchronizer
 
             foreach (var metadata in batch.Emails.OrderBy(email => email.OccurrenceId.Uid.Value))
             {
-                if (await this.TryCarryRelocatedEmailAsync(relocations, folder, metadata, cancellationToken))
+                var placement = FindPlacementOf(placements, folder, metadata.OccurrenceId);
+
+                if (placement is { } relocation
+                    && relocation.Request.Mutation == MailboxMutation.Relocate
+                    && await this.TryCarryRelocatedEmailAsync(relocation, metadata.OccurrenceId, cancellationToken))
                 {
                     relocatedCount++;
+                    suppressedChanges.Add(new SuppressedMailboxChange(
+                        MailboxChangeKind.EmailAppearedInFolder,
+                        relocation.Request.Mutation,
+                        relocation.Request.StoredEmailId,
+                        relocation.Id));
 
                     continue;
                 }
 
-                var occurrence = await this.StoreOccurrenceAsync(mailboxSession, metadata, cancellationToken);
+                // A copy is stored like any other discovery, because the email it duplicates stays where it was and
+                // nothing is carried across. What the record settles is only whose act the arrival was.
+                var copy = placement is { } candidate && candidate.Request.Mutation == MailboxMutation.Copy
+                    ? candidate
+                    : null;
+
+                var occurrence = await this.StoreOccurrenceAsync(mailboxSession, metadata, copy, cancellationToken);
                 if (occurrence.Availability == StoredEmailContentAvailability.Available)
                 {
                     storedCount++;
@@ -199,6 +215,15 @@ public sealed class MailboxSynchronizer
                 if (occurrence.MimeCouldNotBeRead)
                 {
                     unreadableMimeCount++;
+                }
+
+                if (copy is not null)
+                {
+                    suppressedChanges.Add(new SuppressedMailboxChange(
+                        MailboxChangeKind.EmailAppearedInFolder,
+                        copy.Request.Mutation,
+                        occurrence.StoredEmailId,
+                        copy.Id));
                 }
             }
 
@@ -247,15 +272,16 @@ public sealed class MailboxSynchronizer
             relocatedCount,
             hasMore,
             checkpoint,
-            reconciliation);
+            reconciliation,
+            [.. suppressedChanges, .. reconciliation.SuppressedChanges]);
     }
 
-    /// <summary>Reads the relocations whose destination is this folder and whose placement is one of the UIDs this batch discovered.</summary>
+    /// <summary>Reads the mutations whose destination is this folder and whose placement is one of the UIDs this batch discovered.</summary>
     /// <remarks>
     /// A batch that discovered nothing asks nothing. The read is otherwise made once for the whole batch, so recognizing
-    /// MailFathom's own work costs one query per batch on a folder nobody relocates into and never one per message.
+    /// MailFathom's own work costs one query per batch on a folder nobody writes into and never one per message.
     /// </remarks>
-    private async Task<IReadOnlyList<MailboxMutationRecord>> ReadRelocationsPlacedInBatchAsync(
+    private async Task<IReadOnlyList<MailboxMutationRecord>> ReadPlacementsInBatchAsync(
         MailAccountId accountId,
         MailFolderResolution folder,
         ImapUidValidity uidValidity,
@@ -267,13 +293,25 @@ public sealed class MailboxSynchronizer
             return [];
         }
 
-        return await this.mutationStore.ReadRelocationsPlacedAtAsync(
+        return await this.mutationStore.ReadPlacementsAtAsync(
             accountId,
             folder.RemotePath,
             uidValidity,
             [.. batch.Emails.Select(static email => email.OccurrenceId.Uid)],
             cancellationToken);
     }
+
+    /// <summary>Finds the mutation whose reported placement is the occurrence this discovery sits at, if any is.</summary>
+    /// <remarks>
+    /// The first match is taken. Every condition of the read is restated by the record itself rather than trusted, so a
+    /// query widened later cannot quietly widen what counts as MailFathom's own work.
+    /// </remarks>
+    private static MailboxMutationRecord? FindPlacementOf(
+        IReadOnlyList<MailboxMutationRecord> placements,
+        MailFolderResolution folder,
+        EmailOccurrenceId occurrenceId) =>
+        placements.FirstOrDefault(candidate =>
+            candidate.AccountsForPlacementAt(folder.RemotePath, occurrenceId.UidValidity, occurrenceId.Uid));
 
     /// <summary>Carries the local email a relocation moved onto the occurrence it was discovered at, rather than storing a second one.</summary>
     /// <returns><see langword="true" /> when the discovery was this mutation's own and needs nothing further; otherwise, <see langword="false" />.</returns>
@@ -284,26 +322,17 @@ public sealed class MailboxSynchronizer
     /// carried across rather than by the occurrence it sits at.
     /// </para>
     /// <para>
-    /// A discovery that matches nothing, and one whose destination occurrence another row already occupies, both fall
-    /// through to the ordinary path. That is the same treatment mail a person moved in their own client gets, which is
-    /// what keeps this change invisible to every mailbox MailFathom is not writing to.
+    /// A discovery whose destination occurrence another row already occupies falls through to the ordinary path, as one
+    /// that matches nothing does. That is the same treatment mail a person moved in their own client gets, which is
+    /// what keeps this change invisible to every mailbox MailFathom is not writing to — and it leaves the record
+    /// unobserved, so nothing claims a change was accounted for that no local row reflects.
     /// </para>
     /// </remarks>
     private async Task<bool> TryCarryRelocatedEmailAsync(
-        IReadOnlyList<MailboxMutationRecord> relocations,
-        MailFolderResolution folder,
-        RemoteEmailMetadata metadata,
+        MailboxMutationRecord record,
+        EmailOccurrenceId occurrenceId,
         CancellationToken cancellationToken)
     {
-        var occurrenceId = metadata.OccurrenceId;
-        var record = relocations.FirstOrDefault(candidate =>
-            candidate.IsPlacementOf(folder.RemotePath, occurrenceId.UidValidity, occurrenceId.Uid));
-
-        if (record is null)
-        {
-            return false;
-        }
-
         var carried = false;
 
         await this.concurrencyRetryPolicy.CommitAsync(
@@ -365,14 +394,21 @@ public sealed class MailboxSynchronizer
         return reconciledCheckpoint;
     }
 
+    /// <summary>Stores one discovered occurrence, settling the copy that placed it in the same transaction where there was one.</summary>
+    /// <remarks>
+    /// The placement observation belongs in the write that stores the email rather than beside it. A copy whose arrival
+    /// was recorded but whose row was rolled back would answer for a change no local state reflects, and the next run
+    /// would store the message as an arrival nobody accounted for.
+    /// </remarks>
     private async Task<OccurrenceSynchronizationOutcome> StoreOccurrenceAsync(
         IMailboxSession mailboxSession,
         RemoteEmailMetadata metadata,
+        MailboxMutationRecord? placement,
         CancellationToken cancellationToken)
     {
         if (metadata.SizeOctets > this.options.MaxRawMimeBytes)
         {
-            return await this.RecordOversizedOccurrenceAsync(metadata, cancellationToken);
+            return await this.RecordOversizedOccurrenceAsync(metadata, placement, cancellationToken);
         }
 
         var fetch = await mailboxSession.FetchEmailContentWithoutSettingSeenAsync(metadata.OccurrenceId, this.options.MaxRawMimeBytes, cancellationToken);
@@ -380,7 +416,7 @@ public sealed class MailboxSynchronizer
         {
             // The advertised size understated the payload, so the occurrence is recorded without content instead of
             // being silently skipped past by the checkpoint.
-            return await this.RecordOversizedOccurrenceAsync(metadata, cancellationToken);
+            return await this.RecordOversizedOccurrenceAsync(metadata, placement, cancellationToken);
         }
 
         // Enrichment reads the payload this run already fetched, so it costs no second IMAP round trip and cannot reach
@@ -388,10 +424,12 @@ public sealed class MailboxSynchronizer
         // only what the server's envelope reported, and the folder checkpoint still advances past it.
         var extraction = await this.mimeReader.ReadMetadataAsync(content, cancellationToken);
 
+        var storedEmailId = default(StoredEmailId);
+
         await this.concurrencyRetryPolicy.CommitAsync(
             async (persistenceSession, attemptCancellationToken) =>
             {
-                var storedEmailId = await this.metadataRepository.UpsertMetadataAsync(
+                storedEmailId = await this.metadataRepository.UpsertMetadataAsync(
                     persistenceSession,
                     metadata,
                     extraction.Metadata,
@@ -402,35 +440,62 @@ public sealed class MailboxSynchronizer
                     storedEmailId,
                     content,
                     attemptCancellationToken);
+
+                await this.ObservePlacementAsync(persistenceSession, placement, attemptCancellationToken);
             },
             cancellationToken);
 
         return new OccurrenceSynchronizationOutcome(
+            storedEmailId,
             StoredEmailContentAvailability.Available,
             extraction.Outcome != EmailMimeExtractionOutcome.Extracted);
     }
 
     private async Task<OccurrenceSynchronizationOutcome> RecordOversizedOccurrenceAsync(
         RemoteEmailMetadata metadata,
+        MailboxMutationRecord? placement,
         CancellationToken cancellationToken)
     {
+        var storedEmailId = default(StoredEmailId);
+
         await this.concurrencyRetryPolicy.CommitAsync(
             async (persistenceSession, attemptCancellationToken) =>
             {
-                await this.metadataRepository.UpsertMetadataAsync(
+                storedEmailId = await this.metadataRepository.UpsertMetadataAsync(
                     persistenceSession,
                     metadata,
                     extractedMetadata: null,
                     StoredEmailContentAvailability.ExceededSizeLimit,
                     attemptCancellationToken);
+
+                await this.ObservePlacementAsync(persistenceSession, placement, attemptCancellationToken);
             },
             cancellationToken);
 
         // An occurrence whose content was never retrieved has no MIME to read, so it is neither enriched nor counted as
         // unreadable.
         return new OccurrenceSynchronizationOutcome(
+            storedEmailId,
             StoredEmailContentAvailability.ExceededSizeLimit,
             MimeCouldNotBeRead: false);
+    }
+
+    /// <summary>Writes down that the occurrence a copy created has been met, where this discovery was one.</summary>
+    private async Task ObservePlacementAsync(
+        IPersistenceSession persistenceSession,
+        MailboxMutationRecord? placement,
+        CancellationToken cancellationToken)
+    {
+        if (placement is null)
+        {
+            return;
+        }
+
+        await this.mutationStore.RecordPlacementObservedAsync(
+            persistenceSession,
+            placement.Id,
+            this.timeProvider.GetUtcNow(),
+            cancellationToken);
     }
 
     // A checkpoint advance is attempted once rather than retried: the intended progress was derived from the state read
@@ -461,9 +526,11 @@ public sealed class MailboxSynchronizer
     }
 
     /// <summary>States what one occurrence's turn through the run produced.</summary>
+    /// <param name="StoredEmailId">The local email the occurrence was stored as, which a suppressed arrival is named by.</param>
     /// <param name="Availability">Whether the occurrence was stored with its content or as metadata only.</param>
     /// <param name="MimeCouldNotBeRead">Whether enrichment refused the payload that was stored.</param>
     private readonly record struct OccurrenceSynchronizationOutcome(
+        StoredEmailId StoredEmailId,
         StoredEmailContentAvailability Availability,
         bool MimeCouldNotBeRead);
 }
@@ -495,6 +562,11 @@ public enum MailboxSynchronizationOutcome
 /// <param name="HasMoreEmails">Whether the folder still held unprocessed emails when the run's batch budget ran out.</param>
 /// <param name="Checkpoint">The progress the run ended on, which is present exactly when <paramref name="Outcome" /> is <see cref="MailboxSynchronizationOutcome.Synchronized" />.</param>
 /// <param name="Reconciliation">What the run's backward pass found among the emails already stored for this folder.</param>
+/// <param name="SuppressedChanges">
+/// Every change this run discovered and did not raise, because a durable mutation record said MailFathom had made it —
+/// both passes together, since one relocation arrives as an appearance in the forward pass and a disappearance in the
+/// backward one. Without it a rule that files mail would match the mail it had just filed, indefinitely.
+/// </param>
 /// <remarks>
 /// The binding is reported because resolution happens inside the run and a caller that wants to keep watching the
 /// folder afterwards must watch the remote folder the alias actually resolved to. Re-resolving it outside the run would
@@ -510,7 +582,8 @@ public sealed record MailboxSynchronizationResult(
     int RelocatedEmailCount,
     bool HasMoreEmails,
     SynchronizationCheckpoint? Checkpoint,
-    MailboxReconciliationResult Reconciliation)
+    MailboxReconciliationResult Reconciliation,
+    IReadOnlyList<SuppressedMailboxChange> SuppressedChanges)
 {
     /// <summary>Reports a run that reached its folder.</summary>
     /// <param name="folder">The binding the run worked under.</param>
@@ -521,8 +594,9 @@ public sealed record MailboxSynchronizationResult(
     /// <param name="hasMoreEmails">Whether unprocessed emails remain.</param>
     /// <param name="checkpoint">The progress the run ended on.</param>
     /// <param name="reconciliation">What the run's backward pass found.</param>
+    /// <param name="suppressedChanges">The changes the run recognized as MailFathom's own and did not raise.</param>
     /// <returns>A synchronized result.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="folder" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="folder" /> or <paramref name="suppressedChanges" /> is <see langword="null" />.</exception>
     public static MailboxSynchronizationResult Synchronized(
         MailFolderResolution folder,
         int storedEmailCount,
@@ -531,9 +605,11 @@ public sealed record MailboxSynchronizationResult(
         int relocatedEmailCount,
         bool hasMoreEmails,
         SynchronizationCheckpoint checkpoint,
-        MailboxReconciliationResult reconciliation)
+        MailboxReconciliationResult reconciliation,
+        IReadOnlyList<SuppressedMailboxChange> suppressedChanges)
     {
         ArgumentNullException.ThrowIfNull(folder);
+        ArgumentNullException.ThrowIfNull(suppressedChanges);
 
         return new MailboxSynchronizationResult(
             MailboxSynchronizationOutcome.Synchronized,
@@ -544,7 +620,8 @@ public sealed record MailboxSynchronizationResult(
             relocatedEmailCount,
             hasMoreEmails,
             checkpoint,
-            reconciliation);
+            reconciliation,
+            suppressedChanges);
     }
 
     /// <summary>Reports a configured alias that named no single advertised folder.</summary>
@@ -576,6 +653,7 @@ public sealed record MailboxSynchronizationResult(
             0,
             HasMoreEmails: false,
             Checkpoint: null,
-            MailboxReconciliationResult.NothingToReconcile);
+            MailboxReconciliationResult.NothingToReconcile,
+            SuppressedChanges: []);
     }
 }

--- a/src/Application/Synchronization/Reconciliation/MailboxReconciler.cs
+++ b/src/Application/Synchronization/Reconciliation/MailboxReconciler.cs
@@ -35,6 +35,13 @@ namespace MailFathom.Application.Synchronization.Reconciliation;
 /// the occurrence leaving its folder is those changes completing rather than a remote deletion to react to. The durable
 /// mutation record is what tells the two apart, so the pass reads it before the disposition is reached.
 /// </para>
+/// <para>
+/// The same holds of a <c>\Seen</c> flag that has moved, and there it is the whole difficulty. A flag change arrives as
+/// a changed modification sequence, which is the identical signal a person marking mail read in their own client
+/// produces, so a rule conditioned on unread mail that marks mail read would re-evaluate everything it had just acted
+/// on. The record answers it, and both halves of that answer are recorded in the window's own transaction so a change
+/// can never be marked accounted for by a window whose reading of it was rolled back.
+/// </para>
 /// </remarks>
 public sealed class MailboxReconciler
 {
@@ -141,6 +148,12 @@ public sealed class MailboxReconciler
             folder.Id,
             uidValidity,
             cancellationToken);
+        var seenStateChanges = await this.AttributeSeenStateChangesAsync(
+            classification,
+            accountId,
+            folder.Id,
+            uidValidity,
+            cancellationToken);
 
         await this.concurrencyRetryPolicy.CommitAsync(
             async (persistenceSession, attemptCancellationToken) =>
@@ -150,8 +163,8 @@ public sealed class MailboxReconciler
                     outcome,
                     attemptCancellationToken);
 
-                // Written in the window's own transaction, so a record can never say a disappearance was accounted for
-                // by a window whose observation of it was rolled back.
+                // Written in the window's own transaction, so a record can never say a change was accounted for by a
+                // window whose observation of it was rolled back.
                 foreach (var attributed in outcome.RemovedByOwnMutation)
                 {
                     await this.mutationStore.RecordSourceRemovalObservedAsync(
@@ -160,6 +173,7 @@ public sealed class MailboxReconciler
                         outcome.ObservedAt,
                         attemptCancellationToken);
                 }
+
             },
             cancellationToken);
 
@@ -169,8 +183,17 @@ public sealed class MailboxReconciler
             outcome.StillPresent.Count + outcome.ConfirmedUnchanged.Count,
             outcome.Disappeared.Count,
             outcome.RemovedByOwnMutation.Count,
+            seenStateChanges.ExternalCount,
             emailsRemain,
-            emailsRemain ? null : observation.FolderHighestModSeq);
+            emailsRemain ? null : observation.FolderHighestModSeq,
+            [
+                .. outcome.RemovedByOwnMutation.Select(static attributed => new SuppressedMailboxChange(
+                    MailboxChangeKind.EmailLeftFolder,
+                    attributed.Mutation,
+                    attributed.StoredEmailId,
+                    attributed.MutationRecordId)),
+                .. seenStateChanges.Suppressed,
+            ]);
     }
 
     /// <summary>Separates the disappearances MailFathom caused from the ones the disposition answers for.</summary>
@@ -198,7 +221,7 @@ public sealed class MailboxReconciler
         if (classification.Disappeared.Count == 0)
         {
             return new ReconciledFolderOutcome(
-                classification.StillPresent,
+                classification.ObservedFlags,
                 classification.ConfirmedUnchanged,
                 [],
                 [],
@@ -222,7 +245,7 @@ public sealed class MailboxReconciler
             .ToArray();
 
         return new ReconciledFolderOutcome(
-            classification.StillPresent,
+            classification.ObservedFlags,
             classification.ConfirmedUnchanged,
             [.. attributions.Where(static attribution => attribution.Record is null).Select(static attribution => attribution.StoredEmailId)],
             [
@@ -230,10 +253,76 @@ public sealed class MailboxReconciler
                     .Where(static attribution => attribution.Record is not null)
                     .Select(static attribution => new MutationAttributedDisappearance(
                         attribution.StoredEmailId,
-                        attribution.Record!.Id)),
+                        attribution.Record!.Id,
+                        attribution.Record.Request.Mutation)),
             ],
             disposition,
             observedAt);
+    }
+
+    /// <summary>Separates the <c>\Seen</c> flags MailFathom moved from the ones the mailbox owner moved.</summary>
+    /// <remarks>
+    /// <para>
+    /// Only an occurrence whose flag actually stands somewhere new is asked about, so a window over a mailbox nobody has
+    /// touched reads no records at all. An occurrence nobody had observed before has no previous value to differ from,
+    /// so its first flag reading is the initial observation rather than a change — and treating it as one would raise a
+    /// trigger for every message the forward pass had just stored.
+    /// </para>
+    /// <para>
+    /// A change with no record is the mailbox owner's own act and is counted rather than suppressed, which is what keeps
+    /// this about provenance instead of about which field moved.
+    /// </para>
+    /// <para>
+    /// Nothing is written back to the record here, and it needs nothing: a store answers only for a reading taken before
+    /// the occurrence was next observed, and applying this window's outcome is what moves that observation forward. The
+    /// window's own transaction therefore ends the record's answer whether or not anything matched, which is the case a
+    /// mark on the row would miss — an owner who reverted the flag before the first reading would leave such a mark
+    /// unwritten and have their own later change silenced by it.
+    /// </para>
+    /// </remarks>
+    private async Task<ReconciledSeenStateChanges> AttributeSeenStateChangesAsync(
+        ReconciledWindowClassification classification,
+        MailAccountId accountId,
+        MailFolderResolutionId folderResolutionId,
+        ImapUidValidity uidValidity,
+        CancellationToken cancellationToken)
+    {
+        var changed = classification.StillPresent
+            .Where(static observed => observed.SeenStateMoved)
+            .ToArray();
+
+        if (changed.Length == 0)
+        {
+            return ReconciledSeenStateChanges.None;
+        }
+
+        var records = await this.mutationStore.ReadSeenStateChangesOnAsync(
+            accountId,
+            folderResolutionId,
+            uidValidity,
+            [.. changed.Select(static observed => observed.Candidate.Uid)],
+            cancellationToken);
+
+        var attributions = changed
+            .Select(observed => new
+            {
+                observed.Candidate.StoredEmailId,
+                Record = FindRecordSettingSeen(records, observed, accountId, folderResolutionId, uidValidity),
+            })
+            .ToArray();
+
+        IReadOnlyList<SuppressedMailboxChange> suppressed =
+        [
+            .. attributions
+                .Where(static attribution => attribution.Record is not null)
+                .Select(static attribution => new SuppressedMailboxChange(
+                    MailboxChangeKind.SeenStateChanged,
+                    attribution.Record!.Request.Mutation,
+                    attribution.StoredEmailId,
+                    attribution.Record.Id)),
+        ];
+
+        return new ReconciledSeenStateChanges(changed.Length - suppressed.Count, suppressed);
     }
 
     private static MailboxMutationRecord? FindRecordRemoving(
@@ -246,6 +335,38 @@ public sealed class MailboxReconciler
         var occurrence = EmailOccurrenceId.Create(accountId, folderResolutionId, uidValidity, uid);
 
         return records.FirstOrDefault(record => record.AccountsForRemovalOf(occurrence));
+    }
+
+    /// <summary>Finds the <c>\Seen</c> store that put the flag where the server has just reported it, if one did.</summary>
+    /// <remarks>
+    /// The first match is taken, as it is for a disappearance: one occurrence can carry a record per requester, and
+    /// which of them is credited changes nothing about the local row — what matters is that the change does not reach
+    /// evaluation as somebody else's.
+    /// </remarks>
+    private static MailboxMutationRecord? FindRecordSettingSeen(
+        IReadOnlyList<MailboxMutationRecord> records,
+        ObservedWindowCandidate observed,
+        MailAccountId accountId,
+        MailFolderResolutionId folderResolutionId,
+        ImapUidValidity uidValidity)
+    {
+        // A moved flag means the occurrence was observed before, so the window entry carries that reading and this is
+        // never reached without one.
+        if (observed.Candidate.LastObservation is not { } lastObservation)
+        {
+            return null;
+        }
+
+        var occurrence = EmailOccurrenceId.Create(
+            accountId,
+            folderResolutionId,
+            uidValidity,
+            observed.Candidate.Uid);
+
+        return records.FirstOrDefault(record => record.AccountsForSeenStateOf(
+            occurrence,
+            observed.Snapshot.IsSeen,
+            lastObservation.ObservedAt));
     }
 
     /// <summary>Sorts the window into the occurrences the server described, the ones it confirmed, and the ones it accounted for in neither.</summary>
@@ -280,7 +401,7 @@ public sealed class MailboxReconciler
 
         var stillPresent = window
             .Where(candidate => snapshotsByUid.ContainsKey(candidate.Uid))
-            .Select(candidate => new ObservedEmailFlags(candidate.StoredEmailId, snapshotsByUid[candidate.Uid]))
+            .Select(candidate => new ObservedWindowCandidate(candidate, snapshotsByUid[candidate.Uid]))
             .ToArray();
         var confirmedUnchanged = window
             .Where(candidate => !snapshotsByUid.ContainsKey(candidate.Uid) && unchangedUids.Contains(candidate.Uid))
@@ -294,16 +415,51 @@ public sealed class MailboxReconciler
     }
 
     /// <summary>What the server's answer alone says about one window, before anything MailFathom did is taken into account.</summary>
-    /// <param name="StillPresent">The occurrences the server described.</param>
+    /// <param name="StillPresent">The occurrences the server described, each beside the stored state it is compared against.</param>
     /// <param name="ConfirmedUnchanged">The occurrences the server confirmed without describing.</param>
     /// <param name="Disappeared">
     /// The occurrences the folder no longer holds, still carrying their UIDs because that is what a mutation record is
     /// matched against.
     /// </param>
     private sealed record ReconciledWindowClassification(
-        IReadOnlyList<ObservedEmailFlags> StillPresent,
+        IReadOnlyList<ObservedWindowCandidate> StillPresent,
         IReadOnlyList<StoredEmailId> ConfirmedUnchanged,
-        IReadOnlyList<StoredEmailAwaitingReconciliation> Disappeared);
+        IReadOnlyList<StoredEmailAwaitingReconciliation> Disappeared)
+    {
+        /// <summary>Gets the flags to write, which is all the store applying the outcome needs of a described occurrence.</summary>
+        internal IReadOnlyList<ObservedEmailFlags> ObservedFlags =>
+        [
+            .. this.StillPresent.Select(static observed =>
+                new ObservedEmailFlags(observed.Candidate.StoredEmailId, observed.Snapshot)),
+        ];
+    }
+
+    /// <summary>One occurrence the server described, paired with what the last observation of it had recorded.</summary>
+    /// <param name="Candidate">The window entry, which carries the local identity and the previously observed flag.</param>
+    /// <param name="Snapshot">What the server has now reported.</param>
+    private sealed record ObservedWindowCandidate(
+        StoredEmailAwaitingReconciliation Candidate,
+        RemoteEmailFlagSnapshot Snapshot)
+    {
+        /// <summary>Gets whether the remote <c>\Seen</c> flag stands somewhere other than where it was last seen.</summary>
+        /// <remarks>
+        /// An occurrence with no previous reading reports no movement. Nothing changed for it — this is the first time
+        /// anybody looked — and calling that a change would raise a trigger for every message a backfill stores.
+        /// </remarks>
+        internal bool SeenStateMoved =>
+            this.Candidate.LastObservation is { } lastObservation && lastObservation.IsSeen != this.Snapshot.IsSeen;
+    }
+
+    /// <summary>What one window's moved <c>\Seen</c> flags split into once the mutation record has answered for them.</summary>
+    /// <param name="ExternalCount">How many the record accounts for nothing of, which are the mailbox owner's own.</param>
+    /// <param name="Suppressed">The ones MailFathom set itself, each named with the record that says so.</param>
+    private sealed record ReconciledSeenStateChanges(
+        int ExternalCount,
+        IReadOnlyList<SuppressedMailboxChange> Suppressed)
+    {
+        /// <summary>Gets the split of a window in which no flag moved at all.</summary>
+        internal static ReconciledSeenStateChanges None { get; } = new(ExternalCount: 0, Suppressed: []);
+    }
 }
 
 /// <summary>Summarizes one bounded reconciliation window.</summary>
@@ -314,21 +470,33 @@ public sealed class MailboxReconciler
 /// the remotely deleted ones because they are the opposite finding: a change of the owner's own that has come back
 /// through synchronization, rather than one to react to.
 /// </param>
+/// <param name="SeenStateChangedEmailCount">
+/// How many stored emails the server reported a moved <c>\Seen</c> flag for that no mutation of MailFathom's accounts
+/// for. Those are the mailbox owner's own act — read in their client, or marked read there — and they stay a change to
+/// react to, which is what keeps the suppression beside them about provenance rather than about the flag.
+/// </param>
 /// <param name="EmailsRemain">Whether occurrences still await reconciliation after this window.</param>
 /// <param name="ReconciledThroughModSeq">
 /// The folder modification sequence this pass covered the whole folder through, or <see langword="null" /> when the
 /// pass was partial or the server reports no sequence. A caller records it on the folder's checkpoint.
 /// </param>
+/// <param name="SuppressedChanges">
+/// The changes this window found and did not raise, because MailFathom itself had made them. The list is bounded by the
+/// mutations MailFathom has in flight rather than by the size of the window, so it is a handful on the runs that have
+/// any and empty on every run of a mailbox nobody writes to.
+/// </param>
 /// <remarks>
-/// Every field is a count or a sequence number. Nothing derived from a message belongs in a result a worker logs, which
-/// is what makes the audit line this becomes safe to emit for a mailbox nobody may read.
+/// Every field is a count, a sequence number, or an identity MailFathom owns. Nothing derived from a message belongs in
+/// a result a worker logs, which is what makes the audit line this becomes safe to emit for a mailbox nobody may read.
 /// </remarks>
 public sealed record MailboxReconciliationResult(
     int ObservedEmailCount,
     int RemotelyDeletedEmailCount,
     int OwnMutationCompletedEmailCount,
+    int SeenStateChangedEmailCount,
     bool EmailsRemain,
-    ulong? ReconciledThroughModSeq)
+    ulong? ReconciledThroughModSeq,
+    IReadOnlyList<SuppressedMailboxChange> SuppressedChanges)
 {
     /// <summary>Gets the result of a run whose folder had nothing awaiting reconciliation.</summary>
     /// <remarks>
@@ -340,6 +508,8 @@ public sealed record MailboxReconciliationResult(
         ObservedEmailCount: 0,
         RemotelyDeletedEmailCount: 0,
         OwnMutationCompletedEmailCount: 0,
+        SeenStateChangedEmailCount: 0,
         EmailsRemain: false,
-        ReconciledThroughModSeq: null);
+        ReconciledThroughModSeq: null,
+        SuppressedChanges: []);
 }

--- a/src/Application/Synchronization/Reconciliation/ReconciledFolderOutcome.cs
+++ b/src/Application/Synchronization/Reconciliation/ReconciledFolderOutcome.cs
@@ -15,9 +15,14 @@ public sealed record ObservedEmailFlags(StoredEmailId StoredEmailId, RemoteEmail
 /// <summary>Pairs one occurrence the folder no longer holds with the change MailFathom made that took it out.</summary>
 /// <param name="StoredEmailId">The local identity whose occurrence has gone.</param>
 /// <param name="MutationRecordId">The durable record of the change that removed it.</param>
+/// <param name="Mutation">
+/// Which change it was, carried here so the suppression a run reports names the same word its log line and its counter
+/// already use rather than sending a reader back to the record to find out.
+/// </param>
 public sealed record MutationAttributedDisappearance(
     StoredEmailId StoredEmailId,
-    MailboxMutationRecordId MutationRecordId);
+    MailboxMutationRecordId MutationRecordId,
+    MailboxMutation Mutation);
 
 /// <summary>Everything one reconciliation window learned, as one thing to apply.</summary>
 /// <param name="StillPresent">The emails the folder still holds, with the flags to write onto them.</param>

--- a/src/Application/Synchronization/Reconciliation/StoredEmailAwaitingReconciliation.cs
+++ b/src/Application/Synchronization/Reconciliation/StoredEmailAwaitingReconciliation.cs
@@ -9,8 +9,33 @@ namespace MailFathom.Application.Synchronization.Reconciliation;
 /// <summary>One locally stored occurrence a reconciliation window has selected to ask the server about.</summary>
 /// <param name="StoredEmailId">The stable local identity the outcome is written against.</param>
 /// <param name="Uid">The UID the server is asked about, within the folder and UIDVALIDITY the window was opened for.</param>
+/// <param name="LastObservation">
+/// What the previous reading of this occurrence's remote flags recorded, or <see langword="null" /> when no run has read
+/// them yet.
+/// </param>
 /// <remarks>
-/// The pair is everything reconciliation needs and deliberately nothing more. No subject, address, or fragment of a
-/// message takes part in deciding whether an email still exists remotely, so none of it is read to decide it.
+/// <para>
+/// The three values are everything reconciliation needs and deliberately nothing more. No subject, address, or fragment
+/// of a message takes part in deciding whether an email still exists remotely or whether its flags have moved, so none
+/// of it is read to decide it.
+/// </para>
+/// <para>
+/// <paramref name="LastObservation" /> is what turns the flags the server reports into a change rather than a reading.
+/// Absence is a state of its own here: an occurrence nobody has observed has no previous value to differ from, so its
+/// first flag reading is the initial observation and never a change somebody made.
+/// </para>
 /// </remarks>
-public sealed record StoredEmailAwaitingReconciliation(StoredEmailId StoredEmailId, ImapUid Uid);
+public sealed record StoredEmailAwaitingReconciliation(
+    StoredEmailId StoredEmailId,
+    ImapUid Uid,
+    RemoteSeenStateObservation? LastObservation);
+
+/// <summary>The previous reading of one occurrence's remote <c>\Seen</c> flag, and when it was taken.</summary>
+/// <param name="ObservedAt">When the flag below was read from the server.</param>
+/// <param name="IsSeen">The value it stood at then.</param>
+/// <remarks>
+/// The two travel together because both are needed and neither is meaningful alone. The value says whether the flag has
+/// moved since; the moment says whether a change MailFathom made could still be the reason it moved, which is what stops
+/// a mutation record answering for a mailbox somebody has had the chance to change since.
+/// </remarks>
+public readonly record struct RemoteSeenStateObservation(DateTimeOffset ObservedAt, bool IsSeen);

--- a/src/Domain/Mutations/MailboxChangeKind.cs
+++ b/src/Domain/Mutations/MailboxChangeKind.cs
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Mutations;
+
+/// <summary>Names one kind of change to a mailbox that synchronization discovers and rule evaluation would act on.</summary>
+/// <remarks>
+/// <para>
+/// The three kinds are what a mail server can tell MailFathom has happened to a message that is already stored: it is
+/// somewhere it was not, it is no longer where it was, or its <c>\Seen</c> flag stands elsewhere. Every mutation
+/// MailFathom is permitted to make arrives back as one of them, which is what lets provenance be decided once for all
+/// four rather than per mutation.
+/// </para>
+/// <para>
+/// The kind says what changed and never who caused it. That second question is answered from the durable mutation
+/// record, and keeping the two apart is the point: a person moving mail by hand produces exactly the same kind as a
+/// rule that files it, and only the record tells them apart.
+/// </para>
+/// </remarks>
+public enum MailboxChangeKind
+{
+    /// <summary>A folder holds an occurrence of an email it did not hold before.</summary>
+    EmailAppearedInFolder = 0,
+
+    /// <summary>A folder no longer holds an occurrence of an email it did hold.</summary>
+    EmailLeftFolder = 1,
+
+    /// <summary>The remote <c>\Seen</c> flag of a stored email stands at a different value than the one last observed.</summary>
+    SeenStateChanged = 2,
+}

--- a/src/Domain/Mutations/MailboxMutationRecord.cs
+++ b/src/Domain/Mutations/MailboxMutationRecord.cs
@@ -102,10 +102,13 @@ public sealed record MailboxMutationRecord
 
     /// <summary>Gets whether this mutation puts the email somewhere synchronization will later discover it.</summary>
     /// <remarks>
-    /// A copy places one too, and is deliberately absent: whether a second live occurrence of one message is one local
-    /// row or two is the copy action's decision rather than this join's, so nothing here carries a row across for one.
+    /// A copy places an occurrence exactly as a relocation does, and is included for that reason: the discovery is
+    /// MailFathom's own act either way. What a copy does not do is carry the local row across — whether a second live
+    /// occurrence of one message is one local row or two is the copy action's decision rather than this join's — which
+    /// is why <see cref="IsPlacementOf" /> narrows to a relocation and this does not.
     /// </remarks>
-    public bool ExpectsPlacementObservation => this.Request.Mutation == MailboxMutation.Relocate;
+    public bool ExpectsPlacementObservation =>
+        this.Request.Mutation == MailboxMutation.Relocate || this.Request.Mutation == MailboxMutation.Copy;
 
     /// <summary>Gets whether this mutation takes the source occurrence out of the folder it was in.</summary>
     public bool ExpectsSourceRemovalObservation =>
@@ -121,6 +124,64 @@ public sealed record MailboxMutationRecord
     public bool IsReconciled =>
         (!this.ExpectsPlacementObservation || this.PlacementObservedAt is not null)
         && (!this.ExpectsSourceRemovalObservation || this.SourceRemovalObservedAt is not null);
+
+    /// <summary>Reports whether a newly discovered occurrence is one this mutation put there.</summary>
+    /// <param name="discoveredFolderPath">The remote path of the folder the occurrence was discovered in.</param>
+    /// <param name="discoveredUidValidity">The UIDVALIDITY that folder reports now.</param>
+    /// <param name="discoveredUid">The UID the discovered occurrence carries.</param>
+    /// <returns><see langword="true" /> when the server itself named this occurrence as where it put the email.</returns>
+    /// <remarks>
+    /// This is the provenance question, and it is asked of every mutation that places an occurrence rather than only of
+    /// the one that also carries the local row across. A message MailFathom put in a folder arrives at the forward pass
+    /// as an ordinary discovery, and whether it was moved or copied there changes nothing about whose act it was.
+    /// </remarks>
+    public bool AccountsForPlacementAt(
+        RemoteFolderPath discoveredFolderPath,
+        ImapUidValidity discoveredUidValidity,
+        ImapUid discoveredUid) =>
+        this.ExpectsPlacementObservation
+        && this.PlacementObservedAt is null
+        && this.Stage == MailboxMutationStage.Completed
+        && this.Request.DestinationPath is { } destinationPath
+        && string.Equals(destinationPath.Value, discoveredFolderPath.Value, StringComparison.Ordinal)
+        && this.Placement is { UidValidity: { } placedUidValidity, Uid: { } placedUid }
+        && placedUidValidity == discoveredUidValidity
+        && placedUid == discoveredUid;
+
+    /// <summary>Reports whether the remote <c>\Seen</c> flag a folder just reported stands where this mutation set it.</summary>
+    /// <param name="occurrence">The occurrence whose flag changed.</param>
+    /// <param name="observedSeenState">The <c>\Seen</c> value the server has now reported.</param>
+    /// <param name="previouslyObservedAt">When synchronization last read this occurrence's flags before the reading being judged.</param>
+    /// <returns><see langword="true" /> when this mutation is what moved the flag to that value.</returns>
+    /// <remarks>
+    /// <para>
+    /// The direction is compared as well as the occurrence, so a record that asked for the flag to be set accounts for
+    /// the flag becoming set and never for it becoming clear. A rule that marks mail read is therefore not re-triggered
+    /// by its own store, while the owner clearing that flag afterwards reaches evaluation as the change it is.
+    /// </para>
+    /// <para>
+    /// A record still at <see cref="MailboxMutationStage.Recorded" /> matches nothing, because no <c>STORE</c> has
+    /// reached the server for it and the flag standing where it would have put it is somebody else's doing.
+    /// </para>
+    /// <para>
+    /// <paramref name="previouslyObservedAt" /> is what scopes the answer to the one change this record describes, and
+    /// it is the occurrence's own observation rather than a mark on this row. A <c>\Seen</c> store reaches
+    /// synchronization only as a value the flag now stands at, so the reading that first sees the mailbox after the
+    /// store is the whole of what this record can account for — every reading after that is a mailbox somebody else has
+    /// had the chance to change. Anchoring on the row instead would answer only for the readings that happened to
+    /// differ: an owner who reverted the flag before the first reading would leave the record unspent and have their
+    /// own later change silenced by it.
+    /// </para>
+    /// </remarks>
+    public bool AccountsForSeenStateOf(
+        EmailOccurrenceId occurrence,
+        bool observedSeenState,
+        DateTimeOffset previouslyObservedAt) =>
+        this.Request.Mutation == MailboxMutation.SetSeen
+        && this.Stage != MailboxMutationStage.Recorded
+        && previouslyObservedAt < this.StageChangedAt
+        && this.Request.Occurrence == occurrence
+        && this.Request.DesiredSeenState == observedSeenState;
 
     /// <summary>Reports whether a newly discovered occurrence is the one this mutation's placement created.</summary>
     /// <param name="discoveredFolderPath">The remote path of the folder the occurrence was discovered in.</param>
@@ -146,19 +207,17 @@ public sealed record MailboxMutationRecord
     /// local row into the destination then would leave the source occurrence with nothing local pointing at it while
     /// convergence still has to remove it.
     /// </para>
+    /// <para>
+    /// A copy is placed by <see cref="AccountsForPlacementAt" /> and never by this, because a copy leaves the email
+    /// where it was: carrying its row across would move an email that never moved.
+    /// </para>
     /// </remarks>
     public bool IsPlacementOf(
         RemoteFolderPath discoveredFolderPath,
         ImapUidValidity discoveredUidValidity,
         ImapUid discoveredUid) =>
-        this.ExpectsPlacementObservation
-        && this.PlacementObservedAt is null
-        && this.Stage == MailboxMutationStage.Completed
-        && this.Request.DestinationPath is { } destinationPath
-        && string.Equals(destinationPath.Value, discoveredFolderPath.Value, StringComparison.Ordinal)
-        && this.Placement is { UidValidity: { } placedUidValidity, Uid: { } placedUid }
-        && placedUidValidity == discoveredUidValidity
-        && placedUid == discoveredUid;
+        this.Request.Mutation == MailboxMutation.Relocate
+        && this.AccountsForPlacementAt(discoveredFolderPath, discoveredUidValidity, discoveredUid);
 
     /// <summary>Reports whether an occurrence that has left its folder left it because of this mutation.</summary>
     /// <param name="sourceOccurrence">The occurrence the folder no longer holds.</param>

--- a/src/Domain/Mutations/SuppressedMailboxChange.cs
+++ b/src/Domain/Mutations/SuppressedMailboxChange.cs
@@ -1,0 +1,36 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Domain.Mutations;
+
+/// <summary>One change a synchronization run discovered and did not raise, because MailFathom itself had made it.</summary>
+/// <param name="Kind">What the mail server reported had changed.</param>
+/// <param name="Mutation">The change MailFathom had asked for, which is the same word its log line and its counter use.</param>
+/// <param name="StoredEmailId">The local email the change is about.</param>
+/// <param name="MutationRecordId">The durable record that answered <em>was this ours</em>.</param>
+/// <remarks>
+/// <para>
+/// Suppression exists so that a rule which files mail files it once. Every mutation MailFathom performs is a change
+/// synchronization later discovers, so without provenance a rule matching on folder would file a message, discover it
+/// in its new folder, match again, and go round for as long as the mailbox is watched — at the cost of an IMAP command
+/// a lap. Two rules with overlapping conditions do the same to each other.
+/// </para>
+/// <para>
+/// It is decided from the record and from nothing else. A cycle limit or a rate limit would be the alternative and both
+/// are worse: the first stops a loop only after it has run several times, and the second stops legitimate work at the
+/// same threshold. The record answers the question exactly, so the answer is a fact rather than an inference.
+/// </para>
+/// <para>
+/// This value is what makes a suppression explainable. A rule that appears not to have fired is otherwise the same
+/// thing to read as a rule that never matched, so a run reports which change it withheld and which record accounted for
+/// it. It names identities and a mutation name only, never a subject, an address, or any other part of the message.
+/// </para>
+/// </remarks>
+public sealed record SuppressedMailboxChange(
+    MailboxChangeKind Kind,
+    MailboxMutation Mutation,
+    StoredEmailId StoredEmailId,
+    MailboxMutationRecordId MutationRecordId);

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -11,6 +11,7 @@ using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Mail;
 
@@ -326,7 +327,36 @@ internal sealed partial class AccountSynchronizationSupervisor
                 result.Reconciliation.OwnMutationCompletedEmailCount);
         }
 
+        this.ReportSuppressedChanges(folderAlias, result.SuppressedChanges);
         this.ReportReconciliation(folderAlias, remotelyDeletedEmailDisposition, result.Reconciliation);
+    }
+
+    /// <summary>Emits what the run withheld from rule evaluation, so a rule that appears not to have fired can be explained.</summary>
+    /// <remarks>
+    /// The count is stated once at information level and each withheld change once at debug, because the two answer
+    /// different questions: whether MailFathom is acting on its own mailbox at all, and why one particular message did
+    /// not set a rule off. Only identities MailFathom owns appear — a local email identifier, a record identifier, and
+    /// the mutation's own name — never anything derived from the message.
+    /// </remarks>
+    private void ReportSuppressedChanges(string folderAlias, IReadOnlyList<SuppressedMailboxChange> suppressedChanges)
+    {
+        if (suppressedChanges.Count == 0)
+        {
+            return;
+        }
+
+        this.LogChangesSuppressed(this.accountId.Value, folderAlias, suppressedChanges.Count);
+
+        foreach (var suppressed in suppressedChanges)
+        {
+            this.LogChangeSuppressed(
+                this.accountId.Value,
+                folderAlias,
+                suppressed.Kind,
+                suppressed.Mutation.Name,
+                suppressed.StoredEmailId.Value,
+                suppressed.MutationRecordId.Value);
+        }
     }
 
     /// <summary>Emits the audit line for the backward pass, and emits it only when the pass found something to record.</summary>
@@ -348,6 +378,14 @@ internal sealed partial class AccountSynchronizationSupervisor
                 folderAlias,
                 reconciliation.RemotelyDeletedEmailCount,
                 remotelyDeletedEmailDisposition);
+        }
+
+        if (reconciliation.SeenStateChangedEmailCount > 0)
+        {
+            this.LogSeenStateChangesObserved(
+                this.accountId.Value,
+                folderAlias,
+                reconciliation.SeenStateChangedEmailCount);
         }
 
         if (reconciliation.ObservedEmailCount > 0)
@@ -431,6 +469,38 @@ internal sealed partial class AccountSynchronizationSupervisor
         string folderAlias,
         int relocatedEmailCount,
         int ownMutationCompletedEmailCount);
+
+    /// <summary>States how much of what the run discovered was MailFathom's own and was therefore not raised as a change to react to.</summary>
+    /// <remarks>
+    /// A folder that MailFathom never writes to never emits this line. Where it does appear, it is the difference
+    /// between a rule engine that files a message once and one that files it every interval for as long as the mailbox
+    /// is watched, so the count is worth an operator's attention rather than only a debugging session's.
+    /// </remarks>
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Withheld {SuppressedChangeCount} changes in {AccountId}/{FolderAlias} from rule evaluation, because a durable mutation record says MailFathom itself made them.")]
+    private partial void LogChangesSuppressed(string accountId, string folderAlias, int suppressedChangeCount);
+
+    /// <summary>Names one withheld change and the record that accounted for it, which is what a support question about a rule that did not fire is answered from.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Withheld a {MailboxChangeKind} in {AccountId}/{FolderAlias} for stored email {StoredEmailId}; the {Mutation} recorded as {MutationRecordId} accounts for it.")]
+    private partial void LogChangeSuppressed(
+        string accountId,
+        string folderAlias,
+        MailboxChangeKind mailboxChangeKind,
+        string mutation,
+        Guid storedEmailId,
+        Guid mutationRecordId);
+
+    /// <summary>Reports the flag changes the mailbox owner made, which stay changes to react to however many of MailFathom's own were withheld beside them.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Mail server reports a moved \\Seen flag on {SeenStateChangedEmailCount} messages stored for {AccountId}/{FolderAlias} that no change of MailFathom's accounts for.")]
+    private partial void LogSeenStateChangesObserved(
+        string accountId,
+        string folderAlias,
+        int seenStateChangedEmailCount);
 
     /// <summary>Records mail leaving the local copy, which is the one reconciliation outcome an operator has to be able to find afterwards.</summary>
     /// <remarks>

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationReconciliationStore.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationReconciliationStore.cs
@@ -32,7 +32,7 @@ internal sealed class MailboxMutationReconciliationStore(MailFathomDbContext rea
     : IMailboxMutationReconciliationStore
 {
     /// <inheritdoc />
-    public async Task<IReadOnlyList<MailboxMutationRecord>> ReadRelocationsPlacedAtAsync(
+    public async Task<IReadOnlyList<MailboxMutationRecord>> ReadPlacementsAtAsync(
         MailAccountId accountId,
         RemoteFolderPath destinationPath,
         ImapUidValidity uidValidity,
@@ -49,7 +49,7 @@ internal sealed class MailboxMutationReconciliationStore(MailFathomDbContext rea
         var accountValue = accountId.Value;
         var destinationValue = destinationPath.Value;
         var uidValidityValue = uidValidity.Value;
-        var relocateName = MailboxMutation.Relocate.Name;
+        string[] placingMutations = [MailboxMutation.Relocate.Name, MailboxMutation.Copy.Name];
 
         // Nullable so the comparison is against the column as it is stored: a record whose server named no placement
         // holds null there and must match nothing, rather than being coerced into a UID it never reported.
@@ -59,12 +59,52 @@ internal sealed class MailboxMutationReconciliationStore(MailFathomDbContext rea
             .AsNoTracking()
             .Include(mutation => mutation.MailFolder)
             .Where(mutation => mutation.MailboxAccountId == accountValue
-                && mutation.Mutation == relocateName
+                && placingMutations.Contains(mutation.Mutation)
                 && mutation.Stage == MailboxMutationStage.Completed
                 && mutation.PlacementObservedAt == null
                 && mutation.DestinationFolderPath == destinationValue
                 && mutation.PlacementUidValidity == uidValidityValue
                 && placedUids.Contains(mutation.PlacementUid))
+            .OrderBy(mutation => mutation.RecordedAt)
+            .ThenBy(mutation => mutation.Id)
+            .ToArrayAsync(cancellationToken);
+
+        return [.. entities.Select(static entity => MailboxMutationRecordMapping.ToRecord(entity, entity.MailFolder))];
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailboxMutationRecord>> ReadSeenStateChangesOnAsync(
+        MailAccountId accountId,
+        MailFolderResolutionId folderResolutionId,
+        ImapUidValidity uidValidity,
+        IReadOnlyCollection<ImapUid> uids,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(uids);
+
+        if (uids.Count == 0)
+        {
+            return [];
+        }
+
+        var accountValue = accountId.Value;
+        var alias = folderResolutionId.Alias.Value;
+        var generation = folderResolutionId.Generation.Value;
+        var uidValidityValue = uidValidity.Value;
+        var setSeenName = MailboxMutation.SetSeen.Name;
+        uint[] changedUids = [.. uids.Select(static uid => uid.Value)];
+
+        // Reached through the prefix of the identity index — folder, UIDVALIDITY, UID — which is why this question needs
+        // no index of its own, exactly as reading a disappearance back does not.
+        var entities = await readContext.MailboxMutations
+            .AsNoTracking()
+            .Include(mutation => mutation.MailFolder)
+            .Where(mutation => mutation.MailboxAccountId == accountValue
+                && mutation.MailFolder.Alias == alias
+                && mutation.MailFolder.ResolutionGeneration == generation
+                && mutation.UidValidity == uidValidityValue
+                && changedUids.Contains(mutation.Uid)
+                && mutation.Mutation == setSeenName)
             .OrderBy(mutation => mutation.RecordedAt)
             .ThenBy(mutation => mutation.Id)
             .ToArrayAsync(cancellationToken);
@@ -123,8 +163,12 @@ internal sealed class MailboxMutationReconciliationStore(MailFathomDbContext rea
 
         // The row has just left the source folder, so no later window can select it there and observe the disappearance
         // this record would otherwise keep waiting for. The stage that got here is the server's own statement that the
-        // source occurrence is already gone.
-        entity.SourceRemovalObservedAt ??= observedAt;
+        // source occurrence is already gone. A copy takes nothing out of its source folder, so it settles nothing there
+        // and a column written for it would say a disappearance had been accounted for that never happens.
+        if (entity.Mutation == MailboxMutation.Relocate.Name)
+        {
+            entity.SourceRemovalObservedAt ??= observedAt;
+        }
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Persistence/Synchronization/StoredEmailReconciliationStore.cs
+++ b/src/Infrastructure/Persistence/Synchronization/StoredEmailReconciliationStore.cs
@@ -41,19 +41,34 @@ internal sealed class StoredEmailReconciliationStore(MailFathomDbContext readCon
 
         // Read first so the never-observed budget can be computed from how many previously observed emails actually
         // exist: a folder that has none must still fill its whole window with new mail rather than leave it empty.
+        // The previous reading of the \Seen flag travels with the candidate because a flag change is a comparison rather
+        // than a reading: the server reports what the flag is now, and only the earlier value and the moment it was
+        // taken say whether anybody moved it and whether a change MailFathom made could still be why.
         var previouslyObserved = await eligible
             .Where(email => email.RemoteFlagsObservedAt != null)
             .OrderBy(email => email.RemoteFlagsObservedAt)
             .ThenBy(email => email.Uid)
             .Take(maxEmailCount)
-            .Select(email => new { email.Id, email.Uid })
+            .Select(email => new
+            {
+                email.Id,
+                email.Uid,
+                ObservedAt = email.RemoteFlagsObservedAt,
+                email.IsRemotelySeen,
+            })
             .ToArrayAsync(cancellationToken);
 
         var neverObserved = await eligible
             .Where(email => email.RemoteFlagsObservedAt == null)
             .OrderBy(email => email.Uid)
             .Take(ReconciliationWindowBudget.NeverObservedShareOf(maxEmailCount, previouslyObserved.Length))
-            .Select(email => new { email.Id, email.Uid })
+            .Select(email => new
+            {
+                email.Id,
+                email.Uid,
+                ObservedAt = (DateTimeOffset?)null,
+                email.IsRemotelySeen,
+            })
             .ToArrayAsync(cancellationToken);
 
         return
@@ -62,7 +77,10 @@ internal sealed class StoredEmailReconciliationStore(MailFathomDbContext readCon
                 .Concat(previouslyObserved.Take(maxEmailCount - neverObserved.Length))
                 .Select(static candidate => new StoredEmailAwaitingReconciliation(
                     StoredEmailId.Create(candidate.Id),
-                    ImapUid.Create(candidate.Uid))),
+                    ImapUid.Create(candidate.Uid),
+                    candidate.ObservedAt is { } observedAt
+                        ? new RemoteSeenStateObservation(observedAt, candidate.IsRemotelySeen)
+                        : null)),
         ];
     }
 

--- a/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -163,6 +163,121 @@ public sealed class MailboxSynchronizerTests
         var observed = mutationStore.RecordOf(record.Id);
         Assert.Equal(clock.GetUtcNow(), observed.PlacementObservedAt);
         Assert.True(observed.IsReconciled);
+
+        // The arrival is MailFathom's own, so it is withheld rather than raised. Without this a rule matching on folder
+        // would match the message it has just filed, and two such rules would bounce it between folders indefinitely.
+        var suppressed = Assert.Single(result.SuppressedChanges);
+        Assert.Equal(MailboxChangeKind.EmailAppearedInFolder, suppressed.Kind);
+        Assert.Equal(MailboxMutation.Relocate, suppressed.Mutation);
+        Assert.Equal(relocatedEmailId, suppressed.StoredEmailId);
+        Assert.Equal(record.Id, suppressed.MutationRecordId);
+    }
+
+    /// <summary>A message MailFathom copied is stored like any other discovery, and its arrival is still MailFathom's own act.</summary>
+    /// <remarks>
+    /// A copy leaves the email where it was, so nothing is carried across and whether the second live occurrence is one
+    /// local row or two stays the copy action's decision. What it must not do is set a rule off, which is a question
+    /// about provenance rather than about rows.
+    /// </remarks>
+    [Fact]
+    public async Task SynchronizeAsync_DiscoversTheOccurrenceACopyPlaced_StoresItAndWithholdsTheArrival()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var uid = ImapUid.Create(10);
+        var occurrence = EmailOccurrenceId.Create(accountId, InboxFolder.Id, uidValidity, uid);
+        var copiedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
+        var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        var record = CopyPlacedInInbox(accountId, copiedEmailId, uidValidity, uid);
+        mutationStore.Add(record);
+        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionScopeFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(persistenceSession);
+        persistenceSession.CommitAsync(Arg.Any<CancellationToken>()).Returns(PersistenceCommitResult.Committed);
+        metadataRepository
+            .UpsertMetadataAsync(
+                persistenceSession,
+                Arg.Any<RemoteEmailMetadata>(),
+                Arg.Any<ExtractedEmailMetadata?>(),
+                Arg.Any<StoredEmailContentAvailability>(),
+                Arg.Any<CancellationToken>())
+            .Returns(storedEmailId);
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 8, 7, 12, 0, 0, TimeSpan.Zero));
+        await using var session = CreateSessionDiscovering(occurrence, uidValidity);
+        session
+            .FetchEmailContentWithoutSettingSeenAsync(occurrence, Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(RemoteEmailContentFetchResult.Retrieved(
+                new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]))));
+        var synchronizer = CreateSynchronizer(
+            CreateSessionFactoryFor(accountId, session),
+            CreateCheckpointStoreAt(accountId, uidValidity),
+            sessionScopeFactory,
+            metadataRepository,
+            contentStore: Substitute.For<IEmailContentStore>(),
+            clock,
+            new MailboxSynchronizationOptions(),
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal(0, result.RelocatedEmailCount);
+        await metadataRepository.DidNotReceiveWithAnyArgs().TryCarryToOccurrenceAsync(
+            Arg.Any<IPersistenceSession>(),
+            Arg.Any<StoredEmailId>(),
+            Arg.Any<EmailOccurrenceId>(),
+            Arg.Any<CancellationToken>());
+
+        var suppressed = Assert.Single(result.SuppressedChanges);
+        Assert.Equal(MailboxChangeKind.EmailAppearedInFolder, suppressed.Kind);
+        Assert.Equal(MailboxMutation.Copy, suppressed.Mutation);
+        Assert.Equal(storedEmailId, suppressed.StoredEmailId);
+
+        // The placement is spent, so a folder later renumbered onto the same UID is not attributed to this copy. The
+        // source removal stays unwritten, because a copy takes nothing out of the folder it read from.
+        var observed = mutationStore.RecordOf(record.Id);
+        Assert.Equal(clock.GetUtcNow(), observed.PlacementObservedAt);
+        Assert.Null(observed.SourceRemovalObservedAt);
+    }
+
+    /// <summary>Mail that arrives on its own is what rules exist for, so a discovery no record accounts for is withheld from nothing.</summary>
+    [Fact]
+    public async Task SynchronizeAsync_MessageNoMutationAccountsFor_WithholdsNothing()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var occurrence = EmailOccurrenceId.Create(accountId, InboxFolder.Id, uidValidity, ImapUid.Create(10));
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionScopeFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(persistenceSession);
+        persistenceSession.CommitAsync(Arg.Any<CancellationToken>()).Returns(PersistenceCommitResult.Committed);
+        await using var session = CreateSessionDiscovering(occurrence, uidValidity);
+        session
+            .FetchEmailContentWithoutSettingSeenAsync(occurrence, Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(RemoteEmailContentFetchResult.Retrieved(
+                new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]))));
+        var synchronizer = CreateSynchronizer(
+            CreateSessionFactoryFor(accountId, session),
+            CreateCheckpointStoreAt(accountId, uidValidity),
+            sessionScopeFactory,
+            metadataRepository: Substitute.For<IEmailMetadataRepository>(),
+            contentStore: Substitute.For<IEmailContentStore>(),
+            new FakeTimeProvider(new DateTimeOffset(2026, 8, 7, 12, 0, 0, TimeSpan.Zero)),
+            new MailboxSynchronizationOptions(),
+            mutationStore: new InMemoryMailboxMutationReconciliationStore());
+
+        // Act
+        var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.StoredEmailCount);
+        Assert.Empty(result.SuppressedChanges);
     }
 
     /// <summary>An occurrence another local email already occupies is stored rather than carried, because only the mailbox could say which of the two is right.</summary>
@@ -1558,7 +1673,7 @@ public sealed class MailboxSynchronizerTests
         var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 31, 12, 0, 0, TimeSpan.Zero));
         var reconciliationStore = Substitute.For<IStoredEmailReconciliationStore>();
         IReadOnlyList<StoredEmailAwaitingReconciliation> window =
-            [new StoredEmailAwaitingReconciliation(storedEmailId, ImapUid.Create(10))];
+            [new StoredEmailAwaitingReconciliation(storedEmailId, ImapUid.Create(10), LastObservation: null)];
         reconciliationStore
             .GetReconciliationWindowAsync(accountId, folder.Id, uidValidity, Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(window));
@@ -1715,7 +1830,7 @@ public sealed class MailboxSynchronizerTests
         var sessionFactory = Substitute.For<IMailboxSessionFactory>();
         var reconciliationStore = Substitute.For<IStoredEmailReconciliationStore>();
         IReadOnlyList<StoredEmailAwaitingReconciliation> window =
-            [new StoredEmailAwaitingReconciliation(StoredEmailId.Create(Guid.CreateVersion7()), ImapUid.Create(10))];
+            [new StoredEmailAwaitingReconciliation(StoredEmailId.Create(Guid.CreateVersion7()), ImapUid.Create(10), LastObservation: null)];
         reconciliationStore
             .GetReconciliationWindowAsync(accountId, InboxFolder.Id, uidValidity, Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(window));
@@ -1797,6 +1912,26 @@ public sealed class MailboxSynchronizerTests
             LastFailure = null,
             PlacementObservedAt = null,
             SourceRemovalObservedAt = null,
+        };
+    }
+
+    /// <summary>Builds the record a copy into the folder under synchronization would have left, with the placement the server named.</summary>
+    private static MailboxMutationRecord CopyPlacedInInbox(
+        MailAccountId accountId,
+        StoredEmailId copiedEmailId,
+        ImapUidValidity placedUidValidity,
+        ImapUid placedUid)
+    {
+        var record = RelocationPlacedInInbox(accountId, copiedEmailId, placedUidValidity, placedUid);
+
+        return record with
+        {
+            Request = MailboxMutationRequest.Copy(
+                copiedEmailId,
+                record.Request.Occurrence,
+                record.Request.Requester,
+                InboxFolder.RemotePath),
+            RequiresSourceRemoval = false,
         };
     }
 

--- a/tests/Application.UnitTests/Synchronization/Reconciliation/MailboxReconcilerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/Reconciliation/MailboxReconcilerTests.cs
@@ -242,6 +242,267 @@ public sealed class MailboxReconcilerTests
         Assert.Null(row.RemoteExpungeObservedAt);
     }
 
+    /// <summary>A rule that marks mail read must not re-evaluate everything it just marked, which is the cheapest mutation looping hardest.</summary>
+    /// <remarks>
+    /// The flag comes back as a changed modification sequence, indistinguishable in the protocol from a person reading
+    /// the message in their own client. Only the record separates them, so the withheld change names the record that
+    /// accounted for it and the stored snapshot still follows the server.
+    /// </remarks>
+    [Fact]
+    public async Task ReconcileAsync_SeenFlagMailFathomSetItself_WithholdsTheChange()
+    {
+        // Arrange
+        var store = new FakeReconciliationStore(ObservedOccurrence(10, isSeen: false));
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        var record = MutationSettingSeen(store.StoredEmailIdOf(10), uid: 10, isSeen: true);
+        mutationStore.Add(record);
+        await using var mailboxSession = CreateSessionReportingSeenState(isSeen: true, 10);
+        var reconciler = CreateReconciler(
+            store,
+            RemotelyDeletedEmailDisposition.RetainTombstone,
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await reconciler.ReconcileAsync(
+            mailboxSession,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, result.SeenStateChangedEmailCount);
+        var suppressed = Assert.Single(result.SuppressedChanges);
+        Assert.Equal(MailboxChangeKind.SeenStateChanged, suppressed.Kind);
+        Assert.Equal(MailboxMutation.SetSeen, suppressed.Mutation);
+        Assert.Equal(store.StoredEmailIdOf(10), suppressed.StoredEmailId);
+        Assert.Equal(record.Id, suppressed.MutationRecordId);
+
+        // The stored snapshot still follows the server, because what was withheld is the trigger and never the reading.
+        Assert.True(store.RowOf(10).Snapshot!.IsSeen);
+    }
+
+    /// <summary>Marking mail read by hand is the mailbox owner's act, and it stays a change to react to.</summary>
+    [Fact]
+    public async Task ReconcileAsync_OwnerMarkedMailReadThemselves_RaisesTheChange()
+    {
+        // Arrange
+        var store = new FakeReconciliationStore(ObservedOccurrence(10, isSeen: false));
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        await using var mailboxSession = CreateSessionReportingSeenState(isSeen: true, 10);
+        var reconciler = CreateReconciler(
+            store,
+            RemotelyDeletedEmailDisposition.RetainTombstone,
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await reconciler.ReconcileAsync(
+            mailboxSession,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.SeenStateChangedEmailCount);
+        Assert.Empty(result.SuppressedChanges);
+    }
+
+    /// <summary>The suppression is scoped to the one change the record describes, so the owner setting that flag again later is their act.</summary>
+    /// <remarks>
+    /// This is the case a record that answered forever would get wrong, and it is silent when it happens: a rule
+    /// conditioned on read mail would simply never fire again for a message MailFathom had once marked read.
+    /// </remarks>
+    [Fact]
+    public async Task ReconcileAsync_OwnerRestoresTheFlagMailFathomSetEarlier_RaisesItAsTheirOwnChange()
+    {
+        // Arrange
+        var store = new FakeReconciliationStore(ObservedOccurrence(10, isSeen: false));
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        mutationStore.Add(MutationSettingSeen(store.StoredEmailIdOf(10), uid: 10, isSeen: true));
+        var reconciler = CreateReconciler(
+            store,
+            RemotelyDeletedEmailDisposition.RetainTombstone,
+            mutationStore: mutationStore);
+
+        // Act
+        await using var afterOwnStore = CreateSessionReportingSeenState(isSeen: true, 10);
+        var ownChange = await reconciler.ReconcileAsync(
+            mailboxSession: afterOwnStore,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        await using var afterOwnerCleared = CreateSessionReportingSeenState(isSeen: false, 10);
+        var clearedByOwner = await reconciler.ReconcileAsync(
+            mailboxSession: afterOwnerCleared,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        await using var afterOwnerSetItAgain = CreateSessionReportingSeenState(isSeen: true, 10);
+        var setAgainByOwner = await reconciler.ReconcileAsync(
+            mailboxSession: afterOwnerSetItAgain,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Single(ownChange.SuppressedChanges);
+        Assert.Equal(0, ownChange.SeenStateChangedEmailCount);
+        Assert.Empty(clearedByOwner.SuppressedChanges);
+        Assert.Equal(1, clearedByOwner.SeenStateChangedEmailCount);
+        Assert.Empty(setAgainByOwner.SuppressedChanges);
+        Assert.Equal(1, setAgainByOwner.SeenStateChangedEmailCount);
+    }
+
+    /// <summary>A record stops answering once the occurrence has been read, whether or not that reading found the flag where it put it.</summary>
+    /// <remarks>
+    /// This is the case that decides where the expiry is recorded. The owner reverts the flag before any window sees it,
+    /// so the first window finds nothing changed and there is no matching change to mark a record spent by — and if the
+    /// expiry lived on the record, the owner marking the message read weeks later would be silently withheld. Anchoring
+    /// it to the occurrence's own last observation is what makes that window count.
+    /// </remarks>
+    [Fact]
+    public async Task ReconcileAsync_OwnerRevertedTheFlagBeforeAnyWindowSawIt_StillRaisesTheirLaterChange()
+    {
+        // Arrange
+        var store = new FakeReconciliationStore(ObservedOccurrence(10, isSeen: false));
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        mutationStore.Add(MutationSettingSeen(store.StoredEmailIdOf(10), uid: 10, isSeen: true));
+        var reconciler = CreateReconciler(
+            store,
+            RemotelyDeletedEmailDisposition.RetainTombstone,
+            mutationStore: mutationStore);
+
+        // Act
+        await using var afterTheOwnerReverted = CreateSessionReportingSeenState(isSeen: false, 10);
+        var sawNothingChanged = await reconciler.ReconcileAsync(
+            mailboxSession: afterTheOwnerReverted,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        await using var afterTheOwnerMarkedItRead = CreateSessionReportingSeenState(isSeen: true, 10);
+        var ownerMarkedItRead = await reconciler.ReconcileAsync(
+            mailboxSession: afterTheOwnerMarkedItRead,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, sawNothingChanged.SeenStateChangedEmailCount);
+        Assert.Empty(sawNothingChanged.SuppressedChanges);
+        Assert.Equal(1, ownerMarkedItRead.SeenStateChangedEmailCount);
+        Assert.Empty(ownerMarkedItRead.SuppressedChanges);
+    }
+
+    /// <summary>A record whose <c>STORE</c> never went out accounts for nothing, because the flag standing there is somebody else's doing.</summary>
+    [Fact]
+    public async Task ReconcileAsync_SeenStoreThatNeverReachedTheServer_RaisesTheChange()
+    {
+        // Arrange
+        var store = new FakeReconciliationStore(ObservedOccurrence(10, isSeen: false));
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        mutationStore.Add(MutationSettingSeen(
+            store.StoredEmailIdOf(10),
+            uid: 10,
+            isSeen: true,
+            MailboxMutationStage.Recorded));
+        await using var mailboxSession = CreateSessionReportingSeenState(isSeen: true, 10);
+        var reconciler = CreateReconciler(
+            store,
+            RemotelyDeletedEmailDisposition.RetainTombstone,
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await reconciler.ReconcileAsync(
+            mailboxSession,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.SeenStateChangedEmailCount);
+        Assert.Empty(result.SuppressedChanges);
+    }
+
+    /// <summary>A record answers for the direction it asked for and never for the opposite one.</summary>
+    [Fact]
+    public async Task ReconcileAsync_FlagMovedOppositeToWhatWasAsked_RaisesTheChange()
+    {
+        // Arrange
+        var store = new FakeReconciliationStore(ObservedOccurrence(10, isSeen: false));
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        mutationStore.Add(MutationSettingSeen(store.StoredEmailIdOf(10), uid: 10, isSeen: false));
+        await using var mailboxSession = CreateSessionReportingSeenState(isSeen: true, 10);
+        var reconciler = CreateReconciler(
+            store,
+            RemotelyDeletedEmailDisposition.RetainTombstone,
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await reconciler.ReconcileAsync(
+            mailboxSession,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.SeenStateChangedEmailCount);
+        Assert.Empty(result.SuppressedChanges);
+    }
+
+    /// <summary>The first reading of an occurrence's flags is an observation rather than a change, and a window where nothing moved asks nothing.</summary>
+    /// <remarks>
+    /// Both halves guard the same mistake from opposite sides. Treating a first reading as a change would raise a
+    /// trigger for every message a backfill stores, and asking the database about a window in which nothing moved would
+    /// put a query on every run of every folder for an answer that is always empty.
+    /// </remarks>
+    [Fact]
+    public async Task ReconcileAsync_NoFlagHasMoved_ReportsNoChangeAndAsksNothing()
+    {
+        // Arrange
+        var store = new FakeReconciliationStore(StoredOccurrences(10, 11));
+        var mutationStore = new InMemoryMailboxMutationReconciliationStore();
+        await using var mailboxSession = CreateSessionReportingSeenState(isSeen: true, 10, 11);
+        var reconciler = CreateReconciler(
+            store,
+            RemotelyDeletedEmailDisposition.RetainTombstone,
+            mutationStore: mutationStore);
+
+        // Act
+        var result = await reconciler.ReconcileAsync(
+            mailboxSession,
+            Account,
+            InboxFolder,
+            SelectedUidValidity,
+            reconciledThroughModSeq: null,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(0, result.SeenStateChangedEmailCount);
+        Assert.Empty(result.SuppressedChanges);
+        Assert.Equal(0, mutationStore.SeenStateChangeReadCount);
+        Assert.True(store.RowOf(10).Snapshot!.IsSeen);
+    }
+
     /// <summary>A large folder is reconciled across runs rather than scanned in one, and the run says so.</summary>
     [Fact]
     public async Task ReconcileAsync_MoreEmailsThanTheWindowHolds_BoundsTheWindowAndReportsRemainingWork()
@@ -671,6 +932,35 @@ public sealed class MailboxReconcilerTests
         return mailboxSession;
     }
 
+    /// <summary>Builds a session whose folder holds the named UIDs and reports one <c>\Seen</c> value for all of them.</summary>
+    private static IMailboxSession CreateSessionReportingSeenState(bool isSeen, params uint[] presentUids)
+    {
+        var mailboxSession = Substitute.For<IMailboxSession>();
+        IReadOnlyList<RemoteEmailFlagObservation> observations =
+        [
+            .. presentUids.Select(uid => new RemoteEmailFlagObservation(
+                ImapUid.Create(uid),
+                new RemoteEmailFlagSnapshot(
+                    RunInstant,
+                    isSeen,
+                    IsAnswered: false,
+                    IsFlagged: false,
+                    IsDraft: false,
+                    IsDeleted: false))),
+        ];
+
+        mailboxSession
+            .ObserveWindowWithoutSettingSeenAsync(Arg.Any<IReadOnlyList<ImapUid>>(), Arg.Any<ulong?>(), Arg.Any<CancellationToken>())
+            .Returns(call => Task.FromResult(RemoteFolderWindowObservation.FromDescribedOccurrences(
+                [
+                    .. observations.Where(observation =>
+                        call.Arg<IReadOnlyList<ImapUid>>()!.Contains(observation.Uid)),
+                ],
+                folderHighestModSeq: null)));
+
+        return mailboxSession;
+    }
+
     /// <summary>Builds a session whose folder still holds exactly the named UIDs, and says nothing about the rest.</summary>
     private static IMailboxSession CreateSessionHolding(params uint[] presentUids) =>
         CreateSessionHolding(folderHighestModSeq: null, presentUids);
@@ -762,6 +1052,35 @@ public sealed class MailboxReconcilerTests
         };
     }
 
+    /// <summary>Builds the record a completed <c>\Seen</c> store against one stored occurrence would have left behind.</summary>
+    private static MailboxMutationRecord MutationSettingSeen(
+        StoredEmailId storedEmailId,
+        uint uid,
+        bool isSeen,
+        MailboxMutationStage stage = MailboxMutationStage.Completed)
+    {
+        var occurrence = EmailOccurrenceId.Create(Account, InboxFolder.Id, SelectedUidValidity, ImapUid.Create(uid));
+
+        return new MailboxMutationRecord
+        {
+            Id = MailboxMutationRecordId.Create(Guid.CreateVersion7(RunInstant)),
+            Request = MailboxMutationRequest.SetSeen(
+                storedEmailId,
+                occurrence,
+                MailboxMutationRequester.Rule("mark-newsletters-read", 1),
+                isSeen),
+            Stage = stage,
+            RequiresSourceRemoval = false,
+            Placement = RemoteEmailPlacement.NotReported(),
+            AttemptCount = 1,
+            RecordedAt = RunInstant,
+            StageChangedAt = RunInstant,
+            LastFailure = null,
+            PlacementObservedAt = null,
+            SourceRemovalObservedAt = null,
+        };
+    }
+
     private static IReadOnlyList<StoredOccurrence> StoredOccurrences(params uint[] uids) =>
     [
         .. uids.Select(uid => new StoredOccurrence(
@@ -769,8 +1088,27 @@ public sealed class MailboxReconcilerTests
             uid)),
     ];
 
+    /// <summary>Builds one stored occurrence whose remote flags an earlier run already read, so a later reading can differ from them.</summary>
+    private static IReadOnlyList<StoredOccurrence> ObservedOccurrence(uint uid, bool isSeen) =>
+    [
+        new StoredOccurrence(
+            StoredEmailId.Create(Guid.CreateVersion7(RunInstant.AddSeconds(uid))),
+            uid,
+            isSeen),
+    ];
+
     /// <summary>One locally stored occurrence a test arranged, before any run has touched it.</summary>
-    private sealed record StoredOccurrence(StoredEmailId StoredEmailId, uint Uid);
+    /// <param name="StoredEmailId">The local identity the outcome is written against.</param>
+    /// <param name="Uid">The UID the folder holds it at.</param>
+    /// <param name="PreviouslyObservedSeenState">
+    /// The remote <c>\Seen</c> value an earlier run recorded, or <see langword="null" /> when no run has read this
+    /// occurrence's flags. Supplying one is what makes the row previously observed, exactly as the column pair does in
+    /// the database.
+    /// </param>
+    private sealed record StoredOccurrence(
+        StoredEmailId StoredEmailId,
+        uint Uid,
+        bool? PreviouslyObservedSeenState = null);
 
     /// <summary>
     /// Holds the reconciliation queue the way the database does, because the queue is the mechanism under test: the
@@ -785,7 +1123,7 @@ public sealed class MailboxReconcilerTests
         {
             this.rowsById = storedOccurrences.ToDictionary(
                 occurrence => occurrence.StoredEmailId,
-                occurrence => new ReconciledRow(occurrence.Uid));
+                static occurrence => new ReconciledRow(occurrence.Uid, occurrence.PreviouslyObservedSeenState));
         }
 
         public List<uint> AskedAboutUids { get; } = [];
@@ -843,7 +1181,12 @@ public sealed class MailboxReconcilerTests
             [
                 .. neverObserved
                     .Concat(previouslyObserved.Take(maxEmailCount - neverObserved.Length))
-                    .Select(entry => new StoredEmailAwaitingReconciliation(entry.Key, ImapUid.Create(entry.Value.Uid))),
+                    .Select(static entry => new StoredEmailAwaitingReconciliation(
+                        entry.Key,
+                        ImapUid.Create(entry.Value.Uid),
+                        entry.Value.ObservedAt is { } observedAt
+                            ? new RemoteSeenStateObservation(observedAt, entry.Value.Snapshot?.IsSeen ?? false)
+                            : null)),
             ];
 
             this.AskedAboutUids.AddRange(window.Select(candidate => candidate.Uid.Value));
@@ -916,9 +1259,35 @@ public sealed class MailboxReconcilerTests
     }
 
     /// <summary>The columns reconciliation writes on one stored email.</summary>
-    private sealed class ReconciledRow(uint uid)
+    /// <remarks>
+    /// A seeded <c>\Seen</c> value arrives as an observation rather than as a bare flag, because that is the only shape
+    /// the database can hold: the stored flags and the timestamp saying they were read move together, and a fake that
+    /// let them disagree would answer a window with a previous value nobody had ever observed.
+    /// </remarks>
+    private sealed class ReconciledRow
     {
-        public uint Uid { get; } = uid;
+        public ReconciledRow(uint uid, bool? previouslyObservedSeenState = null)
+        {
+            this.Uid = uid;
+
+            if (previouslyObservedSeenState is not { } seenState)
+            {
+                return;
+            }
+
+            var seededAt = RunInstant.AddHours(-1);
+
+            this.ObservedAt = seededAt;
+            this.Snapshot = new RemoteEmailFlagSnapshot(
+                seededAt,
+                seenState,
+                IsAnswered: false,
+                IsFlagged: false,
+                IsDraft: false,
+                IsDeleted: false);
+        }
+
+        public uint Uid { get; }
 
         public DateTimeOffset? ObservedAt { get; set; }
 

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationReconciliationStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationReconciliationStore.cs
@@ -29,6 +29,14 @@ internal sealed class InMemoryMailboxMutationReconciliationStore : IMailboxMutat
 {
     private readonly Dictionary<MailboxMutationRecordId, MailboxMutationRecord> recordsById = [];
 
+    /// <summary>Gets how many times a caller asked which <c>\Seen</c> changes were MailFathom's own.</summary>
+    /// <remarks>
+    /// A window over a mailbox nobody has touched must ask nothing, which is a cost guarantee no assertion about the
+    /// answer can express: a store that returned nothing would satisfy every other test while still costing a query on
+    /// every run of every folder.
+    /// </remarks>
+    internal int SeenStateChangeReadCount { get; private set; }
+
     /// <summary>Puts a record into the state a completed mutation would have left.</summary>
     internal void Add(MailboxMutationRecord record) => this.recordsById[record.Id] = record;
 
@@ -36,7 +44,7 @@ internal sealed class InMemoryMailboxMutationReconciliationStore : IMailboxMutat
     internal MailboxMutationRecord RecordOf(MailboxMutationRecordId recordId) => this.recordsById[recordId];
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<MailboxMutationRecord>> ReadRelocationsPlacedAtAsync(
+    public Task<IReadOnlyList<MailboxMutationRecord>> ReadPlacementsAtAsync(
         MailAccountId accountId,
         RemoteFolderPath destinationPath,
         ImapUidValidity uidValidity,
@@ -49,7 +57,8 @@ internal sealed class InMemoryMailboxMutationReconciliationStore : IMailboxMutat
         [
             .. this.recordsById.Values
                 .Where(record => record.Request.Occurrence.AccountId == accountId
-                    && record.Request.Mutation == MailboxMutation.Relocate
+                    && (record.Request.Mutation == MailboxMutation.Relocate
+                        || record.Request.Mutation == MailboxMutation.Copy)
                     && record.Stage == MailboxMutationStage.Completed
                     && record.PlacementObservedAt is null
                     && record.Request.DestinationPath?.Value == destinationPath.Value
@@ -61,6 +70,33 @@ internal sealed class InMemoryMailboxMutationReconciliationStore : IMailboxMutat
         ];
 
         return Task.FromResult(placed);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<MailboxMutationRecord>> ReadSeenStateChangesOnAsync(
+        MailAccountId accountId,
+        MailFolderResolutionId folderResolutionId,
+        ImapUidValidity uidValidity,
+        IReadOnlyCollection<ImapUid> uids,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(uids);
+
+        this.SeenStateChangeReadCount++;
+
+        IReadOnlyList<MailboxMutationRecord> setting =
+        [
+            .. this.recordsById.Values
+                .Where(record => record.Request.Occurrence.AccountId == accountId
+                    && record.Request.Occurrence.FolderResolutionId == folderResolutionId
+                    && record.Request.Occurrence.UidValidity == uidValidity
+                    && uids.Contains(record.Request.Occurrence.Uid)
+                    && record.Request.Mutation == MailboxMutation.SetSeen)
+                .OrderBy(record => record.RecordedAt)
+                .ThenBy(record => record.Id.Value),
+        ];
+
+        return Task.FromResult(setting);
     }
 
     /// <inheritdoc />
@@ -101,7 +137,12 @@ internal sealed class InMemoryMailboxMutationReconciliationStore : IMailboxMutat
         this.recordsById[recordId] = record with
         {
             PlacementObservedAt = record.PlacementObservedAt ?? observedAt,
-            SourceRemovalObservedAt = record.SourceRemovalObservedAt ?? observedAt,
+
+            // A copy takes nothing out of its source folder, so the real store settles no removal for one and a fake
+            // that did would let a test pass against a record production never writes.
+            SourceRemovalObservedAt = record.Request.Mutation == MailboxMutation.Relocate
+                ? record.SourceRemovalObservedAt ?? observedAt
+                : record.SourceRemovalObservedAt,
         };
 
         return Task.CompletedTask;

--- a/tests/Domain.UnitTests/Mutations/MailboxMutationRecordTests.cs
+++ b/tests/Domain.UnitTests/Mutations/MailboxMutationRecordTests.cs
@@ -27,6 +27,9 @@ public sealed class MailboxMutationRecordTests
 
     private static readonly ImapUid PlacedUid = ImapUid.Create(77);
 
+    /// <summary>The last reading of an occurrence's flags taken before the store this class builds went out.</summary>
+    private static readonly DateTimeOffset ObservedBeforeTheStore = RecordedAt.AddMinutes(-1);
+
     /// <summary>A discovered occurrence the server itself named as the destination of a completed relocation is that relocation's own.</summary>
     [Fact]
     public void IsPlacementOf_TheOccurrenceCopyUidNamed_IsRecognized()
@@ -130,6 +133,135 @@ public sealed class MailboxMutationRecordTests
 
         // Assert
         Assert.False(isPlacement);
+    }
+
+    /// <summary>Whose act an arrival was is the same question for a copy as for a relocation, whatever the two then do with the local row.</summary>
+    [Fact]
+    public void AccountsForPlacementAt_TheOccurrenceACopyPlaced_IsRecognized()
+    {
+        // Arrange
+        var record = CompletedRelocation() with
+        {
+            Request = MailboxMutationRequest.Copy(LocalEmail, SourceOccurrence(), Requester, Archive),
+        };
+
+        // Act
+        var accountsForPlacement = record.AccountsForPlacementAt(Archive, DestinationUidValidity, PlacedUid);
+
+        // Assert
+        Assert.True(accountsForPlacement);
+    }
+
+    /// <summary>A delete and a flag change put the email nowhere, so no discovery is ever theirs.</summary>
+    [Fact]
+    public void AccountsForPlacementAt_AMutationThatPlacesNothing_MatchesNothing()
+    {
+        // Arrange
+        var delete = CompletedRelocation() with
+        {
+            Request = MailboxMutationRequest.Delete(LocalEmail, SourceOccurrence(), Requester),
+        };
+        var setSeen = CompletedRelocation() with
+        {
+            Request = MailboxMutationRequest.SetSeen(LocalEmail, SourceOccurrence(), Requester, isSeen: true),
+        };
+
+        // Act
+        var deleteAccountsForPlacement = delete.AccountsForPlacementAt(Archive, DestinationUidValidity, PlacedUid);
+        var setSeenAccountsForPlacement = setSeen.AccountsForPlacementAt(Archive, DestinationUidValidity, PlacedUid);
+
+        // Assert
+        Assert.False(deleteAccountsForPlacement);
+        Assert.False(setSeenAccountsForPlacement);
+    }
+
+    /// <summary>The flag standing where a completed store put it is that store completing, not the owner reading the message.</summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AccountsForSeenStateOf_TheDirectionItAskedFor_IsRecognized(bool isSeen)
+    {
+        // Arrange
+        var record = CompletedSeenStateChange(isSeen);
+
+        // Act
+        var accountsForSeenState = record.AccountsForSeenStateOf(SourceOccurrence(), isSeen, ObservedBeforeTheStore);
+
+        // Assert
+        Assert.True(accountsForSeenState);
+    }
+
+    /// <summary>A store that asked for one direction says nothing about the flag moving the other way.</summary>
+    [Fact]
+    public void AccountsForSeenStateOf_TheOppositeDirection_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedSeenStateChange(isSeen: true);
+
+        // Act
+        var accountsForSeenState = record.AccountsForSeenStateOf(
+            SourceOccurrence(),
+            observedSeenState: false,
+            ObservedBeforeTheStore);
+
+        // Assert
+        Assert.False(accountsForSeenState);
+    }
+
+    /// <summary>An occurrence read since the store is a mailbox somebody else has had the chance to change, so the record stops answering for it.</summary>
+    /// <remarks>
+    /// This is what scopes the suppression to the one change the record describes, and the case it exists for is the
+    /// quiet one: an owner who reverts the flag before the first reading leaves nothing for the record to be marked
+    /// spent by, and would otherwise have their own later change silenced by it months afterwards.
+    /// </remarks>
+    [Fact]
+    public void AccountsForSeenStateOf_AnOccurrenceObservedSinceTheStore_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedSeenStateChange(isSeen: true);
+
+        // Act
+        var accountsForSeenState = record.AccountsForSeenStateOf(
+            SourceOccurrence(),
+            observedSeenState: true,
+            RecordedAt.AddMinutes(1));
+
+        // Assert
+        Assert.False(accountsForSeenState);
+    }
+
+    /// <summary>No STORE has gone out, so the flag standing there was put there by somebody else.</summary>
+    [Fact]
+    public void AccountsForSeenStateOf_AStoreNothingHasBeenIssuedFor_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedSeenStateChange(isSeen: true) with { Stage = MailboxMutationStage.Recorded };
+
+        // Act
+        var accountsForSeenState = record.AccountsForSeenStateOf(
+            SourceOccurrence(),
+            observedSeenState: true,
+            ObservedBeforeTheStore);
+
+        // Assert
+        Assert.False(accountsForSeenState);
+    }
+
+    /// <summary>A relocation and a delete write no flag, so neither answers for one that moved.</summary>
+    [Fact]
+    public void AccountsForSeenStateOf_AMutationThatWritesNoFlag_MatchesNothing()
+    {
+        // Arrange
+        var record = CompletedRelocation();
+
+        // Act
+        var accountsForSeenState = record.AccountsForSeenStateOf(
+            SourceOccurrence(),
+            observedSeenState: true,
+            ObservedBeforeTheStore);
+
+        // Assert
+        Assert.False(accountsForSeenState);
     }
 
     /// <summary>The source occurrence is written down before any command goes out, so the disappearance needs no COPYUID to be attributed.</summary>
@@ -252,6 +384,9 @@ public sealed class MailboxMutationRecordTests
         // Assert
         Assert.False(delete.IsReconciled);
         Assert.True(deleteObserved.IsReconciled);
+
+        // A flag change moves no occurrence, so there is nothing for synchronization to come back and meet. Its
+        // provenance is settled against the occurrence's own observation rather than against anything on this row.
         Assert.True(setSeen.IsReconciled);
     }
 
@@ -277,5 +412,12 @@ public sealed class MailboxMutationRecordTests
         LastFailure = null,
         PlacementObservedAt = null,
         SourceRemovalObservedAt = null,
+    };
+
+    private static MailboxMutationRecord CompletedSeenStateChange(bool isSeen) => CompletedRelocation() with
+    {
+        Request = MailboxMutationRequest.SetSeen(LocalEmail, SourceOccurrence(), Requester, isSeen),
+        RequiresSourceRemoval = false,
+        Placement = RemoteEmailPlacement.NotReported(),
     };
 }

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -225,13 +225,13 @@ internal static class SynchronizationTestHost
     /// <summary>Builds a store holding no mutations, so nothing a run discovers is one MailFathom itself made.</summary>
     /// <remarks>
     /// These tests are about how a supervisor schedules and isolates folder work units. An unconfigured substitute would
-    /// answer both reads with a null task the run then faults on, which surfaces as a supervision that never signals.
+    /// answer every read with a null task the run then faults on, which surfaces as a supervision that never signals.
     /// </remarks>
     private static IMailboxMutationReconciliationStore CreateMutationStoreWithNothingRecorded()
     {
         var mutationStore = Substitute.For<IMailboxMutationReconciliationStore>();
         mutationStore
-            .ReadRelocationsPlacedAtAsync(
+            .ReadPlacementsAtAsync(
                 Arg.Any<MailAccountId>(),
                 Arg.Any<RemoteFolderPath>(),
                 Arg.Any<ImapUidValidity>(),
@@ -240,6 +240,14 @@ internal static class SynchronizationTestHost
             .Returns(Task.FromResult<IReadOnlyList<MailboxMutationRecord>>([]));
         mutationStore
             .ReadMutationsRemovingAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailFolderResolutionId>(),
+                Arg.Any<ImapUidValidity>(),
+                Arg.Any<IReadOnlyCollection<ImapUid>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<MailboxMutationRecord>>([]));
+        mutationStore
+            .ReadSeenStateChangesOnAsync(
                 Arg.Any<MailAccountId>(),
                 Arg.Any<MailFolderResolutionId>(),
                 Arg.Any<ImapUidValidity>(),

--- a/tests/IntegrationTests/Mailbox/OrchestratedMailbox.cs
+++ b/tests/IntegrationTests/Mailbox/OrchestratedMailbox.cs
@@ -139,6 +139,38 @@ internal sealed class OrchestratedMailbox(OrchestratedMailServerEndpoints endpoi
         await client.DisconnectAsync(quit: true, cancellationToken);
     }
 
+    /// <summary>Moves one message between folders over a connection MailFathom knows nothing about.</summary>
+    /// <param name="sourceFolderPath">The folder holding the message.</param>
+    /// <param name="destinationFolderPath">The folder to move it into.</param>
+    /// <param name="uid">The message to move.</param>
+    /// <param name="cancellationToken">Cancels the move.</param>
+    /// <returns>The UID the destination folder reports for the message, where the server named one.</returns>
+    /// <remarks>
+    /// This is the mailbox owner doing by hand exactly what a rule would ask MailFathom to do, and it is the control the
+    /// suppression is only meaningful against: the two produce the same two events in the same two folders, and the only
+    /// thing that separates them is whether MailFathom wrote a record before the command went out. A suppression that
+    /// silenced this one would silence the owner's own mailbox.
+    /// </remarks>
+    internal async Task<ImapUid?> MoveAsync(
+        string sourceFolderPath,
+        string destinationFolderPath,
+        ImapUid uid,
+        CancellationToken cancellationToken)
+    {
+        using var client = await this.ConnectAndAuthenticateAsync(cancellationToken);
+
+        var source = await client.GetFolderAsync(sourceFolderPath, cancellationToken);
+        var destination = await client.GetFolderAsync(destinationFolderPath, cancellationToken);
+        await source.OpenAsync(FolderAccess.ReadWrite, cancellationToken);
+
+        var placed = await source.MoveToAsync(new UniqueId(uid.Value), destination, cancellationToken);
+
+        await source.CloseAsync(expunge: false, cancellationToken);
+        await client.DisconnectAsync(quit: true, cancellationToken);
+
+        return placed is { } placement ? ImapUid.Create(placement.Id) : null;
+    }
+
     /// <summary>Flags one message <c>\Deleted</c> without expunging it, the way another mail client would.</summary>
     /// <param name="folderPath">The folder holding the message.</param>
     /// <param name="uid">The message to flag.</param>

--- a/tests/IntegrationTests/Synchronization/OrchestratedRelocationReconciliationTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedRelocationReconciliationTests.cs
@@ -30,6 +30,16 @@ namespace MailFathom.IntegrationTests.Synchronization;
 /// reconciled first — which is the second test, and also the out-of-order case an operator's mailbox will produce
 /// whenever the destination folder is not one MailFathom synchronizes on the same schedule.
 /// </para>
+/// <para>
+/// Both also assert what each half was withheld from, and the third test is the control that makes those assertions
+/// mean anything: the mailbox owner performs the same move by hand, over a connection MailFathom never sees, and the
+/// same two events are raised rather than withheld. An absence proves nothing unless the same observation would report
+/// it present, and the two tests differ in exactly one thing — whether a record was written before the command.
+/// </para>
+/// <para>
+/// The same mechanism applied to a <c>\Seen</c> flag is proved by <c>OrchestratedSeenStateProvenanceTests</c>, which
+/// this class deliberately leaves alone: nothing about a flag is a folder change, and neither run here would observe it.
+/// </para>
 /// </remarks>
 [Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
 [TestCaseOrderer(typeof(MailboxStateSequenceOrderer))]
@@ -39,6 +49,10 @@ public sealed class OrchestratedRelocationReconciliationTests(MailFathomOrchestr
 
     private const string TargetFolderName = "RelocationTarget";
 
+    private const string ManualSourceFolderName = "ManualMoveSource";
+
+    private const string ManualTargetFolderName = "ManualMoveTarget";
+
     private static readonly MailFolderMapping SourceMapping = MailFolderMapping.ToRemotePath(
         MailFolderAlias.Create("relocation-source"),
         RemoteFolderPath.Create(SourceFolderName, hierarchyDelimiter: '.'));
@@ -46,6 +60,14 @@ public sealed class OrchestratedRelocationReconciliationTests(MailFathomOrchestr
     private static readonly MailFolderMapping TargetMapping = MailFolderMapping.ToRemotePath(
         MailFolderAlias.Create("relocation-target"),
         RemoteFolderPath.Create(TargetFolderName, hierarchyDelimiter: '.'));
+
+    private static readonly MailFolderMapping ManualSourceMapping = MailFolderMapping.ToRemotePath(
+        MailFolderAlias.Create("manual-move-source"),
+        RemoteFolderPath.Create(ManualSourceFolderName, hierarchyDelimiter: '.'));
+
+    private static readonly MailFolderMapping ManualTargetMapping = MailFolderMapping.ToRemotePath(
+        MailFolderAlias.Create("manual-move-target"),
+        RemoteFolderPath.Create(ManualTargetFolderName, hierarchyDelimiter: '.'));
 
     private static readonly RemoteFolderPath TargetPath =
         RemoteFolderPath.Create(TargetFolderName, hierarchyDelimiter: '.');
@@ -96,6 +118,13 @@ public sealed class OrchestratedRelocationReconciliationTests(MailFathomOrchestr
         var record = await ReadRecordAsync(services, outcome.RecordId, cancellationToken);
         Assert.NotNull(record.PlacementObservedAt);
         Assert.NotNull(record.SourceRemovalObservedAt);
+
+        // The arrival was MailFathom's own, so it is withheld from rule evaluation. Raising it is what would let a rule
+        // that files mail match the mail it has just filed, on every interval, for as long as the folder is watched.
+        var suppressed = Assert.Single(result.SuppressedChanges);
+        Assert.Equal(MailboxChangeKind.EmailAppearedInFolder, suppressed.Kind);
+        Assert.Equal(MailboxMutation.Relocate, suppressed.Mutation);
+        Assert.Equal(outcome.RecordId, suppressed.MutationRecordId);
     }
 
     /// <summary>The source occurrence vanishing is the relocation completing, not a deletion somebody else made.</summary>
@@ -133,6 +162,60 @@ public sealed class OrchestratedRelocationReconciliationTests(MailFathomOrchestr
         var record = await ReadRecordAsync(services, outcome.RecordId, cancellationToken);
         Assert.NotNull(record.SourceRemovalObservedAt);
         Assert.Null(record.PlacementObservedAt);
+
+        var suppressed = Assert.Single(result.SuppressedChanges);
+        Assert.Equal(MailboxChangeKind.EmailLeftFolder, suppressed.Kind);
+        Assert.Equal(MailboxMutation.Relocate, suppressed.Mutation);
+        Assert.Equal(stored.StoredEmailId, suppressed.StoredEmailId);
+        Assert.Equal(outcome.RecordId, suppressed.MutationRecordId);
+    }
+
+    /// <summary>The mailbox owner moving mail by hand produces the same two events, and both stay changes to react to.</summary>
+    /// <remarks>
+    /// <para>
+    /// This is the control for the two tests above. The server reports the identical arrival and the identical
+    /// disappearance whichever side issued the command, so an assertion that MailFathom's own were withheld says nothing
+    /// until the same runs raise the owner's. It also proves the suppression is scoped to the occurrence a record names
+    /// rather than to the folders a rule happens to write to.
+    /// </para>
+    /// <para>
+    /// It owns a folder pair of its own rather than reusing the one above, because the tests above deliberately leave a
+    /// relocation half-observed: the message the second test moved is still waiting to be met in the target folder, and
+    /// its source occurrence is still recorded as MailFathom's. Reusing those folders would let this test's runs meet
+    /// that message and report a withheld change this test never made.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    [MailboxStateStep(3)]
+    public async Task SynchronizeAsync_AfterAFolderChangeMadeOutsideMailFathom_RaisesBothHalvesOfIt()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mailbox = new OrchestratedMailbox(orchestration.MailServer);
+        await mailbox.RecreateFolderAsync(ManualSourceFolderName, cancellationToken);
+        await mailbox.RecreateFolderAsync(ManualTargetFolderName, cancellationToken);
+
+        var subject = $"relocation-by-hand-{Guid.NewGuid():N}";
+        await mailbox.AppendAsync(ManualSourceFolderName, subject, cancellationToken);
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        Assert.Equal(1, (await SynchronizeAsync(services, ManualSourceMapping, cancellationToken)).StoredEmailCount);
+
+        var stored = await ReadStoredEmailAsync(services, subject, cancellationToken);
+        await mailbox.MoveAsync(ManualSourceFolderName, ManualTargetFolderName, stored.Uid, cancellationToken);
+
+        // Act
+        var sourceRun = await SynchronizeAsync(services, ManualSourceMapping, cancellationToken);
+        var targetRun = await SynchronizeAsync(services, ManualTargetMapping, cancellationToken);
+
+        // Assert
+        Assert.Empty(sourceRun.SuppressedChanges);
+        Assert.Equal(1, sourceRun.Reconciliation.RemotelyDeletedEmailCount);
+        Assert.Equal(0, sourceRun.Reconciliation.OwnMutationCompletedEmailCount);
+
+        Assert.Empty(targetRun.SuppressedChanges);
+        Assert.Equal(1, targetRun.StoredEmailCount);
+        Assert.Equal(0, targetRun.RelocatedEmailCount);
     }
 
     private static Task<MailboxSynchronizationResult> SynchronizeAsync(

--- a/tests/IntegrationTests/Synchronization/OrchestratedSeenStateProvenanceTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedSeenStateProvenanceTests.cs
@@ -1,0 +1,166 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.IntegrationTests.Mailbox;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Synchronization;
+
+/// <summary>Proves that a <c>\Seen</c> flag MailFathom set is told from one the mailbox owner set, against a real server and a real database.</summary>
+/// <remarks>
+/// <para>
+/// One test, and it carries both messages, because the whole claim is a comparison: the server reports the identical
+/// moved flag whichever side wrote it, and the only thing separating them is a record MailFathom wrote before the
+/// <c>STORE</c> went out. Two tests would pay twice for one composition and could not observe both halves of the same
+/// run.
+/// </para>
+/// <para>
+/// What only real infrastructure establishes here is the query. Whether a change is withheld is decided in the domain
+/// and covered by unit tests; whether the read that finds the candidate records translates, filters by the folder
+/// binding it claims to, and returns the row is a statement about PostgreSQL and EF Core that no substitute can make.
+/// It is the one read of that store nothing else in this suite reaches.
+/// </para>
+/// <para>
+/// The suppression does not rest on <c>CONDSTORE</c>, which is what makes this provable against a server advertising
+/// neither it nor <c>QRESYNC</c>. A moved flag is the value the server reports differing from the value last stored, and
+/// the ordinary window reads both. What <c>CONDSTORE</c> would change is how much of the folder the server has to
+/// describe, never how a change is attributed.
+/// </para>
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedSeenStateProvenanceTests(MailFathomOrchestrationFixture orchestration)
+{
+    private const string FolderName = "SeenStateProvenance";
+
+    private static readonly MailFolderMapping Mapping = MailFolderMapping.ToRemotePath(
+        MailFolderAlias.Create("seen-state-provenance"),
+        RemoteFolderPath.Create(FolderName, hierarchyDelimiter: '.'));
+
+    private static readonly MailboxMutationRequester Requester =
+        MailboxMutationRequester.Rule("mark-newsletters-read", 1);
+
+    /// <summary>The flag MailFathom set is withheld from rule evaluation, and the one the owner set beside it is not.</summary>
+    [Fact]
+    public async Task SynchronizeAsync_AfterTwoSeenFlagsOneSideEach_WithholdsOnlyTheOneMailFathomSet()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mailbox = new OrchestratedMailbox(orchestration.MailServer);
+        await mailbox.RecreateFolderAsync(FolderName, cancellationToken);
+
+        var markedByMailFathom = $"seen-by-mailfathom-{Guid.NewGuid():N}";
+        var markedByOwner = $"seen-by-owner-{Guid.NewGuid():N}";
+        await mailbox.AppendAsync(FolderName, markedByMailFathom, cancellationToken);
+        await mailbox.AppendAsync(FolderName, markedByOwner, cancellationToken);
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+
+        // The first run stores both and reads their flags, which is what gives the second run a previous value to
+        // compare against. Without it neither message would have a moved flag at all.
+        var firstRun = await SynchronizeAsync(services, cancellationToken);
+        Assert.Equal(2, firstRun.StoredEmailCount);
+        Assert.Equal(2, firstRun.Reconciliation.ObservedEmailCount);
+
+        var ours = await ReadStoredEmailAsync(services, markedByMailFathom, cancellationToken);
+        var theirs = await ReadStoredEmailAsync(services, markedByOwner, cancellationToken);
+
+        var outcome = await MarkSeenAsync(services, ours, cancellationToken);
+        Assert.Equal(MailboxMutationStatus.Performed, outcome.Status);
+
+        await mailbox.MarkSeenAsync(FolderName, theirs.Uid, cancellationToken);
+
+        // Act
+        var result = await SynchronizeAsync(services, cancellationToken);
+
+        // Assert
+        Assert.Equal(1, result.Reconciliation.SeenStateChangedEmailCount);
+
+        var suppressed = Assert.Single(result.SuppressedChanges);
+        Assert.Equal(MailboxChangeKind.SeenStateChanged, suppressed.Kind);
+        Assert.Equal(MailboxMutation.SetSeen, suppressed.Mutation);
+        Assert.Equal(ours.StoredEmailId, suppressed.StoredEmailId);
+        Assert.Equal(outcome.RecordId, suppressed.MutationRecordId);
+
+        // The stored snapshot follows the server for both, because what was withheld is the trigger and never the
+        // reading. An assertion that one flag was withheld says nothing unless the other one really did move.
+        Assert.True(await IsRemotelySeenAsync(services, markedByMailFathom, cancellationToken));
+        Assert.True(await IsRemotelySeenAsync(services, markedByOwner, cancellationToken));
+    }
+
+    private static Task<MailboxSynchronizationResult> SynchronizeAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailboxSynchronizer>().SynchronizeAsync(
+                SyntheticMailAccount.AccountId,
+                Mapping,
+                token),
+            cancellationToken);
+
+    /// <summary>Marks one stored email read through the production performer, which writes the record the join reads.</summary>
+    private static Task<MailboxMutationOutcome> MarkSeenAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailRow stored,
+        CancellationToken cancellationToken)
+    {
+        var folder = MailFolderResolution.FirstBindingOf(Mapping.Alias, Mapping.RemotePath!.Value);
+        var occurrence = EmailOccurrenceId.Create(
+            SyntheticMailAccount.AccountId,
+            folder.Id,
+            stored.UidValidity,
+            stored.Uid);
+        var request = MailboxMutationRequest.SetSeen(stored.StoredEmailId, occurrence, Requester, isSeen: true);
+
+        return services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IMailboxMutationPerformer>().PerformAsync(
+                request,
+                folder,
+                scope.GetRequiredService<IMailTransportSecurityPolicyReader>()
+                    .GetPolicy(SyntheticMailAccount.AccountId),
+                token),
+            cancellationToken);
+    }
+
+    private static Task<StoredEmailRow> ReadStoredEmailAsync(
+        OrchestratedMailFathomServices services,
+        string subject,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) => await scope.GetRequiredService<MailFathomDbContext>()
+                .StoredEmails
+                .AsNoTracking()
+                .Where(storedEmail => storedEmail.Subject == subject)
+                .Select(storedEmail => new StoredEmailRow(
+                    StoredEmailId.Create(storedEmail.Id),
+                    ImapUidValidity.Create(storedEmail.UidValidity),
+                    ImapUid.Create(storedEmail.Uid)))
+                .SingleAsync(token),
+            cancellationToken);
+
+    private static Task<bool> IsRemotelySeenAsync(
+        OrchestratedMailFathomServices services,
+        string subject,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) => await scope.GetRequiredService<MailFathomDbContext>()
+                .StoredEmails
+                .AsNoTracking()
+                .Where(storedEmail => storedEmail.Subject == subject)
+                .Select(storedEmail => storedEmail.IsRemotelySeen)
+                .SingleAsync(token),
+            cancellationToken);
+
+    /// <summary>The columns of one stored email this class reads back.</summary>
+    private sealed record StoredEmailRow(
+        StoredEmailId StoredEmailId,
+        ImapUidValidity UidValidity,
+        ImapUid Uid);
+}


### PR DESCRIPTION
## What this changes

Every mutation MailFathom performs is a change synchronization later discovers, so once a rule can write to a mailbox the same rule meets its own work. A rule matching on folder would file a message, meet it in its new folder, match again, and go round for as long as the folder is watched — at an IMAP command a lap. Two rules with overlapping conditions do the same to each other.

A synchronization run now decides the provenance of every change it discovers and **withholds** the ones a durable mutation record accounts for. No cycle counter, no depth limit, no rate limit: a cycle limit stops a loop only after it has run several times, and a rate limit stops legitimate work at the same threshold. The record answers the question exactly.

## All four mutations

| Change discovered | How provenance is decided |
|---|---|
| An occurrence appears in a folder | Matched against relocations **and copies** whose `COPYUID` named this UIDVALIDITY and UID. A relocation still carries the local row across; a copy is stored like any other discovery, because it left the email where it was — what the record settles for it is only whose act the arrival was. |
| An occurrence leaves a folder | Matched against the source occurrence the record wrote down before the first IMAP command (already in place from #449). |
| The remote `\Seen` flag stands somewhere new | Matched against the `\Seen` stores issued against that occurrence, direction included: a store that asked for the flag to be set answers for it becoming set and never for it becoming clear. |

`\Seen` is the case that made this mandatory. A flag change arrives as a changed modification sequence — exactly what a person marking mail read in their own client produces — so a rule conditioned on unread mail that marks mail read would re-evaluate everything it had just acted on.

## Where the expiry lives, and why not on the record

A store accounts for a flag reading only while the *occurrence's own* last observation predates the moment the store completed. Every reconciliation window advances that observation for every occurrence it asked about, so the first reading after a store ends what the record can answer for — whether or not the flag was still where it was put.

The obvious alternative was a `SeenStateObservedAt` column beside the two observation columns #449 added. It is weaker, and silently: it would be written only when a reading actually *differed*, so an owner who reverted the flag before any window saw MailFathom's change would leave it unwritten, and their own later change to that flag would be withheld months afterwards. `ReconcileAsync_OwnerRevertedTheFlagBeforeAnyWindowSawIt_StillRaisesTheirLaterChange` is that case.

**No database schema change and no migration.** Both facts this needs were already durable.

## Observability

A rule that appears not to have fired is otherwise the same thing to read as a rule that never matched. Each folder's run reports how many changes it withheld at `Information`, and names each one at `Debug` with its kind, the mutation, the local email, and the record that accounted for it. Nothing derived from a message reaches either line, and a folder MailFathom never writes to emits neither.

## Tests

Unit tests cover a rule that would re-trigger itself, a flag change that would re-trigger, the owner's own move, delete, and flag change still triggering, the direction and stage guards, a first flag reading not counting as a change, and a window in which nothing moved asking the database nothing.

The integration suite proves a folder change MailFathom made is withheld and the same move made by hand over a connection MailFathom never sees is raised — the control that makes the first assertion mean anything.

**Deviation from the issue, in the direction of more coverage.** The issue expected the flag half to be unprovable in the orchestrated topology because GreenMail advertises no `CONDSTORE` or `QRESYNC`. It turned out not to rest on `CONDSTORE` at all: a moved flag is the value the server reports differing from the value last stored, and the ordinary window reads both. So `OrchestratedSeenStateProvenanceTests` proves it end to end — two messages, one marked read by MailFathom and one by the mailbox owner, one run, one withheld and one raised. That also covers `ReadSeenStateChangesOnAsync`, which nothing else in the suite reaches.

## Breaking changes

None to the MCP tool contract, the configuration schema, the database schema, or the deployment contract.

Closes #450
