### PR TITLE
[#526] Bump main version to 0.5.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
        same assembly identity. InformationalVersion is left to the SDK, which is what composes VersionPrefix,
        VersionSuffix, and SourceRevisionId into the single string the runtime reports. -->
   <PropertyGroup>
-    <VersionPrefix>0.4.0</VersionPrefix>
+    <VersionPrefix>0.5.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
   </PropertyGroup>

--- a/src/AI/packages.lock.json
+++ b/src/AI/packages.lock.json
@@ -428,7 +428,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.4.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/src/Cli/packages.lock.json
+++ b/src/Cli/packages.lock.json
@@ -53,7 +53,7 @@
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.2.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/src/Host/packages.lock.json
+++ b/src/Host/packages.lock.json
@@ -598,8 +598,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
-          "MailFathom.Application": "[0.4.0, )",
-          "MailFathom.Domain": "[0.4.0, )",
+          "MailFathom.Application": "[0.5.0, )",
+          "MailFathom.Domain": "[0.5.0, )",
           "Microsoft.Agents.AI": "[1.15.0, )",
           "Microsoft.Extensions.AI": "[10.8.1, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.8.1, )",
@@ -611,13 +611,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.4.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.4.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -628,9 +628,9 @@
         "dependencies": {
           "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL": "[13.4.6, )",
           "HtmlSanitizer": "[9.1.974, )",
-          "MailFathom.Application": "[0.4.0, )",
-          "MailFathom.Common": "[0.4.0, )",
-          "MailFathom.Domain": "[0.4.0, )",
+          "MailFathom.Application": "[0.5.0, )",
+          "MailFathom.Common": "[0.5.0, )",
+          "MailFathom.Domain": "[0.5.0, )",
           "MailKit": "[4.17.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",
@@ -646,8 +646,8 @@
       "MailFathom.Mcp": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Application": "[0.4.0, )",
-          "MailFathom.Domain": "[0.4.0, )",
+          "MailFathom.Application": "[0.5.0, )",
+          "MailFathom.Domain": "[0.5.0, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }
       },

--- a/src/Infrastructure/packages.lock.json
+++ b/src/Infrastructure/packages.lock.json
@@ -710,13 +710,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.4.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.4.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/src/Mcp/packages.lock.json
+++ b/src/Mcp/packages.lock.json
@@ -130,7 +130,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.2.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/AI.UnitTests/packages.lock.json
+++ b/tests/AI.UnitTests/packages.lock.json
@@ -520,8 +520,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
-          "MailFathom.Application": "[0.4.0, )",
-          "MailFathom.Domain": "[0.4.0, )",
+          "MailFathom.Application": "[0.5.0, )",
+          "MailFathom.Domain": "[0.5.0, )",
           "Microsoft.Agents.AI": "[1.15.0, )",
           "Microsoft.Extensions.AI": "[10.8.1, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.8.1, )",
@@ -534,7 +534,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.4.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/Application.UnitTests/packages.lock.json
+++ b/tests/Application.UnitTests/packages.lock.json
@@ -267,7 +267,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.2.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/Cli.UnitTests/packages.lock.json
+++ b/tests/Cli.UnitTests/packages.lock.json
@@ -245,7 +245,7 @@
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.2.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -254,7 +254,7 @@
       "mfctl": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Common": "[0.2.0, )",
+          "MailFathom.Common": "[0.5.0, )",
           "System.CommandLine": "[2.0.10, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.10, )"
         }

--- a/tests/Common.UnitTests/packages.lock.json
+++ b/tests/Common.UnitTests/packages.lock.json
@@ -245,7 +245,7 @@
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.2.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/Host.UnitTests/packages.lock.json
+++ b/tests/Host.UnitTests/packages.lock.json
@@ -770,8 +770,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
-          "MailFathom.Application": "[0.4.0, )",
-          "MailFathom.Domain": "[0.4.0, )",
+          "MailFathom.Application": "[0.5.0, )",
+          "MailFathom.Domain": "[0.5.0, )",
           "Microsoft.Agents.AI": "[1.15.0, )",
           "Microsoft.Extensions.AI": "[10.8.1, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.8.1, )",
@@ -784,13 +784,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.4.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.4.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -799,12 +799,12 @@
       "MailFathom.Host": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.AI": "[0.4.0, )",
-          "MailFathom.Application": "[0.4.0, )",
-          "MailFathom.Common": "[0.4.0, )",
-          "MailFathom.Domain": "[0.4.0, )",
-          "MailFathom.Infrastructure": "[0.4.0, )",
-          "MailFathom.Mcp": "[0.4.0, )",
+          "MailFathom.AI": "[0.5.0, )",
+          "MailFathom.Application": "[0.5.0, )",
+          "MailFathom.Common": "[0.5.0, )",
+          "MailFathom.Domain": "[0.5.0, )",
+          "MailFathom.Infrastructure": "[0.5.0, )",
+          "MailFathom.Mcp": "[0.5.0, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.10, )",
           "Microsoft.Extensions.Http.Resilience": "[10.6.0, )",
           "Microsoft.Extensions.ServiceDiscovery": "[10.6.0, )",
@@ -820,9 +820,9 @@
         "dependencies": {
           "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL": "[13.4.6, )",
           "HtmlSanitizer": "[9.1.974, )",
-          "MailFathom.Application": "[0.4.0, )",
-          "MailFathom.Common": "[0.4.0, )",
-          "MailFathom.Domain": "[0.4.0, )",
+          "MailFathom.Application": "[0.5.0, )",
+          "MailFathom.Common": "[0.5.0, )",
+          "MailFathom.Domain": "[0.5.0, )",
           "MailKit": "[4.17.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",
@@ -841,8 +841,8 @@
       "MailFathom.Mcp": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Application": "[0.4.0, )",
-          "MailFathom.Domain": "[0.4.0, )",
+          "MailFathom.Application": "[0.5.0, )",
+          "MailFathom.Domain": "[0.5.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }

--- a/tests/Infrastructure.UnitTests/packages.lock.json
+++ b/tests/Infrastructure.UnitTests/packages.lock.json
@@ -580,13 +580,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.4.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.4.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -597,9 +597,9 @@
         "dependencies": {
           "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL": "[13.4.6, )",
           "HtmlSanitizer": "[9.1.974, )",
-          "MailFathom.Application": "[0.4.0, )",
-          "MailFathom.Common": "[0.4.0, )",
-          "MailFathom.Domain": "[0.4.0, )",
+          "MailFathom.Application": "[0.5.0, )",
+          "MailFathom.Common": "[0.5.0, )",
+          "MailFathom.Domain": "[0.5.0, )",
           "MailKit": "[4.17.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",

--- a/tests/Mcp.UnitTests/packages.lock.json
+++ b/tests/Mcp.UnitTests/packages.lock.json
@@ -312,7 +312,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.2.0, )"
+          "MailFathom.Domain": "[0.5.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -321,8 +321,8 @@
       "MailFathom.Mcp": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Application": "[0.2.0, )",
-          "MailFathom.Domain": "[0.2.0, )",
+          "MailFathom.Application": "[0.5.0, )",
+          "MailFathom.Domain": "[0.5.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }


### PR DESCRIPTION
The second half of the `0.4.0` release, tracked by #526. `main` returns to naming the release being worked toward
rather than the one just published.

**Merge this after the tag, never before.** #550 carries the changelog and is what gets tagged and published; merging
this first would leave the tagged commit declaring `0.5.0` and the release workflow refusing the tag it asserts
`VersionPrefix` against.

Closes #526 — the release is finished here rather than at the changelog merge, because the tag and this bump are both
still outstanding at that point.

## What is in the diff

- `Directory.Build.props` — `VersionPrefix` `0.4.0` → `0.5.0`. It is the only place a version is *written*: the image's
  tags and labels arrive as build arguments, and the chart's `version` and `appVersion` are supplied at package time
  from the same declaration.
- Twelve `packages.lock.json` files — each records the version of every `MailFathom.*` project it references, so
  raising the declaration leaves them naming a version the tree no longer has. Regenerated with
  `dotnet restore MailFathom.slnx --force-evaluate`.

`AppHost` and `IntegrationTests` carry no lock file and are not given one: the Aspire SDK picks part of their graph
from the host platform's runtime identifier.

## The check that matters here

```console
$ git diff -U0 -- '**/packages.lock.json' | grep -E '^[+-][^+-]' | grep -v 'MailFathom\.'
$ git grep -hoE '"MailFathom\.[A-Za-z]+": "\[[0-9]+\.[0-9]+\.[0-9]+' -- '**/packages.lock.json' | grep -v '0.5.0'
```

Both print nothing. The first says no transitive resolution moved behind the bump — a dependency change hidden inside
a version bump is one nobody reviewed. The second says nothing still names another version, checked against `0.5.0`
rather than against `0.4.0`, since a lock file records whatever was current when it was last regenerated.

`deploy/helm/mailfathom/Chart.yaml` is deliberately untouched: its `version` is a `0.0.0` placeholder, it declares no
`appVersion`, and the release run supplies both as one number equal to the application's.

The prose files naming the release are in #550 rather than here. They describe what has just been *published*, and this
pull request merges after the tag — a `README.md` corrected here would be a `README.md` that was wrong in the tagged
tree.

## Verification

`scripts/verify-fast.sh` — **3358 passed, 0 failed**, which is what confirms the raised declaration still builds the
whole solution.
