### PR TITLE
[#430] Give an embedding profile the approximate index that belongs to it

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -224,7 +224,25 @@ assembled at the failure site.
 
 The recipient and search-vector indexes are GIN rather than B-tree because both serve containment tests. A B-tree over an array column serves only equality against a whole array, and over a `tsvector` it serves nothing search asks for; a GIN index is what turns either into an index scan.
 
-Two indexes the architecture draft lists are still deliberately absent. The partial indexes excluding remotely deleted messages wait for specification 10, which introduces the state they would filter on. The per-profile HNSW index over the vector column is not created by any migration at all: it is tied to one profile's dimension, so it is built when that profile is activated and dropped when the generation it serves is removed.
+The partial indexes over remotely deleted messages that the architecture draft lists are still deliberately absent; they wait for specification 10, which introduces the state they would filter on. The per-profile HNSW index is absent from the migrations for a different reason, and permanently.
+
+### The index no migration creates
+
+An approximate index over `Embedding` covers one width and one generation, and neither is known when a migration runs. So `email_embeddings` carries one per profile, built and removed as a profile's lifecycle asks rather than when the table is created:
+
+```sql
+CREATE INDEX IF NOT EXISTS "ix_email_embeddings_hnsw_0198f3d24b6a7c1e9f042a5b8c7d6e10"
+ON email_embeddings USING hnsw (("Embedding"::vector(1536)) vector_cosine_ops)
+WHERE "EmbeddingProfileId" = '0198f3d2-4b6a-7c1e-9f04-2a5b8c7d6e10'::uuid
+```
+
+Both unusual halves follow from the dimensionless column. The cast is what gives HNSW a width to index; the predicate is what keeps this index over the rows that have that width, so a second generation is served by an index of its own instead of colliding with this one. The operator class follows the profile's metric — `vector_cosine_ops`, `vector_ip_ops`, or `vector_l2_ops` — because a space indexed under a distance it was not built for returns a plausible number rather than an error.
+
+The name is the profile's identifier written as thirty-two hexadecimal digits, which does two things. It keeps the whole name inside the sixty-three bytes PostgreSQL keeps of an identifier, where truncation would let two profiles share one index. And because a profile's identity is immutable, an index already carrying the name *is* the index a repeated build would have produced — which is what makes `IF NOT EXISTS` safe here, given that PostgreSQL does not compare an existing index against the one asked for.
+
+**Nothing in either statement comes from a caller.** PostgreSQL accepts no parameter in a utility statement, so the width, the operator class, the predicate value, and the name are all part of the text; each is read from the registered profile's own immutable columns or chosen by a closed mapping over an enum. The provider and model names a profile carries never enter it at all.
+
+Building one is therefore an administrative act rather than a schema migration, and it is the one place MailFathom changes the schema outside the artifact an operator applies. [Applying the database schema](../operations/database-schema.md#the-one-index-mailfathom-creates-itself) states what that costs a deployment that separates its migrating role from its serving one. Before an index exists, a vector search over that profile is exact — correct, and linear in the number of vectors — which is what makes a failure to build one a performance finding rather than a wrong answer.
 
 ## The timeline ordering contract
 

--- a/docs/features/embedding-generation.md
+++ b/docs/features/embedding-generation.md
@@ -74,6 +74,11 @@ pgvector stores far more than it indexes: a `vector` column holds up to 16000 di
 2000. So a model is not merely large or small — it is indexable, or it is stored and searched exactly, which is
 correct but linear in the number of vectors.
 
+The index that covers it belongs to one profile rather than to the table, which is why a width is a property of a
+generation instead of of the schema. [Stored email
+schema](../architecture/stored-email-schema.md#the-index-no-migration-creates) describes its shape and what maintaining
+one costs.
+
 `AllowTrimVectors` decides which, and it is off by default. With it off, a declared dimension above what an index
 covers is refused at startup, naming the dimension and the ceiling, rather than quietly producing an instance whose
 semantic search never becomes fast. With it on, the declared width is what the profile records and what the stored

--- a/docs/operations/database-schema.md
+++ b/docs/operations/database-schema.md
@@ -1,6 +1,6 @@
 # Applying the database schema
 
-<!-- describes: src/Infrastructure/Persistence/Migrations/**, src/AppHost/**, scripts/build-schema-artifact.sh -->
+<!-- describes: src/Infrastructure/Persistence/Migrations/**, src/Infrastructure/Persistence/Embeddings/EmbeddingProfileVectorIndex.cs, src/AppHost/**, scripts/build-schema-artifact.sh -->
 
 MailFathom never applies a schema change while starting, in any environment. It verifies the migration history and
 refuses to serve against a schema it does not recognize, so bringing a new version up *tells* you a migration is
@@ -70,6 +70,39 @@ ALTER DEFAULT PRIVILEGES FOR ROLE mailfathom_migrator IN SCHEMA public
 
 Grant rather than transfer: handing the tables to the service's role would leave the migrator unable to alter them next
 time, and would give the role that serves requests the privilege to drop what it serves.
+
+### The one index MailFathom creates itself
+
+Every index in the script is the migrating role's, with one exception that is not in the script at all. The approximate
+index over stored vectors covers one embedding profile's width, and no migration can know a width that a later
+activation chooses — so MailFathom issues that `CREATE INDEX` itself, under the role it connects as. [Stored email
+schema](../architecture/stored-email-schema.md#the-index-no-migration-creates) describes the index and why it has to be
+per profile.
+
+**Creating an index requires owning the table.** PostgreSQL treats the right to modify an object as inherent in being
+its owner and offers no privilege that grants it separately, so the two roles above need one more arrangement before
+that index can be built:
+
+```sql
+GRANT mailfathom TO mailfathom_migrator;
+ALTER TABLE email_embeddings OWNER TO mailfathom;
+```
+
+The grant comes first because a role may only hand a table to one it is a member of, and it is what keeps the migrator
+able to alter that table in a later migration — it acts there as a member of the role that now owns it. This is the one
+table the serving role owns, and it is the price of an index a migration cannot contain. A deployment where a single
+role both applies the schema and serves requests — which the Docker Compose deployment is — already satisfies this and
+needs neither statement.
+
+**How long it takes depends on when it is built.** The index covers only the rows its predicate selects, so a profile
+indexed before its generation holds any vectors is built in an instant, and every vector written afterwards enters the
+index as it is stored. Building one over a generation that is already embedded takes time proportional to the vectors
+in it, and a non-concurrent `CREATE INDEX` blocks writes to `email_embeddings` for that time — the same caution
+[Locks and timeouts](#locks-and-timeouts) states for the script.
+
+**A refusal costs performance and nothing else.** Where the privilege is missing, or the build fails for any other
+reason, MailFathom reports which profile and why, and the vectors are untouched. Vector search over that profile stays
+exact until an index exists: correct, and linear in the number of vectors it reads.
 
 ## Applying it
 

--- a/src/Application/Emails/Embeddings/Indexing/EmbeddingVectorIndexFailedException.cs
+++ b/src/Application/Emails/Embeddings/Indexing/EmbeddingVectorIndexFailedException.cs
@@ -1,0 +1,40 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Failures;
+
+namespace MailFathom.Application.Emails.Embeddings.Indexing;
+
+/// <summary>Indicates that the approximate index belonging to one embedding profile could not be built or removed.</summary>
+/// <remarks>
+/// <para>
+/// An exception rather than a result, because the fact travels past code that cannot decide what it means: the database
+/// refused a statement, and whether that ends an activation or merely leaves it slower is the operator command's call
+/// rather than the store's. What it carries is what such a caller needs to report — which profile, and which of the two
+/// operations — with the database's own words kept as the inner exception for a log.
+/// </para>
+/// <para>
+/// The message names the profile by its identifier and nothing else. A profile is a model, a width, and a metric, so
+/// none of it is personal data; a vector, a passage, and a message are absent by construction, because this operation
+/// never reads one.
+/// </para>
+/// </remarks>
+public sealed class EmbeddingVectorIndexFailedException : MailFathomException
+{
+    /// <summary>Initializes a new failure to bring one profile's approximate index into the state its lifecycle asked for.</summary>
+    /// <param name="operatorSafeMessage">A message naming the profile and which operation was refused.</param>
+    /// <param name="profileId">The profile whose index the refused statement was for.</param>
+    /// <param name="innerException">The database failure that revealed it.</param>
+    public EmbeddingVectorIndexFailedException(
+        string operatorSafeMessage,
+        EmbeddingProfileId profileId,
+        Exception innerException)
+        : base(operatorSafeMessage, innerException) => this.ProfileId = profileId;
+
+    /// <inheritdoc />
+    public override MailFathomErrorCode ErrorCode => MailFathomErrorCode.EmbeddingVectorIndexUnavailable;
+
+    /// <summary>Gets the profile whose approximate index is not in the state its lifecycle asked for.</summary>
+    public EmbeddingProfileId ProfileId { get; }
+}

--- a/src/Application/Emails/Embeddings/Indexing/IEmbeddingProfileVectorIndex.cs
+++ b/src/Application/Emails/Embeddings/Indexing/IEmbeddingProfileVectorIndex.cs
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Indexing;
+
+/// <summary>Maintains the one approximate index through which a profile's vectors are searched.</summary>
+/// <remarks>
+/// <para>
+/// The index belongs to a profile rather than to the table, which is a consequence of the dimensionless vector column:
+/// one index covers one width, so a table holding two generations of different widths cannot be served by a single one.
+/// That is why no migration creates it and why building it is an administrative act — activating a profile is what
+/// calls for one, and removing or superseding that profile is what calls for it to go. See
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md">ADR 0006</see>.
+/// </para>
+/// <para>
+/// Nothing here decides <em>when</em> to activate, and neither operation changes an answer. Before an approximate index
+/// exists, a vector search is exact: correct, and linear in the number of vectors. That is what makes both operations
+/// safe to perform after the fact and what keeps a failure to build one a performance finding rather than a wrong
+/// result.
+/// </para>
+/// </remarks>
+public interface IEmbeddingProfileVectorIndex
+{
+    /// <summary>Builds the approximate index for one profile, leaving an existing one in place.</summary>
+    /// <param name="profile">The profile whose vectors the index serves, and whose geometry decides its shape.</param>
+    /// <param name="cancellationToken">Cancels the build.</param>
+    /// <returns>A task that completes when the profile has its index.</returns>
+    /// <remarks>
+    /// Idempotent, so activating a profile that already has its index builds nothing and does not fail. A profile's
+    /// identity is immutable and the index is named after that identity, so an index already carrying the name is the
+    /// index this call would have built rather than a differently shaped one wearing the same name.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="profile" /> is <see langword="null" />.</exception>
+    /// <exception cref="EmbeddingVectorIndexFailedException">Thrown when the database refused to build the index.</exception>
+    Task EnsureBuiltAsync(ActiveEmbeddingProfile profile, CancellationToken cancellationToken);
+
+    /// <summary>Removes the approximate index belonging to one profile, if it has one.</summary>
+    /// <param name="profileId">The profile whose index is to go.</param>
+    /// <param name="cancellationToken">Cancels the removal.</param>
+    /// <returns>A task that completes when the profile has no index.</returns>
+    /// <remarks>
+    /// Takes the identifier alone rather than the profile, because a superseded generation is removed by a caller that
+    /// holds nothing else about it, and the index is named after the identifier. Removing an index a profile never had
+    /// is not a failure.
+    /// </remarks>
+    /// <exception cref="EmbeddingVectorIndexFailedException">Thrown when the database refused to remove the index.</exception>
+    Task RemoveAsync(EmbeddingProfileId profileId, CancellationToken cancellationToken);
+}

--- a/src/Domain/Failures/MailFathomErrorCode.cs
+++ b/src/Domain/Failures/MailFathomErrorCode.cs
@@ -120,6 +120,22 @@ public readonly record struct MailFathomErrorCode
     /// <summary>Gets subcategory 2, schema state: the lexical index was built with a different text search configuration than the one configured.</summary>
     public static MailFathomErrorCode DatabaseSchemaTextSearchConfigurationMismatch { get; } = new(32003);
 
+    /// <summary>Gets subcategory 3, vector indexes: the approximate index one embedding profile's vectors are searched through is not in the state its lifecycle asked for.</summary>
+    /// <remarks>
+    /// <para>
+    /// One code covers a build that did not happen and a removal that did not, because both leave the same finding for
+    /// an operator to act on: the index a profile's lifecycle calls for is not the index the database holds. Which of
+    /// the two it was is in the message, which names the profile.
+    /// </para>
+    /// <para>
+    /// It is a subcategory of its own rather than one more schema-state failure, because the state it describes is not
+    /// the migration history. This index belongs to no migration at all — it is tied to one profile's dimension, so it
+    /// is built when that profile is activated — and a database missing it is serving correct results slowly rather
+    /// than running against a schema the build does not recognize.
+    /// </para>
+    /// </remarks>
+    public static MailFathomErrorCode EmbeddingVectorIndexUnavailable { get; } = new(33001);
+
     #endregion
 
     #region Category 4 — Outbound resilience
@@ -242,6 +258,7 @@ public readonly record struct MailFathomErrorCode
         DatabaseSchemaOutOfDate,
         DatabaseSchemaStateUnreadable,
         DatabaseSchemaTextSearchConfigurationMismatch,
+        EmbeddingVectorIndexUnavailable,
         OutboundDependencyUnavailable,
         MailboxQueryPageSizeOutOfRange,
         MailboxQueryFilterInvalid,

--- a/src/Infrastructure/Persistence/Embeddings/EmbeddingProfileVectorIndex.cs
+++ b/src/Infrastructure/Persistence/Embeddings/EmbeddingProfileVectorIndex.cs
@@ -1,0 +1,98 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Data.Common;
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.CodeCoverage;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.Infrastructure.Persistence.Embeddings;
+
+/// <summary>Builds and removes the partial HNSW index that serves one profile's vectors.</summary>
+/// <remarks>
+/// <para>
+/// This is the one place MailFathom changes the schema outside a migration, and it is deliberate: the index covers one
+/// width and one profile, so it cannot be written into a migration that runs before either is known. Both statements
+/// are therefore data-definition rather than data-manipulation, which has one consequence an operator has to plan for
+/// — creating an index requires owning the table, a right PostgreSQL says is inherent in ownership and cannot be
+/// granted on its own, so a deployment that applies its schema as a separate migrating role has to hand
+/// <c>email_embeddings</c> to the role MailFathom connects as. Where it has not, the refusal arrives here, named,
+/// while exact search goes on answering correctly.
+/// </para>
+/// <para>
+/// Both run on the scoped context, so a caller that has opened a transaction gets them inside it. Neither uses
+/// <c>CONCURRENTLY</c>, which PostgreSQL forbids inside a transaction block and which buys nothing at the moment this
+/// is called: a profile is activated before its generation holds any vectors, so the build reads an empty predicate and
+/// returns immediately, and every vector afterwards enters the index as it is written.
+/// </para>
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed partial class EmbeddingProfileVectorIndex(
+    MailFathomDbContext dbContext,
+    ILogger<EmbeddingProfileVectorIndex> logger) : IEmbeddingProfileVectorIndex
+{
+    /// <inheritdoc />
+    public async Task EnsureBuiltAsync(ActiveEmbeddingProfile profile, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        var indexName = EmbeddingVectorIndexStatements.IndexNameFor(profile.Id);
+
+        await this.ExecuteAsync(
+            EmbeddingVectorIndexStatements.CreateIndexFor(profile),
+            profile.Id,
+            $"The approximate vector index for embedding profile {profile.Id} could not be built. "
+                + "The vectors under that profile are unaffected and are searched exactly until it exists.",
+            cancellationToken);
+
+        LogIndexBuilt(logger, indexName, profile.Id.Value, profile.Identity.Dimension);
+    }
+
+    /// <inheritdoc />
+    public async Task RemoveAsync(EmbeddingProfileId profileId, CancellationToken cancellationToken)
+    {
+        var indexName = EmbeddingVectorIndexStatements.IndexNameFor(profileId);
+
+        await this.ExecuteAsync(
+            EmbeddingVectorIndexStatements.DropIndexFor(profileId),
+            profileId,
+            $"The approximate vector index for embedding profile {profileId} could not be removed. "
+                + "It goes on occupying storage for a generation that is no longer read.",
+            cancellationToken);
+
+        LogIndexRemoved(logger, indexName, profileId.Value);
+    }
+
+    private async Task ExecuteAsync(
+        string statement,
+        EmbeddingProfileId profileId,
+        string operatorSafeMessage,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // The raw overload rather than the interpolated one, which is the opposite of what every other store here
+            // does and is not a choice: PostgreSQL accepts no parameter in a utility statement, so a parameterized
+            // `CREATE INDEX` is not a safer way to write this one — it is not a statement PostgreSQL would run.
+            // `EmbeddingVectorIndexStatements` is where the text comes from and where that safety is argued and tested.
+            await dbContext.Database.ExecuteSqlRawAsync(statement, cancellationToken);
+        }
+        catch (DbException refusal)
+        {
+            throw new EmbeddingVectorIndexFailedException(operatorSafeMessage, profileId, refusal);
+        }
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Built the approximate vector index {IndexName} for embedding profile {EmbeddingProfileId} at {Dimension} dimensions.")]
+    private static partial void LogIndexBuilt(ILogger logger, string indexName, Guid embeddingProfileId, int dimension);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Removed the approximate vector index {IndexName} for embedding profile {EmbeddingProfileId}.")]
+    private static partial void LogIndexRemoved(ILogger logger, string indexName, Guid embeddingProfileId);
+}

--- a/src/Infrastructure/Persistence/Embeddings/EmbeddingVectorIndexStatements.cs
+++ b/src/Infrastructure/Persistence/Embeddings/EmbeddingVectorIndexStatements.cs
@@ -1,0 +1,109 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Application.Emails.Embeddings;
+
+namespace MailFathom.Infrastructure.Persistence.Embeddings;
+
+/// <summary>Composes the two statements that maintain one profile's approximate vector index.</summary>
+/// <remarks>
+/// <para>
+/// <b>These statements are composed rather than parameterized, and that is not a choice.</b> PostgreSQL accepts no
+/// parameters in a utility statement, so an index name, a width, an operator class, and a predicate value all have to
+/// be part of the text. What makes that safe is where each of them comes from: the width and the metric are columns of
+/// a registered profile, whose identity was validated before the row was written and is immutable afterwards; the
+/// identifier is a <see cref="Guid" />; and the operator class is chosen by a closed mapping over an enum. Nothing a
+/// caller types reaches the text, which is why the profile — and never a declaration, a configuration value, or a
+/// request — is what these methods take.
+/// </para>
+/// <para>
+/// Composition lives here, apart from the statements' execution, so exactly that property is provable without a
+/// database: a test can hand this a profile whose provider and model names are hostile and read the whole statement
+/// back.
+/// </para>
+/// </remarks>
+internal static class EmbeddingVectorIndexStatements
+{
+    /// <summary>The table every one of these statements is about.</summary>
+    private const string Table = "email_embeddings";
+
+    /// <summary>The dimensionless column the expression index casts to a width.</summary>
+    private const string VectorColumn = "Embedding";
+
+    /// <summary>The column whose value restricts the partial index to one profile.</summary>
+    private const string ProfileColumn = "EmbeddingProfileId";
+
+    /// <summary>What every index name here begins with, before the profile that owns it.</summary>
+    /// <remarks>
+    /// Twenty-five characters, followed by a UUID written as thirty-two hexadecimal digits, is fifty-seven — inside the
+    /// sixty-three bytes PostgreSQL keeps of an identifier before truncating it. Truncation would be the worst
+    /// available failure here, because two profiles whose names collided after it would look to
+    /// <c>CREATE INDEX IF NOT EXISTS</c> like one index that already exists.
+    /// </remarks>
+    private const string IndexNamePrefix = "ix_email_embeddings_hnsw_";
+
+    /// <summary>Names the approximate index belonging to one profile.</summary>
+    /// <param name="profileId">The profile that owns the index.</param>
+    /// <returns>The index name, derived from the identifier alone.</returns>
+    /// <remarks>
+    /// Derived rather than stored, so removal needs nothing about a profile but its identifier, and so no second record
+    /// can disagree with the index that actually exists.
+    /// </remarks>
+    internal static string IndexNameFor(EmbeddingProfileId profileId) =>
+        IndexNamePrefix + profileId.Value.ToString("N", CultureInfo.InvariantCulture);
+
+    /// <summary>Composes the statement that builds one profile's approximate index.</summary>
+    /// <param name="profile">The profile whose geometry decides the index's width and operator class.</param>
+    /// <returns>A <c>CREATE INDEX</c> statement, idempotent in the profile it is for.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="profile" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the profile records a metric pgvector has no operator class for.</exception>
+    internal static string CreateIndexFor(ActiveEmbeddingProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        var dimension = profile.Identity.Dimension.ToString(CultureInfo.InvariantCulture);
+        var operatorClass = OperatorClassFor(profile.Identity.DistanceMetric);
+
+        // The cast to a width is what lets one dimensionless column hold several generations, and the predicate is what
+        // keeps this index reading only the rows of the width it was built for. `IF NOT EXISTS` carries the caveat that
+        // PostgreSQL does not compare the existing index with the one asked for — which is exactly why the name is
+        // derived from an immutable identity, so a name already taken is taken by this same index.
+        return $"""
+                CREATE INDEX IF NOT EXISTS "{IndexNameFor(profile.Id)}"
+                ON {Table} USING hnsw (("{VectorColumn}"::vector({dimension})) {operatorClass})
+                WHERE "{ProfileColumn}" = '{Identifier(profile.Id)}'::uuid
+                """;
+    }
+
+    /// <summary>Composes the statement that removes one profile's approximate index.</summary>
+    /// <param name="profileId">The profile whose index is to go.</param>
+    /// <returns>A <c>DROP INDEX</c> statement that succeeds whether or not the index is there.</returns>
+    internal static string DropIndexFor(EmbeddingProfileId profileId) =>
+        $"""
+         DROP INDEX IF EXISTS "{IndexNameFor(profileId)}"
+         """;
+
+    /// <summary>Chooses the operator class that measures distance the way the profile's space does.</summary>
+    /// <remarks>
+    /// A closed mapping over the metric rather than a name carried in the profile: an operator class is pgvector's
+    /// vocabulary rather than MailFathom's, and one taken from a record would be a string reaching a statement no
+    /// parameter can protect. Indexing under the wrong one returns a number instead of an error, which is why an
+    /// unmapped metric is refused rather than defaulted.
+    /// </remarks>
+    private static string OperatorClassFor(EmbeddingDistanceMetric distanceMetric) => distanceMetric switch
+    {
+        EmbeddingDistanceMetric.Cosine => "vector_cosine_ops",
+        EmbeddingDistanceMetric.InnerProduct => "vector_ip_ops",
+        EmbeddingDistanceMetric.EuclideanDistance => "vector_l2_ops",
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(distanceMetric),
+            distanceMetric,
+            "The distance metric has no pgvector operator class."),
+    };
+
+    /// <summary>Writes a profile identifier as the hyphenated hexadecimal literal PostgreSQL reads as a UUID.</summary>
+    private static string Identifier(EmbeddingProfileId profileId) =>
+        profileId.Value.ToString("D", CultureInfo.InvariantCulture);
+}

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.EmailContent.Repair;
 using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.GetEmailContent;
 using MailFathom.Application.Emails.ListEmails;
@@ -182,6 +183,10 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<EmailEmbeddingTelemetry>();
         services.AddScoped<IActiveEmbeddingProfileReader, ActiveEmbeddingProfileReader>();
         services.AddScoped<IEmailEmbeddingStore, EmailEmbeddingStore>();
+        // The only registration here that changes the schema. It is scoped like every other store so that a caller
+        // which has opened a persistence session gets its statement inside that session's transaction rather than
+        // beside it.
+        services.AddScoped<IEmbeddingProfileVectorIndex, EmbeddingProfileVectorIndex>();
         // Registered here beside the store it writes through, for the reason the chunk writer above is: its
         // `ITextEmbeddingGenerator` comes from the AI boundary, which this project may not reference, so a composition
         // root that registers persistence without an embedding provider resolves nothing — which is correct, because

--- a/tests/Application.UnitTests/Emails/Embeddings/Indexing/EmbeddingVectorIndexFailedExceptionTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Indexing/EmbeddingVectorIndexFailedExceptionTests.cs
@@ -1,0 +1,56 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Domain.Failures;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Embeddings.Indexing;
+
+/// <summary>Covers what a failed index operation publishes to the command that has to report it.</summary>
+public sealed class EmbeddingVectorIndexFailedExceptionTests
+{
+    private static readonly EmbeddingProfileId ProfileId =
+        EmbeddingProfileId.Create(new Guid("0198f3d2-4b6a-7c1e-9f04-2a5b8c7d6e10"));
+
+    /// <summary>
+    /// One allocated code, in the persistence category, so a boundary reports the failure without recognizing the type.
+    /// </summary>
+    [Fact]
+    public void ErrorCode_IsTheAllocatedVectorIndexCode()
+    {
+        // Arrange
+        var thrown = FailureOf("The approximate vector index could not be built.");
+
+        // Assert
+        Assert.Equal(33001, thrown.ErrorCode.Value);
+        Assert.Contains(thrown.ErrorCode, MailFathomErrorCode.All);
+    }
+
+    /// <summary>
+    /// The profile travels with the failure so a caller names which generation is unindexed, and the database's own
+    /// words stay in the inner exception, where a log reads them and a boundary does not.
+    /// </summary>
+    [Fact]
+    public void Failure_CarriesTheProfileAndKeepsTheDatabaseWordsOutOfTheMessage()
+    {
+        // Arrange
+        var refusal = new InvalidOperationException("permission denied for table email_embeddings at db.internal");
+
+        // Act
+        var thrown = new EmbeddingVectorIndexFailedException(
+            $"The approximate vector index for embedding profile {ProfileId} could not be built.",
+            ProfileId,
+            refusal);
+
+        // Assert
+        Assert.Equal(ProfileId, thrown.ProfileId);
+        Assert.Same(refusal, thrown.InnerException);
+        Assert.DoesNotContain("db.internal", thrown.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static EmbeddingVectorIndexFailedException FailureOf(string operatorSafeMessage) =>
+        new(operatorSafeMessage, ProfileId, new InvalidOperationException("refused"));
+}

--- a/tests/Infrastructure.UnitTests/Persistence/Embeddings/EmbeddingVectorIndexStatementsTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Embeddings/EmbeddingVectorIndexStatementsTests.cs
@@ -1,0 +1,160 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Infrastructure.Persistence.Embeddings;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Embeddings;
+
+/// <summary>
+/// Covers what makes composed data-definition SQL safe to compose: that every value in the statement comes from a
+/// registered profile's own columns or from a closed mapping, and that a name PostgreSQL would truncate is never
+/// produced.
+/// </summary>
+/// <remarks>
+/// Whether the database accepts these statements is the integration suite's question. What is asked here is the one a
+/// database could not answer: that nothing a caller wrote reaches the text.
+/// </remarks>
+public sealed class EmbeddingVectorIndexStatementsTests
+{
+    private static readonly Guid ProfileIdentifier = new("0198f3d2-4b6a-7c1e-9f04-2a5b8c7d6e10");
+
+    /// <summary>
+    /// The statement casts the dimensionless column to the profile's width, measures under the profile's metric, and
+    /// restricts itself to the profile's own rows — which together are what let one column carry two generations.
+    /// </summary>
+    [Fact]
+    public void CreateIndexFor_ACosineProfile_ComposesThePartialExpressionIndexForItsWidth()
+    {
+        // Arrange
+        var profile = ProfileOf(dimension: 1536, EmbeddingDistanceMetric.Cosine);
+
+        // Act
+        var statement = EmbeddingVectorIndexStatements.CreateIndexFor(profile);
+
+        // Assert
+        Assert.Equal(
+            """
+            CREATE INDEX IF NOT EXISTS "ix_email_embeddings_hnsw_0198f3d24b6a7c1e9f042a5b8c7d6e10"
+            ON email_embeddings USING hnsw (("Embedding"::vector(1536)) vector_cosine_ops)
+            WHERE "EmbeddingProfileId" = '0198f3d2-4b6a-7c1e-9f04-2a5b8c7d6e10'::uuid
+            """,
+            statement);
+    }
+
+    /// <summary>
+    /// Each metric names the operator class pgvector measures it with. Indexing under the wrong one returns a number
+    /// rather than an error, so the mapping is the whole of what keeps a distance meaning what it claims to mean.
+    /// </summary>
+    [Theory]
+    [InlineData(EmbeddingDistanceMetric.Cosine, "vector_cosine_ops")]
+    [InlineData(EmbeddingDistanceMetric.InnerProduct, "vector_ip_ops")]
+    [InlineData(EmbeddingDistanceMetric.EuclideanDistance, "vector_l2_ops")]
+    public void CreateIndexFor_EachDistanceMetric_NamesThePgvectorOperatorClassThatMeasuresIt(
+        EmbeddingDistanceMetric distanceMetric,
+        string expectedOperatorClass)
+    {
+        // Arrange
+        var profile = ProfileOf(dimension: 768, distanceMetric);
+
+        // Act
+        var statement = EmbeddingVectorIndexStatements.CreateIndexFor(profile);
+
+        // Assert
+        Assert.Contains($"(\"Embedding\"::vector(768)) {expectedOperatorClass}", statement, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A metric outside the mapped set is refused rather than defaulted, because a default would index a space under a
+    /// distance it was not built for and every search afterwards would return plausible wrong neighbours.
+    /// </summary>
+    [Fact]
+    public void CreateIndexFor_AMetricWithNoOperatorClass_IsRefused()
+    {
+        // Arrange
+        var profile = ProfileOf(dimension: 4, (EmbeddingDistanceMetric)int.MaxValue);
+
+        // Act
+        var refusal = Record.Exception(() => EmbeddingVectorIndexStatements.CreateIndexFor(profile));
+
+        // Assert
+        Assert.IsType<ArgumentOutOfRangeException>(refusal);
+    }
+
+    /// <summary>
+    /// The provider and the model name a profile carries are vendor-supplied text this system stores verbatim, and no
+    /// parameter can protect a utility statement. None of it reaches the statement at all, which is what makes that
+    /// irrelevant rather than merely unlikely.
+    /// </summary>
+    [Fact]
+    public void CreateIndexFor_AProfileWhoseNamesCarrySql_LeavesNoneOfThatTextInTheStatement()
+    {
+        // Arrange
+        var profile = ProfileOf(
+            dimension: 3,
+            EmbeddingDistanceMetric.Cosine,
+            provider: "'; DROP TABLE email_embeddings; --",
+            modelIdentifier: "\" OR 1=1 --",
+            passageInstruction: "'); DELETE FROM embedding_profiles; --");
+
+        // Act
+        var statement = EmbeddingVectorIndexStatements.CreateIndexFor(profile);
+
+        // Assert
+        Assert.DoesNotContain("DROP TABLE", statement, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("DELETE", statement, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("OR 1=1", statement, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// PostgreSQL keeps sixty-three bytes of an identifier and silently truncates the rest. Two profiles whose names
+    /// collided after truncation would look to <c>CREATE INDEX IF NOT EXISTS</c> like one index that already exists, so
+    /// the second generation would be served by the first one's index.
+    /// </summary>
+    [Fact]
+    public void IndexNameFor_AnyProfile_StaysInsideThePostgresIdentifierLimit()
+    {
+        // Arrange
+        const int postgresIdentifierByteLimit = 63;
+
+        // Act
+        var name = EmbeddingVectorIndexStatements.IndexNameFor(EmbeddingProfileId.Create(ProfileIdentifier));
+
+        // Assert
+        Assert.Equal("ix_email_embeddings_hnsw_0198f3d24b6a7c1e9f042a5b8c7d6e10", name);
+        Assert.True(name.Length <= postgresIdentifierByteLimit, $"The index name is {name.Length} characters.");
+    }
+
+    /// <summary>
+    /// Removal is named from the identifier alone, so a caller holding nothing but a superseded generation's identifier
+    /// can drop its index — and dropping one that was never built is not a failure.
+    /// </summary>
+    [Fact]
+    public void DropIndexFor_AProfile_NamesTheIndexBuiltForItAndToleratesItsAbsence()
+    {
+        // Act
+        var statement = EmbeddingVectorIndexStatements.DropIndexFor(EmbeddingProfileId.Create(ProfileIdentifier));
+
+        // Assert
+        Assert.Equal(
+            "DROP INDEX IF EXISTS \"ix_email_embeddings_hnsw_0198f3d24b6a7c1e9f042a5b8c7d6e10\"",
+            statement);
+    }
+
+    private static ActiveEmbeddingProfile ProfileOf(
+        int dimension,
+        EmbeddingDistanceMetric distanceMetric,
+        string provider = "mailfathom-test-vendor",
+        string modelIdentifier = "test-embedding",
+        string? passageInstruction = null) => new(
+            EmbeddingProfileId.Create(ProfileIdentifier),
+            EmbeddingProfileIdentity.Create(
+                provider,
+                modelIdentifier,
+                modelVersion: null,
+                dimension,
+                distanceMetric,
+                EmbeddingInputPreparation.Create(8000, passageInstruction, normalizesVector: true)));
+}

--- a/tests/IntegrationTests/Persistence/OrchestratedEmbeddingVectorIndexTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmbeddingVectorIndexTests.cs
@@ -1,0 +1,187 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.Infrastructure.Persistence.Embeddings;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Persistence;
+
+/// <summary>
+/// Proves that the statements composed for a profile's approximate index are ones pgvector actually accepts, that two
+/// generations of different widths each get an index of their own over the one dimensionless column, and that both
+/// operations are repeatable.
+/// </summary>
+/// <remarks>
+/// None of it is reachable without a real server. Whether an HNSW expression index over a cast column is legal, whether
+/// two of them may coexist, and what <c>IF NOT EXISTS</c> does on the second call are all PostgreSQL's answers; a
+/// substitute would report every one of them as satisfied. What a unit test already covers — that no text a caller
+/// wrote reaches the statement — is deliberately not repeated here.
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedEmbeddingVectorIndexTests(MailFathomOrchestrationFixture orchestration)
+{
+    /// <summary>
+    /// One run over the whole lifecycle, because each step is what makes the next one meaningful: an index that exists
+    /// is what a repeated build must not duplicate, and an index observed present is what makes its later absence a
+    /// removal rather than a predicate that never matched. The second profile is there throughout to show that neither
+    /// operation reaches beyond the generation it names.
+    /// </summary>
+    [Fact]
+    public async Task MaintainingTheIndex_TwoProfilesOfDifferentWidths_EachKeepsItsOwnAndOnlyItsOwn()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var narrow = await RegisterProfileAsync(services, dimension: 2, "index-narrow", cancellationToken);
+        var wide = await RegisterProfileAsync(services, dimension: 4, "index-wide", cancellationToken);
+
+        // Act
+        await EnsureBuiltAsync(services, narrow, cancellationToken);
+        await EnsureBuiltAsync(services, narrow, cancellationToken);
+        await EnsureBuiltAsync(services, wide, cancellationToken);
+
+        // Assert
+        var narrowDefinition = await IndexDefinitionAsync(services, narrow.Id, cancellationToken);
+        var wideDefinition = await IndexDefinitionAsync(services, wide.Id, cancellationToken);
+
+        Assert.NotNull(narrowDefinition);
+        Assert.NotNull(wideDefinition);
+        Assert.Contains("USING hnsw", narrowDefinition, StringComparison.Ordinal);
+        Assert.Contains("vector(2)", narrowDefinition, StringComparison.Ordinal);
+        Assert.Contains("vector_cosine_ops", narrowDefinition, StringComparison.Ordinal);
+        Assert.Contains(narrow.Id.Value.ToString(), narrowDefinition, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("vector(4)", wideDefinition, StringComparison.Ordinal);
+
+        // The name is derived from the profile's immutable identity, so the second build found the first index rather
+        // than adding one beside it. Counted by the predicate rather than by the name, because a name that was not
+        // derived is exactly the defect this would otherwise miss.
+        Assert.Equal(1, await CountIndexesForAsync(services, narrow.Id, cancellationToken));
+
+        await RemoveAsync(services, narrow.Id, cancellationToken);
+        await RemoveAsync(services, narrow.Id, cancellationToken);
+
+        Assert.Null(await IndexDefinitionAsync(services, narrow.Id, cancellationToken));
+        Assert.NotNull(await IndexDefinitionAsync(services, wide.Id, cancellationToken));
+
+        await RemoveAsync(services, wide.Id, cancellationToken);
+
+        Assert.Equal(0, await CountIndexesForAsync(services, wide.Id, cancellationToken));
+    }
+
+    private static async Task EnsureBuiltAsync(
+        OrchestratedMailFathomServices services,
+        ActiveEmbeddingProfile profile,
+        CancellationToken cancellationToken) => await services.InScopeAsync(
+            async (scope, token) =>
+            {
+                await scope.GetRequiredService<IEmbeddingProfileVectorIndex>().EnsureBuiltAsync(profile, token);
+
+                return profile.Id;
+            },
+            cancellationToken);
+
+    private static async Task RemoveAsync(
+        OrchestratedMailFathomServices services,
+        EmbeddingProfileId profileId,
+        CancellationToken cancellationToken) => await services.InScopeAsync(
+            async (scope, token) =>
+            {
+                await scope.GetRequiredService<IEmbeddingProfileVectorIndex>().RemoveAsync(profileId, token);
+
+                return profileId;
+            },
+            cancellationToken);
+
+    private static async Task<ActiveEmbeddingProfile> RegisterProfileAsync(
+        OrchestratedMailFathomServices services,
+        int dimension,
+        string modelIdentifier,
+        CancellationToken cancellationToken)
+    {
+        var identity = EmbeddingProfileIdentity.Create(
+            "mailfathom-test-vendor",
+            modelIdentifier,
+            modelVersion: null,
+            dimension,
+            EmbeddingDistanceMetric.Cosine,
+            EmbeddingInputPreparation.Create(8_000, passageInstruction: null, normalizesVector: true));
+        var profileId = Guid.CreateVersion7();
+
+        await services.InScopeAsync(
+            async (scope, token) =>
+            {
+                var context = scope.GetRequiredService<MailFathomDbContext>();
+
+                context.EmbeddingProfiles.Add(new EmbeddingProfileEntity
+                {
+                    Id = profileId,
+                    Provider = identity.Provider,
+                    ModelIdentifier = identity.ModelIdentifier,
+                    ModelVersion = identity.ModelVersion,
+                    Dimension = identity.Dimension,
+                    DistanceMetric = identity.DistanceMetric,
+                    InputCharacterLimit = identity.InputPreparation.InputCharacterLimit,
+                    PassageInstruction = identity.InputPreparation.PassageInstruction,
+                    NormalizesVector = identity.InputPreparation.NormalizesVector,
+                    IdentityFingerprint = EmbeddingProfileFingerprint.Compute(identity).Value,
+                    LifecycleState = EmbeddingProfileLifecycleState.Active,
+                    RegisteredAt = TimeProvider.System.GetUtcNow(),
+                    ActivatedAt = TimeProvider.System.GetUtcNow(),
+                });
+
+                return await context.SaveChangesAsync(token);
+            },
+            cancellationToken);
+
+        return new ActiveEmbeddingProfile(EmbeddingProfileId.Create(profileId), identity);
+    }
+
+    /// <summary>Reads what PostgreSQL says the index is, which is the only account of it a test can trust.</summary>
+    /// <remarks>
+    /// The name comes from the production composer rather than from a copy of it here. What this test is about is the
+    /// database's answer; that the name is what it is, and short enough to survive, is the unit tests' question.
+    /// </remarks>
+    private static Task<string?> IndexDefinitionAsync(
+        OrchestratedMailFathomServices services,
+        EmbeddingProfileId profileId,
+        CancellationToken cancellationToken)
+    {
+        var indexName = EmbeddingVectorIndexStatements.IndexNameFor(profileId);
+
+        return services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailFathomDbContext>().Database
+                .SqlQuery<string>($"""SELECT indexdef AS "Value" FROM pg_indexes WHERE indexname = {indexName}""")
+                .FirstOrDefaultAsync(token),
+            cancellationToken);
+    }
+
+    /// <summary>Counts every approximate index restricted to one profile, whatever it happens to be named.</summary>
+    private static Task<int> CountIndexesForAsync(
+        OrchestratedMailFathomServices services,
+        EmbeddingProfileId profileId,
+        CancellationToken cancellationToken)
+    {
+        var predicate = $"%{profileId.Value}%";
+
+        return services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailFathomDbContext>().Database
+                .SqlQuery<int>(
+                    $"""
+                     SELECT COUNT(*)::int AS "Value"
+                     FROM pg_indexes
+                     WHERE tablename = 'email_embeddings'
+                       AND indexdef LIKE '%USING hnsw%'
+                       AND indexdef LIKE {predicate}
+                     """)
+                .SingleAsync(token),
+            cancellationToken);
+    }
+}


### PR DESCRIPTION
Closes #430

## What this is

An HNSW index covers one width, and `email_embeddings.Embedding` is deliberately dimensionless so two generations can share the column. No migration can therefore create the index that makes a vector search fast — it is tied to one profile's dimension, so it belongs to the profile's lifecycle rather than to the table's.

This adds that operation: `IEmbeddingProfileVectorIndex`, with a PostgreSQL adapter behind it.

| | |
| --- | --- |
| `EnsureBuiltAsync(profile)` | The partial expression index for one profile, at its width and under its metric. Idempotent |
| `RemoveAsync(profileId)` | The same index gone. Removing one a profile never had is not a failure |

## Scope

This is the index half of activation, which is what the parent's order table means by "#433 needs #430". The operator-facing act that calls it is #435's, and the generation switch that calls the removal is #433's; neither is here, and nothing in this change decides *when* to activate — the issue puts that out of scope explicitly. The capability is therefore dormant until one of those lands, and the documentation describes the schema and the operation rather than a command an operator can run today.

## The part worth reading twice

**The statements are composed rather than parameterized, and PostgreSQL leaves no alternative:** it accepts no parameter in a utility statement, so the width, the operator class, the predicate value, and the index name are all part of the text. A parameterized `CREATE INDEX` is not a safer way to write this one — it is not a statement PostgreSQL would run.

What makes that safe is where each value comes from. `EmbeddingVectorIndexStatements` reads them from a registered profile's own immutable columns, or chooses them by a closed mapping over `EmbeddingDistanceMetric`; the provider and model names a profile carries never enter the statement at all. Composition sits apart from execution so exactly that is provable without a database — one unit test hands it a profile whose provider, model, and passage instruction are hostile and reads the whole statement back.

**The index name is the profile identifier as thirty-two hexadecimal digits**, which does two things. It keeps the whole name at fifty-seven characters, inside the sixty-three bytes PostgreSQL keeps of an identifier, where truncation would let two profiles share one index. And because a profile's identity is immutable, an index already carrying the name *is* the one a repeated build would have produced — which is what makes `IF NOT EXISTS` safe, given that PostgreSQL explicitly does not compare an existing index against the one asked for.

## Failure

`EmbeddingVectorIndexFailedException`, error code `33001`, naming the profile and which of the two operations was refused, with the database's own words kept in the inner exception where a log reads them and a boundary does not. It is a new persistence subcategory rather than one more schema-state failure: a database missing this index is serving correct results slowly, not running against a schema the build does not recognize.

An exception rather than a result, because whether a refusal ends an activation or merely leaves it slower is the operator command's call rather than the store's.

## One operational consequence, documented rather than absorbed

**Creating an index requires owning the table.** PostgreSQL treats the right to modify an object as inherent in ownership and offers no privilege that grants it separately, and `MAINTAIN` does not cover `CREATE INDEX`. So the split-role arrangement `docs/operations/database-schema.md` recommends — a `mailfathom_migrator` that applies the schema, a `mailfathom` that serves — needs one more step before this index can be built:

```sql
GRANT mailfathom TO mailfathom_migrator;
ALTER TABLE email_embeddings OWNER TO mailfathom;
```

The grant comes first because a role may only hand a table to one it is a member of, and it is what keeps the migrator able to alter that table later. A single-role deployment, which the Docker Compose one is, already satisfies this and needs neither statement. The page now says so, together with how long a build takes and that a refusal costs performance and nothing else.

## Public surfaces

**Nothing breaks.** No configuration key, database column, MCP tool argument, or deployment contract moves, and the migration set is untouched — this index is created outside migrations by construction.

## Tests

- **Unit** (`EmbeddingVectorIndexStatementsTests`) — the exact statement for a cosine profile, the operator class per metric, an unmapped metric refused rather than defaulted, a hostile profile leaving no trace in the SQL, and the name inside the identifier limit.
- **Unit** (`EmbeddingVectorIndexFailedExceptionTests`) — the allocated code, the profile carried, and the database's words kept out of the message.
- **Integration** (`OrchestratedEmbeddingVectorIndexTests`) — one run over the whole lifecycle against a real PostgreSQL: two profiles of different widths each get an index over the one dimensionless column, a repeated build adds none, and removal reaches only the generation it names and tolerates a second call. What only a real server can answer — whether an HNSW expression index over a cast column is legal, whether two may coexist, what `IF NOT EXISTS` does on the second call — and nothing a unit test already covers.

## Verification

`scripts/verify-full.sh` — 3264 tests, 0 failed, aggregate line coverage 94.52% (required 85%), workflow contracts 118/118, formatting clean. `scripts/build-docs-site.sh` — 0 errors. The integration suite is not run locally; dispatch the `Integration tests` workflow against this branch.

## References

Draft § 9.3 fixes the index shape and the rule that exact search is correct before one exists. [ADR 0006](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md) makes the profile the generation and its identity immutable, which is what the derived name and `IF NOT EXISTS` rest on. pgvector's own guidance is the source for the partial expression index and the three operator classes.
