### PR TITLE
[#451] Converge a pending mutation after a restart or an unavailable server

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -167,7 +167,14 @@ requires.
 `AttemptCount` is written before each attempt rather than after it, which is what makes an attempt that kills the
 process count against `MailSynchronization:MaxMutationAttempts`. Spending that bound moves the row to `Abandoned`, and a
 row that is not `Completed` stays in the answer an operator reads — being given up on is what stops a change being
-retried, and it would be worth nothing if it also stopped the change being seen.
+retried, and it would be worth nothing if it also stopped the change being seen. Two other things reach `Abandoned`
+without spending the bound: a refusal the server has already given once and will give again, and an unacknowledged
+placement that outlasts `MailSynchronization:UnknownMutationOutcomeGrace` without the mailbox settling it.
+
+Every row that is not `Completed` is read once per account run, oldest first and bounded by
+`MailSynchronization:MaxMutationsPerConvergencePass`, and each is carried further or given up on. The same rows are
+counted by stage in one grouped query per run, which is what the outstanding-mutation gauges report; the partial index
+below is what makes both cheap, because it holds what is outstanding rather than the mailbox's whole mutation history.
 
 `PlacementObservedAt` and `SourceRemovalObservedAt` are what synchronization has since seen come back, and they are
 separate facts from `Stage` because they answer a different question and are written by a different run. The stage says

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -282,7 +282,8 @@ reading and writing closes the window two concurrent writers fall through.
 whose flag landed reissues only the expunge; a `\Seen` change simply repeats, because the store is idempotent on the
 wire. The one case that is never retried is a placement command whose answer was never read: `COPY` issued twice is a
 second message, and nothing in the destination folder afterwards says whether the first attempt landed. Such a mutation
-is reported as an unknown outcome, records that as the reason it is stuck, and stays visible for a person to resolve.
+is reported as an unknown outcome and records that as the reason it is stuck; what becomes of it afterwards is
+[the section below](#a-change-nobody-finished-finishes-by-itself).
 
 What a half-finished relocation still owes is read from the record rather than asked of the server again. `MOVE`
 removes the source itself and a copy does not, so the same stage means opposite things depending on which ran, and the
@@ -292,13 +293,59 @@ folders for good. Which path ran is still invisible above `Debug`: it changes wh
 the operation is called.
 
 **What became of it.** `MaxMutationAttempts` bounds how many attempts one change may spend, counted before each attempt
-so one that kills the process still counts. A change that spends them, or that a server has no safe way to carry, stops
-being attempted and stays readable as stuck rather than looking busy forever.
+so one that kills the process still counts. A change that spends them stops being attempted and stays readable as stuck
+rather than looking busy forever. Two refusals do not wait for that bound at all: a server that advertises no safe way
+to carry the change, and one that answers that the destination folder is not there, have each already given the answer
+every later attempt would receive, so those stop at the first refusal.
 
 The record holds no mail. A folder path, a UID, a mutation name, a requester identity, and a five-digit failure code are
 all it carries, and it is removed with the email it describes — including when the change it recorded was that email's
 deletion. [Stored email schema](../architecture/stored-email-schema.md#recorded-mailbox-mutations) states the columns and
 the stages in full.
+
+### A change nobody finished finishes by itself
+
+Every account run begins by taking that account's unfinished changes in hand, before its folders are touched. Nothing
+has to be scheduled for it and nothing has to be asked for: a service restarted between a copy and an expunge, a change
+recorded while the server was unreachable, and a command whose acknowledgement was lost on the way back all leave a
+durable record in a non-final state, and the first run after the interruption reads it and carries it the rest of the
+way. The mailbox ends in the state that was asked for however the process behaved in between.
+
+A change has exactly two acceptable endings, and *pending forever* is deliberately not one of them, because that is the
+one state that looks like success from every screen an operator reads.
+
+| Where a change is left | What the next run does |
+| --- | --- |
+| Recorded, nothing issued | Issues it, from the beginning |
+| A relocation whose copy the server confirmed | Removes the source; the copy is never repeated |
+| A delete whose `\Deleted` flag landed | Reissues the expunge alone |
+| A placement whose answer never arrived | Never reissues it — see below |
+| Given up on | Nothing; it stays counted and readable |
+
+An unacknowledged placement is the one case that cannot simply be resumed, and how it ends depends on which sequence
+issued it. A relocation the server carried with `MOVE` removes the source as part of the same command, so once
+synchronization has seen that source occurrence leave its folder the server has said the command ran, and the change is
+completed from that observation. A copy and a relocation on a server without `MOVE` both leave the source where it was,
+so nothing about it distinguishes a command that landed from one that never arrived — and finding out by searching the
+destination folder for a message that looks right would replace a fact with a guess, which
+[ADR 0007](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md)
+refuses. Those wait `UnknownMutationOutcomeGrace` for an observation that may still settle them, and are then given up
+on so they stand as dead-lettered rather than as changes still apparently happening.
+
+| Bound | Setting | Default | What it decides |
+| --- | --- | --- | --- |
+| Changes per run | `MaxMutationsPerConvergencePass` | 50 | How much of a backlog one run takes on; the rest waits for the next run, oldest first |
+| Unknown outcome | `UnknownMutationOutcomeGrace` | 6 h | How long an unacknowledged placement waits to be settled before it is given up on |
+
+Nothing here retries on a schedule of its own. A change that fails fails the account's run, so the same jittered backoff
+that defers a failing account's folders defers its changes, and one stuck account never delays another — the accounts
+run under the same slot count they always did. What bounds a change that keeps failing is still `MaxMutationAttempts`,
+counted across runs rather than within one.
+
+What is outstanding is readable while it is outstanding: `mailfathom.mailbox.mutations.outstanding` counts the changes
+an account is waiting on, and `mailfathom.mailbox.mutations.oldest_outstanding_age` says how long the oldest has waited.
+Both are broken down by the change and by whether it is *pending*, *converging*, or *dead-lettered*, so a count that
+stops falling is visible without reading a log. [Telemetry](../operations/telemetry.md) lists them with the rest.
 
 ### Renewal
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -81,6 +81,8 @@ shape the coordinator loop itself, which are read once at start and marked *rest
 | `MailSynchronization:MaxConcurrentFoldersPerAccount` | int | `1` | 1 – 20 | reload |
 | `MailSynchronization:WriteConnectionIdlePeriod` | TimeSpan | `00:02:00` | 5 s – 30 min; how long an account's single write connection keeps its slot after the last change it carried | restart |
 | `MailSynchronization:MaxMutationAttempts` | int | `5` | 1 – 100; how many attempts one recorded change to a mailbox may spend before it is given up on and left visible as stuck | restart |
+| `MailSynchronization:MaxMutationsPerConvergencePass` | int | `50` | 1 – 1000; how many unfinished changes one account run takes in hand before the rest wait for the next run | reload |
+| `MailSynchronization:UnknownMutationOutcomeGrace` | TimeSpan | `06:00:00` | 1 min – 7 days; how long a change whose placement was never acknowledged waits to be settled by observation before it is given up on | reload |
 | `MailSynchronization:ShutdownDrainTimeout` | TimeSpan | `00:00:10` | 0 – 2 min | restart |
 | `MailSynchronization:MaxMetadataBatchSize` | int | `100` | 1 – 1000 | reload |
 | `MailSynchronization:MaxRawMimeBytes` | long | `26214400` (25 MiB) | 1024 – 104857600; larger messages are stored without content | reload |

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -76,6 +76,16 @@ offered RFC 6851 `MOVE` or the copy-flag-expunge sequence was used instead, and 
 exactly what would make a missing server extension look like a different operation on a dashboard. Which path ran is in
 the debug log.
 
+That counter answers what happened; two gauges beside it answer what has not happened yet, which is the question an
+operator opens a dashboard with. `mailfathom.mailbox.mutations.outstanding` reports how many changes an account has
+asked a mail server for and not seen finished, and `mailfathom.mailbox.mutations.oldest_outstanding_age` reports in
+seconds how long the oldest of them has been waiting. Both carry the account, the mutation, and a lifecycle of
+`pending`, `converging`, or `dead-lettered`; a completed change is not on them, because it is already the counter's
+success outcome and an age is meaningless for it. Each account's values are republished by its own convergence pass and
+replaced whole, so a lifecycle that empties stops being reported instead of reporting its last non-zero value forever.
+A `dead-lettered` count that stops falling is the reading worth alerting on: those are changes nothing will attempt
+again, waiting for somebody to look.
+
 Embedding publishes the depth of its backlog, how many messages the bound turned away, and how many messages and
 passages it embedded and how long that took, broken down by outcome and by the classification of a provider failure.
 [Automatic embedding](../features/automatic-embedding.md#what-an-operator-can-see) names each instrument and what it

--- a/src/Application/Mail/Mutations/Convergence/MailboxConvergenceOptions.cs
+++ b/src/Application/Mail/Mutations/Convergence/MailboxConvergenceOptions.cs
@@ -1,0 +1,45 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Mail.Mutations.Convergence;
+
+/// <summary>Bounds one convergence pass and says how long an unresolved outcome may stay unresolved.</summary>
+/// <remarks>
+/// Neither setting is a retry policy. How often a pass runs and how far apart two attempts of the same change are is the
+/// account's synchronization schedule, and how many attempts one change may spend is
+/// <see cref="MailboxMutationOptions.MaximumAttempts" />. What is configured here is the width of a pass and the one
+/// deadline convergence owns.
+/// </remarks>
+public sealed class MailboxConvergenceOptions
+{
+    /// <summary>Gets or sets how many outstanding mutations one pass takes in hand.</summary>
+    /// <remarks>
+    /// <para>
+    /// A pass is bounded so an account that has accumulated a backlog cannot turn one run into an unbounded sequence of
+    /// mail-server round trips while the folders it is meant to synchronize wait behind it. What the bound leaves is
+    /// picked up by the next pass, oldest first, so nothing is dropped by it.
+    /// </para>
+    /// <para>
+    /// A mutation is a write to a mail server rather than a row to process, so the useful values are small. Raising it
+    /// drains a backlog in fewer runs at the cost of a longer run.
+    /// </para>
+    /// </remarks>
+    public int MaxMutationsPerPass { get; set; } = 50;
+
+    /// <summary>Gets or sets how long a mutation whose placement was never acknowledged waits to be settled by observation.</summary>
+    /// <remarks>
+    /// <para>
+    /// A placement command that went out without an answer is never issued again, so the only thing that can still
+    /// finish it is the mailbox itself: a later synchronization run sees the source occurrence gone and the record
+    /// accounts for the disappearance. That takes as long as it takes the account's folders to come round again, which
+    /// is why this is a period rather than an attempt count.
+    /// </para>
+    /// <para>
+    /// When it elapses the mutation is given up on and stays visible as dead-lettered. Waiting forever instead would be
+    /// the exact failure this design exists to remove: a change that looks busy and is not. Raising it buys patience on
+    /// an account with long synchronization intervals; lowering it surfaces an unresolvable copy sooner.
+    /// </para>
+    /// </remarks>
+    public TimeSpan UnknownOutcomeGrace { get; set; } = TimeSpan.FromHours(6);
+}

--- a/src/Application/Mail/Mutations/Convergence/MailboxConvergenceReport.cs
+++ b/src/Application/Mail/Mutations/Convergence/MailboxConvergenceReport.cs
@@ -1,0 +1,34 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Mail.Mutations.Convergence;
+
+/// <summary>States what one convergence pass did and what the account is left owing.</summary>
+/// <param name="CompletedCount">How many mutations this pass carried to the stage that says the server made the change.</param>
+/// <param name="DeadLetteredCount">How many it gave up on, each of which now stands visible rather than pending.</param>
+/// <param name="DeferredCount">How many it left where they were, to be picked up by a later pass or settled by observation.</param>
+/// <param name="FailedCount">How many ended in a failure that the mutation's own attempt bound will eventually settle.</param>
+/// <param name="Outstanding">What the account still owes after the pass, by kind and lifecycle.</param>
+/// <remarks>
+/// <para>
+/// The four counts describe the pass and <paramref name="Outstanding" /> describes the account, which are different
+/// questions and are read by different people. A pass that did nothing is ordinary — most passes have nothing to do —
+/// while an account whose dead-lettered count keeps growing is the finding this whole mechanism exists to surface.
+/// </para>
+/// <para>
+/// Nothing here is derived from a message. Counts, mutation names, and lifecycles are MailFathom's own words for its
+/// own work.
+/// </para>
+/// </remarks>
+public sealed record MailboxConvergenceReport(
+    int CompletedCount,
+    int DeadLetteredCount,
+    int DeferredCount,
+    int FailedCount,
+    IReadOnlyList<MailboxMutationLifecycleCount> Outstanding)
+{
+    /// <summary>Gets whether the pass changed nothing, which is what an account with no outstanding work produces.</summary>
+    public bool ChangedNothing =>
+        this.CompletedCount == 0 && this.DeadLetteredCount == 0 && this.FailedCount == 0;
+}

--- a/src/Application/Mail/Mutations/Convergence/MailboxMutationConverger.cs
+++ b/src/Application/Mail/Mutations/Convergence/MailboxMutationConverger.cs
@@ -170,11 +170,20 @@ public sealed class MailboxMutationConverger
         {
             throw;
         }
+        catch (MailboxMutationRefusedException)
+        {
+            // The server answered, the performer has already moved the record to its terminal stage, and no later
+            // attempt will be made. Counting it as failed would say three untrue things at once: the operator's log
+            // line would promise another attempt, the pass's own report would describe a record its attempt bound is
+            // still going to settle, and the account would back off from a healthy server over a decision somebody has
+            // to change a folder or a configuration to alter.
+            tally.DeadLetteredCount++;
+        }
         catch (Exception)
         {
-            // The performer has already written the failure onto the record, and abandoned it where that failure was
-            // terminal or spent the last attempt, so nothing is lost by swallowing it here. What the count is for is the
-            // caller: a pass that failed is a run that failed, which is what puts the account into backoff.
+            // The performer has already written the failure onto the record, and abandoned it where the last attempt
+            // was spent, so nothing is lost by swallowing it here. What the count is for is the caller: a pass that
+            // failed is a run that failed, which is what puts the account into backoff.
             tally.FailedCount++;
         }
     }

--- a/src/Application/Mail/Mutations/Convergence/MailboxMutationConverger.cs
+++ b/src/Application/Mail/Mutations/Convergence/MailboxMutationConverger.cs
@@ -1,0 +1,258 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Transport;
+
+namespace MailFathom.Application.Mail.Mutations.Convergence;
+
+/// <summary>Drives one account's unfinished mutations towards the only two endings a change is allowed to have.</summary>
+/// <remarks>
+/// <para>
+/// The durable record makes a remote write resumable; this is what makes it converge. A mutation somebody authored is
+/// not a request that succeeded or failed at one moment — it is a state the mailbox is heading for — and the endings
+/// are completed, or given up on where a person can see it. Pending forever is the third ending this exists to remove,
+/// because it looks exactly like success from every screen an operator reads.
+/// </para>
+/// <para>
+/// A pass is deliberately not a retry loop. It takes each outstanding record in hand once and either moves it or leaves
+/// it, and everything about *when* to come back belongs to the account's synchronization schedule: an unreachable
+/// server fails the run, the run's jittered backoff defers the next one, and the mutation's own attempt bound decides
+/// when a change that keeps failing stops being attempted. Adding a wait here would put a second retry policy around
+/// the same commands, which is the storm both the resilience pipeline and that backoff are shaped to avoid.
+/// </para>
+/// <para>
+/// Resuming is one call: the request is read back off the record and handed to the performer, which finds the record by
+/// its idempotency identity, counts the attempt, and continues the protocol sequence from the stage the record names.
+/// Nothing here knows what a relocation is made of, and nothing here decides which command to skip.
+/// </para>
+/// <para>
+/// The one case that is not resumed is a placement whose answer never came back. Reissuing it would put a second
+/// message in the destination folder and nothing there afterwards would say which one MailFathom made, so it is settled
+/// from what the mailbox has since shown about the source occurrence, or given up on when it stays unsettled for the
+/// configured grace period.
+/// </para>
+/// </remarks>
+public sealed class MailboxMutationConverger
+{
+    private readonly IMailboxMutationRecordStore store;
+    private readonly IMailboxMutationPerformer performer;
+    private readonly IMailTransportSecurityPolicyReader transportSecurityPolicyReader;
+    private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly MailboxConvergenceOptions options;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes the converger from the record store and the one path able to perform a change.</summary>
+    /// <param name="store">Reads the outstanding records and, through the journal, is written back to.</param>
+    /// <param name="performer">Resumes a mutation from the stage its record names.</param>
+    /// <param name="transportSecurityPolicyReader">Supplies the connection and authentication policy every attempt obeys.</param>
+    /// <param name="commitPolicy">Commits the record movements this class makes without the performer.</param>
+    /// <param name="options">Bounds one pass and carries the unknown-outcome grace period.</param>
+    /// <param name="timeProvider">Measures how long an unresolved outcome has been unresolved.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the configured pass bound is below one or the grace period is negative.</exception>
+    public MailboxMutationConverger(
+        IMailboxMutationRecordStore store,
+        IMailboxMutationPerformer performer,
+        IMailTransportSecurityPolicyReader transportSecurityPolicyReader,
+        OptimisticConcurrencyRetryPolicy commitPolicy,
+        MailboxConvergenceOptions options,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(performer);
+        ArgumentNullException.ThrowIfNull(transportSecurityPolicyReader);
+        ArgumentNullException.ThrowIfNull(commitPolicy);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxMutationsPerPass, 1, nameof(options));
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.UnknownOutcomeGrace, TimeSpan.Zero, nameof(options));
+
+        this.store = store;
+        this.performer = performer;
+        this.transportSecurityPolicyReader = transportSecurityPolicyReader;
+        this.commitPolicy = commitPolicy;
+        this.options = options;
+        this.timeProvider = timeProvider;
+    }
+
+    /// <summary>Takes one bounded pass over everything the account has asked a mail server for and not seen finished.</summary>
+    /// <param name="accountId">The account whose mutations are converged.</param>
+    /// <param name="cancellationToken">Cancels the pass; a mutation already under way is cancelled with it.</param>
+    /// <returns>What the pass did, and what the account still owes afterwards.</returns>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels the pass.</exception>
+    /// <remarks>
+    /// One record's failure never ends the pass. A mail server that refuses one change is usually refusing every change,
+    /// so the remaining records fail quickly beside it and the account's next run is what defers them; a change that is
+    /// broken on its own must not stop the ones that are not, which is the whole of what "does not block unrelated work"
+    /// means here.
+    /// </remarks>
+    public async Task<MailboxConvergenceReport> ConvergeAsync(
+        MailAccountId accountId,
+        CancellationToken cancellationToken)
+    {
+        var outstanding = await this.store.ReadOutstandingAsync(
+            accountId,
+            this.options.MaxMutationsPerPass,
+            cancellationToken);
+
+        if (outstanding.Count == 0)
+        {
+            // Nothing outstanding is nothing to count: the lifecycle read answers over the same rows, so an account with
+            // no unfinished mutation — which is nearly every account on nearly every run — costs one query rather than two.
+            return new MailboxConvergenceReport(0, 0, 0, 0, []);
+        }
+
+        var transportSecurityPolicy = this.transportSecurityPolicyReader.GetPolicy(accountId);
+        var tally = new ConvergenceTally();
+
+        foreach (var candidate in outstanding)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // An abandoned record is in this answer so it stays visible, not so it is worked on again. It is counted
+            // where an operator reads it, in the lifecycle totals below.
+            if (candidate.Record.IsTerminal)
+            {
+                continue;
+            }
+
+            await this.ConvergeOneAsync(candidate, transportSecurityPolicy, tally, cancellationToken);
+        }
+
+        var outstandingCounts = await this.store.ReadLifecycleCountsAsync(accountId, cancellationToken);
+
+        return new MailboxConvergenceReport(
+            tally.CompletedCount,
+            tally.DeadLetteredCount,
+            tally.DeferredCount,
+            tally.FailedCount,
+            outstandingCounts);
+    }
+
+    /// <summary>Moves one record, and absorbs whatever moving it failed on.</summary>
+    /// <remarks>
+    /// The isolation is around both paths rather than around the mail server alone, because a record read at the start
+    /// of the pass can be moved by a concurrent run before this one acts on it — a stage that will not go backwards is
+    /// refused where it is written, which is the point of that rule, and a refusal there must cost this account its
+    /// remaining mutations no more than a refusal from a mail server does.
+    /// </remarks>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "A pass isolates one mutation's failure so the account's remaining mutations still converge; the record already carries how far it got and the account's run backoff defers the next attempt.")]
+    private async Task ConvergeOneAsync(
+        OutstandingMailboxMutation candidate,
+        MailTransportSecurityPolicy transportSecurityPolicy,
+        ConvergenceTally tally,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (candidate.Record.HasUnknownOutcome)
+            {
+                await this.SettleUnknownOutcomeAsync(candidate.Record, tally, cancellationToken);
+
+                return;
+            }
+
+            var outcome = await this.performer.PerformAsync(
+                candidate.Record.Request,
+                candidate.Folder,
+                transportSecurityPolicy,
+                cancellationToken);
+
+            tally.Count(outcome.Status);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            // The performer has already written the failure onto the record, and abandoned it where that failure was
+            // terminal or spent the last attempt, so nothing is lost by swallowing it here. What the count is for is the
+            // caller: a pass that failed is a run that failed, which is what puts the account into backoff.
+            tally.FailedCount++;
+        }
+    }
+
+    /// <summary>Settles a placement whose answer never came back, from the mailbox rather than by asking again.</summary>
+    /// <remarks>
+    /// <para>
+    /// The three mutations differ here, and the difference is why this is bounded work rather than a retry. A relocation
+    /// carried by <c>MOVE</c> removes the source as part of the same command, so a source that has since been seen to
+    /// leave its folder is the server's own statement that the command ran, against an occurrence the record names
+    /// exactly. A copy and a fallback relocation both leave the source in place, so nothing about it distinguishes a
+    /// command that landed from one that never arrived, and the only way to tell would be to search the destination
+    /// folder for a message that looks like the right one — a guess about identity, which
+    /// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md">ADR 0007</see>
+    /// refuses.
+    /// </para>
+    /// <para>
+    /// What is left for those is time. The record waits for the grace period in case a later run settles it, and is then
+    /// given up on so it stands as dead-lettered rather than as a change that is still apparently happening. Giving up
+    /// removes nothing and duplicates nothing: it stops MailFathom claiming to know an outcome it does not.
+    /// </para>
+    /// </remarks>
+    private async Task SettleUnknownOutcomeAsync(
+        MailboxMutationRecord record,
+        ConvergenceTally tally,
+        CancellationToken cancellationToken)
+    {
+        var journal = new MailboxMutationJournal(this.store, this.commitPolicy, record);
+
+        if (record.IsUnknownPlacementSettledBySourceRemoval)
+        {
+            await journal.CompleteAsync(record.Placement, cancellationToken);
+            tally.CompletedCount++;
+
+            return;
+        }
+
+        if (this.timeProvider.GetUtcNow() - record.StageChangedAt < this.options.UnknownOutcomeGrace)
+        {
+            tally.DeferredCount++;
+
+            return;
+        }
+
+        await journal.AbandonAsync(MailFathomErrorCode.MailboxMutationOutcomeUnknown, cancellationToken);
+        tally.DeadLetteredCount++;
+    }
+
+    /// <summary>Accumulates what one pass did, so the counting is not spread across four call sites.</summary>
+    private sealed class ConvergenceTally
+    {
+        internal int CompletedCount { get; set; }
+
+        internal int DeadLetteredCount { get; set; }
+
+        internal int DeferredCount { get; set; }
+
+        internal int FailedCount { get; set; }
+
+        internal void Count(MailboxMutationStatus status)
+        {
+            switch (status)
+            {
+                case MailboxMutationStatus.Performed:
+                case MailboxMutationStatus.AlreadyPerformed:
+                    this.CompletedCount++;
+                    break;
+                case MailboxMutationStatus.Abandoned:
+                    this.DeadLetteredCount++;
+                    break;
+
+                // A record that reached the performer at an unacknowledged placement was read before this pass settled
+                // it, which a concurrent writer can produce. It is left exactly where the performer left it.
+                case MailboxMutationStatus.OutcomeUnknown:
+                default:
+                    this.DeferredCount++;
+                    break;
+            }
+        }
+    }
+}

--- a/src/Application/Mail/Mutations/Convergence/MailboxMutationLifecycleCount.cs
+++ b/src/Application/Mail/Mutations/Convergence/MailboxMutationLifecycleCount.cs
@@ -1,0 +1,30 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Mail.Mutations.Convergence;
+
+/// <summary>States how many of one account's mutations of one kind stand in one lifecycle, and how long the oldest has.</summary>
+/// <param name="Mutation">The change those records asked for.</param>
+/// <param name="Lifecycle">Where in its lifecycle every record in this group stands.</param>
+/// <param name="Count">How many records the group holds.</param>
+/// <param name="OldestRecordedAt">When the earliest of them was written down, which is what an age is measured from.</param>
+/// <remarks>
+/// <para>
+/// The age is carried as the instant rather than as a duration, because whoever reports it knows what time it is now
+/// and this read does not. Measuring here would fix the age at whatever moment the query ran.
+/// </para>
+/// <para>
+/// A completed mutation is not in this answer. It is counted where a completion already is — the mutation counter's
+/// success outcome — and asking a growing table how many changes have ever succeeded, once per account per run, would
+/// buy nothing the counter does not already say. What this exists for is the three lifecycles nothing else reports: a
+/// change waiting, a change in flight, and a change that has stopped.
+/// </para>
+/// </remarks>
+public sealed record MailboxMutationLifecycleCount(
+    MailboxMutation Mutation,
+    MailboxMutationLifecycle Lifecycle,
+    int Count,
+    DateTimeOffset OldestRecordedAt);

--- a/src/Application/Mail/Mutations/IMailboxMutationRecordStore.cs
+++ b/src/Application/Mail/Mutations/IMailboxMutationRecordStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Failures;
@@ -99,7 +100,7 @@ public interface IMailboxMutationRecordStore
         MailFathomErrorCode failure,
         CancellationToken cancellationToken);
 
-    /// <summary>Reads the mutations of one account that have not completed.</summary>
+    /// <summary>Reads the mutations of one account that have not completed, with the folder binding each was recorded against.</summary>
     /// <param name="accountId">The account whose mutations are read.</param>
     /// <param name="limit">The greatest number of records to return.</param>
     /// <param name="cancellationToken">Cancels the read.</param>
@@ -114,11 +115,30 @@ public interface IMailboxMutationRecordStore
     /// </para>
     /// <para>
     /// Oldest first, because the answer starts with whatever has been outstanding longest. It is bounded like every
-    /// other public query.
+    /// other public query, and convergence treats the bound as a page it comes back for rather than as a cut.
     /// </para>
     /// </remarks>
-    Task<IReadOnlyList<MailboxMutationRecord>> ReadOutstandingAsync(
+    Task<IReadOnlyList<OutstandingMailboxMutation>> ReadOutstandingAsync(
         MailAccountId accountId,
         int limit,
+        CancellationToken cancellationToken);
+
+    /// <summary>Counts one account's uncompleted mutations by kind and by where in its lifecycle each one stands.</summary>
+    /// <param name="accountId">The account whose mutations are counted.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>One entry per kind and lifecycle that has at least one record, in no particular order.</returns>
+    /// <remarks>
+    /// <para>
+    /// It is an aggregate rather than a count of what <see cref="ReadOutstandingAsync" /> returned, because that read is
+    /// bounded and a bounded count is wrong exactly when it matters — the moment an account has more stuck changes than
+    /// one pass looks at is the moment somebody needs the real number.
+    /// </para>
+    /// <para>
+    /// The database groups and counts, so the answer is a handful of rows however many mutations the account has: at
+    /// most one per permitted mutation per lifecycle. Nothing derived from a message takes part in it.
+    /// </para>
+    /// </remarks>
+    Task<IReadOnlyList<MailboxMutationLifecycleCount>> ReadLifecycleCountsAsync(
+        MailAccountId accountId,
         CancellationToken cancellationToken);
 }

--- a/src/Application/Mail/Mutations/IMailboxWriteSession.cs
+++ b/src/Application/Mail/Mutations/IMailboxWriteSession.cs
@@ -57,6 +57,7 @@ public interface IMailboxWriteSession : IAsyncDisposable
     /// <exception cref="ArgumentException">Thrown when <paramref name="occurrenceId" /> does not belong to this session.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="journal" /> is <see langword="null" />.</exception>
     /// <exception cref="MailboxMutationUnsupportedException">Thrown when the server advertises neither <c>MOVE</c> nor the <c>UIDPLUS</c> the fallback needs to remove only the moved message.</exception>
+    /// <exception cref="MailboxDestinationFolderMissingException">Thrown when the server holds no folder at <paramref name="destinationPath" />, which is settled rather than deferred.</exception>
     /// <exception cref="MailboxUnavailableException">Thrown when the mail server did not serve the relocation within its configured resilience budget.</exception>
     /// <exception cref="MailboxFolderRecreatedException">Thrown when a recovered connection reselected the folder with a different UIDVALIDITY.</exception>
     /// <remarks>
@@ -118,6 +119,7 @@ public interface IMailboxWriteSession : IAsyncDisposable
     /// <returns>Where the destination folder put the email, when the server named it.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="occurrenceId" /> does not belong to this session.</exception>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="journal" /> is <see langword="null" />.</exception>
+    /// <exception cref="MailboxDestinationFolderMissingException">Thrown when the server holds no folder at <paramref name="destinationPath" />, which is settled rather than deferred.</exception>
     /// <exception cref="MailboxUnavailableException">Thrown when the mail server did not serve the copy within its configured resilience budget.</exception>
     /// <exception cref="MailboxFolderRecreatedException">Thrown when a recovered connection reselected the folder with a different UIDVALIDITY.</exception>
     /// <remarks>

--- a/src/Application/Mail/Mutations/MailboxDestinationFolderMissingException.cs
+++ b/src/Application/Mail/Mutations/MailboxDestinationFolderMissingException.cs
@@ -29,7 +29,7 @@ namespace MailFathom.Application.Mail.Mutations;
 /// a remote folder path is the mailbox owner's own naming of their mail, which no message an operator reads may carry.
 /// </para>
 /// </remarks>
-public sealed class MailboxDestinationFolderMissingException : MailFathomException
+public sealed class MailboxDestinationFolderMissingException : MailboxMutationRefusedException
 {
     /// <summary>Initializes a new refusal naming the mutation whose destination folder the server does not have.</summary>
     /// <param name="accountId">The account the mutation was requested for.</param>

--- a/src/Application/Mail/Mutations/MailboxDestinationFolderMissingException.cs
+++ b/src/Application/Mail/Mutations/MailboxDestinationFolderMissingException.cs
@@ -1,0 +1,69 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Mail.Mutations;
+
+/// <summary>Indicates that the folder a relocation or a copy names as its destination does not exist on the server.</summary>
+/// <remarks>
+/// <para>
+/// It is raised rather than returned, and it is terminal on its first occurrence, because it says the same thing about
+/// repeating the work as <see cref="MailboxMutationUnsupportedException" /> does: a folder the server does not have will
+/// not be there on the next run either. Somebody deleted or renamed it, or whatever asked for the change named a path
+/// that was never right, and both remedies are an operator's rather than a wait's. Letting it spend the mutation's
+/// attempt bound instead would cost a login and a round trip per attempt to be told the same thing, and would leave the
+/// operator reading a change that merely looks busy.
+/// </para>
+/// <para>
+/// It is separate from <see cref="Synchronization.Sessions.MailboxUnavailableException" /> for that reason alone. A mail
+/// server that did not answer is expected to answer later; one that answered and said the folder is not there has
+/// answered.
+/// </para>
+/// <para>
+/// The message names the account alias, the folder alias, and the mutation. The destination path is deliberately absent:
+/// a remote folder path is the mailbox owner's own naming of their mail, which no message an operator reads may carry.
+/// </para>
+/// </remarks>
+public sealed class MailboxDestinationFolderMissingException : MailFathomException
+{
+    /// <summary>Initializes a new refusal naming the mutation whose destination folder the server does not have.</summary>
+    /// <param name="accountId">The account the mutation was requested for.</param>
+    /// <param name="folderAlias">The folder the email is in, which is the one MailFathom has a name of its own for.</param>
+    /// <param name="mutation">The mutation that was asked for.</param>
+    /// <param name="innerException">The mail-library failure that reported the folder as absent.</param>
+    public MailboxDestinationFolderMissingException(
+        MailAccountId accountId,
+        MailFolderAlias folderAlias,
+        MailboxMutation mutation,
+        Exception innerException)
+        : base(DescribeMissingDestination(accountId, folderAlias, mutation), innerException)
+    {
+        this.AccountId = accountId;
+        this.FolderAlias = folderAlias;
+        this.Mutation = mutation;
+    }
+
+    /// <inheritdoc />
+    public override MailFathomErrorCode ErrorCode => MailFathomErrorCode.MailboxMutationDestinationMissing;
+
+    /// <summary>Gets the account the mutation was requested for.</summary>
+    public MailAccountId AccountId { get; }
+
+    /// <summary>Gets the folder the email is in.</summary>
+    public MailFolderAlias FolderAlias { get; }
+
+    /// <summary>Gets the mutation that was asked for.</summary>
+    public MailboxMutation Mutation { get; }
+
+    private static string DescribeMissingDestination(
+        MailAccountId accountId,
+        MailFolderAlias folderAlias,
+        MailboxMutation mutation) =>
+        $"The mail server for {accountId.Value}/{folderAlias.Value} holds no folder at the destination a "
+        + $"{mutation.Name} named, so the change was given up on rather than attempted again.";
+}

--- a/src/Application/Mail/Mutations/MailboxMutationPerformer.cs
+++ b/src/Application/Mail/Mutations/MailboxMutationPerformer.cs
@@ -123,6 +123,15 @@ public sealed class MailboxMutationPerformer : IMailboxMutationPerformer
         _ => null,
     };
 
+    /// <summary>Reports whether the mail server has answered in a way no later attempt would improve on.</summary>
+    /// <remarks>
+    /// Both members say the same thing about repeating the work, which is the opposite of what an unavailable mailbox
+    /// says: the server was reached, it answered, and the answer will be the same one until an operator changes
+    /// something. Deferring either would hide a change that needs a person behind an operation that always looks busy.
+    /// </remarks>
+    private static bool IsSettledByTheServer(MailFathomException failure) =>
+        failure is MailboxMutationUnsupportedException or MailboxDestinationFolderMissingException;
+
     /// <summary>Refuses a binding that is not the one the request's occurrence was read under.</summary>
     /// <remarks>
     /// The session would refuse it too, but only after a connection had been opened and a folder selected. Refusing here
@@ -175,11 +184,12 @@ public sealed class MailboxMutationPerformer : IMailboxMutationPerformer
 
             return new MailboxMutationOutcome(journal.RecordId, MailboxMutationStatus.Performed, placement);
         }
-        catch (MailboxMutationUnsupportedException unsupported)
+        catch (MailFathomException refusal) when (IsSettledByTheServer(refusal))
         {
-            // A server that advertises no way to carry the change safely will advertise none tomorrow either, so this
-            // is terminal on its first occurrence rather than after the attempt bound is spent on it.
-            await journal.AbandonAsync(unsupported.ErrorCode, cancellationToken);
+            // A server that advertises no way to carry the change safely will advertise none tomorrow either, and a
+            // folder it does not have is not one it is about to grow, so both are terminal on their first occurrence
+            // rather than after the attempt bound has been spent finding that out one login at a time.
+            await journal.AbandonAsync(refusal.ErrorCode, cancellationToken);
 
             throw;
         }

--- a/src/Application/Mail/Mutations/MailboxMutationPerformer.cs
+++ b/src/Application/Mail/Mutations/MailboxMutationPerformer.cs
@@ -123,15 +123,6 @@ public sealed class MailboxMutationPerformer : IMailboxMutationPerformer
         _ => null,
     };
 
-    /// <summary>Reports whether the mail server has answered in a way no later attempt would improve on.</summary>
-    /// <remarks>
-    /// Both members say the same thing about repeating the work, which is the opposite of what an unavailable mailbox
-    /// says: the server was reached, it answered, and the answer will be the same one until an operator changes
-    /// something. Deferring either would hide a change that needs a person behind an operation that always looks busy.
-    /// </remarks>
-    private static bool IsSettledByTheServer(MailFathomException failure) =>
-        failure is MailboxMutationUnsupportedException or MailboxDestinationFolderMissingException;
-
     /// <summary>Refuses a binding that is not the one the request's occurrence was read under.</summary>
     /// <remarks>
     /// The session would refuse it too, but only after a connection had been opened and a folder selected. Refusing here
@@ -184,7 +175,7 @@ public sealed class MailboxMutationPerformer : IMailboxMutationPerformer
 
             return new MailboxMutationOutcome(journal.RecordId, MailboxMutationStatus.Performed, placement);
         }
-        catch (MailFathomException refusal) when (IsSettledByTheServer(refusal))
+        catch (MailboxMutationRefusedException refusal)
         {
             // A server that advertises no way to carry the change safely will advertise none tomorrow either, and a
             // folder it does not have is not one it is about to grow, so both are terminal on their first occurrence

--- a/src/Application/Mail/Mutations/MailboxMutationRefusedException.cs
+++ b/src/Application/Mail/Mutations/MailboxMutationRefusedException.cs
@@ -1,0 +1,45 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Failures;
+
+namespace MailFathom.Application.Mail.Mutations;
+
+/// <summary>Indicates that a mail server was reached, answered, and will answer the same way every later time.</summary>
+/// <remarks>
+/// <para>
+/// It exists so the two callers that act on that fact name one type instead of each keeping a list of the concrete
+/// refusals. The performer abandons a mutation raising one of these on its first occurrence rather than spending the
+/// attempt bound, and a convergence pass counts it as given up on rather than as failed — and those two decisions would
+/// silently disagree the moment a third refusal was added to one list and not the other.
+/// </para>
+/// <para>
+/// What every subclass asserts is the same thing, and it is the opposite of what
+/// <see cref="Synchronization.Sessions.MailboxUnavailableException" /> asserts: the server did not fail to answer, it
+/// answered, and the answer is a decision an operator has to change something to alter. A failure that might clear on
+/// its own is not one of these, however certain it looks.
+/// </para>
+/// <para>
+/// It carries no <see cref="MailFathomErrorCode" /> of its own, because a code names one failure a boundary reports and
+/// each subclass has one. Being abstract, it is never raised and never caught in place of knowing which refusal
+/// happened where that matters.
+/// </para>
+/// </remarks>
+public abstract class MailboxMutationRefusedException : MailFathomException
+{
+    /// <summary>Initializes a new refusal with a message safe to surface.</summary>
+    /// <param name="operatorSafeMessage">A message free of credentials, hosts, remote paths, message content, and personal data.</param>
+    protected MailboxMutationRefusedException(string operatorSafeMessage)
+        : base(operatorSafeMessage)
+    {
+    }
+
+    /// <summary>Initializes a new refusal with a message safe to surface and the failure that revealed it.</summary>
+    /// <param name="operatorSafeMessage">A message free of credentials, hosts, remote paths, message content, and personal data.</param>
+    /// <param name="innerException">The failure this refusal was raised for.</param>
+    protected MailboxMutationRefusedException(string operatorSafeMessage, Exception innerException)
+        : base(operatorSafeMessage, innerException)
+    {
+    }
+}

--- a/src/Application/Mail/Mutations/MailboxMutationUnsupportedException.cs
+++ b/src/Application/Mail/Mutations/MailboxMutationUnsupportedException.cs
@@ -29,7 +29,7 @@ namespace MailFathom.Application.Mail.Mutations;
 /// MailFathom's own configured or protocol-registered names, and none of them is mail content or a remote path.
 /// </para>
 /// </remarks>
-public sealed class MailboxMutationUnsupportedException : MailFathomException
+public sealed class MailboxMutationUnsupportedException : MailboxMutationRefusedException
 {
     /// <summary>Initializes a new refusal naming the mutation and the extension the server does not advertise.</summary>
     /// <param name="accountId">The account whose mail server advertises no way to carry the mutation.</param>

--- a/src/Application/Mail/Mutations/OutstandingMailboxMutation.cs
+++ b/src/Application/Mail/Mutations/OutstandingMailboxMutation.cs
@@ -1,0 +1,20 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Mail.Mutations;
+
+/// <summary>Pairs one mutation that has not completed with the folder binding it was recorded against.</summary>
+/// <param name="Record">The durable record, exactly as it stands.</param>
+/// <param name="Folder">The binding the source occurrence belongs to, including the remote path a session selects.</param>
+/// <remarks>
+/// The binding travels with the record because the alias and generation a record carries name a folder without saying
+/// where it is, and every use of an outstanding record needs both: performing the change again selects the remote path,
+/// and reporting the change to an operator names the alias. Re-resolving the alias against the server instead would ask
+/// a mail server a question the row already answers, and could answer it with a folder the record was never written
+/// against.
+/// </remarks>
+public sealed record OutstandingMailboxMutation(MailboxMutationRecord Record, MailFolderResolution Folder);

--- a/src/Domain/Failures/MailFathomErrorCode.cs
+++ b/src/Domain/Failures/MailFathomErrorCode.cs
@@ -104,6 +104,16 @@ public readonly record struct MailFathomErrorCode
     /// </remarks>
     public static MailFathomErrorCode MailboxMutationFailedUnexpectedly { get; } = new(25004);
 
+    /// <summary>Gets subcategory 5, mutation support: the folder a relocation or a copy names as its destination does not exist on the server.</summary>
+    /// <remarks>
+    /// It sits beside <see cref="MailboxMutationUnsupported" /> rather than among the availability failures for the same
+    /// reason that one does: a folder the server does not have is not a round trip that went badly, and asking again
+    /// every interval would spend a login apiece to be told the same thing. The remedy is an operator's — recreate the
+    /// folder, or correct whatever asked for that path — so the mutation is given up on visibly at the first refusal
+    /// instead of after its attempt bound.
+    /// </remarks>
+    public static MailFathomErrorCode MailboxMutationDestinationMissing { get; } = new(25005);
+
     #endregion
 
     #region Category 3 — Persistence
@@ -254,6 +264,7 @@ public readonly record struct MailFathomErrorCode
         MailboxMutationOutcomeUnknown,
         MailboxMutationAttemptsExhausted,
         MailboxMutationFailedUnexpectedly,
+        MailboxMutationDestinationMissing,
         PersistenceConcurrencyConflict,
         DatabaseSchemaOutOfDate,
         DatabaseSchemaStateUnreadable,

--- a/src/Domain/Mutations/MailboxMutationLifecycle.cs
+++ b/src/Domain/Mutations/MailboxMutationLifecycle.cs
@@ -1,0 +1,183 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Domain.Mutations;
+
+/// <summary>Names where in its lifecycle one recorded mutation stands, in the four words an operator asks about.</summary>
+/// <remarks>
+/// <para>
+/// <see cref="MailboxMutationStage" /> says which IMAP command a sequence has reached, which is what a resumed attempt
+/// needs and what nobody watching a deployment wants to read. This is the reading beside it: whether a change has been
+/// asked for and not started, is on its way, is done, or has stopped and needs a person. Three stages collapse into
+/// <see cref="Converging" /> because all three mean the same thing to that question, and none of them collapses into
+/// another lifecycle value, so the mapping is total and one-way.
+/// </para>
+/// <para>
+/// The type is a closed enumeration rather than a C# <see langword="enum" />, because the name is the identity: it is
+/// the dimension a gauge is broken down by and the word a runbook is written against, and an ordinal would carry no
+/// meaning outside this assembly. Nothing persists it — every row stores its stage, and this is derived on the way out —
+/// so widening the set is a decision about what an operator is shown rather than a schema change.
+/// </para>
+/// <para>
+/// Being a struct, <see langword="default" /> is reachable and names no lifecycle; <see cref="IsSpecified" /> reports
+/// that. Every value reaches a caller through <see cref="Of" />, which is total over the stages, so the default cannot
+/// arrive from a record.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(MailboxMutationLifecycleJsonConverter))]
+public readonly record struct MailboxMutationLifecycle
+{
+    private readonly string? name;
+
+    private MailboxMutationLifecycle(string name) => this.name = name;
+
+    /// <summary>Gets the lifecycle of a change that is durable and that no IMAP command has gone out for.</summary>
+    public static MailboxMutationLifecycle Pending { get; } = new("pending");
+
+    /// <summary>Gets the lifecycle of a change whose sequence has started and has not finished.</summary>
+    /// <remarks>
+    /// It covers an unacknowledged placement as well as an acknowledged one, because both are a mailbox on its way to
+    /// the state that was asked for. Which of them a mutation is at is the stage's answer, and an operator reading a
+    /// count of changes in flight is not asking it.
+    /// </remarks>
+    public static MailboxMutationLifecycle Converging { get; } = new("converging");
+
+    /// <summary>Gets the lifecycle of a change the server has made.</summary>
+    public static MailboxMutationLifecycle Completed { get; } = new("completed");
+
+    /// <summary>Gets the lifecycle of a change nothing will attempt again, which is waiting for a person.</summary>
+    /// <remarks>
+    /// This is the value the whole convergence design exists to make reachable. A change that cannot be made has to
+    /// become visible instead of staying pending forever, because pending forever looks exactly like success from every
+    /// screen an operator reads.
+    /// </remarks>
+    public static MailboxMutationLifecycle DeadLettered { get; } = new("dead-lettered");
+
+    /// <summary>Gets every lifecycle a mutation can stand in.</summary>
+    /// <remarks>Declared last so the members it lists are already initialized when this initializer runs.</remarks>
+    public static IReadOnlyList<MailboxMutationLifecycle> All { get; } =
+        [Pending, Converging, Completed, DeadLettered];
+
+    /// <summary>Gets whether this value names a lifecycle rather than the unusable struct default.</summary>
+    public bool IsSpecified => this.name is not null;
+
+    /// <summary>Gets the name a log line and a gauge dimension both use for the lifecycle.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a lifecycle.</exception>
+    public string Name => this.name
+        ?? throw new InvalidOperationException("The value is the default of the struct and names no mutation lifecycle.");
+
+    /// <summary>Reads which lifecycle one recorded stage stands in.</summary>
+    /// <param name="stage">The stage a record carries.</param>
+    /// <returns>The lifecycle that stage belongs to.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the stage is not one this build declares.</exception>
+    public static MailboxMutationLifecycle Of(MailboxMutationStage stage) => stage switch
+    {
+        MailboxMutationStage.Recorded => Pending,
+        MailboxMutationStage.PlacementIssued
+            or MailboxMutationStage.PlacementConfirmed
+            or MailboxMutationStage.SourceFlaggedDeleted => Converging,
+        MailboxMutationStage.Completed => Completed,
+        MailboxMutationStage.Abandoned => DeadLettered,
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(stage),
+            stage,
+            "No mutation lifecycle is defined for this stage."),
+    };
+
+    /// <summary>Parses a recorded name back into the lifecycle it names.</summary>
+    /// <param name="name">The name read from a log, a dashboard query, or a serialized document.</param>
+    /// <param name="lifecycle">The parsed lifecycle when the name is one of the four; otherwise the unspecified default.</param>
+    /// <returns><see langword="true" /> when the name is a declared lifecycle; otherwise <see langword="false" />.</returns>
+    public static bool TryParseName(string? name, out MailboxMutationLifecycle lifecycle)
+    {
+        lifecycle = default;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        var normalizedName = name.Trim();
+
+        // No declared lifecycle is the struct default, so an unmatched name yields the unspecified value the caller
+        // already receives when parsing fails.
+        lifecycle = All.FirstOrDefault(candidate => StringComparer.Ordinal.Equals(candidate.Name, normalizedName));
+
+        return lifecycle.IsSpecified;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => this.name ?? "(unspecified)";
+}
+
+/// <summary>Serializes <see cref="MailboxMutationLifecycle" /> as its name.</summary>
+/// <remarks>
+/// The type carries this converter through <see cref="JsonConverterAttribute" />, so every serializer that meets the
+/// value uses it without per-call registration. The JSON form is the name for the same reason the value object exists:
+/// the name is the published identity, and an ordinal would change meaning silently if the set were ever reordered.
+/// </remarks>
+public sealed class MailboxMutationLifecycleJsonConverter : JsonConverter<MailboxMutationLifecycle>
+{
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the token is not a string or does not name a declared lifecycle.</exception>
+    public override MailboxMutationLifecycle Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException($"A mutation lifecycle must be a JSON string, but the token was {reader.TokenType}.");
+        }
+
+        return ParseOrThrow(reader.GetString());
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the value is the unspecified struct default.</exception>
+    public override void Write(
+        Utf8JsonWriter writer,
+        MailboxMutationLifecycle value,
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WriteStringValue(NameOrThrow(value));
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the property name does not name a declared lifecycle.</exception>
+    public override MailboxMutationLifecycle ReadAsPropertyName(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options) => ParseOrThrow(reader.GetString());
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the value is the unspecified struct default.</exception>
+    public override void WriteAsPropertyName(
+        Utf8JsonWriter writer,
+        MailboxMutationLifecycle value,
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WritePropertyName(NameOrThrow(value));
+    }
+
+    private static MailboxMutationLifecycle ParseOrThrow(string? name)
+    {
+        if (!MailboxMutationLifecycle.TryParseName(name, out var lifecycle))
+        {
+            throw new JsonException($"'{name}' does not name a mailbox mutation lifecycle.");
+        }
+
+        return lifecycle;
+    }
+
+    private static string NameOrThrow(MailboxMutationLifecycle lifecycle) => lifecycle.IsSpecified
+        ? lifecycle.Name
+        : throw new JsonException("An unspecified mutation lifecycle cannot be serialized.");
+}

--- a/src/Domain/Mutations/MailboxMutationRecord.cs
+++ b/src/Domain/Mutations/MailboxMutationRecord.cs
@@ -100,6 +100,40 @@ public sealed record MailboxMutationRecord
     /// <summary>Gets whether the record has reached a stage nothing moves it out of.</summary>
     public bool IsTerminal => this.Stage is MailboxMutationStage.Completed or MailboxMutationStage.Abandoned;
 
+    /// <summary>Gets where in its lifecycle the mutation stands, in the reading somebody watching a deployment asks for.</summary>
+    public MailboxMutationLifecycle Lifecycle => MailboxMutationLifecycle.Of(this.Stage);
+
+    /// <summary>Gets whether the one command that may never be issued twice went out and its answer never came back.</summary>
+    /// <remarks>
+    /// A record here is not resumed. Reissuing the placement would put a second message in the destination folder, and
+    /// nothing in that folder afterwards distinguishes a copy MailFathom made from one a person made, so the outcome is
+    /// re-established from what the mailbox now shows or the record is given up on visibly.
+    /// </remarks>
+    public bool HasUnknownOutcome => this.Stage == MailboxMutationStage.PlacementIssued;
+
+    /// <summary>Reports whether an unacknowledged placement has since been settled by the source occurrence leaving its folder.</summary>
+    /// <remarks>
+    /// <para>
+    /// It answers for one shape only, and the narrowness is the point. A relocation carried by <c>MOVE</c> removes the
+    /// source as part of the same command, so a source that has gone is the server's own statement that the command
+    /// ran — a fact about an occurrence the record names exactly, rather than a guess about which message in the
+    /// destination folder is the one that was placed. A copy and a fallback relocation both leave the source where it
+    /// was, so its presence says nothing about either and neither is settled here.
+    /// </para>
+    /// <para>
+    /// The one way this reads wrong is an owner who deleted the source message themselves between the command going out
+    /// and the folder being read again, which would credit the move for a disappearance it did not cause. The mutation
+    /// is completed anyway, deliberately: the email has left the source folder either way, nothing is duplicated by
+    /// saying so, and reissuing a <c>MOVE</c> against a UID the folder no longer holds could only fail. It is the same
+    /// direction <see cref="AccountsForRemovalOf" /> already takes for the same reason.
+    /// </para>
+    /// </remarks>
+    public bool IsUnknownPlacementSettledBySourceRemoval =>
+        this.HasUnknownOutcome
+        && this.Request.Mutation == MailboxMutation.Relocate
+        && !this.RequiresSourceRemoval
+        && this.SourceRemovalObservedAt is not null;
+
     /// <summary>Gets whether this mutation puts the email somewhere synchronization will later discover it.</summary>
     /// <remarks>
     /// A copy places an occurrence exactly as a relocation does, and is included for that reason: the discovery is

--- a/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
+++ b/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
@@ -98,9 +98,9 @@ internal sealed class MailSynchronizationOptions
     /// <remarks>
     /// <para>
     /// A change MailFathom is asked to make is written down before it is issued and attempted again from that record
-    /// until it succeeds. This is where that stops. A mail server that is refusing, a destination folder somebody
-    /// deleted, and a message another client already removed all fail identically on the next run, and repeating them
-    /// costs a login and a round trip each time while hiding the problem behind an operation that always looks busy.
+    /// until it succeeds. This is where that stops. A mail server that is refusing and a message another client already
+    /// removed fail identically on the next run, and repeating them costs a login and a round trip each time while
+    /// hiding the problem behind an operation that always looks busy.
     /// </para>
     /// <para>
     /// It bounds attempts of the whole change rather than retries inside one, which the account's resilience pipeline
@@ -108,9 +108,42 @@ internal sealed class MailSynchronizationOptions
     /// and stays visible as stuck rather than disappearing, so raising this buys patience with a failing server and
     /// lowering it surfaces a broken one sooner.
     /// </para>
+    /// <para>
+    /// Not every refusal waits for it. A server that advertises no way to carry the change safely, and one that answers
+    /// that the destination folder is not there, have both already given the answer every later attempt would receive,
+    /// so those are given up on at the first refusal whatever this is set to.
+    /// </para>
     /// </remarks>
     [Range(1, 100)]
     public int MaxMutationAttempts { get; set; } = 5;
+
+    /// <summary>Gets or sets how many outstanding changes one account converges per synchronization run.</summary>
+    /// <remarks>
+    /// Every run begins by taking the account's unfinished changes in hand — a filing interrupted by a restart, a change
+    /// recorded while the server was unreachable — and finishing them or giving up on them. The bound is what keeps a
+    /// backlog from turning one run into an unbounded sequence of mail-server round trips while the folders behind it
+    /// wait; what it leaves is picked up by the next run, oldest first. Each one is a write to a mail server rather than
+    /// a row to process, so the useful values are small.
+    /// </remarks>
+    [Range(1, 1000)]
+    public int MaxMutationsPerConvergencePass { get; set; } = 50;
+
+    /// <summary>Gets or sets how long a change whose outcome is unknown waits to be settled before it is given up on.</summary>
+    /// <remarks>
+    /// <para>
+    /// A command that puts a message in another folder is never issued twice, because a second one is a second message
+    /// rather than a repeat of the first. When such a command goes out and its answer never arrives, the only thing that
+    /// can still settle it is the mailbox itself coming back through an ordinary run, which takes as long as this
+    /// account's folders take to come round again — so this is a period rather than a number of attempts.
+    /// </para>
+    /// <para>
+    /// When it elapses the change is given up on and stays visible as dead-lettered, because a change that looks busy
+    /// forever is worse than one that says it stopped. Set it comfortably above the interval, so an ordinary run has
+    /// several chances to settle the change before the deadline is reached.
+    /// </para>
+    /// </remarks>
+    [Range(typeof(TimeSpan), "00:01:00", "7.00:00:00")]
+    public TimeSpan UnknownMutationOutcomeGrace { get; set; } = TimeSpan.FromHours(6);
 
     /// <summary>Gets or sets how long shutdown waits for the work units already under way before cancelling them.</summary>
     /// <remarks>

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Reconciliation;
@@ -14,6 +15,7 @@ using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
 using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Mail;
+using MailFathom.Infrastructure.Observability;
 
 namespace MailFathom.Host.Hosting.Workers;
 
@@ -179,6 +181,7 @@ internal sealed partial class AccountSynchronizationSupervisor
         var scheduledFolders = account.EffectiveFolders;
         var resolvedFolders = new ConcurrentBag<MailFolderResolution>();
         var failedFolderCount = 0;
+        var convergenceFailed = false;
 
         await this.accountRunSlots.WaitAsync(schedulingToken);
 
@@ -186,6 +189,15 @@ internal sealed partial class AccountSynchronizationSupervisor
 
         try
         {
+            // Convergence comes before the folders, and inside the account's slot, for two reasons that point the same
+            // way. A change the previous process left half-made is finished before this run reads the mailbox, so the
+            // run observes a mailbox that has stopped moving; and the account's one write connection is taken and given
+            // back before the folder connections are opened, rather than beside them.
+            if (!schedulingToken.IsCancellationRequested)
+            {
+                convergenceFailed = await this.ConvergeOutstandingMutationsAsync(runSettings, workUnitToken);
+            }
+
             await Parallel.ForEachAsync(
                 scheduledFolders,
                 new ParallelOptions
@@ -230,7 +242,53 @@ internal sealed partial class AccountSynchronizationSupervisor
             failedFolderCount,
             runDuration);
 
-        return new AccountRunOutcome(failedFolderCount > 0, [.. resolvedFolders]);
+        return new AccountRunOutcome(failedFolderCount > 0 || convergenceFailed, [.. resolvedFolders]);
+    }
+
+    /// <summary>Finishes or gives up on the changes this account asked a mail server for and has not seen completed.</summary>
+    /// <returns><see langword="true" /> when at least one change failed, which puts the account into backoff.</returns>
+    /// <remarks>
+    /// <para>
+    /// This is what makes a change survive a restart without anybody noticing it had to. The record was written before
+    /// the first IMAP command, so a process that stopped halfway through a filing left a statement of what it was doing
+    /// and how far it got, and the first run after the restart reads that statement and carries it the rest of the way.
+    /// Nothing here has to be scheduled separately, because an account already has a loop that runs it.
+    /// </para>
+    /// <para>
+    /// A failed pass fails the run rather than being logged and passed over, which is the whole of the backoff story: an
+    /// unreachable mail server defers the account's next run through the same jittered delay a failed folder does, so a
+    /// change waiting on that server is approached less often instead of once per interval forever. What bounds the
+    /// change itself is its own attempt count, which is written before each attempt and therefore survives a crash.
+    /// </para>
+    /// </remarks>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "A convergence pass that ended unexpectedly defers this account's next run and leaves its folders to synchronize; every mutation's own record already carries how far it got.")]
+    private async Task<bool> ConvergeOutstandingMutationsAsync(
+        MailSynchronizationOptions runSettings,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = this.scopeFactory.CreateScope();
+
+            scope.ServiceProvider.GetRequiredService<ScopedMailSynchronizationSettings>().UseRunSnapshot(runSettings);
+
+            var converger = scope.ServiceProvider.GetRequiredService<MailboxMutationConverger>();
+            var report = await converger.ConvergeAsync(this.accountId, cancellationToken);
+
+            scope.ServiceProvider.GetRequiredService<MailboxConvergenceTelemetry>().Report(this.accountId, report);
+
+            return report.FailedCount > 0;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            this.LogMutationConvergenceFailed(exception, this.accountId.Value);
+
+            return true;
+        }
     }
 
     /// <summary>Synchronizes one folder in a scope of its own and reports whether it completed and what it resolved to.</summary>
@@ -532,6 +590,12 @@ internal sealed partial class AccountSynchronizationSupervisor
     private partial void LogFolderAliasAmbiguous(
         string accountId,
         string folderAlias);
+
+    /// <summary>Separates a convergence pass that ended unexpectedly from the ordinary case of one change failing, which the pass itself absorbs.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Converging the outstanding mailbox mutations of account {AccountId} ended unexpectedly; its folders still synchronized and its next run is backed off, and every change keeps the record of how far it got.")]
+    private partial void LogMutationConvergenceFailed(Exception exception, string accountId);
 
     [LoggerMessage(
         Level = LogLevel.Warning,

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -11,6 +11,7 @@ using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
@@ -200,6 +201,15 @@ try
     {
         MaximumAttempts = provider.GetRequiredService<ISettingsSnapshot<MailSynchronizationOptions>>()
             .Current.MaxMutationAttempts,
+    });
+    builder.Services.AddScoped(provider =>
+    {
+        var synchronizationSettings = provider.GetRequiredService<MailSynchronizationOptions>();
+        return new MailboxConvergenceOptions
+        {
+            MaxMutationsPerPass = synchronizationSettings.MaxMutationsPerConvergencePass,
+            UnknownOutcomeGrace = synchronizationSettings.UnknownMutationOutcomeGrace,
+        };
     });
     builder.Services.AddScoped(provider =>
     {

--- a/src/Infrastructure/Mail/MailKit/Writes/MailKitImapWriteSession.cs
+++ b/src/Infrastructure/Mail/MailKit/Writes/MailKitImapWriteSession.cs
@@ -179,7 +179,11 @@ internal sealed class MailKitImapWriteSession : IMailboxWriteSession
                     return journal.Placement;
                 }
 
-                var destination = await client.GetFolderAsync(destinationPath.Value, attemptToken);
+                var destination = await this.GetDestinationFolderAsync(
+                    client,
+                    destinationPath,
+                    MailboxMutation.Copy,
+                    attemptToken);
 
                 // A copy owes no source removal: leaving the source exactly where it is *is* the operation.
                 await journal.PlacementIssuedAsync(requiresSourceRemoval: false, attemptToken);
@@ -223,6 +227,40 @@ internal sealed class MailKitImapWriteSession : IMailboxWriteSession
                 ImapUidValidity.Create(placedUid.Validity),
                 ImapUid.Create(placedUid.Id))
             : RemoteEmailPlacement.NotReported();
+
+    /// <summary>Resolves the folder a relocation or a copy names, and reports its absence as the settled answer it is.</summary>
+    /// <remarks>
+    /// <para>
+    /// MailKit raises <see cref="FolderNotFoundException" /> here, which is a plain exception carrying a remote path and
+    /// nothing else about what was being attempted. Left alone it would reach the record as an unclassified failure and
+    /// be attempted once per run until the mutation's attempt bound was spent, which buys a login per attempt to be told
+    /// the same thing. Translating it is what lets the change be given up on at once and stand visible for the operator
+    /// whose folder it is.
+    /// </para>
+    /// <para>
+    /// The resolution happens before the journal is advanced, on both paths, so a missing destination leaves the record
+    /// exactly where it was and nothing has to be undone.
+    /// </para>
+    /// </remarks>
+    private async Task<IMailFolder> GetDestinationFolderAsync(
+        IImapClient client,
+        RemoteFolderPath destinationPath,
+        MailboxMutation mutation,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await client.GetFolderAsync(destinationPath.Value, cancellationToken);
+        }
+        catch (FolderNotFoundException absent)
+        {
+            throw new MailboxDestinationFolderMissingException(
+                this.SessionAccountId,
+                this.folder.Alias,
+                mutation,
+                absent);
+        }
+    }
 
     private static void RequireCapability(
         IImapClient client,
@@ -290,7 +328,11 @@ internal sealed class MailKitImapWriteSession : IMailboxWriteSession
             return journal.Placement;
         }
 
-        var destination = await client.GetFolderAsync(destinationPath.Value, cancellationToken);
+        var destination = await this.GetDestinationFolderAsync(
+            client,
+            destinationPath,
+            MailboxMutation.Relocate,
+            cancellationToken);
         var sourceUid = new UniqueId(occurrenceId.Uid.Value);
 
         if (client.Capabilities.HasFlag(ImapCapabilities.Move))

--- a/src/Infrastructure/Observability/MailboxConvergenceTelemetry.cs
+++ b/src/Infrastructure/Observability/MailboxConvergenceTelemetry.cs
@@ -1,0 +1,149 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using MailFathom.Application.Mail.Mutations.Convergence;
+using MailFathom.Common.Observability;
+using MailFathom.Domain.Accounts;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.Infrastructure.Observability;
+
+/// <summary>Makes a change MailFathom asked for and has not seen finished visible while it is still unfinished.</summary>
+/// <remarks>
+/// <para>
+/// The counter beside this one already reports every mutation that ended, which answers what happened. This answers the
+/// question an operator actually opens a dashboard with: what is outstanding right now, for how long, and is any of it
+/// stuck. Those are levels rather than events, so they are gauges read at scrape time from the last pass's answer, and
+/// the age is computed when the gauge is read rather than when the pass ran — otherwise an account whose runs are an
+/// interval apart would report an age that stepped rather than grew.
+/// </para>
+/// <para>
+/// An account is published from its own pass and replaced whole by the next one, so a lifecycle that emptied stops
+/// being reported instead of reporting its last non-zero value forever. Nothing is remembered for an account that has
+/// never converged.
+/// </para>
+/// <para>
+/// The dimensions are the account alias, the mutation name, and the lifecycle. All three are MailFathom's own words,
+/// bounded by the configured accounts times four mutations times three lifecycles, and none of them is derived from a
+/// message.
+/// </para>
+/// </remarks>
+public sealed partial class MailboxConvergenceTelemetry
+{
+    private const string AccountTagName = "mailfathom.mail.account";
+    private const string MutationTagName = "mailfathom.mailbox.mutation";
+    private const string LifecycleTagName = "mailfathom.mailbox.mutation.lifecycle";
+
+    private readonly ConcurrentDictionary<string, IReadOnlyList<MailboxMutationLifecycleCount>> outstandingByAccount =
+        new(StringComparer.Ordinal);
+
+    private readonly ILogger<MailboxConvergenceTelemetry> logger;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes the gauges an outstanding mutation is read through.</summary>
+    /// <param name="logger">Records what a pass did, in counts and MailFathom's own names only.</param>
+    /// <param name="timeProvider">Measures how long the oldest outstanding mutation has been outstanding.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
+    public MailboxConvergenceTelemetry(ILogger<MailboxConvergenceTelemetry> logger, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.logger = logger;
+        this.timeProvider = timeProvider;
+
+        Telemetry.Meter.CreateObservableGauge(
+            "mailfathom.mailbox.mutations.outstanding",
+            this.ObserveOutstandingCounts,
+            unit: "{mutation}",
+            description: "Changes MailFathom has asked a mail server for and not seen finished, by mutation and lifecycle.");
+        Telemetry.Meter.CreateObservableGauge(
+            "mailfathom.mailbox.mutations.oldest_outstanding_age",
+            this.ObserveOldestAges,
+            unit: "s",
+            description: "How long the oldest unfinished change of each mutation and lifecycle has been outstanding.");
+    }
+
+    /// <summary>Publishes what one account's convergence pass found, and records what the pass did.</summary>
+    /// <param name="accountId">The account the pass ran for.</param>
+    /// <param name="report">What the pass did and what the account still owes.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="report" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A pass that changed nothing emits no log line, because most passes have nothing to do and a line per account per
+    /// interval would be noise an operator learns to ignore. The gauges are published either way, since an account
+    /// whose outstanding work is unchanged is exactly the account somebody needs to be able to see.
+    /// </remarks>
+    public void Report(MailAccountId accountId, MailboxConvergenceReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        this.outstandingByAccount[accountId.Value] = report.Outstanding;
+
+        if (report.ChangedNothing)
+        {
+            return;
+        }
+
+        this.LogConvergencePassFinished(
+            accountId.Value,
+            report.CompletedCount,
+            report.DeadLetteredCount,
+            report.DeferredCount,
+            report.FailedCount);
+    }
+
+    /// <summary>States what a pass moved, in the four outcomes a mutation can have reached in one.</summary>
+    /// <remarks>
+    /// The dead-lettered count is the one worth reacting to: it names changes nothing will attempt again, which stay on
+    /// the gauge until somebody deals with them.
+    /// </remarks>
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Converged the outstanding mailbox mutations of account {AccountId}; {CompletedCount} completed, {DeadLetteredCount} were given up on and stay visible, {DeferredCount} await a later pass, and {FailedCount} failed and will be attempted again.")]
+    private partial void LogConvergencePassFinished(
+        string accountId,
+        int completedCount,
+        int deadLetteredCount,
+        int deferredCount,
+        int failedCount);
+
+    private IEnumerable<Measurement<long>> ObserveOutstandingCounts() =>
+        [.. this.EnumerateOutstanding().Select(outstanding => new Measurement<long>(
+            outstanding.Group.Count,
+            TagsOf(outstanding.AccountId, outstanding.Group)))];
+
+    private IEnumerable<Measurement<double>> ObserveOldestAges()
+    {
+        var observedAt = this.timeProvider.GetUtcNow();
+
+        return
+        [
+            .. this.EnumerateOutstanding().Select(outstanding => new Measurement<double>(
+                Math.Max(0, (observedAt - outstanding.Group.OldestRecordedAt).TotalSeconds),
+                TagsOf(outstanding.AccountId, outstanding.Group))),
+        ];
+    }
+
+    /// <summary>Flattens the published snapshots into one measurement source both gauges read.</summary>
+    /// <remarks>
+    /// The result is materialized by each caller before it is handed to the meter, because a gauge callback is invoked
+    /// on the collector's schedule and a deferred query would be enumerated against whatever the dictionary held then
+    /// rather than against what the snapshot said.
+    /// </remarks>
+    private IEnumerable<(string AccountId, MailboxMutationLifecycleCount Group)> EnumerateOutstanding() =>
+        this.outstandingByAccount.SelectMany(
+            account => account.Value,
+            (account, group) => (account.Key, group));
+
+    private static TagList TagsOf(string accountId, MailboxMutationLifecycleCount group) =>
+        new()
+        {
+            { AccountTagName, accountId },
+            { MutationTagName, group.Mutation.Name },
+            { LifecycleTagName, group.Lifecycle.Name },
+        };
+}

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordStore.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordStore.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
@@ -151,7 +152,7 @@ internal sealed class MailboxMutationRecordStore(MailFathomDbContext readContext
     }
 
     /// <inheritdoc />
-    public async Task<IReadOnlyList<MailboxMutationRecord>> ReadOutstandingAsync(
+    public async Task<IReadOnlyList<OutstandingMailboxMutation>> ReadOutstandingAsync(
         MailAccountId accountId,
         int limit,
         CancellationToken cancellationToken)
@@ -161,7 +162,7 @@ internal sealed class MailboxMutationRecordStore(MailFathomDbContext readContext
         var accountValue = accountId.Value;
 
         // The binding is joined rather than copied onto the row, because it is what turns a folder key back into the
-        // alias and generation an occurrence identity is made of.
+        // alias and generation an occurrence identity is made of, and the remote path a resumed attempt selects.
         var entities = await readContext.MailboxMutations
             .AsNoTracking()
             .Include(mutation => mutation.MailFolder)
@@ -172,8 +173,67 @@ internal sealed class MailboxMutationRecordStore(MailFathomDbContext readContext
             .Take(limit)
             .ToArrayAsync(cancellationToken);
 
-        return [.. entities.Select(entity => MailboxMutationRecordMapping.ToRecord(entity, entity.MailFolder))];
+        return
+        [
+            .. entities.Select(entity => new OutstandingMailboxMutation(
+                MailboxMutationRecordMapping.ToRecord(entity, entity.MailFolder),
+                MailFolderEntityResolver.ToResolution(entity.MailFolder))),
+        ];
     }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<MailboxMutationLifecycleCount>> ReadLifecycleCountsAsync(
+        MailAccountId accountId,
+        CancellationToken cancellationToken)
+    {
+        var accountValue = accountId.Value;
+
+        // Grouped by the stored stage rather than by the lifecycle, because the lifecycle is derived by a domain method
+        // the provider cannot translate. Collapsing the three converging stages happens once the rows are here, over an
+        // answer that is at most one row per mutation per stage.
+        var groupedStages = await readContext.MailboxMutations
+            .AsNoTracking()
+            .Where(mutation => mutation.MailboxAccountId == accountValue &&
+                mutation.Stage != MailboxMutationStage.Completed)
+            .GroupBy(mutation => new { mutation.Mutation, mutation.Stage })
+            .Select(group => new
+            {
+                group.Key.Mutation,
+                group.Key.Stage,
+                Count = group.Count(),
+                OldestRecordedAt = group.Min(mutation => mutation.RecordedAt),
+            })
+            .ToArrayAsync(cancellationToken);
+
+        return
+        [
+            .. groupedStages
+                .Select(group => new
+                {
+                    Mutation = ParseMutationOrThrow(group.Mutation),
+                    Lifecycle = MailboxMutationLifecycle.Of(group.Stage),
+                    group.Count,
+                    group.OldestRecordedAt,
+                })
+                .GroupBy(group => new { group.Mutation, group.Lifecycle })
+                .Select(group => new MailboxMutationLifecycleCount(
+                    group.Key.Mutation,
+                    group.Key.Lifecycle,
+                    group.Sum(stage => stage.Count),
+                    group.Min(stage => stage.OldestRecordedAt))),
+        ];
+    }
+
+    /// <summary>Reads a stored mutation name back, refusing one this build does not permit.</summary>
+    /// <remarks>
+    /// A name that no longer parses is the same defect here as it is when a whole record is rebuilt, and it is refused
+    /// the same way: a count broken down by a mutation nothing performs would report work that cannot exist.
+    /// </remarks>
+    private static MailboxMutation ParseMutationOrThrow(string mutationName) =>
+        MailboxMutation.TryParseName(mutationName, out var mutation)
+            ? mutation
+            : throw new InvalidOperationException(
+                $"Mailbox mutation records name '{mutationName}', which is not a permitted mutation.");
 
     /// <summary>Refuses a stage that would pull the record backwards or move it out of a terminal one.</summary>
     /// <remarks>

--- a/src/Infrastructure/Persistence/Synchronization/MailFolderEntityResolver.cs
+++ b/src/Infrastructure/Persistence/Synchronization/MailFolderEntityResolver.cs
@@ -77,4 +77,24 @@ internal static class MailFolderEntityResolver
 
         return folder;
     }
+
+    /// <summary>Rebuilds the alias binding one row states.</summary>
+    /// <param name="entity">The binding row.</param>
+    /// <returns>The resolution that row describes, including the remote path a session selects.</returns>
+    /// <remarks>
+    /// It is the exact inverse of what <see cref="AddAsync" /> writes, and it lives beside it so the two cannot drift:
+    /// the delimiter in particular is stored as text and read back as the one character it holds, and a second reading
+    /// of that would be a second chance to disagree about an empty string.
+    /// </remarks>
+    public static MailFolderResolution ToResolution(MailFolderEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        return new MailFolderResolution(
+            MailFolderAlias.Create(entity.Alias),
+            MailFolderResolutionGeneration.Create(entity.ResolutionGeneration),
+            RemoteFolderPath.Create(
+                entity.RemotePath,
+                entity.HierarchyDelimiter is { Length: > 0 } delimiter ? delimiter[0] : null));
+    }
 }

--- a/src/Infrastructure/Persistence/Synchronization/MailFolderResolutionStore.cs
+++ b/src/Infrastructure/Persistence/Synchronization/MailFolderResolutionStore.cs
@@ -7,7 +7,6 @@ using MailFathom.Application.Persistence;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
-using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
 using Microsoft.EntityFrameworkCore;
 
@@ -37,7 +36,7 @@ internal sealed class MailFolderResolutionStore(MailFathomDbContext readContext)
             .OrderByDescending(folder => folder.ResolutionGeneration)
             .FirstOrDefaultAsync(cancellationToken);
 
-        return entity is null ? null : ToResolution(entity);
+        return entity is null ? null : MailFolderEntityResolver.ToResolution(entity);
     }
 
     /// <inheritdoc />
@@ -68,17 +67,10 @@ internal sealed class MailFolderResolutionStore(MailFathomDbContext readContext)
         // otherwise both proceed: the loser would adopt the winner's row and store its own folder's occurrences and
         // checkpoint under it, so one (alias, generation) would name two remote folders — exactly what the generation
         // exists to make impossible. It is reported as a conflict, and the next run resolves against what is durable.
-        if (ToResolution(existingBinding) != resolution)
+        if (MailFolderEntityResolver.ToResolution(existingBinding) != resolution)
         {
             throw new PersistenceConcurrencyConflictException(
                 $"Folder alias {accountId.Value}/{resolution.Id} was bound to a different remote folder by another writer before this run recorded its own binding.");
         }
     }
-
-    private static MailFolderResolution ToResolution(MailFolderEntity entity) => new(
-        MailFolderAlias.Create(entity.Alias),
-        MailFolderResolutionGeneration.Create(entity.ResolutionGeneration),
-        RemoteFolderPath.Create(
-            entity.RemotePath,
-            entity.HierarchyDelimiter is { Length: > 0 } delimiter ? delimiter[0] : null));
 }

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ using MailFathom.Application.Emails.SearchEmails;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
 using MailFathom.Application.Synchronization;
@@ -280,6 +281,10 @@ public static class ServiceCollectionExtensions
         // run is recognized as MailFathom's own instead of being stored as a second email.
         services.AddScoped<IMailboxMutationReconciliationStore, MailboxMutationReconciliationStore>();
         services.AddScoped<IMailboxMutationPerformer, MailboxMutationPerformer>();
+        // A singleton, because the gauges it publishes are the process's and the account snapshots behind them outlive
+        // any one run; the pass that fills them is scoped like everything else that reaches a mail server.
+        services.AddSingleton<MailboxConvergenceTelemetry>();
+        services.AddScoped<MailboxMutationConverger>();
         services.AddScoped<IRemoteFolderCatalog>(provider => new MailKitRemoteFolderCatalog(
             static () => new ImapClient(),
             provider.GetRequiredService<IImapAccountSettingsProvider>(),

--- a/tests/Application.UnitTests/Mail/Mutations/Convergence/MailboxMutationConvergerTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Convergence/MailboxMutationConvergerTests.cs
@@ -1,0 +1,478 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Convergence;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization.Sessions;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Transport;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Mail.Mutations.Convergence;
+
+public sealed class MailboxMutationConvergerTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("personal");
+
+    private static readonly MailFolderResolution InboxFolder = MailFolderResolution.FirstBindingOf(
+        MailFolderAlias.Create("inbox"),
+        RemoteFolderPath.Create("INBOX", '/'));
+
+    private static readonly RemoteFolderPath ArchivePath = RemoteFolderPath.Create("Archive", '/');
+
+    private static readonly MailTransportSecurityPolicy TransportPolicy = MailTransportSecurityPolicy.Create(
+        MailConnectionSecurity.TlsOnConnect,
+        MailAuthenticationPolicy.Create(
+            [MailAuthenticationMechanism.Plain],
+            allowInsecureConnection: false,
+            allowClearTextAuthenticationOverUnencryptedConnection: false),
+        MailServerCertificateTrust.SystemTrustStore,
+        trustedCertificateAuthorityReference: null);
+
+    /// <summary>
+    /// The restart case, which is the whole point: the previous process wrote the record and stopped, and the first run
+    /// after it carries the change the rest of the way with nobody asking for anything.
+    /// </summary>
+    [Fact]
+    public async Task ConvergeAsync_AMutationLeftHalfFinishedByAStoppedProcess_IsCarriedToCompletion()
+    {
+        // Arrange
+        var context = new ConvergerContext();
+        var request = await context.LeaveOutstandingAsync(
+            RelocationRequest(),
+            record => record with { Stage = MailboxMutationStage.PlacementConfirmed, RequiresSourceRemoval = true });
+
+        // Act
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, report.CompletedCount);
+        Assert.Equal(MailboxMutationStage.Completed, context.Store.RecordOf(request).Stage);
+        await context.WriteSession.Received(1).RelocateAsync(
+            request.Occurrence,
+            ArchivePath,
+            Arg.Any<IMailboxMutationJournal>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>The binding the record was written against is what a resumed attempt selects, not one resolved afresh.</summary>
+    [Fact]
+    public async Task ConvergeAsync_ResumingAMutation_OpensTheWriteSessionOnTheRecordedBinding()
+    {
+        // Arrange
+        var context = new ConvergerContext();
+        context.Store.BindFolder(InboxFolder);
+        await context.LeaveOutstandingAsync(RelocationRequest(), record => record);
+
+        // Act
+        await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        await context.WriteSessionFactory.Received(1).OpenForWritingAsync(
+            Account,
+            InboxFolder,
+            TransportPolicy,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A server that is not answering fails the pass rather than spinning inside it, and the failure is what the caller
+    /// backs the account off on. The record keeps the code, so what an operator reads is why rather than only that.
+    /// </summary>
+    [Fact]
+    public async Task ConvergeAsync_WhenTheServerIsUnreachable_ReportsTheFailureAndAttemptsTheMutationOnce()
+    {
+        // Arrange
+        var context = new ConvergerContext();
+        var request = await context.LeaveOutstandingAsync(RelocationRequest(), record => record);
+        context.FailRelocationWith(new MailboxUnavailableException(
+            Account,
+            new TimeoutException("The mail server did not answer within its budget.")));
+
+        // Act
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        var record = context.Store.RecordOf(request);
+        Assert.Equal(1, report.FailedCount);
+        Assert.Equal(0, report.CompletedCount);
+        Assert.Equal(1, record.AttemptCount);
+        Assert.Equal(MailFathomErrorCode.MailboxUnavailable, record.LastFailure);
+    }
+
+    /// <summary>One broken change must not stop the ones that are not broken, which is the whole of "does not block unrelated work".</summary>
+    [Fact]
+    public async Task ConvergeAsync_WhenOneMutationFails_TheAccountsOtherMutationsStillConverge()
+    {
+        // Arrange
+        var context = new ConvergerContext();
+        var failing = await context.LeaveOutstandingAsync(RelocationRequest(), record => record);
+        var healthy = await context.LeaveOutstandingAsync(DeleteRequest(uid: 43U), record => record);
+        context.FailRelocationWith(new MailboxUnavailableException(Account, new TimeoutException("Not answering.")));
+
+        // Act
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, report.FailedCount);
+        Assert.Equal(1, report.CompletedCount);
+        Assert.Equal(MailFathomErrorCode.MailboxUnavailable, context.Store.RecordOf(failing).LastFailure);
+        Assert.Equal(MailboxMutationStage.Completed, context.Store.RecordOf(healthy).Stage);
+    }
+
+    /// <summary>
+    /// A destination folder somebody removed is an answer the server has already given, so the change stops rather than
+    /// being attempted once per run until its bound is spent.
+    /// </summary>
+    [Fact]
+    public async Task ConvergeAsync_WhenTheDestinationFolderIsGone_GivesTheMutationUpVisibly()
+    {
+        // Arrange
+        var context = new ConvergerContext();
+        var request = await context.LeaveOutstandingAsync(RelocationRequest(), record => record);
+        context.FailRelocationWith(new MailboxDestinationFolderMissingException(
+            Account,
+            InboxFolder.Alias,
+            MailboxMutation.Relocate,
+            new InvalidOperationException("The folder could not be found.")));
+
+        // Act
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        var record = context.Store.RecordOf(request);
+        Assert.Equal(MailboxMutationStage.Abandoned, record.Stage);
+        Assert.Equal(1, record.AttemptCount);
+        Assert.Equal(MailFathomErrorCode.MailboxMutationDestinationMissing, record.LastFailure);
+        Assert.Contains(
+            report.Outstanding,
+            group => group.Lifecycle == MailboxMutationLifecycle.DeadLettered && group.Count == 1);
+    }
+
+    /// <summary>
+    /// The command that may never be issued twice is never issued again, whichever mutation it belonged to. This is the
+    /// assertion the whole unknown-outcome design exists for.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ConvergeAsync_AnUnacknowledgedPlacement_IsNeverIssuedAgain(bool isCopy)
+    {
+        // Arrange
+        var context = new ConvergerContext();
+        var request = isCopy ? CopyRequest() : RelocationRequest();
+        await context.LeaveOutstandingAsync(
+            request,
+            record => record with { Stage = MailboxMutationStage.PlacementIssued });
+
+        // Act
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, report.DeferredCount);
+        await context.WriteSessionFactory.DidNotReceive().OpenForWritingAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<MailFolderResolution>(),
+            Arg.Any<MailTransportSecurityPolicy>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The one unknown outcome the mailbox itself can settle: a relocation carried by <c>MOVE</c> whose source has since
+    /// been seen to leave its folder. The server removed it, so the command ran.
+    /// </summary>
+    [Fact]
+    public async Task ConvergeAsync_AnUnacknowledgedNativeRelocationWhoseSourceHasGone_IsCompletedFromTheObservation()
+    {
+        // Arrange
+        var context = new ConvergerContext();
+        var request = await context.LeaveOutstandingAsync(
+            RelocationRequest(),
+            record => record with
+            {
+                Stage = MailboxMutationStage.PlacementIssued,
+                RequiresSourceRemoval = false,
+                SourceRemovalObservedAt = context.Clock.GetUtcNow(),
+            });
+
+        // Act
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, report.CompletedCount);
+        Assert.Equal(MailboxMutationStage.Completed, context.Store.RecordOf(request).Stage);
+        await context.WriteSessionFactory.DidNotReceive().OpenForWritingAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<MailFolderResolution>(),
+            Arg.Any<MailTransportSecurityPolicy>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// An outcome nothing can establish still has to stop being apparently in flight, because a change that looks busy
+    /// forever is exactly the failure mode this design exists to remove.
+    /// </summary>
+    [Fact]
+    public async Task ConvergeAsync_AnUnknownOutcomeThatOutlastsItsGrace_IsDeadLetteredAndStaysVisible()
+    {
+        // Arrange
+        var context = new ConvergerContext(unknownOutcomeGrace: TimeSpan.FromHours(6));
+        var request = await context.LeaveOutstandingAsync(
+            CopyRequest(),
+            record => record with { Stage = MailboxMutationStage.PlacementIssued });
+
+        // Act
+        context.Clock.Advance(TimeSpan.FromHours(7));
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        var record = context.Store.RecordOf(request);
+        Assert.Equal(1, report.DeadLetteredCount);
+        Assert.Equal(MailboxMutationStage.Abandoned, record.Stage);
+        Assert.Equal(MailFathomErrorCode.MailboxMutationOutcomeUnknown, record.LastFailure);
+        Assert.Equal(MailboxMutationLifecycle.DeadLettered, record.Lifecycle);
+    }
+
+    /// <summary>A record nothing will attempt again is still read back, because being seen is what giving up on it buys.</summary>
+    [Fact]
+    public async Task ConvergeAsync_AnAlreadyDeadLetteredMutation_IsReportedAndNotAttempted()
+    {
+        // Arrange
+        var context = new ConvergerContext();
+        await context.LeaveOutstandingAsync(
+            RelocationRequest(),
+            record => record with { Stage = MailboxMutationStage.Abandoned });
+
+        // Act
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.True(report.ChangedNothing);
+        Assert.Contains(
+            report.Outstanding,
+            group => group.Lifecycle == MailboxMutationLifecycle.DeadLettered
+                && group.Mutation == MailboxMutation.Relocate
+                && group.Count == 1);
+        await context.WriteSessionFactory.DidNotReceive().OpenForWritingAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<MailFolderResolution>(),
+            Arg.Any<MailTransportSecurityPolicy>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Most passes have nothing to do, and one that does nothing must not cost a mail server anything.</summary>
+    [Fact]
+    public async Task ConvergeAsync_AnAccountWithNothingOutstanding_TouchesNoMailServer()
+    {
+        // Arrange
+        var context = new ConvergerContext();
+
+        // Act
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.True(report.ChangedNothing);
+        Assert.Empty(report.Outstanding);
+        Assert.Equal(0, report.DeferredCount);
+        await context.WriteSessionFactory.DidNotReceive().OpenForWritingAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<MailFolderResolution>(),
+            Arg.Any<MailTransportSecurityPolicy>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>A backlog is drained over runs rather than turning one run into an unbounded sequence of round trips.</summary>
+    [Fact]
+    public async Task ConvergeAsync_MoreOutstandingThanOnePassTakes_ConvergesTheOldestAndLeavesTheRest()
+    {
+        // Arrange
+        var context = new ConvergerContext(maxMutationsPerPass: 2);
+
+        // Recorded one at a time, because the store stamps each record as it is written and the pass takes the oldest
+        // first; writing them together would leave which two it takes to whichever call happened to run first.
+        foreach (var uid in Enumerable.Range(41, 3).Select(offset => (uint)offset))
+        {
+            await context.LeaveOutstandingAsync(DeleteRequest(uid), record => record);
+        }
+
+        // Act
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, report.CompletedCount);
+        Assert.Contains(
+            report.Outstanding,
+            group => group.Lifecycle == MailboxMutationLifecycle.Pending && group.Count == 1);
+    }
+
+    /// <summary>The counts and the age are what an operator reads, so they have to name the kind as well as the lifecycle.</summary>
+    [Fact]
+    public async Task ConvergeAsync_OutstandingMutations_AreCountedByKindAndLifecycle()
+    {
+        // Arrange
+        var context = new ConvergerContext();
+        var recordedAt = context.Clock.GetUtcNow();
+        await context.LeaveOutstandingAsync(
+            CopyRequest(),
+            record => record with { Stage = MailboxMutationStage.PlacementIssued, RecordedAt = recordedAt });
+        await context.LeaveOutstandingAsync(
+            RelocationRequest(),
+            record => record with { Stage = MailboxMutationStage.Abandoned, RecordedAt = recordedAt });
+
+        // Act
+        var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
+
+        // Assert
+        var outstanding = report.Outstanding
+            .Select(group => (
+                Mutation: group.Mutation.Name,
+                Lifecycle: group.Lifecycle.Name,
+                group.Count,
+                group.OldestRecordedAt))
+            .OrderBy(group => group.Mutation, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(ExpectedOutstandingCounts(recordedAt), outstanding);
+    }
+
+    private static (string Mutation, string Lifecycle, int Count, DateTimeOffset OldestRecordedAt)[]
+        ExpectedOutstandingCounts(DateTimeOffset recordedAt) =>
+        [
+            ("copy", "converging", 1, recordedAt),
+            ("relocate", "dead-lettered", 1, recordedAt),
+        ];
+
+    private static EmailOccurrenceId Occurrence(uint uid) => EmailOccurrenceId.Create(
+        Account,
+        InboxFolder.Id,
+        ImapUidValidity.Create(7U),
+        ImapUid.Create(uid));
+
+    private static MailboxMutationRequest RelocationRequest() => MailboxMutationRequest.Relocate(
+        StoredEmailId.Create(Guid.CreateVersion7()),
+        Occurrence(42U),
+        MailboxMutationRequester.Rule("file-newsletters", 3),
+        ArchivePath);
+
+    private static MailboxMutationRequest CopyRequest() => MailboxMutationRequest.Copy(
+        StoredEmailId.Create(Guid.CreateVersion7()),
+        Occurrence(42U),
+        MailboxMutationRequester.Rule("keep-a-copy", 4),
+        ArchivePath);
+
+    private static MailboxMutationRequest DeleteRequest(uint uid) => MailboxMutationRequest.Delete(
+        StoredEmailId.Create(Guid.CreateVersion7()),
+        Occurrence(uid),
+        MailboxMutationRequester.Rule("drop-notifications", 5));
+
+    /// <summary>Assembles the converger over the same in-memory record store the performer's own tests use.</summary>
+    /// <remarks>
+    /// The performer is the real one rather than a substitute, because what convergence delegates to it — the attempt
+    /// count, the settled answers, the stage a resumed sequence continues from — is exactly what these tests are about.
+    /// Only the mail server below it is substituted.
+    /// </remarks>
+    private sealed class ConvergerContext
+    {
+        internal ConvergerContext(
+            int maxMutationsPerPass = 50,
+            TimeSpan? unknownOutcomeGrace = null,
+            int maximumAttempts = 5)
+        {
+            var persistenceSession = Substitute.For<IPersistenceSession>();
+            persistenceSession.CommitAsync(Arg.Any<CancellationToken>()).Returns(PersistenceCommitResult.Committed);
+            var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+            sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(persistenceSession);
+            var commitPolicy = new OptimisticConcurrencyRetryPolicy(
+                sessionFactory,
+                new PersistenceConcurrencyOptions { MaximumCommitAttempts = 1 },
+                TimeProvider.System);
+
+            this.WriteSession = Substitute.For<IMailboxWriteSession>();
+            this.WriteSession.RelocateAsync(
+                    Arg.Any<EmailOccurrenceId>(),
+                    Arg.Any<RemoteFolderPath>(),
+                    Arg.Any<IMailboxMutationJournal>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(RemoteEmailPlacement.NotReported());
+            this.WriteSession.CopyAsync(
+                    Arg.Any<EmailOccurrenceId>(),
+                    Arg.Any<RemoteFolderPath>(),
+                    Arg.Any<IMailboxMutationJournal>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(RemoteEmailPlacement.NotReported());
+
+            this.WriteSessionFactory = Substitute.For<IMailboxWriteSessionFactory>();
+            this.WriteSessionFactory.OpenForWritingAsync(
+                    Arg.Any<MailAccountId>(),
+                    Arg.Any<MailFolderResolution>(),
+                    Arg.Any<MailTransportSecurityPolicy>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(this.WriteSession);
+
+            this.Performer = new MailboxMutationPerformer(
+                this.Store,
+                this.WriteSessionFactory,
+                commitPolicy,
+                new MailboxMutationOptions { MaximumAttempts = maximumAttempts });
+
+            var transportSecurityPolicyReader = Substitute.For<IMailTransportSecurityPolicyReader>();
+            transportSecurityPolicyReader.GetPolicy(Account).Returns(TransportPolicy);
+
+            this.Converger = new MailboxMutationConverger(
+                this.Store,
+                this.Performer,
+                transportSecurityPolicyReader,
+                commitPolicy,
+                new MailboxConvergenceOptions
+                {
+                    MaxMutationsPerPass = maxMutationsPerPass,
+                    UnknownOutcomeGrace = unknownOutcomeGrace ?? TimeSpan.FromHours(6),
+                },
+                this.Clock);
+        }
+
+        internal InMemoryMailboxMutationRecordStore Store { get; } = new();
+
+        internal FakeTimeProvider Clock { get; } = new(new DateTimeOffset(2026, 8, 7, 12, 0, 0, TimeSpan.Zero));
+
+        internal IMailboxWriteSession WriteSession { get; }
+
+        internal IMailboxWriteSessionFactory WriteSessionFactory { get; }
+
+        internal MailboxMutationPerformer Performer { get; }
+
+        internal MailboxMutationConverger Converger { get; }
+
+        /// <summary>Writes a record down and leaves it in the state a stopped process would have.</summary>
+        internal async Task<MailboxMutationRequest> LeaveOutstandingAsync(
+            MailboxMutationRequest request,
+            Func<MailboxMutationRecord, MailboxMutationRecord> stoppedAt)
+        {
+            await this.Store.OpenAsync(
+                Substitute.For<IPersistenceSession>(),
+                request,
+                CancellationToken.None);
+            this.Store.Arrange(request, stoppedAt);
+
+            return request;
+        }
+
+        internal void FailRelocationWith(Exception failure) =>
+            this.WriteSession.RelocateAsync(
+                    Arg.Any<EmailOccurrenceId>(),
+                    Arg.Any<RemoteFolderPath>(),
+                    Arg.Any<IMailboxMutationJournal>(),
+                    Arg.Any<CancellationToken>())
+                .ThrowsAsync(failure);
+    }
+}

--- a/tests/Application.UnitTests/Mail/Mutations/Convergence/MailboxMutationConvergerTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Convergence/MailboxMutationConvergerTests.cs
@@ -132,20 +132,34 @@ public sealed class MailboxMutationConvergerTests
     }
 
     /// <summary>
-    /// A destination folder somebody removed is an answer the server has already given, so the change stops rather than
-    /// being attempted once per run until its bound is spent.
+    /// A refusal the server has already given is an answer rather than a bad moment, so the change stops at once
+    /// instead of being attempted once per run until its bound is spent — and the pass counts it as given up on rather
+    /// than as failed, because counting it as failed would promise an attempt nobody will make and would back the
+    /// account off from a server that is working.
     /// </summary>
-    [Fact]
-    public async Task ConvergeAsync_WhenTheDestinationFolderIsGone_GivesTheMutationUpVisibly()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ConvergeAsync_WhenTheServerRefusesTheChangeOutright_GivesItUpWithoutFailingThePass(
+        bool isUnsupported)
     {
         // Arrange
         var context = new ConvergerContext();
         var request = await context.LeaveOutstandingAsync(RelocationRequest(), record => record);
-        context.FailRelocationWith(new MailboxDestinationFolderMissingException(
-            Account,
-            InboxFolder.Alias,
-            MailboxMutation.Relocate,
-            new InvalidOperationException("The folder could not be found.")));
+        var expectedFailure = isUnsupported
+            ? MailFathomErrorCode.MailboxMutationUnsupported
+            : MailFathomErrorCode.MailboxMutationDestinationMissing;
+        context.FailRelocationWith(isUnsupported
+            ? new MailboxMutationUnsupportedException(
+                Account,
+                InboxFolder.Alias,
+                MailboxMutation.Relocate,
+                "UIDPLUS extension (RFC 4315)")
+            : new MailboxDestinationFolderMissingException(
+                Account,
+                InboxFolder.Alias,
+                MailboxMutation.Relocate,
+                new InvalidOperationException("The folder could not be found.")));
 
         // Act
         var report = await context.Converger.ConvergeAsync(Account, CancellationToken.None);
@@ -154,7 +168,9 @@ public sealed class MailboxMutationConvergerTests
         var record = context.Store.RecordOf(request);
         Assert.Equal(MailboxMutationStage.Abandoned, record.Stage);
         Assert.Equal(1, record.AttemptCount);
-        Assert.Equal(MailFathomErrorCode.MailboxMutationDestinationMissing, record.LastFailure);
+        Assert.Equal(expectedFailure, record.LastFailure);
+        Assert.Equal(1, report.DeadLetteredCount);
+        Assert.Equal(0, report.FailedCount);
         Assert.Contains(
             report.Outstanding,
             group => group.Lifecycle == MailboxMutationLifecycle.DeadLettered && group.Count == 1);

--- a/tests/Application.UnitTests/Mail/Mutations/MailboxMutationPerformerTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/MailboxMutationPerformerTests.cs
@@ -277,6 +277,33 @@ public sealed class MailboxMutationPerformerTests
         Assert.Equal(MailFathomErrorCode.MailboxMutationUnsupported, record.LastFailure);
     }
 
+    /// <summary>
+    /// A destination folder the server does not have is an answer rather than a bad moment, so the change is given up
+    /// on at once instead of spending a login per attempt to be told the same thing five times.
+    /// </summary>
+    [Fact]
+    public async Task PerformAsync_WhenTheDestinationFolderIsMissing_AbandonsOnTheFirstAttempt()
+    {
+        // Arrange
+        var context = new PerformerContext(maximumAttempts: 5);
+        var request = RelocationRequest();
+        context.FailRelocationWith(new MailboxDestinationFolderMissingException(
+            Account,
+            InboxFolder.Alias,
+            MailboxMutation.Relocate,
+            new InvalidOperationException("The folder could not be found.")));
+
+        // Act
+        await Assert.ThrowsAsync<MailboxDestinationFolderMissingException>(
+            () => context.Performer.PerformAsync(request, InboxFolder, TransportPolicy, CancellationToken.None));
+
+        // Assert
+        var record = context.Store.RecordOf(request);
+        Assert.Equal(MailboxMutationStage.Abandoned, record.Stage);
+        Assert.Equal(1, record.AttemptCount);
+        Assert.Equal(MailFathomErrorCode.MailboxMutationDestinationMissing, record.LastFailure);
+    }
+
     /// <summary>A failure MailFathom did not raise itself still has to leave a code on the record an operator can read.</summary>
     [Fact]
     public async Task PerformAsync_WhenTheAttemptFailsUnexpectedly_RecordsTheUnclassifiedCode()

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationRecordStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationRecordStore.cs
@@ -3,9 +3,11 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
 
 namespace MailFathom.Application.UnitTests.TestDoubles;
@@ -20,6 +22,7 @@ internal sealed class InMemoryMailboxMutationRecordStore : IMailboxMutationRecor
 {
     private readonly Dictionary<MailboxMutationRecordId, MailboxMutationRecord> recordsById = [];
     private readonly Dictionary<string, MailboxMutationRecordId> identities = [];
+    private readonly Dictionary<MailFolderResolutionId, MailFolderResolution> folderBindings = [];
     private DateTimeOffset now = new(2026, 8, 7, 12, 0, 0, TimeSpan.Zero);
 
     /// <summary>Gets how many requests were written down, which is one per idempotency identity however often it was asked.</summary>
@@ -136,24 +139,50 @@ internal sealed class InMemoryMailboxMutationRecordStore : IMailboxMutationRecor
     }
 
     /// <inheritdoc />
-    public Task<IReadOnlyList<MailboxMutationRecord>> ReadOutstandingAsync(
+    public Task<IReadOnlyList<OutstandingMailboxMutation>> ReadOutstandingAsync(
         MailAccountId accountId,
         int limit,
         CancellationToken cancellationToken)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
 
-        IReadOnlyList<MailboxMutationRecord> outstanding =
+        IReadOnlyList<OutstandingMailboxMutation> outstanding =
         [
-            .. this.recordsById.Values
-                .Where(record => record.Request.Occurrence.AccountId == accountId &&
-                    record.Stage != MailboxMutationStage.Completed)
+            .. this.OutstandingOf(accountId)
                 .OrderBy(record => record.RecordedAt)
-                .Take(limit),
+                .Take(limit)
+                .Select(record => new OutstandingMailboxMutation(record, this.BindingOf(record))),
         ];
 
         return Task.FromResult(outstanding);
     }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<MailboxMutationLifecycleCount>> ReadLifecycleCountsAsync(
+        MailAccountId accountId,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<MailboxMutationLifecycleCount> counts =
+        [
+            .. this.OutstandingOf(accountId)
+                .GroupBy(record => new { record.Request.Mutation, record.Lifecycle })
+                .Select(group => new MailboxMutationLifecycleCount(
+                    group.Key.Mutation,
+                    group.Key.Lifecycle,
+                    group.Count(),
+                    group.Min(record => record.RecordedAt))),
+        ];
+
+        return Task.FromResult(counts);
+    }
+
+    /// <summary>States the remote folder one alias binding names, for the records read back through it.</summary>
+    /// <remarks>
+    /// The real store joins the binding row; there is none here, so a test that cares which folder a resumed mutation
+    /// selects says so. Everything else takes the alias itself as the path, which is the shape most fixtures use.
+    /// </remarks>
+    internal void BindFolder(MailFolderResolution resolution) =>
+        this.folderBindings[resolution.Id] = resolution;
 
     /// <summary>Reads back the one record written for a request, as a test asserts against it.</summary>
     internal MailboxMutationRecord RecordOf(MailboxMutationRequest request) =>
@@ -174,6 +203,22 @@ internal sealed class InMemoryMailboxMutationRecordStore : IMailboxMutationRecor
         request.Requester.Origin,
         request.Requester.Identity,
         request.Mutation.Name);
+
+    private IEnumerable<MailboxMutationRecord> OutstandingOf(MailAccountId accountId) =>
+        this.recordsById.Values.Where(record => record.Request.Occurrence.AccountId == accountId &&
+            record.Stage != MailboxMutationStage.Completed);
+
+    private MailFolderResolution BindingOf(MailboxMutationRecord record)
+    {
+        var folderResolutionId = record.Request.Occurrence.FolderResolutionId;
+
+        return this.folderBindings.TryGetValue(folderResolutionId, out var binding)
+            ? binding
+            : new MailFolderResolution(
+                folderResolutionId.Alias,
+                folderResolutionId.Generation,
+                RemoteFolderPath.Create(folderResolutionId.Alias.Value, hierarchyDelimiter: null));
+    }
 
     private MailboxMutationRecord Require(MailboxMutationRecordId recordId) =>
         this.recordsById.TryGetValue(recordId, out var record)

--- a/tests/Domain.UnitTests/Mutations/MailboxMutationLifecycleTests.cs
+++ b/tests/Domain.UnitTests/Mutations/MailboxMutationLifecycleTests.cs
@@ -1,0 +1,135 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json;
+using MailFathom.Domain.Mutations;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Mutations;
+
+public sealed class MailboxMutationLifecycleTests
+{
+    /// <summary>Every stage a record can carry has to have a lifecycle, or a count would silently omit those records.</summary>
+    [Fact]
+    public void Of_EveryDeclaredStage_NamesALifecycle()
+    {
+        // Arrange
+        var declaredStages = Enum.GetValues<MailboxMutationStage>();
+
+        // Act
+        var lifecycles = declaredStages.Select(MailboxMutationLifecycle.Of).ToArray();
+
+        // Assert
+        Assert.All(lifecycles, lifecycle => Assert.True(lifecycle.IsSpecified));
+        Assert.All(lifecycles, lifecycle => Assert.Contains(lifecycle, MailboxMutationLifecycle.All));
+    }
+
+    /// <summary>The mapping is the whole contract, and the three converging stages collapsing into one is the point of it.</summary>
+    [Theory]
+    [InlineData(MailboxMutationStage.Recorded, "pending")]
+    [InlineData(MailboxMutationStage.PlacementIssued, "converging")]
+    [InlineData(MailboxMutationStage.PlacementConfirmed, "converging")]
+    [InlineData(MailboxMutationStage.SourceFlaggedDeleted, "converging")]
+    [InlineData(MailboxMutationStage.Completed, "completed")]
+    [InlineData(MailboxMutationStage.Abandoned, "dead-lettered")]
+    public void Of_AStage_NamesTheLifecycleAnOperatorReads(MailboxMutationStage stage, string expectedName)
+    {
+        // Act
+        var lifecycle = MailboxMutationLifecycle.Of(stage);
+
+        // Assert
+        Assert.Equal(expectedName, lifecycle.Name);
+    }
+
+    /// <summary>A number no member carries is a stage this build does not have, and reporting it as one would be a lie.</summary>
+    [Fact]
+    public void Of_AStageThisBuildDoesNotDeclare_IsRefused()
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentOutOfRangeException>(
+            () => MailboxMutationLifecycle.Of((MailboxMutationStage)97));
+
+        // Assert
+        Assert.Equal("stage", refusal.ParamName);
+    }
+
+    /// <summary>The name is the published identity, so a name that round-trips is the whole of what the type guarantees.</summary>
+    [Fact]
+    public void TryParseName_EveryDeclaredName_ReturnsTheLifecycleThatCarriesIt()
+    {
+        // Act
+        var reparsed = MailboxMutationLifecycle.All
+            .Select(lifecycle => MailboxMutationLifecycle.TryParseName(lifecycle.Name, out var parsed)
+                ? parsed
+                : default)
+            .ToArray();
+
+        // Assert
+        Assert.Equal(MailboxMutationLifecycle.All, reparsed);
+    }
+
+    /// <summary>A name that was never a lifecycle must be recognized as unknown rather than reconstructed.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("stuck")]
+    [InlineData("DeadLettered")]
+    public void TryParseName_AnUnknownName_IsRefused(string? name)
+    {
+        // Act
+        var parsed = MailboxMutationLifecycle.TryParseName(name, out var lifecycle);
+
+        // Assert
+        Assert.False(parsed);
+        Assert.False(lifecycle.IsSpecified);
+    }
+
+    /// <summary>The struct default is reachable and names nothing, which every member has to say rather than pretend otherwise.</summary>
+    [Fact]
+    public void Name_TheStructDefault_IsRefused()
+    {
+        // Arrange
+        var unspecified = default(MailboxMutationLifecycle);
+
+        // Act
+        var refusal = Assert.Throws<InvalidOperationException>(() => unspecified.Name);
+
+        // Assert
+        Assert.False(unspecified.IsSpecified);
+        Assert.Equal("(unspecified)", unspecified.ToString());
+        Assert.Contains("names no mutation lifecycle", refusal.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>The serialized form is the name for the same reason the value object exists.</summary>
+    [Fact]
+    public void Serialization_ALifecycle_RoundTripsThroughItsName()
+    {
+        // Act
+        var json = JsonSerializer.Serialize(MailboxMutationLifecycle.DeadLettered);
+        var restored = JsonSerializer.Deserialize<MailboxMutationLifecycle>(json);
+
+        // Assert
+        Assert.Equal("\"dead-lettered\"", json);
+        Assert.Equal(MailboxMutationLifecycle.DeadLettered, restored);
+    }
+
+    /// <summary>A document naming a lifecycle this build does not have is refused rather than read as the nearest one.</summary>
+    [Theory]
+    [InlineData("\"stuck\"")]
+    [InlineData("7")]
+    public void Deserialization_AValueThatNamesNoLifecycle_IsRefused(string json)
+    {
+        // Act, Assert
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MailboxMutationLifecycle>(json));
+    }
+
+    /// <summary>An unspecified value cannot be written, because nothing would name it on the way back.</summary>
+    [Fact]
+    public void Serialization_TheStructDefault_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<JsonException>(() => JsonSerializer.Serialize(default(MailboxMutationLifecycle)));
+    }
+}

--- a/tests/Domain.UnitTests/Mutations/MailboxMutationRecordTests.cs
+++ b/tests/Domain.UnitTests/Mutations/MailboxMutationRecordTests.cs
@@ -390,6 +390,104 @@ public sealed class MailboxMutationRecordTests
         Assert.True(setSeen.IsReconciled);
     }
 
+    /// <summary>The lifecycle is what somebody watching a deployment reads, and the three converging stages are one answer to them.</summary>
+    [Theory]
+    [InlineData(MailboxMutationStage.Recorded)]
+    [InlineData(MailboxMutationStage.PlacementIssued)]
+    [InlineData(MailboxMutationStage.PlacementConfirmed)]
+    [InlineData(MailboxMutationStage.SourceFlaggedDeleted)]
+    [InlineData(MailboxMutationStage.Completed)]
+    [InlineData(MailboxMutationStage.Abandoned)]
+    public void Lifecycle_AnyStage_ReadsTheStageTheRecordCarries(MailboxMutationStage stage)
+    {
+        // Arrange
+        var record = CompletedRelocation() with { Stage = stage };
+
+        // Act
+        var lifecycle = record.Lifecycle;
+
+        // Assert
+        Assert.Equal(MailboxMutationLifecycle.Of(stage), lifecycle);
+    }
+
+    /// <summary>The one stage a retry may not act on is the one convergence has to recognize before it does anything.</summary>
+    [Theory]
+    [InlineData(MailboxMutationStage.Recorded, false)]
+    [InlineData(MailboxMutationStage.PlacementIssued, true)]
+    [InlineData(MailboxMutationStage.PlacementConfirmed, false)]
+    [InlineData(MailboxMutationStage.SourceFlaggedDeleted, false)]
+    [InlineData(MailboxMutationStage.Completed, false)]
+    [InlineData(MailboxMutationStage.Abandoned, false)]
+    public void HasUnknownOutcome_AnyStage_IsTrueOnlyWhileThePlacementIsUnacknowledged(
+        MailboxMutationStage stage,
+        bool expected)
+    {
+        // Arrange
+        var record = CompletedRelocation() with { Stage = stage };
+
+        // Act
+        var hasUnknownOutcome = record.HasUnknownOutcome;
+
+        // Assert
+        Assert.Equal(expected, hasUnknownOutcome);
+    }
+
+    /// <summary>
+    /// A relocation carried by <c>MOVE</c> removes the source itself, so the source having gone is the server's own
+    /// statement that the command ran — which is what settles an outcome nothing may ask the server about twice.
+    /// </summary>
+    [Fact]
+    public void IsUnknownPlacementSettledBySourceRemoval_ANativeRelocationWhoseSourceHasGone_IsSettled()
+    {
+        // Arrange
+        var unacknowledged = UnacknowledgedNativeRelocation();
+
+        // Act
+        var settled = unacknowledged with { SourceRemovalObservedAt = RecordedAt.AddMinutes(5) };
+
+        // Assert
+        Assert.False(unacknowledged.IsUnknownPlacementSettledBySourceRemoval);
+        Assert.True(settled.IsUnknownPlacementSettledBySourceRemoval);
+    }
+
+    /// <summary>
+    /// A copy and a fallback relocation both leave the source where it was, so nothing about it distinguishes a command
+    /// that landed from one that never arrived. Settling either from a disappearance would be a guess.
+    /// </summary>
+    [Fact]
+    public void IsUnknownPlacementSettledBySourceRemoval_ASequenceThatLeavesTheSource_IsNeverSettledByIt()
+    {
+        // Arrange
+        var observedAt = RecordedAt.AddMinutes(5);
+        var fallbackRelocation = UnacknowledgedNativeRelocation() with
+        {
+            RequiresSourceRemoval = true,
+            SourceRemovalObservedAt = observedAt,
+        };
+        var copy = UnacknowledgedNativeRelocation() with
+        {
+            Request = MailboxMutationRequest.Copy(LocalEmail, SourceOccurrence(), Requester, Archive),
+            SourceRemovalObservedAt = observedAt,
+        };
+
+        // Act
+        var settledStates = new[]
+        {
+            fallbackRelocation.IsUnknownPlacementSettledBySourceRemoval,
+            copy.IsUnknownPlacementSettledBySourceRemoval,
+        };
+
+        // Assert
+        Assert.Equal([false, false], settledStates);
+    }
+
+    private static MailboxMutationRecord UnacknowledgedNativeRelocation() => CompletedRelocation() with
+    {
+        Stage = MailboxMutationStage.PlacementIssued,
+        RequiresSourceRemoval = false,
+        Placement = RemoteEmailPlacement.NotReported(),
+    };
+
     private static MailFolderResolutionId InboxBinding =>
         new(MailFolderAlias.Create(Inbox.Value), MailFolderResolutionGeneration.First);
 

--- a/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Application.Folders;
+using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Sessions;
@@ -278,6 +279,87 @@ public sealed class AccountSynchronizationSupervisorTests
             message => message.Contains("Account primary has failed 1 runs in a row", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// A change the previous process left half-made is finished by the first run after a restart, with nobody asking
+    /// for it. The account's own loop is what schedules that, which is why no separate worker exists for it.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_EveryRun_ConvergesTheAccountsOutstandingMutationsBeforeItsFolders()
+    {
+        // Arrange
+        var convergedBeforeAnyFolderWasOpened = new TaskCompletionSource<bool>();
+        var recordStore = Substitute.For<IMailboxMutationRecordStore>();
+        var folderWasOpened = 0;
+        recordStore
+            .ReadOutstandingAsync(Arg.Any<MailAccountId>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                convergedBeforeAnyFolderWasOpened.TrySetResult(Volatile.Read(ref folderWasOpened) == 0);
+
+                return Task.FromResult<IReadOnlyList<OutstandingMailboxMutation>>([]);
+            });
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        sessionFactory
+            .OpenReadOnlyAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailFolderResolution>(),
+                Arg.Any<MailTransportSecurityPolicy>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Volatile.Write(ref folderWasOpened, 1);
+
+                return Task.FromException<IMailboxSession>(new InvalidOperationException("connect failed"));
+            });
+        using var harness = CreateHarness(
+            SynchronizationTestHost.CreateSingleAccountOptions(enabled: true, "INBOX"),
+            sessionFactory,
+            mutationRecordStore: recordStore);
+
+        // Act
+        await harness.SuperviseUntilAsync(convergedBeforeAnyFolderWasOpened.Task);
+
+        // Assert
+        Assert.True(await convergedBeforeAnyFolderWasOpened.Task);
+    }
+
+    /// <summary>
+    /// A convergence pass that could not run defers the account exactly as a failed folder does, so a change waiting on
+    /// an unreachable server is approached less often instead of once per interval forever.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_ConvergencePassFails_DefersTheAccountsNextRun()
+    {
+        // Arrange
+        var passFailed = new TaskCompletionSource();
+        var recordStore = Substitute.For<IMailboxMutationRecordStore>();
+        recordStore
+            .ReadOutstandingAsync(Arg.Any<MailAccountId>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<OutstandingMailboxMutation>>>(_ =>
+            {
+                passFailed.TrySetResult();
+
+                throw new InvalidOperationException("The outstanding mutations could not be read.");
+            });
+        using var harness = CreateHarness(
+            SynchronizationTestHost.CreateSingleAccountOptions(enabled: true, "INBOX"),
+            Substitute.For<IMailboxSessionFactory>(),
+            mutationRecordStore: recordStore);
+
+        // Act
+        await harness.SuperviseUntilAsync(passFailed.Task);
+
+        // Assert
+        Assert.Contains(
+            harness.Logger.Messages,
+            message => message.Contains(
+                "Converging the outstanding mailbox mutations of account primary ended unexpectedly",
+                StringComparison.Ordinal));
+        Assert.Contains(
+            harness.Logger.Messages,
+            message => message.Contains("runs in a row", StringComparison.Ordinal));
+    }
+
     /// <summary>An alias nobody advertises is fixed by an edit, so waiting longer for it would only slow the folders that work.</summary>
     [Fact]
     public async Task RunAsync_OnlyAnAliasFailedToResolve_DoesNotDeferTheAccount()
@@ -532,6 +614,7 @@ public sealed class AccountSynchronizationSupervisorTests
         IMailboxSessionFactory sessionFactory,
         FakeMailboxNotificationSessionFactory? notificationSessionFactory = null,
         IRemoteFolderCatalog? remoteFolderCatalog = null,
+        IMailboxMutationRecordStore? mutationRecordStore = null,
         params string[] unadvertisedAliases)
     {
         var clock = new FakeTimeProvider();
@@ -543,6 +626,7 @@ public sealed class AccountSynchronizationSupervisorTests
             clock,
             notificationSessionFactory,
             remoteFolderCatalog,
+            mutationRecordStore,
             unadvertisedAliases);
 
         return new SupervisorHarness(

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
@@ -22,6 +23,7 @@ using MailFathom.Domain.Transport;
 using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Mail;
 using MailFathom.Infrastructure.Mail;
+using MailFathom.Infrastructure.Observability;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
@@ -71,6 +73,7 @@ internal static class SynchronizationTestHost
     /// <param name="timeProvider">The clock the scoped graph shares with the code under test.</param>
     /// <param name="notificationSessionFactory">Stands in for the server's push mechanism; a server that advertises none is the default.</param>
     /// <param name="remoteFolderCatalog">Replaces the catalog that advertises exactly the configured folders.</param>
+    /// <param name="mutationRecordStore">Replaces the record store that reports nothing outstanding to converge.</param>
     /// <param name="unadvertisedAliases">Aliases the modelled server does not advertise.</param>
     /// <returns>A provider whose scopes resolve a synchronizer over substituted infrastructure.</returns>
     internal static ServiceProvider BuildServiceProvider(
@@ -80,6 +83,7 @@ internal static class SynchronizationTestHost
         TimeProvider timeProvider,
         IMailboxNotificationSessionFactory? notificationSessionFactory = null,
         IRemoteFolderCatalog? remoteFolderCatalog = null,
+        IMailboxMutationRecordStore? mutationRecordStore = null,
         params string[] unadvertisedAliases)
     {
         var services = new ServiceCollection();
@@ -108,6 +112,18 @@ internal static class SynchronizationTestHost
         services.AddScoped<OptimisticConcurrencyRetryPolicy>();
         services.AddScoped<MailboxSynchronizer>();
         services.AddScoped<MailboxReconciler>();
+
+        // Every account run begins by converging what the account has asked a mail server for and not seen finished,
+        // so a supervisor resolves these from its scope exactly as it resolves the synchronizer. The record store
+        // answers that there is nothing outstanding, which is the state a test that is about folders wants.
+        services.AddSingleton(mutationRecordStore ?? CreateRecordStoreWithNothingOutstanding());
+        services.AddSingleton(new MailboxMutationOptions());
+        services.AddSingleton(new MailboxConvergenceOptions());
+        services.AddSingleton(Substitute.For<IMailboxWriteSessionFactory>());
+        services.AddSingleton<MailboxConvergenceTelemetry>();
+        services.AddScoped<IMailboxMutationPerformer, MailboxMutationPerformer>();
+        services.AddScoped<MailboxMutationConverger>();
+        services.AddLogging();
 
         // Each run hands its own snapshot to the scopes it opens, and every per-account reader answers from that
         // snapshot rather than from the one the container was composed with. The host wires it exactly this way, which
@@ -231,6 +247,20 @@ internal static class SynchronizationTestHost
     /// These tests are about how a supervisor schedules and isolates folder work units. An unconfigured substitute would
     /// answer every read with a null task the run then faults on, which surfaces as a supervision that never signals.
     /// </remarks>
+    /// <summary>Answers a convergence pass that the account has asked for nothing that has not finished.</summary>
+    private static IMailboxMutationRecordStore CreateRecordStoreWithNothingOutstanding()
+    {
+        var recordStore = Substitute.For<IMailboxMutationRecordStore>();
+        recordStore
+            .ReadOutstandingAsync(Arg.Any<MailAccountId>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<OutstandingMailboxMutation>>([]));
+        recordStore
+            .ReadLifecycleCountsAsync(Arg.Any<MailAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<MailboxMutationLifecycleCount>>([]));
+
+        return recordStore;
+    }
+
     private static IMailboxMutationReconciliationStore CreateMutationStoreWithNothingRecorded()
     {
         var mutationStore = Substitute.For<IMailboxMutationReconciliationStore>();

--- a/tests/Infrastructure.UnitTests/Mail/MailKit/Writes/MailKitImapWriteSessionTests.cs
+++ b/tests/Infrastructure.UnitTests/Mail/MailKit/Writes/MailKitImapWriteSessionTests.cs
@@ -130,6 +130,45 @@ public sealed class MailKitImapWriteSessionTests
     }
 
     /// <summary>
+    /// A destination folder the server does not have arrives from MailKit as a plain exception carrying a remote path
+    /// and nothing about what was being attempted. Translating it is what lets the change be given up on at once, and
+    /// it is what keeps that path out of a message an operator reads.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task PlacingMutations_DestinationFolderTheServerDoesNotHave_AreRefusedBeforeAnythingIsIssued(bool isCopy)
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient { Capabilities = ImapCapabilities.Move | ImapCapabilities.UidPlus };
+        client.AbsentFolderPaths.Add(ArchivePath);
+        var openFolder = CreateWritableFolder();
+        var journal = new RecordingMailboxMutationJournal();
+        await using var harness = CreateHarness(resilience, client, openFolder);
+        await using var session = await harness.OpenSessionAsync();
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<MailboxDestinationFolderMissingException>(
+            () => isCopy
+                ? session.CopyAsync(CreateOccurrenceId(42U), Archive, journal, CancellationToken.None)
+                : session.RelocateAsync(CreateOccurrenceId(42U), Archive, journal, CancellationToken.None));
+
+        // Assert
+        Assert.Equal(MailFathomErrorCode.MailboxMutationDestinationMissing, refusal.ErrorCode);
+        Assert.DoesNotContain(ArchivePath, refusal.Message, StringComparison.Ordinal);
+        Assert.Equal(MailboxMutationStage.Recorded, journal.Stage);
+        await openFolder.DidNotReceive().CopyToAsync(
+            Arg.Any<IList<UniqueId>>(),
+            Arg.Any<IMailFolder>(),
+            Arg.Any<CancellationToken>());
+        await openFolder.DidNotReceive().MoveToAsync(
+            Arg.Any<IList<UniqueId>>(),
+            Arg.Any<IMailFolder>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
     /// Both halves of the placement come out of the <c>COPYUID</c> response, which is the only place the destination's
     /// UIDVALIDITY is available: the folder was resolved by path and never selected, so it reports zero. Reading it
     /// there would raise a failure while describing a relocation that had already moved the message — the worst

--- a/tests/Infrastructure.UnitTests/Observability/MailboxConvergenceTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/MailboxConvergenceTelemetryTests.cs
@@ -1,0 +1,221 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using MailFathom.Application.Mail.Mutations.Convergence;
+using MailFathom.Common.Observability;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Mutations;
+using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Observability;
+
+/// <summary>Covers the gauges an operator reads while a change is still unfinished.</summary>
+/// <remarks>
+/// One telemetry instance serves the whole class, because it is a singleton in the process it belongs to and its
+/// instruments are created on the application's one meter — an instance per test would leave a gauge per test observing
+/// the meter for the rest of the run. Each test therefore names an account of its own, which is what keeps the
+/// measurements it asserts on apart from the ones the other tests published.
+/// </remarks>
+public sealed class MailboxConvergenceTelemetryTests : IDisposable
+{
+    private const string OutstandingInstrumentName = "mailfathom.mailbox.mutations.outstanding";
+
+    private const string OldestAgeInstrumentName = "mailfathom.mailbox.mutations.oldest_outstanding_age";
+
+    private const string AccountTagName = "mailfathom.mail.account";
+
+    private static readonly DateTimeOffset RecordedAt = new(2026, 8, 7, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly RecordingLoggerProvider logs = new();
+    private readonly ILoggerFactory loggerFactory;
+    private readonly FakeTimeProvider clock = new(RecordedAt);
+    private readonly MailboxConvergenceTelemetry telemetry;
+
+    public MailboxConvergenceTelemetryTests()
+    {
+        this.loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(this.logs));
+        this.telemetry = new MailboxConvergenceTelemetry(
+            this.loggerFactory.CreateLogger<MailboxConvergenceTelemetry>(),
+            this.clock);
+    }
+
+    public void Dispose()
+    {
+        this.loggerFactory.Dispose();
+        this.logs.Dispose();
+    }
+
+    /// <summary>The gauge is what says a change is still waiting, broken down the way an operator asks about it.</summary>
+    [Fact]
+    public void Report_OutstandingMutations_PublishesACountPerMutationAndLifecycle()
+    {
+        // Arrange
+        var account = MailAccountId.Create("counts-by-kind");
+        using var collector = new GaugeCollector();
+
+        // Act
+        this.telemetry.Report(account, ReportWith(
+            new MailboxMutationLifecycleCount(
+                MailboxMutation.Relocate,
+                MailboxMutationLifecycle.DeadLettered,
+                Count: 2,
+                RecordedAt)));
+
+        // Assert
+        var published = Assert.Single(collector.Read(OutstandingInstrumentName, account));
+        Assert.Equal(2, published.Value);
+        Assert.Equal("relocate", published.Tags["mailfathom.mailbox.mutation"]);
+        Assert.Equal("dead-lettered", published.Tags["mailfathom.mailbox.mutation.lifecycle"]);
+    }
+
+    /// <summary>
+    /// The age is measured when the gauge is read rather than when the pass ran, so an account whose runs are an
+    /// interval apart reports an age that grows rather than one that steps.
+    /// </summary>
+    [Fact]
+    public void Report_ReadAfterTimePasses_MeasuresTheAgeAtTheMomentTheGaugeIsRead()
+    {
+        // Arrange
+        var account = MailAccountId.Create("age-at-read-time");
+        using var collector = new GaugeCollector();
+        this.telemetry.Report(account, ReportWith(
+            new MailboxMutationLifecycleCount(
+                MailboxMutation.Copy,
+                MailboxMutationLifecycle.Converging,
+                Count: 1,
+                RecordedAt)));
+
+        // Act
+        this.clock.Advance(TimeSpan.FromMinutes(30));
+        var ages = collector.Read(OldestAgeInstrumentName, account);
+
+        // Assert
+        Assert.Equal(TimeSpan.FromMinutes(30).TotalSeconds, Assert.Single(ages).Value);
+    }
+
+    /// <summary>
+    /// A lifecycle that emptied has to stop being reported. A gauge that kept its last non-zero value would say an
+    /// account is stuck long after somebody dealt with it, which is the opposite of what it exists for.
+    /// </summary>
+    [Fact]
+    public void Report_AnAccountThatHasNothingOutstandingAnyMore_StopsPublishingItsPreviousCounts()
+    {
+        // Arrange
+        var account = MailAccountId.Create("emptied");
+        using var collector = new GaugeCollector();
+        this.telemetry.Report(account, ReportWith(
+            new MailboxMutationLifecycleCount(
+                MailboxMutation.Delete,
+                MailboxMutationLifecycle.Pending,
+                Count: 3,
+                RecordedAt)));
+
+        // Act
+        this.telemetry.Report(account, new MailboxConvergenceReport(1, 0, 0, 0, []));
+
+        // Assert
+        Assert.Empty(collector.Read(OutstandingInstrumentName, account));
+    }
+
+    /// <summary>Most passes have nothing to do, and a line per account per interval is noise an operator learns to ignore.</summary>
+    [Fact]
+    public void Report_APassThatChangedNothing_WritesNoLogLine()
+    {
+        // Arrange
+        var account = MailAccountId.Create("quiet-pass");
+
+        // Act
+        this.telemetry.Report(account, new MailboxConvergenceReport(0, 0, 2, 0, []));
+
+        // Assert
+        Assert.Empty(this.RecordsFor(account));
+    }
+
+    /// <summary>What a pass moved is worth a line, and the dead-lettered count is the part somebody has to act on.</summary>
+    [Fact]
+    public void Report_APassThatGaveAChangeUp_RecordsWhatItMovedAtInformation()
+    {
+        // Arrange
+        var account = MailAccountId.Create("gave-one-up");
+
+        // Act
+        this.telemetry.Report(account, new MailboxConvergenceReport(1, 2, 3, 4, []));
+
+        // Assert
+        var record = Assert.Single(this.RecordsFor(account));
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.Equal(2, record.Properties["DeadLetteredCount"]);
+    }
+
+    private static MailboxConvergenceReport ReportWith(params MailboxMutationLifecycleCount[] outstanding) =>
+        new(0, 0, 0, 0, outstanding);
+
+    private IReadOnlyList<RecordingLoggerProvider.LogRecord> RecordsFor(MailAccountId accountId) =>
+        [
+            .. this.logs.Records.Where(record =>
+                record.Properties.TryGetValue("AccountId", out var loggedAccount)
+                && Equals(loggedAccount, accountId.Value)),
+        ];
+
+    /// <summary>Reads MailFathom's own meter on demand, which is the only way an observable gauge can be asserted on.</summary>
+    private sealed class GaugeCollector : IDisposable
+    {
+        private readonly MeterListener listener = new();
+        private readonly List<PublishedMeasurement> measurements = [];
+
+        internal GaugeCollector()
+        {
+            this.listener.InstrumentPublished = (instrument, activeListener) =>
+            {
+                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
+                {
+                    activeListener.EnableMeasurementEvents(instrument);
+                }
+            };
+            this.listener.SetMeasurementEventCallback<long>(this.Record);
+            this.listener.SetMeasurementEventCallback<double>(this.Record);
+            this.listener.Start();
+        }
+
+        public void Dispose() => this.listener.Dispose();
+
+        /// <summary>Collects every gauge once and returns what one instrument published for one account.</summary>
+        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName, MailAccountId accountId)
+        {
+            this.measurements.Clear();
+            this.listener.RecordObservableInstruments();
+
+            return
+            [
+                .. this.measurements.Where(measurement =>
+                    StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)
+                    && measurement.Tags.TryGetValue(AccountTagName, out var account)
+                    && Equals(account, accountId.Value)),
+            ];
+        }
+
+        private void Record<TMeasurement>(
+            Instrument instrument,
+            TMeasurement measurement,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags,
+            object? state)
+            where TMeasurement : struct =>
+            this.measurements.Add(new PublishedMeasurement(
+                instrument.Name,
+                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
+                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
+    }
+
+    /// <summary>One measurement a gauge published, with the dimensions it carried.</summary>
+    private sealed record PublishedMeasurement(
+        string InstrumentName,
+        double Value,
+        IReadOnlyDictionary<string, object?> Tags);
+}

--- a/tests/Infrastructure.UnitTests/TestDoubles/FakeImapClient.cs
+++ b/tests/Infrastructure.UnitTests/TestDoubles/FakeImapClient.cs
@@ -111,6 +111,10 @@ internal sealed class FakeImapClient
 
     internal List<string> RequestedFolderPaths { get; } = [];
 
+    /// <summary>Gets the paths this server answers for the way MailKit reports a folder that is not there.</summary>
+    /// <remarks>A folder somebody deleted between a change being decided on and being issued is an ordinary case, and this is how a test models it.</remarks>
+    internal HashSet<string> AbsentFolderPaths { get; } = new(StringComparer.Ordinal);
+
     internal SecureSocketOptions? ConnectSocketOptions { get; private set; }
 
     internal RemoteCertificateValidationCallback? ValidationCallbackWhenConnected { get; private set; }
@@ -235,6 +239,11 @@ internal sealed class FakeImapClient
                 var requestedPath = call.Arg<string>()!;
                 this.GetFolderAsyncCount++;
                 this.RequestedFolderPaths.Add(requestedPath);
+
+                if (this.AbsentFolderPaths.Contains(requestedPath))
+                {
+                    throw new FolderNotFoundException(requestedPath);
+                }
 
                 if (this.foldersByPath.TryGetValue(requestedPath, out var folderAtPath))
                 {

--- a/tests/IntegrationTests/Mailbox/OrchestratedMailbox.cs
+++ b/tests/IntegrationTests/Mailbox/OrchestratedMailbox.cs
@@ -252,6 +252,26 @@ internal sealed class OrchestratedMailbox(OrchestratedMailServerEndpoints endpoi
         return uidValidity;
     }
 
+    /// <summary>Removes one folder from the mailbox, so a test can model a destination somebody deleted.</summary>
+    /// <param name="folderName">The folder to remove; it must exist, because a test that removed nothing proves nothing.</param>
+    /// <param name="cancellationToken">Cancels the connection and the command.</param>
+    /// <returns>A task that completes once the server no longer holds the folder.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the mailbox holds no folder of that name.</exception>
+    internal async Task DeleteFolderAsync(string folderName, CancellationToken cancellationToken)
+    {
+        using var client = await this.ConnectAndAuthenticateAsync(cancellationToken);
+
+        var personalNamespace = await client.GetFolderAsync(client.PersonalNamespaces[0].Path, cancellationToken);
+        var existingFolders = await personalNamespace.GetSubfoldersAsync(subscribedOnly: false, cancellationToken);
+        var folderToRemove = existingFolders.FirstOrDefault(
+            folder => StringComparer.Ordinal.Equals(folder.Name, folderName))
+            ?? throw new InvalidOperationException(
+                $"The mail server holds no folder named '{folderName}', so nothing was removed.");
+
+        await folderToRemove.DeleteAsync(cancellationToken);
+        await client.DisconnectAsync(quit: true, cancellationToken);
+    }
+
     private static Task DelayPastTheNextSecondAsync(CancellationToken cancellationToken)
     {
         var millisecondsIntoTheCurrentSecond = TimeProvider.System.GetUtcNow().Millisecond;

--- a/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
+++ b/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
@@ -96,6 +97,7 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
         // to resolve here for the same reason every bound setting above is supplied: the suite does not start the host.
         builder.Services.AddSingleton(new MailboxWriteSessionOptions());
         builder.Services.AddSingleton(new MailboxMutationOptions());
+        builder.Services.AddSingleton(new MailboxConvergenceOptions());
         builder.Services.AddSingleton(new PersistenceConcurrencyOptions { MaximumCommitAttempts = 3 });
         // The bound a composition root reads from the Embeddings section. The backlog itself is registered by
         // AddInfrastructure, because every committed message is offered into it whether or not this deployment embeds.

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxConvergenceTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxConvergenceTests.cs
@@ -1,0 +1,350 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Convergence;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Resilience;
+using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Infrastructure.Mail.MailKit.Writes;
+using MailFathom.Infrastructure.Observability;
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.Infrastructure.Resilience;
+using MailFathom.IntegrationTests.Mailbox;
+using MailFathom.IntegrationTests.Orchestration;
+using MailFathom.IntegrationTests.Persistence;
+using MailKit.Net.Imap;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Synchronization;
+
+/// <summary>Proves that a change nobody finished converges by itself, against a real mail server and a real database.</summary>
+/// <remarks>
+/// <para>
+/// Two tests, because there are two claims no substitute can establish. The first is that a mutation a stopped process
+/// left in a non-final state completes on the next start with no operator action, which needs a server that really
+/// copied a message, a database that really kept the stage across the stop, and the production convergence pass reading
+/// both. The second is that a change whose destination folder was removed stops instead of being attempted again —
+/// which needs a server that really answers that the folder is not there, since the whole point of the translation is
+/// what a real mail library raises.
+/// </para>
+/// <para>
+/// Everything else about convergence — the grace period, the counts, which stage a resumed sequence continues from — is
+/// a rule the unit suite already exercises against substitutes and buys nothing here.
+/// </para>
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedMailboxConvergenceTests(MailFathomOrchestrationFixture orchestration)
+{
+    private const string ArchiveFolderName = "ConvergenceArchive";
+
+    private const string RemovedFolderName = "ConvergenceRemovedTarget";
+
+    /// <summary>The alias this class owns, bound to the real inbox so a write session selects it.</summary>
+    private static readonly MailFolderResolution Inbox = MailFolderResolution.FirstBindingOf(
+        MailFolderAlias.Create("convergence-inbox"),
+        RemoteFolderPath.Create(OrchestratedMailbox.InboxPath, hierarchyDelimiter: '.'));
+
+    private static readonly RemoteFolderPath ArchivePath =
+        RemoteFolderPath.Create(ArchiveFolderName, hierarchyDelimiter: '.');
+
+    private static readonly RemoteFolderPath RemovedPath =
+        RemoteFolderPath.Create(RemovedFolderName, hierarchyDelimiter: '.');
+
+    private static readonly MailboxMutationRequester Requester =
+        MailboxMutationRequester.Rule("converge-to-archive", 1);
+
+    /// <summary>
+    /// The restart case the whole design exists for. A process stopped between the copy and the expunge left the
+    /// message in both folders and a record saying so; the next process runs a convergence pass, which nobody asked for,
+    /// and the mailbox ends in the state that was requested.
+    /// </summary>
+    [Fact]
+    public async Task ConvergeAsync_AMutationAStoppedProcessLeftUnfinished_CompletesWithNoOperatorAction()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mailbox = new OrchestratedMailbox(orchestration.MailServer);
+        await mailbox.RecreateFolderAsync(ArchiveFolderName, cancellationToken);
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await CommitInboxBindingAsync(services, cancellationToken);
+
+        var subject = $"converge-relocate-{Guid.NewGuid():N}";
+        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
+        var storedEmailId = await StoreMetadataAsync(services, occurrence, subject, cancellationToken);
+        var request = MailboxMutationRequest.Relocate(storedEmailId, occurrence, Requester, ArchivePath);
+
+        await StopAfterTheCopyAsync(services, request, occurrence, cancellationToken);
+
+        // The state a stopped process leaves: the copy landed, the source is still there, and the record is the only
+        // thing that knows the two are one relocation.
+        Assert.Contains(
+            await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken),
+            email => email.Subject == subject);
+        Assert.Equal(
+            MailboxMutationStage.PlacementConfirmed,
+            (await ReadRecordRowAsync(services, occurrence, cancellationToken)).Stage);
+
+        // Act
+        var report = await services.InScopeAsync(
+            (scope, token) => ConvergeWithoutMoveExtensionAsync(scope, token),
+            cancellationToken);
+
+        // Assert
+        Assert.Equal(1, report.CompletedCount);
+        Assert.DoesNotContain(
+            await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken),
+            email => email.Subject == subject);
+        Assert.Single(
+            await mailbox.ReadAsync(ArchiveFolderName, cancellationToken),
+            email => email.Subject == subject);
+        Assert.Equal(
+            MailboxMutationStage.Completed,
+            (await ReadRecordRowAsync(services, occurrence, cancellationToken)).Stage);
+    }
+
+    /// <summary>
+    /// A destination folder somebody removed is an answer the server has already given, so the change reaches its
+    /// terminal visible stage on the first pass rather than being attempted once per run until its bound is spent.
+    /// </summary>
+    [Fact]
+    public async Task ConvergeAsync_AMutationWhoseTargetFolderWasRemoved_StopsVisiblyInsteadOfRetrying()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mailbox = new OrchestratedMailbox(orchestration.MailServer);
+        await mailbox.RecreateFolderAsync(RemovedFolderName, cancellationToken);
+        await mailbox.DeleteFolderAsync(RemovedFolderName, cancellationToken);
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await CommitInboxBindingAsync(services, cancellationToken);
+
+        var subject = $"converge-missing-target-{Guid.NewGuid():N}";
+        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
+        var storedEmailId = await StoreMetadataAsync(services, occurrence, subject, cancellationToken);
+        var request = MailboxMutationRequest.Relocate(storedEmailId, occurrence, Requester, RemovedPath);
+        await RecordIntentAsync(services, request, cancellationToken);
+
+        // Act
+        var report = await services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailboxMutationConverger>()
+                .ConvergeAsync(SyntheticMailAccount.AccountId, token),
+            cancellationToken);
+
+        // Assert
+        var row = await ReadRecordRowAsync(services, occurrence, cancellationToken);
+        Assert.Equal(MailboxMutationStage.Abandoned, row.Stage);
+        Assert.Equal(1, row.AttemptCount);
+        Assert.Equal(MailFathomErrorCode.MailboxMutationDestinationMissing.Value, row.LastFailureCode);
+        Assert.Contains(
+            report.Outstanding,
+            group => group.Lifecycle == MailboxMutationLifecycle.DeadLettered
+                && group.Mutation == MailboxMutation.Relocate);
+
+        // The message is where it was: a refusal that had copied first would have left one in a folder nobody can name.
+        Assert.Contains(
+            await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken),
+            email => email.Subject == subject);
+    }
+
+    /// <summary>Runs the production convergence pass over a connection whose server advertises no <c>MOVE</c>.</summary>
+    /// <remarks>
+    /// Only the client factory is substituted, for the reason the sibling class states: the capability mask is what a
+    /// test has to control, and a relocation resumed on the native path would have nothing left to do. The store, the
+    /// commit policy, the performer, and the converger itself are the production ones.
+    /// </remarks>
+    private static async Task<MailboxConvergenceReport> ConvergeWithoutMoveExtensionAsync(
+        IServiceProvider scope,
+        CancellationToken cancellationToken)
+    {
+        await using var pool = CreateMoveMaskedPool(scope);
+        var commitPolicy = scope.GetRequiredService<OptimisticConcurrencyRetryPolicy>();
+        var store = scope.GetRequiredService<IMailboxMutationRecordStore>();
+        var converger = new MailboxMutationConverger(
+            store,
+            new MailboxMutationPerformer(
+                store,
+                new MailKitImapWriteSessionFactory(pool, CreateTelemetry()),
+                commitPolicy,
+                new MailboxMutationOptions()),
+            scope.GetRequiredService<IMailTransportSecurityPolicyReader>(),
+            commitPolicy,
+            new MailboxConvergenceOptions(),
+            TimeProvider.System);
+
+        return await converger.ConvergeAsync(SyntheticMailAccount.AccountId, cancellationToken);
+    }
+
+    /// <summary>Issues the copy half of a relocation and stops, leaving the record exactly where a crash would.</summary>
+    private static async Task StopAfterTheCopyAsync(
+        OrchestratedMailFathomServices services,
+        MailboxMutationRequest request,
+        EmailOccurrenceId occurrence,
+        CancellationToken cancellationToken)
+    {
+        var recordId = await RecordIntentAsync(services, request, cancellationToken);
+
+        var placement = await services.InScopeAsync(
+            async (scope, token) =>
+            {
+                await using var pool = CreateMoveMaskedPool(scope);
+                var factory = new MailKitImapWriteSessionFactory(pool, CreateTelemetry());
+                await using var session = await factory.OpenForWritingAsync(
+                    SyntheticMailAccount.AccountId,
+                    Inbox,
+                    scope.GetRequiredService<IMailTransportSecurityPolicyReader>()
+                        .GetPolicy(SyntheticMailAccount.AccountId),
+                    token);
+
+                return await session.CopyAsync(
+                    occurrence,
+                    ArchivePath,
+                    new InMemoryMailboxMutationJournal(),
+                    token);
+            },
+            cancellationToken);
+
+        Assert.Equal(
+            PersistenceCommitResult.Committed,
+            await services.CommitAsync(
+                async (scope, session, token) =>
+                {
+                    var store = scope.GetRequiredService<IMailboxMutationRecordStore>();
+                    await store.CountAttemptAsync(session, recordId, token);
+                    await store.RecordPlacementIssuedAsync(session, recordId, requiresSourceRemoval: true, token);
+                    await store.AdvanceAsync(
+                        session,
+                        recordId,
+                        MailboxMutationStage.PlacementConfirmed,
+                        placement,
+                        token);
+                },
+                cancellationToken));
+    }
+
+    private static Task<MailboxMutationRecordId> RecordIntentAsync(
+        OrchestratedMailFathomServices services,
+        MailboxMutationRequest request,
+        CancellationToken cancellationToken) => CommitForAsync(
+            services,
+            async (scope, session, token) => (await scope.GetRequiredService<IMailboxMutationRecordStore>()
+                .OpenAsync(session, request, token)).Id,
+            cancellationToken);
+
+    private static MailboxWriteConnectionPool CreateMoveMaskedPool(IServiceProvider scope) => new(
+        () => CapabilityMaskedImapClient.HidingCapabilities(ImapCapabilities.Move),
+        scope.GetRequiredService<IServiceScopeFactory>(),
+        scope.GetRequiredService<OutboundOperationExecutor>(),
+        scope.GetRequiredService<ITransientFailureClassifier>(),
+        new MailboxWriteSessionOptions(),
+        TimeProvider.System,
+        NullLogger<MailboxWriteConnectionPool>.Instance);
+
+    private static MailboxMutationTelemetry CreateTelemetry() =>
+        new(NullLogger<MailboxMutationTelemetry>.Instance, TimeProvider.System);
+
+    /// <summary>Reads the one recorded mutation for an occurrence straight out of its table.</summary>
+    /// <remarks>
+    /// Read from the row rather than through the port, because a completed mutation has left the outstanding answer by
+    /// design and what is asserted here is the completion itself.
+    /// </remarks>
+    private static Task<MailboxMutationRow> ReadRecordRowAsync(
+        OrchestratedMailFathomServices services,
+        EmailOccurrenceId occurrence,
+        CancellationToken cancellationToken)
+    {
+        var alias = occurrence.FolderResolutionId.Alias.Value;
+        var generation = occurrence.FolderResolutionId.Generation.Value;
+        var uid = occurrence.Uid.Value;
+
+        return services.InScopeAsync(
+            async (scope, token) => await scope
+                .GetRequiredService<MailFathomDbContext>()
+                .MailboxMutations
+                .AsNoTracking()
+                .Where(mutation => mutation.MailFolder.Alias == alias
+                    && mutation.MailFolder.ResolutionGeneration == generation
+                    && mutation.Uid == uid)
+                .Select(mutation => new MailboxMutationRow(
+                    mutation.Stage,
+                    mutation.AttemptCount,
+                    mutation.LastFailureCode))
+                .SingleAsync(token),
+            cancellationToken);
+    }
+
+    private static async Task CommitInboxBindingAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken) =>
+        Assert.Equal(
+            PersistenceCommitResult.Committed,
+            await services.CommitAsync(
+                (scope, session, token) => scope.GetRequiredService<IMailFolderResolutionStore>().SaveResolutionAsync(
+                    session,
+                    SyntheticMailAccount.AccountId,
+                    Inbox,
+                    token),
+                cancellationToken));
+
+    private static Task<StoredEmailId> StoreMetadataAsync(
+        OrchestratedMailFathomServices services,
+        EmailOccurrenceId occurrence,
+        string subject,
+        CancellationToken cancellationToken) => CommitForAsync(
+            services,
+            (scope, session, token) => scope.GetRequiredService<IEmailMetadataRepository>().UpsertMetadataAsync(
+                session,
+                SyntheticEmail.RemoteMetadataOf(occurrence, subject),
+                extractedMetadata: null,
+                StoredEmailContentAvailability.ExceededSizeLimit,
+                token),
+            cancellationToken);
+
+    private static Task<TResult> CommitForAsync<TResult>(
+        OrchestratedMailFathomServices services,
+        Func<IServiceProvider, IPersistenceSession, CancellationToken, Task<TResult>> write,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) =>
+            {
+                await using var session = await scope.GetRequiredService<IPersistenceSessionFactory>()
+                    .BeginSessionAsync(token);
+
+                var produced = await write(scope, session, token);
+
+                Assert.Equal(PersistenceCommitResult.Committed, await session.CommitAsync(token));
+
+                return produced;
+            },
+            cancellationToken);
+
+    private static async Task<EmailOccurrenceId> DeliverAndLocateAsync(
+        OrchestratedMailbox mailbox,
+        string subject,
+        CancellationToken cancellationToken)
+    {
+        await mailbox.DeliverAsync(subject, cancellationToken);
+
+        var inbox = await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken);
+        var delivered = Assert.Single(inbox, email => email.Subject == subject);
+
+        return EmailOccurrenceId.Create(
+            SyntheticMailAccount.AccountId,
+            Inbox.Id,
+            await mailbox.ReadUidValidityAsync(OrchestratedMailbox.InboxPath, cancellationToken),
+            delivered.Uid);
+    }
+
+    /// <summary>The columns of one mutation record a test reads back.</summary>
+    private sealed record MailboxMutationRow(MailboxMutationStage Stage, int AttemptCount, int? LastFailureCode);
+}

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationRecordTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationRecordTests.cs
@@ -160,7 +160,7 @@ public sealed class OrchestratedMailboxMutationRecordTests(MailFathomOrchestrati
             (scope, token) => scope.GetRequiredService<IMailboxMutationRecordStore>()
                 .ReadOutstandingAsync(SyntheticMailAccount.AccountId, limit: 100, token),
             cancellationToken);
-        Assert.Single(outstanding, record => record.Request.Occurrence == occurrence);
+        Assert.Single(outstanding, candidate => candidate.Record.Request.Occurrence == occurrence);
     }
 
     /// <summary>Issues the copy half of a relocation and stops, leaving the record exactly where a crash would.</summary>


### PR DESCRIPTION
Closes #451

The durable mutation record (#448) made a remote write resumable. This makes it **converge**: a change somebody authored ends either completed or given up on where a person can see it, and never stays pending forever — which is the failure mode worth naming, because it looks exactly like success from every screen an operator reads.

## Where convergence runs

Every account run now begins with a bounded pass over that account's unfinished changes, before its folders are touched. Nothing is scheduled for it, deliberately: the account already has a loop with per-account isolation, a slot count, and jittered run backoff, so reusing it means an unreachable server defers a waiting change through the same delay that defers the account's folders, one stuck account starves no other, and nothing spins. What bounds a change that keeps failing is still `MaxMutationAttempts`, counted across runs rather than within one.

Running it before the folders also means a run reads a mailbox that has stopped moving, and the account's one write connection is taken and given back before the folder connections are opened.

## The unknown outcome

A placement command whose answer never came back is never reissued — a second `COPY` is a second message. How it ends depends on which sequence issued it:

- **A relocation carried by `MOVE`** removes the source as part of the same command, so once synchronization has seen that source occurrence leave its folder the server has said the command ran, and the record is completed from that observation. That is a fact about an occurrence the record names exactly, not a guess about which message in the destination folder is the placed one.
- **A copy, and a relocation on a server without `MOVE`,** both leave the source where it was, so nothing about it distinguishes a command that landed from one that never arrived. Finding out would mean searching the destination folder for a message that looks right, which [ADR 0007](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md) refuses. Those wait `UnknownMutationOutcomeGrace` for an observation that may still settle them and are then dead-lettered — visible rather than apparently busy.

## A missing destination folder is an answer, not a bad moment

MailKit reports it as a plain `FolderNotFoundException` carrying a remote path and nothing about what was being attempted. It is now translated at the write session into `MailboxDestinationFolderMissingException` / `MailFathomErrorCode.MailboxMutationDestinationMissing` (**25005**, category 2 subcategory 5), terminal on its first refusal alongside `MailboxMutationUnsupported` rather than after five logins spent receiving the same answer. The message names the account and folder aliases and never the remote path.

## What an operator can see

Two gauges on the existing `MailFathom` meter: `mailfathom.mailbox.mutations.outstanding` and `mailfathom.mailbox.mutations.oldest_outstanding_age`, both by account, mutation, and a lifecycle of `pending`, `converging`, or `dead-lettered`. Completed changes stay on the existing counter's success outcome, where an age would mean nothing. Each account's values are republished whole by its own pass, so a lifecycle that empties stops being reported.

## Breaking changes

Two, both below `1.0.0` and neither needing an operator action:

- **Configuration schema — additive.** `MailSynchronization:MaxMutationsPerConvergencePass` (default `50`) and `MailSynchronization:UnknownMutationOutcomeGrace` (default `06:00:00`), both *reload*. A deployment that writes neither behaves as documented.
- **No database schema change.** No migration; the existing partial index on the outstanding rows serves both the per-run read and the grouped count.

## Tests

- `MailboxMutationConvergerTests` — restart mid-sequence, an unreachable server, one failure not blocking the account's other changes, a missing target folder, an unacknowledged placement never reissued for either kind, the observation that settles a native relocation, the grace period expiring, a backlog wider than one pass, and the counts by kind and lifecycle.
- `MailboxMutationLifecycleTests`, additions to `MailboxMutationRecordTests` — the stage-to-lifecycle mapping is total, and which shapes a source removal may settle.
- `MailKitImapWriteSessionTests` — a missing destination is refused before any command goes out, on both placing mutations, and the refusal carries no remote path.
- `MailboxConvergenceTelemetryTests` — the gauge dimensions, the age measured at read time, and a lifecycle that empties ceasing to report.
- `AccountSynchronizationSupervisorTests` — convergence runs before any folder is opened, and a failed pass defers the account.
- `OrchestratedMailboxConvergenceTests` (integration, two tests) — a mutation a stopped process left unfinished completes with no operator action against the real server and database, and one whose target folder was really removed reaches its terminal visible stage on the first pass with the message still where it was.

Full gate green: 3310 tests, 0 failed, aggregate line coverage 94.48%.