### PR TITLE
[#526] Prepare release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ The fourth release, and the first that asks every deployment to edit its configu
 every installation states have moved: **where each surface is served, and how a credential is configured.** Neither
 previous form is ignored — both fail startup naming what replaces them — so an upgrade that skips the edit stops rather
 than quietly serving something you did not configure. **The database schema moves as well**, by five migrations that
-only add tables, so the schema step belongs to this upgrade; it applies while `0.3.0` is still running, and `0.3.0`
-serves the result unchanged if you go back.
+add three tables and then refine one of the three, and that touch nothing `0.3.0` reads — so the schema step belongs to
+this upgrade, it applies while `0.3.0` is still running, and `0.3.0` serves the result unchanged if you go back.
 
 Nothing else `0.3.0` promised is withdrawn. The MCP tool contract is untouched — `list_emails`, `get_email_content`,
 and `search_emails` answer exactly as they did — and every setting not named below still means what it meant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,159 @@ previous tag, and that same pull request is the one whose merge commit is tagged
 registries. `CHANGELOG.md` is a protected path for the same reason: an edit to it outside that flow changes what a
 release claims it shipped.
 
+## [0.4.0] - 2026-08-07
+
+The fourth release, and the first that asks every deployment to edit its configuration before it will start. Two things
+every installation states have moved: **where each surface is served, and how a credential is configured.** Neither
+previous form is ignored — both fail startup naming what replaces them — so an upgrade that skips the edit stops rather
+than quietly serving something you did not configure. **The database schema moves as well**, by five migrations that
+only add tables, so the schema step belongs to this upgrade; it applies while `0.3.0` is still running, and `0.3.0`
+serves the result unchanged if you go back.
+
+Nothing else `0.3.0` promised is withdrawn. The MCP tool contract is untouched — `list_emails`, `get_email_content`,
+and `search_emails` answer exactly as they did — and every setting not named below still means what it meant.
+
+**The defect `0.3.0` shipped with is gone.** A deployment that set `HealthEndpoints:Enabled` to `false` and enabled the
+administrative endpoint lost its application listener and refused every MCP client. There is no application listener to
+lose now, because every surface binds the socket its own section names.
+
+### Added
+
+**A key pair as a third way to authenticate, on both endpoints.** The client holds the private key and the deployment
+holds only the public half, so nothing this host stores in order to verify a request is worth stealing from it — not
+from the configuration, not from a backup of it, and not from the deployment tool that wrote it
+([#527](https://github.com/Krzysztof318/MailFathom/pull/527)).
+
+- Configure a `PublicKey` entry under `Authentication` exactly as you would a key: one named secret, reached through
+  every reference scheme the deployment already has, with a `Name` diagnostics correlate on and a `Lifetime` that is
+  enforced. Startup refuses material that is not a PEM public key, an RSA key below 2048 bits, a curve outside P-256,
+  P-384, and P-521, and — explicitly — material carrying a private key.
+- The client mints a short-lived JSON Web Token, signs it with the private half, and presents it as an ordinary bearer
+  credential: the arrangement RFC 7523 describes and OpenID Connect deploys as `private_key_jwt`. It carries `typ:
+  mailfathom-client-assertion+jwt`, an audience of `urn:mailfathom:mcp` or `urn:mailfathom:admin`, an expiry no more
+  than five minutes ahead, and a fresh identifier the endpoint refuses to serve twice — so a captured assertion stops
+  working on its own, and cannot be replayed even inside its remaining seconds.
+- `mfctl login --mode keypair --private-key <file>` mints all of it and stores no credential; every command signs its
+  own assertion.
+- Rotating a key is an overlap with no secret to coordinate across two machines: add the new public key as a second
+  entry, move the client to the new private key, remove the old entry.
+  [Key pairs](https://krzysztof318.github.io/MailFathom/operations/mcp-endpoint.html#key-pairs) is the page.
+
+**`mfctl` from the Windows Package Manager.** Each release submits its own manifest, so `winget install
+MailFathom.mfctl` becomes a packaged path beside the download and `winget upgrade` carries you to the next release
+([#498](https://github.com/Krzysztof318/MailFathom/pull/498)). The manifest names the same release asset the releases
+page does and carries the same hash the checksum file does, so both paths install the same bytes and check them the
+same way. A version is offered a little after it is attached here, because the community repository reviews the
+submission; until one is accepted, the releases page is where the command comes from on every platform.
+
+**The metrics and traces the libraries underneath MailFathom already emit.** Where `OTEL_EXPORTER_OTLP_ENDPOINT` names
+a destination, four more meters now reach it: `Npgsql` for connection-pool state and command durations and counts,
+`Microsoft.EntityFrameworkCore` for contexts, queries, saves, compiled-query cache hits, and concurrency failures,
+`Experimental.ModelContextProtocol` for MCP session duration and per-operation duration broken down by protocol method
+and tool name, and `Polly` for every outbound pipeline's attempts, outcomes, timeouts, and circuit-breaker transitions
+([#521](https://github.com/Krzysztof318/MailFathom/pull/521)). Database commands and MCP protocol operations are
+spanned as well and correlated with the request that caused them; the probe paths stay untraced, because a probe
+arrives every few seconds and says the same thing every time.
+
+- Every tag on them is a bounded set — a protocol method, a transport, one of the three tool names, an outcome — so
+  none of them opens a time series per message or per person.
+- What MailFathom publishes under a name of its own goes under exactly one: **`MailFathom`**, serving as both activity
+  source and meter, which is what a dashboard filters on to see this process and nothing a library emits
+  ([#510](https://github.com/Krzysztof318/MailFathom/pull/510)).
+  [Telemetry](https://krzysztof318.github.io/MailFathom/operations/telemetry.html) records each of them.
+
+### Changed
+
+- **Breaking (configuration schema)** — **every surface states where it is served, and the host's own ways of naming a
+  listener are refused.** `ASPNETCORE_URLS`, `ASPNETCORE_HTTP_PORTS`, `ASPNETCORE_HTTPS_PORTS`, `--urls`, and any entry
+  under `Kestrel:Endpoints` each fail startup with a message naming the setting that replaces them. Write
+  `McpEndpoint:BindAddress`, `McpEndpoint:Port`, and `McpEndpoint:Transport`; the administrative endpoint and the probes
+  take the same three. **A deployment of your own that sets `ASPNETCORE_HTTP_PORTS` sets `McpEndpoint__Port` instead** —
+  the published image and the packaged chart already do, so an upgrade that takes both as they ship needs no edit here
+  ([#459](https://github.com/Krzysztof318/MailFathom/pull/459)). They are refused rather than ignored because ignoring
+  them is silent: Kestrel drops URL-shaped addresses as soon as a listener is bound in code, which every surface now
+  does, and a configured endpoint would otherwise be bound beside them on a socket no section describes and no
+  credential guards. A deployment that enables no surface at all is refused for the same reason.
+- **Breaking (configuration schema)** — **the administrative endpoint's default port is `8080`, the MCP endpoint's**,
+  where `0.3.0` gave it `8090`. Two surfaces may deliberately share one socket now — the posture a single-node
+  deployment behind one ingress wants — so a deployment that enabled the administrative endpoint without stating a port
+  publishes it wherever `8080` is published rather than on a port of its own. State `AdminEndpoint:Port`, where `8090`
+  restores what you had, unless sharing is what you want; the socket serves each surface's own paths either way, and a
+  path a surface does not own is still refused there with a `404`
+  ([#459](https://github.com/Krzysztof318/MailFathom/pull/459)).
+- **Breaking (configuration schema)** — **`Transport` decides what a surface's clear-text socket does**, where `0.3.0`
+  inferred that from whether HTTPS profiles were configured. `Http` serves the routes and refuses profiles,
+  `HttpAndHttps` binds the profiles and redirects the clear-text socket to them, and `HttpsOnly` does not open it at
+  all. `Http` is the default, so adopting this release costs no certificate work
+  ([#459](https://github.com/Krzysztof318/MailFathom/pull/459)).
+- **Breaking (configuration schema)** — **`Https:Redirect` no longer binds a port of its own.** `0.3.0` gave it `8080`
+  beside the MCP profiles and `8091` beside the administrative ones; the redirect now answers on the surface's own
+  `BindAddress` and `Port`. A deployment that published `8091` to reach the administrative redirect publishes that
+  surface's own port instead ([#459](https://github.com/Krzysztof318/MailFathom/pull/459)).
+- **Breaking (configuration schema)** — **authentication is a list of the credentials an endpoint accepts**, where
+  `0.3.0` named methods in a flag set and configured each in a sibling section. `McpEndpoint:Authentication` and
+  `AdminEndpoint:Authentication` each take entries, and the block an entry carries is what selects the method that
+  judges it — there is no setting naming the method any more. `Authentication: "ApiKey"` beside an `ApiKeys` list
+  becomes one entry per key, each carrying an `ApiKey` block; `Authentication: "OAuth"` beside an `OAuth` section
+  becomes an entry carrying that section. An entry carrying no block fails startup, named by its position
+  ([#515](https://github.com/Krzysztof318/MailFathom/pull/515)).
+  - **`RequiredScopes` is per entry** rather than per endpoint, so two authorization servers one endpoint accepts may
+    demand different scopes. Every OAuth entry still names the same `Resource`, because the endpoint publishes one
+    metadata document.
+  - An empty list warns at startup exactly as `None` did, and a value written where the list belongs fails it rather
+    than being read as a method name.
+- **Breaking (configuration schema)** — **a setting only the process environment can deliver, written anywhere else,
+  fails startup** naming every such variable at once, with error code `12002`. `OPENSSL_CONF`, `OTEL_SERVICE_NAME`, and
+  every `OTEL_*`, `ASPNETCORE_*`, and `DOTNET_*` variable are read before MailFathom's configuration exists or by a
+  library that never consults it, so a value written into an appsettings file, a provisioned configuration file, or a
+  command-line argument reached nobody — while the file read it back happily and nothing said which of the two you were
+  looking at. Set each on the host process, or remove it
+  ([#509](https://github.com/Krzysztof318/MailFathom/pull/509)).
+- **Every synchronized message is also cut into passages and stored**, in the same transaction that stores what was
+  extracted from it, so a mailbox costs more storage per message than it did under `0.3.0` — roughly its extracted text
+  again, in overlapping windows ([#488](https://github.com/Krzysztof318/MailFathom/pull/488)). A message that yielded no
+  text is cut into nothing, mail stored before this release is not revisited, and nothing else in this release reads a
+  passage.
+
+### Removed
+
+- **Breaking (deployment contract)** — **`GET /` no longer answers.** `0.3.0` served
+  `{"service":"MailFathom","status":"ready"}` at the root of the application listener; the MCP endpoint's port serves
+  `/mcp` and answers everything else with `404`. An external check pointed at `/` moves to the probes on their own
+  listener — `/alive` for liveness, `/health` for readiness, `/started` for startup, on `HealthEndpoints:Port` unless
+  you moved it ([#459](https://github.com/Krzysztof318/MailFathom/pull/459)).
+
+### Fixed
+
+- **A `file:` secret reference pointing at a FIFO or a stalled mount hung the host indefinitely.** Opening the file is
+  bounded now, so an unreachable mount is reported as one line of the startup failure report rather than as a process
+  that never finishes starting and never says why
+  ([#511](https://github.com/Krzysztof318/MailFathom/pull/511)).
+- **The device sign-in prompt raced the rest of `mfctl`'s output.** Both device-code flows handed the verification
+  address and the short code to the console through a type that marshals onto a synchronization context a console
+  process does not have, so nothing ordered the printing of the code against the wait for you to type it. The prompt now
+  reaches the terminal before polling begins, on the thread that asked for it
+  ([#418](https://github.com/Krzysztof318/MailFathom/pull/418)).
+- **`HealthEndpoints:Enabled: false` beside an enabled administrative endpoint no longer costs the application
+  listener** — the defect `0.3.0`'s notes named as shipped with it
+  ([#419](https://github.com/Krzysztof318/MailFathom/pull/419)), and one that cannot recur now that each surface binds
+  its own socket ([#459](https://github.com/Krzysztof318/MailFathom/pull/459)).
+
+### Security
+
+- **A key pair leaves nothing on the host worth stealing.** An API key is a shared secret, so a copy of every credential
+  that reaches the mailbox sits in the configuration and in whatever produced it; a public key verifies the same client
+  and is not a secret at all. It is the method for a scheduled job, which has no person to sign in as
+  ([#527](https://github.com/Krzysztof318/MailFathom/pull/527)).
+- **The administrative endpoint shares the MCP endpoint's port unless you say otherwise.** Administering the service is
+  a different authority from reading the mailbox, and the probes answer without a credential, so putting either on the
+  endpoint's port publishes it wherever that port is published. The ports exist so the decision is yours; take it rather
+  than inherit it ([#459](https://github.com/Krzysztof318/MailFathom/pull/459)).
+- **A listener nothing configured can no longer be bound.** Refusing the host's own address settings closes the case
+  where a `Kestrel:Endpoints` entry survived beside a listener bound in code and served the routes on a socket no
+  section describes, no credential guards, and no isolation middleware was composed for
+  ([#459](https://github.com/Krzysztof318/MailFathom/pull/459)).
+
 ## [0.3.0] - 2026-08-04
 
 The third release, and the first whose upgrade is a new image and nothing else: **the database schema does not move.**
@@ -395,6 +548,7 @@ is the whole surface, key by key, including which keys reload and which need a r
   [`THIRD_PARTY_LICENSES.md`](https://github.com/Krzysztof318/MailFathom/blob/main/THIRD_PARTY_LICENSES.md) registers
   every dependency it ships beside ([#173](https://github.com/Krzysztof318/MailFathom/pull/173)).
 
+[0.4.0]: https://github.com/Krzysztof318/MailFathom/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Krzysztof318/MailFathom/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Krzysztof318/MailFathom/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Krzysztof318/MailFathom/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ A connected agent can list, read, and search your mail. It cannot send, delete, 
 
 ## Project status
 
-`0.3.0` is the current release, and it builds on `0.2.0` — OAuth mailbox authentication, push synchronization, and the administrative endpoint an operator reaches with the `mfctl` command.
+`0.4.0` is the current release, and it builds on `0.3.0` — OAuth mailbox authentication, push synchronization, the administrative endpoint an operator reaches with the `mfctl` command, and a deployment behind a TLS-terminating reverse proxy.
 
-- **What it adds** is what stands in front of the service: a trusted reverse proxy the public scheme and host are read from, a clear-text listener that redirects to HTTPS on both endpoints, and rate limiting on the administrative surface.
-- **Upgrading from `0.2.0`** is a new image and no schema step, because its database schema is `0.2.0`'s.
+- **What it adds** is a key pair as a third way to authenticate, with the deployment holding only the public half; `mfctl` from the Windows Package Manager; and the metrics and traces the libraries underneath it emit.
+- **Upgrading from `0.3.0`** is a schema step and a configuration edit. Every surface now states where it is served in its own section, and an endpoint's accepted credentials are a list rather than a flag set; both previous forms fail startup naming what replaces them. [The changelog](https://krzysztof318.github.io/MailFathom/CHANGELOG.html) states each break against the surface it breaks.
 - **What it ships** is a container image, a Helm chart, the SQL script that creates the schema it expects, and an `mfctl` binary per platform — [where the artifacts are published](https://github.com/Krzysztof318/MailFathom#where-the-artifacts-are-published) has the references. There is no binary artifact for the service itself, so a native installation starts from a checkout of this repository.
 - **What it promises** across the MCP tool contract, the configuration schema, the database schema, and the deployment contract is stated in [the changelog](https://krzysztof318.github.io/MailFathom/CHANGELOG.html).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,8 +34,8 @@ A confirmed vulnerability is fixed on `main` and reaches you in a release that c
 
 | Version | Supported |
 |---|---|
-| `0.3.x` | Yes — the newest released minor line |
-| `0.2.x` | Only by a decision recorded on the issue asking for it |
+| `0.4.x` | Yes — the newest released minor line |
+| `0.3.x` | Only by a decision recorded on the issue asking for it |
 | Any older release line | Only by a decision recorded on the issue asking for it |
 | `main`, and the `-nightly.<n>` builds from it | No. A fix lands here first, but nothing built from `main` carries a release promise |
 

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -80,7 +80,7 @@ docker compose up -d
 | Base | `mcr.microsoft.com/dotnet/aspnet:10.0.10-noble-chiseled-extra`, pinned to an exact patch version |
 | Platforms | `linux/amd64` and `linux/arm64` |
 | User | `1654`, the unprivileged `app` account — never root |
-| Ports | `8080` for `/` and `/mcp`; `8081` for the probes, on a listener of its own |
+| Ports | `8080` for `/mcp`, which `McpEndpoint:Port` moves; `8081` for the probes, on a listener of its own |
 | Writable paths | `/tmp` only, which a deployment supplies as a tmpfs or an `emptyDir` |
 | Entrypoint | `dotnet /app/MailFathom.Host.dll` |
 | Health check | None in the image. Startup, readiness, and liveness probes answer on `8081`. |

--- a/docs/features/initial-scope.md
+++ b/docs/features/initial-scope.md
@@ -4,7 +4,7 @@
 
 The initial scaffold creates the project boundaries needed for the first release without implementing mail, persistence, retrieval, or MCP behavior yet.
 
-The ASP.NET Core host exposes a root readiness response. It also serves three probes — `/started`, `/health`, and `/alive` — on a listener of their own, on port 8081 unless a deployment configures another, in every environment; `docs/operations/health-endpoints.md` states what each one consults, why they are kept off the port that serves `/` and `/mcp`, and how a deployment turns them off or puts TLS in front of them, and `docs/architecture/solution-structure.md` records why the service defaults belong to `Host`. Those defaults wire OpenTelemetry, HTTP resilience, and service discovery. The Aspire AppHost wires the host to a PostgreSQL resource for future persistence work.
+The ASP.NET Core host serves three probes — `/started`, `/health`, and `/alive` — on a listener of their own, on port 8081 unless a deployment configures another, in every environment; `docs/operations/health-endpoints.md` states what each one consults, why they are kept off the port that serves `/mcp`, and how a deployment turns them off or puts TLS in front of them, and `docs/architecture/solution-structure.md` records why the service defaults belong to `Host`. Those defaults wire OpenTelemetry, HTTP resilience, and service discovery. The Aspire AppHost wires the host to a PostgreSQL resource for future persistence work.
 
 
 ## IMAP synchronization status

--- a/docs/operations/health-endpoints.md
+++ b/docs/operations/health-endpoints.md
@@ -39,7 +39,7 @@ behind a configured certificate reference is the exception the [secret machinery
 rotating what a reference points at needs no configuration change, though this listener reads its certificate once,
 while starting.
 
-**The probe listener is never the MCP endpoint's.** A probe path asked on the port that serves `/` and `/mcp` is
+**The probe listener is never the MCP endpoint's.** A probe path asked on the port that serves `/mcp` is
 answered with `404`, and `/mcp` asked on the probe port is answered with `404` as well. The decision is taken from the
 port the connection arrived at — a property of the socket the operating system accepted it on, not a header the caller
 wrote — so publishing the probe port to an orchestrator's network does not publish the mailbox to it, and publishing the

--- a/docs/users/README.md
+++ b/docs/users/README.md
@@ -21,9 +21,9 @@ Two properties hold everywhere and are worth knowing before anything is installe
 
 ## The state of the release
 
-`0.3.0` is the current release. The container image is published to both registries, the Helm chart is published, and
+`0.4.0` is the current release. The container image is published to both registries, the Helm chart is published, and
 the schema file you apply and the `mfctl` binaries are attached to the GitHub release — so an installation starts from
-a versioned artifact rather than from a checkout. Where a page describes something that arrives later than `0.3.0`, it
+a versioned artifact rather than from a checkout. Where a page describes something that arrives later than `0.4.0`, it
 says so and names the release, rather than describing it as though you could already download it.
 
 ## The path


### PR DESCRIPTION
The changelog half of the `0.4.0` release, tracked by #526. **This pull request's merge commit is what gets tagged and
published**, so it carries the released changelog and the prose files naming the release they ship in. It closes
nothing: the release is finished by the version bump that follows the tag.

Pairs with the version bump in #551. **Merge this one first, then the tag, then that one** — the tag has to land
between the two.

## The 0.4.0 section

Composed from the 51 commits merged since `v0.3.0` and written for whoever runs MailFathom, not for a reader of this
repository. What earned an entry is what reaches one of the four public surfaces, a defect that was observable from
outside, or a change with a security consequence; the refactors, tests, workflow changes, and documentation edits in
that range earned none.

The release breaks the configuration schema in four places and the deployment contract in one, each opened with
`**Breaking (<surface>)**` and each stating the operator's action:

- every surface states where it is served, and `ASPNETCORE_HTTP_PORTS`, `ASPNETCORE_URLS`, `--urls`, and
  `Kestrel:Endpoints` fail startup (#459);
- the administrative endpoint's default port is now `8080`, the MCP endpoint's, where `0.3.0` gave it `8090` — an
  exposure decision, so it is in **Security** as well;
- `Transport` decides what a clear-text socket does, and `Https:Redirect` no longer binds a port of its own (#459);
- an endpoint's accepted credentials are a list of method blocks rather than a flag set beside sibling sections (#515);
- a setting only the process environment can deliver now fails startup when written elsewhere (#509);
- `GET /` no longer answers (#459), which is the one deployment-contract break.

The database schema moves by five migrations — three create a table and two refine one of those three — so the summary paragraph states that the step applies
while `0.3.0` runs and that `0.3.0` serves the result if you go back.

## What is deliberately not announced

Each closed issue was resolved against its parent through the sub-issue links. Three parents still hold open children:

| Parent | State | What it means here |
|---|---|---|
| #436 — semantic retrieval over synchronized mail | 7/12 | #435 (the `mfctl` activation commands) is open, so no profile can be activated and nothing embeds. No capability entry, in any tense. |
| #452 — let MailFathom write to the remote mailbox | 6/10 | #474–#476 are the mutations themselves. The record, the write session, the convergence, and the loopback suppression are all unreachable. |
| #85 — instrument the pinned libraries | 2/7 | #500 and #501 did land and are observable, so the entry names exactly the four meters and the two span sources, and never the whole request path. |

What the first two do cost an operator is written, because that follows from the action rather than from the feature:
the schema step, and — the one reachable consequence — that **every synchronized message is now also cut into passages
and stored**, which is real storage per message and belongs in **Changed**.

## The prose files

- `README.md` — the **Project status** paragraph. The artifacts table needed nothing: `0.3.0` already listed winget.
- `docs/users/README.md` — the **state of the release** section.
- `SECURITY.md` — `0.4.x` becomes the supported line and `0.3.x` moves down a row.

## The release-state sweep

11 hits, **0 corrected**. Every one is either about what the documentation site publishes, the `0.x` pre-release status
that is still true, or the sweep's own patterns quoted back in `docs/operations/release-procedure.md`.

**One thing the sweep does not catch, and this release turned it up anyway.** Three sentences still described `GET /`,
which #459 removed — `docs/operations/health-endpoints.md`, `docs/features/initial-scope.md`, and
`deploy/docker/README.md`. The last is the Docker Hub repository overview **this release publishes**, so leaving it
would ship a misstatement of what the image serves to the page an operator reads before pulling it. They are corrected
here rather than deferred; `docs/operations/container-image.md` already had the correct wording, and the overview now
matches it. This is the one part of the diff that goes beyond what `$prepare-release` prescribes, and it is flagged
rather than folded in quietly.

## Verification

No C# changed, so the contract suite is the evidence: `scripts/test-agent-workflow.sh` — **121 passed, 0 failed**.
`scripts/read-changelog-section.sh 0.4.0` reads the new section back, which is what the release workflow uses for the
notes. `scripts/review-obligations.sh` named `docs/operations/container-image.md` and `docs/users/installation.md`
against the `deploy/docker/README.md` change; both were read and both are already current.

## Milestones

`0.4.0` is closed, holding only #526 — expected, since that issue closes on the version bump after the tag. The one
other open item, #404, moved to `0.5.0`. The `0.5.0` milestone already existed and now carries its own tracking issue,
#549, placed on the board as `Area: Release`, `Queue: Later`, `Size: S`.

