### PR TITLE
[#552] Reach a deployment whose certificate is not trusted, by asking once and pinning it

### DIFF
--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -391,7 +391,7 @@ to make out of habit:
 ```console
 $ mfctl login --endpoint http://mail.internal.example:8090 --name internal
 
-mail.internal.example:8090 is an HTTP address, so nothing protects this connection.
+http://mail.internal.example:8090 is an HTTP address, so nothing protects this connection.
 The credential you are about to present, and every later request from this profile, cross the network in clear text.
 A redirect the deployment might send to an https:// address would not change that: the credential is already on the wire by then.
 

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -337,6 +337,98 @@ the profile, because it is the deployment you just chose to work with.
 When a deployment issues a new credential, sign in again by profile name rather than by address — `mfctl login
 --endpoint production` — and the address it already holds is reused.
 
+## When the connection is weaker than the default
+
+A deployment on an internal host commonly serves a certificate no workstation trusts — self-signed, or issued by an
+authority only your organization carries — and some are reached over `http://` at all. Neither is refused outright and
+neither is waved through: `login` asks about it once, records the answer on the profile, and no later command asks
+again. Both questions default to no, and refusing either stores nothing and signs in to nothing.
+
+### A certificate this machine does not trust
+
+Nothing happens for a deployment whose certificate validates on its own; the question exists only where it does not.
+
+```console
+$ mfctl login --endpoint https://mail.internal.example:8443 --name internal
+
+https://mail.internal.example:8443 presented a certificate this machine does not trust:
+
+  Subject:     CN=mail.internal.example
+  Issuer:      CN=Example internal authority
+  Fingerprint: 3B:9A:1C:…:7F
+  Valid:       2026-01-04 09:12:00Z to 2027-01-04 09:12:00Z
+  Not trusted: this machine does not trust the chain it was presented with (UntrustedRoot)
+
+Accepting it stores this fingerprint on the profile. Every later command then accepts this certificate and refuses any other,
+so a deployment that renews or replaces its certificate is signed in to again rather than trusted silently.
+
+Trust this certificate for this profile? [y/N]: y
+Signed in to https://mail.internal.example:8443 as 'workstation' (MailFathom 0.5.0), saved as profile 'internal' and selected. The connection is protected by a pinned certificate rather than by a chain this machine trusts; the profile now accepts 3B:9A:1C:…:7F and refuses any other.
+```
+
+Read the fingerprint against the deployment's own before answering — `openssl x509 -in server.crt -noout -fingerprint
+-sha256` prints it in the same form. Nothing is sent until you answer: the handshake was refused, so the credential was
+never on the wire.
+
+**A pin is stricter than what it replaces, not weaker.** Ordinary chain validation accepts any certificate a trusted
+authority signed; a pinned profile accepts one certificate and refuses every other, including one your machine would
+have trusted on its own. That is what makes accepting a self-signed certificate once safe to live with — a later
+substitution fails as loudly as an untrusted certificate does today, naming both fingerprints.
+
+The consequence is that a **renewed certificate ends the profile's connection until you accept the new one**. Run
+`mfctl login --endpoint internal` again: the sign-in starts from ordinary validation, presents whatever the deployment
+now serves, and asks again. `mfctl logout` removes the pin with the profile.
+
+The pin covers the deployment and nothing else. An OAuth sign-in reaches an authorization server as well, and every
+request to it goes out under ordinary chain validation, because a fingerprint taken at your deployment says nothing
+about the machine your identity platform runs on.
+
+### An endpoint reached over `http://`
+
+An address is taken as written and no scheme is guessed onto a bare host, so `http://` is a decision — one that is easy
+to make out of habit:
+
+```console
+$ mfctl login --endpoint http://mail.internal.example:8090 --name internal
+
+mail.internal.example:8090 is an HTTP address, so nothing protects this connection.
+The credential you are about to present, and every later request from this profile, cross the network in clear text.
+A redirect the deployment might send to an https:// address would not change that: the credential is already on the wire by then.
+
+Sign in over an unprotected connection anyway? [y/N]:
+```
+
+The redirect sentence is the part worth taking seriously. `mfctl` never follows a redirect — that is what stops a
+request carrying a bearer credential from being moved to an address you did not name — and
+[the redirect this endpoint serves](#redirecting-mfctl-after-you-configure-tls) protects the *next* request rather than
+the one that arrived. So the question is asked from the address alone, before anything is sent, and a deployment that
+would have answered `308` never gets to answer it. Sign in to the `https://` address instead wherever there is one.
+
+Accepting is recorded on the profile and widens nothing else: a clear-text profile that later answers over HTTPS with
+an untrusted certificate is still refused.
+
+### Signing in with nobody at the terminal
+
+`--mode key` reads the credential from standard input, so a piped sign-in has no terminal to read an answer from. Both
+questions are therefore stated up front instead, and a sign-in that needed one and did not get it fails naming the
+switch rather than prompting into the pipe:
+
+```console
+$ printf '%s' "$MAILFATHOM_KEY" | mfctl login \
+    --endpoint https://mail.internal.example:8443 --trust-untrusted-certificate
+```
+
+| Switch | What it accepts |
+| --- | --- |
+| `--trust-untrusted-certificate` | Whatever certificate the deployment presents at this sign-in. It is pinned to the profile exactly as an interactively accepted one is, so the switch weakens the one sign-in rather than the profile it produces. |
+| `--allow-clear-text` | That an `http://` endpoint carries the credential and every later request unprotected. |
+
+There is deliberately no fingerprint to pass: somebody who had to obtain the fingerprint first could have installed the
+certificate instead. Neither switch has any effect on a deployment whose transport is already protected.
+
+Nothing on the service side changes for any of this, and no configuration key turns certificate validation or
+clear-text protection off globally. These are the client's decisions about one deployment.
+
 ## How long an OAuth sign-in lasts
 
 An access token is typically minted for an hour, and you should never notice. Every command checks the stored token
@@ -434,6 +526,13 @@ there is no sealed token in the file and nothing an attacker could present even 
 path is not a secret and is stored in clear; what it names is, and it is protected by that file's own permissions rather
 than by anything here.
 
+**A profile that accepted something about its transport records that too**, beside the endpoint and in clear: the
+pinned certificate's SHA-256 fingerprint, and whether the connection is unprotected. Neither is a secret — a fingerprint
+is what the deployment presents to anybody who connects — and what they protect is that the profile keeps talking to the
+same deployment. A profile that accepted nothing beyond the default records nothing, so the presence of the entry is
+itself the statement that something was accepted, and a file written before the entry existed reads as an ordinary
+profile rather than failing.
+
 Be clear about what that buys. A credentials file that leaves the machine — in a backup, a synced folder, a support
 bundle, a screenshot of a directory listing — discloses nothing on its own. Someone already able to read your files on
 your machine can read the key too, and on Linux nothing prevents that; the file mode is what answers that case, and the
@@ -456,6 +555,11 @@ encryption answers the copy. Holding the credential in the platform's own secret
 | `rather than storing the token` | The endpoint answered with neither an acceptance nor an explained refusal. The token was not stored and the account is unchanged. A `500` here is most often a deployment with no `DataEncryption` key ring, which is what a stored token is sealed under; its own log names the cause. |
 | `did not identify itself as MailFathom` | Something else is answering on that port — a proxy, or another service. |
 | `could not be reached` | Nothing is listening, or a firewall is in the way. The endpoint binds only what `BindAddress` names; `127.0.0.1` is unreachable from another machine by design. |
+| `presented a certificate this machine does not trust` | On `login`, the question described in [when the connection is weaker than the default](#when-the-connection-is-weaker-than-the-default). On any other command, a profile that holds no pin met a certificate that stopped validating — sign in again to review it. Nothing was sent either way. |
+| `presented a certificate this profile has not pinned` | The deployment's certificate is not the one this profile accepted. Both fingerprints are named. A renewal is the ordinary cause and `mfctl login` is the answer; anything else is worth finding out about before you accept it. |
+| `The deployment's certificate was refused` | You answered no. Nothing was signed in to and nothing was stored. |
+| `Transport protection was refused` | You answered no to the clear-text question. Sign in to the `https://` address, or accept the unprotected connection. |
+| `there is no terminal to ask on` | A piped or non-interactive `login` met one of the two questions. Pass `--trust-untrusted-certificate` or `--allow-clear-text`, whichever the message names. |
 | `did not answer in time` | The connection was accepted and no answer arrived within 30 seconds, so the address and the port are right and the deployment is what to look at — an overloaded host, a stalled process, or a firewall that drops rather than refuses. |
 | `The stored credential could not be read.` | The credentials file and the key that opens it no longer match, which is what a store copied from another machine or another user looks like. Sign in again to replace it. |
 | `No deployment was named.` | `login` needs an address the first time. Pass `--endpoint`, or set `MAILFATHOM_ENDPOINT`. |

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -107,6 +107,26 @@ request, each good for about a minute, and the only thing the service holds is a
 [Signing in with a key pair](../operations/admin-endpoint.md#with-a-key-pair) has the `openssl` commands and the entry
 to add.
 
+If your deployment serves a certificate your workstation does not trust — self-signed, or issued by an authority only
+your organization carries — the sign-in shows you that certificate and asks once whether to trust it, the way an SSH
+client asks about a host key:
+
+```console
+$ mfctl login --endpoint https://mail.internal.example:8443 --name internal
+…
+  Fingerprint: 3B:9A:1C:…:7F
+Trust this certificate for this profile? [y/N]:
+```
+
+Compare the fingerprint against the deployment's own before you answer; nothing has been sent yet. Saying yes stores
+that fingerprint on the profile, which makes the profile **stricter** rather than looser: from then on it accepts that
+one certificate and refuses every other, so a renewal or a substitution stops the profile rather than passing
+unnoticed. You accept a renewed certificate by signing in again. An `http://` address gets a question of its own,
+because the credential and every later request would cross the network in clear text and a redirect to `https://`
+arrives too late to change that.
+[When the connection is weaker than the default](../operations/admin-endpoint.md#when-the-connection-is-weaker-than-the-default)
+has both questions in full, and the two switches a scripted sign-in states the answers with.
+
 What is stored afterwards is one small file per user, with the tokens encrypted and the key beside it — and for a
 key-pair profile, no credential at all;
 [where the credential is kept](../operations/admin-endpoint.md#where-the-credential-is-kept) states the paths, what

--- a/src/Cli/Administration/AdminApiClient.cs
+++ b/src/Cli/Administration/AdminApiClient.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using MailFathom.Cli.Transport;
 
 namespace MailFathom.Cli.Administration;
 
@@ -17,12 +18,12 @@ namespace MailFathom.Cli.Administration;
 /// </remarks>
 internal sealed class AdminApiClient
 {
-    private readonly HttpClient transport;
+    private readonly DeploymentTransport transport;
 
     /// <summary>Initializes a client over a transport the caller owns.</summary>
-    /// <param name="transport">The transport, whose <see cref="HttpClient.BaseAddress" /> names the deployment.</param>
+    /// <param name="transport">The transport, whose base address names the deployment.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="transport" /> is <see langword="null" />.</exception>
-    internal AdminApiClient(HttpClient transport)
+    internal AdminApiClient(DeploymentTransport transport)
     {
         ArgumentNullException.ThrowIfNull(transport);
 
@@ -127,20 +128,28 @@ internal sealed class AdminApiClient
     }
 
     /// <summary>Turns a transport failure into something the operator can act on.</summary>
-    /// <remarks>A cancelled request is left alone: the operator interrupted it, and reporting that as a deployment problem would be wrong.</remarks>
+    /// <remarks>
+    /// A cancelled request is left alone: the operator interrupted it, and reporting that as a deployment problem would
+    /// be wrong. A refused certificate is the one transport failure that has a cause worth naming rather than a
+    /// message to repeat, because the platform reports it as an ordinary connection failure and the operator would
+    /// otherwise go looking at the address, the port, and the firewall.
+    /// </remarks>
     private async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         try
         {
-            return await this.transport.SendAsync(request, cancellationToken);
+            return await this.transport.Client.SendAsync(request, cancellationToken);
         }
         catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            throw new CliFailure($"The deployment at {this.transport.BaseAddress} did not answer in time.");
+            throw new CliFailure($"The deployment at {this.transport.Client.BaseAddress} did not answer in time.");
         }
         catch (HttpRequestException failure)
         {
-            throw new CliFailure($"The deployment at {this.transport.BaseAddress} could not be reached: {failure.Message}", failure);
+            throw new CliFailure(
+                this.transport.DescribeRefusal()
+                ?? $"The deployment at {this.transport.Client.BaseAddress} could not be reached: {failure.Message}",
+                failure);
         }
     }
 

--- a/src/Cli/Administration/DeploymentAccess.cs
+++ b/src/Cli/Administration/DeploymentAccess.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.Cli.Authorization;
 using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Transport;
 
 namespace MailFathom.Cli.Administration;
 
@@ -29,7 +30,7 @@ namespace MailFathom.Cli.Administration;
 internal sealed class DeploymentAccess
 {
     private readonly CredentialStore store;
-    private readonly Func<Uri, HttpClient> openTransport;
+    private readonly Func<Uri, StoredTransportTrust, DeploymentTransport> openTransport;
     private readonly TimeProvider timeProvider;
 
     /// <summary>Initializes access over the store, the transport, and the clock a command was given.</summary>
@@ -37,7 +38,10 @@ internal sealed class DeploymentAccess
     /// <param name="openTransport">Opens a transport aimed at one address; this type disposes what it opens.</param>
     /// <param name="timeProvider">Decides whether the stored access token is still usable.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
-    internal DeploymentAccess(CredentialStore store, Func<Uri, HttpClient> openTransport, TimeProvider timeProvider)
+    internal DeploymentAccess(
+        CredentialStore store,
+        Func<Uri, StoredTransportTrust, DeploymentTransport> openTransport,
+        TimeProvider timeProvider)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(openTransport);
@@ -82,7 +86,9 @@ internal sealed class DeploymentAccess
         OAuthSession session,
         CancellationToken cancellationToken)
     {
-        using var transport = this.openTransport(session.TokenEndpoint);
+        // The authorization server rather than the deployment, so the profile's own certificate pin does not travel
+        // here: it names the deployment's certificate and would refuse every certificate this host could present.
+        using var transport = this.openTransport(session.TokenEndpoint, StoredTransportTrust.Protected);
 
         var authorization = new DeploymentAuthorization(
             session.Issuer,
@@ -92,7 +98,7 @@ internal sealed class DeploymentAccess
             session.Resource,
             session.Scope);
 
-        var renewed = await new DeploymentAuthorizer(transport, this.timeProvider)
+        var renewed = await new DeploymentAuthorizer(transport.Client, this.timeProvider)
             .RefreshAsync(authorization, session.ClientId, session.RefreshToken, cancellationToken);
 
         this.store.RenewAccessToken(profile.Name, renewed.AccessToken, renewed.AccessTokenExpiresAt);

--- a/src/Cli/Authorization/DeploymentAuthorizationDiscovery.cs
+++ b/src/Cli/Authorization/DeploymentAuthorizationDiscovery.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using MailFathom.Cli.Administration;
+using MailFathom.Cli.Transport;
 using MailFathom.Common.OAuth;
 
 namespace MailFathom.Cli.Authorization;
@@ -27,16 +28,28 @@ namespace MailFathom.Cli.Authorization;
 /// </remarks>
 internal sealed class DeploymentAuthorizationDiscovery
 {
-    private readonly HttpClient transport;
+    private readonly DeploymentTransport deployment;
 
-    /// <summary>Initializes discovery over a transport aimed at one deployment.</summary>
-    /// <param name="transport">The transport, whose <see cref="HttpClient.BaseAddress" /> names the deployment.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transport" /> is <see langword="null" />.</exception>
-    internal DeploymentAuthorizationDiscovery(HttpClient transport)
+    private readonly Func<Uri, DeploymentTransport> openAuthorizationServerTransport;
+
+    /// <summary>Initializes discovery over the deployment's transport and a way to open one at the server it names.</summary>
+    /// <param name="deployment">The transport aimed at the deployment, whose base address names it.</param>
+    /// <param name="openAuthorizationServerTransport">Opens a transport aimed at the authorization server; this type disposes what it opens.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Two transports because the two documents come from two machines. The deployment's transport carries whatever that
+    /// profile accepted about the deployment — a pinned certificate, in particular — and applying that to the
+    /// authorization server would refuse it for presenting a certificate it was never asked to present.
+    /// </remarks>
+    internal DeploymentAuthorizationDiscovery(
+        DeploymentTransport deployment,
+        Func<Uri, DeploymentTransport> openAuthorizationServerTransport)
     {
-        ArgumentNullException.ThrowIfNull(transport);
+        ArgumentNullException.ThrowIfNull(deployment);
+        ArgumentNullException.ThrowIfNull(openAuthorizationServerTransport);
 
-        this.transport = transport;
+        this.deployment = deployment;
+        this.openAuthorizationServerTransport = openAuthorizationServerTransport;
     }
 
     /// <summary>Reads what one deployment and its authorization server publish about signing in.</summary>
@@ -191,11 +204,17 @@ internal sealed class DeploymentAuthorizationDiscovery
         string issuer,
         CancellationToken cancellationToken)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, candidateAddress);
+        if (!Uri.TryCreate(candidateAddress, UriKind.Absolute, out var address))
+        {
+            return null;
+        }
+
+        using var authorizationServer = this.openAuthorizationServerTransport(address);
+        using var request = new HttpRequestMessage(HttpMethod.Get, address);
 
         try
         {
-            using var response = await this.transport.SendAsync(request, cancellationToken);
+            using var response = await authorizationServer.Client.SendAsync(request, cancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -223,16 +242,17 @@ internal sealed class DeploymentAuthorizationDiscovery
 
         try
         {
-            return await this.transport.SendAsync(request, cancellationToken);
+            return await this.deployment.Client.SendAsync(request, cancellationToken);
         }
         catch (TaskCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            throw new CliFailure($"The deployment at {this.transport.BaseAddress} did not answer in time.");
+            throw new CliFailure($"The deployment at {this.deployment.Client.BaseAddress} did not answer in time.");
         }
         catch (HttpRequestException failure)
         {
             throw new CliFailure(
-                $"The deployment at {this.transport.BaseAddress} could not be reached: {failure.Message}",
+                this.deployment.DescribeRefusal()
+                ?? $"The deployment at {this.deployment.Client.BaseAddress} could not be reached: {failure.Message}",
                 failure);
         }
     }

--- a/src/Cli/CliConsole.cs
+++ b/src/Cli/CliConsole.cs
@@ -21,6 +21,20 @@ internal interface ICliConsole
     /// <param name="prompt">What to ask for, written only when a person is there to read it.</param>
     /// <returns>The credential, empty when none was supplied.</returns>
     string ReadSecret(string prompt);
+
+    /// <summary>Gets a value indicating whether a person is at the terminal to answer a question.</summary>
+    /// <remarks>
+    /// A command that would weaken a protection has to ask, and a command whose input is a pipe has nobody to ask: the
+    /// answer would be read out of whatever the caller piped in, which for the credential mode is the credential itself.
+    /// So the caller checks this first and requires the answer up front instead.
+    /// </remarks>
+    bool CanConfirm { get; }
+
+    /// <summary>Asks a question that is refused unless it is answered yes.</summary>
+    /// <param name="question">The question, written where the answer is typed rather than into a command's output.</param>
+    /// <returns><see langword="true" /> only when the answer was yes.</returns>
+    /// <remarks>Only called where <see cref="CanConfirm" /> reports that somebody is there; the default is no, so an empty line, an interrupted read, and anything unrecognized all decline.</remarks>
+    bool Confirm(string question);
 }
 
 /// <summary>The terminal the command actually runs against.</summary>
@@ -35,6 +49,25 @@ internal sealed class SystemCliConsole : ICliConsole
 
     /// <inheritdoc />
     public void WriteError(string message) => Console.Error.WriteLine(message);
+
+    /// <inheritdoc />
+    public bool CanConfirm => !Console.IsInputRedirected;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The question goes to standard error beside the prompts, and only <c>y</c> or <c>yes</c> accepts. Reading the
+    /// answer as a line rather than as a keystroke is what lets a person correct a typed letter before committing to it,
+    /// which matters more here than for a credential nobody re-reads.
+    /// </remarks>
+    public bool Confirm(string question)
+    {
+        Console.Error.Write(question);
+
+        var answer = Console.In.ReadLine()?.Trim() ?? string.Empty;
+
+        return answer.Equals("y", StringComparison.OrdinalIgnoreCase)
+            || answer.Equals("yes", StringComparison.OrdinalIgnoreCase);
+    }
 
     /// <inheritdoc />
     /// <remarks>

--- a/src/Cli/CliContext.cs
+++ b/src/Cli/CliContext.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Diagnostics.CodeAnalysis;
 using MailFathom.Cli.Administration;
 using MailFathom.Cli.Authorization;
 using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Transport;
 
 namespace MailFathom.Cli;
 
@@ -18,42 +18,24 @@ namespace MailFathom.Cli;
 /// </remarks>
 /// <param name="Console">The terminal the command reads from and writes to.</param>
 /// <param name="Store">Where the command remembers the deployments signed in to.</param>
-/// <param name="OpenTransport">Opens a transport aimed at one deployment; the caller disposes it.</param>
+/// <param name="OpenTransport">Opens a transport aimed at one address, accepting what the given trust allows there; the caller disposes it.</param>
 /// <param name="AwaitRedirect">Binds the loopback address an authorization redirect arrives at; the caller disposes it.</param>
 /// <param name="OpenBrowser">Opens an address in this machine's browser, reporting whether the attempt was made.</param>
 /// <param name="Clock">Decides whether a stored access token is still usable, and paces a device sign-in's polling.</param>
 internal sealed record CliContext(
     ICliConsole Console,
     CredentialStore Store,
-    Func<Uri, HttpClient> OpenTransport,
+    Func<Uri, StoredTransportTrust, DeploymentTransport> OpenTransport,
     Func<Uri, IMailboxRedirectAwaiter> AwaitRedirect,
     Func<Uri, bool> OpenBrowser,
     TimeProvider Clock)
 {
-    /// <summary>How long any single request to a deployment may take.</summary>
-    /// <remarks>
-    /// A person is waiting at a terminal, so the bound is what keeps an unreachable host from looking like a hung
-    /// command. It is generous enough for a deployment behind a slow link and short enough that a wrong address is
-    /// reported rather than waited out.
-    /// </remarks>
-    internal static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(30);
-
-    /// <summary>The largest response the command reads from anything, beyond which the request fails.</summary>
-    /// <remarks>
-    /// Every document the command fetches is a few kilobytes: a session, a protected resource metadata document, an
-    /// authorization server's discovery document, a token response. The limit exists because two of the machines
-    /// answering are not the deployment's — an authorization server is reached during a sign-in, and a mistyped or
-    /// hijacked address is reached by definition — and none of them should be able to make the command buffer an
-    /// unbounded body. The same number the service bounds its own metadata retrieval by, for the same reason.
-    /// </remarks>
-    internal const int ResponseSizeLimitInBytes = 256 * 1024;
-
     /// <summary>Builds the context the command runs under in production.</summary>
     /// <returns>The context.</returns>
     internal static CliContext ForTerminal() => new(
         new SystemCliConsole(),
         new CredentialStore(CredentialStore.DefaultPath(), new TokenProtector(CredentialStore.DefaultKeyPath())),
-        OpenSystemTransport,
+        DeploymentTransport.Open,
         redirectUri => new LoopbackRedirectAwaiter(redirectUri),
         WebBrowserLauncher.TryOpen,
         TimeProvider.System);
@@ -62,20 +44,14 @@ internal sealed record CliContext(
     /// <returns>The access seam every command that sends a request goes through.</returns>
     internal DeploymentAccess Deployment() => new(this.Store, this.OpenTransport, this.Clock);
 
-    /// <summary>Opens a transport aimed at one address.</summary>
+    /// <summary>Opens a transport aimed at an address no profile has accepted anything about.</summary>
+    /// <param name="address">The address, which is an authorization server rather than a deployment.</param>
+    /// <returns>The transport, which the caller disposes.</returns>
     /// <remarks>
-    /// Three bounds, and each answers a different way a remote machine could misbehave. Redirects are not followed,
-    /// because a redirect would move a request carrying a bearer credential to an address the operator never named. The
-    /// timeout keeps an unresponsive host from looking like a hung command. The buffer limit stops any of the machines
-    /// the command talks to from answering with an unbounded body — which matters most during a sign-in, where one of
-    /// them is an authorization server rather than the deployment.
+    /// A profile's pin belongs to the deployment it was taken at and to nothing else, so a request to an authorization
+    /// server goes out under ordinary chain validation. Reusing the deployment's transport for it would apply the pin to
+    /// a host it says nothing about, and every such request would be refused for presenting the wrong certificate.
     /// </remarks>
-    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The handler is handed to the HttpClient with disposeHandler: true, so the client the caller disposes disposes it; disposing it here would leave that client without a transport.")]
-    private static HttpClient OpenSystemTransport(Uri endpoint) =>
-        new(new SocketsHttpHandler { AllowAutoRedirect = false }, disposeHandler: true)
-        {
-            BaseAddress = endpoint,
-            Timeout = RequestTimeout,
-            MaxResponseContentBufferSize = ResponseSizeLimitInBytes,
-        };
+    internal DeploymentTransport OpenUnpinnedTransport(Uri address) =>
+        this.OpenTransport(address, StoredTransportTrust.Protected);
 }

--- a/src/Cli/Commands/AuthorizeMailboxCommand.cs
+++ b/src/Cli/Commands/AuthorizeMailboxCommand.cs
@@ -187,8 +187,8 @@ internal static class AuthorizeMailboxCommand
 
         // The transport is aimed at the authorization server rather than at a deployment, and it is the same seam every
         // other command reaches the network through: a bounded per-request timeout, and redirects not followed.
-        using var transport = context.OpenTransport(preset.TokenEndpoint);
-        var authorizer = new MailboxAuthorizer(transport, TimeProvider.System);
+        using var transport = context.OpenUnpinnedTransport(preset.TokenEndpoint);
+        var authorizer = new MailboxAuthorizer(transport.Client, TimeProvider.System);
 
         // The catch translates failures of the exchange with the authorization server, so what the deployment does with
         // the result is deliberately outside it: a transport failure reaching a deployment would otherwise be reported
@@ -378,7 +378,9 @@ internal static class AuthorizeMailboxCommand
         MailboxAuthorizationGrant grant,
         CancellationToken cancellationToken)
     {
-        using var transport = context.OpenTransport(destination.Deployment.Endpoint);
+        using var transport = context.OpenTransport(
+            destination.Deployment.Endpoint,
+            destination.Deployment.Trust);
 
         await new AdminApiClient(transport).StoreMailboxRefreshTokenAsync(
             destination.Deployment.Token,

--- a/src/Cli/Commands/LoginCommand.cs
+++ b/src/Cli/Commands/LoginCommand.cs
@@ -6,6 +6,7 @@ using System.CommandLine;
 using MailFathom.Cli.Administration;
 using MailFathom.Cli.Authorization;
 using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Transport;
 using MailFathom.Common.OAuth;
 
 namespace MailFathom.Cli.Commands;
@@ -98,6 +99,16 @@ internal static class LoginCommand
             Description = $"The loopback address registered with the authorization server, which the interactive mode catches the redirect on. Defaults to {DefaultRedirectAddress}.",
         };
 
+        Option<bool> trustUntrustedCertificateOption = new(SignInConnection.AllowanceOption)
+        {
+            Description = "Accept whatever certificate this deployment presents at sign-in and pin it to the profile, without asking. For a sign-in with nobody at the terminal; every later command still refuses any other certificate.",
+        };
+
+        Option<bool> allowClearTextOption = new(ClearTextDecision.AllowanceOption)
+        {
+            Description = "Accept that an http:// endpoint carries the credential and every later request unprotected, without asking. For a sign-in with nobody at the terminal.",
+        };
+
         Command command = new("login", "Sign in to a deployment's administrative endpoint.")
         {
             endpointOption,
@@ -107,6 +118,8 @@ internal static class LoginCommand
             clientIdOption,
             issuerOption,
             redirectUriOption,
+            trustUntrustedCertificateOption,
+            allowClearTextOption,
         };
 
         command.SetAction((result, cancellationToken) => RunAsync(
@@ -118,7 +131,9 @@ internal static class LoginCommand
                 result.GetValue(privateKeyOption),
                 result.GetValue(clientIdOption),
                 result.GetValue(issuerOption),
-                result.GetValue(redirectUriOption)),
+                result.GetValue(redirectUriOption),
+                result.GetValue(trustUntrustedCertificateOption),
+                result.GetValue(allowClearTextOption)),
             cancellationToken));
 
         return command;
@@ -133,14 +148,26 @@ internal static class LoginCommand
     {
         var (endpoint, profileName) = ResolveTarget(context, requestedDeployment, requestedName);
 
-        using var transport = context.OpenTransport(endpoint);
+        // Both questions about the connection belong here: before anything is sent, and at the one command where a
+        // decision about a deployment's transport is actually being taken. The clear-text one is settled from the
+        // address alone; the certificate one can only be settled once the deployment has presented one, which is what
+        // the connection does on its first use.
+        var acceptsClearText = ClearTextDecision.Settle(context.Console, endpoint, request.AllowClearText);
 
-        var (token, session, keyPair) = await ProduceCredentialAsync(context, transport, request, cancellationToken);
+        using SignInConnection connection = new(
+            context.Console,
+            context.OpenTransport,
+            endpoint,
+            acceptsClearText,
+            request.TrustUntrustedCertificate);
+
+        var (token, session, keyPair) = await ProduceCredentialAsync(context, connection, request, cancellationToken);
 
         // Whichever way the credential arrived, the deployment is what decides it is usable. Storing one it has not
         // accepted would turn a wrong client registration or a narrow scope into a failure at some later command. For a
         // key pair it also proves the deployment holds the matching public key, which nothing else on this machine can.
-        var deploymentSession = await new AdminApiClient(transport).ReadSessionAsync(token, cancellationToken);
+        var deploymentSession = await connection.RunAsync(
+            transport => new AdminApiClient(transport).ReadSessionAsync(token, cancellationToken));
         var credentialName = deploymentSession.Credential ?? "unnamed";
 
         // The minted assertion is deliberately not the stored token: it is spent within the minute and every later
@@ -151,10 +178,11 @@ internal static class LoginCommand
             keyPair is null ? token : string.Empty,
             credentialName,
             session,
-            keyPair);
+            keyPair,
+            connection.Trust);
 
         context.Console.WriteLine(
-            $"Signed in to {endpoint.GetLeftPart(UriPartial.Authority)} as '{credentialName}' (MailFathom {deploymentSession.Version}), saved as profile '{profileName}' and selected.");
+            $"Signed in to {endpoint.GetLeftPart(UriPartial.Authority)} as '{credentialName}' (MailFathom {deploymentSession.Version}), saved as profile '{profileName}' and selected.{DescribeTransport(connection.Trust)}");
 
         if (session is not null)
         {
@@ -171,11 +199,30 @@ internal static class LoginCommand
         return CliExitCode.Success;
     }
 
+    /// <summary>Says what the connection this profile was signed in over is not protected by, when it is not.</summary>
+    /// <remarks>On the confirmation line rather than beside it, because it qualifies what just happened: the operator accepted something a moment ago and the line that reports success is where they read what it was.</remarks>
+    private static string DescribeTransport(StoredTransportTrust trust) => trust switch
+    {
+        { AcceptsClearText: true } =>
+            " Nothing protects this connection: the credential and every later request cross the network in clear text.",
+        { PinnedCertificateFingerprint: { } fingerprint } =>
+            $" The connection is protected by a pinned certificate rather than by a chain this machine trusts; the profile now accepts {fingerprint} and refuses any other.",
+        _ => string.Empty,
+    };
+
     /// <summary>Produces the credential this sign-in verifies, in whichever of the four ways the operator asked for.</summary>
-    /// <remarks>A key-pair sign-in returns both a credential to verify with and the key that produced it, because the two answer different questions: one proves the deployment accepts this client now, the other is what every later command will use.</remarks>
+    /// <remarks>
+    /// A key-pair sign-in returns both a credential to verify with and the key that produced it, because the two answer
+    /// different questions: one proves the deployment accepts this client now, the other is what every later command
+    /// will use.
+    /// <para>
+    /// The two ways that need no network run outside the connection, so the credential a person types is read once and
+    /// a settled certificate question never costs them a second prompt for it.
+    /// </para>
+    /// </remarks>
     private static async Task<(string Token, OAuthSession? Session, StoredKeyPair? KeyPair)> ProduceCredentialAsync(
         CliContext context,
-        HttpClient transport,
+        SignInConnection connection,
         SignInRequest request,
         CancellationToken cancellationToken)
     {
@@ -194,7 +241,8 @@ internal static class LoginCommand
                 keyPair);
         }
 
-        var (token, session) = await AuthorizeAsync(context, transport, request, cancellationToken);
+        var (token, session) = await connection.RunAsync(
+            transport => AuthorizeAsync(context, transport, request, cancellationToken));
 
         return (token, session, null);
     }
@@ -235,7 +283,7 @@ internal static class LoginCommand
     /// <summary>Runs an OAuth sign-in against whichever server the deployment names.</summary>
     private static async Task<(string Token, OAuthSession Session)> AuthorizeAsync(
         CliContext context,
-        HttpClient transport,
+        DeploymentTransport transport,
         SignInRequest request,
         CancellationToken cancellationToken)
     {
@@ -245,13 +293,13 @@ internal static class LoginCommand
                 "An OAuth sign-in needs the client identifier registered with the authorization server. Pass --client-id, or use --mode key to present an API key instead.");
         }
 
-        var authorization = await new DeploymentAuthorizationDiscovery(transport)
+        var authorization = await new DeploymentAuthorizationDiscovery(transport, context.OpenUnpinnedTransport)
             .ReadAsync(request.Issuer, cancellationToken);
 
         // Aimed at the authorization server rather than at the deployment, through the same seam every other request
         // goes out by: a bounded per-request timeout, and redirects not followed.
-        using var authorizationServerTransport = context.OpenTransport(authorization.TokenEndpoint);
-        var authorizer = new DeploymentAuthorizer(authorizationServerTransport, context.Clock);
+        using var authorizationServerTransport = context.OpenUnpinnedTransport(authorization.TokenEndpoint);
+        var authorizer = new DeploymentAuthorizer(authorizationServerTransport.Client, context.Clock);
 
         var grant = request.Mode == SignInMode.Device
             ? await AuthorizeWithDeviceAsync(context, authorizer, authorization, clientId, cancellationToken)
@@ -422,10 +470,14 @@ internal static class LoginCommand
     /// <param name="ClientId">The client identifier for an OAuth sign-in, absent from a presented credential.</param>
     /// <param name="Issuer">Which authorization server to use, absent unless the deployment accepts several.</param>
     /// <param name="RedirectAddress">Where an interactive sign-in catches the redirect, absent to use the default.</param>
+    /// <param name="TrustUntrustedCertificate">Whether the invocation stated up front that whatever certificate this deployment presents is to be accepted and pinned.</param>
+    /// <param name="AllowClearText">Whether the invocation stated up front that an unprotected connection to this deployment is acceptable.</param>
     private sealed record SignInRequest(
         SignInMode Mode,
         string? PrivateKeyPath,
         string? ClientId,
         string? Issuer,
-        string? RedirectAddress);
+        string? RedirectAddress,
+        bool TrustUntrustedCertificate,
+        bool AllowClearText);
 }

--- a/src/Cli/Commands/StatusCommand.cs
+++ b/src/Cli/Commands/StatusCommand.cs
@@ -45,7 +45,7 @@ internal static class StatusCommand
     {
         var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
 
-        using var transport = context.OpenTransport(profile.Endpoint);
+        using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
         var session = await new AdminApiClient(transport).ReadSessionAsync(profile.Token, cancellationToken);
 
         context.Console.WriteLine(

--- a/src/Cli/Credentials/CredentialStore.cs
+++ b/src/Cli/Credentials/CredentialStore.cs
@@ -112,7 +112,10 @@ internal sealed class CredentialStore
             this.protector.Unprotect(credential.Token, credential.Endpoint),
             credential.Credential,
             this.OpenSession(credential),
-            credential.KeyPair);
+            credential.KeyPair)
+        {
+            Trust = credential.Transport ?? StoredTransportTrust.Protected,
+        };
     }
 
     /// <summary>Settles which profile a command acts on, without opening its token.</summary>
@@ -154,7 +157,8 @@ internal sealed class CredentialStore
     /// <param name="credentialName">The name the deployment reported for the credential.</param>
     /// <param name="session">What an OAuth sign-in left behind, whose refresh token is sealed alongside the access token, or <see langword="null" /> for a presented credential.</param>
     /// <param name="keyPair">Where a key-pair profile's private key lives, or <see langword="null" /> when the profile stores a credential of its own.</param>
-    /// <exception cref="ArgumentNullException">Thrown when an argument other than <paramref name="session" /> or <paramref name="keyPair" /> is <see langword="null" />.</exception>
+    /// <param name="trust">What the operator accepted about this deployment's transport, or <see langword="null" /> when they accepted nothing beyond the default.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument other than <paramref name="session" />, <paramref name="keyPair" />, or <paramref name="trust" /> is <see langword="null" />.</exception>
     /// <exception cref="CliFailure">Thrown when the store cannot be written.</exception>
     /// <remarks>
     /// Signing in makes the new profile the default, because it is the deployment the operator just chose to work with;
@@ -170,7 +174,8 @@ internal sealed class CredentialStore
         string token,
         string credentialName,
         OAuthSession? session = null,
-        StoredKeyPair? keyPair = null)
+        StoredKeyPair? keyPair = null,
+        StoredTransportTrust? trust = null)
     {
         ArgumentNullException.ThrowIfNull(name);
         ArgumentNullException.ThrowIfNull(endpoint);
@@ -185,7 +190,8 @@ internal sealed class CredentialStore
             this.protector.Protect(token, address),
             credentialName,
             this.Seal(session, address),
-            keyPair);
+            keyPair,
+            Recorded(trust));
 
         this.Write(stored with { Default = name });
     }
@@ -303,6 +309,11 @@ internal sealed class CredentialStore
     private static string DescribeKnownProfiles(StoredCredentials stored) => stored.Profiles.Count == 0
         ? $"No deployment has been signed in to yet; run '{CliRootCommand.CommandName} login --endpoint https://host:port'."
         : $"Signed in: {string.Join(", ", stored.Profiles.Keys.Order(StringComparer.OrdinalIgnoreCase))}.";
+
+    /// <summary>Reports what a profile has to record about its transport, which is nothing when it accepted nothing.</summary>
+    /// <remarks>Leaving the default out keeps the file of an ordinary HTTPS profile exactly as it was, so the presence of the member is itself the statement that something was accepted.</remarks>
+    private static StoredTransportTrust? Recorded(StoredTransportTrust? trust) =>
+        trust is null || trust == StoredTransportTrust.Protected ? null : trust;
 
     /// <summary>Reduces an endpoint to what identifies the deployment.</summary>
     /// <remarks>The authority without a trailing slash, lowercased by the URI parser, so two spellings of one address are one profile rather than two — and so the value bound into the sealed token is stable across them.</remarks>

--- a/src/Cli/Credentials/SignedInProfile.cs
+++ b/src/Cli/Credentials/SignedInProfile.cs
@@ -29,6 +29,14 @@ internal sealed record SignedInProfile(
     OAuthSession? Session = null,
     StoredKeyPair? KeyPair = null)
 {
+    /// <summary>Gets what this profile's connection to the deployment may accept.</summary>
+    /// <remarks>
+    /// Never absent as a command reads it, unlike the stored member it comes from: a profile written before the member
+    /// existed, and one signed in over an ordinary HTTPS connection, both hold the default rather than nothing, so no
+    /// call site has to decide what an absent value would mean.
+    /// </remarks>
+    internal StoredTransportTrust Trust { get; init; } = StoredTransportTrust.Protected;
+
     /// <inheritdoc />
     /// <remarks>Redacted, so no diagnostic or exception message prints the token by formatting the record it lives in.</remarks>
     public override string ToString() => $"{nameof(SignedInProfile)} {{ {this.Name}, {this.Endpoint}, {this.Credential} }}";

--- a/src/Cli/Credentials/StoredCredential.cs
+++ b/src/Cli/Credentials/StoredCredential.cs
@@ -12,6 +12,7 @@ namespace MailFathom.Cli.Credentials;
 /// <param name="Credential">The name the deployment reported for the credential, kept so the command can say who it is signed in as without asking again.</param>
 /// <param name="Session">What an OAuth sign-in left behind, absent from a profile holding an API key or a pasted token.</param>
 /// <param name="KeyPair">Where a key-pair profile's private key lives, absent from every other kind of profile.</param>
+/// <param name="Transport">What the operator accepted about this deployment's transport, absent from a profile that accepted nothing beyond the default.</param>
 /// <remarks>
 /// <para>
 /// The ways of signing in leave different amounts behind, and the difference is two nullable members rather than three
@@ -24,13 +25,19 @@ namespace MailFathom.Cli.Credentials;
 /// command mints a fresh assertion from the key named here, which is why the two members are never both present: one
 /// says how a stored credential is renewed and the other says that there is none to renew.
 /// </para>
+/// <para>
+/// <see cref="Transport" /> is orthogonal to all three: it says what the connection carrying the credential is protected
+/// by, whichever kind the credential is. It is absent from a profile signed in over an ordinary HTTPS connection, which
+/// is why a store written before the member existed still reads.
+/// </para>
 /// </remarks>
 internal sealed record StoredCredential(
     [property: JsonPropertyName("endpoint")] string Endpoint,
     [property: JsonPropertyName("token")] string Token,
     [property: JsonPropertyName("credential")] string Credential,
     [property: JsonPropertyName("session")] StoredOAuthSession? Session = null,
-    [property: JsonPropertyName("keyPair")] StoredKeyPair? KeyPair = null)
+    [property: JsonPropertyName("keyPair")] StoredKeyPair? KeyPair = null,
+    [property: JsonPropertyName("transport")] StoredTransportTrust? Transport = null)
 {
     /// <inheritdoc />
     /// <remarks>Redacted, so no diagnostic or exception message prints the token by formatting the record it lives in — even encrypted, which is a value worth not scattering.</remarks>
@@ -50,6 +57,31 @@ internal sealed record StoredCredential(
 /// </remarks>
 internal sealed record StoredKeyPair(
     [property: JsonPropertyName("privateKeyPath")] string PrivateKeyPath);
+
+/// <summary>What an operator accepted about one deployment's transport, beyond what is protected by default.</summary>
+/// <param name="PinnedCertificateFingerprint">The SHA-256 fingerprint of the one certificate this profile accepts, or <see langword="null" /> to require a certificate this machine trusts on its own.</param>
+/// <param name="AcceptsClearText">Whether the operator accepted that this profile's requests cross the network unprotected.</param>
+/// <remarks>
+/// <para>
+/// Both members record a decision taken once, at <c>login</c>, about one deployment. Neither is a switch that turns a
+/// protection off: a pin is stricter than the chain validation it replaces, because the profile then accepts exactly the
+/// certificate the operator was shown and refuses every other, including one that would have validated on its own. The
+/// clear-text member records that the operator was told the credential travels unprotected and said to continue anyway,
+/// so no later command asks again and none of them widens into the other.
+/// </para>
+/// <para>
+/// Neither is a secret and both are stored in clear, like the endpoint beside them. A fingerprint is a public value by
+/// construction — it is what the deployment presents to anybody who connects — and what it protects is that this profile
+/// keeps talking to the same deployment.
+/// </para>
+/// </remarks>
+internal sealed record StoredTransportTrust(
+    [property: JsonPropertyName("pinnedCertificateFingerprint")] string? PinnedCertificateFingerprint = null,
+    [property: JsonPropertyName("clearText")] bool AcceptsClearText = false)
+{
+    /// <summary>Gets the trust a profile holds when it accepted nothing beyond what is protected by default.</summary>
+    internal static StoredTransportTrust Protected { get; } = new();
+}
 
 /// <summary>What an OAuth sign-in has to remember so the next command does not ask the operator to sign in again.</summary>
 /// <param name="RefreshToken">The credential a spent access token is exchanged for a new one with, encrypted; see <see cref="TokenProtector" />.</param>

--- a/src/Cli/Transport/ClearTextDecision.cs
+++ b/src/Cli/Transport/ClearTextDecision.cs
@@ -1,0 +1,66 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Commands;
+
+namespace MailFathom.Cli.Transport;
+
+/// <summary>Settles whether a sign-in may talk to a deployment over a connection nothing protects.</summary>
+/// <remarks>
+/// <para>
+/// An <c>http://</c> address is taken as written, and the transport does not follow redirects, so a deployment's
+/// HTTP-to-HTTPS redirect never upgrades the connection in flight — the credential is already on the wire by the time
+/// the redirect is read. That is why the question is asked from the address alone, before anything is sent, and why the
+/// deployment's own answer cannot stand in for it.
+/// </para>
+/// <para>
+/// It is asked at <c>login</c> and nowhere else. A later command acts on a decision already taken, and a tool that asks
+/// the same question on every invocation trains an operator to answer it without reading it.
+/// </para>
+/// </remarks>
+internal static class ClearTextDecision
+{
+    /// <summary>The switch a sign-in with nobody at the terminal states the answer with.</summary>
+    internal const string AllowanceOption = "--allow-clear-text";
+
+    /// <summary>Settles whether this sign-in accepts an unprotected connection to the address it names.</summary>
+    /// <param name="console">The terminal the question is asked on.</param>
+    /// <param name="address">The address the operator named.</param>
+    /// <param name="allowedUpFront">Whether the invocation stated the answer with <see cref="AllowanceOption" />.</param>
+    /// <returns><see langword="true" /> when the profile is being signed in over an unprotected connection.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the operator refused, or when nobody could be asked and the invocation did not state the answer.</exception>
+    internal static bool Settle(ICliConsole console, Uri address, bool allowedUpFront)
+    {
+        ArgumentNullException.ThrowIfNull(console);
+        ArgumentNullException.ThrowIfNull(address);
+
+        if (address.Scheme != Uri.UriSchemeHttp)
+        {
+            return false;
+        }
+
+        if (allowedUpFront)
+        {
+            return true;
+        }
+
+        if (!console.CanConfirm)
+        {
+            throw new CliFailure(
+                $"{address.GetLeftPart(UriPartial.Authority)} is reached over HTTP, so the credential and every later request would cross the network unprotected, and there is no terminal to ask on. Sign in to an https:// address instead, or pass {AllowanceOption} to accept an unprotected connection to this deployment.");
+        }
+
+        console.WriteError(string.Empty);
+        console.WriteError($"{address.GetLeftPart(UriPartial.Authority)} is an HTTP address, so nothing protects this connection.");
+        console.WriteError("The credential you are about to present, and every later request from this profile, cross the network in clear text.");
+        console.WriteError("A redirect the deployment might send to an https:// address would not change that: the credential is already on the wire by then.");
+        console.WriteError(string.Empty);
+
+        return console.Confirm("Sign in over an unprotected connection anyway? [y/N]: ")
+            ? true
+            : throw new CliFailure(
+                $"Transport protection was refused, so nothing was signed in to and nothing was stored. Sign in to an https:// address, or run '{CliRootCommand.CommandName} login' again and accept the unprotected connection.");
+    }
+}

--- a/src/Cli/Transport/DeploymentTransport.cs
+++ b/src/Cli/Transport/DeploymentTransport.cs
@@ -1,0 +1,106 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography.X509Certificates;
+using MailFathom.Cli.Credentials;
+
+namespace MailFathom.Cli.Transport;
+
+/// <summary>One connection aimed at one address, together with what it may accept there.</summary>
+/// <remarks>
+/// <para>
+/// The client and the certificate policy travel as one value because a caller that meets a transport failure has to be
+/// able to ask what refused it. <see cref="HttpClient" /> reports a refused handshake as an ordinary request failure
+/// with no certificate in it, so a command holding the client alone could only say that the deployment could not be
+/// reached — which is the wrong sentence for the one case an operator can act on.
+/// </para>
+/// <para>
+/// A transport is opened per operation and disposed by whoever opened it, which is what keeps a pinned certificate from
+/// outliving the profile it belongs to.
+/// </para>
+/// </remarks>
+internal sealed class DeploymentTransport : IDisposable
+{
+    /// <summary>How long any single request to a deployment may take.</summary>
+    /// <remarks>
+    /// A person is waiting at a terminal, so the bound is what keeps an unreachable host from looking like a hung
+    /// command. It is generous enough for a deployment behind a slow link and short enough that a wrong address is
+    /// reported rather than waited out.
+    /// </remarks>
+    internal static readonly TimeSpan RequestTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>The largest response the command reads from anything, beyond which the request fails.</summary>
+    /// <remarks>
+    /// Every document the command fetches is a few kilobytes: a session, a protected resource metadata document, an
+    /// authorization server's discovery document, a token response. The limit exists because two of the machines
+    /// answering are not the deployment's — an authorization server is reached during a sign-in, and a mistyped or
+    /// hijacked address is reached by definition — and none of them should be able to make the command buffer an
+    /// unbounded body. The same number the service bounds its own metadata retrieval by, for the same reason.
+    /// </remarks>
+    internal const int ResponseSizeLimitInBytes = 256 * 1024;
+
+    private readonly ServerCertificatePolicy policy;
+
+    /// <summary>Initializes a transport over a client and the policy that decided what it accepted.</summary>
+    /// <param name="client">The client, whose <see cref="HttpClient.BaseAddress" /> names what it is aimed at.</param>
+    /// <param name="policy">What the connection may accept, and what it refused.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal DeploymentTransport(HttpClient client, ServerCertificatePolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(policy);
+
+        this.Client = client;
+        this.policy = policy;
+    }
+
+    /// <summary>Gets the client requests are sent through.</summary>
+    internal HttpClient Client { get; }
+
+    /// <summary>Gets the certificate this connection refused, or <see langword="null" /> when it refused none.</summary>
+    internal PresentedCertificate? RefusedCertificate => this.policy.Refused;
+
+    /// <summary>Opens a transport aimed at one address, accepting only what the profile has already accepted.</summary>
+    /// <param name="address">The address the transport is aimed at.</param>
+    /// <param name="trust">What the operator has accepted about this deployment's transport.</param>
+    /// <returns>The transport, which the caller disposes.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Four bounds, and each answers a different way a remote machine could misbehave. Redirects are not followed,
+    /// because a redirect would move a request carrying a bearer credential to an address the operator never named. The
+    /// timeout keeps an unresponsive host from looking like a hung command. The buffer limit stops any of the machines
+    /// the command talks to from answering with an unbounded body — which matters most during a sign-in, where one of
+    /// them is an authorization server rather than the deployment. The certificate policy is the fourth, and it is the
+    /// only one an operator can widen, once, at sign-in.
+    /// </remarks>
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The handler is handed to the HttpClient with disposeHandler: true, so the client this transport disposes disposes it; disposing it here would leave that client without a transport.")]
+    internal static DeploymentTransport Open(Uri address, StoredTransportTrust trust)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+        ArgumentNullException.ThrowIfNull(trust);
+
+        ServerCertificatePolicy policy = new(trust.PinnedCertificateFingerprint);
+
+        SocketsHttpHandler handler = new() { AllowAutoRedirect = false };
+        handler.SslOptions.RemoteCertificateValidationCallback =
+            (_, certificate, chain, errors) => policy.Accepts(certificate as X509Certificate2, chain, errors);
+
+        return new DeploymentTransport(
+            new HttpClient(handler, disposeHandler: true)
+            {
+                BaseAddress = address,
+                Timeout = RequestTimeout,
+                MaxResponseContentBufferSize = ResponseSizeLimitInBytes,
+            },
+            policy);
+    }
+
+    /// <summary>Says why the connection was refused, when a certificate is what refused it.</summary>
+    /// <returns>The sentence an operator reads, or <see langword="null" /> when the failure was something else.</returns>
+    internal string? DescribeRefusal() => this.policy.DescribeRefusal(this.Client.BaseAddress);
+
+    /// <inheritdoc />
+    public void Dispose() => this.Client.Dispose();
+}

--- a/src/Cli/Transport/PresentedCertificate.cs
+++ b/src/Cli/Transport/PresentedCertificate.cs
@@ -1,0 +1,131 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace MailFathom.Cli.Transport;
+
+/// <summary>The certificate a deployment presented, in the terms an operator has to read to decide about it.</summary>
+/// <param name="Subject">Who the certificate says the deployment is.</param>
+/// <param name="Issuer">Who signed it, which is what says whether an internal authority or nobody vouched for it.</param>
+/// <param name="Fingerprint">The SHA-256 fingerprint, which is what a profile pins and what an operator compares.</param>
+/// <param name="NotBefore">When it starts being valid.</param>
+/// <param name="NotAfter">When it stops being valid.</param>
+/// <param name="ValidationFailure">Why this machine would not accept it on its own.</param>
+/// <remarks>
+/// MailFathom's own value rather than an <see cref="X509Certificate2" />, because the decision this feeds is an
+/// operator's and everything above the transport deals in what they were shown: five fields to read and one to compare.
+/// It also keeps the certificate object itself, which owns unmanaged state, from travelling up into a command that would
+/// have to remember to dispose it.
+/// </remarks>
+internal sealed record PresentedCertificate(
+    string Subject,
+    string Issuer,
+    string Fingerprint,
+    DateTimeOffset NotBefore,
+    DateTimeOffset NotAfter,
+    string ValidationFailure)
+{
+    /// <summary>Describes a certificate as it was presented, together with why it was not accepted.</summary>
+    /// <param name="certificate">The certificate the deployment presented.</param>
+    /// <param name="errors">What the platform found wrong with it, which is <see cref="SslPolicyErrors.None" /> for a certificate refused only by a pin.</param>
+    /// <param name="chain">The chain the platform built, or <see langword="null" /> when it built none.</param>
+    /// <returns>The description.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="certificate" /> is <see langword="null" />.</exception>
+    internal static PresentedCertificate Describe(
+        X509Certificate2 certificate,
+        SslPolicyErrors errors,
+        X509Chain? chain = null)
+    {
+        ArgumentNullException.ThrowIfNull(certificate);
+
+        return new PresentedCertificate(
+            certificate.Subject,
+            certificate.Issuer,
+            FingerprintOf(certificate),
+            certificate.NotBefore,
+            certificate.NotAfter,
+            DescribeFailure(errors, chain));
+    }
+
+    /// <summary>Reports the SHA-256 fingerprint of a certificate, in the form an operator sees elsewhere.</summary>
+    /// <param name="certificate">The certificate.</param>
+    /// <returns>The fingerprint as colon-separated uppercase hexadecimal.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="certificate" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Colon-separated because that is what <c>openssl x509 -fingerprint -sha256</c> prints and what a deployment's
+    /// operator will be reading it from. One form is stored, printed, and compared, so nothing has to convert between
+    /// two spellings of the same value.
+    /// </remarks>
+    internal static string FingerprintOf(X509Certificate2 certificate)
+    {
+        ArgumentNullException.ThrowIfNull(certificate);
+
+        return string.Join(':', Convert.ToHexString(certificate.GetCertHash(HashAlgorithmName.SHA256)).Chunk(2)
+            .Select(pair => new string(pair)));
+    }
+
+    /// <summary>Reports whether a fingerprint a profile pinned names this certificate.</summary>
+    /// <param name="pinnedFingerprint">The fingerprint the profile holds.</param>
+    /// <param name="presentedFingerprint">The fingerprint of the certificate the deployment presented.</param>
+    /// <returns><see langword="true" /> when the two name the same certificate.</returns>
+    /// <remarks>
+    /// Separators and case are ignored, because the stored value is a line in a file an operator may have copied from
+    /// somewhere that prints it differently. What is compared is the hash itself, and only an equal hash passes.
+    /// </remarks>
+    internal static bool NamesTheSameCertificate(string? pinnedFingerprint, string? presentedFingerprint) =>
+        pinnedFingerprint is { Length: > 0 }
+        && presentedFingerprint is { Length: > 0 }
+        && string.Equals(
+            Normalize(pinnedFingerprint),
+            Normalize(presentedFingerprint),
+            StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Reports the certificate as the lines an operator reads before answering.</summary>
+    /// <returns>The lines, in the order they are written.</returns>
+    internal IReadOnlyList<string> Lines() =>
+    [
+        $"  Subject:     {this.Subject}",
+        $"  Issuer:      {this.Issuer}",
+        $"  Fingerprint: {this.Fingerprint}",
+        $"  Valid:       {this.NotBefore:u} to {this.NotAfter:u}",
+        $"  Not trusted: {this.ValidationFailure}",
+    ];
+
+    private static string Normalize(string fingerprint) => fingerprint.Replace(":", string.Empty, StringComparison.Ordinal).Trim();
+
+    /// <summary>Says why this machine refused the certificate, in stable English rather than the platform's localized text.</summary>
+    /// <remarks>
+    /// The chain statuses are named as well as the policy errors, because "the chain is not trusted" and "the chain is
+    /// not trusted because its root is unknown" send an operator to different places, and the second is what a
+    /// self-signed deployment produces.
+    /// </remarks>
+    private static string DescribeFailure(SslPolicyErrors errors, X509Chain? chain)
+    {
+        List<string> reasons = [];
+
+        if (errors.HasFlag(SslPolicyErrors.RemoteCertificateNotAvailable))
+        {
+            reasons.Add("the deployment presented no certificate");
+        }
+
+        if (errors.HasFlag(SslPolicyErrors.RemoteCertificateNameMismatch))
+        {
+            reasons.Add("it does not name the host this address reaches");
+        }
+
+        if (errors.HasFlag(SslPolicyErrors.RemoteCertificateChainErrors))
+        {
+            var statuses = chain?.ChainStatus ?? [];
+
+            reasons.Add(statuses.Length == 0
+                ? "this machine does not trust the chain it was presented with"
+                : $"this machine does not trust the chain it was presented with ({string.Join(", ", statuses.Select(status => status.Status))})");
+        }
+
+        return reasons.Count == 0 ? "it is not the certificate this profile pinned" : string.Join("; ", reasons);
+    }
+}

--- a/src/Cli/Transport/PresentedCertificate.cs
+++ b/src/Cli/Transport/PresentedCertificate.cs
@@ -12,8 +12,8 @@ namespace MailFathom.Cli.Transport;
 /// <param name="Subject">Who the certificate says the deployment is.</param>
 /// <param name="Issuer">Who signed it, which is what says whether an internal authority or nobody vouched for it.</param>
 /// <param name="Fingerprint">The SHA-256 fingerprint, which is what a profile pins and what an operator compares.</param>
-/// <param name="NotBefore">When it starts being valid.</param>
-/// <param name="NotAfter">When it stops being valid.</param>
+/// <param name="NotBefore">When it starts being valid, in UTC.</param>
+/// <param name="NotAfter">When it stops being valid, in UTC.</param>
 /// <param name="ValidationFailure">Why this machine would not accept it on its own.</param>
 /// <remarks>
 /// MailFathom's own value rather than an <see cref="X509Certificate2" />, because the decision this feeds is an
@@ -35,6 +35,12 @@ internal sealed record PresentedCertificate(
     /// <param name="chain">The chain the platform built, or <see langword="null" /> when it built none.</param>
     /// <returns>The description.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="certificate" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The validity window is converted rather than merely carried. <see cref="X509Certificate2" /> surfaces it as a
+    /// local <see cref="DateTime" />, and while the implicit conversion to <see cref="DateTimeOffset" /> keeps the
+    /// instant — which is what the <c>u</c> format an operator reads renders in UTC — a value that is UTC as stored
+    /// cannot be rendered as local wall clock by a later caller that formats it some other way.
+    /// </remarks>
     internal static PresentedCertificate Describe(
         X509Certificate2 certificate,
         SslPolicyErrors errors,
@@ -46,8 +52,8 @@ internal sealed record PresentedCertificate(
             certificate.Subject,
             certificate.Issuer,
             FingerprintOf(certificate),
-            certificate.NotBefore,
-            certificate.NotAfter,
+            certificate.NotBefore.ToUniversalTime(),
+            certificate.NotAfter.ToUniversalTime(),
             DescribeFailure(errors, chain));
     }
 

--- a/src/Cli/Transport/ServerCertificatePolicy.cs
+++ b/src/Cli/Transport/ServerCertificatePolicy.cs
@@ -1,0 +1,100 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace MailFathom.Cli.Transport;
+
+/// <summary>Decides which certificate one connection may accept, and remembers the one it turned away.</summary>
+/// <remarks>
+/// <para>
+/// Two postures and no third. Without a pin the platform's own answer stands, which is the posture every deployment with
+/// a publicly trusted certificate keeps. With one, exactly the pinned certificate is accepted and every other is refused
+/// — including one that would have validated on its own, because a profile that pinned a certificate said which
+/// deployment it is talking to and a substitution is the event the pin exists to catch.
+/// </para>
+/// <para>
+/// Refusing is not enough on its own. A refused handshake reaches a command as a transport failure with no certificate
+/// in it, so what was presented is recorded here instead: it is what <c>login</c> shows an operator before asking, and
+/// what every other command names when the certificate has changed under a pinned profile.
+/// </para>
+/// </remarks>
+internal sealed class ServerCertificatePolicy
+{
+    private readonly string? pinnedCertificateFingerprint;
+
+    /// <summary>Initializes a policy for one connection.</summary>
+    /// <param name="pinnedCertificateFingerprint">The SHA-256 fingerprint this connection accepts, or <see langword="null" /> to require an ordinary chain.</param>
+    internal ServerCertificatePolicy(string? pinnedCertificateFingerprint) =>
+        this.pinnedCertificateFingerprint = pinnedCertificateFingerprint;
+
+    /// <summary>Gets the certificate this policy refused, or <see langword="null" /> when it has refused none.</summary>
+    internal PresentedCertificate? Refused { get; private set; }
+
+    /// <summary>Gets a value indicating whether this connection is bound to one certificate rather than to a chain.</summary>
+    internal bool IsPinned => this.pinnedCertificateFingerprint is { Length: > 0 };
+
+    /// <summary>Decides whether the certificate a deployment presented may be accepted.</summary>
+    /// <param name="certificate">The certificate the deployment presented, or <see langword="null" /> when it presented none.</param>
+    /// <param name="chain">The chain the platform built, or <see langword="null" /> when it built none.</param>
+    /// <param name="errors">What the platform found wrong with the certificate.</param>
+    /// <returns><see langword="true" /> when the connection may proceed.</returns>
+    /// <remarks>Called on the handshake path, so it decides and records and does nothing else; asking the operator anything from here would put a prompt inside a connection attempt.</remarks>
+    internal bool Accepts(X509Certificate2? certificate, X509Chain? chain, SslPolicyErrors errors)
+    {
+        if (certificate is null)
+        {
+            this.Refused = new PresentedCertificate(
+                Subject: string.Empty,
+                Issuer: string.Empty,
+                Fingerprint: string.Empty,
+                NotBefore: default,
+                NotAfter: default,
+                "the deployment presented no certificate");
+
+            return false;
+        }
+
+        if (this.IsPinned)
+        {
+            var presented = PresentedCertificate.FingerprintOf(certificate);
+
+            if (PresentedCertificate.NamesTheSameCertificate(this.pinnedCertificateFingerprint, presented))
+            {
+                return true;
+            }
+
+            this.Refused = PresentedCertificate.Describe(certificate, errors, chain);
+
+            return false;
+        }
+
+        if (errors == SslPolicyErrors.None)
+        {
+            return true;
+        }
+
+        this.Refused = PresentedCertificate.Describe(certificate, errors, chain);
+
+        return false;
+    }
+
+    /// <summary>Says why the connection was refused, in a sentence naming what an operator does about it.</summary>
+    /// <param name="address">The address the connection was aimed at.</param>
+    /// <returns>The sentence, or <see langword="null" /> when no certificate was refused.</returns>
+    internal string? DescribeRefusal(Uri? address)
+    {
+        if (this.Refused is not { } presented)
+        {
+            return null;
+        }
+
+        var deployment = address is null ? "the deployment" : $"the deployment at {address.GetLeftPart(UriPartial.Authority)}";
+
+        return this.IsPinned
+            ? $"{deployment} presented a certificate this profile has not pinned. Pinned: {this.pinnedCertificateFingerprint}. Presented: {presented.Fingerprint} (subject {presented.Subject}, issuer {presented.Issuer}). Nothing was sent. Sign in again to review the new certificate and accept it, or find out why it changed."
+            : $"{deployment} presented a certificate this machine does not trust: {presented.ValidationFailure}. Nothing was sent. Sign in again to review it and accept it for this profile.";
+    }
+}

--- a/src/Cli/Transport/SignInConnection.cs
+++ b/src/Cli/Transport/SignInConnection.cs
@@ -1,0 +1,152 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Credentials;
+
+namespace MailFathom.Cli.Transport;
+
+/// <summary>The connection one sign-in makes to a deployment, settling what it accepts the first time it is used.</summary>
+/// <remarks>
+/// <para>
+/// A certificate this machine does not trust is not a failure to report but a question to ask, and it can only be asked
+/// once the deployment has presented one. So the first operation runs against ordinary chain validation; if the
+/// handshake refuses a certificate, the operator is shown it, and an acceptance reopens the connection pinned to exactly
+/// that certificate and runs the operation again.
+/// </para>
+/// <para>
+/// The retry is bounded to the first operation and to the certificate question, which is what makes it safe. The first
+/// thing every mode of <c>login</c> sends is a read — the deployment's OAuth metadata, or its session — so a repeat
+/// changes nothing at the deployment, and nothing interactive has happened yet: no browser has been opened, no device
+/// code has been printed, and the credential a person types is read before the connection is used at all.
+/// </para>
+/// </remarks>
+internal sealed class SignInConnection : IDisposable
+{
+    /// <summary>The switch a sign-in with nobody at the terminal states the certificate answer with.</summary>
+    internal const string AllowanceOption = "--trust-untrusted-certificate";
+
+    private readonly ICliConsole console;
+
+    private readonly Func<Uri, StoredTransportTrust, DeploymentTransport> openTransport;
+
+    private readonly Uri address;
+
+    private readonly bool trustedUpFront;
+
+    private DeploymentTransport transport;
+
+    private bool settled;
+
+    /// <summary>Opens the connection this sign-in will use.</summary>
+    /// <param name="console">The terminal the certificate question is asked on.</param>
+    /// <param name="openTransport">Opens a transport aimed at one address; this connection disposes what it opens.</param>
+    /// <param name="address">The deployment being signed in to.</param>
+    /// <param name="acceptsClearText">Whether the operator has already accepted an unprotected connection to it.</param>
+    /// <param name="trustedUpFront">Whether the invocation stated the certificate answer with <see cref="AllowanceOption" />.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal SignInConnection(
+        ICliConsole console,
+        Func<Uri, StoredTransportTrust, DeploymentTransport> openTransport,
+        Uri address,
+        bool acceptsClearText,
+        bool trustedUpFront)
+    {
+        ArgumentNullException.ThrowIfNull(console);
+        ArgumentNullException.ThrowIfNull(openTransport);
+        ArgumentNullException.ThrowIfNull(address);
+
+        this.console = console;
+        this.openTransport = openTransport;
+        this.address = address;
+        this.trustedUpFront = trustedUpFront;
+        this.Trust = new StoredTransportTrust(PinnedCertificateFingerprint: null, acceptsClearText);
+        this.transport = openTransport(address, this.Trust);
+    }
+
+    /// <summary>Gets what this sign-in has accepted about the connection, which is what the profile records.</summary>
+    internal StoredTransportTrust Trust { get; private set; }
+
+    /// <summary>Runs one operation against the deployment, settling the certificate question if it is still open.</summary>
+    /// <typeparam name="TResult">What the operation produces.</typeparam>
+    /// <param name="operation">The operation, which must be safe to repeat.</param>
+    /// <returns>What the operation produced.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="operation" /> is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the operation failed for any other reason, and when the operator refused the certificate.</exception>
+    internal async Task<TResult> RunAsync<TResult>(Func<DeploymentTransport, Task<TResult>> operation)
+    {
+        ArgumentNullException.ThrowIfNull(operation);
+
+        try
+        {
+            var result = await operation(this.transport);
+
+            this.settled = true;
+
+            return result;
+        }
+        catch (CliFailure) when (!this.settled && this.transport.RefusedCertificate is not null)
+        {
+            // Swallowed deliberately: the transport refused a certificate rather than failing, and what that means is
+            // a question for the operator rather than a message. Reporting it here would end the sign-in the feature
+            // exists to complete.
+        }
+
+        this.PinPresentedCertificate();
+
+        return await operation(this.transport);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => this.transport.Dispose();
+
+    /// <summary>Accepts the certificate the connection refused, and reopens the connection bound to it.</summary>
+    private void PinPresentedCertificate()
+    {
+        var presented = this.transport.RefusedCertificate
+            ?? throw new InvalidOperationException("The certificate question was settled without a certificate having been refused.");
+
+        if (!this.Accepts(presented))
+        {
+            throw new CliFailure(
+                "The deployment's certificate was refused, so nothing was signed in to and nothing was stored.");
+        }
+
+        this.Trust = this.Trust with { PinnedCertificateFingerprint = presented.Fingerprint };
+        this.settled = true;
+
+        this.transport.Dispose();
+        this.transport = this.openTransport(this.address, this.Trust);
+    }
+
+    /// <summary>Asks whether this certificate may be trusted for this profile, or reads the answer the invocation stated.</summary>
+    private bool Accepts(PresentedCertificate presented)
+    {
+        if (this.trustedUpFront)
+        {
+            return true;
+        }
+
+        if (!this.console.CanConfirm)
+        {
+            throw new CliFailure(
+                $"{this.address.GetLeftPart(UriPartial.Authority)} presented a certificate this machine does not trust ({presented.ValidationFailure}), and there is no terminal to ask on. Pass {AllowanceOption} to accept whatever certificate this deployment presents and pin it to the profile.");
+        }
+
+        this.console.WriteError(string.Empty);
+        this.console.WriteError($"{this.address.GetLeftPart(UriPartial.Authority)} presented a certificate this machine does not trust:");
+        this.console.WriteError(string.Empty);
+
+        foreach (var line in presented.Lines())
+        {
+            this.console.WriteError(line);
+        }
+
+        this.console.WriteError(string.Empty);
+        this.console.WriteError("Accepting it stores this fingerprint on the profile. Every later command then accepts this certificate and refuses any other,");
+        this.console.WriteError("so a deployment that renews or replaces its certificate is signed in to again rather than trusted silently.");
+        this.console.WriteError(string.Empty);
+
+        return this.console.Confirm("Trust this certificate for this profile? [y/N]: ");
+    }
+}

--- a/tests/Cli.UnitTests/AuthorizeMailboxCommandTests.cs
+++ b/tests/Cli.UnitTests/AuthorizeMailboxCommandTests.cs
@@ -465,7 +465,7 @@ public sealed class AuthorizeMailboxCommandTests : IDisposable
                 new CredentialStore(
                     Path.Combine(this.storeDirectory, "credentials.json"),
                     new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key"))),
-                endpoint => new HttpClient(handler, disposeHandler: false) { BaseAddress = endpoint },
+                (endpoint, trust) => FakeDeploymentTransport.Over(handler, endpoint, trust),
                 awaitRedirect,
                 // Never started in a test: opening a browser is a side effect on the machine running the suite.
                 _ => false,

--- a/tests/Cli.UnitTests/Cli.UnitTests.csproj
+++ b/tests/Cli.UnitTests/Cli.UnitTests.csproj
@@ -14,4 +14,9 @@
     <Compile Include="..\shared\FakeHttpMessageHandler.cs" Link="FakeHttpMessageHandler.cs" />
     <Compile Include="..\shared\RecordedHttpRequest.cs" Link="RecordedHttpRequest.cs" />
   </ItemGroup>
+
+  <!-- The certificates the transport-trust tests decide about, issued in memory so no key or anchor is committed. -->
+  <ItemGroup>
+    <Compile Include="..\shared\TestCertificates.cs" Link="TestCertificates.cs" />
+  </ItemGroup>
 </Project>

--- a/tests/Cli.UnitTests/CredentialStoreTests.cs
+++ b/tests/Cli.UnitTests/CredentialStoreTests.cs
@@ -369,6 +369,53 @@ public sealed class CredentialStoreTests : IDisposable
         Assert.Contains("credentials.json", failure.Message, StringComparison.Ordinal);
     }
 
+    /// <summary>What an operator accepted about the transport has to survive the file, or every command would ask again.</summary>
+    [Fact]
+    public void Save_AProfileThatAcceptedSomethingAboutItsTransport_ReadsItBackUnchanged()
+    {
+        // Arrange
+        StoredTransportTrust trust = new("AA:BB:CC", AcceptsClearText: true);
+
+        // Act
+        this.store.Save("production", Production, "not-a-real-token", "workstation", trust: trust);
+
+        // Assert
+        Assert.Equal(trust, this.store.Resolve("production").Trust);
+    }
+
+    /// <summary>An ordinary HTTPS profile records nothing, so the member's presence in the file is itself the statement that something was accepted.</summary>
+    [Fact]
+    public void Save_AProfileThatAcceptedNothingBeyondTheDefault_WritesNoTransportRecord()
+    {
+        // Act
+        this.store.Save("production", Production, "not-a-real-token", "workstation");
+
+        // Assert
+        Assert.Null(this.store.Read().Profiles["production"].Transport);
+        Assert.Equal(StoredTransportTrust.Protected, this.store.Resolve("production").Trust);
+    }
+
+    /// <summary>A store written before the member existed is not a store to fail on: it holds a profile signed in over an ordinary connection.</summary>
+    [Fact]
+    public void Read_AStoreWrittenWithoutATransportRecord_ReadsAsAnOrdinaryProfile()
+    {
+        // Arrange
+        Directory.CreateDirectory(this.storeDirectory);
+        File.WriteAllText(
+            Path.Combine(this.storeDirectory, "credentials.json"),
+            """
+            {"default":"production","profiles":{"production":{"endpoint":"https://mail.example.test:8443","token":"","credential":"workstation"}}}
+            """);
+
+        // Act
+        var (name, credential) = this.store.Locate("production");
+
+        // Assert
+        Assert.Equal("production", name);
+        Assert.Null(credential.Transport);
+        Assert.Equal("workstation", credential.Credential);
+    }
+
     /// <summary>The token is what the file exists to hold, so no diagnostic that formats the record may print it.</summary>
     [Fact]
     public void ToString_AStoredCredential_DoesNotCarryTheToken()

--- a/tests/Cli.UnitTests/FakeDeploymentTransport.cs
+++ b/tests/Cli.UnitTests/FakeDeploymentTransport.cs
@@ -33,27 +33,37 @@ internal static class FakeDeploymentTransport
             new HttpClient(handler, disposeHandler: false) { BaseAddress = address },
             new ServerCertificatePolicy(trust.PinnedCertificateFingerprint));
 
-    /// <summary>Builds a transport that has already met the certificate a deployment presents.</summary>
-    /// <param name="handler">The handler every request goes through, which is one that fails when the certificate was refused.</param>
+    /// <summary>Builds a transport that has already met the certificate a host presents.</summary>
     /// <param name="address">The address the transport is aimed at.</param>
     /// <param name="trust">What the profile accepted about this deployment's transport.</param>
-    /// <param name="presented">The certificate the deployment presents.</param>
+    /// <param name="presented">The certificate the host presents.</param>
     /// <param name="errors">What this machine found wrong with it, which is none for a certificate refused only by a pin.</param>
-    /// <returns>The transport, refusing or not exactly as the real policy decided.</returns>
+    /// <param name="answering">The handler a connection the policy accepted sends through.</param>
+    /// <param name="refusingHandshake">The handler a connection the policy refused sends through, which answers nothing.</param>
+    /// <returns>The transport, sending through whichever of the two the real policy's decision selects.</returns>
+    /// <remarks>
+    /// Which handler answers is decided by the policy rather than by the caller, because that is the part a real
+    /// connection couples: a refused handshake means the request never reaches the host. A double that let a refused
+    /// connection answer anyway would report every pin as working, which is the opposite of what these tests assert.
+    /// </remarks>
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The client is handed to the DeploymentTransport the command disposes, which disposes it; disposing it here would return a transport with nothing to send through.")]
     internal static DeploymentTransport Presenting(
-        HttpMessageHandler handler,
         Uri address,
         StoredTransportTrust trust,
         X509Certificate2 presented,
-        SslPolicyErrors errors = SslPolicyErrors.RemoteCertificateChainErrors)
+        SslPolicyErrors errors,
+        HttpMessageHandler answering,
+        HttpMessageHandler refusingHandshake)
     {
         ServerCertificatePolicy policy = new(trust.PinnedCertificateFingerprint);
 
         policy.Accepts(presented, chain: null, errors);
 
         return new DeploymentTransport(
-            new HttpClient(handler, disposeHandler: false) { BaseAddress = address },
+            new HttpClient(policy.Refused is null ? answering : refusingHandshake, disposeHandler: false)
+            {
+                BaseAddress = address,
+            },
             policy);
     }
 }

--- a/tests/Cli.UnitTests/FakeDeploymentTransport.cs
+++ b/tests/Cli.UnitTests/FakeDeploymentTransport.cs
@@ -1,0 +1,59 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Transport;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>The transport seam a command is given, with the network substituted and the certificate decision real.</summary>
+/// <remarks>
+/// The policy is not faked. A test that wants a deployment whose certificate this machine would refuse hands the real
+/// <see cref="ServerCertificatePolicy" /> a real certificate and the errors a handshake would have reported, and takes
+/// whatever it decides. Substituting the decision instead would leave the one rule these tests exist for — that a pin
+/// accepts exactly one certificate — asserted against a double rather than against the code.
+/// </remarks>
+internal static class FakeDeploymentTransport
+{
+    /// <summary>Builds a transport over a handler, for a deployment whose certificate never comes up.</summary>
+    /// <param name="handler">The handler every request goes through.</param>
+    /// <param name="address">The address the transport is aimed at.</param>
+    /// <param name="trust">What the profile accepted about this deployment's transport.</param>
+    /// <returns>The transport.</returns>
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The client is handed to the DeploymentTransport the command disposes, which disposes it; disposing it here would return a transport with nothing to send through.")]
+    internal static DeploymentTransport Over(
+        HttpMessageHandler handler,
+        Uri address,
+        StoredTransportTrust trust) =>
+        new(
+            new HttpClient(handler, disposeHandler: false) { BaseAddress = address },
+            new ServerCertificatePolicy(trust.PinnedCertificateFingerprint));
+
+    /// <summary>Builds a transport that has already met the certificate a deployment presents.</summary>
+    /// <param name="handler">The handler every request goes through, which is one that fails when the certificate was refused.</param>
+    /// <param name="address">The address the transport is aimed at.</param>
+    /// <param name="trust">What the profile accepted about this deployment's transport.</param>
+    /// <param name="presented">The certificate the deployment presents.</param>
+    /// <param name="errors">What this machine found wrong with it, which is none for a certificate refused only by a pin.</param>
+    /// <returns>The transport, refusing or not exactly as the real policy decided.</returns>
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The client is handed to the DeploymentTransport the command disposes, which disposes it; disposing it here would return a transport with nothing to send through.")]
+    internal static DeploymentTransport Presenting(
+        HttpMessageHandler handler,
+        Uri address,
+        StoredTransportTrust trust,
+        X509Certificate2 presented,
+        SslPolicyErrors errors = SslPolicyErrors.RemoteCertificateChainErrors)
+    {
+        ServerCertificatePolicy policy = new(trust.PinnedCertificateFingerprint);
+
+        policy.Accepts(presented, chain: null, errors);
+
+        return new DeploymentTransport(
+            new HttpClient(handler, disposeHandler: false) { BaseAddress = address },
+            policy);
+    }
+}

--- a/tests/Cli.UnitTests/KeyPairSignInTests.cs
+++ b/tests/Cli.UnitTests/KeyPairSignInTests.cs
@@ -255,7 +255,7 @@ public sealed class KeyPairSignInTests : IDisposable
     private CliContext Context(CredentialStore store, FakeHttpMessageHandler handler) => new(
         this.console,
         store,
-        endpoint => new HttpClient(handler, disposeHandler: false) { BaseAddress = endpoint },
+        (endpoint, trust) => FakeDeploymentTransport.Over(handler, endpoint, trust),
         FakeMailboxRedirect.Silent(),
         _ => false,
         this.clock);

--- a/tests/Cli.UnitTests/LoginCommandTests.cs
+++ b/tests/Cli.UnitTests/LoginCommandTests.cs
@@ -432,7 +432,7 @@ public sealed class LoginCommandTests : IDisposable
     private CliContext Context(CredentialStore store, FakeHttpMessageHandler handler) => new(
         this.console,
         store,
-        endpoint => new HttpClient(handler, disposeHandler: false) { BaseAddress = endpoint },
+        (endpoint, trust) => FakeDeploymentTransport.Over(handler, endpoint, trust),
         FakeMailboxRedirect.Silent(),
         _ => false,
         this.clock);

--- a/tests/Cli.UnitTests/OAuthSignInTests.cs
+++ b/tests/Cli.UnitTests/OAuthSignInTests.cs
@@ -718,7 +718,7 @@ public sealed class OAuthSignInTests : IDisposable
         Func<Uri, IMailboxRedirectAwaiter> awaitRedirect) => new(
         this.console,
         store,
-        endpoint => new HttpClient(handler, disposeHandler: false) { BaseAddress = endpoint },
+        (endpoint, trust) => FakeDeploymentTransport.Over(handler, endpoint, trust),
         awaitRedirect,
 
         // Never started in a test: opening a browser is a side effect on the machine running the suite.

--- a/tests/Cli.UnitTests/RecordingCliConsole.cs
+++ b/tests/Cli.UnitTests/RecordingCliConsole.cs
@@ -20,6 +20,19 @@ internal sealed class RecordingCliConsole : ICliConsole
     /// <summary>Gets the prompt the command last asked with, or <see langword="null" /> when it asked for nothing.</summary>
     internal string? LastPrompt { get; private set; }
 
+    /// <summary>Gets or sets a value indicating whether a person is at this terminal to answer a question.</summary>
+    /// <remarks>Set to <see langword="false" /> to model the case the flags exist for: input redirected from a pipe, where the answer would otherwise be read out of whatever the caller piped in.</remarks>
+    internal bool AnswersQuestions { get; set; } = true;
+
+    /// <summary>Gets or sets the answer this terminal gives to a question.</summary>
+    internal bool AnswerToGive { get; set; }
+
+    /// <summary>Gets the questions the command asked, in order.</summary>
+    internal List<string> Questions { get; } = [];
+
+    /// <inheritdoc />
+    public bool CanConfirm => this.AnswersQuestions;
+
     /// <inheritdoc />
     public void WriteLine(string message) => this.Lines.Add(message);
 
@@ -32,5 +45,13 @@ internal sealed class RecordingCliConsole : ICliConsole
         this.LastPrompt = prompt;
 
         return this.SecretToSupply;
+    }
+
+    /// <inheritdoc />
+    public bool Confirm(string question)
+    {
+        this.Questions.Add(question);
+
+        return this.AnswerToGive;
     }
 }

--- a/tests/Cli.UnitTests/ServerCertificatePolicyTests.cs
+++ b/tests/Cli.UnitTests/ServerCertificatePolicyTests.cs
@@ -1,0 +1,212 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Transport;
+using MailFathom.TestSupport;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers which certificate one connection accepts, and what it records about the one it refused.</summary>
+/// <remarks>
+/// The claim worth defending is that a pin narrows rather than widens: a profile that pinned a certificate accepts that
+/// one and refuses every other, including one this machine would have trusted on its own. Without that, accepting a
+/// self-signed certificate once would leave the profile accepting anything for as long as it exists.
+/// </remarks>
+public sealed class ServerCertificatePolicyTests : IDisposable
+{
+    private readonly X509Certificate2 authority = TestCertificates.CreateCertificateAuthority("MailFathom test authority");
+
+    private readonly X509Certificate2 deploymentCertificate;
+
+    private readonly X509Certificate2 replacementCertificate;
+
+    public ServerCertificatePolicyTests()
+    {
+        this.deploymentCertificate = TestCertificates.IssueServerCertificate(this.authority, "mail.example.test");
+        this.replacementCertificate = TestCertificates.IssueServerCertificate(this.authority, "mail.example.test");
+    }
+
+    [Fact]
+    public void Accepts_AChainThisMachineTrustsAndNoPin_IsAcceptedAndNothingIsRecorded()
+    {
+        // Arrange
+        ServerCertificatePolicy policy = new(pinnedCertificateFingerprint: null);
+
+        // Act
+        var accepted = policy.Accepts(this.deploymentCertificate, chain: null, SslPolicyErrors.None);
+
+        // Assert
+        Assert.True(accepted);
+        Assert.Null(policy.Refused);
+    }
+
+    /// <summary>What a self-signed deployment looks like on the first connection, and the whole input to the question the operator is asked.</summary>
+    [Fact]
+    public void Accepts_AnUntrustedCertificateAndNoPin_IsRefusedAndRecordedWithWhatAnOperatorHasToRead()
+    {
+        // Arrange
+        ServerCertificatePolicy policy = new(pinnedCertificateFingerprint: null);
+
+        // Act
+        var accepted = policy.Accepts(
+            this.deploymentCertificate,
+            chain: null,
+            SslPolicyErrors.RemoteCertificateChainErrors);
+
+        // Assert
+        Assert.False(accepted);
+        Assert.Equal(
+            PresentedCertificate.FingerprintOf(this.deploymentCertificate),
+            policy.Refused?.Fingerprint);
+        Assert.Equal(this.deploymentCertificate.Subject, policy.Refused?.Subject);
+        Assert.Equal(this.deploymentCertificate.Issuer, policy.Refused?.Issuer);
+        Assert.Contains("does not trust the chain", policy.Refused!.ValidationFailure, StringComparison.Ordinal);
+    }
+
+    /// <summary>The point of the feature: the certificate the operator accepted is accepted afterwards, chain or no chain.</summary>
+    [Fact]
+    public void Accepts_ThePinnedCertificate_IsAcceptedEvenThoughItsChainIsStillUntrusted()
+    {
+        // Arrange
+        ServerCertificatePolicy policy = new(PresentedCertificate.FingerprintOf(this.deploymentCertificate));
+
+        // Act
+        var accepted = policy.Accepts(
+            this.deploymentCertificate,
+            chain: null,
+            SslPolicyErrors.RemoteCertificateChainErrors);
+
+        // Assert
+        Assert.True(accepted);
+        Assert.Null(policy.Refused);
+    }
+
+    /// <summary>
+    /// A pin is not "trust this one as well". A different certificate is refused even where this machine would have
+    /// accepted it on its own, because a profile that pinned one said which deployment it is talking to.
+    /// </summary>
+    [Fact]
+    public void Accepts_ADifferentCertificateUnderAPin_IsRefusedEvenWhenItValidatesOnItsOwn()
+    {
+        // Arrange
+        ServerCertificatePolicy policy = new(PresentedCertificate.FingerprintOf(this.deploymentCertificate));
+
+        // Act
+        var accepted = policy.Accepts(this.replacementCertificate, chain: null, SslPolicyErrors.None);
+
+        // Assert
+        Assert.False(accepted);
+        Assert.Equal(
+            PresentedCertificate.FingerprintOf(this.replacementCertificate),
+            policy.Refused?.Fingerprint);
+    }
+
+    [Fact]
+    public void Accepts_NoCertificateAtAll_IsRefused()
+    {
+        // Arrange
+        ServerCertificatePolicy policy = new(pinnedCertificateFingerprint: null);
+
+        // Act
+        var accepted = policy.Accepts(certificate: null, chain: null, SslPolicyErrors.RemoteCertificateNotAvailable);
+
+        // Assert
+        Assert.False(accepted);
+        Assert.Contains("presented no certificate", policy.Refused!.ValidationFailure, StringComparison.Ordinal);
+    }
+
+    /// <summary>The platform reports a refused handshake as an ordinary connection failure, so the fingerprint change has to be named here or nowhere.</summary>
+    [Fact]
+    public void DescribeRefusal_ACertificateChangeUnderAPin_NamesBothFingerprints()
+    {
+        // Arrange
+        var pinned = PresentedCertificate.FingerprintOf(this.deploymentCertificate);
+        ServerCertificatePolicy policy = new(pinned);
+        policy.Accepts(this.replacementCertificate, chain: null, SslPolicyErrors.None);
+
+        // Act
+        var described = policy.DescribeRefusal(new Uri("https://mail.example.test:8443"));
+
+        // Assert
+        Assert.Contains(pinned, described!, StringComparison.Ordinal);
+        Assert.Contains(
+            PresentedCertificate.FingerprintOf(this.replacementCertificate),
+            described!,
+            StringComparison.Ordinal);
+        Assert.Contains("mail.example.test:8443", described!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DescribeRefusal_AConnectionThatRefusedNothing_ReportsNoCertificateReason()
+    {
+        // Arrange
+        ServerCertificatePolicy policy = new(pinnedCertificateFingerprint: null);
+
+        // Act
+        var described = policy.DescribeRefusal(new Uri("https://mail.example.test:8443"));
+
+        // Assert
+        Assert.Null(described);
+    }
+
+    /// <summary>A stored fingerprint is a line in a file, so a spelling an operator pasted from elsewhere still has to name the same certificate.</summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void NamesTheSameCertificate_TheSameHashSpelledDifferently_Matches(bool withoutSeparators)
+    {
+        // Arrange
+        var fingerprint = PresentedCertificate.FingerprintOf(this.deploymentCertificate);
+        var spelling = withoutSeparators
+            ? fingerprint.Replace(":", string.Empty, StringComparison.Ordinal)
+            : new string([.. fingerprint.Select(char.ToLowerInvariant)]);
+
+        // Act
+        var matches = PresentedCertificate.NamesTheSameCertificate(spelling, fingerprint);
+
+        // Assert
+        Assert.True(matches);
+    }
+
+    /// <summary>The bounds every request to a deployment goes out under, which nothing above the transport can restate.</summary>
+    [Fact]
+    public void Open_ATransportAimedAtADeployment_CarriesTheBoundsEveryRequestGoesOutUnder()
+    {
+        // Act
+        using var transport = DeploymentTransport.Open(
+            new Uri("https://mail.example.test:8443"),
+            StoredTransportTrust.Protected);
+
+        // Assert
+        Assert.Equal(new Uri("https://mail.example.test:8443"), transport.Client.BaseAddress);
+        Assert.Equal(DeploymentTransport.RequestTimeout, transport.Client.Timeout);
+        Assert.Equal(DeploymentTransport.ResponseSizeLimitInBytes, transport.Client.MaxResponseContentBufferSize);
+        Assert.Null(transport.RefusedCertificate);
+    }
+
+    [Fact]
+    public void FingerprintOf_ACertificate_IsTheColonSeparatedSha256()
+    {
+        // Act
+        var fingerprint = PresentedCertificate.FingerprintOf(this.deploymentCertificate);
+
+        // Assert
+        Assert.Equal(95, fingerprint.Length);
+        Assert.Equal(
+            this.deploymentCertificate.GetCertHashString(HashAlgorithmName.SHA256),
+            fingerprint.Replace(":", string.Empty, StringComparison.Ordinal));
+    }
+
+    public void Dispose()
+    {
+        this.authority.Dispose();
+        this.deploymentCertificate.Dispose();
+        this.replacementCertificate.Dispose();
+    }
+}

--- a/tests/Cli.UnitTests/TransportTrustSignInTests.cs
+++ b/tests/Cli.UnitTests/TransportTrustSignInTests.cs
@@ -104,10 +104,13 @@ public sealed class TransportTrustSignInTests : IDisposable
         Assert.Contains(this.deploymentCertificate.Issuer, reported, StringComparison.Ordinal);
         Assert.Contains(PresentedCertificate.FingerprintOf(this.deploymentCertificate), reported, StringComparison.Ordinal);
         Assert.Contains(
-            new DateTimeOffset(this.deploymentCertificate.NotAfter).ToString("u"),
+            this.deploymentCertificate.NotAfter.ToUniversalTime().ToString("u"),
             reported,
             StringComparison.Ordinal);
         Assert.Contains("does not trust the chain", reported, StringComparison.Ordinal);
+        Assert.Contains(
+            this.console.Errors,
+            line => line.StartsWith($"{SecureEndpoint} presented a certificate", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -214,6 +217,11 @@ public sealed class TransportTrustSignInTests : IDisposable
         Assert.Contains(
             this.console.Lines,
             line => line.Contains("clear text", StringComparison.Ordinal));
+
+        // The scheme is part of the line, because that is what an operator compares their terminal against.
+        Assert.Contains(
+            this.console.Errors,
+            line => line.StartsWith($"{ClearTextEndpoint} is an HTTP address", StringComparison.Ordinal));
     }
 
     /// <summary>The question is asked from the address alone, before anything is sent, so a deployment that would have redirected never gets to answer it.</summary>

--- a/tests/Cli.UnitTests/TransportTrustSignInTests.cs
+++ b/tests/Cli.UnitTests/TransportTrustSignInTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Net;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using MailFathom.Cli.Credentials;
 using MailFathom.Cli.Transport;
@@ -48,6 +49,9 @@ public sealed class TransportTrustSignInTests : IDisposable
     /// <summary>What a connection whose handshake was refused answers, which is nothing: the request never reaches the deployment.</summary>
     private readonly FakeHttpMessageHandler refusedHandshake = FakeAdminEndpoint.Unreachable();
 
+    /// <summary>What each host a command reached was trusted with, so a test can assert which trust travelled where.</summary>
+    private readonly Dictionary<string, StoredTransportTrust> trustPerHost = new(StringComparer.Ordinal);
+
     public TransportTrustSignInTests()
     {
         this.deploymentCertificate = TestCertificates.IssueServerCertificate(this.authority, "mail.example.test");
@@ -65,7 +69,7 @@ public sealed class TransportTrustSignInTests : IDisposable
 
         // Act
         var exitCode = await RunAsync(
-            this.CertificateContext(store, handler), "login", "--endpoint", SecureEndpoint);
+            this.PresentingContext(store, handler), "login", "--endpoint", SecureEndpoint);
 
         // Assert
         Assert.Equal(0, exitCode);
@@ -85,7 +89,7 @@ public sealed class TransportTrustSignInTests : IDisposable
         this.console.AnswerToGive = true;
 
         // Act
-        await RunAsync(this.CertificateContext(this.CreateStore(), handler), "login", "--endpoint", SecureEndpoint);
+        await RunAsync(this.PresentingContext(this.CreateStore(), handler), "login", "--endpoint", SecureEndpoint);
 
         // Assert
         var reported = string.Join('\n', this.console.Errors);
@@ -109,7 +113,7 @@ public sealed class TransportTrustSignInTests : IDisposable
         this.console.AnswerToGive = false;
 
         // Act
-        var exitCode = await RunAsync(this.CertificateContext(store, handler), "login", "--endpoint", SecureEndpoint);
+        var exitCode = await RunAsync(this.PresentingContext(store, handler), "login", "--endpoint", SecureEndpoint);
 
         // Assert
         Assert.Equal(1, exitCode);
@@ -130,7 +134,7 @@ public sealed class TransportTrustSignInTests : IDisposable
         this.console.AnswersQuestions = false;
 
         // Act
-        var exitCode = await RunAsync(this.CertificateContext(store, handler), "login", "--endpoint", SecureEndpoint);
+        var exitCode = await RunAsync(this.PresentingContext(store, handler), "login", "--endpoint", SecureEndpoint);
 
         // Assert
         Assert.Equal(1, exitCode);
@@ -153,7 +157,7 @@ public sealed class TransportTrustSignInTests : IDisposable
 
         // Act
         var exitCode = await RunAsync(
-            this.CertificateContext(store, handler),
+            this.PresentingContext(store, handler),
             "login",
             "--endpoint",
             SecureEndpoint,
@@ -317,14 +321,15 @@ public sealed class TransportTrustSignInTests : IDisposable
             "not-a-real-key",
             "workstation",
             trust: new StoredTransportTrust(pinned));
-        using var handler = FakeAdminEndpoint.Unreachable();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
 
         // Act
         var exitCode = await RunAsync(
             this.PresentingContext(store, handler, this.replacementCertificate), "status");
 
-        // Assert
+        // Assert: the deployment would have answered, so the refusal is the pin's and nothing was sent.
         Assert.Equal(1, exitCode);
+        Assert.Empty(handler.RecordedRequests);
         Assert.Contains(this.console.Errors, line => line.Contains(pinned, StringComparison.Ordinal));
         Assert.Contains(
             this.console.Errors,
@@ -373,7 +378,7 @@ public sealed class TransportTrustSignInTests : IDisposable
 
         // Act
         var exitCode = await RunAsync(
-            this.CertificateContext(store, handler, this.replacementCertificate),
+            this.PresentingContext(store, handler, this.replacementCertificate),
             "login",
             "--endpoint",
             "production");
@@ -383,6 +388,80 @@ public sealed class TransportTrustSignInTests : IDisposable
         Assert.Equal(
             PresentedCertificate.FingerprintOf(this.replacementCertificate),
             store.Resolve("production").Trust.PinnedCertificateFingerprint);
+    }
+
+    /// <summary>
+    /// A profile's pin names the deployment's certificate and says nothing about the authorization server's, so a
+    /// silent renewal must reach that server under ordinary chain validation. Applying the pin there instead would
+    /// refuse every renewal for exactly the operators this feature exists for, and it would do it on an ordinary
+    /// command rather than at sign-in, where nothing would say which certificate was the problem.
+    /// </summary>
+    [Fact]
+    public async Task Status_APinnedProfileWhoseAccessTokenExpired_RenewsAgainstTheAuthorizationServersOwnCertificate()
+    {
+        // Arrange
+        var deployment = FakeOAuthDeployment.Answering();
+        using var handler = deployment.Handler();
+        var store = this.CreateStore();
+        store.Save(
+            "production",
+            new Uri(SecureEndpoint),
+            "a-spent-access-token",
+            "workstation",
+            new OAuthSession(
+                "a-refresh-token",
+                this.clock.GetUtcNow().AddMinutes(-1),
+                new Uri(FakeOAuthDeployment.TokenEndpoint),
+                FakeOAuthDeployment.Issuer,
+                "mfctl",
+                FakeOAuthDeployment.Resource,
+                "mailfathom.admin"),
+            trust: new StoredTransportTrust(PresentedCertificate.FingerprintOf(this.deploymentCertificate)));
+
+        // Act: the deployment presents the pinned certificate, the authorization server its own trusted one.
+        var exitCode = await RunAsync(this.TwoHostContext(store, handler), "status");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Equal("refresh_token", deployment.LastTokenRequest["grant_type"]);
+        Assert.Equal("an-access-token", store.Resolve("production").Token);
+        Assert.Equal(
+            StoredTransportTrust.Protected,
+            this.trustPerHost[new Uri(FakeOAuthDeployment.TokenEndpoint).Host]);
+    }
+
+    /// <summary>The same isolation for a clear-text profile: an unprotected deployment does not make the renewal unprotected.</summary>
+    [Fact]
+    public async Task Status_AClearTextProfileWhoseAccessTokenExpired_RenewsWithoutCarryingTheClearTextDecision()
+    {
+        // Arrange
+        var deployment = FakeOAuthDeployment.Answering();
+        using var handler = deployment.Handler();
+        var store = this.CreateStore();
+        store.Save(
+            "production",
+            new Uri(ClearTextEndpoint),
+            "a-spent-access-token",
+            "workstation",
+            new OAuthSession(
+                "a-refresh-token",
+                this.clock.GetUtcNow().AddMinutes(-1),
+                new Uri(FakeOAuthDeployment.TokenEndpoint),
+                FakeOAuthDeployment.Issuer,
+                "mfctl",
+                FakeOAuthDeployment.Resource,
+                "mailfathom.admin"),
+            trust: new StoredTransportTrust(PinnedCertificateFingerprint: null, AcceptsClearText: true));
+
+        // Act
+        var exitCode = await RunAsync(this.TwoHostContext(store, handler), "status");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Equal("refresh_token", deployment.LastTokenRequest["grant_type"]);
+        Assert.Equal(
+            StoredTransportTrust.Protected,
+            this.trustPerHost[new Uri(FakeOAuthDeployment.TokenEndpoint).Host]);
     }
 
     private static Task<int> RunAsync(CliContext context, params string[] args) =>
@@ -402,42 +481,61 @@ public sealed class TransportTrustSignInTests : IDisposable
         this.clock);
 
     /// <summary>Builds a context for a deployment presenting one certificate to every connection a command opens.</summary>
+    /// <remarks>
+    /// A connection the policy refuses answers nothing, which is what a failed handshake looks like from above: the
+    /// request never reaches the deployment. So a test asserting that a command completed is asserting that the profile's
+    /// own trust is what carried it, and one asserting a failure is asserting that nothing was sent.
+    /// </remarks>
     private CliContext PresentingContext(
         CredentialStore store,
         FakeHttpMessageHandler handler,
-        X509Certificate2 presented) => new(
+        X509Certificate2? presented = null) => new(
         this.console,
         store,
-        (address, trust) => FakeDeploymentTransport.Presenting(handler, address, trust, presented),
+        (address, trust) => FakeDeploymentTransport.Presenting(
+            address,
+            trust,
+            presented ?? this.deploymentCertificate,
+            SslPolicyErrors.RemoteCertificateChainErrors,
+            handler,
+            this.refusedHandshake),
         FakeMailboxRedirect.Silent(),
         _ => false,
         this.clock);
 
-    /// <summary>Builds a context for a deployment whose certificate this machine refuses until the profile pins it.</summary>
+    /// <summary>Builds a context for the two hosts an OAuth profile reaches: the deployment, and the server that renews its token.</summary>
     /// <remarks>
-    /// The refusing connection answers nothing, which is what a failed handshake looks like from above: the request never
-    /// reaches the deployment. Only the connection opened after the pin was taken can carry one, so a test asserting that
-    /// the sign-in completed is asserting that the pin is what carried it.
+    /// The authorization server presents a certificate of its own that this machine trusts, which is the ordinary case
+    /// and the one that fails loudly if a profile's pin ever travelled here: the pin names the deployment's certificate,
+    /// so a pinned connection would refuse this one and the renewal would never be sent.
     /// </remarks>
-    private CliContext CertificateContext(
-        CredentialStore store,
-        FakeHttpMessageHandler handler,
-        X509Certificate2? presented = null)
-    {
-        var certificate = presented ?? this.deploymentCertificate;
+    private CliContext TwoHostContext(CredentialStore store, FakeHttpMessageHandler handler) => new(
+        this.console,
+        store,
+        (address, trust) =>
+        {
+            this.trustPerHost[address.Host] = trust;
 
-        return new CliContext(
-            this.console,
-            store,
-            (address, trust) => FakeDeploymentTransport.Presenting(
-                trust.PinnedCertificateFingerprint is null ? this.refusedHandshake : handler,
+            // An http address completes no handshake, so no certificate is presented over one and the ordinary
+            // transport is what a command meets there.
+            if (address.Scheme == Uri.UriSchemeHttp)
+            {
+                return FakeDeploymentTransport.Over(handler, address, trust);
+            }
+
+            var reachesTheDeployment = address.Host == new Uri(SecureEndpoint).Host;
+
+            return FakeDeploymentTransport.Presenting(
                 address,
                 trust,
-                certificate),
-            FakeMailboxRedirect.Silent(),
-            _ => false,
-            this.clock);
-    }
+                reachesTheDeployment ? this.deploymentCertificate : this.replacementCertificate,
+                reachesTheDeployment ? SslPolicyErrors.RemoteCertificateChainErrors : SslPolicyErrors.None,
+                handler,
+                this.refusedHandshake);
+        },
+        FakeMailboxRedirect.Silent(),
+        _ => false,
+        this.clock);
 
     public void Dispose()
     {

--- a/tests/Cli.UnitTests/TransportTrustSignInTests.cs
+++ b/tests/Cli.UnitTests/TransportTrustSignInTests.cs
@@ -5,6 +5,8 @@
 using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
+using System.Web;
+using MailFathom.Cli.Authorization;
 using MailFathom.Cli.Credentials;
 using MailFathom.Cli.Transport;
 using MailFathom.TestSupport;
@@ -49,8 +51,13 @@ public sealed class TransportTrustSignInTests : IDisposable
     /// <summary>What a connection whose handshake was refused answers, which is nothing: the request never reaches the deployment.</summary>
     private readonly FakeHttpMessageHandler refusedHandshake = FakeAdminEndpoint.Unreachable();
 
-    /// <summary>What each host a command reached was trusted with, so a test can assert which trust travelled where.</summary>
-    private readonly Dictionary<string, StoredTransportTrust> trustPerHost = new(StringComparer.Ordinal);
+    /// <summary>Every connection a command opened, in order, so a test can assert which trust travelled to which address.</summary>
+    /// <remarks>
+    /// By address rather than by host, because the authorization server serves both the discovery document and the token
+    /// endpoint: keying on the host would let a correctly opened token-endpoint connection stand in for a discovery
+    /// connection that was never opened, which is exactly the regression these assertions exist to catch.
+    /// </remarks>
+    private readonly List<(Uri Address, StoredTransportTrust Trust)> openedConnections = [];
 
     public TransportTrustSignInTests()
     {
@@ -427,7 +434,7 @@ public sealed class TransportTrustSignInTests : IDisposable
         Assert.Equal("an-access-token", store.Resolve("production").Token);
         Assert.Equal(
             StoredTransportTrust.Protected,
-            this.trustPerHost[new Uri(FakeOAuthDeployment.TokenEndpoint).Host]);
+            this.TrustCarriedTo(new Uri(FakeOAuthDeployment.TokenEndpoint)));
     }
 
     /// <summary>The same isolation for a clear-text profile: an unprotected deployment does not make the renewal unprotected.</summary>
@@ -461,11 +468,73 @@ public sealed class TransportTrustSignInTests : IDisposable
         Assert.Equal("refresh_token", deployment.LastTokenRequest["grant_type"]);
         Assert.Equal(
             StoredTransportTrust.Protected,
-            this.trustPerHost[new Uri(FakeOAuthDeployment.TokenEndpoint).Host]);
+            this.TrustCarriedTo(new Uri(FakeOAuthDeployment.TokenEndpoint)));
     }
+
+    /// <summary>
+    /// The same isolation one step earlier, and on the path where the pin does not exist yet. A sign-in reads the
+    /// deployment's metadata through the connection whose certificate is still in question and the authorization
+    /// server's through one of its own, so threading the deployment's transport into both would refuse every OAuth
+    /// sign-in to a self-signed deployment — at the authorization server, which is the wrong machine to send an
+    /// operator to look at.
+    /// </summary>
+    [Fact]
+    public async Task Login_AnInteractiveSignInToAnUntrustedDeployment_DiscoversTheAuthorizationServerUnpinned()
+    {
+        // Arrange
+        var deployment = FakeOAuthDeployment.Answering();
+        using var handler = deployment.Handler();
+        var store = this.CreateStore();
+        this.console.AnswerToGive = true;
+
+        // Act
+        var exitCode = await RunAsync(
+            this.TwoHostContext(store, handler, FakeMailboxRedirect.ApprovingWhenAsked(
+                "an-authorization-code",
+                this.StateTheCommandGenerated)),
+            "login",
+            "--endpoint",
+            FakeOAuthDeployment.DeploymentAddress,
+            "--mode",
+            "interactive",
+            "--client-id",
+            "mfctl");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Equal("an-access-token", store.Resolve(requestedDeployment: null).Token);
+        Assert.Equal(
+            PresentedCertificate.FingerprintOf(this.deploymentCertificate),
+            store.Resolve(requestedDeployment: null).Trust.PinnedCertificateFingerprint);
+        Assert.Equal(StoredTransportTrust.Protected, this.TrustCarriedToTheDiscoveryDocument());
+    }
+
+    /// <summary>Reports the trust one address was reached under, failing when no connection was opened to it at all.</summary>
+    private StoredTransportTrust TrustCarriedTo(Uri address) =>
+        this.openedConnections.SingleOrDefault(opened => opened.Address == address).Trust
+        ?? throw new InvalidOperationException($"No connection was opened to {address}.");
+
+    /// <summary>Reports the trust the authorization server's discovery document was fetched under.</summary>
+    /// <remarks>Matched on the metadata address rather than on the host, so a token-endpoint connection opened correctly cannot stand in for a discovery connection that was never opened.</remarks>
+    private StoredTransportTrust TrustCarriedToTheDiscoveryDocument() =>
+        this.openedConnections
+            .Where(opened => opened.Address.AbsolutePath.StartsWith("/.well-known/", StringComparison.Ordinal))
+            .Select(opened => opened.Trust)
+            .FirstOrDefault()
+        ?? throw new InvalidOperationException("No connection was opened to fetch a discovery document.");
 
     private static Task<int> RunAsync(CliContext context, params string[] args) =>
         CliRunner.RunAsync(context, args);
+
+    /// <summary>Reads the anti-forgery value out of the address the command printed, the way the person's browser does.</summary>
+    private string StateTheCommandGenerated()
+    {
+        var address = this.console.Errors.LastOrDefault(line => line.Contains("state=", StringComparison.Ordinal))?.Trim()
+            ?? throw new InvalidOperationException("The command printed no authorization address.");
+
+        return HttpUtility.ParseQueryString(new Uri(address).Query)["state"]
+            ?? throw new InvalidOperationException("The printed authorization address carried no state.");
+    }
 
     private CredentialStore CreateStore() => new(
         Path.Combine(this.storeDirectory, "credentials.json"),
@@ -503,18 +572,22 @@ public sealed class TransportTrustSignInTests : IDisposable
         _ => false,
         this.clock);
 
-    /// <summary>Builds a context for the two hosts an OAuth profile reaches: the deployment, and the server that renews its token.</summary>
+    /// <summary>Builds a context for the two hosts an OAuth sign-in reaches: the deployment, and the server that authorizes it.</summary>
     /// <remarks>
     /// The authorization server presents a certificate of its own that this machine trusts, which is the ordinary case
-    /// and the one that fails loudly if a profile's pin ever travelled here: the pin names the deployment's certificate,
-    /// so a pinned connection would refuse this one and the renewal would never be sent.
+    /// and the one that fails loudly if the deployment's trust ever travelled here: it names the deployment's
+    /// certificate, so a pinned connection would refuse this one and the request — a discovery document at sign-in, a
+    /// renewal afterwards — would never be sent.
     /// </remarks>
-    private CliContext TwoHostContext(CredentialStore store, FakeHttpMessageHandler handler) => new(
+    private CliContext TwoHostContext(
+        CredentialStore store,
+        FakeHttpMessageHandler handler,
+        Func<Uri, IMailboxRedirectAwaiter>? awaitRedirect = null) => new(
         this.console,
         store,
         (address, trust) =>
         {
-            this.trustPerHost[address.Host] = trust;
+            this.openedConnections.Add((address, trust));
 
             // An http address completes no handshake, so no certificate is presented over one and the ordinary
             // transport is what a command meets there.
@@ -533,7 +606,9 @@ public sealed class TransportTrustSignInTests : IDisposable
                 handler,
                 this.refusedHandshake);
         },
-        FakeMailboxRedirect.Silent(),
+        awaitRedirect ?? FakeMailboxRedirect.Silent(),
+
+        // Never started in a test: opening a browser is a side effect on the machine running the suite.
         _ => false,
         this.clock);
 

--- a/tests/Cli.UnitTests/TransportTrustSignInTests.cs
+++ b/tests/Cli.UnitTests/TransportTrustSignInTests.cs
@@ -1,0 +1,454 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Transport;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers the two ways a deployment's transport can be weaker than the default, and what accepting one costs.</summary>
+/// <remarks>
+/// <para>
+/// Both questions are asked once, at <c>login</c>, and what they leave behind is a record on the profile rather than a
+/// protection turned off. The claims worth defending are that refusing either stores nothing and signs in to nothing,
+/// that an accepted certificate narrows the profile to exactly that certificate, and that no later command asks again.
+/// </para>
+/// <para>
+/// Driven through the command rather than against <see cref="ClearTextDecision" /> and
+/// <see cref="SignInConnection" /> directly, because what each of those decides is only meaningful as a step of a
+/// sign-in: whether anything was sent before the question, whether the credential was read twice, and what ended up in
+/// the store. A test of either in isolation could pass while the sign-in around it did the wrong thing.
+/// </para>
+/// </remarks>
+public sealed class TransportTrustSignInTests : IDisposable
+{
+    private const string SecureEndpoint = "https://mail.example.test:8443";
+
+    private const string ClearTextEndpoint = "http://mail.example.test:8080";
+
+    private readonly string storeDirectory =
+        Path.Combine(Path.GetTempPath(), $"mailfathom-transport-tests-{Guid.NewGuid():N}");
+
+    private readonly RecordingCliConsole console = new();
+
+    private readonly FakeTimeProvider clock = new(new DateTimeOffset(2026, 8, 3, 12, 0, 0, TimeSpan.Zero));
+
+    private readonly X509Certificate2 authority = TestCertificates.CreateCertificateAuthority("MailFathom test authority");
+
+    private readonly X509Certificate2 deploymentCertificate;
+
+    private readonly X509Certificate2 replacementCertificate;
+
+    /// <summary>What a connection whose handshake was refused answers, which is nothing: the request never reaches the deployment.</summary>
+    private readonly FakeHttpMessageHandler refusedHandshake = FakeAdminEndpoint.Unreachable();
+
+    public TransportTrustSignInTests()
+    {
+        this.deploymentCertificate = TestCertificates.IssueServerCertificate(this.authority, "mail.example.test");
+        this.replacementCertificate = TestCertificates.IssueServerCertificate(this.authority, "mail.example.test");
+    }
+
+    [Fact]
+    public async Task Login_AnUntrustedCertificateAccepted_PinsItToTheProfileAndSignsIn()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "not-a-real-key";
+        this.console.AnswerToGive = true;
+
+        // Act
+        var exitCode = await RunAsync(
+            this.CertificateContext(store, handler), "login", "--endpoint", SecureEndpoint);
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Equal(
+            PresentedCertificate.FingerprintOf(this.deploymentCertificate),
+            store.Resolve(requestedDeployment: null).Trust.PinnedCertificateFingerprint);
+        Assert.Contains(this.console.Questions, question => question.Contains("Trust this certificate", StringComparison.Ordinal));
+    }
+
+    /// <summary>The operator has to see what they are accepting, or the question is a prompt to press y at.</summary>
+    [Fact]
+    public async Task Login_AnUntrustedCertificate_ShowsItsSubjectIssuerFingerprintValidityAndWhyItFailed()
+    {
+        // Arrange
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "not-a-real-key";
+        this.console.AnswerToGive = true;
+
+        // Act
+        await RunAsync(this.CertificateContext(this.CreateStore(), handler), "login", "--endpoint", SecureEndpoint);
+
+        // Assert
+        var reported = string.Join('\n', this.console.Errors);
+        Assert.Contains(this.deploymentCertificate.Subject, reported, StringComparison.Ordinal);
+        Assert.Contains(this.deploymentCertificate.Issuer, reported, StringComparison.Ordinal);
+        Assert.Contains(PresentedCertificate.FingerprintOf(this.deploymentCertificate), reported, StringComparison.Ordinal);
+        Assert.Contains(
+            new DateTimeOffset(this.deploymentCertificate.NotAfter).ToString("u"),
+            reported,
+            StringComparison.Ordinal);
+        Assert.Contains("does not trust the chain", reported, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Login_AnUntrustedCertificateRefused_StoresNothingAndFails()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "not-a-real-key";
+        this.console.AnswerToGive = false;
+
+        // Act
+        var exitCode = await RunAsync(this.CertificateContext(store, handler), "login", "--endpoint", SecureEndpoint);
+
+        // Assert
+        Assert.Equal(1, exitCode);
+        Assert.Empty(store.Read().Profiles);
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains("certificate was refused", StringComparison.Ordinal));
+    }
+
+    /// <summary>A sign-in with nobody at the terminal must never prompt: the answer would be read out of whatever was piped in.</summary>
+    [Fact]
+    public async Task Login_AnUntrustedCertificateWithNoTerminal_FailsNamingTheSwitchThatWouldHaveAllowedIt()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "not-a-real-key";
+        this.console.AnswersQuestions = false;
+
+        // Act
+        var exitCode = await RunAsync(this.CertificateContext(store, handler), "login", "--endpoint", SecureEndpoint);
+
+        // Assert
+        Assert.Equal(1, exitCode);
+        Assert.Empty(store.Read().Profiles);
+        Assert.Empty(this.console.Questions);
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains("--trust-untrusted-certificate", StringComparison.Ordinal));
+    }
+
+    /// <summary>The switch weakens the one sign-in and not the profile it produces: what the deployment presented is still pinned.</summary>
+    [Fact]
+    public async Task Login_AnUntrustedCertificateAllowedUpFront_PinsItWithoutAskingAnything()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "not-a-real-key";
+        this.console.AnswersQuestions = false;
+
+        // Act
+        var exitCode = await RunAsync(
+            this.CertificateContext(store, handler),
+            "login",
+            "--endpoint",
+            SecureEndpoint,
+            "--trust-untrusted-certificate");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Empty(this.console.Questions);
+        Assert.Equal(
+            PresentedCertificate.FingerprintOf(this.deploymentCertificate),
+            store.Resolve(requestedDeployment: null).Trust.PinnedCertificateFingerprint);
+    }
+
+    /// <summary>A deployment with a certificate this machine trusts signs in as it always did, and records nothing.</summary>
+    [Fact]
+    public async Task Login_ACertificateThisMachineTrusts_AsksNothingAndPinsNothing()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "not-a-real-key";
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "login", "--endpoint", SecureEndpoint);
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Empty(this.console.Questions);
+        Assert.Equal(StoredTransportTrust.Protected, store.Resolve(requestedDeployment: null).Trust);
+    }
+
+    [Fact]
+    public async Task Login_AClearTextEndpointAccepted_RecordsItAndSaysWhatIsUnprotected()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "not-a-real-key";
+        this.console.AnswerToGive = true;
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "login", "--endpoint", ClearTextEndpoint);
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.True(store.Resolve(requestedDeployment: null).Trust.AcceptsClearText);
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("clear text", StringComparison.Ordinal));
+    }
+
+    /// <summary>The question is asked from the address alone, before anything is sent, so a deployment that would have redirected never gets to answer it.</summary>
+    [Fact]
+    public async Task Login_AClearTextEndpointThatWouldRedirectToHttps_IsStillAskedAboutBeforeAnythingIsSent()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Answering(HttpStatusCode.MovedPermanently);
+        this.console.SecretToSupply = "not-a-real-key";
+        this.console.AnswerToGive = false;
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "login", "--endpoint", ClearTextEndpoint);
+
+        // Assert
+        Assert.Equal(1, exitCode);
+        Assert.Empty(handler.RecordedRequests);
+        Assert.Contains(this.console.Questions, question => question.Contains("unprotected", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Login_AClearTextEndpointRefused_StoresNothingAndSaysWhichProtectionWasRefused()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "not-a-real-key";
+        this.console.AnswerToGive = false;
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "login", "--endpoint", ClearTextEndpoint);
+
+        // Assert
+        Assert.Equal(1, exitCode);
+        Assert.Empty(store.Read().Profiles);
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains("Transport protection was refused", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Login_AClearTextEndpointWithNoTerminal_FailsNamingTheSwitchThatWouldHaveAllowedIt()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "not-a-real-key";
+        this.console.AnswersQuestions = false;
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "login", "--endpoint", ClearTextEndpoint);
+
+        // Assert
+        Assert.Equal(1, exitCode);
+        Assert.Empty(store.Read().Profiles);
+        Assert.Empty(handler.RecordedRequests);
+        Assert.Contains(this.console.Errors, line => line.Contains("--allow-clear-text", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Login_AClearTextEndpointAllowedUpFront_SignsInWithoutAskingAnything()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "not-a-real-key";
+        this.console.AnswersQuestions = false;
+
+        // Act
+        var exitCode = await RunAsync(
+            this.Context(store, handler), "login", "--endpoint", ClearTextEndpoint, "--allow-clear-text");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Empty(this.console.Questions);
+        Assert.True(store.Resolve(requestedDeployment: null).Trust.AcceptsClearText);
+    }
+
+    /// <summary>The decision is taken once. A command that asked again would train an operator to answer without reading.</summary>
+    [Fact]
+    public async Task Status_AClearTextProfile_ProceedsWithoutAskingAgain()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        store.Save(
+            "production",
+            new Uri(ClearTextEndpoint),
+            "not-a-real-key",
+            "workstation",
+            trust: new StoredTransportTrust(PinnedCertificateFingerprint: null, AcceptsClearText: true));
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "status");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Empty(this.console.Questions);
+    }
+
+    /// <summary>What the pin is for: the deployment substituted its certificate, and the command says so rather than reporting a connection failure.</summary>
+    [Fact]
+    public async Task Status_APinnedProfileMeetingADifferentCertificate_RefusesAndNamesTheChange()
+    {
+        // Arrange
+        var pinned = PresentedCertificate.FingerprintOf(this.deploymentCertificate);
+        var store = this.CreateStore();
+        store.Save(
+            "production",
+            new Uri(SecureEndpoint),
+            "not-a-real-key",
+            "workstation",
+            trust: new StoredTransportTrust(pinned));
+        using var handler = FakeAdminEndpoint.Unreachable();
+
+        // Act
+        var exitCode = await RunAsync(
+            this.PresentingContext(store, handler, this.replacementCertificate), "status");
+
+        // Assert
+        Assert.Equal(1, exitCode);
+        Assert.Contains(this.console.Errors, line => line.Contains(pinned, StringComparison.Ordinal));
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains(
+                PresentedCertificate.FingerprintOf(this.replacementCertificate),
+                StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Status_APinnedProfileMeetingThePinnedCertificate_ReachesTheDeployment()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        store.Save(
+            "production",
+            new Uri(SecureEndpoint),
+            "not-a-real-key",
+            "workstation",
+            trust: new StoredTransportTrust(PresentedCertificate.FingerprintOf(this.deploymentCertificate)));
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+
+        // Act
+        var exitCode = await RunAsync(
+            this.PresentingContext(store, handler, this.deploymentCertificate), "status");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Empty(this.console.Questions);
+    }
+
+    /// <summary>A renewed certificate is accepted by signing in again, which is what re-asks rather than trusting it silently.</summary>
+    [Fact]
+    public async Task Login_APinnedProfileWhoseCertificateChanged_AsksAgainAndPinsTheNewOne()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        store.Save(
+            "production",
+            new Uri(SecureEndpoint),
+            "the-old-key",
+            "workstation",
+            trust: new StoredTransportTrust(PresentedCertificate.FingerprintOf(this.deploymentCertificate)));
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        this.console.SecretToSupply = "the-new-key";
+        this.console.AnswerToGive = true;
+
+        // Act
+        var exitCode = await RunAsync(
+            this.CertificateContext(store, handler, this.replacementCertificate),
+            "login",
+            "--endpoint",
+            "production");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Equal(
+            PresentedCertificate.FingerprintOf(this.replacementCertificate),
+            store.Resolve("production").Trust.PinnedCertificateFingerprint);
+    }
+
+    private static Task<int> RunAsync(CliContext context, params string[] args) =>
+        CliRunner.RunAsync(context, args);
+
+    private CredentialStore CreateStore() => new(
+        Path.Combine(this.storeDirectory, "credentials.json"),
+        new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key")));
+
+    /// <summary>Builds a context for a deployment whose certificate never comes up.</summary>
+    private CliContext Context(CredentialStore store, FakeHttpMessageHandler handler) => new(
+        this.console,
+        store,
+        (address, trust) => FakeDeploymentTransport.Over(handler, address, trust),
+        FakeMailboxRedirect.Silent(),
+        _ => false,
+        this.clock);
+
+    /// <summary>Builds a context for a deployment presenting one certificate to every connection a command opens.</summary>
+    private CliContext PresentingContext(
+        CredentialStore store,
+        FakeHttpMessageHandler handler,
+        X509Certificate2 presented) => new(
+        this.console,
+        store,
+        (address, trust) => FakeDeploymentTransport.Presenting(handler, address, trust, presented),
+        FakeMailboxRedirect.Silent(),
+        _ => false,
+        this.clock);
+
+    /// <summary>Builds a context for a deployment whose certificate this machine refuses until the profile pins it.</summary>
+    /// <remarks>
+    /// The refusing connection answers nothing, which is what a failed handshake looks like from above: the request never
+    /// reaches the deployment. Only the connection opened after the pin was taken can carry one, so a test asserting that
+    /// the sign-in completed is asserting that the pin is what carried it.
+    /// </remarks>
+    private CliContext CertificateContext(
+        CredentialStore store,
+        FakeHttpMessageHandler handler,
+        X509Certificate2? presented = null)
+    {
+        var certificate = presented ?? this.deploymentCertificate;
+
+        return new CliContext(
+            this.console,
+            store,
+            (address, trust) => FakeDeploymentTransport.Presenting(
+                trust.PinnedCertificateFingerprint is null ? this.refusedHandshake : handler,
+                address,
+                trust,
+                certificate),
+            FakeMailboxRedirect.Silent(),
+            _ => false,
+            this.clock);
+    }
+
+    public void Dispose()
+    {
+        this.authority.Dispose();
+        this.deploymentCertificate.Dispose();
+        this.replacementCertificate.Dispose();
+        this.refusedHandshake.Dispose();
+
+        if (Directory.Exists(this.storeDirectory))
+        {
+            Directory.Delete(this.storeDirectory, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Closes #552

`mfctl` opened every connection under the platform's default certificate validation, so a deployment serving its own certificate — self-signed, or issued by an internal authority the workstation does not carry — could not be signed in to at all. The failure arrived as a handshake exception rather than as a decision, which left an operator no move except installing the certificate into the machine's trust store: a change to every process on the machine, to reach one deployment.

`login` now asks about it once, the way an SSH client asks about a host key, and remembers the answer on the profile.

## What changed

**A certificate this machine does not trust.** Where the chain fails to validate, `login` prints the certificate's subject, issuer, SHA-256 fingerprint, validity window, and why validation failed, then asks a Yes/No question defaulting to no. Nothing is sent before the answer — the handshake was refused, so the credential was never on the wire. Accepting pins that fingerprint to the profile.

**A pin narrows rather than widens.** A pinned profile accepts exactly the certificate the operator was shown and refuses every other, *including* one this machine would have trusted on its own. A later substitution therefore fails as loudly as an untrusted certificate does today, and the message names both fingerprints instead of reporting a connection failure. The cost is that a renewed certificate stops the profile until `login` runs again, which is how the new one is reviewed and accepted; `logout` removes the pin with the profile.

**An `http://` endpoint.** An address is taken as written, no scheme is guessed onto a bare host, and redirects are never followed — so a deployment's HTTP-to-HTTPS redirect arrives after the credential is already on the wire and cannot stand in for the operator's decision. The question is therefore asked from the address alone, before anything is sent, and a deployment that would have answered `308` never gets to answer it.

**A sign-in with nobody at the terminal.** `--mode key` reads the credential from standard input, so neither question can be read from there. `--trust-untrusted-certificate` and `--allow-clear-text` state the answers up front; without the one that was needed the sign-in fails naming it rather than prompting into a pipe. The certificate switch weakens the one sign-in rather than the profile it produces — what the deployment presented is still pinned afterwards.

**Neither question is asked outside `login`.** A later command acts on a decision already taken, and a tool that asks the same question every time trains an operator to answer it without reading it.

Nothing on the service side changes, and no configuration key disables certificate validation or clear-text protection globally.

## Two decisions worth reviewing

**The certificate question is settled on the connection's first use, not by a probe.** A probe would add a round trip to every `login`, and settling it after credential production would leave the OAuth modes reaching the network first anyway. Instead `SignInConnection` runs the first operation under ordinary validation and, if the handshake refused a certificate, asks and runs it again pinned. The retry is bounded to the first operation and to the certificate question: the first thing every mode sends is a read, nothing interactive has happened yet — no browser opened, no device code printed — and the typed credential is read before the connection is used at all, so no prompt is repeated.

**A pin covers the deployment and nothing else.** `DeploymentAuthorizationDiscovery` previously fetched the authorization server's discovery document through the deployment's own transport, at an absolute address on a different host. That was already a conflation and becomes a defect under a pin, which would refuse the authorization server for presenting a certificate it was never asked to present. Authorization-server metadata now travels on its own transport under ordinary chain validation, as the token endpoint already did.

## Breaking change

**Configuration schema — the CLI's own on-disk profile format.** `StoredCredential` gains an optional `transport` member holding the pinned fingerprint and the clear-text decision. Both are stored in clear beside the endpoint, because neither is a secret: a fingerprint is what the deployment presents to anybody who connects.

**No operator action.** A profile that accepted nothing beyond the default records nothing, so a credentials file written before this change reads as an ordinary profile rather than failing — covered by `Read_AStoreWrittenWithoutATransportRecord_ReadsAsAnOrdinaryProfile`. The presence of the member is itself the statement that something was accepted.

The MCP tool contract, the database schema, and the deployment contract are untouched.

## Tests

3393 unit tests pass; aggregate line coverage 94.70%, threshold 85%.

- `ServerCertificatePolicyTests` drives the real policy with certificates issued in memory from the shared `TestCertificates`: a trusted chain accepted and nothing recorded, an untrusted one refused with everything the prompt needs, the pinned certificate accepted with its chain still untrusted, a *different* certificate refused under a pin **even when it validates on its own**, no certificate at all, and the refusal sentence naming both fingerprints. It also asserts the bounds `DeploymentTransport.Open` builds every request under.
- `TransportTrustSignInTests` drives both questions through the command: each accepted, each refused, each with no terminal and no switch, each with the switch and no terminal, the clear-text question asked even where the deployment would have redirected, a pinned profile meeting the pinned certificate and meeting a different one, a re-`login` after a certificate change, and that a deployment with a trusted certificate is asked nothing and records nothing.
- `CredentialStoreTests` covers the round trip, the absent record for an ordinary profile, and the older file.

The certificate decision is not faked anywhere: the test double hands the real `ServerCertificatePolicy` a real certificate and the errors a handshake would have reported, and takes whatever it decides.

## Documentation

- `docs/operations/admin-endpoint.md` — a new *When the connection is weaker than the default* section covering both prompts, both switches, what a pin means, how a certificate is renewed, why an accepted clear-text profile is not upgraded by the deployment's redirect, and why the pin does not reach the authorization server; plus the transport record in *Where the credential is kept* and six troubleshooting rows.
- `docs/users/administering.md` — the guide-level paragraph, leading with the SSH-host-key analogy and the point that a pin makes the profile stricter.
