### PR TITLE
[#438] Compose the retrieval agent over Agent Framework

### DIFF
--- a/docs/architecture/outbound-resilience.md
+++ b/docs/architecture/outbound-resilience.md
@@ -155,6 +155,12 @@ is the layer rather than something MailFathom re-implements:
   answer's size follows the configured output budget while an embedding response's is fixed by the declared geometry,
   and one client would have to take the larger ceiling and would then bound neither. [Chat
   generation](../features/chat-generation.md#bounds-every-call-carries) carries the rest of what one call may spend.
+
+  An answering run sends over that same registration, under the same pipeline and the same alias, but reaches it
+  differently: a run is several calls made by an orchestration framework holding one client, so the deadline and the
+  pipeline sit *inside* the client rather than around a single request. [Mail
+  answering](../features/mail-answering.md#a-run-is-several-calls-and-each-carries-the-bounds-of-one) states what that
+  costs and what it does not change.
 - **EF Core.** `EnableRetryOnFailure` is deliberately not configured. The obstacle is not the unit of work: with a
   retrying execution strategy each query and each `SaveChangesAsync` is already replayed as its own retriable unit. It
   is the *user-initiated* transaction. `PersistenceSessionFactory` opens one with `BeginTransactionAsync` for every

--- a/docs/features/chat-generation.md
+++ b/docs/features/chat-generation.md
@@ -17,7 +17,8 @@ reported on independently. That is deliberate, because the states they produce a
 
 - **No embedding provider.** Semantic search is off and lexical search continues. [Embedding
   generation](embedding-generation.md) describes that half.
-- **No chat provider.** Search is unaffected, and only the answering capability stops being offered.
+- **No chat provider.** Search is unaffected, and only the answering capability stops being offered. [Mail
+  answering](mail-answering.md) describes what that capability is composed of.
 
 An instance may reasonably have one and not the other, so a single "AI is configured" flag would be wrong in both
 directions. Writing neither section is a supported deployment: nothing is generated, no provider is called, no

--- a/docs/features/mail-answering.md
+++ b/docs/features/mail-answering.md
@@ -1,0 +1,114 @@
+# Mail answering
+
+<!-- describes: src/AI/Orchestration/**, src/AI/Retrieval/**, src/AI/ProviderAdapters/ResilientChatClient.cs, src/Application/Retrieval/** -->
+
+A question about the mailbox, answered from the mail the model looks up while answering. This page describes the
+composition that does it: what the model may reach, when it reaches it, how much of it leaves the process, and what an
+answer carries back.
+
+**No MCP tool reaches this yet.** The composition is in place and is exercised by its own tests; the tool that would
+expose it, the formatter that separates retrieved mail from instructions, and the ceilings an operator configures are
+each their own change. What is described below is what the code does today.
+
+## The model asks for mail; nothing is pushed at it
+
+Retrieval runs **on demand**. The agent is composed with one tool, `search_mail`, and the model calls it when it decides
+it needs context. Nothing is retrieved before the first call, and a question that needs no mail — "what can you do" —
+costs one provider call and reads no mailbox at all.
+
+The alternative would be to search before every call and inject the results. That answers a greeting by dragging a
+mailbox through a provider, and it makes every question cost the same as the most expensive one.
+
+## The scope is bound before the model sees anything
+
+A question carries the accounts and folders it may be answered from. That scope is bound into the run when it is
+composed, and the tool the model is offered takes **a query and nothing else** — there is no argument, no instruction,
+and no retrieved message that can widen it.
+
+This is the property worth stating plainly, because it is what makes the boundary structural rather than a request in a
+prompt: a model that writes `everything in the secondary account` as its query gets the caller's scope searched for
+those words. The scope is not part of the conversation, so nothing in the conversation can move it.
+
+Two further narrowings apply underneath, and neither can widen anything:
+
+- Retrieval goes through the same mailbox search a caller reaches with `search_emails`, which restricts every query to
+  the accounts the deployment actually serves. Answering a question therefore cannot see mail that searching for it
+  would not. [Email search](email-search.md) describes that ranking and its filters.
+- An account or folder named in the scope that the deployment does not serve simply matches nothing.
+
+## What one retrieval may hand over
+
+Two bounds, applied where the passages are built rather than where they are sent:
+
+| Bound | Default | What it controls |
+| --- | --- | --- |
+| Passages per retrieval | 8 | How many messages one lookup can draw on |
+| Characters per passage | 1200 | How much of any single message it can draw out |
+
+They are two numbers rather than one total on purpose. A single total would let one enormous extract satisfy the same
+ceiling as a spread across several messages, and the two say different things about a mailbox: the count is how far a
+question reaches, the size is how deeply.
+
+The passage count is capped by what one search can rank, so a bound beyond that is refused rather than accepted and
+never met. Neither is configurable today; both are fixed in code.
+
+A query with no usable text finds nothing rather than failing. The text is written by a model rather than by a caller
+who could be told to correct it, and a run whose lookup found nothing still has an answer to give.
+
+## What a passage carries
+
+Each passage is a bounded extract plus the identity an answer is traced through:
+
+- the stable local message identifier, which is the same one every other read names an email by;
+- the account and the folder alias it was read from;
+- the subject and the received time, where the message carried them;
+- the extract itself, already cut to the bound above.
+
+Nothing else travels. The participants, the size, the flags, and the attachment summary that a listing publishes are
+dropped before a provider is reached, because an answer does not need them.
+
+A message whose body yielded no text — encrypted mail, or mail whose content lives entirely in an attachment — can match
+on its subject or its participants and still produce no extract. Such a match is dropped rather than sent as an
+identifier with nothing beside it.
+
+## What an answer carries back
+
+The answer text, and the passages the run retrieved. The passages travel with it because they are what make it
+checkable: each names a message that can then be fetched whole.
+
+They are what the run *retrieved*, not what the model demonstrably used. Nothing outside the model knows which of them
+it drew on, so claiming the narrower set would state something this system cannot observe.
+
+An answer with no text at all is a failure rather than an empty answer, classified the same way any other empty
+generation is. [Chat generation § What a failing call is classified
+as](chat-generation.md#what-a-failing-call-is-classified-as) holds the table.
+
+## A run is several calls, and each carries the bounds of one
+
+A run is a conversation with the provider: the model asks for mail, the tool answers, the model writes the answer. Every
+one of those calls carries the deployment's declared generation parameters, its request deadline, its resilience budget,
+and its health reporting — the same bounds a single chat request carries, applied per call rather than per run.
+
+The one thing this shape gives up is stated rather than hidden: the transport underneath is opened once for the run
+instead of once per attempt, so a retried call reuses the handler chain the run began with. A run is short, and an
+endpoint that moves mid-run is reached at its new address by the next run.
+
+The question itself is bounded before anything is sent, by the same conversation bound a single call carries: a question
+larger than one call may send is refused rather than truncated.
+
+## The run cannot change anything
+
+The agent is composed with one tool and that tool searches. There is nothing that sends, deletes, moves, or marks mail
+as read, so a question is never a mutating act — a property of what the agent is made of rather than a rule written
+beside it. Retrieval reaches no mail server either: it answers from what synchronization has already stored.
+
+## What never reaches a log
+
+No question, no answer, no query the model wrote, and no retrieved passage. A record of a run carries the endpoint
+alias, how many passages were retrieved, and how many messages they came from — counts and a name the operator chose.
+
+The orchestration framework's own switch for logging queries and retrieved text is set off explicitly rather than left
+at its default, because what it would emit is somebody's question and extracts of their mail.
+
+Retrieved mail is untrusted input, and so is what the model writes from it. [Chat generation § What never reaches a
+log](chat-generation.md#what-never-reaches-a-log) states the same rule for the transport underneath.

--- a/docs/features/toc.yml
+++ b/docs/features/toc.yml
@@ -23,5 +23,7 @@
   href: embedding-backfill.md
 - name: Chat generation
   href: chat-generation.md
+- name: Mail answering
+  href: mail-answering.md
 - name: MCP tools
   href: mcp-tools.md

--- a/src/AI/AiServiceCollectionExtensions.cs
+++ b/src/AI/AiServiceCollectionExtensions.cs
@@ -5,11 +5,13 @@
 using MailFathom.AI.Chat;
 using MailFathom.AI.Chunking;
 using MailFathom.AI.Embeddings;
+using MailFathom.AI.Orchestration;
 using MailFathom.AI.ProviderAdapters;
 using MailFathom.AI.Providers;
 using MailFathom.Application.Chat;
 using MailFathom.Application.Emails.Chunking;
 using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Retrieval;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -135,6 +137,32 @@ public static class AiServiceCollectionExtensions
         services.AddSingleton<IChatModelClient, ProviderChatModelClient>();
 
         AddChatProviderTransport(services);
+
+        return services;
+    }
+
+    /// <summary>Registers the agent that answers a question about the mailbox from what it retrieves while answering.</summary>
+    /// <param name="services">The service collection to add to.</param>
+    /// <returns>The same service collection, so registration reads as one expression.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="services" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Called only where a chat endpoint was declared, and beside <see cref="AddChatProviderAdapter" /> rather than inside
+    /// it: they are two capabilities over one endpoint, and an instance that answers questions is not the same decision as
+    /// one that can generate text.
+    /// </para>
+    /// <para>
+    /// Scoped, because a run retrieves through the mailbox search, and that reads through the scoped persistence context.
+    /// It adds no transport of its own — a run's requests go to the same endpoint under the same bounds as any other chat
+    /// request, so it sends over the client that registration named.
+    /// </para>
+    /// </remarks>
+    public static IServiceCollection AddMailAnsweringAgent(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.TryAddSingleton<OpenAiCompatibleClientFactory>();
+        services.AddScoped<IMailQuestionAnswerer, MailAnsweringAgent>();
 
         return services;
     }

--- a/src/AI/Orchestration/MailAnsweringAgent.cs
+++ b/src/AI/Orchestration/MailAnsweringAgent.cs
@@ -1,0 +1,134 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.AI.Chat;
+using MailFathom.AI.ProviderAdapters;
+using MailFathom.AI.Providers;
+using MailFathom.AI.Retrieval;
+using MailFathom.Application.AiProviders;
+using MailFathom.Application.Chat;
+using MailFathom.Application.Resilience;
+using MailFathom.Application.Retrieval;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.AI.Orchestration;
+
+/// <summary>Answers one question by running the composed agent against the declared chat endpoint.</summary>
+/// <remarks>
+/// <para>
+/// The boundary between the application's question and an orchestration framework. Everything the framework publishes —
+/// the agent, its session, its messages, its context providers, its tools — stops here, and what leaves is an answer and
+/// the passages the run retrieved.
+/// </para>
+/// <para>
+/// Each run opens its own credential, transport, chat client, and agent, and releases all four with the run. That is the
+/// same lifetime the single-request chat adapter uses and for the same reasons: a rotated key is picked up by the next
+/// question rather than at the next restart, and one caller's retrieved mail cannot outlive the call that retrieved it.
+/// </para>
+/// </remarks>
+internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
+{
+    private readonly ChatGenerationPlan plan;
+    private readonly IProviderEndpointCredentialSource credentialSource;
+    private readonly OpenAiCompatibleClientFactory clientFactory;
+    private readonly IHttpClientFactory transportFactory;
+    private readonly IEmailKnowledgeSearch knowledgeSearch;
+    private readonly IOutboundOperationRunner operationRunner;
+    private readonly IAiProviderHealthRecorder healthRecorder;
+    private readonly ILoggerFactory loggerFactory;
+    private readonly ILogger<MailAnsweringAgent> logger;
+
+    /// <summary>Initializes the answering agent over the declared endpoint, its credentials, its transport, and this deployment's retrieval.</summary>
+    /// <param name="plan">The validated declaration: which endpoint answers and with which parameters.</param>
+    /// <param name="credentialSource">Resolves what a request presents to the endpoint.</param>
+    /// <param name="clientFactory">Opens a provider client over the endpoint.</param>
+    /// <param name="transportFactory">Opens the transport a run's requests are sent over.</param>
+    /// <param name="knowledgeSearch">Finds the mail a run retrieves, within the scope the question carries.</param>
+    /// <param name="operationRunner">Applies the provider resilience budget to every call the run makes.</param>
+    /// <param name="healthRecorder">Records what each call established about the provider.</param>
+    /// <param name="loggerFactory">Creates the loggers the framework's own components record through.</param>
+    /// <param name="logger">Records the outcome without recording any question, answer, or passage.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public MailAnsweringAgent(
+        ChatGenerationPlan plan,
+        IProviderEndpointCredentialSource credentialSource,
+        OpenAiCompatibleClientFactory clientFactory,
+        IHttpClientFactory transportFactory,
+        IEmailKnowledgeSearch knowledgeSearch,
+        IOutboundOperationRunner operationRunner,
+        IAiProviderHealthRecorder healthRecorder,
+        ILoggerFactory loggerFactory,
+        ILogger<MailAnsweringAgent> logger)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(credentialSource);
+        ArgumentNullException.ThrowIfNull(clientFactory);
+        ArgumentNullException.ThrowIfNull(transportFactory);
+        ArgumentNullException.ThrowIfNull(knowledgeSearch);
+        ArgumentNullException.ThrowIfNull(operationRunner);
+        ArgumentNullException.ThrowIfNull(healthRecorder);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this.plan = plan;
+        this.credentialSource = credentialSource;
+        this.clientFactory = clientFactory;
+        this.transportFactory = transportFactory;
+        this.knowledgeSearch = knowledgeSearch;
+        this.operationRunner = operationRunner;
+        this.healthRecorder = healthRecorder;
+        this.loggerFactory = loggerFactory;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<MailAnswer> AnswerAsync(MailQuestion question, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(question);
+
+        // The question is one turn, so the bound on what one call may carry is the bound on the question. What the
+        // retrieval adds beside it is bounded where the passages are built.
+        ChatRequestBounds.Require(
+            [new ChatMessage(ChatRole.User, question.Text)],
+            this.plan.MaximumMessagesPerRequest,
+            this.plan.MaximumRequestCharacters);
+
+        var retrieval = new ScopedMailKnowledgeRetrieval(this.knowledgeSearch, question.Scope);
+        var endpoint = this.plan.Endpoint;
+
+        // Resolved per run and released with it, so a rotated key is picked up by the next question and the material
+        // exists for one run rather than for process uptime.
+        using var credential = await this.credentialSource.ResolveAsync(endpoint.Alias, cancellationToken);
+        using var transport = this.transportFactory.CreateClient(ProviderChatModelClient.TransportName);
+        using var providerClient = this.clientFactory.OpenChatClient(endpoint, credential, transport);
+        using var chatClient = new ResilientChatClient(
+            providerClient,
+            endpoint,
+            this.plan.RequestTimeout,
+            this.operationRunner,
+            this.healthRecorder,
+            this.loggerFactory.CreateLogger<ResilientChatClient>());
+
+        var agent = MailAnsweringAgentComposition.Compose(chatClient, this.plan, retrieval, this.loggerFactory);
+        var response = await agent.RunAsync(question.Text, session: null, options: null, cancellationToken);
+        var passages = retrieval.Retrieved;
+
+        if (string.IsNullOrWhiteSpace(response.Text))
+        {
+            // Logged before the failure is raised, because the failure names only that no text arrived, while the count
+            // says whether the run had anything to answer from.
+            MailAnsweringEvents.LogRunProducedNoAnswer(this.logger, endpoint.Alias, passages.Count);
+
+            throw new ChatGenerationFailedException(endpoint.Alias, ChatGenerationFailure.AnswerEmpty);
+        }
+
+        // Smaller than the passage count wherever one message answered two of the model's queries, which is what makes
+        // the pair worth recording: it says how much of the mailbox one question actually reached.
+        var emailCount = passages.DistinctBy(static passage => passage.StoredEmailId).Count();
+
+        MailAnsweringEvents.LogAnswered(this.logger, endpoint.Alias, passages.Count, emailCount);
+
+        return new MailAnswer(response.Text, passages);
+    }
+}

--- a/src/AI/Orchestration/MailAnsweringAgentComposition.cs
+++ b/src/AI/Orchestration/MailAnsweringAgentComposition.cs
@@ -1,0 +1,70 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.AI.Chat;
+using MailFathom.AI.Retrieval;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.AI.Orchestration;
+
+/// <summary>Composes the agent that answers a question about the mailbox.</summary>
+/// <remarks>
+/// <para>
+/// The composition is separate from what opens the provider connection, so what the agent is can be exercised over a
+/// substituted chat client and no network: the tool loop, the scope the retrieval is bound to, and the parameters the
+/// deployment declared are all decided here.
+/// </para>
+/// <para>
+/// The agent holds one capability and it reads. There is no tool that sends, deletes, moves, or marks mail, and that is a
+/// property of this expression rather than a rule stated somewhere else — a mutating agent would be one composed with a
+/// mutating tool, and this composes none.
+/// </para>
+/// <para>
+/// The agent is given no instructions. What separates retrieved mail from the instructions the system writes belongs to
+/// the context formatter rather than to the composition, so the framework's own context prompt stands until that formatter
+/// exists.
+/// </para>
+/// </remarks>
+internal static class MailAnsweringAgentComposition
+{
+    /// <summary>Names the composed agent in whatever reads a run.</summary>
+    internal const string AgentName = "mailfathom-mail-answering";
+
+    /// <summary>Composes the agent over one chat client and one run's retrieval.</summary>
+    /// <param name="chatClient">The provider-neutral client every turn of the run is sent through.</param>
+    /// <param name="plan">The validated declaration: the generation parameters one call runs with.</param>
+    /// <param name="retrieval">The mail this run may reach, already bound to the caller's scope.</param>
+    /// <param name="loggerFactory">Creates the loggers the framework's own components record through.</param>
+    /// <returns>The composed agent.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal static ChatClientAgent Compose(
+        IChatClient chatClient,
+        ChatGenerationPlan plan,
+        ScopedMailKnowledgeRetrieval retrieval,
+        ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(chatClient);
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(retrieval);
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        var options = new ChatClientAgentOptions
+        {
+            Name = AgentName,
+            ChatOptions = new ChatOptions
+            {
+                MaxOutputTokens = plan.MaximumOutputTokens,
+                Temperature = plan.Temperature,
+                TopP = plan.TopP,
+            },
+
+            // The one context provider, and the only route by which mail reaches the model.
+            AIContextProviders = [retrieval.CreateContextProvider(loggerFactory)],
+        };
+
+        return new ChatClientAgent(chatClient, options, loggerFactory);
+    }
+}

--- a/src/AI/Orchestration/MailAnsweringEvents.cs
+++ b/src/AI/Orchestration/MailAnsweringEvents.cs
@@ -1,0 +1,35 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.AI.Orchestration;
+
+/// <summary>Records what one answering run did, and nothing about what it was carrying.</summary>
+/// <remarks>
+/// Every parameter here is either a name the operator chose or a count. The question, the answer, the queries the model
+/// wrote, and the passages the run retrieved are all somebody's mail or somebody's words about it, and none of them
+/// reaches these events — which is what lets them stay on in a deployment holding real mail.
+/// </remarks>
+internal static partial class MailAnsweringEvents
+{
+    [LoggerMessage(
+        EventId = 1,
+        Level = LogLevel.Debug,
+        Message = "Chat endpoint {EndpointAlias} answered a question from {PassageCount} passages of {EmailCount} emails.")]
+    internal static partial void LogAnswered(
+        ILogger logger,
+        string endpointAlias,
+        int passageCount,
+        int emailCount);
+
+    [LoggerMessage(
+        EventId = 2,
+        Level = LogLevel.Error,
+        Message = "Chat endpoint {EndpointAlias} ended an answering run without producing any text, having retrieved {PassageCount} passages.")]
+    internal static partial void LogRunProducedNoAnswer(
+        ILogger logger,
+        string endpointAlias,
+        int passageCount);
+}

--- a/src/AI/ProviderAdapters/ProviderChatModelClient.cs
+++ b/src/AI/ProviderAdapters/ProviderChatModelClient.cs
@@ -15,9 +15,9 @@ namespace MailFathom.AI.ProviderAdapters;
 /// <summary>Produces answers by calling the declared chat endpoint.</summary>
 /// <remarks>
 /// <para>
-/// The only type in this system that speaks to a chat provider. Everything provider-specific stops here: the client
-/// library, its options, its exceptions, and the two authentication shapes are all confined to this namespace, so a
-/// second provider is a new endpoint declaration rather than a change anywhere above.
+/// The whole of the single-request path to a chat provider. Everything provider-specific stops in this namespace: the
+/// client library, its options, its exceptions, and the two authentication shapes, so a second provider is a new
+/// endpoint declaration rather than a change anywhere above.
 /// </para>
 /// <para>
 /// It composes nothing. The conversation arrives built, the model and its parameters arrive validated in the plan, and

--- a/src/AI/ProviderAdapters/ResilientChatClient.cs
+++ b/src/AI/ProviderAdapters/ResilientChatClient.cs
@@ -1,0 +1,193 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.AI.Chat;
+using MailFathom.Application.AiProviders;
+using MailFathom.Application.Chat;
+using MailFathom.Application.Resilience;
+using MailFathom.Domain.Failures;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.AI.ProviderAdapters;
+
+/// <summary>Puts this deployment's deadline, resilience budget, failure classification, and health reporting around each chat call a run makes.</summary>
+/// <remarks>
+/// <para>
+/// A decorator rather than a call site, because an agent run is several provider calls rather than one and the framework
+/// makes them: it holds one client for the length of the run and calls it once per turn of the tool loop. The bounds
+/// therefore have to sit inside the client, where every call passes through them, instead of around a single request.
+/// </para>
+/// <para>
+/// It is the reason an agent run is governed at all. Without it a run would hold whatever timeout the provider library
+/// defaults to, retry inside no budget, and tell the health state nothing — three properties every other outbound call in
+/// this system has.
+/// </para>
+/// <para>
+/// The transport underneath is opened once for the run rather than per attempt, which is the one thing this shape gives
+/// up against a single bounded request: the framework holds the client, so a retried call reuses the handler chain the
+/// run began with. A run is short and an endpoint that moves mid-run is reached at its new address by the next run.
+/// </para>
+/// </remarks>
+internal sealed class ResilientChatClient : Microsoft.Extensions.AI.DelegatingChatClient
+{
+    private readonly ChatEndpoint endpoint;
+    private readonly TimeSpan requestTimeout;
+    private readonly IOutboundOperationRunner operationRunner;
+    private readonly IAiProviderHealthRecorder healthRecorder;
+    private readonly ILogger logger;
+
+    /// <summary>Initializes the decorator over the client one run sends through.</summary>
+    /// <param name="innerClient">The provider client every call is delegated to.</param>
+    /// <param name="endpoint">The declared endpoint, whose alias keys the budget and names the failure.</param>
+    /// <param name="requestTimeout">The time one call may take before it is abandoned.</param>
+    /// <param name="operationRunner">Applies the provider resilience budget.</param>
+    /// <param name="healthRecorder">Records what each call established about the provider.</param>
+    /// <param name="logger">Records the outcome without recording any prompt or answer.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal ResilientChatClient(
+        Microsoft.Extensions.AI.IChatClient innerClient,
+        ChatEndpoint endpoint,
+        TimeSpan requestTimeout,
+        IOutboundOperationRunner operationRunner,
+        IAiProviderHealthRecorder healthRecorder,
+        ILogger logger)
+        : base(innerClient)
+    {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        ArgumentNullException.ThrowIfNull(operationRunner);
+        ArgumentNullException.ThrowIfNull(healthRecorder);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this.endpoint = endpoint;
+        this.requestTimeout = requestTimeout;
+        this.operationRunner = operationRunner;
+        this.healthRecorder = healthRecorder;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="ChatGenerationFailedException">Thrown when the call produced no response, naming which kind of failure ended it.</exception>
+    public override async Task<Microsoft.Extensions.AI.ChatResponse> GetResponseAsync(
+        IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages,
+        Microsoft.Extensions.AI.ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var response = await this.SendUnderBudgetAsync(messages, options, cancellationToken);
+
+            this.healthRecorder.RecordServed(AiProviderRole.Chat);
+
+            return response;
+        }
+        catch (ChatGenerationFailedException failure)
+        {
+            ChatProviderEvents.LogCallFailed(this.logger, this.endpoint.Alias, failure.Failure);
+
+            this.RecordFailure(failure);
+
+            throw;
+        }
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Answering as it arrives is a shape nothing here needs: a run produces one answer to one question, and a streaming
+    /// call would carry its own cancellation and partial-answer semantics through the budget above. Refusing it outright
+    /// is what keeps a caller from reaching the provider along a path none of these bounds apply to.
+    /// </remarks>
+    /// <exception cref="NotSupportedException">Always thrown, because no caller streams and an unbounded path must not exist for one to find.</exception>
+    public override IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages,
+        Microsoft.Extensions.AI.ChatOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException(
+            "Streaming a chat response is not supported: the deadline and resilience budget this deployment applies are written for a call that returns one answer.");
+
+    /// <summary>Runs one call under the resilience budget, translating a pipeline refusal into this system's failure.</summary>
+    private async Task<Microsoft.Extensions.AI.ChatResponse> SendUnderBudgetAsync(
+        IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages,
+        Microsoft.Extensions.AI.ChatOptions? options,
+        CancellationToken cancellationToken)
+    {
+        // Materialized once, because the pipeline may make several attempts and a sequence built by the framework is not
+        // promised to survive a second enumeration.
+        var conversation = messages as IReadOnlyList<Microsoft.Extensions.AI.ChatMessage> ?? [.. messages];
+
+        try
+        {
+            // Keyed by the endpoint alias, which is the deployment's own name for it, so nothing personal reaches
+            // resilience telemetry and a chat outage opens a circuit of its own rather than the embedding provider's.
+            return await this.operationRunner.RunAsync(
+                OutboundDependency.AiProviderInvocation,
+                this.endpoint.Alias,
+                attemptToken => this.SendAsync(conversation, options, attemptToken),
+                cancellationToken);
+        }
+        catch (MailFathomException rejection)
+            when (rejection.ErrorCode == MailFathomErrorCode.OutboundDependencyUnavailable)
+        {
+            // The pipeline declined to call the endpoint at all — its circuit is open, or its concurrency budget is
+            // spent. Recognized by code rather than by type, which is what a stable error code is for: the resilience
+            // library and the exception it raises belong to another adapter boundary that this one may not reference.
+            throw new ChatGenerationFailedException(
+                this.endpoint.Alias,
+                ChatGenerationFailure.TransportFaulted,
+                rejection);
+        }
+    }
+
+    /// <summary>Sends one attempt under this deployment's own deadline.</summary>
+    private async Task<Microsoft.Extensions.AI.ChatResponse> SendAsync(
+        IReadOnlyList<Microsoft.Extensions.AI.ChatMessage> conversation,
+        Microsoft.Extensions.AI.ChatOptions? options,
+        CancellationToken cancellationToken)
+    {
+        // The deadline is this deployment's and is applied here rather than left to the client, so one attempt is
+        // bounded whichever provider library is underneath and whatever it defaults to.
+        using var attemptDeadline = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        attemptDeadline.CancelAfter(this.requestTimeout);
+
+        try
+        {
+            return await this.InnerClient.GetResponseAsync(conversation, options, attemptDeadline.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The caller did not cancel, so the deadline above did. Reporting it as a cancellation would tell the
+            // pipeline that this system stopped the work, and a timeout is the dependency failing to answer.
+            throw new ChatGenerationFailedException(this.endpoint.Alias, ChatGenerationFailure.RequestTimedOut);
+        }
+        catch (Exception failure) when (ProviderCallFailureClassification.Classify(failure) is { } classified)
+        {
+            throw new ChatGenerationFailedException(this.endpoint.Alias, ToChatFailure(classified), failure);
+        }
+    }
+
+    /// <summary>Records what the failure established about the provider, at the granularity an operator acts on.</summary>
+    /// <remarks>
+    /// The split follows the exception's own <see cref="ChatGenerationFailedException.IsWorthRepeating" />, so the health
+    /// state and the resilience pipeline can never disagree about whether waiting is the answer.
+    /// </remarks>
+    private void RecordFailure(ChatGenerationFailedException failure)
+    {
+        if (failure.IsWorthRepeating)
+        {
+            this.healthRecorder.RecordUnavailable(AiProviderRole.Chat);
+
+            return;
+        }
+
+        this.healthRecorder.RecordMisconfigured(AiProviderRole.Chat);
+    }
+
+    private static ChatGenerationFailure ToChatFailure(ProviderCallFailure failure) => failure switch
+    {
+        ProviderCallFailure.CredentialRejected => ChatGenerationFailure.CredentialRejected,
+        ProviderCallFailure.RateLimited => ChatGenerationFailure.RateLimited,
+        ProviderCallFailure.RequestTimedOut => ChatGenerationFailure.RequestTimedOut,
+        ProviderCallFailure.RequestRefused => ChatGenerationFailure.RequestRefused,
+        _ => ChatGenerationFailure.TransportFaulted,
+    };
+}

--- a/src/AI/Retrieval/ScopedMailKnowledgeRetrieval.cs
+++ b/src/AI/Retrieval/ScopedMailKnowledgeRetrieval.cs
@@ -1,0 +1,122 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Retrieval;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.AI.Retrieval;
+
+/// <summary>The mail one run may reach, and the record of what it reached.</summary>
+/// <remarks>
+/// <para>
+/// This is where the scope stops being negotiable. The framework is handed a search that takes a query and nothing else,
+/// because the accounts and folders were bound into this object when the run was composed: a model can write any query it
+/// likes and every one of them is answered from the same scope. Nothing in an instruction, a retrieved message, or a tool
+/// argument reaches the value, which is what makes the boundary structural rather than a rule the prompt asks for.
+/// </para>
+/// <para>
+/// One instance serves one run. It records the passages it handed over so the answer can carry them, and that record is
+/// per run for the same reason the scope is: one caller's retrieved mail must never appear beside another's.
+/// </para>
+/// </remarks>
+internal sealed class ScopedMailKnowledgeRetrieval
+{
+    /// <summary>Names the tool the model calls to look mail up.</summary>
+    /// <remarks>
+    /// Named after what it does rather than after the framework's default <c>Search</c>, so a model holding several tools
+    /// can tell what this one searches, and so a trace of a run reads as mail retrieval rather than as an unspecified
+    /// lookup.
+    /// </remarks>
+    internal const string SearchToolName = "search_mail";
+
+    private const string SearchToolDescription =
+        "Searches the local copy of the mailbox for messages relevant to a query and returns short extracts from them.";
+
+    private readonly IEmailKnowledgeSearch knowledgeSearch;
+    private readonly MailboxScope scope;
+    private readonly Lock gate = new();
+    private readonly List<EmailKnowledgePassage> retrieved = [];
+
+    /// <summary>Initializes the retrieval one run may make.</summary>
+    /// <param name="knowledgeSearch">Finds the mail relevant to a query.</param>
+    /// <param name="scope">The accounts and folders every retrieval of this run is answered from.</param>
+    /// <exception cref="ArgumentNullException">Thrown when either argument is <see langword="null" />.</exception>
+    internal ScopedMailKnowledgeRetrieval(IEmailKnowledgeSearch knowledgeSearch, MailboxScope scope)
+    {
+        ArgumentNullException.ThrowIfNull(knowledgeSearch);
+        ArgumentNullException.ThrowIfNull(scope);
+
+        this.knowledgeSearch = knowledgeSearch;
+        this.scope = scope;
+    }
+
+    /// <summary>Gets the passages this run has handed over, in the order it handed them over.</summary>
+    internal IReadOnlyList<EmailKnowledgePassage> Retrieved
+    {
+        get
+        {
+            lock (this.gate)
+            {
+                return [.. this.retrieved];
+            }
+        }
+    }
+
+    /// <summary>Builds the context provider the framework retrieves through.</summary>
+    /// <param name="loggerFactory">Creates the logger the provider records its own decisions through.</param>
+    /// <returns>The provider, which searches only when the model asks it to.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="loggerFactory" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// On demand rather than before every call, which is the difference between a question that needed no mail costing
+    /// nothing and one that drags a mailbox through a provider to answer "what can you do". The model decides it needs
+    /// context and asks; nothing is pushed at it.
+    /// </remarks>
+    internal TextSearchProvider CreateContextProvider(ILoggerFactory loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(loggerFactory);
+
+        var options = new TextSearchProviderOptions
+        {
+            SearchTime = TextSearchProviderOptions.TextSearchBehavior.OnDemandFunctionCalling,
+            FunctionToolName = SearchToolName,
+            FunctionToolDescription = SearchToolDescription,
+
+            // The framework's own switch for putting queries and retrieved text into its logs. It defaults to off and is
+            // set here anyway, because what it would emit is somebody's question and extracts of their mail, and a
+            // default is a thing a package update may change.
+            EnableSensitiveTelemetryData = false,
+        };
+
+        return new TextSearchProvider(this.SearchAsync, options, loggerFactory);
+    }
+
+    /// <summary>Answers one lookup the model asked for.</summary>
+    /// <remarks>
+    /// The result carries the passage itself as its raw representation rather than only the text, so whatever formats the
+    /// context reaches the message identity and the source coordinates without searching for them again.
+    /// </remarks>
+    private async Task<IEnumerable<TextSearchProvider.TextSearchResult>> SearchAsync(
+        string query,
+        CancellationToken cancellationToken)
+    {
+        var passages = await this.knowledgeSearch.FindPassagesAsync(this.scope, query, cancellationToken);
+
+        lock (this.gate)
+        {
+            this.retrieved.AddRange(passages);
+        }
+
+        return
+        [
+            .. passages.Select(static passage => new TextSearchProvider.TextSearchResult
+            {
+                Text = passage.Text,
+                SourceName = passage.StoredEmailId.ToString(),
+                RawRepresentation = passage,
+            }),
+        ];
+    }
+}

--- a/src/Application/Retrieval/EmailKnowledgeBounds.cs
+++ b/src/Application/Retrieval/EmailKnowledgeBounds.cs
@@ -1,0 +1,69 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Application.Emails.Search;
+
+namespace MailFathom.Application.Retrieval;
+
+/// <summary>How much mail one retrieval may hand to a model.</summary>
+/// <remarks>
+/// <para>
+/// The ceiling on what leaves the process for a question, expressed where the passages are built rather than where they
+/// are sent. A model asks for context by writing a query, so nothing about the request bounds the answer — this does,
+/// and it does so before the passages exist, which is what makes the bound impossible to widen from the model's side.
+/// </para>
+/// <para>
+/// Two numbers rather than one total, because they control different things. The count is how many messages one question
+/// can draw on, and the per-passage size is how much of any single message it can draw out; a single total would let one
+/// enormous extract satisfy the same ceiling as a spread across several messages.
+/// </para>
+/// </remarks>
+public sealed record EmailKnowledgeBounds
+{
+    private EmailKnowledgeBounds(int maximumPassages, int maximumCharactersPerPassage)
+    {
+        this.MaximumPassages = maximumPassages;
+        this.MaximumCharactersPerPassage = maximumCharactersPerPassage;
+    }
+
+    /// <summary>Gets the bounds a deployment that states none receives.</summary>
+    /// <remarks>
+    /// Deliberately narrower than a search window. A search returns results a person reads and discards; a retrieval
+    /// fills a model's context, is paid for by the token, and leaves the process, so the conservative number is the one
+    /// that costs least in every sense.
+    /// </remarks>
+    public static EmailKnowledgeBounds Default { get; } = new(8, 1200);
+
+    /// <summary>Gets the greatest number of passages one retrieval may return.</summary>
+    public int MaximumPassages { get; }
+
+    /// <summary>Gets the greatest number of characters one passage may carry.</summary>
+    public int MaximumCharactersPerPassage { get; }
+
+    /// <summary>Creates bounds, refusing values no retrieval could run under.</summary>
+    /// <param name="maximumPassages">The greatest number of passages one retrieval may return.</param>
+    /// <param name="maximumCharactersPerPassage">The greatest number of characters one passage may carry.</param>
+    /// <returns>The validated bounds.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when either value is outside the range this type accepts.</exception>
+    /// <remarks>
+    /// The passage count is capped by what one search can rank, because a retrieval is answered from a search window and
+    /// asking for more passages than that window holds would state a bound no run could reach.
+    /// </remarks>
+    public static EmailKnowledgeBounds Create(int maximumPassages, int maximumCharactersPerPassage)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumPassages, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(maximumPassages, EmailSearchResultLimit.MaximumValue);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maximumCharactersPerPassage, 1);
+
+        return new EmailKnowledgeBounds(maximumPassages, maximumCharactersPerPassage);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => string.Format(
+        CultureInfo.InvariantCulture,
+        "{0} passages of at most {1} characters",
+        this.MaximumPassages,
+        this.MaximumCharactersPerPassage);
+}

--- a/src/Application/Retrieval/EmailKnowledgePassage.cs
+++ b/src/Application/Retrieval/EmailKnowledgePassage.cs
@@ -1,0 +1,47 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Application.Retrieval;
+
+/// <summary>One bounded extract of mail, with the identity and the coordinates an answer is traced back through.</summary>
+/// <remarks>
+/// <para>
+/// This is the only shape mail content travels in on its way to a model. It carries an extract rather than a message:
+/// the bound is applied before the passage exists, so nothing downstream can widen it, and a retrieval that matched a
+/// long thread hands over what was relevant rather than the thread.
+/// </para>
+/// <para>
+/// The identity travels with the text because an answer that cannot say where a claim came from cannot be checked. The
+/// stored identifier is the same one every other read names an email by, so a reader given a passage can fetch the whole
+/// message; the account and the folder alias are the deployment's own names for where it was read from.
+/// </para>
+/// <para>
+/// A passage is mail content and inherits the classification of the message it was cut from. It is never logged, never
+/// attached to a span, and never exported.
+/// </para>
+/// </remarks>
+public sealed record EmailKnowledgePassage
+{
+    /// <summary>Gets the stable local identity of the email the extract came from.</summary>
+    public required StoredEmailId StoredEmailId { get; init; }
+
+    /// <summary>Gets the account whose mailbox the email was read from.</summary>
+    public required MailAccountId AccountId { get; init; }
+
+    /// <summary>Gets the folder alias the email was read from.</summary>
+    public required MailFolderAlias FolderAlias { get; init; }
+
+    /// <summary>Gets the subject the email carried, or <see langword="null" /> when it carried none.</summary>
+    public string? Subject { get; init; }
+
+    /// <summary>Gets when the last receiving hop recorded the message, or <see langword="null" /> when no header carried a usable date.</summary>
+    public DateTimeOffset? ReceivedAt { get; init; }
+
+    /// <summary>Gets the extract itself, already cut to the size one passage may carry.</summary>
+    public required string Text { get; init; }
+}

--- a/src/Application/Retrieval/IEmailKnowledgeSearch.cs
+++ b/src/Application/Retrieval/IEmailKnowledgeSearch.cs
@@ -1,0 +1,46 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Mailboxes;
+
+namespace MailFathom.Application.Retrieval;
+
+/// <summary>Finds the mail relevant to a question, as bounded extracts an answer can be written from and traced to.</summary>
+/// <remarks>
+/// <para>
+/// The retrieval side of answering, and the only route by which mail reaches a model. It exists as a port rather than as
+/// a call into the search use case because the caller is an orchestration framework: what that framework may ask for is
+/// a question in free text, and everything else about the retrieval — which accounts, which folders, how many passages,
+/// how much of any message — is decided by whoever composed the run.
+/// </para>
+/// <para>
+/// The scope is a parameter rather than part of the query for exactly that reason. It comes from the caller that has
+/// already established what the requester may see, so no instruction reaching the model, and no query the model writes,
+/// can widen it. An implementation narrows the scope further where the deployment serves fewer accounts than were named;
+/// it never widens it.
+/// </para>
+/// <para>
+/// Nothing here reaches a mail server. A question is answered from what synchronization has already stored and what
+/// indexing has already derived, which is what keeps answering independent of IMAP availability, and no call of this port
+/// changes any remote state.
+/// </para>
+/// </remarks>
+public interface IEmailKnowledgeSearch
+{
+    /// <summary>Finds the passages relevant to one query within one scope.</summary>
+    /// <param name="scope">The accounts and folders the passages may be drawn from, decided by the caller.</param>
+    /// <param name="queryText">What to look for, which is free text a model may have written.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>The passages, most relevant first, bounded in number and in the size of each.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="scope" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A query that finds nothing, and one that carries no usable text, both produce an empty list. Neither is a failure:
+    /// the text is written by a model rather than by a caller who can be told to correct it, and a run whose retrieval
+    /// found nothing still has an answer to give.
+    /// </remarks>
+    Task<IReadOnlyList<EmailKnowledgePassage>> FindPassagesAsync(
+        MailboxScope scope,
+        string queryText,
+        CancellationToken cancellationToken);
+}

--- a/src/Application/Retrieval/IMailQuestionAnswerer.cs
+++ b/src/Application/Retrieval/IMailQuestionAnswerer.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Chat;
+
+namespace MailFathom.Application.Retrieval;
+
+/// <summary>Answers one question about the mailbox from the mail it retrieves while answering.</summary>
+/// <remarks>
+/// <para>
+/// The whole of the answering capability as the rest of the system sees it: a question and a scope in, an answer and the
+/// passages behind it out. What sits behind it is an agent composed over a chat model and this deployment's retrieval,
+/// and none of that shape appears here — the orchestration framework, its messages, its tools, and its context providers
+/// stay inside the adapter, so replacing it changes nothing above this line.
+/// </para>
+/// <para>
+/// One call is one run and keeps nothing. There is no conversation across calls, because a stored conversation is stored
+/// mail content by another name and would carry one caller's retrieved passages into another caller's context.
+/// </para>
+/// <para>
+/// The run reads and never writes. It reaches no mail server, sends no mail, and changes no remote flag, which is a
+/// property of what it is composed of rather than a rule it observes.
+/// </para>
+/// </remarks>
+public interface IMailQuestionAnswerer
+{
+    /// <summary>Answers one question, retrieving mail from within its scope as the model asks for it.</summary>
+    /// <param name="question">What was asked, and the mail the answer may be drawn from.</param>
+    /// <param name="cancellationToken">Cancels the run and every provider call remaining in it.</param>
+    /// <returns>The answer and the passages the run retrieved.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="question" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when the question carries no text.</exception>
+    /// <exception cref="ChatGenerationFailedException">Thrown when the run produced no answer, naming which kind of failure ended it.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancelled, which is never reported as a provider failure.</exception>
+    Task<MailAnswer> AnswerAsync(MailQuestion question, CancellationToken cancellationToken);
+}

--- a/src/Application/Retrieval/MailAnswer.cs
+++ b/src/Application/Retrieval/MailAnswer.cs
@@ -1,0 +1,20 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Retrieval;
+
+/// <summary>What one run produced: the answer, and the mail it was written from.</summary>
+/// <param name="Text">The answer, which is never empty.</param>
+/// <param name="Passages">The passages the run retrieved, in the order it retrieved them.</param>
+/// <remarks>
+/// <para>
+/// The passages travel with the answer because they are what makes it checkable: each carries the stable identifier of
+/// the message it was cut from, so a reader can fetch that message rather than take the answer's word for it.
+/// </para>
+/// <para>
+/// They are what the run retrieved rather than what the model demonstrably used. Nothing outside the model knows which
+/// of them it drew on, so claiming the narrower set would be stating something this system cannot observe.
+/// </para>
+/// </remarks>
+public sealed record MailAnswer(string Text, IReadOnlyList<EmailKnowledgePassage> Passages);

--- a/src/Application/Retrieval/MailQuestion.cs
+++ b/src/Application/Retrieval/MailQuestion.cs
@@ -1,0 +1,17 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Mailboxes;
+
+namespace MailFathom.Application.Retrieval;
+
+/// <summary>What a caller asks about their mail, and the mail the answer may be drawn from.</summary>
+/// <param name="Text">The question, in the words the caller wrote it in.</param>
+/// <param name="Scope">The accounts and folders the answer may be drawn from.</param>
+/// <remarks>
+/// The scope belongs to the question rather than to the deployment because it is the caller's authorization expressed as
+/// data: a question asked over one account must not be answerable from another, whatever the model is later told. It is
+/// resolved before the run starts and applied to every retrieval the run makes.
+/// </remarks>
+public sealed record MailQuestion(string Text, MailboxScope Scope);

--- a/src/Application/Retrieval/MailboxKnowledgeSearch.cs
+++ b/src/Application/Retrieval/MailboxKnowledgeSearch.cs
@@ -1,0 +1,124 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Emails.Search;
+using MailFathom.Application.Emails.SearchEmails;
+
+namespace MailFathom.Application.Retrieval;
+
+/// <summary>Answers a retrieval from the mailbox search this deployment already serves.</summary>
+/// <remarks>
+/// <para>
+/// The whole of the retrieval side, and deliberately thin: hybrid ranking, the account restriction, and the extracts
+/// themselves all belong to <see cref="MailboxSearchReader" />, which is the same retrieval a caller reaches through
+/// <c>search_emails</c>. Answering a question therefore cannot see mail that searching for it would not, and improving
+/// the ranking improves both.
+/// </para>
+/// <para>
+/// What this adds is the shape a model's context needs rather than a reader's: one bounded extract per message instead
+/// of a summary and several highlighted fragments, carrying only the identity an answer is traced through. Everything a
+/// listing publishes and an answer does not need — the participants, the size, the flags, the attachment summary — is
+/// dropped here rather than sent to a provider.
+/// </para>
+/// </remarks>
+public sealed class MailboxKnowledgeSearch : IEmailKnowledgeSearch
+{
+    /// <summary>Separates the extracts of one message where several were cut from it.</summary>
+    /// <remarks>
+    /// A line break rather than a joining word: the fragments are discontiguous parts of one body, and any word placed
+    /// between them would be text this system wrote inside content it did not.
+    /// </remarks>
+    private const char SnippetSeparator = '\n';
+
+    private readonly MailboxSearchReader searchReader;
+    private readonly EmailKnowledgeBounds bounds;
+
+    /// <summary>Initializes the retrieval over the mailbox search and the bounds it hands its results over under.</summary>
+    /// <param name="searchReader">Ranks and cuts the mail a query matched.</param>
+    /// <param name="bounds">How much of what it found may be handed over.</param>
+    /// <exception cref="ArgumentNullException">Thrown when either argument is <see langword="null" />.</exception>
+    public MailboxKnowledgeSearch(MailboxSearchReader searchReader, EmailKnowledgeBounds bounds)
+    {
+        ArgumentNullException.ThrowIfNull(searchReader);
+        ArgumentNullException.ThrowIfNull(bounds);
+
+        this.searchReader = searchReader;
+        this.bounds = bounds;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<EmailKnowledgePassage>> FindPassagesAsync(
+        MailboxScope scope,
+        string queryText,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+
+        // Written by a model rather than by a caller who could be told to correct it, so unusable text is a retrieval
+        // that found nothing rather than a request to refuse. Checked here so the search use case, whose callers are
+        // people, keeps refusing the same text.
+        if (string.IsNullOrWhiteSpace(queryText))
+        {
+            return [];
+        }
+
+        var request = new SearchEmailsRequest
+        {
+            QueryText = queryText,
+            AccountIds = scope.AccountIds,
+            FolderAliases = scope.FolderAliases,
+            ResultLimit = this.bounds.MaximumPassages,
+        };
+
+        var result = await this.searchReader.SearchEmailsAsync(request, cancellationToken);
+
+        return
+        [
+            .. result.Matches
+                .Select(this.ToPassage)
+                .Where(static passage => passage.Text.Length is not 0),
+        ];
+    }
+
+    /// <summary>Reads one match into the passage a model receives.</summary>
+    /// <remarks>
+    /// A message whose extracts are empty produces a passage with no text, which the caller drops. That is a message
+    /// matched on its subject or its participants while its body yielded none — encrypted mail, or mail whose content
+    /// lives in an attachment — and sending an identifier with nothing beside it would spend context on a message the
+    /// model cannot read a word of.
+    /// </remarks>
+    private EmailKnowledgePassage ToPassage(EmailSearchMatch match)
+    {
+        var summary = match.Summary;
+
+        return new EmailKnowledgePassage
+        {
+            StoredEmailId = summary.StoredEmailId,
+            AccountId = summary.AccountId,
+            FolderAlias = summary.FolderAlias,
+            Subject = summary.Subject,
+            ReceivedAt = summary.ReceivedAt,
+            Text = this.Bounded(string.Join(SnippetSeparator, match.Snippets)),
+        };
+    }
+
+    /// <summary>Cuts an extract to the size one passage may carry.</summary>
+    /// <remarks>
+    /// A cut that would fall between the halves of a surrogate pair takes the whole pair instead. Mail carries emoji and
+    /// every script outside the basic plane, and a lone surrogate is not text: it survives no serialization the passage
+    /// is about to cross, and what a provider would receive is a replacement character or a refused request.
+    /// </remarks>
+    private string Bounded(string text)
+    {
+        var limit = this.bounds.MaximumCharactersPerPassage;
+
+        if (text.Length <= limit)
+        {
+            return text;
+        }
+
+        return text[..(char.IsLowSurrogate(text[limit]) ? limit - 1 : limit)];
+    }
+}

--- a/src/Application/Retrieval/MailboxKnowledgeSearch.cs
+++ b/src/Application/Retrieval/MailboxKnowledgeSearch.cs
@@ -56,17 +56,14 @@ public sealed class MailboxKnowledgeSearch : IEmailKnowledgeSearch
     {
         ArgumentNullException.ThrowIfNull(scope);
 
-        // Written by a model rather than by a caller who could be told to correct it, so unusable text is a retrieval
-        // that found nothing rather than a request to refuse. Checked here so the search use case, whose callers are
-        // people, keeps refusing the same text.
-        if (string.IsNullOrWhiteSpace(queryText))
+        if (UsableQueryText(queryText) is not { } validatedQueryText)
         {
             return [];
         }
 
         var request = new SearchEmailsRequest
         {
-            QueryText = queryText,
+            QueryText = validatedQueryText.Value,
             AccountIds = scope.AccountIds,
             FolderAliases = scope.FolderAliases,
             ResultLimit = this.bounds.MaximumPassages,
@@ -80,6 +77,32 @@ public sealed class MailboxKnowledgeSearch : IEmailKnowledgeSearch
                 .Select(this.ToPassage)
                 .Where(static passage => passage.Text.Length is not 0),
         ];
+    }
+
+    /// <summary>Validates the one part of a retrieval a model wrote, treating text no query accepts as no result.</summary>
+    /// <remarks>
+    /// <para>
+    /// The asymmetry this method exists for: the query is free-form model output, while the scope beside it is the
+    /// caller's own authorization. So unusable text is a retrieval that found nothing — nobody can be told to correct
+    /// it, and a run whose lookup found nothing still has an answer to give — while an unusable scope stays a failure
+    /// and still travels to the caller that supplied it.
+    /// </para>
+    /// <para>
+    /// It asks the query text's own type rather than restating its rules, which is why blank text, text longer than one
+    /// query carries, and text holding a character no document could are all one answer here. A rule added there is
+    /// covered here without this method learning about it.
+    /// </para>
+    /// </remarks>
+    private static EmailSearchQueryText? UsableQueryText(string queryText)
+    {
+        try
+        {
+            return EmailSearchQueryText.Create(queryText);
+        }
+        catch (MailboxQueryFilterInvalidException)
+        {
+            return null;
+        }
     }
 
     /// <summary>Reads one match into the passage a model receives.</summary>

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -383,6 +383,7 @@ try
             ?? throw new InvalidOperationException(
                 "The chat endpoint was declared at registration and is absent from the validated configuration."));
         builder.Services.AddChatProviderAdapter();
+        builder.Services.AddMailAnsweringAgent();
         // Readiness alone, and never worse than degraded. Neither provider serves a request path, so a failing one must
         // not take the instance out of traffic and must never reach the liveness probe: restarting the process cannot
         // fix a provider and would turn one outage into an outage plus a restart loop. The registration says all of

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
+using MailFathom.Application.Retrieval;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.Synchronization.Reconciliation;
@@ -268,6 +269,11 @@ public static class ServiceCollectionExtensions
         services.AddScoped<MailboxTimelineReader>();
         services.AddScoped<EmailContentReader>();
         services.AddScoped<MailboxSearchReader>();
+        // Registered for every deployment rather than only where a chat endpoint was declared, because what it is is a
+        // reading of the search above: an instance that answers no questions simply resolves it and never calls it, and
+        // the bounds it hands passages over under are the same wherever the retrieval is reached from.
+        services.AddSingleton(EmailKnowledgeBounds.Default);
+        services.AddScoped<IEmailKnowledgeSearch, MailboxKnowledgeSearch>();
         // The cache outlives every scope because a token is valid for whichever work unit next needs the account,
         // while the source that fills it is scoped to the configuration snapshot it resolves settings from.
         services.AddSingleton<MailAccessTokenCache>();

--- a/tests/AI.UnitTests/AiServiceCollectionExtensionsTests.cs
+++ b/tests/AI.UnitTests/AiServiceCollectionExtensionsTests.cs
@@ -11,6 +11,7 @@ using MailFathom.Application.Chat;
 using MailFathom.Application.Emails.Chunking;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Resilience;
+using MailFathom.Application.Retrieval;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
@@ -193,6 +194,46 @@ public sealed class AiServiceCollectionExtensionsTests
     {
         // Act, Assert
         Assert.Throws<ArgumentNullException>(() => AiServiceCollectionExtensions.AddChatProviderAdapter(null!));
+    }
+
+    /// <summary>
+    /// A run retrieves through the mailbox search, which reads through the scoped persistence context, so the agent is
+    /// scoped too: a singleton would capture one scope's reader and answer every later question through it.
+    /// </summary>
+    [Fact]
+    public void AddMailAnsweringAgent_ResolvesTheAnsweringPortOncePerScope()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddHttpClient();
+        services.AddLogging();
+        services.AddSingleton(ChatDeclarations.Plan());
+        services.AddSingleton(Substitute.For<IProviderEndpointCredentialSource>());
+        services.AddSingleton(Substitute.For<IOutboundOperationRunner>());
+        services.AddSingleton(Substitute.For<IAiProviderHealthRecorder>());
+        services.AddScoped<IEmailKnowledgeSearch, RecordingEmailKnowledgeSearch>();
+
+        // Beside the adapter, as the composition root registers them: a run sends over the transport that call names.
+        services.AddChatProviderAdapter();
+
+        // Act
+        services.AddMailAnsweringAgent();
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        using var otherScope = provider.CreateScope();
+
+        Assert.NotSame(
+            scope.ServiceProvider.GetRequiredService<IMailQuestionAnswerer>(),
+            otherScope.ServiceProvider.GetRequiredService<IMailQuestionAnswerer>());
+    }
+
+    [Fact]
+    public void AddMailAnsweringAgent_WithoutAServiceCollection_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => AiServiceCollectionExtensions.AddMailAnsweringAgent(null!));
     }
 
     [Fact]

--- a/tests/AI.UnitTests/Orchestration/MailAnsweringAgentCompositionTests.cs
+++ b/tests/AI.UnitTests/Orchestration/MailAnsweringAgentCompositionTests.cs
@@ -1,0 +1,187 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.AI.Orchestration;
+using MailFathom.AI.Retrieval;
+using MailFathom.AI.UnitTests.TestDoubles;
+using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MailFathom.AI.UnitTests.Orchestration;
+
+/// <summary>Covers what the composed agent is: what it may retrieve, when it retrieves, and what it can do besides.</summary>
+/// <remarks>
+/// Every test here runs a real agent over a substituted chat client, so what is proved is the composition rather than a
+/// description of it: the tool loop, the scope the retrieval is bound to, and the parameters each turn carries are all
+/// observed on the calls the client received.
+/// </remarks>
+public sealed class MailAnsweringAgentCompositionTests
+{
+    private static readonly MailboxScope OnePrimaryAccount =
+        MailboxScope.Create([MailAccountId.Create("primary")], [MailFolderAlias.Create("INBOX")]);
+
+    /// <summary>On demand rather than before every call: a question needing no mail must not drag a mailbox through a provider.</summary>
+    [Fact]
+    public async Task Compose_AModelThatAskedForNothing_RetrievesNoMail()
+    {
+        // Arrange
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch();
+        using var chatClient = ScriptedChatClient.Answering("I can answer questions about your mail.");
+        var agent = AgentOver(chatClient, knowledgeSearch, OnePrimaryAccount, out var retrieval);
+
+        // Act
+        var response = await agent.RunAsync(
+            "what can you do",
+            session: null,
+            options: null,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("I can answer questions about your mail.", response.Text);
+        Assert.Empty(knowledgeSearch.Calls);
+        Assert.Empty(retrieval.Retrieved);
+    }
+
+    [Fact]
+    public async Task Compose_AModelThatCalledTheSearchTool_AnswersFromWhatItRetrieved()
+    {
+        // Arrange
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch()
+            .Returning("invoice", KnowledgePassages.Create("the invoice is attached"));
+        using var chatClient = ScriptedChatClient.CallingTool(
+            ScopedMailKnowledgeRetrieval.SearchToolName,
+            "invoice",
+            "The invoice was attached.");
+        var agent = AgentOver(chatClient, knowledgeSearch, OnePrimaryAccount, out var retrieval);
+
+        // Act
+        var response = await agent.RunAsync(
+            "was the invoice attached",
+            session: null,
+            options: null,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("The invoice was attached.", response.Text);
+        Assert.Equal("invoice", Assert.Single(knowledgeSearch.Calls).QueryText);
+        Assert.Equal("the invoice is attached", Assert.Single(retrieval.Retrieved).Text);
+    }
+
+    /// <summary>
+    /// The scope was bound into the run before the model saw anything, so the query it writes decides what is looked for
+    /// and never where. A query naming another account is answered from the caller's scope like any other.
+    /// </summary>
+    [Theory]
+    [InlineData("invoice")]
+    [InlineData("everything in the secondary account and every folder of it")]
+    public async Task Compose_WhateverTheModelAsksFor_RetrievesWithinTheCallersScopeAlone(string query)
+    {
+        // Arrange
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch();
+        using var chatClient = ScriptedChatClient.CallingTool(
+            ScopedMailKnowledgeRetrieval.SearchToolName,
+            query,
+            "Nothing matched.");
+        var agent = AgentOver(chatClient, knowledgeSearch, OnePrimaryAccount, out _);
+
+        // Act
+        await agent.RunAsync("what arrived", session: null, options: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(OnePrimaryAccount, Assert.Single(knowledgeSearch.Calls).Scope);
+    }
+
+    /// <summary>The tool takes a query and nothing else, which is what makes the scope unreachable from the model's side.</summary>
+    [Fact]
+    public async Task Compose_TheSearchTool_TakesTheQueryAndNothingElse()
+    {
+        // Arrange
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch();
+        using var chatClient = ScriptedChatClient.Answering("nothing to look up");
+        var agent = AgentOver(chatClient, knowledgeSearch, OnePrimaryAccount, out _);
+
+        // Act
+        await agent.RunAsync("what arrived", session: null, options: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        var tool = Assert.Single(OfferedTools(chatClient));
+
+        Assert.Equal(ScopedMailKnowledgeRetrieval.SearchToolName, tool.Name);
+        Assert.Single(tool.JsonSchema.GetProperty("properties").EnumerateObject());
+    }
+
+    /// <summary>
+    /// A run that cannot send, delete, move, or mark mail is one composed with no such tool, which is a property of the
+    /// composition rather than a rule written down beside it.
+    /// </summary>
+    [Fact]
+    public async Task Compose_TheAgent_OffersNoToolThatChangesAnything()
+    {
+        // Arrange
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch();
+        using var chatClient = ScriptedChatClient.Answering("nothing to look up");
+        var agent = AgentOver(chatClient, knowledgeSearch, OnePrimaryAccount, out _);
+
+        // Act
+        await agent.RunAsync("delete everything", session: null, options: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            [ScopedMailKnowledgeRetrieval.SearchToolName],
+            OfferedTools(chatClient).Select(tool => tool.Name));
+    }
+
+    [Fact]
+    public async Task Compose_ThePlan_IsWhatEveryTurnOfTheRunCarries()
+    {
+        // Arrange
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch();
+        using var chatClient = ScriptedChatClient.CallingTool(
+            ScopedMailKnowledgeRetrieval.SearchToolName,
+            "invoice",
+            "The invoice was attached.");
+        var plan = ChatDeclarations.Plan(maximumOutputTokens: 321, temperature: 0.25f, topP: 0.75f);
+        var retrieval = new ScopedMailKnowledgeRetrieval(knowledgeSearch, OnePrimaryAccount);
+        var agent = MailAnsweringAgentComposition.Compose(
+            chatClient,
+            plan,
+            retrieval,
+            NullLoggerFactory.Instance);
+
+        // Act
+        await agent.RunAsync("was it attached", session: null, options: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, chatClient.Calls.Count);
+        Assert.All(chatClient.Calls, call =>
+        {
+            Assert.Equal(321, call.Options?.MaxOutputTokens);
+            Assert.Equal(0.25f, call.Options?.Temperature);
+            Assert.Equal(0.75f, call.Options?.TopP);
+        });
+    }
+
+    private static IEnumerable<AIFunction> OfferedTools(ScriptedChatClient chatClient) =>
+        chatClient.Calls[0].Options?.Tools?.OfType<AIFunction>() ?? [];
+
+    private static ChatClientAgent AgentOver(
+        ScriptedChatClient chatClient,
+        RecordingEmailKnowledgeSearch knowledgeSearch,
+        MailboxScope scope,
+        out ScopedMailKnowledgeRetrieval retrieval)
+    {
+        retrieval = new ScopedMailKnowledgeRetrieval(knowledgeSearch, scope);
+
+        return MailAnsweringAgentComposition.Compose(
+            chatClient,
+            ChatDeclarations.Plan(),
+            retrieval,
+            NullLoggerFactory.Instance);
+    }
+}

--- a/tests/AI.UnitTests/Orchestration/MailAnsweringAgentTests.cs
+++ b/tests/AI.UnitTests/Orchestration/MailAnsweringAgentTests.cs
@@ -1,0 +1,178 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using System.Text;
+using MailFathom.AI.Orchestration;
+using MailFathom.AI.ProviderAdapters;
+using MailFathom.AI.Providers;
+using MailFathom.AI.UnitTests.TestDoubles;
+using MailFathom.Application.AiProviders;
+using MailFathom.Application.Chat;
+using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Resilience;
+using MailFathom.Application.Retrieval;
+using MailFathom.Domain.Accounts;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.AI.UnitTests.Orchestration;
+
+/// <summary>Covers what one answering run does around the composed agent: what it bounds, what it opens, and what it publishes.</summary>
+/// <remarks>
+/// The run goes over a real provider client and a scripted transport, so what is exercised is the client construction,
+/// the credential resolution, and the mapping of a provider's answer. What the agent itself is composed of is proved
+/// against a substituted chat client instead, where the tool loop can be driven directly.
+/// </remarks>
+public sealed class MailAnsweringAgentTests
+{
+    private static readonly MailQuestion Question = new(
+        "was the invoice attached",
+        MailboxScope.Create([MailAccountId.Create("primary")], []));
+
+    [Fact]
+    public async Task AnswerAsync_AProviderThatAnswered_ReturnsTheAnswerAndWhatTheRunRetrieved()
+    {
+        // Arrange
+        using var provider = ScriptedTransport.Answering(Completion("The invoice was attached."));
+        var agent = provider.AgentOver(new RecordingEmailKnowledgeSearch());
+
+        // Act
+        var answer = await agent.AnswerAsync(Question, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("The invoice was attached.", answer.Text);
+        Assert.Empty(answer.Passages);
+        provider.HealthRecorder.Received(1).RecordServed(AiProviderRole.Chat);
+    }
+
+    /// <summary>An empty string reaching a caller reads as a model that had nothing to say rather than as a run that produced nothing.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task AnswerAsync_AProviderThatProducedNoText_IsAnEmptyAnswerFailure(string content)
+    {
+        // Arrange
+        using var provider = ScriptedTransport.Answering(Completion(content));
+        var agent = provider.AgentOver(new RecordingEmailKnowledgeSearch());
+
+        // Act
+        var failure = await Assert.ThrowsAsync<ChatGenerationFailedException>(() =>
+            agent.AnswerAsync(Question, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(ChatGenerationFailure.AnswerEmpty, failure.Failure);
+    }
+
+    /// <summary>The question is one turn, so what bounds a turn bounds the question, and it is refused before anything is sent.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task AnswerAsync_AQuestionWithNoText_IsRefusedWithoutReachingTheProvider(string text)
+    {
+        // Arrange
+        using var provider = ScriptedTransport.Answering(Completion("never reached"));
+        var agent = provider.AgentOver(new RecordingEmailKnowledgeSearch());
+
+        // Act
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            agent.AnswerAsync(Question with { Text = text }, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(0, provider.RequestCount);
+    }
+
+    [Fact]
+    public async Task AnswerAsync_AQuestionLargerThanOneCallSends_IsRefusedWithoutReachingTheProvider()
+    {
+        // Arrange
+        using var provider = ScriptedTransport.Answering(Completion("never reached"));
+        var agent = provider.AgentOver(new RecordingEmailKnowledgeSearch());
+
+        // Act
+        await Assert.ThrowsAsync<ArgumentException>(() => agent.AnswerAsync(
+            Question with { Text = new string('a', 5000) },
+            TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(0, provider.RequestCount);
+    }
+
+    /// <summary>Builds the chat-completion payload a provider answers with.</summary>
+    private static string Completion(string content) =>
+        "{\"id\":\"chatcmpl-1\",\"object\":\"chat.completion\",\"created\":1,\"model\":\"a-chat-model\","
+        + "\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\""
+        + content
+        + "\"},\"finish_reason\":\"stop\"}]}";
+
+    /// <summary>A provider that answers from a script, so the run is exercised over a real client and no network.</summary>
+    private sealed class ScriptedTransport : IDisposable
+    {
+        private readonly FakeHttpMessageHandler handler;
+        private string payload = string.Empty;
+
+        private ScriptedTransport() =>
+            this.handler = new FakeHttpMessageHandler((_, _) =>
+            {
+                this.RequestCount++;
+
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(this.payload, Encoding.UTF8, "application/json"),
+                });
+            });
+
+        /// <summary>The health state every call this provider serves reports into, so a test can read what the run established.</summary>
+        public IAiProviderHealthRecorder HealthRecorder { get; } = Substitute.For<IAiProviderHealthRecorder>();
+
+        public int RequestCount { get; private set; }
+
+        public static ScriptedTransport Answering(string payload) => new() { payload = payload };
+
+        public MailAnsweringAgent AgentOver(IEmailKnowledgeSearch knowledgeSearch)
+        {
+            var transportFactory = Substitute.For<IHttpClientFactory>();
+            transportFactory
+                .CreateClient(Arg.Any<string>())
+                .Returns(_ => new HttpClient(this.handler, disposeHandler: false));
+
+            var credentialSource = Substitute.For<IProviderEndpointCredentialSource>();
+            credentialSource
+                .ResolveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(_ => Task.FromResult(
+                    ProviderEndpointCredential.FromApiKey("a-configured-key", resolvedMaterial: null)));
+
+            var operationRunner = Substitute.For<IOutboundOperationRunner>();
+            operationRunner
+                .RunAsync(
+                    Arg.Any<OutboundDependency>(),
+                    Arg.Any<string>(),
+                    Arg.Any<Func<CancellationToken, Task<Microsoft.Extensions.AI.ChatResponse>>>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(call =>
+                {
+                    // The substitute cannot know the argument is present, and it always is: this configuration matches
+                    // the only overload the decorator calls.
+                    var operation = call.Arg<Func<CancellationToken, Task<Microsoft.Extensions.AI.ChatResponse>>>()!;
+
+                    return operation(call.Arg<CancellationToken>());
+                });
+
+            return new MailAnsweringAgent(
+                ChatDeclarations.Plan(),
+                credentialSource,
+                new OpenAiCompatibleClientFactory(),
+                transportFactory,
+                knowledgeSearch,
+                operationRunner,
+                this.HealthRecorder,
+                NullLoggerFactory.Instance,
+                NullLogger<MailAnsweringAgent>.Instance);
+        }
+
+        public void Dispose() => this.handler.Dispose();
+    }
+}

--- a/tests/AI.UnitTests/ProviderAdapters/ResilientChatClientTests.cs
+++ b/tests/AI.UnitTests/ProviderAdapters/ResilientChatClientTests.cs
@@ -1,0 +1,235 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using MailFathom.AI.ProviderAdapters;
+using MailFathom.AI.UnitTests.TestDoubles;
+using MailFathom.Application.AiProviders;
+using MailFathom.Application.Chat;
+using MailFathom.Application.Resilience;
+using MailFathom.Domain.Failures;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.AI.UnitTests.ProviderAdapters;
+
+/// <summary>Covers the bounds every chat call of an agent run passes through.</summary>
+/// <remarks>
+/// The decorator is what a run has instead of the single-request adapter's per-call arrangement, so the same four
+/// properties are proved here: one call is deadlined, a provider failure is classified rather than passed on, the health
+/// state hears what each call established, and a pipeline that declined to call at all is a transport fault.
+/// </remarks>
+public sealed class ResilientChatClientTests
+{
+    private static readonly TimeSpan Deadline = TimeSpan.FromMilliseconds(200);
+
+    private static readonly Microsoft.Extensions.AI.ChatMessage[] Conversation =
+        [new(Microsoft.Extensions.AI.ChatRole.User, "what did they say")];
+
+    [Fact]
+    public async Task GetResponseAsync_AProviderThatAnswered_ReturnsTheAnswerAndReportsTheProviderWorking()
+    {
+        // Arrange
+        var healthRecorder = Substitute.For<IAiProviderHealthRecorder>();
+        using var inner = ScriptedChatClient.Answering("they said yes");
+        using var client = ClientOver(inner, healthRecorder);
+
+        // Act
+        var response = await client.GetResponseAsync(
+            Conversation,
+            options: null,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("they said yes", response.Text);
+        healthRecorder.Received(1).RecordServed(AiProviderRole.Chat);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized, ChatGenerationFailure.CredentialRejected, false)]
+    [InlineData(HttpStatusCode.TooManyRequests, ChatGenerationFailure.RateLimited, true)]
+    [InlineData(HttpStatusCode.BadRequest, ChatGenerationFailure.RequestRefused, false)]
+    [InlineData(HttpStatusCode.BadGateway, ChatGenerationFailure.TransportFaulted, true)]
+    public async Task GetResponseAsync_AProviderThatRefused_IsClassifiedAndReportedAtThatGranularity(
+        HttpStatusCode status,
+        ChatGenerationFailure expected,
+        bool isWorthRepeating)
+    {
+        // Arrange
+        var healthRecorder = Substitute.For<IAiProviderHealthRecorder>();
+        using var inner = FailingChatClient.Throwing(
+            new HttpRequestException($"The endpoint refused with {(int)status}.", inner: null, status));
+        using var client = ClientOver(inner, healthRecorder);
+
+        // Act
+        var failure = await Assert.ThrowsAsync<ChatGenerationFailedException>(() =>
+            client.GetResponseAsync(Conversation, options: null, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(expected, failure.Failure);
+
+        if (isWorthRepeating)
+        {
+            healthRecorder.Received(1).RecordUnavailable(AiProviderRole.Chat);
+        }
+        else
+        {
+            healthRecorder.Received(1).RecordMisconfigured(AiProviderRole.Chat);
+        }
+    }
+
+    /// <summary>The deadline is this deployment's, so a slow endpoint surfaces as its timeout rather than as a cancellation.</summary>
+    [Fact]
+    public async Task GetResponseAsync_AnEndpointThatNeverAnswers_EndsAsThisDeploymentsTimeout()
+    {
+        // Arrange
+        var healthRecorder = Substitute.For<IAiProviderHealthRecorder>();
+        using var inner = FailingChatClient.Stalling();
+        using var client = ClientOver(inner, healthRecorder);
+
+        // Act
+        var failure = await Assert.ThrowsAsync<ChatGenerationFailedException>(() =>
+            client.GetResponseAsync(Conversation, options: null, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(ChatGenerationFailure.RequestTimedOut, failure.Failure);
+        healthRecorder.Received(1).RecordUnavailable(AiProviderRole.Chat);
+    }
+
+    /// <summary>A caller who stopped waiting says nothing about the provider, so it must not be reported against it.</summary>
+    [Fact]
+    public async Task GetResponseAsync_ACallerThatCancelled_IsNotReportedAsAProviderFailure()
+    {
+        // Arrange
+        var healthRecorder = Substitute.For<IAiProviderHealthRecorder>();
+        using var inner = FailingChatClient.Stalling();
+        using var client = ClientOver(inner, healthRecorder);
+        using var caller = new CancellationTokenSource();
+
+        await caller.CancelAsync();
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.GetResponseAsync(Conversation, options: null, caller.Token));
+
+        // Assert
+        healthRecorder.DidNotReceive().RecordUnavailable(AiProviderRole.Chat);
+        healthRecorder.DidNotReceive().RecordMisconfigured(AiProviderRole.Chat);
+        healthRecorder.DidNotReceive().RecordServed(AiProviderRole.Chat);
+    }
+
+    /// <summary>A pipeline that declined to call the endpoint is recognized by its stable error code, not by its type.</summary>
+    [Fact]
+    public async Task GetResponseAsync_APipelineThatDeclinedTheCall_IsATransportFault()
+    {
+        // Arrange
+        var healthRecorder = Substitute.For<IAiProviderHealthRecorder>();
+        using var inner = ScriptedChatClient.Answering("never reached");
+        using var client = ClientOver(inner, healthRecorder, declineTheCall: true);
+
+        // Act
+        var failure = await Assert.ThrowsAsync<ChatGenerationFailedException>(() =>
+            client.GetResponseAsync(Conversation, options: null, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(ChatGenerationFailure.TransportFaulted, failure.Failure);
+        Assert.Equal(MailFathomErrorCode.ChatProviderUnavailable, failure.ErrorCode);
+    }
+
+    /// <summary>An unbounded path to the provider must not exist for a later caller to find.</summary>
+    [Fact]
+    public void GetStreamingResponseAsync_AnyCall_IsRefusedRatherThanSentUnbounded()
+    {
+        // Arrange
+        using var inner = ScriptedChatClient.Answering("never reached");
+        using var client = ClientOver(inner, Substitute.For<IAiProviderHealthRecorder>());
+
+        // Act, Assert
+        Assert.Throws<NotSupportedException>(() =>
+            client.GetStreamingResponseAsync(Conversation, options: null, TestContext.Current.CancellationToken));
+    }
+
+    private static ResilientChatClient ClientOver(
+        Microsoft.Extensions.AI.IChatClient inner,
+        IAiProviderHealthRecorder healthRecorder,
+        bool declineTheCall = false)
+    {
+        var operationRunner = Substitute.For<IOutboundOperationRunner>();
+        operationRunner
+            .RunAsync(
+                Arg.Any<OutboundDependency>(),
+                Arg.Any<string>(),
+                Arg.Any<Func<CancellationToken, Task<Microsoft.Extensions.AI.ChatResponse>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                if (declineTheCall)
+                {
+                    throw new PipelineDeclinedTheOperation();
+                }
+
+                // The substitute cannot know the argument is present, and it always is: this configuration matches the
+                // only overload the decorator calls.
+                var operation = call.Arg<Func<CancellationToken, Task<Microsoft.Extensions.AI.ChatResponse>>>()!;
+
+                return operation(call.Arg<CancellationToken>());
+            });
+
+        return new ResilientChatClient(
+            inner,
+            ChatDeclarations.Endpoint(),
+            Deadline,
+            operationRunner,
+            healthRecorder,
+            NullLogger.Instance);
+    }
+
+    /// <summary>Stands in for whatever the resilience boundary raises when a configured limit stopped an operation.</summary>
+    [SuppressMessage("Design", "CA1064:Exceptions should be public", Justification = "A test double for one behavior of one test class, which nothing outside it raises or catches.")]
+    private sealed class PipelineDeclinedTheOperation()
+        : MailFathomException("An outbound resilience limit stopped the operation.")
+    {
+        public override MailFathomErrorCode ErrorCode => MailFathomErrorCode.OutboundDependencyUnavailable;
+    }
+
+    /// <summary>A provider client that fails the way a test names, so the decorator's own reading of it is what is proved.</summary>
+    private sealed class FailingChatClient : Microsoft.Extensions.AI.IChatClient
+    {
+        private readonly Func<CancellationToken, Task<Microsoft.Extensions.AI.ChatResponse>> answer;
+
+        private FailingChatClient(Func<CancellationToken, Task<Microsoft.Extensions.AI.ChatResponse>> answer) =>
+            this.answer = answer;
+
+        public static FailingChatClient Throwing(Exception failure) => new(_ => throw failure);
+
+        /// <summary>An endpoint that never answers, so the decorator's own deadline is what ends the call.</summary>
+        public static FailingChatClient Stalling() => new(async cancellationToken =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+
+            throw new InvalidOperationException("The stall was never meant to end.");
+        });
+
+        public Task<Microsoft.Extensions.AI.ChatResponse> GetResponseAsync(
+            IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages,
+            Microsoft.Extensions.AI.ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            this.answer(cancellationToken);
+
+        public IAsyncEnumerable<Microsoft.Extensions.AI.ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<Microsoft.Extensions.AI.ChatMessage> messages,
+            Microsoft.Extensions.AI.ChatOptions? options = null,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException("This client answers whole responses only.");
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+        public void Dispose()
+        {
+            // Nothing is held.
+        }
+    }
+}

--- a/tests/AI.UnitTests/TestDoubles/KnowledgePassages.cs
+++ b/tests/AI.UnitTests/TestDoubles/KnowledgePassages.cs
@@ -1,0 +1,36 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Retrieval;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.AI.UnitTests.TestDoubles;
+
+/// <summary>Builds the passages a retrieval hands over, so a test states only what it is about.</summary>
+internal static class KnowledgePassages
+{
+    /// <summary>Builds one passage.</summary>
+    /// <param name="text">The extract itself.</param>
+    /// <param name="storedEmailId">The stable identity, or <see langword="null" /> to generate one.</param>
+    /// <param name="accountId">The account the message belongs to.</param>
+    /// <param name="folderAlias">The folder alias the message belongs to.</param>
+    /// <param name="subject">The subject, or <see langword="null" /> for a message that carried none.</param>
+    /// <returns>The passage.</returns>
+    public static EmailKnowledgePassage Create(
+        string text,
+        Guid? storedEmailId = null,
+        string accountId = "primary",
+        string folderAlias = "INBOX",
+        string? subject = null) => new()
+        {
+            StoredEmailId = StoredEmailId.Create(storedEmailId ?? Guid.CreateVersion7()),
+            AccountId = MailAccountId.Create(accountId),
+            FolderAlias = MailFolderAlias.Create(folderAlias),
+            Subject = subject,
+            ReceivedAt = null,
+            Text = text,
+        };
+}

--- a/tests/AI.UnitTests/TestDoubles/RecordingEmailKnowledgeSearch.cs
+++ b/tests/AI.UnitTests/TestDoubles/RecordingEmailKnowledgeSearch.cs
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Retrieval;
+
+namespace MailFathom.AI.UnitTests.TestDoubles;
+
+/// <summary>Stands in for this deployment's retrieval, recording the scope and query every lookup arrived with.</summary>
+/// <remarks>
+/// A recorder rather than a substitute, because what the tests using it assert is the scope each call carried — an
+/// argument matcher would state the expectation in the assertion instead of reading what actually reached the port.
+/// </remarks>
+internal sealed class RecordingEmailKnowledgeSearch : IEmailKnowledgeSearch
+{
+    private readonly List<KnowledgeSearchCall> calls = [];
+    private readonly Dictionary<string, IReadOnlyList<EmailKnowledgePassage>> passagesByQuery =
+        new(StringComparer.Ordinal);
+
+    /// <summary>Gets what each lookup asked for, in order.</summary>
+    public IReadOnlyList<KnowledgeSearchCall> Calls => this.calls;
+
+    /// <summary>Arranges what one query finds.</summary>
+    /// <param name="queryText">The query to answer.</param>
+    /// <param name="passages">What it finds.</param>
+    /// <returns>This retrieval, so arrangement reads as one statement.</returns>
+    public RecordingEmailKnowledgeSearch Returning(string queryText, params EmailKnowledgePassage[] passages)
+    {
+        this.passagesByQuery[queryText] = passages;
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<EmailKnowledgePassage>> FindPassagesAsync(
+        MailboxScope scope,
+        string queryText,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(scope);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        this.calls.Add(new KnowledgeSearchCall(scope, queryText));
+
+        return Task.FromResult(this.passagesByQuery.GetValueOrDefault(queryText, []));
+    }
+
+    /// <summary>What one lookup asked for.</summary>
+    /// <param name="Scope">The accounts and folders the lookup was restricted to.</param>
+    /// <param name="QueryText">The text the model wrote.</param>
+    internal sealed record KnowledgeSearchCall(MailboxScope Scope, string QueryText);
+}

--- a/tests/AI.UnitTests/TestDoubles/ScriptedChatClient.cs
+++ b/tests/AI.UnitTests/TestDoubles/ScriptedChatClient.cs
@@ -1,0 +1,136 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Microsoft.Extensions.AI;
+
+namespace MailFathom.AI.UnitTests.TestDoubles;
+
+/// <summary>A chat client that answers from a script, so a composed agent can be run without a provider.</summary>
+/// <remarks>
+/// <para>
+/// The framework's own interface rather than a port of this repository's, because what the composition hands the agent
+/// is exactly this: substituting anything else would prove something about a copy of the seam instead of the seam.
+/// </para>
+/// <para>
+/// It records what each turn was asked to send, which is what lets a test assert the tools the agent offered and the
+/// generation parameters it carried without reaching a network.
+/// </para>
+/// </remarks>
+internal sealed class ScriptedChatClient : IChatClient
+{
+    private readonly Queue<ChatResponse> answers;
+    private readonly List<ChatCall> calls = [];
+
+    private ScriptedChatClient(IEnumerable<ChatResponse> answers) => this.answers = new Queue<ChatResponse>(answers);
+
+    /// <summary>Gets what each turn of the run was asked to send, in order.</summary>
+    public IReadOnlyList<ChatCall> Calls => this.calls;
+
+    /// <summary>Builds a client that answers with text and asks for nothing.</summary>
+    public static ScriptedChatClient Answering(string text) =>
+        new([new ChatResponse(new ChatMessage(ChatRole.Assistant, text)) { FinishReason = ChatFinishReason.Stop }]);
+
+    /// <summary>Builds a client that calls one tool with one argument and then answers with text.</summary>
+    /// <param name="toolName">The tool to call, which the run must have offered.</param>
+    /// <param name="argument">The single argument to call it with, whose name is read from the offered tool's schema.</param>
+    /// <param name="text">What to answer once the tool has answered.</param>
+    /// <remarks>
+    /// The argument name is discovered rather than written down, because it is the framework's reading of a delegate's
+    /// parameter and a test that hard-coded it would fail on a framework update for a reason unrelated to what it proves.
+    /// </remarks>
+    public static ScriptedChatClient CallingTool(string toolName, string argument, string text)
+    {
+        var client = new ScriptedChatClient([]);
+
+        client.answers.Enqueue(new ChatResponse(new ChatMessage(
+            ChatRole.Assistant,
+            [new ToolCallPlaceholder(toolName, argument)])));
+        client.answers.Enqueue(new ChatResponse(new ChatMessage(ChatRole.Assistant, text))
+        {
+            FinishReason = ChatFinishReason.Stop,
+        });
+
+        return client;
+    }
+
+    /// <inheritdoc />
+    public Task<ChatResponse> GetResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        this.calls.Add(new ChatCall([.. messages], options));
+
+        if (this.answers.Count is 0)
+        {
+            throw new InvalidOperationException("The script names no further answer.");
+        }
+
+        return Task.FromResult(Resolved(this.answers.Dequeue(), options));
+    }
+
+    /// <inheritdoc />
+    public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        CancellationToken cancellationToken = default) =>
+        throw new NotSupportedException("The script answers whole responses only.");
+
+    /// <inheritdoc />
+    public object? GetService(Type serviceType, object? serviceKey = null) => null;
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        // Nothing is held.
+    }
+
+    /// <summary>Turns a placeholder into the call the offered tool actually accepts.</summary>
+    private static ChatResponse Resolved(ChatResponse answer, ChatOptions? options)
+    {
+        if (answer.Messages[0].Contents is not [ToolCallPlaceholder placeholder])
+        {
+            return answer;
+        }
+
+        var tool = options?.Tools?.OfType<AIFunction>().FirstOrDefault(offered => offered.Name == placeholder.ToolName)
+            ?? throw new InvalidOperationException(
+                $"The run offered no tool named '{placeholder.ToolName}' for the script to call.");
+
+        return new ChatResponse(new ChatMessage(
+            ChatRole.Assistant,
+            [
+                new FunctionCallContent(
+                    "call-1",
+                    tool.Name,
+                    new Dictionary<string, object?> { [SoleParameterNameOf(tool)] = placeholder.Argument }),
+            ]));
+    }
+
+    /// <summary>Reads the name of the one argument the offered tool takes.</summary>
+    private static string SoleParameterNameOf(AIFunction tool)
+    {
+        var properties = tool.JsonSchema.GetProperty("properties").EnumerateObject().ToArray();
+
+        return properties.Length is 1
+            ? properties[0].Name
+            : throw new InvalidOperationException(
+                $"Tool '{tool.Name}' takes {properties.Length} arguments, and the script calls tools that take one.");
+    }
+
+    /// <summary>What one turn of a run was asked to send.</summary>
+    /// <param name="Messages">The conversation as the agent had composed it by that turn.</param>
+    /// <param name="Options">The options the agent carried, including the tools it offered.</param>
+    internal sealed record ChatCall(IReadOnlyList<ChatMessage> Messages, ChatOptions? Options);
+
+    /// <summary>Stands in for a tool call until the offered tool's own argument name is known.</summary>
+    private sealed class ToolCallPlaceholder(string toolName, string argument) : AIContent
+    {
+        public string ToolName { get; } = toolName;
+
+        public string Argument { get; } = argument;
+    }
+}

--- a/tests/Application.UnitTests/ApplicationDependencyBoundaryTests.cs
+++ b/tests/Application.UnitTests/ApplicationDependencyBoundaryTests.cs
@@ -1,0 +1,47 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Reflection;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests;
+
+/// <summary>Covers what the two inner boundaries are allowed to depend on.</summary>
+/// <remarks>
+/// The answering capability is the first thing MailFathom composes over an orchestration framework, and the port it is
+/// reached through publishes a question and an answer rather than any of that framework's shapes. What guarantees it is
+/// structural rather than reviewed: an assembly cannot name a type it does not reference, so asserting the reference
+/// list proves it for every port added later as well as for the ones here now.
+/// </remarks>
+public sealed class ApplicationDependencyBoundaryTests
+{
+    /// <summary>
+    /// An agent framework, a chat client library, a mail library, or a persistence provider arriving here would mean an
+    /// application contract had started speaking one of their vocabularies. Each would have to become a reference
+    /// first, which is what this refuses.
+    /// </summary>
+    [Theory]
+    [InlineData("MailFathom.Application")]
+    [InlineData("MailFathom.Domain")]
+    public void InnerAssembly_ReferencesNothingButTheBoundariesInsideIt(string assemblyName)
+    {
+        // Arrange
+        var assembly = Assembly.Load(assemblyName);
+
+        // Act
+        var referenced = assembly
+            .GetReferencedAssemblies()
+            .Select(reference => reference.Name)
+            .OfType<string>()
+            .Where(name => !name.StartsWith("System.", StringComparison.Ordinal)
+                && !string.Equals(name, "netstandard", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        // Assert
+        Assert.Equal(
+            assemblyName == "MailFathom.Application" ? ["MailFathom.Domain"] : [],
+            referenced);
+    }
+}

--- a/tests/Application.UnitTests/Retrieval/EmailKnowledgeBoundsTests.cs
+++ b/tests/Application.UnitTests/Retrieval/EmailKnowledgeBoundsTests.cs
@@ -1,0 +1,73 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Search;
+using MailFathom.Application.Retrieval;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Retrieval;
+
+/// <summary>Covers the ceiling on what one retrieval may hand a model.</summary>
+public sealed class EmailKnowledgeBoundsTests
+{
+    [Fact]
+    public void Default_IsNarrowerThanASearchWindow()
+    {
+        // Arrange
+        var bounds = EmailKnowledgeBounds.Default;
+
+        // Act
+        var maximumPassages = bounds.MaximumPassages;
+
+        // Assert
+        Assert.True(maximumPassages < EmailSearchResultLimit.DefaultValue);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(EmailSearchResultLimit.MaximumValue)]
+    public void Create_APassageCountInsideWhatOneSearchRanks_IsAccepted(int maximumPassages)
+    {
+        // Arrange, Act
+        var bounds = EmailKnowledgeBounds.Create(maximumPassages, maximumCharactersPerPassage: 100);
+
+        // Assert
+        Assert.Equal(maximumPassages, bounds.MaximumPassages);
+    }
+
+    /// <summary>A retrieval is answered from a search window, so a bound beyond one states something no run could reach.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(EmailSearchResultLimit.MaximumValue + 1)]
+    public void Create_APassageCountNoSearchCouldFill_IsRefused(int maximumPassages)
+    {
+        // Arrange, Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            EmailKnowledgeBounds.Create(maximumPassages, maximumCharactersPerPassage: 100));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Create_APassageSizeThatCarriesNothing_IsRefused(int maximumCharactersPerPassage)
+    {
+        // Arrange, Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            EmailKnowledgeBounds.Create(maximumPassages: 4, maximumCharactersPerPassage));
+    }
+
+    [Fact]
+    public void ToString_ABound_NamesBothHalvesOfIt()
+    {
+        // Arrange
+        var bounds = EmailKnowledgeBounds.Create(maximumPassages: 4, maximumCharactersPerPassage: 900);
+
+        // Act
+        var described = bounds.ToString();
+
+        // Assert
+        Assert.Equal("4 passages of at most 900 characters", described);
+    }
+}

--- a/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
+++ b/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Accounts;
+using MailFathom.Application.AiProviders;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
@@ -12,6 +13,7 @@ using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
+using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
 
@@ -21,6 +23,8 @@ namespace MailFathom.Application.UnitTests.Retrieval;
 public sealed class MailboxKnowledgeSearchTests
 {
     private static readonly DateTimeOffset FirstJuly = new(2026, 7, 1, 8, 0, 0, TimeSpan.Zero);
+
+    private static readonly DateTimeOffset SearchedAt = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
 
     private static readonly MailAccountId[] EveryServedAccount =
     [
@@ -174,11 +178,15 @@ public sealed class MailboxKnowledgeSearchTests
 
     /// <summary>
     /// The query is written by a model rather than by a caller who could be told to correct it, so unusable text is a
-    /// retrieval that found nothing rather than a failed run.
+    /// retrieval that found nothing rather than a failed run. Every shape the query text refuses is one answer here:
+    /// blank text, text longer than one query carries, and text holding a character no document could — the last two
+    /// being ordinary shapes free-form model output takes.
     /// </summary>
     [Theory]
     [InlineData("")]
     [InlineData("   ")]
+    [InlineData("an invoice\nfrom last week")]
+    [InlineData("an invoice\u0000from last week")]
     public async Task FindPassagesAsync_AQueryWithNoUsableText_FindsNothingWithoutSearching(string queryText)
     {
         // Arrange
@@ -189,6 +197,25 @@ public sealed class MailboxKnowledgeSearchTests
         var passages = await search.FindPassagesAsync(
             MailboxScope.Unrestricted,
             queryText,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(passages);
+        Assert.Empty(index.RankedCandidatesCalls);
+    }
+
+    /// <summary>The length bound is the one an unbounded free-form query meets first, and it cannot be written inline.</summary>
+    [Fact]
+    public async Task FindPassagesAsync_AQueryLongerThanOneSearchCarries_FindsNothingWithoutSearching()
+    {
+        // Arrange
+        var index = new InMemoryEmailSearchIndex().With(SyntheticEmailSummaries.Create(FirstJuly), snippets: "a mention");
+        var search = SearchOver(index);
+
+        // Act
+        var passages = await search.FindPassagesAsync(
+            MailboxScope.Unrestricted,
+            new string('a', EmailSearchQueryText.MaximumLength + 1),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -242,11 +269,26 @@ public sealed class MailboxKnowledgeSearchTests
             EmailSearchSnippetBounds.Default),
         bounds ?? EmailKnowledgeBounds.Default);
 
-    /// <summary>Builds the semantic half of a deployment that configured no embedding provider.</summary>
+    /// <summary>Builds the semantic half of a deployment that configured no embedding provider and activated nothing.</summary>
     private static SemanticEmailSearch LexicalOnlySemanticSearch() => new(
         Substitute.For<IActiveEmbeddingProfileReader>(),
         new InMemoryEmailVectorSearchIndex(),
+        ServingProviderHealth(),
+        new FakeTimeProvider(SearchedAt),
         textEmbeddingGenerator: null);
+
+    /// <summary>Reports every provider as answering, so retrieval is decided by the profile and the generator alone.</summary>
+    private static IAiProviderHealthReader ServingProviderHealth()
+    {
+        var reader = Substitute.For<IAiProviderHealthReader>();
+        reader.Read(Arg.Any<AiProviderRole>())
+            .Returns(call => new AiProviderHealth(
+                call.Arg<AiProviderRole>(),
+                AiProviderHealthState.Serving,
+                SearchedAt));
+
+        return reader;
+    }
 
     private static IMailAccountCatalog CatalogServing(params MailAccountId[] servedAccountIds)
     {

--- a/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
+++ b/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
@@ -1,0 +1,270 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Accounts;
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Emails.Search;
+using MailFathom.Application.Emails.SearchEmails;
+using MailFathom.Application.Retrieval;
+using MailFathom.Application.Synchronization.Checkpoints;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Retrieval;
+
+/// <summary>Covers the retrieval a model reaches mail through: what it bounds, what it carries, and what it refuses to send.</summary>
+public sealed class MailboxKnowledgeSearchTests
+{
+    private static readonly DateTimeOffset FirstJuly = new(2026, 7, 1, 8, 0, 0, TimeSpan.Zero);
+
+    private static readonly MailAccountId[] EveryServedAccount =
+    [
+        MailAccountId.Create(SyntheticEmailSummaries.DefaultAccountId),
+        MailAccountId.Create("secondary"),
+    ];
+
+    [Fact]
+    public async Task FindPassagesAsync_MailMatchingTheQuery_ReturnsOnePassagePerMessageMostRelevantFirst()
+    {
+        // Arrange
+        var mostRelevant = SyntheticEmailSummaries.Create(FirstJuly, subject: "the invoice");
+        var lessRelevant = SyntheticEmailSummaries.Create(FirstJuly.AddDays(1));
+        var index = new InMemoryEmailSearchIndex()
+            .With(lessRelevant, relevanceRank: 0.2f, matchedText: "invoice", "a later mention")
+            .With(mostRelevant, relevanceRank: 0.9f, matchedText: "invoice", "the invoice is attached");
+        var search = SearchOver(index);
+
+        // Act
+        var passages = await search.FindPassagesAsync(
+            MailboxScope.Unrestricted,
+            "invoice",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            [mostRelevant.StoredEmailId, lessRelevant.StoredEmailId],
+            passages.Select(passage => passage.StoredEmailId));
+    }
+
+    /// <summary>An answer that cannot say which message a claim came from cannot be checked.</summary>
+    [Fact]
+    public async Task FindPassagesAsync_AMatch_CarriesItsIdentityAndSourceCoordinates()
+    {
+        // Arrange
+        var matched = SyntheticEmailSummaries.Create(
+            FirstJuly,
+            accountId: "secondary",
+            folderAlias: "ARCHIVE",
+            subject: "the invoice");
+        var index = new InMemoryEmailSearchIndex().With(matched, snippets: "the invoice is attached");
+        var search = SearchOver(index);
+
+        // Act
+        var passages = await search.FindPassagesAsync(
+            MailboxScope.Unrestricted,
+            "invoice",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var passage = Assert.Single(passages);
+
+        Assert.Equal(matched.StoredEmailId, passage.StoredEmailId);
+        Assert.Equal(MailAccountId.Create("secondary"), passage.AccountId);
+        Assert.Equal(MailFolderAlias.Create("ARCHIVE"), passage.FolderAlias);
+        Assert.Equal("the invoice", passage.Subject);
+        Assert.Equal(FirstJuly, passage.ReceivedAt);
+        Assert.Equal("the invoice is attached", passage.Text);
+    }
+
+    /// <summary>The count is the bound on how many messages one question can draw on, and it is asked of the search itself.</summary>
+    [Fact]
+    public async Task FindPassagesAsync_MoreMatchesThanTheBoundAllows_AsksForOnlyThatMany()
+    {
+        // Arrange
+        var index = new InMemoryEmailSearchIndex();
+        foreach (var email in SyntheticEmailSummaries.CreateDailyRun(10, FirstJuly))
+        {
+            index.With(email, snippets: "a mention");
+        }
+
+        var search = SearchOver(index, EmailKnowledgeBounds.Create(maximumPassages: 3, maximumCharactersPerPassage: 100));
+
+        // Act
+        var passages = await search.FindPassagesAsync(
+            MailboxScope.Unrestricted,
+            "invoice",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(3, passages.Count);
+        Assert.Equal(3, Assert.Single(index.RankedCandidatesCalls).Limit);
+    }
+
+    [Fact]
+    public async Task FindPassagesAsync_AMatchLongerThanOnePassageMayCarry_CutsItToTheBound()
+    {
+        // Arrange
+        var index = new InMemoryEmailSearchIndex()
+            .With(SyntheticEmailSummaries.Create(FirstJuly), snippets: new string('a', 400));
+        var search = SearchOver(index, EmailKnowledgeBounds.Create(maximumPassages: 4, maximumCharactersPerPassage: 120));
+
+        // Act
+        var passages = await search.FindPassagesAsync(
+            MailboxScope.Unrestricted,
+            "invoice",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(120, Assert.Single(passages).Text.Length);
+    }
+
+    /// <summary>
+    /// Mail carries emoji and every script outside the basic plane. A cut through a surrogate pair leaves a lone
+    /// surrogate, which is not text: it survives no serialization the passage is about to cross.
+    /// </summary>
+    [Fact]
+    public async Task FindPassagesAsync_ACutThatWouldFallInsideACharacter_TakesTheWholeCharacterInstead()
+    {
+        // Arrange
+        var index = new InMemoryEmailSearchIndex()
+            .With(SyntheticEmailSummaries.Create(FirstJuly), snippets: new string('a', 9) + "🧾🧾");
+        var search = SearchOver(index, EmailKnowledgeBounds.Create(maximumPassages: 4, maximumCharactersPerPassage: 10));
+
+        // Act
+        var passages = await search.FindPassagesAsync(
+            MailboxScope.Unrestricted,
+            "invoice",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var text = Assert.Single(passages).Text;
+
+        Assert.Equal(9, text.Length);
+        Assert.DoesNotContain(text, char.IsSurrogate);
+    }
+
+    /// <summary>
+    /// A message matched on its subject or its participants while its body yielded no text. Sending its identity with
+    /// nothing beside it would spend a model's context on a message it cannot read a word of.
+    /// </summary>
+    [Fact]
+    public async Task FindPassagesAsync_AMatchWithNoExtracts_IsNotHandedOver()
+    {
+        // Arrange
+        var withText = SyntheticEmailSummaries.Create(FirstJuly.AddDays(1));
+        var index = new InMemoryEmailSearchIndex()
+            .With(SyntheticEmailSummaries.Create(FirstJuly), relevanceRank: 0.9f)
+            .With(withText, relevanceRank: 0.2f, matchedText: null, "a mention");
+        var search = SearchOver(index);
+
+        // Act
+        var passages = await search.FindPassagesAsync(
+            MailboxScope.Unrestricted,
+            "invoice",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(withText.StoredEmailId, Assert.Single(passages).StoredEmailId);
+    }
+
+    /// <summary>
+    /// The query is written by a model rather than by a caller who could be told to correct it, so unusable text is a
+    /// retrieval that found nothing rather than a failed run.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task FindPassagesAsync_AQueryWithNoUsableText_FindsNothingWithoutSearching(string queryText)
+    {
+        // Arrange
+        var index = new InMemoryEmailSearchIndex().With(SyntheticEmailSummaries.Create(FirstJuly), snippets: "a mention");
+        var search = SearchOver(index);
+
+        // Act
+        var passages = await search.FindPassagesAsync(
+            MailboxScope.Unrestricted,
+            queryText,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(passages);
+        Assert.Empty(index.RankedCandidatesCalls);
+    }
+
+    /// <summary>The scope decides which mail a question can be answered from, and it comes from the caller rather than the query.</summary>
+    [Fact]
+    public async Task FindPassagesAsync_AScopeNamingOneAccount_FindsNothingInAnother()
+    {
+        // Arrange
+        var index = new InMemoryEmailSearchIndex()
+            .With(SyntheticEmailSummaries.Create(FirstJuly, accountId: "secondary"), snippets: "a mention");
+        var search = SearchOver(index);
+        var scope = MailboxScope.Create([MailAccountId.Create(SyntheticEmailSummaries.DefaultAccountId)], []);
+
+        // Act
+        var passages = await search.FindPassagesAsync(scope, "invoice", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(passages);
+    }
+
+    [Fact]
+    public async Task FindPassagesAsync_AScopeNamingAFolder_ForwardsItToTheSearch()
+    {
+        // Arrange
+        var inArchive = SyntheticEmailSummaries.Create(FirstJuly, folderAlias: "ARCHIVE");
+        var index = new InMemoryEmailSearchIndex()
+            .With(SyntheticEmailSummaries.Create(FirstJuly), snippets: "an inbox mention")
+            .With(inArchive, snippets: "an archived mention");
+        var search = SearchOver(index);
+        var scope = MailboxScope.Create([], [MailFolderAlias.Create("ARCHIVE")]);
+
+        // Act
+        var passages = await search.FindPassagesAsync(scope, "invoice", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(inArchive.StoredEmailId, Assert.Single(passages).StoredEmailId);
+    }
+
+    private static MailboxKnowledgeSearch SearchOver(
+        InMemoryEmailSearchIndex index,
+        EmailKnowledgeBounds? bounds = null) => new(
+        new MailboxSearchReader(
+            index,
+            LexicalOnlySemanticSearch(),
+            FreshnessReaderReturningNothing(),
+            new MailboxScopeResolver(CatalogServing(EveryServedAccount)),
+            EmailSearchSnippetBounds.Default),
+        bounds ?? EmailKnowledgeBounds.Default);
+
+    /// <summary>Builds the semantic half of a deployment that configured no embedding provider.</summary>
+    private static SemanticEmailSearch LexicalOnlySemanticSearch() => new(
+        Substitute.For<IActiveEmbeddingProfileReader>(),
+        new InMemoryEmailVectorSearchIndex(),
+        textEmbeddingGenerator: null);
+
+    private static IMailAccountCatalog CatalogServing(params MailAccountId[] servedAccountIds)
+    {
+        var catalog = Substitute.For<IMailAccountCatalog>();
+        catalog.ServedAccountIds.Returns(
+        [
+            .. servedAccountIds.OrderBy(accountId => accountId.Value, StringComparer.Ordinal),
+        ]);
+
+        return catalog;
+    }
+
+    private static ISynchronizationFreshnessReader FreshnessReaderReturningNothing()
+    {
+        var reader = Substitute.For<ISynchronizationFreshnessReader>();
+        reader.ReadAsync(Arg.Any<MailboxScope>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<MailboxFolderFreshness>>([]));
+
+        return reader;
+    }
+}

--- a/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -6,6 +6,7 @@ using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Emails.SearchEmails;
+using MailFathom.Application.Retrieval;
 using MailFathom.Infrastructure.Persistence.Connections;
 using MailFathom.Infrastructure.Secrets.Resolution;
 using Microsoft.Extensions.DependencyInjection;
@@ -124,6 +125,33 @@ public sealed class ServiceCollectionExtensionsTests
             services,
             descriptor => descriptor.ServiceType == typeof(MailboxSearchReader)
                 && descriptor.Lifetime == ServiceLifetime.Scoped);
+    }
+
+    /// <summary>
+    /// The retrieval an answering run reaches mail through is a reading of the search above, so it is registered for
+    /// every deployment rather than only where a chat endpoint was declared: an instance that answers no questions
+    /// resolves it and never calls it, while one that does would otherwise fail to compose its agent.
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_WithoutAChatEndpoint_StillRegistersTheRetrievalAnAnsweringRunUses()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddInfrastructure(
+            _ => new PostgresConnectionSettings("Host=localhost;Database=mailfathom", null, null),
+            PostgresTextSearchConfiguration.Default);
+
+        // Assert
+        Assert.Contains(
+            services,
+            descriptor => descriptor.ServiceType == typeof(IEmailKnowledgeSearch)
+                && descriptor.Lifetime == ServiceLifetime.Scoped);
+        Assert.Contains(
+            services,
+            descriptor => descriptor.ServiceType == typeof(EmailKnowledgeBounds)
+                && descriptor.Lifetime == ServiceLifetime.Singleton);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #438

Answering a question about the mailbox is now a composed agent rather than a plan: a `ChatClientAgent` over the provider-neutral chat client, retrieving through a `TextSearchProvider` in `OnDemandFunctionCalling` mode. A question that needs no mail — "what can you do" — costs one provider call and reads no mailbox at all.

## The scope is the part worth reading

A question carries the accounts and folders it may be answered from. That scope is bound into the run when it is composed, and the tool the model is offered takes **a query and nothing else**. A model that writes `everything in the secondary account` as its query gets the caller's scope searched for those words: the scope is not part of the conversation, so nothing in the conversation can move it. Underneath, retrieval goes through the same `MailboxSearchReader` a caller reaches with `search_emails`, which restricts every query to the accounts the deployment actually serves.

## What the change adds

- **`Application/Retrieval`.** `IEmailKnowledgeSearch` answers a query within a `MailboxScope` as bounded passages, each carrying the stable message identifier and its source coordinates; `IMailQuestionAnswerer` publishes a question and an answer. `MailboxKnowledgeSearch` is the reading of the mailbox search that produces them — one bounded extract per message instead of a summary and several fragments, with everything an answer does not need dropped before a provider is reached.
- **`EmailKnowledgeBounds`.** Eight passages of at most 1200 characters, applied where the passages are built rather than where they are sent. Two numbers rather than one total, because a single total would let one enormous extract satisfy the same ceiling as a spread across several messages. Fixed in code; the configurable ceilings are #442.
- **`AI/Retrieval` and `AI/Orchestration`.** The scoped retrieval, the composition, and the run that opens a credential, a transport, and a client per question and releases all four with it.
- **`ResilientChatClient`.** A run is several calls made by a framework holding one client, so this deployment's deadline, resilience budget, failure classification, and health reporting sit inside the client rather than around a single request. Streaming is refused outright so no unbounded path to the provider exists for a later caller to find.

## Boundaries

No agent-framework type reaches `Application`, `Domain`, or `Mcp`. `McpDependencyBoundaryTests` already proved that structurally for `Mcp`; `ApplicationDependencyBoundaryTests` now does the same for the inner two by asserting their referenced assemblies.

## Privacy

No question, answer, model-written query, or retrieved passage reaches a log. A run records the endpoint alias and two counts. `TextSearchProviderOptions.EnableSensitiveTelemetryData` is set to `false` explicitly rather than left at its default, and no Agent Framework or `Microsoft.Extensions.AI` activity source is subscribed by the host, so nothing reaches a span or an exporter either.

## Not in this change, by the issue's own division

The context formatter that separates retrieved mail from instructions (#439), the `ask_mail` tool (#441), and the configurable spend ceilings (#442). The agent is composed with no instructions of its own, because the system instruction belongs to #439.

## Contract surfaces

No break. No configuration key, database column, MCP tool argument, or deployment contract moves. `Microsoft.Agents.AI` 1.15.0 was already pinned, referenced, and recorded in `THIRD_PARTY_LICENSES.md` naming `ChatClientAgent` and `TextSearchProvider` as its purpose — this is the change that uses it, so no pin, lock file, or register row moves.

## Verification

`scripts/verify-full.sh` passes: 3600 tests, aggregate line coverage 94.90%, formatting clean.
