### PR TITLE
[#558] Ignore a design-time connection string that is not one

### DIFF
--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -1,6 +1,6 @@
 # Local development
 
-<!-- describes: scripts/**, global.json, .config/dotnet-tools.json, .config/typos.toml, .config/CodeCoverage.proj, .config/testconfig.json, src/AppHost/**, .github/workflows/** -->
+<!-- describes: scripts/**, global.json, .config/dotnet-tools.json, .config/typos.toml, .config/CodeCoverage.proj, .config/testconfig.json, src/AppHost/**, src/Infrastructure/Persistence/MailFathomDbContextDesignTimeFactory.cs, .github/workflows/** -->
 
 Use the .NET SDK pinned in `global.json`. Test execution is configured for Microsoft Testing Platform through the repository-level `global.json` test runner setting.
 
@@ -333,6 +333,10 @@ That split is why generating a migration needs no Docker and takes seconds, whil
 `Host` is the startup project, because it is the resource the orchestration issues the connection string to, and it therefore carries a design-time-only reference to `Microsoft.EntityFrameworkCore.Design`. `Infrastructure` owns the context, the design-time factory, and the migrations under `src/Infrastructure/Persistence/Migrations/`.
 
 `MailFathomDbContextDesignTimeFactory` gives EF Core a context without starting the host, which matters because the host composes its connection string during startup and design-time tooling never runs that. It reads `ConnectionStrings__mailfathom` when the orchestration supplies it, then `MAILFATHOM_DESIGN_TIME_CONNECTION_STRING` for a command run outside it, and falls back to `Host=localhost;Database=mailfathom;Username=mailfathom`. The orchestrated value wins so a stale override left in a shell cannot point a migration at a different database than the one being migrated.
+
+It is used only when it is a connection string. Under `aspire publish` there is no database to name, so that variable carries the unresolved manifest expression `{mailfathom.connectionString}` — non-empty, and therefore not caught by an emptiness check — and the schema artifact the release attaches is generated in exactly that mode. A value the Npgsql parser rejects is skipped as though the variable were unset, because no connection could be opened from it and a command that opens none should not fail on it. The vector mapping is what made this observable: it needs a data source, which the provider builds while the options are constructed, so the string is parsed by every command rather than only by one that connects.
+
+`MAILFATHOM_DESIGN_TIME_CONNECTION_STRING` is deliberately not covered by that tolerance. It is written by hand for a command that usually does reach a database, so a malformed one fails rather than quietly sending `ef-database-update` to `localhost`.
 
 Every migration in the repository is permanent. A model change appends one with `scripts/add-migration.sh <MigrationName>` and never regenerates, renames, reorders, or deletes an existing one, because a migration identifier that a database has written into its `__EFMigrationsHistory` can never be reached again once it is regenerated: that database can then only be recreated, destroying whatever it held. Nothing in the repository deletes a migration, and no command offers to.
 

--- a/src/Infrastructure/Persistence/MailFathomDbContextDesignTimeFactory.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContextDesignTimeFactory.cs
@@ -5,6 +5,7 @@
 using MailFathom.Infrastructure.Persistence.Connections;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Npgsql;
 
 namespace MailFathom.Infrastructure.Persistence;
 
@@ -83,19 +84,64 @@ internal sealed class MailFathomDbContextDesignTimeFactory : IDesignTimeDbContex
     /// <param name="designTimeConnectionString">The developer's own override, or <see langword="null" />.</param>
     /// <returns>Options bound to the first configured database, or to the local development default.</returns>
     /// <remarks>
+    /// <para>
     /// The orchestrated value wins so that a stale override left in a shell cannot silently point a migration at a
     /// different database than the one the resource being migrated is running against.
+    /// </para>
+    /// <para>
+    /// An orchestrated value that is not a connection string at all is ignored rather than used. Under
+    /// <c>aspire publish</c> there is no database to name, so the variable carries the unresolved manifest expression
+    /// <c>{mailfathom.connectionString}</c> — non-empty, and therefore past the emptiness check above. Nothing had to
+    /// notice until the vector mapping arrived: it needs an <see cref="NpgsqlDataSource" />, which the provider
+    /// builds while the options are constructed, so the string is now parsed by every command rather than only by one
+    /// that opens a connection. Generating a migration script opens none, and refusing to produce the release's schema
+    /// artifact over an address nobody was going to dial is the failure this avoids.
+    /// </para>
+    /// <para>
+    /// The developer's own override is deliberately not covered by that tolerance. It is written by hand for a command
+    /// that usually does connect, so a malformed one is a typo worth failing on rather than a reason to quietly apply a
+    /// migration to <see cref="LocalDevelopmentConnectionString" /> instead of to the database that was meant.
+    /// </para>
     /// </remarks>
     internal static DbContextOptions<MailFathomDbContext> BuildOptions(
         string? orchestratedConnectionString,
         string? designTimeConnectionString)
     {
-        var connectionString = new[] { orchestratedConnectionString, designTimeConnectionString }
+        var usableOrchestratedConnectionString =
+            IsConnectionString(orchestratedConnectionString) ? orchestratedConnectionString : null;
+
+        var connectionString = new[] { usableOrchestratedConnectionString, designTimeConnectionString }
             .FirstOrDefault(candidate => !string.IsNullOrWhiteSpace(candidate))
             ?? LocalDevelopmentConnectionString;
 
         return new DbContextOptionsBuilder<MailFathomDbContext>()
             .UseNpgsql(connectionString, npgsql => npgsql.UseVector())
             .Options;
+    }
+
+    /// <summary>Reports whether a candidate is a connection string Npgsql can parse.</summary>
+    /// <param name="candidate">The value read from the environment, or <see langword="null" /> when unset.</param>
+    /// <returns><see langword="true" /> when the candidate parses; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// Parsing is the test rather than a pattern match on the manifest expression's braces, because what makes a value
+    /// unusable is that no connection could be opened from it, and that is exactly what the parser decides.
+    /// </remarks>
+    private static bool IsConnectionString(string? candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return false;
+        }
+
+        try
+        {
+            _ = new NpgsqlConnectionStringBuilder(candidate);
+
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
     }
 }

--- a/tests/Infrastructure.UnitTests/Persistence/MailFathomDbContextDesignTimeFactoryTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/MailFathomDbContextDesignTimeFactoryTests.cs
@@ -59,6 +59,54 @@ public sealed class MailFathomDbContextDesignTimeFactoryTests
     }
 
     [Fact]
+    public void BuildOptions_PublishModeIssuedAnUnresolvedExpression_GeneratesTheScriptAnyway()
+    {
+        // Act
+        var options = MailFathomDbContextDesignTimeFactory.BuildOptions(
+            "{mailfathom.connectionString}",
+            designTimeConnectionString: null);
+
+        // Assert
+        using var context = new MailFathomDbContext(options, PostgresTextSearchConfiguration.Default);
+        Assert.Equal(
+            MailFathomDbContextDesignTimeFactory.LocalDevelopmentConnectionString,
+            context.Database.GetConnectionString());
+    }
+
+    [Fact]
+    public void BuildOptions_PublishModeIssuedAnUnresolvedExpression_StillPrefersTheDesignTimeOverride()
+    {
+        // Act
+        var options = MailFathomDbContextDesignTimeFactory.BuildOptions(
+            "{mailfathom.connectionString}",
+            "Host=db.test;Database=mailfathom;Username=dev");
+
+        // Assert
+        using var context = new MailFathomDbContext(options, PostgresTextSearchConfiguration.Default);
+        Assert.Equal("Host=db.test;Database=mailfathom;Username=dev", context.Database.GetConnectionString());
+    }
+
+    [Fact]
+    public void BuildOptions_MalformedDesignTimeOverride_FailsRatherThanRetargetingTheLocalDatabase()
+    {
+        // Arrange
+        var options = MailFathomDbContextDesignTimeFactory.BuildOptions(
+            orchestratedConnectionString: null,
+            designTimeConnectionString: "nonsense-that-names-no-keyword");
+
+        // Act, Assert
+        // The override is kept rather than swapped for the local default, so the command fails on the value the
+        // developer wrote. Where that surfaces is the provider's own business — building the data source the vector
+        // mapping needs — so the assertion is that it surfaces at all, not that BuildOptions is where it does.
+        Assert.Throws<ArgumentException>(() =>
+        {
+            using var context = new MailFathomDbContext(options, PostgresTextSearchConfiguration.Default);
+
+            return context.Model;
+        });
+    }
+
+    [Fact]
     public void ReadTextSearchConfiguration_NoneConfigured_UsesTheDefaultTheModelWouldUse()
     {
         // Act


### PR DESCRIPTION
Closes #558.

**This blocks the `0.4.0` tag.** `publish-container-image` has `needs: schema-artifact`, so the release would fail before publishing anything — a safe failure, but it would spend the `v0.4.0` tag, and re-cutting one costs a manual deletion in both registries. #550 is merged and #551 is approved; the tag waits on this.

## The defect

The nightly of 2026-08-08 ([run 31230058887](https://github.com/Krzysztof318/MailFathom/actions/runs/31230058887)) failed in `Schema artifact / Build the schema artifact`:

```
Unable to create a 'DbContext' of type 'MailFathomDbContext'. The exception 'Format of the initialization
string does not conform to specification starting at index 0.' was thrown while attempting to create an instance.
```

`aspire publish` generates the migration script with no database to name, so the EF tool resource receives `ConnectionStrings__mailfathom` as an unresolved manifest expression. The value is literally `{mailfathom.connectionString}` — observed, not inferred: I put a temporary write of the variable into the factory, ran `scripts/build-schema-artifact.sh`, and read it back.

That value has always been what publish mode carries. What changed is #523, which added `npgsql.UseVector()` to `BuildOptions`: the vector mapping needs an `NpgsqlDataSource`, and the provider builds one — and so parses the connection string — while the options are constructed. Plain `UseNpgsql` deferred the parse until a connection was opened, which `migrations script` never does, so the same unparseable value sat there harmlessly. `IsNullOrWhiteSpace` was the existing guard and does not catch a non-empty placeholder.

Narrowed three ways locally, each against `scripts/build-schema-artifact.sh`:

| Condition | Result |
| --- | --- |
| Variable unset | Succeeds — falls back to `LocalDevelopmentConnectionString` |
| Variable set to `{mailfathom.connectionString}` | Fails with exactly the message above |
| `UseVector()` removed, placeholder kept | Fails **later**, on `The 'Vector' property … could not be mapped` |

The third row is what proves the mechanism rather than merely correlating with it: without `UseVector()` the bad string gets past options construction and into model building, so the parse really is what became eager — and removing `UseVector()` is not an available fix, because the model needs it.

## The change

`BuildOptions` uses the orchestrated variable only when Npgsql can parse it. The predicate is `new NpgsqlConnectionStringBuilder(candidate)` rather than a match on the expression's braces, because what makes a value unusable is that no connection could be opened from it, and the parser is what decides that.

**`MAILFATHOM_DESIGN_TIME_CONNECTION_STRING` is deliberately left strict**, and that asymmetry is the one judgement call here. It is written by hand for a command that usually does reach a database, so a malformed one should fail on the value the developer wrote rather than quietly retarget an `ef-database-update` at `localhost` — the failure mode that would be far worse than the one being fixed. Tolerance is granted only where publish mode is known to inject a non-value.

## Verification

- `bash scripts/build-schema-artifact.sh <dir> 0.4.0` now **succeeds** on this branch with no database and no orchestration, producing `mailfathom-schema-0.4.0.sql` (19 895 bytes, checksum `05fc26a8…`) carrying all 8 migrations from `20260801190024_Initial` to `20260807154642_AddMailboxMutationObservations`. That is the job that failed, run end to end.
- `scripts/verify-full.sh` — **3364 passed, 0 failed**, aggregate line coverage 94.60%.
- Three unit tests added: the publish-mode placeholder ignored, the placeholder still yielding to a design-time override that *is* valid, and a malformed override still failing. The third asserts at context construction rather than at `BuildOptions`, because that is where the provider actually surfaces it — I wrote it the other way first and the test told me otherwise.

## Documentation

`docs/operations/local-development.md` § *EF Core design-time commands* stated the resolution order in a way this change makes incomplete, so it gains the distinction and the reason for it.

Its `describes:` marker did not cover `MailFathomDbContextDesignTimeFactory.cs`, so `scripts/review-obligations.sh` never listed the page — exactly the gap `AGENTS.md` describes, where a page a marker misses can still be wrong. The marker now covers the file, so the next change here reaches the page through the index.

## Worth deciding separately

`build-schema-artifact.yml` is called by `nightly.yml` and `release.yml` alone. No `pull_request` workflow generates the script, which is why #523 merged green and this surfaced on a schedule. Giving the pull-request checks their own generation would close that gap at the cost of an `aspire publish` on every pull request — a trade worth its own issue rather than a decision smuggled into a fix. Noted in #558 as out of scope.
