### PR TITLE
[#553] Register the embedding units of work where their generator is

### DIFF
--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -330,6 +330,10 @@ try
             ?? throw new InvalidOperationException(
                 "The embedding chain was declared at registration and is absent from the validated configuration."));
         builder.Services.AddEmbeddingProviderAdapter();
+        // Beside the adapter rather than inside AddInfrastructure, because these two resolve the generator that call
+        // registers. An instance that declared no chain registers neither and starts; one that declared one registers
+        // both and the workers below have something to resolve.
+        builder.Services.AddEmailEmbeddingGeneration();
     }
     builder.Services.AddInfrastructure(
         provider => provider.GetRequiredService<DatabaseConnectionSettingsMapper>()

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -122,10 +122,17 @@ public static class ServiceCollectionExtensions
     /// <returns>The service collection, for chaining.</returns>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     /// <remarks>
+    /// <para>
     /// The settings arrive already read rather than as an <c>IConfiguration</c> this method reaches into, so which key
     /// holds them stays a host decision and this assembly gains no configuration dependency. They arrive as an
     /// accessor rather than as a value because a secret reference can be repointed by a configuration reload, and a
     /// value captured at registration would keep authenticating with the reference the operator replaced.
+    /// </para>
+    /// <para>
+    /// The embedding stores registered here are the tables; the units of work that write vectors into them are not,
+    /// and belong to <see cref="AddEmailEmbeddingGeneration" /> for the reason that method states. A registration
+    /// added here that resolves an <see cref="ITextEmbeddingGenerator" /> belongs there instead.
+    /// </para>
     /// </remarks>
     public static IServiceCollection AddInfrastructure(
         this IServiceCollection services,
@@ -193,15 +200,6 @@ public static class ServiceCollectionExtensions
         // beside it.
         services.AddScoped<IEmbeddingProfileVectorIndex, EmbeddingProfileVectorIndex>();
         services.AddScoped<IStoredEmailEmbeddingBackfillStore, StoredEmailEmbeddingBackfillStore>();
-        // Registered here beside the store it writes through, for the reason the chunk writer above is: its
-        // `ITextEmbeddingGenerator` comes from the AI boundary, which this project may not reference, so a composition
-        // root that registers persistence without an embedding provider resolves nothing — which is correct, because
-        // such a deployment starts no worker to ask for one.
-        services.AddScoped<StoredEmailEmbeddingGenerator>();
-        // Beside the generator it drives, and conditional on the same thing: the backfill's unit of work is one message
-        // brought up to date, which is the generator's, so a deployment that resolves no generator starts no backfill
-        // either.
-        services.AddScoped<StoredEmailEmbeddingBackfill>();
         services.AddScoped<IEmailMetadataRepository, StoredEmailMetadataRepository>();
         services.AddScoped<IDatabaseSchemaInspector, EfCoreDatabaseSchemaInspector>();
         services.AddScoped<IEmailContentStore, EmailContentStore>();
@@ -300,6 +298,35 @@ public static class ServiceCollectionExtensions
             provider.GetRequiredService<IMailAccessTokenSource>(),
             provider.GetRequiredService<OutboundOperationExecutor>(),
             provider.GetRequiredService<ITransientFailureClassifier>()));
+
+        return services;
+    }
+
+    /// <summary>Registers the units of work that turn a message's passages into vectors.</summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Separate from <see cref="AddInfrastructure" /> because both of these resolve an
+    /// <see cref="ITextEmbeddingGenerator" />, which comes from the AI boundary and exists only where a deployment
+    /// declared an embedding chain. Registering them beside the stores they write through would put a descriptor in
+    /// every container that cannot be constructed in most of them, and a container that validates its descriptors on
+    /// build — which is what a Development run does — then fails to start an instance that was never going to embed
+    /// anything. Serving lexical search alone is a supported state, so the condition is expressed by not making the
+    /// registration rather than by making one that would fail.
+    /// </para>
+    /// <para>
+    /// The two are one call because they are one decision: the backfill's unit of work is one message brought up to
+    /// date by that same generator, so a deployment that resolves neither is the only other shape.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddEmailEmbeddingGeneration(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddScoped<StoredEmailEmbeddingGenerator>();
+        services.AddScoped<StoredEmailEmbeddingBackfill>();
 
         return services;
     }

--- a/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Embeddings.Backfill;
+using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Infrastructure.Persistence.Connections;
 using MailFathom.Infrastructure.Secrets.Resolution;
 using Microsoft.Extensions.DependencyInjection;
@@ -73,6 +75,56 @@ public sealed class ServiceCollectionExtensionsTests
 
         // Act, Assert
         Assert.Throws<InvalidOperationException>(provider.GetRequiredService<NpgsqlDataSource>);
+    }
+
+    /// <summary>
+    /// Serving lexical search alone is a supported state, so an instance that declared no embedding chain resolves no
+    /// text embedding generator. A descriptor needing one would then be registered and unconstructable, which is a
+    /// different thing from being absent: the container reports the first by throwing and the second by answering
+    /// nothing, and only the second survives the build-time validation a Development run performs.
+    /// </summary>
+    [Fact]
+    public async Task AddInfrastructure_WithoutAnEmbeddingChain_RegistersNeitherTheGenerationNorItsBackfill()
+    {
+        // Arrange
+        await using var provider = BuildConfiguredProvider();
+
+        // Act, Assert
+        Assert.Null(provider.GetService<StoredEmailEmbeddingGenerator>());
+        Assert.Null(provider.GetService<StoredEmailEmbeddingBackfill>());
+    }
+
+    /// <summary>
+    /// The other half of the same decision: an instance that declared a chain registers both units of work. Asserted
+    /// against the descriptors rather than by resolving them, because constructing either reaches the stores they
+    /// write through and those open a database this suite has none of.
+    /// </summary>
+    [Fact]
+    public void AddEmailEmbeddingGeneration_OnAServiceCollection_RegistersTheGenerationAndTheBackfillItDrives()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddEmailEmbeddingGeneration();
+
+        // Assert
+        Assert.Contains(
+            services,
+            descriptor => descriptor.ServiceType == typeof(StoredEmailEmbeddingGenerator)
+                && descriptor.Lifetime == ServiceLifetime.Scoped);
+        Assert.Contains(
+            services,
+            descriptor => descriptor.ServiceType == typeof(StoredEmailEmbeddingBackfill)
+                && descriptor.Lifetime == ServiceLifetime.Scoped);
+    }
+
+    [Fact]
+    public void AddEmailEmbeddingGeneration_WithoutAServiceCollection_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(
+            () => ServiceCollectionExtensions.AddEmailEmbeddingGeneration(null!));
     }
 
     private static ServiceProvider BuildConfiguredProvider()

--- a/tests/IntegrationTests/Mailbox/OrchestratedMailbox.cs
+++ b/tests/IntegrationTests/Mailbox/OrchestratedMailbox.cs
@@ -252,11 +252,41 @@ internal sealed class OrchestratedMailbox(OrchestratedMailServerEndpoints endpoi
         return uidValidity;
     }
 
+    /// <summary>Puts an empty folder under a name the server does not hold, without selecting it.</summary>
+    /// <param name="folderName">The folder to create beneath the personal namespace root.</param>
+    /// <param name="cancellationToken">Cancels the connection and the command.</param>
+    /// <returns>A task that completes once the server holds the folder.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the server accepts the creation without answering with the folder.</exception>
+    /// <remarks>
+    /// The folder is deliberately never opened, which is what separates this from <see cref="RecreateFolderAsync" />
+    /// and what makes it the one creation a later <see cref="DeleteFolderAsync" /> may be paired with: the remarks on
+    /// that method record why a selected folder cannot be deleted here. Nothing is retired out of the way either, so a
+    /// name the server already holds fails the creation rather than being silently replaced.
+    /// </remarks>
+    internal async Task CreateFolderAsync(string folderName, CancellationToken cancellationToken)
+    {
+        using var client = await this.ConnectAndAuthenticateAsync(cancellationToken);
+
+        var personalNamespace = await client.GetFolderAsync(client.PersonalNamespaces[0].Path, cancellationToken);
+
+        _ = await personalNamespace.CreateAsync(folderName, isMessageFolder: true, cancellationToken)
+            ?? throw new InvalidOperationException(
+                $"The mail server accepted CREATE for '{folderName}' without returning the folder it created.");
+
+        await client.DisconnectAsync(quit: true, cancellationToken);
+    }
+
     /// <summary>Removes one folder from the mailbox, so a test can model a destination somebody deleted.</summary>
     /// <param name="folderName">The folder to remove; it must exist, because a test that removed nothing proves nothing.</param>
     /// <param name="cancellationToken">Cancels the connection and the command.</param>
     /// <returns>A task that completes once the server no longer holds the folder.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the mailbox holds no folder of that name.</exception>
+    /// <remarks>
+    /// Only a folder no session has selected may be removed this way. GreenMail 2.1.11 drops the connection when it
+    /// deletes a folder an earlier session selected, for the reason <see cref="RecreateFolderAsync" /> records at
+    /// length — which is why that method retires a folder by renaming it and why pairing it with this one reaches the
+    /// defect rather than avoiding it. <see cref="CreateFolderAsync" /> is the creation this is paired with.
+    /// </remarks>
     internal async Task DeleteFolderAsync(string folderName, CancellationToken cancellationToken)
     {
         using var client = await this.ConnectAndAuthenticateAsync(cancellationToken);

--- a/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
+++ b/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
@@ -123,6 +123,10 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
         builder.Services.AddInfrastructure(
             _ => new PostgresConnectionSettings(orchestration.DatabaseConnectionString, null, null),
             PostgresTextSearchConfiguration.Default);
+        // Registered by a composition root for the reason the generator above is: AddInfrastructure registers neither
+        // the embedding generation nor the backfill, because both resolve a text embedding generator an instance that
+        // declared no chain does not have. This suite declared one, so it registers both.
+        builder.Services.AddEmailEmbeddingGeneration();
 
         // The ring a composition root would build from the DataEncryption section. It is supplied here for the reason
         // every other bound setting above is: the suite does not start the host resource, so nothing else binds it, and

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingGenerationTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingGenerationTests.cs
@@ -60,7 +60,7 @@ public sealed class OrchestratedEmailEmbeddingGenerationTests(MailFathomOrchestr
         Assert.Equal(passageCount, first.EmbeddedChunkCount);
         Assert.Equal(StoredEmailEmbeddingOutcome.Embedded, repeat.Outcome);
         Assert.Equal(0, repeat.EmbeddedChunkCount);
-        Assert.Equal(passageCount, await CountVectorsAsync(services, profileId, cancellationToken));
+        Assert.Equal(passageCount, await CountVectorsAsync(services, storedEmailId, profileId, cancellationToken));
     }
 
     /// <summary>
@@ -151,13 +151,23 @@ public sealed class OrchestratedEmailEmbeddingGenerationTests(MailFathomOrchestr
                 .CountAsync(chunk => chunk.StoredEmailId == storedEmailId.Value, token),
             cancellationToken);
 
+    /// <summary>Counts the vectors one message holds under one profile.</summary>
+    /// <remarks>
+    /// Narrowed to the message rather than counting the profile's whole table, because the suite shares one database
+    /// and every class embedding into the deterministic geometry writes into the same profile. A count of everything
+    /// would report whatever the classes before this one happened to leave behind.
+    /// </remarks>
     private static Task<int> CountVectorsAsync(
         OrchestratedMailFathomServices services,
+        StoredEmailId storedEmailId,
         EmbeddingProfileId profileId,
         CancellationToken cancellationToken) => services.InScopeAsync(
             (scope, token) => scope.GetRequiredService<MailFathomDbContext>().EmailEmbeddings
                 .AsNoTracking()
-                .CountAsync(embedding => embedding.EmbeddingProfileId == profileId.Value, token),
+                .CountAsync(
+                    embedding => embedding.EmbeddingProfileId == profileId.Value
+                        && embedding.EmailChunk!.StoredEmailId == storedEmailId.Value,
+                    token),
             cancellationToken);
 
     /// <summary>Registers a geometry no generator in this process produces, which is what a superseded one looks like.</summary>

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxConvergenceTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxConvergenceTests.cs
@@ -124,7 +124,9 @@ public sealed class OrchestratedMailboxConvergenceTests(MailFathomOrchestrationF
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
         var mailbox = new OrchestratedMailbox(orchestration.MailServer);
-        await mailbox.RecreateFolderAsync(RemovedFolderName, cancellationToken);
+        // Created and removed rather than recreated and removed: the server has to have accepted the name for its
+        // absence to mean a folder somebody deleted, and a folder this suite selected cannot be deleted at all.
+        await mailbox.CreateFolderAsync(RemovedFolderName, cancellationToken);
         await mailbox.DeleteFolderAsync(RemovedFolderName, cancellationToken);
 
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);


### PR DESCRIPTION
Closes #553

The `Integration tests` run on `main` at `4b58b91` failed 13 of 84 tests. Three defects produced them, one in production code and two in the suite.

## An instance that declares no embedding chain could not build its container

`AddInfrastructure` registered `StoredEmailEmbeddingGenerator` and `StoredEmailEmbeddingBackfill` unconditionally. Both resolve `ITextEmbeddingGenerator`, which only `AddEmbeddingProviderAdapter` registers, and the host calls that only where `Embeddings` declares a chain. The comment beside the two registrations claimed such a composition root "resolves nothing"; nothing made that true, because the descriptors were there either way. Where the container validates its descriptors on build — every Development run — startup ended with `Unable to resolve service for type 'ITextEmbeddingGenerator'` before Kestrel bound a listener.

Serving lexical search alone is a supported state that `docs/features/embedding-generation.md` describes, so this made a documented deployment unstartable. It is also what failed the eleven composed-host tests: the host resource never served, and every request sat until the client's 100-second timeout. The mutual-TLS host passed in the same run only because it starts in `Production`, where the validation is off.

`AddEmailEmbeddingGeneration` now makes those two registrations and the host calls it beside the provider adapter, under the one condition that already decides whether the embedding workers are started. `AddInfrastructure` keeps the stores — they are the tables, and they need no generator — and its remarks say where a registration that resolves one belongs.

## Two arrangements were failing on their own terms

`OrchestratedEmailEmbeddingGenerationTests` counted every vector under the active profile rather than its own message's, so it reported whatever the shared database held. Once the backfill sweep began embedding everything stored under the same profile, it read 1233 where it expected 8. The count is now narrowed by `StoredEmailId`, which is what the sibling backfill class already does.

`OrchestratedMailboxConvergenceTests` produced its removed destination by calling `RecreateFolderAsync` and then `DeleteFolderAsync`. `RecreateFolderAsync` opens the folder it creates to read its UIDVALIDITY, and its own remarks record why that cannot then be deleted: GreenMail drops the connection when it deletes a folder an earlier session selected, which is the whole reason that method retires a folder by renaming it. The arrangement reached the documented defect and failed with `The IMAP server has unexpectedly disconnected`. A non-selecting `CreateFolderAsync` is now the creation a deletion may be paired with, and `DeleteFolderAsync` records the constraint it carries.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves. The public surface gains one registration extension and loses no behavior: a deployment that declared an embedding chain registers exactly what it did before, and one that declared none now starts.

## Verification

- `scripts/verify-full.sh`: passed, 3361 tests, aggregate line coverage 94.59%.
- Three unit tests in `Infrastructure.UnitTests` cover both halves of the decision and the argument guard. The first would have failed before this change: a registered but unconstructable descriptor makes the container throw where an absent one makes it answer nothing.
- The `Integration tests` workflow is dispatched against this branch, since that suite is what the change is answering and no pull-request check runs it.