### PR TITLE
[#477] Keep an audit trail of every mutation MailFathom made, off by default and enabled per account

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -225,6 +225,50 @@ No mail content is here. A folder path, a UID, a mutation name, and a requester 
 MailFathom's own names for things, and a failure is kept as its five-digit code rather than as the message text
 assembled at the failure site.
 
+`AuditTrailEnabled` is the one column on this row that is about something other than performing the change: it is the
+account's audit-trail setting as it stood when the intent was written down, and it decides whether the ending of this
+mutation is kept in the table below. It is stored for the reason `LocalDisposition` is — a mutation ends in a later run,
+and reading the setting there would apply whatever an operator had changed it to in the meantime, producing a history
+whose gaps look like changes nobody made.
+
+## The audit trail of finished mutations
+
+`mailbox_mutation_audit_entries` holds one row per change MailFathom **finished** making to a remote mailbox, written
+once when the mutation reaches `Completed` or `Abandoned`. It is a separate table from `mailbox_mutations` because the
+two answer different questions with different lifetimes: that one is operational state a retry reads, and its useful
+life ends when the change does; this one is written once, read by nothing the mechanism depends on, and its whole value
+is that it is still there months later when somebody asks what happened to a message. One table for both would decide
+two retention policies with one answer — operational state that is never pruned grows without bound, and history pruned
+on completion answers nothing.
+
+**Every identity on the row is a value rather than an association, and no foreign key leaves it.** That is the design
+rather than an omission. If the trail inherited the deletion path of the email it describes, then erasing that message
+would erase the record that MailFathom deleted it — which removes exactly the entry an audit of deletions exists to
+hold. So `StoredEmailId`, `MailboxAccountId`, and both folder paths are stored as values, and the entry outlives every
+one of them.
+
+| Column | What it records |
+|---|---|
+| `MutationRecordId`, unique | Which mutation this was, while that record still exists; the uniqueness is what makes a repeated append leave one entry |
+| `MailboxAccountId`, `StoredEmailId` | Whose mailbox and which local email, as values that survive both being removed |
+| `Mutation` | The change, by the name a log line and a metric already use |
+| `SourceFolderPath`, `SourceHierarchyDelimiter`, `SourceUidValidity`, `SourceUid` | The occurrence the IMAP command was aimed at, with the folder written as its remote path rather than as a key into a binding a later rebinding replaces |
+| `DestinationFolderPath`, `DestinationHierarchyDelimiter` | Where a relocation or a copy was aimed, and null for every other mutation |
+| `PlacementUidValidity`, `PlacementUid` | Where the server said it put the message, where it supplied `COPYUID` |
+| `DesiredSeenState` | Which way a `\Seen` change was asked for, and null for every other mutation |
+| `RequesterOrigin`, `RequesterIdentity` | Who asked — a rule together with the revision that matched, or one invocation |
+| `RequestedAt`, `CompletedAt` | When it was asked for and when it ended |
+| `Outcome`, `FailureCode` | `Performed`, or `Abandoned` with the five-digit code it was given up on for |
+
+Nothing amends a row. An entry states an ending that has already happened, so the table only ever grows and shrinks and
+carries no concurrency token; the two writes it takes are the append and the erasure that retention or a data-subject
+request calls for.
+
+No mail content is here either, and the omission is the same one the mutation record makes for the same reason: no
+subject, no address, no body fragment, no filename. What makes this table's version of that promise worth stating
+separately is that this one outlives the mail, so an entry that carried content would be content kept past the erasure
+of the message it came from.
+
 ## Indexes
 
 | Index | Columns | Purpose |
@@ -243,6 +287,8 @@ assembled at the failure site.
 | `ix_mailbox_mutations_identity` | `(MailFolderId, UidValidity, Uid, RequesterOrigin, RequesterIdentity, Mutation)`, unique | A mutation's idempotency identity, which is what makes the same request twice perform one change |
 | `ix_mailbox_mutations_outstanding` | `(MailboxAccountId, RecordedAt)` where the stage is not `Completed` | The changes an operator asks about: those in flight and those given up on |
 | `ix_mailbox_mutations_placement` | `(MailboxAccountId, DestinationFolderPath, PlacementUidValidity, PlacementUid)` where `PlacementObservedAt` is null | The question the forward pass asks of every batch it discovers: is one of these UIDs where a relocation or a copy put an email |
+| `ix_mailbox_mutation_audit_entries_mutation` | `(MutationRecordId)`, unique | One audit entry per mutation ending, whatever a repeated append attempts |
+| `ix_mailbox_mutation_audit_entries_account_completed` | `(MailboxAccountId, CompletedAt, Id)` | The two ways the trail is worked: a keyset-paginated page of an account's history, and the retention pass that erases what ended before a cutoff |
 
 The recipient and search-vector indexes are GIN rather than B-tree because both serve containment tests. A B-tree over an array column serves only equality against a whole array, and over a `tsvector` it serves nothing search asks for; a GIN index is what turns either into an index scan.
 
@@ -287,6 +333,8 @@ Participants, subject, and thread identifiers are personal data. They are stored
 The derived search document is not a lesser classification of the same data. Body text, the copied subject and addresses, and the search vector built from them are mail content, and none of them is anonymous merely because it was derived; they inherit the retention, access, export, and erasure obligations of the message they came from. The cascade from `stored_emails` is what makes that structural rather than a rule somebody has to remember.
 
 `mailbox_mutations` is derived personal data too, and for a reason worth stating plainly: a mutation history says where a person's mail has been and what was done to it. It therefore inherits the retention and deletion obligations of the email it describes rather than outliving it, and the cascade from `stored_emails` is what makes that structural — including where the recorded mutation was the deletion itself.
+
+`mailbox_mutation_audit_entries` is the one table on this page that deliberately does **not** inherit those obligations, and it is the only one that needs an operator's decision before it holds anything at all. It is derived personal data by the same reading — where a person's mail has been, when, and at whose instruction — and the reason it outlives the mail is that an audit of deletions whose entries are erased by the deletions they record holds nothing. What replaces the cascade is a bound of its own: the trail is off unless an account turns it on, each account states how long its entries are kept, and every account run erases what has outlived that window. A data-subject erasure reaches it separately for the same reason, and [Administrative endpoint](../operations/admin-endpoint.md#reading-what-mailfathom-changed) states that path.
 
 The same holds for `email_chunks`, and one thing about it is deliberate: a chunk records the message it came from and the span inside it, and nothing else. The account, folder, sender, recipients, date, and subject a retrieval will want to cite are reached through that message rather than copied onto the passage, so cutting mail into chunks widens no access, export, or erasure surface — it only adds rows the same cascade erases.
 

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -1,6 +1,6 @@
 # IMAP synchronization
 
-<!-- describes: src/Application/Synchronization/**, src/Domain/Synchronization/**, src/Infrastructure/Mail/** -->
+<!-- describes: src/Application/Synchronization/**, src/Domain/Synchronization/**, src/Infrastructure/Mail/**, src/Application/Mail/Mutations/**, src/Domain/Mutations/** -->
 
 MailFathom synchronizes mailboxes read-only, on a bounded schedule, and — for an account that asks for it — the moment the mail server says something changed. Both mechanisms run the same synchronization pass over the same read-only session; what differs is only what starts one.
 
@@ -302,6 +302,59 @@ The record holds no mail. A folder path, a UID, a mutation name, a requester ide
 all it carries, and it is removed with the email it describes — including when the change it recorded was that email's
 deletion. [Stored email schema](../architecture/stored-email-schema.md#recorded-mailbox-mutations) states the columns and
 the stages in full.
+
+### An account can keep a record of what was done to it, and none does by default
+
+The record above exists to make a change correct, and its useful life ends when the change does. A durable answer to
+"why is this message in this folder" months later is a different artifact with a different lifetime, so it is a second
+table: `mailbox_mutation_audit_entries`, written once when a mutation reaches a terminal stage and read by nothing the
+mechanism depends on.
+
+**It is off by default and enabled per account.** An audit trail of mail movements is derived personal data — it says
+where a person's mail has been, when, and at whose instruction — so a deployment that never asked for it never
+accumulates one. An account turns it on and states how long it keeps entries:
+
+```yaml
+Mail:
+  Synchronization:
+    Accounts:
+      - AccountId: work
+        AuditTrail:
+          Enabled: true
+          Retention: 90.00:00:00
+```
+
+The answer is resolved when a change is written down and travels on its record, so switching the trail on or off while a
+change is in flight decides nothing about a change already begun. Turning it off stops new entries and leaves the
+existing ones to age out under the window that was configured for them.
+
+**One entry per finished change, of every kind.** A relocation, a delete, a `\Seen` change, and a copy each leave one,
+naming the change, the local email, the source folder path with its UIDVALIDITY and UID, the destination folder path and
+the UID the server reported where there was one, the flag direction where the change was one, who asked — a rule with
+its revision, or one invocation — when it was asked for, when it ended, and whether it was performed or given up on with
+the failure code it was given up on for.
+
+**It holds no mail content and it outlives the mail.** No subject, no address, no body fragment, no filename: folder
+paths, identifiers, and MailFathom's own configured names are what an entry carries. It references the email by its
+local identifier rather than hanging on it, so erasing that email leaves the entry standing — including when the change
+recorded *was* the deletion, which is exactly the entry an audit of deletions exists to hold.
+
+**Writing an entry never costs a change.** The append is a commit of its own, made after the terminal stage is already
+durable, so it can neither roll back a mailbox somebody's mail server has already changed nor fail the operation that
+changed it. An append that does not happen is reported as a warning naming the account and the mutation, and counted by
+`mailfathom.mailbox.mutation.audit.refused_appends`, so a deployment that undertook to hold this history can see the
+moment it stops holding it.
+
+**Retention rides the account's own run.** Every account run erases the entries that have outlived the window the
+account configured, which makes the window honored as often as the account comes round rather than to the minute. One
+pass erases at most five thousand entries, oldest first, so an operator shortening a long window clears the backlog over
+several runs instead of one delete that locks the trail against every append behind it. A failure there never puts the
+account into backoff: retention is a storage-limitation obligation rather than a mail operation, and the next run erases
+what this one did not.
+
+The trail is read through the administrative endpoint, in bounded keyset-paginated pages filterable by account, by
+mutation, and by time; [Administrative endpoint](../operations/admin-endpoint.md#reading-what-mailfathom-changed) states
+the route, and it also states the erasure path a data-subject request is answered through.
 
 ### Marking mail read is an act, never a side effect of reading
 

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -315,13 +315,12 @@ where a person's mail has been, when, and at whose instruction — so a deployme
 accumulates one. An account turns it on and states how long it keeps entries:
 
 ```yaml
-Mail:
-  Synchronization:
-    Accounts:
-      - AccountId: work
-        AuditTrail:
-          Enabled: true
-          Retention: 90.00:00:00
+MailSynchronization:
+  Accounts:
+    - AccountId: work
+      AuditTrail:
+        Enabled: true
+        Retention: 90.00:00:00
 ```
 
 The answer is resolved when a change is written down and travels on its record, so switching the trail on or off while a

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -99,7 +99,7 @@ instruction, so a caller names whose history they are reading rather than asking
 
 ```console
 $ curl -sS -H "X-API-Key: $MAILFATHOM_ADMIN_KEY" \
-    "http://127.0.0.1:8081/api/admin/mailbox/mutations/audit?account=work&mutation=delete&pageSize=2"
+    "http://127.0.0.1:8090/api/admin/mailbox/mutations/audit?account=work&mutation=delete&pageSize=2"
 ```
 
 The response carries the entries and, while more remain, the cursor the next page is asked with. **A walk ends when no
@@ -111,6 +111,11 @@ the range, a range that ends where it begins, and a cursor this deployment did n
 
 Nothing in the answer is mail. Folder paths, UIDs, the local email identifier, the requester, the two timestamps, and
 the outcome are what an entry holds, which is what makes the route readable without exposing the message it is about.
+
+An entry a later build wrote and this one cannot interpret — one naming a change this version does not permit — is left
+out of the page rather than failing it, and a warning names the account and how many were left out. The rows stay in the
+trail and a build that permits the change reads them; what the warning exists for is that a page quietly short of
+entries would be worse than one that says so, on a surface whose whole value is being complete.
 
 **Erasing entries for a data-subject request.** Retention erases what has outlived each account's configured window, and
 that is the ordinary path. A request that reaches further — erase everything held about one person's mail now — is

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -70,6 +70,7 @@ reverse proxy, write the public URL and keep the path: `https://mail.example.tes
 | --- | --- |
 | `GET /api/admin/session` | Reports the credential that authenticated and the running version. This is what `login` and `status` ask. |
 | `POST /api/admin/mailbox/refresh-token` | Stores a mailbox refresh token for one configured account, sealed under the deployment's data-encryption key. This is what [`mfctl mailbox authorize --account`](mailbox-oauth.md#sending-the-token-to-the-deployment) sends. |
+| `GET /api/admin/mailbox/mutations/audit` | Reads one account's record of the changes MailFathom made to its mailbox, where that account [keeps one](../features/imap-synchronization.md#an-account-can-keep-a-record-of-what-was-done-to-it-and-none-does-by-default). |
 
 The write route's body carries a long-lived credential for a named mailbox owner, which is what makes the clear-text
 warning below matter more here than it does for a session probe. It refuses, with `400` and a sentence naming what was
@@ -81,6 +82,51 @@ can be read back out through it.
 Storing seals the token under the deployment's [data-encryption key](secret-provisioning.md). A deployment that
 configures no key ring cannot store one, and the route answers `500` rather than a refusal it can explain, because
 nothing about the request was wrong.
+
+### Reading what MailFathom changed
+
+The audit route serves one bounded, keyset-paginated page of one account's finished changes, newest first. The account
+is required rather than optional, and that is deliberate: the answer says where a person's mail has been and at whose
+instruction, so a caller names whose history they are reading rather than asking for a deployment-wide list.
+
+| Query parameter | What it does |
+| --- | --- |
+| `account` | Required. The configured identifier of the account whose trail is read. |
+| `mutation` | Narrows to one change: `relocate`, `delete`, `set-seen`, or `copy`. |
+| `from`, `before` | Narrows to entries that ended within a range; `from` is inclusive and `before` is exclusive. |
+| `pageSize` | Between 1 and 200; 50 when omitted. |
+| `cursor` | The `nextCursor` the previous page returned. |
+
+```console
+$ curl -sS -H "X-API-Key: $MAILFATHOM_ADMIN_KEY" \
+    "http://127.0.0.1:8081/api/admin/mailbox/mutations/audit?account=work&mutation=delete&pageSize=2"
+```
+
+The response carries the entries and, while more remain, the cursor the next page is asked with. **A walk ends when no
+cursor comes back**, never by comparing a short page against the size you asked for. A cursor names a boundary within
+the filters it was issued for, so presenting one alongside different filters is refused with `400`; changing only the
+page size is not, because pacing is not a filter. Every other refusal is `400` too, with a sentence naming what to
+change: an account this deployment does not configure, a mutation name that is not one of the four, a page size outside
+the range, a range that ends where it begins, and a cursor this deployment did not issue.
+
+Nothing in the answer is mail. Folder paths, UIDs, the local email identifier, the requester, the two timestamps, and
+the outcome are what an entry holds, which is what makes the route readable without exposing the message it is about.
+
+**Erasing entries for a data-subject request.** Retention erases what has outlived each account's configured window, and
+that is the ordinary path. A request that reaches further — erase everything held about one person's mail now — is
+answered against the table directly, because the trail deliberately survives the deletion of the mail it describes and
+therefore has no cascade to ride:
+
+```sql
+DELETE FROM mailbox_mutation_audit_entries
+WHERE "MailboxAccountId" = 'work'
+  AND "StoredEmailId" = ANY($1);
+```
+
+The identifiers are the local email identifiers the entries name, which the same account's mailbox queries return for
+the messages in scope; erasing the whole of one account's trail is the same statement without the second predicate.
+Take it as a deliberate administrative act on a database you have a backup of: nothing here replays an erasure, and the
+entries it removes are the accountability evidence for the changes they recorded.
 
 ## Rate limiting
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -109,7 +109,16 @@ shape the coordinator loop itself, which are read once at start and marked *rest
 | `…:EarliestEmailReceivedDate` | date | unset (everything) | Not in the future (compared in UTC) | reload |
 | `…:RemotelyDeletedEmailDisposition` | enum | `RetainTombstone` | `RetainTombstone`, `EraseLocalCopy` | reload; governs disappearances observed from then on |
 | `…:AuthoredDeleteEmailDisposition` | enum | `RetainLocalCopy` | `RetainLocalCopy`, `RetainTombstone`, `EraseLocalCopy`; what becomes of the local copy of mail MailFathom itself deleted, and it takes precedence over the key above for those | reload; governs deletes authored from then on |
+| `…:AuditTrail:Enabled` | bool | `false` | Whether a finished change to this account's mailbox leaves a durable audit entry | reload; governs changes authored from then on |
+| `…:AuditTrail:Retention` | TimeSpan | `90.00:00:00` | 1 day – 3650 days; how long this account's audit entries are kept | reload; the next account run erases against the new window |
 | `…:Folders` | list | inbox by role | Aliases unique; each entry below | reload |
+
+`AuditTrail` is off by default because the record it keeps is derived personal data: it says where a person's mail has
+been, when, and at whose instruction. Turning it on commits the deployment to holding that history, describing it, and
+erasing it — which is why the retention is configured beside the switch rather than left unbounded, and why turning the
+switch back off stops new entries while leaving the existing ones to age out under the window they were written under.
+[An account can keep a record of what was done to it](../features/imap-synchronization.md#an-account-can-keep-a-record-of-what-was-done-to-it-and-none-does-by-default)
+states what an entry holds and what it deliberately does not.
 
 A folder entry names `Alias` (required — your stable name for the folder) and **exactly one** of `RemotePath` (the
 server's own path) or `SpecialUse` (a role discovery resolves: `Inbox`, `Archive`, `Drafts`, `Sent`, `Junk`, `Trash`,

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -86,6 +86,14 @@ replaced whole, so a lifecycle that empties stops being reported instead of repo
 A `dead-lettered` count that stops falling is the reading worth alerting on: those are changes nothing will attempt
 again, waiting for somebody to look.
 
+One counter beside them answers a question about the record rather than about the change.
+`mailfathom.mailbox.mutation.audit.refused_appends` counts the audit entries a finished mutation owed and the trail
+could not be given, by mutation and account, alongside a warning naming the record. It is zero on a deployment that
+keeps no trail, because nothing is owed there. On one that keeps a trail it is the reading worth alerting on outright:
+the change was made and the history of it is missing, which is exactly the gap an audit cannot recover afterwards. It
+exists because writing an entry may never fail the mutation that produced it — a trail that could roll back somebody's
+mailbox would be worse than a reported hole — so swallowing the failure is only defensible while it is counted.
+
 Embedding publishes the depth of its backlog, how many messages the bound turned away, and how many messages and
 passages it embedded and how long that took, broken down by outcome and by the classification of a provider failure.
 [Automatic embedding](../features/automatic-embedding.md#what-an-operator-can-see) names each instrument and what it

--- a/src/Application/Mail/Mutations/Audit/IMailboxMutationAuditEntryStore.cs
+++ b/src/Application/Mail/Mutations/Audit/IMailboxMutationAuditEntryStore.cs
@@ -1,0 +1,63 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Mutations.Audit;
+
+namespace MailFathom.Application.Mail.Mutations.Audit;
+
+/// <summary>Keeps the audit trail of the changes MailFathom made to remote mailboxes.</summary>
+/// <remarks>
+/// The trail is append-only through this port. Nothing amends an entry, because an entry states an ending that has
+/// already happened; the only write besides an append is the erasure the account's retention or a data-subject request
+/// calls for, which removes whole entries rather than editing them.
+/// </remarks>
+public interface IMailboxMutationAuditEntryStore
+{
+    /// <summary>Appends one entry to the trail.</summary>
+    /// <param name="session">The session the append is staged in.</param>
+    /// <param name="entry">The entry to keep.</param>
+    /// <param name="cancellationToken">Cancels the staging.</param>
+    /// <returns>A task that completes once the append is staged.</returns>
+    /// <remarks>
+    /// An entry whose identity is already in the trail is left alone rather than duplicated, so a retried append after a
+    /// commit whose answer was lost keeps one entry per mutation ending.
+    /// </remarks>
+    Task AppendAsync(
+        IPersistenceSession session,
+        MailboxMutationAuditEntry entry,
+        CancellationToken cancellationToken);
+
+    /// <summary>Reads one bounded page of an account's trail, newest first.</summary>
+    /// <param name="query">The account, the filters, and the boundary the page continues from.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The page, and the cursor the following page continues from where one exists.</returns>
+    Task<MailboxMutationAuditPage> ReadPageAsync(
+        MailboxMutationAuditQuery query,
+        CancellationToken cancellationToken);
+
+    /// <summary>Erases up to a bounded number of one account's entries that ended before a given instant.</summary>
+    /// <param name="accountId">The account whose trail is aged.</param>
+    /// <param name="completedBefore">The instant entries must have ended before to be erased.</param>
+    /// <param name="limit">The greatest number of entries one call may erase.</param>
+    /// <param name="cancellationToken">Cancels the erasure.</param>
+    /// <returns>How many entries were erased, which reaching <paramref name="limit" /> means more remain.</returns>
+    /// <remarks>
+    /// <para>
+    /// It joins no session, because it is a set-based delete rather than a change to state a caller is composing. It is
+    /// idempotent: running it twice over the same window erases nothing the second time.
+    /// </para>
+    /// <para>
+    /// The bound is what keeps an operator shortening a long retention from turning one pass into a delete that locks
+    /// the table against every append behind it. What is left over is erased by the next pass, oldest first.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="limit" /> is not positive.</exception>
+    Task<int> EraseCompletedBeforeAsync(
+        MailAccountId accountId,
+        DateTimeOffset completedBefore,
+        int limit,
+        CancellationToken cancellationToken);
+}

--- a/src/Application/Mail/Mutations/Audit/IMailboxMutationAuditSettingsReader.cs
+++ b/src/Application/Mail/Mutations/Audit/IMailboxMutationAuditSettingsReader.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.Mail.Mutations.Audit;
+
+/// <summary>Answers what one account has decided about keeping a record of the changes MailFathom made to its mailbox.</summary>
+/// <remarks>
+/// It is read where a mutation is written down rather than where the mutation ends, because those are different runs and
+/// often different days. Reading it at the ending would apply whatever the operator had changed it to in the meantime,
+/// which is how a history acquires a gap that looks like a change nobody made.
+/// </remarks>
+public interface IMailboxMutationAuditSettingsReader
+{
+    /// <summary>Gets the audit trail settings configured for one account.</summary>
+    /// <param name="accountId">The account whose mailbox is being changed.</param>
+    /// <returns>The settings, which are <see cref="MailboxMutationAuditSettings.Disabled" /> for an account that configured none.</returns>
+    MailboxMutationAuditSettings GetAuditSettings(MailAccountId accountId);
+}

--- a/src/Application/Mail/Mutations/Audit/IMailboxMutationAuditTrail.cs
+++ b/src/Application/Mail/Mutations/Audit/IMailboxMutationAuditTrail.cs
@@ -1,0 +1,36 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Mail.Mutations.Audit;
+
+/// <summary>Writes the durable history one finished mutation leaves behind.</summary>
+/// <remarks>
+/// <para>
+/// It is asked of every mutation that ends, and it decides for itself whether an entry is written: the record carries
+/// the answer that was resolved when it was opened, so the caller never has to read a setting the mutation already
+/// settled.
+/// </para>
+/// <para>
+/// <strong>It fails no mutation for a reason of its own, and rolls nothing back.</strong> The change has already been
+/// made to somebody's mailbox by the time this is called, and a history that could undo it — or fail the operation that
+/// produced it — would be worse than a history with a hole in it. Every entry that does not get written is reported and
+/// counted where an operator can see it, and the mutation stands. The one thing that travels on is the caller's own
+/// cancellation, which is reported the same way before it is re-raised.
+/// </para>
+/// </remarks>
+public interface IMailboxMutationAuditTrail
+{
+    /// <summary>Appends the entry one terminal mutation record states, where the account's trail is on.</summary>
+    /// <param name="record">The mutation record, at the terminal stage it ended in.</param>
+    /// <param name="sourceFolder">The binding the source occurrence was read under, which supplies its remote path.</param>
+    /// <param name="cancellationToken">Cancels the durable write.</param>
+    /// <returns>A task that completes once the entry is durable, was refused, or was not owed at all.</returns>
+    Task RecordAsync(
+        MailboxMutationRecord record,
+        MailFolderResolution sourceFolder,
+        CancellationToken cancellationToken);
+}

--- a/src/Application/Mail/Mutations/Audit/MailboxMutationAuditCursor.cs
+++ b/src/Application/Mail/Mutations/Audit/MailboxMutationAuditCursor.cs
@@ -67,9 +67,29 @@ public readonly record struct MailboxMutationAuditCursor
     public static MailboxMutationAuditCursor After(MailboxMutationAuditEntry entry, string filterFingerprint)
     {
         ArgumentNullException.ThrowIfNull(entry);
+
+        return After(entry.CompletedAt, entry.Id, filterFingerprint);
+    }
+
+    /// <summary>Creates the cursor that continues a walk after one position in the trail.</summary>
+    /// <param name="completedAt">The completion instant the page ended on.</param>
+    /// <param name="entryId">The identity of the entry at that instant.</param>
+    /// <param name="filterFingerprint">The fingerprint of the filters the page was read under.</param>
+    /// <returns>The cursor.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="filterFingerprint" /> is blank.</exception>
+    /// <remarks>
+    /// The position is taken rather than an entry, because a page advances by the rows it read rather than by the
+    /// entries it could present. A row this build cannot interpret is left out of the page and still passed, so a walk
+    /// never stalls on one and never repeats the rows either side of it.
+    /// </remarks>
+    public static MailboxMutationAuditCursor After(
+        DateTimeOffset completedAt,
+        MailboxMutationAuditEntryId entryId,
+        string filterFingerprint)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(filterFingerprint);
 
-        return new MailboxMutationAuditCursor(entry.CompletedAt, entry.Id, filterFingerprint);
+        return new MailboxMutationAuditCursor(completedAt, entryId, filterFingerprint);
     }
 
     /// <summary>Reads a cursor a caller presented.</summary>

--- a/src/Application/Mail/Mutations/Audit/MailboxMutationAuditCursor.cs
+++ b/src/Application/Mail/Mutations/Audit/MailboxMutationAuditCursor.cs
@@ -1,0 +1,158 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+using MailFathom.Domain.Mutations.Audit;
+
+namespace MailFathom.Application.Mail.Mutations.Audit;
+
+/// <summary>Marks where one page of an audit trail ended, so the next page continues from it.</summary>
+/// <remarks>
+/// <para>
+/// The trail is ordered newest first by completion instant, with the entry identifier breaking a tie, and this pairs
+/// those two values with a fingerprint of the filters the page was read under. The pair is what makes pagination
+/// keyset-based rather than offset-based: the next page asks for entries beyond a known boundary, so a mutation
+/// finishing between two requests neither shifts a window nor causes an entry to be skipped or repeated. The fingerprint
+/// is what makes the boundary meaningful, because a position names a page edge only within the filtered set it was
+/// computed for.
+/// </para>
+/// <para>
+/// It carries no secret and needs no signature: every value in it is one the caller already supplied or already
+/// received. Encoding is about opacity rather than protection — a client that cannot read a cursor does not build one,
+/// and a built cursor is how a caller would ask for a boundary this system never computed.
+/// </para>
+/// </remarks>
+public readonly record struct MailboxMutationAuditCursor
+{
+    /// <summary>The greatest number of characters an encoded cursor may carry before it is refused unread.</summary>
+    public const int MaximumEncodedLength = 512;
+
+    /// <summary>
+    /// The encoded form's version. It leads the payload so a later change to the fields refuses the cursors this version
+    /// issued instead of misreading them.
+    /// </summary>
+    private const string FormatVersion = "1";
+
+    /// <summary>Separates the encoded fields, chosen because it appears in none of them.</summary>
+    private const char FieldSeparator = '.';
+
+    private MailboxMutationAuditCursor(
+        DateTimeOffset completedAt,
+        MailboxMutationAuditEntryId entryId,
+        string filterFingerprint)
+    {
+        this.CompletedAt = completedAt;
+        this.EntryId = entryId;
+        this.FilterFingerprint = filterFingerprint;
+    }
+
+    /// <summary>Gets the completion instant of the last entry the page returned.</summary>
+    public DateTimeOffset CompletedAt { get; }
+
+    /// <summary>Gets the identity of that entry, which breaks a tie between two that finished together.</summary>
+    public MailboxMutationAuditEntryId EntryId { get; }
+
+    /// <summary>Gets the fingerprint of the filters this cursor was issued for.</summary>
+    public string FilterFingerprint { get; }
+
+    /// <summary>Creates the cursor that continues a walk after one entry.</summary>
+    /// <param name="entry">The last entry the page returned.</param>
+    /// <param name="filterFingerprint">The fingerprint of the filters the page was read under.</param>
+    /// <returns>The cursor.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="entry" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="filterFingerprint" /> is blank.</exception>
+    public static MailboxMutationAuditCursor After(MailboxMutationAuditEntry entry, string filterFingerprint)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filterFingerprint);
+
+        return new MailboxMutationAuditCursor(entry.CompletedAt, entry.Id, filterFingerprint);
+    }
+
+    /// <summary>Reads a cursor a caller presented.</summary>
+    /// <param name="text">The encoded cursor, as a previous page returned it.</param>
+    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise the struct default.</param>
+    /// <returns><see langword="true" /> when the text decoded into a usable cursor; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// Whether a decoded cursor belongs to the current request is a separate question its
+    /// <see cref="FilterFingerprint" /> answers, and one this method deliberately does not ask.
+    /// </remarks>
+    public static bool TryDecode(string? text, out MailboxMutationAuditCursor cursor)
+    {
+        cursor = default;
+
+        if (text is null || text.Length is 0 or > MaximumEncodedLength)
+        {
+            return false;
+        }
+
+        // Validity is checked separately because the decoder's Try form reports only that a destination was too small
+        // and throws on text that is not base64url at all, which is the shape a caller most easily presents.
+        if (!Base64Url.IsValid(text))
+        {
+            return false;
+        }
+
+        Span<byte> decoded = stackalloc byte[Base64Url.GetMaxDecodedLength(MaximumEncodedLength)];
+        if (!Base64Url.TryDecodeFromChars(text, decoded, out var decodedLength))
+        {
+            return false;
+        }
+
+        var fields = Encoding.UTF8.GetString(decoded[..decodedLength]).Split(FieldSeparator);
+
+        if (fields is not [FormatVersion, var completedField, var identifierField, var fingerprintField]
+            || !TryReadCompletedAt(completedField, out var completedAt)
+            || !Guid.TryParseExact(identifierField, "N", out var identifier)
+            || identifier == Guid.Empty
+            || fingerprintField.Length is 0)
+        {
+            return false;
+        }
+
+        cursor = new MailboxMutationAuditCursor(
+            completedAt,
+            MailboxMutationAuditEntryId.Create(identifier),
+            fingerprintField);
+
+        return true;
+    }
+
+    /// <summary>Writes the cursor as the opaque string a caller presents to continue the walk.</summary>
+    /// <returns>The encoded cursor.</returns>
+    /// <remarks>
+    /// The completion instant is written as its UTC tick count, which is the form the order compares: two timestamps
+    /// naming the same instant in different offsets encode identically.
+    /// </remarks>
+    public string Encode()
+    {
+        var payload = string.Join(
+            FieldSeparator,
+            FormatVersion,
+            this.CompletedAt.UtcTicks.ToString(CultureInfo.InvariantCulture),
+            this.EntryId.Value.ToString("N", CultureInfo.InvariantCulture),
+            this.FilterFingerprint);
+
+        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
+    }
+
+    private static bool TryReadCompletedAt(string field, out DateTimeOffset completedAt)
+    {
+        completedAt = default;
+
+        // NumberStyles.None refuses a sign, so no negative tick count reaches the range check below.
+        if (!long.TryParse(field, NumberStyles.None, CultureInfo.InvariantCulture, out var utcTicks)
+            || utcTicks < DateTime.MinValue.Ticks
+            || utcTicks > DateTime.MaxValue.Ticks)
+        {
+            return false;
+        }
+
+        completedAt = new DateTimeOffset(utcTicks, TimeSpan.Zero);
+
+        return true;
+    }
+}

--- a/src/Application/Mail/Mutations/Audit/MailboxMutationAuditPage.cs
+++ b/src/Application/Mail/Mutations/Audit/MailboxMutationAuditPage.cs
@@ -1,0 +1,19 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Mutations.Audit;
+
+namespace MailFathom.Application.Mail.Mutations.Audit;
+
+/// <summary>Carries one bounded page of an account's audit trail and the boundary the next page continues from.</summary>
+/// <param name="Entries">The entries, newest first.</param>
+/// <param name="NextCursor">The cursor a caller presents for the following page, or <see langword="null" /> when this page reached the end of the trail.</param>
+/// <remarks>
+/// The absent cursor is the end of the walk rather than a page that happened to be short: a page is only ever short
+/// because the filtered trail held nothing more, so a caller stops when the cursor stops instead of comparing the count
+/// against the size it asked for.
+/// </remarks>
+public sealed record MailboxMutationAuditPage(
+    IReadOnlyList<MailboxMutationAuditEntry> Entries,
+    MailboxMutationAuditCursor? NextCursor);

--- a/src/Application/Mail/Mutations/Audit/MailboxMutationAuditQuery.cs
+++ b/src/Application/Mail/Mutations/Audit/MailboxMutationAuditQuery.cs
@@ -1,0 +1,150 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Mail.Mutations.Audit;
+
+/// <summary>Asks one bounded, keyset-paginated page of an account's audit trail.</summary>
+/// <remarks>
+/// <para>
+/// The account is required rather than optional, and every other filter narrows within it. Enabling the trail, its
+/// retention, and its erasure are all decisions one account's operator makes, so reading it is scoped the same way — and
+/// a surface over derived personal data is better for making a caller name whose mail they are looking at than for
+/// serving a deployment-wide list nobody asked a question about.
+/// </para>
+/// <para>
+/// A page is always bounded and always ordered newest first, so a caller that supplies nothing gets the most recent
+/// <see cref="DefaultPageSize" /> entries rather than the whole trail.
+/// </para>
+/// </remarks>
+public sealed record MailboxMutationAuditQuery
+{
+    /// <summary>The page size a request that names none is served.</summary>
+    public const int DefaultPageSize = 50;
+
+    /// <summary>The greatest page size one request may ask for.</summary>
+    public const int MaximumPageSize = 200;
+
+    /// <summary>Separates the fingerprint's fields, chosen because no filter value can contain it.</summary>
+    private const char FingerprintFieldSeparator = '\u001f';
+
+    /// <summary>How many hexadecimal characters of the filter digest a cursor carries.</summary>
+    /// <remarks>
+    /// Short because it distinguishes one caller's own filter sets rather than resisting a search for a collision: a
+    /// forged fingerprint buys a boundary inside a page that same caller is already entitled to read.
+    /// </remarks>
+    private const int FingerprintLength = 16;
+
+    private MailboxMutationAuditQuery(
+        MailAccountId accountId,
+        MailboxMutation mutation,
+        DateTimeOffset? completedFrom,
+        DateTimeOffset? completedBefore,
+        int pageSize,
+        MailboxMutationAuditCursor? cursor)
+    {
+        this.AccountId = accountId;
+        this.Mutation = mutation;
+        this.CompletedFrom = completedFrom;
+        this.CompletedBefore = completedBefore;
+        this.PageSize = pageSize;
+        this.Cursor = cursor;
+    }
+
+    /// <summary>Gets the account whose trail is read.</summary>
+    public MailAccountId AccountId { get; }
+
+    /// <summary>Gets the mutation the page is narrowed to, or the unspecified default when every mutation is served.</summary>
+    public MailboxMutation Mutation { get; }
+
+    /// <summary>Gets the earliest completion instant served, inclusive, or <see langword="null" /> when the page reaches back as far as the trail does.</summary>
+    public DateTimeOffset? CompletedFrom { get; }
+
+    /// <summary>Gets the completion instant the page stops before, exclusive, or <see langword="null" /> when it reaches the newest entry.</summary>
+    public DateTimeOffset? CompletedBefore { get; }
+
+    /// <summary>Gets how many entries the page holds at most.</summary>
+    public int PageSize { get; }
+
+    /// <summary>Gets the boundary a continued walk reads beyond, or <see langword="null" /> for the first page.</summary>
+    public MailboxMutationAuditCursor? Cursor { get; }
+
+    /// <summary>Gets the fingerprint of the filters this query reads under, which its cursors are issued against.</summary>
+    /// <remarks>
+    /// The page size is deliberately not part of it. A caller may ask for a shorter or longer page while continuing the
+    /// same walk, and refusing that would be a rule about pacing rather than about which entries the boundary sits in.
+    /// </remarks>
+    public string FilterFingerprint => ComputeFingerprint(
+        this.AccountId,
+        this.Mutation,
+        this.CompletedFrom,
+        this.CompletedBefore);
+
+    /// <summary>Builds a validated query from what a caller asked for, or reports why the request names no page.</summary>
+    /// <param name="accountId">The account whose trail is read.</param>
+    /// <param name="mutation">The mutation to narrow to, or the unspecified default for every mutation.</param>
+    /// <param name="completedFrom">The earliest completion instant served, inclusive, or <see langword="null" /> for none.</param>
+    /// <param name="completedBefore">The completion instant to stop before, exclusive, or <see langword="null" /> for none.</param>
+    /// <param name="pageSize">How many entries the page may hold, or <see langword="null" /> for <see cref="DefaultPageSize" />.</param>
+    /// <param name="cursor">The boundary a continued walk reads beyond, or <see langword="null" /> for the first page.</param>
+    /// <returns>The accepted query, or the refusal naming what the caller has to change.</returns>
+    public static MailboxMutationAuditQueryResult Create(
+        MailAccountId accountId,
+        MailboxMutation mutation,
+        DateTimeOffset? completedFrom,
+        DateTimeOffset? completedBefore,
+        int? pageSize,
+        MailboxMutationAuditCursor? cursor)
+    {
+        var resolvedPageSize = pageSize ?? DefaultPageSize;
+
+        if (resolvedPageSize is < 1 or > MaximumPageSize)
+        {
+            return MailboxMutationAuditQueryResult.Refused(MailboxMutationAuditQueryOutcome.PageSizeOutOfRange);
+        }
+
+        if (completedFrom is { } from && completedBefore is { } before && from >= before)
+        {
+            return MailboxMutationAuditQueryResult.Refused(MailboxMutationAuditQueryOutcome.TimeRangeEmpty);
+        }
+
+        var query = new MailboxMutationAuditQuery(
+            accountId,
+            mutation,
+            completedFrom,
+            completedBefore,
+            resolvedPageSize,
+            cursor);
+
+        if (cursor is { } presentedCursor
+            && !string.Equals(presentedCursor.FilterFingerprint, query.FilterFingerprint, StringComparison.Ordinal))
+        {
+            return MailboxMutationAuditQueryResult.Refused(MailboxMutationAuditQueryOutcome.CursorFilterMismatch);
+        }
+
+        return MailboxMutationAuditQueryResult.Accepted(query);
+    }
+
+    /// <summary>Reduces the filters to the short stable text a cursor carries to prove it belongs to this walk.</summary>
+    private static string ComputeFingerprint(
+        MailAccountId accountId,
+        MailboxMutation mutation,
+        DateTimeOffset? completedFrom,
+        DateTimeOffset? completedBefore)
+    {
+        var material = string.Join(
+            FingerprintFieldSeparator,
+            accountId.Value,
+            mutation.IsSpecified ? mutation.Name : string.Empty,
+            completedFrom?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
+            completedBefore?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
+
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..FingerprintLength];
+    }
+}

--- a/src/Application/Mail/Mutations/Audit/MailboxMutationAuditQueryResult.cs
+++ b/src/Application/Mail/Mutations/Audit/MailboxMutationAuditQueryResult.cs
@@ -1,0 +1,72 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Mail.Mutations.Audit;
+
+/// <summary>States whether a request named a page of an audit trail, and what stopped it when it did not.</summary>
+public enum MailboxMutationAuditQueryOutcome
+{
+    /// <summary>The request names a page, and the query is present.</summary>
+    Accepted = 0,
+
+    /// <summary>The page size asked for lies outside the range the trail serves.</summary>
+    PageSizeOutOfRange = 1,
+
+    /// <summary>The time range ends at or before it begins, so it names no entries.</summary>
+    TimeRangeEmpty = 2,
+
+    /// <summary>The continuation cursor was issued for a different set of filters than the request carries.</summary>
+    CursorFilterMismatch = 3,
+}
+
+/// <summary>Carries the query a request named, or the reason it named none.</summary>
+/// <remarks>
+/// A refusal is a result rather than an exception because the immediate caller acts on it and continues: the
+/// administrative endpoint turns it into a <c>400</c> naming what the caller has to change, and nothing above that has
+/// to decide what a malformed page request means.
+/// </remarks>
+public sealed record MailboxMutationAuditQueryResult
+{
+    private MailboxMutationAuditQueryResult(
+        MailboxMutationAuditQueryOutcome outcome,
+        MailboxMutationAuditQuery? query)
+    {
+        this.Outcome = outcome;
+        this.Query = query;
+    }
+
+    /// <summary>Gets what happened.</summary>
+    public MailboxMutationAuditQueryOutcome Outcome { get; }
+
+    /// <summary>Gets the query, which is present exactly when <see cref="Outcome" /> is <see cref="MailboxMutationAuditQueryOutcome.Accepted" />.</summary>
+    public MailboxMutationAuditQuery? Query { get; }
+
+    /// <summary>Reports a request that names a page.</summary>
+    /// <param name="query">The validated query.</param>
+    /// <returns>An accepted result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="query" /> is <see langword="null" />.</exception>
+    public static MailboxMutationAuditQueryResult Accepted(MailboxMutationAuditQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        return new MailboxMutationAuditQueryResult(MailboxMutationAuditQueryOutcome.Accepted, query);
+    }
+
+    /// <summary>Reports a request that names no page.</summary>
+    /// <param name="outcome">What the caller has to change.</param>
+    /// <returns>A refused result.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="outcome" /> names an acceptance rather than a refusal.</exception>
+    public static MailboxMutationAuditQueryResult Refused(MailboxMutationAuditQueryOutcome outcome)
+    {
+        if (outcome == MailboxMutationAuditQueryOutcome.Accepted || !Enum.IsDefined(outcome))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(outcome),
+                outcome,
+                "A refused audit trail query must name a declared refusal.");
+        }
+
+        return new MailboxMutationAuditQueryResult(outcome, query: null);
+    }
+}

--- a/src/Application/Mail/Mutations/Audit/MailboxMutationAuditSettings.cs
+++ b/src/Application/Mail/Mutations/Audit/MailboxMutationAuditSettings.cs
@@ -1,0 +1,34 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Mail.Mutations.Audit;
+
+/// <summary>States what one account has decided about keeping a record of the changes MailFathom made to its mailbox.</summary>
+/// <param name="IsEnabled">Whether a finished mutation on this account leaves an audit entry behind.</param>
+/// <param name="Retention">How long an entry of this account's is kept before it is erased.</param>
+/// <remarks>
+/// <para>
+/// The two travel together because neither answers the accountability question on its own. A trail nobody turned on
+/// holds nothing to describe, and a trail with no bound on it is a growing store of derived personal data that no
+/// operator undertook to keep — so a deployment that decides to hold the record decides how long it holds it in the same
+/// breath.
+/// </para>
+/// <para>
+/// <see cref="Disabled" /> is what an account that configured nothing gets. The default is off rather than on because
+/// the entry says where a person's mail has been and at whose instruction, and data minimization by default means an
+/// installation that never asked for that never accumulates it.
+/// </para>
+/// </remarks>
+public sealed record MailboxMutationAuditSettings(bool IsEnabled, TimeSpan Retention)
+{
+    /// <summary>Gets the settings of an account that has not turned the trail on, which is every account by default.</summary>
+    /// <remarks>
+    /// The retention is <see cref="TimeSpan.Zero" />, which names no window and erases nothing. That is the honest
+    /// answer for an account this deployment does not configure: there is no operator decision to apply, and reading the
+    /// absence as "erase immediately" would destroy a trail on the strength of a missing configuration section. An
+    /// account that turns the trail off keeps the window it configured, so its existing entries age out as they were
+    /// always going to.
+    /// </remarks>
+    public static MailboxMutationAuditSettings Disabled { get; } = new(IsEnabled: false, TimeSpan.Zero);
+}

--- a/src/Application/Mail/Mutations/Audit/MailboxMutationAuditTrailRetention.cs
+++ b/src/Application/Mail/Mutations/Audit/MailboxMutationAuditTrailRetention.cs
@@ -1,0 +1,87 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.Mail.Mutations.Audit;
+
+/// <summary>Ages one account's audit trail out at the window that account configured.</summary>
+/// <remarks>
+/// <para>
+/// A trail that is never pruned is a store of derived personal data growing without an end anybody undertook to hold it
+/// to, which is the storage-limitation half of what enabling the trail commits an operator to. The window is the
+/// account's own, so a deployment holding one mailbox for accountability and another for convenience answers for each
+/// separately.
+/// </para>
+/// <para>
+/// It runs on the account's own synchronization run rather than on a worker of its own, for the reason convergence does:
+/// an account already has a loop that comes round, and a second schedule would be a second thing to configure, watch,
+/// and reason about for work that is one bounded delete.
+/// </para>
+/// <para>
+/// The window is read from the account's current configuration rather than from the entries. Retention is a decision
+/// about what the deployment is willing to keep now, unlike the enablement an in-flight mutation carries with it, and an
+/// operator who shortens it means the entries already written as much as the ones still to come.
+/// </para>
+/// </remarks>
+public sealed class MailboxMutationAuditTrailRetention
+{
+    /// <summary>The greatest number of entries one pass erases.</summary>
+    /// <remarks>
+    /// It is a constant rather than a setting because nothing an operator would tune depends on it: a pass that reaches
+    /// the bound is followed by another on the account's next run, so the number decides how long a backlog takes to
+    /// clear rather than what is kept. What it exists for is the one case that produces a backlog at all — an operator
+    /// shortening a long window — where an unbounded delete would lock the trail against every append behind it.
+    /// </remarks>
+    public const int MaximumEntriesErasedPerPass = 5_000;
+
+    private readonly IMailboxMutationAuditSettingsReader settingsReader;
+    private readonly IMailboxMutationAuditEntryStore store;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes the retention pass from the account's settings and the trail it erases from.</summary>
+    /// <param name="settingsReader">Supplies the window one account keeps its entries for.</param>
+    /// <param name="store">Holds the trail the pass erases from.</param>
+    /// <param name="timeProvider">Measures the window back from now.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
+    public MailboxMutationAuditTrailRetention(
+        IMailboxMutationAuditSettingsReader settingsReader,
+        IMailboxMutationAuditEntryStore store,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(settingsReader);
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.settingsReader = settingsReader;
+        this.store = store;
+        this.timeProvider = timeProvider;
+    }
+
+    /// <summary>Erases everything in one account's trail that has outlived the window it configured.</summary>
+    /// <param name="accountId">The account whose trail is aged.</param>
+    /// <param name="cancellationToken">Cancels the erasure.</param>
+    /// <returns>How many entries were erased.</returns>
+    /// <remarks>
+    /// It runs whether or not the trail is currently on, because an account that has just been switched off still holds
+    /// the entries written while it was on and those are what the window was configured for. A window of zero or less
+    /// names no boundary at all and erases nothing, which is what an account this deployment no longer configures
+    /// reports.
+    /// </remarks>
+    public Task<int> EraseExpiredAsync(MailAccountId accountId, CancellationToken cancellationToken)
+    {
+        var retention = this.settingsReader.GetAuditSettings(accountId).Retention;
+
+        if (retention <= TimeSpan.Zero)
+        {
+            return Task.FromResult(0);
+        }
+
+        return this.store.EraseCompletedBeforeAsync(
+            accountId,
+            this.timeProvider.GetUtcNow() - retention,
+            MaximumEntriesErasedPerPass,
+            cancellationToken);
+    }
+}

--- a/src/Application/Mail/Mutations/Convergence/MailboxMutationConverger.cs
+++ b/src/Application/Mail/Mutations/Convergence/MailboxMutationConverger.cs
@@ -3,10 +3,10 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Failures;
-using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Transport;
 
 namespace MailFathom.Application.Mail.Mutations.Convergence;
@@ -44,6 +44,7 @@ public sealed class MailboxMutationConverger
     private readonly IMailboxMutationPerformer performer;
     private readonly IMailTransportSecurityPolicyReader transportSecurityPolicyReader;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly IMailboxMutationAuditTrail auditTrail;
     private readonly MailboxConvergenceOptions options;
     private readonly TimeProvider timeProvider;
 
@@ -52,6 +53,7 @@ public sealed class MailboxMutationConverger
     /// <param name="performer">Resumes a mutation from the stage its record names.</param>
     /// <param name="transportSecurityPolicyReader">Supplies the connection and authentication policy every attempt obeys.</param>
     /// <param name="commitPolicy">Commits the record movements this class makes without the performer.</param>
+    /// <param name="auditTrail">Keeps the history a finished mutation leaves behind, where the account asked for one.</param>
     /// <param name="options">Bounds one pass and carries the unknown-outcome grace period.</param>
     /// <param name="timeProvider">Measures how long an unresolved outcome has been unresolved.</param>
     /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
@@ -61,6 +63,7 @@ public sealed class MailboxMutationConverger
         IMailboxMutationPerformer performer,
         IMailTransportSecurityPolicyReader transportSecurityPolicyReader,
         OptimisticConcurrencyRetryPolicy commitPolicy,
+        IMailboxMutationAuditTrail auditTrail,
         MailboxConvergenceOptions options,
         TimeProvider timeProvider)
     {
@@ -68,6 +71,7 @@ public sealed class MailboxMutationConverger
         ArgumentNullException.ThrowIfNull(performer);
         ArgumentNullException.ThrowIfNull(transportSecurityPolicyReader);
         ArgumentNullException.ThrowIfNull(commitPolicy);
+        ArgumentNullException.ThrowIfNull(auditTrail);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(timeProvider);
         ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxMutationsPerPass, 1, nameof(options));
@@ -77,6 +81,7 @@ public sealed class MailboxMutationConverger
         this.performer = performer;
         this.transportSecurityPolicyReader = transportSecurityPolicyReader;
         this.commitPolicy = commitPolicy;
+        this.auditTrail = auditTrail;
         this.options = options;
         this.timeProvider = timeProvider;
     }
@@ -153,7 +158,7 @@ public sealed class MailboxMutationConverger
         {
             if (candidate.Record.HasUnknownOutcome)
             {
-                await this.SettleUnknownOutcomeAsync(candidate.Record, tally, cancellationToken);
+                await this.SettleUnknownOutcomeAsync(candidate, tally, cancellationToken);
 
                 return;
             }
@@ -207,11 +212,17 @@ public sealed class MailboxMutationConverger
     /// </para>
     /// </remarks>
     private async Task SettleUnknownOutcomeAsync(
-        MailboxMutationRecord record,
+        OutstandingMailboxMutation candidate,
         ConvergenceTally tally,
         CancellationToken cancellationToken)
     {
-        var journal = new MailboxMutationJournal(this.store, this.commitPolicy, record);
+        var record = candidate.Record;
+        var journal = new MailboxMutationJournal(
+            this.store,
+            this.commitPolicy,
+            this.auditTrail,
+            record,
+            candidate.Folder);
 
         if (record.IsUnknownPlacementSettledBySourceRemoval)
         {

--- a/src/Application/Mail/Mutations/MailboxMutationJournal.cs
+++ b/src/Application/Mail/Mutations/MailboxMutationJournal.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
 
 namespace MailFathom.Application.Mail.Mutations;
@@ -21,44 +23,52 @@ namespace MailFathom.Application.Mail.Mutations;
 /// attempted once. A concurrent reader of the same account's mutations is ordinary, and losing a race is not a reason to
 /// leave a stage unwritten.
 /// </para>
+/// <para>
+/// Being that single writer is also why the audit trail is appended from here rather than from the callers. The two
+/// terminal stages are reached from four places between the performer and convergence, and an entry owed by one of them
+/// and not written by another would be a history whose gaps mean nothing. The append happens after the terminal stage is
+/// durable and cannot fail the mutation, which <see cref="IMailboxMutationAuditTrail" /> states in full.
+/// </para>
 /// </remarks>
 internal sealed class MailboxMutationJournal : IMailboxMutationJournal
 {
     private readonly IMailboxMutationRecordStore store;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly IMailboxMutationAuditTrail auditTrail;
+    private readonly MailFolderResolution sourceFolder;
+    private MailboxMutationRecord record;
 
     internal MailboxMutationJournal(
         IMailboxMutationRecordStore store,
         OptimisticConcurrencyRetryPolicy commitPolicy,
-        MailboxMutationRecord record)
+        IMailboxMutationAuditTrail auditTrail,
+        MailboxMutationRecord record,
+        MailFolderResolution sourceFolder)
     {
         this.store = store;
         this.commitPolicy = commitPolicy;
-        this.RecordId = record.Id;
-        this.Stage = record.Stage;
-        this.Placement = record.Placement;
-        this.RequiresSourceRemoval = record.RequiresSourceRemoval;
-        this.AttemptCount = record.AttemptCount;
-        this.LastFailure = record.LastFailure;
+        this.auditTrail = auditTrail;
+        this.record = record;
+        this.sourceFolder = sourceFolder;
     }
 
     /// <summary>Gets the record every write here names.</summary>
-    internal MailboxMutationRecordId RecordId { get; }
+    internal MailboxMutationRecordId RecordId => this.record.Id;
 
     /// <inheritdoc />
-    public MailboxMutationStage Stage { get; private set; }
+    public MailboxMutationStage Stage => this.record.Stage;
 
     /// <inheritdoc />
-    public RemoteEmailPlacement Placement { get; private set; }
+    public RemoteEmailPlacement Placement => this.record.Placement;
 
     /// <inheritdoc />
-    public bool RequiresSourceRemoval { get; private set; }
+    public bool RequiresSourceRemoval => this.record.RequiresSourceRemoval;
 
     /// <summary>Gets how many attempts the record has counted, including one this journal has just counted.</summary>
-    internal int AttemptCount { get; private set; }
+    internal int AttemptCount => this.record.AttemptCount;
 
     /// <summary>Gets the failure the last attempt ended in, or <see langword="null" /> while none has.</summary>
-    internal MailFathomErrorCode? LastFailure { get; private set; }
+    internal MailFathomErrorCode? LastFailure => this.record.LastFailure;
 
     /// <inheritdoc />
     public async Task PlacementIssuedAsync(bool requiresSourceRemoval, CancellationToken cancellationToken)
@@ -71,8 +81,11 @@ internal sealed class MailboxMutationJournal : IMailboxMutationJournal
                 token),
             cancellationToken);
 
-        this.Stage = MailboxMutationStage.PlacementIssued;
-        this.RequiresSourceRemoval = requiresSourceRemoval;
+        this.record = this.record with
+        {
+            Stage = MailboxMutationStage.PlacementIssued,
+            RequiresSourceRemoval = requiresSourceRemoval,
+        };
     }
 
     /// <inheritdoc />
@@ -90,12 +103,16 @@ internal sealed class MailboxMutationJournal : IMailboxMutationJournal
     /// <summary>Counts one attempt before it is made, so an attempt that never returns still counted.</summary>
     internal async Task CountAttemptAsync(CancellationToken cancellationToken)
     {
+        var countedAttempts = 0;
+
         await this.commitPolicy.CommitAsync(
             async (session, token) =>
             {
-                this.AttemptCount = await this.store.CountAttemptAsync(session, this.RecordId, token);
+                countedAttempts = await this.store.CountAttemptAsync(session, this.RecordId, token);
             },
             cancellationToken);
+
+        this.record = this.record with { AttemptCount = countedAttempts };
     }
 
     /// <summary>Ends the record in the stage that says the change was made.</summary>
@@ -116,7 +133,7 @@ internal sealed class MailboxMutationJournal : IMailboxMutationJournal
             (session, token) => this.store.RecordFailureAsync(session, this.RecordId, failure, token),
             cancellationToken);
 
-        this.LastFailure = failure;
+        this.record = this.record with { LastFailure = failure };
     }
 
     private async Task AdvanceAsync(
@@ -128,11 +145,15 @@ internal sealed class MailboxMutationJournal : IMailboxMutationJournal
             (session, token) => this.store.AdvanceAsync(session, this.RecordId, stage, placement, token),
             cancellationToken);
 
-        this.Stage = stage;
-
-        if (placement is not null)
+        this.record = this.record with
         {
-            this.Placement = placement;
+            Stage = stage,
+            Placement = placement ?? this.record.Placement,
+        };
+
+        if (this.record.IsTerminal)
+        {
+            await this.auditTrail.RecordAsync(this.record, this.sourceFolder, cancellationToken);
         }
     }
 }

--- a/src/Application/Mail/Mutations/MailboxMutationPerformer.cs
+++ b/src/Application/Mail/Mutations/MailboxMutationPerformer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
@@ -29,12 +30,14 @@ public sealed class MailboxMutationPerformer : IMailboxMutationPerformer
     private readonly IMailboxMutationRecordStore store;
     private readonly IMailboxWriteSessionFactory writeSessionFactory;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly IMailboxMutationAuditTrail auditTrail;
     private readonly int maximumAttempts;
 
     /// <summary>Initializes the performer from the record store, the write session it acts through, and its attempt bound.</summary>
     /// <param name="store">Keeps the durable record every mutation is written to.</param>
     /// <param name="writeSessionFactory">Opens the one session able to change a mailbox.</param>
     /// <param name="commitPolicy">Commits the record's first write, retrying an optimistic conflict.</param>
+    /// <param name="auditTrail">Keeps the history a finished mutation leaves behind, where the account asked for one.</param>
     /// <param name="options">Supplies how many attempts one mutation may spend.</param>
     /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the configured attempt bound is below one.</exception>
@@ -42,17 +45,20 @@ public sealed class MailboxMutationPerformer : IMailboxMutationPerformer
         IMailboxMutationRecordStore store,
         IMailboxWriteSessionFactory writeSessionFactory,
         OptimisticConcurrencyRetryPolicy commitPolicy,
+        IMailboxMutationAuditTrail auditTrail,
         MailboxMutationOptions options)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(writeSessionFactory);
         ArgumentNullException.ThrowIfNull(commitPolicy);
+        ArgumentNullException.ThrowIfNull(auditTrail);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentOutOfRangeException.ThrowIfLessThan(options.MaximumAttempts, 1, nameof(options));
 
         this.store = store;
         this.writeSessionFactory = writeSessionFactory;
         this.commitPolicy = commitPolicy;
+        this.auditTrail = auditTrail;
         this.maximumAttempts = options.MaximumAttempts;
     }
 
@@ -74,13 +80,13 @@ public sealed class MailboxMutationPerformer : IMailboxMutationPerformer
         {
             if (settledOutcome.Status == MailboxMutationStatus.OutcomeUnknown)
             {
-                await this.RecordUnknownOutcomeAsync(record, cancellationToken);
+                await this.RecordUnknownOutcomeAsync(record, folder, cancellationToken);
             }
 
             return settledOutcome;
         }
 
-        var journal = new MailboxMutationJournal(this.store, this.commitPolicy, record);
+        var journal = this.OpenJournal(record, folder);
 
         // The bound is checked before the attempt is counted, so a mutation whose every attempt crashed the process
         // reaches its terminal stage on the next run rather than counting a further attempt it will not survive either.
@@ -144,16 +150,23 @@ public sealed class MailboxMutationPerformer : IMailboxMutationPerformer
     /// so an operator reading the outstanding mutations would see it as merely old. It is written once: a record that
     /// already names this failure is left alone, so asking repeatedly costs no write.
     /// </remarks>
-    private async Task RecordUnknownOutcomeAsync(MailboxMutationRecord record, CancellationToken cancellationToken)
+    private async Task RecordUnknownOutcomeAsync(
+        MailboxMutationRecord record,
+        MailFolderResolution folder,
+        CancellationToken cancellationToken)
     {
         if (record.LastFailure == MailFathomErrorCode.MailboxMutationOutcomeUnknown)
         {
             return;
         }
 
-        await new MailboxMutationJournal(this.store, this.commitPolicy, record)
+        await this.OpenJournal(record, folder)
             .RecordFailureAsync(MailFathomErrorCode.MailboxMutationOutcomeUnknown, cancellationToken);
     }
+
+    /// <summary>Opens the single writer of one record, which is also what appends its audit entry when it ends.</summary>
+    private MailboxMutationJournal OpenJournal(MailboxMutationRecord record, MailFolderResolution folder) =>
+        new(this.store, this.commitPolicy, this.auditTrail, record, folder);
 
     private async Task<MailboxMutationOutcome> AttemptAsync(
         MailboxMutationRequest request,

--- a/src/Domain/Mutations/Audit/MailboxMutationAuditEntry.cs
+++ b/src/Domain/Mutations/Audit/MailboxMutationAuditEntry.cs
@@ -1,0 +1,163 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Domain.Mutations.Audit;
+
+/// <summary>States one change MailFathom finished making to a mailbox, in the form that outlives the mail it changed.</summary>
+/// <remarks>
+/// <para>
+/// This is the opposite artifact from <see cref="MailboxMutationRecord" /> and shares nothing but its source. The record
+/// exists to make a mutation correct — it carries the idempotency identity, the stage a retry resumes from, and the
+/// provenance that stops a rule reacting to its own effect — and its useful life ends when the mutation reaches a
+/// terminal stage. This is written once at exactly that moment, read by nothing the mechanism depends on, and kept for
+/// as long as its account's retention says.
+/// </para>
+/// <para>
+/// It names the email by <see cref="StoredEmailId" /> and holds every folder as a path rather than as a binding, which
+/// is what lets it survive the email's deletion — including when the mutation recorded <em>was</em> that deletion.
+/// Inheriting the mail's deletion path would erase the record that MailFathom deleted it, which removes exactly the
+/// entry an audit of deletions exists to hold.
+/// </para>
+/// <para>
+/// It holds no mail content: no subject, no address, no body fragment, no filename. A folder path, a UIDVALIDITY, a UID,
+/// a mutation name, and a requester identity are the server's own or MailFathom's own names for things. It is still
+/// derived personal data — it says where a person's mail has been, when, and at whose instruction — which is why it is
+/// written only for an account whose operator turned the trail on.
+/// </para>
+/// </remarks>
+public sealed record MailboxMutationAuditEntry
+{
+    /// <summary>Gets what addresses this entry, independently of the mutation record it was written from.</summary>
+    public required MailboxMutationAuditEntryId Id { get; init; }
+
+    /// <summary>Gets the mutation record this entry was written from.</summary>
+    /// <remarks>
+    /// It correlates the history with the operational record while that record still exists, and stops naming anything
+    /// once it is pruned. Nothing here reads it back: it is a fact about which mutation this was, not a reference the
+    /// entry depends on.
+    /// </remarks>
+    public required MailboxMutationRecordId MutationRecordId { get; init; }
+
+    /// <summary>Gets the account whose mailbox was changed.</summary>
+    public required MailAccountId AccountId { get; init; }
+
+    /// <summary>Gets the local email the change was about.</summary>
+    /// <remarks>
+    /// It is a value rather than an association, so nothing about the email's own lifetime reaches this entry. It stays
+    /// the identifier an operator joins the trail to a mailbox query by while the email exists, and stays readable as an
+    /// identity afterwards.
+    /// </remarks>
+    public required StoredEmailId StoredEmailId { get; init; }
+
+    /// <summary>Gets the change that was made.</summary>
+    public required MailboxMutation Mutation { get; init; }
+
+    /// <summary>Gets the remote path of the folder the email was in when the change was asked for.</summary>
+    public required RemoteFolderPath SourceFolderPath { get; init; }
+
+    /// <summary>Gets the UIDVALIDITY that folder reported when the change was asked for.</summary>
+    public required ImapUidValidity SourceUidValidity { get; init; }
+
+    /// <summary>Gets the UID the email carried in that folder.</summary>
+    public required ImapUid SourceUid { get; init; }
+
+    /// <summary>Gets the remote path of the folder a relocation or a copy named, and <see langword="null" /> for every other mutation.</summary>
+    public required RemoteFolderPath? DestinationFolderPath { get; init; }
+
+    /// <summary>Gets where the destination folder put the email, as far as the server said.</summary>
+    /// <remarks>
+    /// It is <see cref="RemoteEmailPlacement.NotReported" /> for a mutation that places nothing, for one the server
+    /// completed without a <c>COPYUID</c> response, and for one that was abandoned before it placed anything. The
+    /// mutation and the outcome together are what tell those apart.
+    /// </remarks>
+    public required RemoteEmailPlacement Placement { get; init; }
+
+    /// <summary>Gets which way a <c>\Seen</c> change was asked for, and <see langword="null" /> for every other mutation.</summary>
+    public required bool? DesiredSeenState { get; init; }
+
+    /// <summary>Gets the authored act that asked, whose identity carries a rule's revision where a rule asked.</summary>
+    public required MailboxMutationRequester Requester { get; init; }
+
+    /// <summary>Gets when the change was written down, which is when somebody asked for it.</summary>
+    public required DateTimeOffset RequestedAt { get; init; }
+
+    /// <summary>Gets when the change reached the ending this entry records.</summary>
+    public required DateTimeOffset CompletedAt { get; init; }
+
+    /// <summary>Gets how the change ended.</summary>
+    public required MailboxMutationAuditOutcome Outcome { get; init; }
+
+    /// <summary>Gets the code of the failure an abandoned change was given up on for, and <see langword="null" /> for one that was performed.</summary>
+    /// <remarks>
+    /// The code is kept and the message is not, for the reason the mutation record keeps only the code: a code is a
+    /// stable identity somebody can look up months later, while a message is text assembled at the failure site.
+    /// </remarks>
+    public required MailFathomErrorCode? Failure { get; init; }
+
+    /// <summary>Writes the entry one finished mutation leaves behind.</summary>
+    /// <param name="id">The identity the entry is addressed by.</param>
+    /// <param name="record">The mutation record, at the terminal stage it ended in.</param>
+    /// <param name="sourceFolder">The binding the source occurrence was read under, which supplies its remote path.</param>
+    /// <param name="completedAt">When the mutation reached that stage.</param>
+    /// <returns>The entry to append to the trail.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="record" /> or <paramref name="sourceFolder" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="record" /> has not reached a terminal stage, or when <paramref name="sourceFolder" /> is not the binding the record's occurrence names.</exception>
+    /// <remarks>
+    /// The terminal stage is required rather than assumed, because an entry written from a mutation still in flight
+    /// would state an ending that had not happened and no later write corrects it.
+    /// </remarks>
+    public static MailboxMutationAuditEntry Of(
+        MailboxMutationAuditEntryId id,
+        MailboxMutationRecord record,
+        MailFolderResolution sourceFolder,
+        DateTimeOffset completedAt)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        ArgumentNullException.ThrowIfNull(sourceFolder);
+
+        if (!record.IsTerminal)
+        {
+            throw new ArgumentException(
+                $"A mutation at stage {record.Stage} has not ended, so no audit entry states how it ended.",
+                nameof(record));
+        }
+
+        if (sourceFolder.Id != record.Request.Occurrence.FolderResolutionId)
+        {
+            throw new ArgumentException(
+                "The folder binding does not carry the occurrence the mutation was requested for.",
+                nameof(sourceFolder));
+        }
+
+        var wasPerformed = record.Stage == MailboxMutationStage.Completed;
+
+        return new MailboxMutationAuditEntry
+        {
+            Id = id,
+            MutationRecordId = record.Id,
+            AccountId = record.Request.Occurrence.AccountId,
+            StoredEmailId = record.Request.StoredEmailId,
+            Mutation = record.Request.Mutation,
+            SourceFolderPath = sourceFolder.RemotePath,
+            SourceUidValidity = record.Request.Occurrence.UidValidity,
+            SourceUid = record.Request.Occurrence.Uid,
+            DestinationFolderPath = record.Request.DestinationPath,
+            Placement = record.Placement,
+            DesiredSeenState = record.Request.DesiredSeenState,
+            Requester = record.Request.Requester,
+            RequestedAt = record.RecordedAt,
+            CompletedAt = completedAt,
+            Outcome = wasPerformed ? MailboxMutationAuditOutcome.Performed : MailboxMutationAuditOutcome.Abandoned,
+
+            // A performed change carries no failure even where an earlier attempt of it did, because the entry states
+            // how the change ended rather than what it survived on the way.
+            Failure = wasPerformed ? null : record.LastFailure,
+        };
+    }
+}

--- a/src/Domain/Mutations/Audit/MailboxMutationAuditEntryId.cs
+++ b/src/Domain/Mutations/Audit/MailboxMutationAuditEntryId.cs
@@ -1,0 +1,36 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Mutations.Audit;
+
+/// <summary>Identifies one audit entry, independently of the mutation record it was written from.</summary>
+/// <remarks>
+/// It is its own identity rather than the mutation record's because the two have different lifetimes: the record is
+/// operational state that ends when the mutation does, and the entry outlives it. An entry keyed by the record would
+/// stop being addressable the moment the record it borrowed its key from was pruned.
+/// </remarks>
+public readonly record struct MailboxMutationAuditEntryId
+{
+    private MailboxMutationAuditEntryId(Guid value) => this.Value = value;
+
+    /// <summary>Gets the non-empty UUID value.</summary>
+    public Guid Value { get; }
+
+    /// <summary>Creates an audit entry identifier from a non-empty UUID.</summary>
+    /// <param name="value">The UUID to wrap.</param>
+    /// <returns>A validated audit entry identifier.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="value" /> is empty.</exception>
+    public static MailboxMutationAuditEntryId Create(Guid value)
+    {
+        if (value == Guid.Empty)
+        {
+            throw new ArgumentException("A mailbox mutation audit entry identifier cannot be empty.", nameof(value));
+        }
+
+        return new MailboxMutationAuditEntryId(value);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => this.Value.ToString();
+}

--- a/src/Domain/Mutations/Audit/MailboxMutationAuditOutcome.cs
+++ b/src/Domain/Mutations/Audit/MailboxMutationAuditOutcome.cs
@@ -1,0 +1,20 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Mutations.Audit;
+
+/// <summary>Names how a mutation ended, in the only two endings a change is allowed to have.</summary>
+/// <remarks>
+/// There is no pending member, because an entry is written when the mutation reaches a terminal stage and never before.
+/// A trail whose entries could say "still happening" would need rewriting as the mutation moved, and a history that is
+/// rewritten is not the thing an audit exists to hold.
+/// </remarks>
+public enum MailboxMutationAuditOutcome
+{
+    /// <summary>The mail server made the change that was asked for.</summary>
+    Performed = 0,
+
+    /// <summary>The change was given up on, and the entry's failure code says what it was given up on for.</summary>
+    Abandoned = 1,
+}

--- a/src/Domain/Mutations/MailboxMutationRecord.cs
+++ b/src/Domain/Mutations/MailboxMutationRecord.cs
@@ -64,6 +64,21 @@ public sealed record MailboxMutationRecord
     /// </remarks>
     public required bool RequiresSourceRemoval { get; init; }
 
+    /// <summary>Gets whether this mutation leaves an entry in the account's audit trail when it ends.</summary>
+    /// <remarks>
+    /// <para>
+    /// It is resolved from the account's configuration when the record is opened and written down with it, so a trail
+    /// switched on or off while a mutation is in flight decides nothing about a change already begun. Without that, an
+    /// operator turning the trail on halfway through a backlog would produce a history whose gaps look like changes that
+    /// never happened.
+    /// </para>
+    /// <para>
+    /// The trail is off by default and enabled per account, which is data minimization applied to derived personal data:
+    /// an installation that never asked for a record of where its mail has been never accumulates one.
+    /// </para>
+    /// </remarks>
+    public required bool IsAudited { get; init; }
+
     /// <summary>Gets how many times this mutation has been attempted, counted before each attempt rather than after it.</summary>
     /// <remarks>
     /// Counting first is what makes the bound survive a crash loop: an attempt that kills the process still counted, so a

--- a/src/Host/Api/AdminApiEndpoints.cs
+++ b/src/Host/Api/AdminApiEndpoints.cs
@@ -22,8 +22,16 @@ namespace MailFathom.Host.Api;
 /// client needs to tell "signed in" from "reached something else that answers HTTP".
 /// </para>
 /// <para>
-/// The second is the surface's only write, and <see cref="MailboxRefreshTokenEndpoint" /> states what that costs. Both
-/// are mapped into one group so a route cannot be added outside the requirement the endpoint attaches to it.
+/// The second is the surface's only write, and <see cref="MailboxRefreshTokenEndpoint" /> states what that costs.
+/// </para>
+/// <para>
+/// The third reads one account's record of the changes MailFathom made to its mailbox, which
+/// <see cref="MailboxMutationAuditEndpoint" /> describes. It is here rather than on the MCP surface because its answer
+/// is an operator's accountability evidence rather than anything a model reasons over, and because the credential that
+/// bounds administrative access is what bounds who may read where a person's mail has been.
+/// </para>
+/// <para>
+/// All three are mapped into one group so a route cannot be added outside the requirement the endpoint attaches to it.
 /// </para>
 /// </remarks>
 internal static class AdminApiEndpoints
@@ -40,6 +48,7 @@ internal static class AdminApiEndpoints
 
         api.MapGet("/session", (ClaimsPrincipal caller) => Results.Ok(AdminSessionResponse.For(caller)));
         api.MapMailboxRefreshToken();
+        api.MapMailboxMutationAudit();
 
         return api;
     }

--- a/src/Host/Api/MailboxMutationAuditEndpoint.cs
+++ b/src/Host/Api/MailboxMutationAuditEndpoint.cs
@@ -1,0 +1,232 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Accounts;
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MailFathom.Host.Api;
+
+/// <summary>Serves one account's record of the changes MailFathom made to its mailbox.</summary>
+/// <remarks>
+/// <para>
+/// The answer is derived personal data — it says where a person's mail has been, when, and at whose instruction — so it
+/// is served only from the administrative endpoint, only to an authenticated caller, and only for an account the request
+/// names. It carries no mail content: a folder path, a UID, a mutation name, and a requester identity are the server's
+/// own or MailFathom's own names for things.
+/// </para>
+/// <para>
+/// <strong>Every authenticated caller may perform every administrative operation.</strong> The endpoint has no
+/// permission model, which <see cref="MailboxRefreshTokenEndpoint" /> states in full and which an operator provisions
+/// keys against; a credential that can read a session can read this.
+/// </para>
+/// <para>
+/// The page is bounded and keyset-paginated. A caller walks the trail by presenting the cursor the previous page
+/// returned, and the walk ends when no cursor comes back — never by comparing a short page against the size that was
+/// asked for.
+/// </para>
+/// </remarks>
+internal static class MailboxMutationAuditEndpoint
+{
+    /// <summary>The route, relative to the administrative prefix the group is mapped beneath.</summary>
+    internal const string Route = "/mailbox/mutations/audit";
+
+    /// <summary>Maps the read route into the administrative group, so it inherits that group's authorization.</summary>
+    /// <param name="api">The administrative route group.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="api" /> is <see langword="null" />.</exception>
+    internal static void MapMailboxMutationAudit(this RouteGroupBuilder api)
+    {
+        ArgumentNullException.ThrowIfNull(api);
+
+        api.MapGet(Route, ReadAsync);
+    }
+
+    /// <summary>Serves one page of an account's audit trail, or reports what was wrong with the request.</summary>
+    /// <param name="account">The configured identifier of the account whose trail is read.</param>
+    /// <param name="mutation">The mutation name to narrow to, or <see langword="null" /> for every mutation.</param>
+    /// <param name="from">The earliest completion instant served, inclusive, or <see langword="null" /> for none.</param>
+    /// <param name="before">The completion instant to stop before, exclusive, or <see langword="null" /> for none.</param>
+    /// <param name="pageSize">How many entries the page may hold, or <see langword="null" /> for the default.</param>
+    /// <param name="cursor">The cursor the previous page returned, or <see langword="null" /> for the first page.</param>
+    /// <param name="accounts">Reports whether this deployment serves the named account.</param>
+    /// <param name="store">Reads the page.</param>
+    /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
+    /// <returns><c>200</c> with the page, or <c>400</c> naming what was wrong with the request.</returns>
+    /// <remarks>
+    /// Every refusal is <c>400</c>, including an account this deployment does not configure. That mirrors the write
+    /// route beside it and for the same reason: an unknown account is a mistake in the request the caller wrote rather
+    /// than a missing resource, and <c>404</c> is already what a client reads as "this port serves no administrative
+    /// endpoint".
+    /// </remarks>
+    internal static async Task<Results<Ok<MailboxMutationAuditPageResponse>, ProblemHttpResult>> ReadAsync(
+        [FromQuery] string? account,
+        [FromQuery] string? mutation,
+        [FromQuery] DateTimeOffset? from,
+        [FromQuery] DateTimeOffset? before,
+        [FromQuery] int? pageSize,
+        [FromQuery] string? cursor,
+        [FromServices] IMailAccountCatalog accounts,
+        [FromServices] IMailboxMutationAuditEntryStore store,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(accounts);
+        ArgumentNullException.ThrowIfNull(store);
+
+        if (string.IsNullOrWhiteSpace(account))
+        {
+            return TypedResults.Problem("The request named no mail account.", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var accountId = MailAccountId.Create(account);
+
+        if (!accounts.ServedAccountIds.Contains(accountId))
+        {
+            return TypedResults.Problem(
+                $"This deployment configures no mail account named '{accountId.Value}'.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        // The unspecified default is what "every mutation" is written as, so an absent filter and a named one reach the
+        // query the same way rather than through a second parameter saying whether the first one counts.
+        var narrowedMutation = default(MailboxMutation);
+
+        if (mutation is not null && !MailboxMutation.TryParseName(mutation, out narrowedMutation))
+        {
+            return TypedResults.Problem(
+                $"'{mutation}' does not name a change MailFathom makes to a mailbox.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        MailboxMutationAuditCursor? decodedCursor = null;
+
+        if (cursor is not null)
+        {
+            if (!MailboxMutationAuditCursor.TryDecode(cursor, out var presentedCursor))
+            {
+                return TypedResults.Problem(
+                    "The continuation cursor is not one this deployment issued.",
+                    statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            decodedCursor = presentedCursor;
+        }
+
+        var queryResult = MailboxMutationAuditQuery.Create(
+            accountId,
+            narrowedMutation,
+            from,
+            before,
+            pageSize,
+            decodedCursor);
+
+        if (queryResult.Query is not { } query)
+        {
+            return TypedResults.Problem(
+                DescribeRefusal(queryResult.Outcome),
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var page = await store.ReadPageAsync(query, cancellationToken);
+
+        return TypedResults.Ok(MailboxMutationAuditPageResponse.For(page));
+    }
+
+    /// <summary>States what a caller has to change, without restating the filters they already sent.</summary>
+    private static string DescribeRefusal(MailboxMutationAuditQueryOutcome outcome) => outcome switch
+    {
+        MailboxMutationAuditQueryOutcome.PageSizeOutOfRange =>
+            $"An audit trail page holds between 1 and {MailboxMutationAuditQuery.MaximumPageSize} entries.",
+        MailboxMutationAuditQueryOutcome.TimeRangeEmpty =>
+            "The audit trail time range ends at or before it begins, so it names no entries.",
+        _ => "The continuation cursor was issued for a different set of audit trail filters.",
+    };
+}
+
+/// <summary>One page of an account's audit trail, as the administrative endpoint serves it.</summary>
+/// <param name="Entries">The entries, newest first.</param>
+/// <param name="NextCursor">The cursor the following page is asked with, or <see langword="null" /> at the end of the trail.</param>
+internal sealed record MailboxMutationAuditPageResponse(
+    IReadOnlyList<MailboxMutationAuditEntryResponse> Entries,
+    string? NextCursor)
+{
+    /// <summary>Describes one page for the wire.</summary>
+    /// <param name="page">The page read from the trail.</param>
+    /// <returns>The response body.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="page" /> is <see langword="null" />.</exception>
+    internal static MailboxMutationAuditPageResponse For(MailboxMutationAuditPage page)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        return new MailboxMutationAuditPageResponse(
+            [.. page.Entries.Select(MailboxMutationAuditEntryResponse.For)],
+            page.NextCursor?.Encode());
+    }
+}
+
+/// <summary>One recorded change to a mailbox, as the administrative endpoint serves it.</summary>
+/// <param name="Id">What addresses this entry.</param>
+/// <param name="Mutation">The change that was made.</param>
+/// <param name="Email">The local email the change was about.</param>
+/// <param name="SourceFolder">The remote path of the folder the email was in when the change was asked for.</param>
+/// <param name="SourceUidValidity">The UIDVALIDITY that folder reported.</param>
+/// <param name="SourceUid">The UID the email carried in that folder.</param>
+/// <param name="DestinationFolder">The folder a relocation or a copy named, or <see langword="null" /> for every other change.</param>
+/// <param name="PlacementUidValidity">The UIDVALIDITY the destination folder reported, where the server named one.</param>
+/// <param name="PlacementUid">The UID the email was assigned there, where the server named one.</param>
+/// <param name="DesiredSeenState">Which way a <c>\Seen</c> change was asked for, or <see langword="null" /> for every other change.</param>
+/// <param name="RequesterOrigin">What kind of authored act asked.</param>
+/// <param name="Requester">The identity that asked, which carries a rule's revision where a rule asked.</param>
+/// <param name="RequestedAt">When the change was asked for.</param>
+/// <param name="CompletedAt">When the change reached the ending recorded here.</param>
+/// <param name="Outcome">How the change ended.</param>
+/// <param name="FailureCode">The code an abandoned change was given up on for, or <see langword="null" /> for one that was performed.</param>
+internal sealed record MailboxMutationAuditEntryResponse(
+    Guid Id,
+    string Mutation,
+    Guid Email,
+    string SourceFolder,
+    uint SourceUidValidity,
+    uint SourceUid,
+    string? DestinationFolder,
+    uint? PlacementUidValidity,
+    uint? PlacementUid,
+    bool? DesiredSeenState,
+    string RequesterOrigin,
+    string Requester,
+    DateTimeOffset RequestedAt,
+    DateTimeOffset CompletedAt,
+    string Outcome,
+    int? FailureCode)
+{
+    /// <summary>Describes one entry for the wire.</summary>
+    /// <param name="entry">The entry read from the trail.</param>
+    /// <returns>The response body.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="entry" /> is <see langword="null" />.</exception>
+    internal static MailboxMutationAuditEntryResponse For(MailboxMutationAuditEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        return new MailboxMutationAuditEntryResponse(
+            entry.Id.Value,
+            entry.Mutation.Name,
+            entry.StoredEmailId.Value,
+            entry.SourceFolderPath.Value,
+            entry.SourceUidValidity.Value,
+            entry.SourceUid.Value,
+            entry.DestinationFolderPath?.Value,
+            entry.Placement.UidValidity?.Value,
+            entry.Placement.Uid?.Value,
+            entry.DesiredSeenState,
+            entry.Requester.Origin.ToString(),
+            entry.Requester.Identity,
+            entry.RequestedAt,
+            entry.CompletedAt,
+            entry.Outcome.ToString(),
+            entry.Failure?.Value);
+    }
+}

--- a/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
+++ b/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
@@ -8,6 +8,7 @@ using System.Security.Cryptography.X509Certificates;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.Synchronization.Reconciliation;
@@ -31,6 +32,7 @@ internal sealed class MailSynchronizationOptions
         IMailSynchronizationWindowReader,
         IRemotelyDeletedEmailDispositionReader,
         IAuthoredDeleteEmailDispositionReader,
+        IMailboxMutationAuditSettingsReader,
         IMailAccountCatalog
 {
     /// <summary>The shutdown budget the .NET Generic Host applies when nothing configures one.</summary>
@@ -347,6 +349,16 @@ internal sealed class MailSynchronizationOptions
 
     /// <inheritdoc />
     /// <remarks>
+    /// An account this snapshot no longer names reports <see cref="MailboxMutationAuditSettings.Disabled" /> rather
+    /// than failing, unlike every other per-account reader here. The two callers are why: a mutation is only recorded
+    /// for a configured account, and the retention pass runs over accounts a reload may have removed between one run and
+    /// the next — where the honest answer is that no operator decision applies, not that the deployment is broken.
+    /// </remarks>
+    public MailboxMutationAuditSettings GetAuditSettings(MailAccountId accountId) =>
+        this.FindConfiguredAccount(accountId)?.CreateAuditSettings() ?? MailboxMutationAuditSettings.Disabled;
+
+    /// <inheritdoc />
+    /// <remarks>
     /// Configuration is what defines the set of accounts, so this answers from the same bound options every other
     /// per-account reader does. It deliberately ignores <see cref="Enabled" />: that switch stops runs from fetching
     /// mail, and an operator who turned it off has not asked for the copy already stored to become unreadable. An
@@ -504,6 +516,14 @@ internal sealed class MailSynchronizationAccountOptions : IValidatableObject
     public AuthoredDeleteEmailDisposition AuthoredDeleteEmailDisposition { get; set; } =
         AuthoredDeleteEmailDisposition.RetainLocalCopy;
 
+    /// <summary>Gets or sets whether and for how long this account keeps a record of the changes MailFathom made to it.</summary>
+    /// <remarks>
+    /// Omitting the block leaves the trail off, which is the default for the reason the privacy rules require: the trail
+    /// is derived personal data — it says where a person's mail has been, when, and at whose instruction — so a
+    /// deployment that never asked for it never accumulates it.
+    /// </remarks>
+    public MailboxMutationAuditTrailOptions AuditTrail { get; set; } = new();
+
     /// <summary>Gets or sets what starts this account's next synchronization pass.</summary>
     /// <remarks>
     /// <para>
@@ -568,6 +588,23 @@ internal sealed class MailSynchronizationAccountOptions : IValidatableObject
             yield return new ValidationResult(
                 $"Account '{this.AccountId}': the synchronization mode must be one of {string.Join(", ", Enum.GetNames<MailSynchronizationMode>())}.",
                 [nameof(this.Mode)]);
+        }
+
+        // Checked here rather than through a data annotation because nothing binds the block as an options graph of its
+        // own, so an annotation on it would be read by nothing. The window decides when personal data is destroyed, so
+        // a typo in it fails startup instead of quietly selecting a period nobody wrote.
+        if (this.AuditTrail is null)
+        {
+            yield return new ValidationResult(
+                $"Account '{this.AccountId}': the audit trail configuration must be a block.",
+                [nameof(this.AuditTrail)]);
+        }
+        else if (this.AuditTrail.Retention < MailboxMutationAuditTrailOptions.MinimumRetention
+            || this.AuditTrail.Retention > MailboxMutationAuditTrailOptions.MaximumRetention)
+        {
+            yield return new ValidationResult(
+                $"Account '{this.AccountId}': the audit trail retention must be between {MailboxMutationAuditTrailOptions.MinimumRetention} and {MailboxMutationAuditTrailOptions.MaximumRetention}.",
+                [nameof(this.AuditTrail)]);
         }
 
         if (this.Folders is null)
@@ -742,6 +779,11 @@ internal sealed class MailSynchronizationAccountOptions : IValidatableObject
                 [nameof(this.EarliestEmailReceivedDate)]);
         }
     }
+
+    /// <summary>Builds the account's configured audit trail settings.</summary>
+    /// <returns>The settings the account's block names.</returns>
+    internal MailboxMutationAuditSettings CreateAuditSettings() =>
+        new(this.AuditTrail.Enabled, this.AuditTrail.Retention);
 
     /// <summary>Builds the account's configured synchronization window.</summary>
     /// <returns>The window the account's bound names, or an unbounded one when it configured none.</returns>

--- a/src/Host/Configuration/Mail/MailboxMutationAuditTrailOptions.cs
+++ b/src/Host/Configuration/Mail/MailboxMutationAuditTrailOptions.cs
@@ -1,0 +1,56 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace MailFathom.Host.Configuration.Mail;
+
+/// <summary>Configures whether one account keeps a durable record of the changes MailFathom made to its mailbox.</summary>
+/// <remarks>
+/// <para>
+/// The trail answers "why is this message in this folder" months later, without depending on anybody's memory and
+/// without holding any of the message. It is a second store from the operational mutation record, which exists only
+/// until a change finishes, and it is off by default because the two decisions are different: making a change correctly
+/// is something MailFathom does for every account, while keeping a history of where a person's mail has been is
+/// something an operator undertakes to hold, describe, and erase.
+/// </para>
+/// <para>
+/// Turning it off stops new entries and leaves the ones already written to age out under <see cref="Retention" />, which
+/// is why the window is configured whether or not the trail is currently on.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed class MailboxMutationAuditTrailOptions
+{
+    /// <summary>The shortest retention accepted, below which an entry could be erased before the run that would show it.</summary>
+    internal static readonly TimeSpan MinimumRetention = TimeSpan.FromDays(1);
+
+    /// <summary>The longest retention accepted, beyond which the window stops being one anybody could justify holding.</summary>
+    internal static readonly TimeSpan MaximumRetention = TimeSpan.FromDays(3650);
+
+    /// <summary>Gets or sets whether a finished change to this account's mailbox leaves an audit entry behind.</summary>
+    /// <remarks>
+    /// It is read when a change is written down, not when it finishes, and the answer travels on the record. A change
+    /// authored while the trail was on therefore still leaves its entry after the trail is switched off, which is what
+    /// stops a mid-flight toggle from producing a history whose gaps look like changes nobody made.
+    /// </remarks>
+    public bool Enabled { get; set; }
+
+    /// <summary>Gets or sets how long an entry of this account's is kept before it is erased.</summary>
+    /// <remarks>
+    /// <para>
+    /// Erasure rides the account's own synchronization run, so the window is honored as often as the account comes
+    /// round rather than to the minute. It is read from the current configuration rather than from the entries, so
+    /// shortening it applies to the history already held as much as to what is still to come — which is what makes it a
+    /// storage-limitation decision an operator can actually change their mind about.
+    /// </para>
+    /// <para>
+    /// The floor is a day because a shorter window would erase entries before the run that would have shown them, and
+    /// the ceiling is ten years because a retention nobody can justify is the thing this setting exists to prevent. The
+    /// bounds are checked by the account's own validation rather than by a data annotation, because nothing binds this
+    /// nested block as an options graph of its own and an annotation here would never be read.
+    /// </para>
+    /// </remarks>
+    public TimeSpan Retention { get; set; } = TimeSpan.FromDays(90);
+}

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
@@ -228,6 +229,11 @@ internal sealed partial class AccountSynchronizationSupervisor
                         Interlocked.Increment(ref failedFolderCount);
                     }
                 });
+
+            if (!schedulingToken.IsCancellationRequested)
+            {
+                await this.EraseExpiredAuditEntriesAsync(runSettings, workUnitToken);
+            }
         }
         finally
         {
@@ -288,6 +294,50 @@ internal sealed partial class AccountSynchronizationSupervisor
             this.LogMutationConvergenceFailed(exception, this.accountId.Value);
 
             return true;
+        }
+    }
+
+    /// <summary>Erases whatever in this account's audit trail has outlived the window the account configured.</summary>
+    /// <remarks>
+    /// <para>
+    /// It rides the account's own run for the reason convergence does: an account already has a loop that comes round,
+    /// and a second schedule would be another thing to configure and watch for work that is one bounded delete. It runs
+    /// after the folders rather than before them, because holding data a day longer than the window is a smaller wrong
+    /// than delaying the mail this run exists to fetch.
+    /// </para>
+    /// <para>
+    /// A failure never fails the run. Retention is a storage-limitation obligation rather than a mail operation, and
+    /// putting an account into backoff — which is to say fetching its mail less often — because a delete did not run
+    /// would answer the wrong problem with the wrong remedy. The next run erases what this one did not.
+    /// </para>
+    /// </remarks>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Retention is not a mail operation; an erasure that failed is logged and repeated by the next run rather than putting the account into backoff.")]
+    private async Task EraseExpiredAuditEntriesAsync(
+        MailSynchronizationOptions runSettings,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = this.scopeFactory.CreateScope();
+
+            scope.ServiceProvider.GetRequiredService<ScopedMailSynchronizationSettings>().UseRunSnapshot(runSettings);
+
+            var erasedCount = await scope.ServiceProvider
+                .GetRequiredService<MailboxMutationAuditTrailRetention>()
+                .EraseExpiredAsync(this.accountId, cancellationToken);
+
+            if (erasedCount > 0)
+            {
+                this.LogAuditEntriesErased(this.accountId.Value, erasedCount);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            this.LogAuditRetentionFailed(exception, this.accountId.Value);
         }
     }
 
@@ -596,6 +646,17 @@ internal sealed partial class AccountSynchronizationSupervisor
         Level = LogLevel.Warning,
         Message = "Converging the outstanding mailbox mutations of account {AccountId} ended unexpectedly; its folders still synchronized and its next run is backed off, and every change keeps the record of how far it got.")]
     private partial void LogMutationConvergenceFailed(Exception exception, string accountId);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Account {AccountId} erased {ErasedCount} audit entries that had outlived its configured retention.")]
+    private partial void LogAuditEntriesErased(string accountId, int erasedCount);
+
+    /// <summary>Separates a retention pass that did not run from the ordinary case of it having nothing to erase.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Erasing the expired audit entries of account {AccountId} ended unexpectedly; the account is not backed off for it and its next run erases what this one did not.")]
+    private partial void LogAuditRetentionFailed(Exception exception, string accountId);
 
     [LoggerMessage(
         Level = LogLevel.Warning,

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -13,6 +13,7 @@ using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
@@ -206,6 +207,7 @@ try
     builder.Services.AddScoped<IMailSynchronizationWindowReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IRemotelyDeletedEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IAuthoredDeleteEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
+    builder.Services.AddScoped<IMailboxMutationAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IMailAccountCatalog>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IImapAccountSettingsProvider, ConfiguredImapAccountSettingsProvider>();
     builder.Services.AddScoped<IMailOAuthSettingsProvider, ConfiguredMailOAuthSettingsProvider>();

--- a/src/Infrastructure/Observability/MailboxMutationAuditTelemetry.cs
+++ b/src/Infrastructure/Observability/MailboxMutationAuditTelemetry.cs
@@ -1,0 +1,76 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.Metrics;
+using MailFathom.Common.Observability;
+using MailFathom.Domain.Mutations.Audit;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.Infrastructure.Observability;
+
+/// <summary>Reports an audit entry a finished mutation owed and the trail could not be given.</summary>
+/// <remarks>
+/// <para>
+/// It has exactly one thing to say, and that narrowness is what it is for. Writing an entry may never fail the mutation
+/// that produced it — the change has already been made to somebody's mailbox by the time the append runs — so the
+/// failure is swallowed, and swallowing it is only defensible while it is visible. A deployment that undertook to hold
+/// this history can see the moment it stops holding it, on both channels at once.
+/// </para>
+/// <para>
+/// Nothing recorded here is mail. The mutation name, the account, and the mutation record's identifier are MailFathom's
+/// own names for things; no subject, address, folder path, or UID reaches a log, a span, or an exporter.
+/// </para>
+/// </remarks>
+public sealed partial class MailboxMutationAuditTelemetry
+{
+    private const string MutationTagName = "mailfathom.mailbox.mutation";
+    private const string AccountTagName = "mailfathom.mail.account";
+
+    private readonly ILogger<MailboxMutationAuditTelemetry> logger;
+    private readonly Counter<long> refusedAppendCount;
+
+    /// <summary>Initializes the instruments a refused append is reported through.</summary>
+    /// <param name="logger">Records the entry that was not kept.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="logger" /> is <see langword="null" />.</exception>
+    public MailboxMutationAuditTelemetry(ILogger<MailboxMutationAuditTelemetry> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this.logger = logger;
+        this.refusedAppendCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.mailbox.mutation.audit.refused_appends",
+            unit: "{entry}",
+            description: "Audit entries a finished mutation owed and the trail could not be given, by mutation.");
+    }
+
+    /// <summary>Says on both channels that a history somebody asked to keep was not kept.</summary>
+    /// <param name="entry">The entry the trail was not given.</param>
+    /// <param name="failure">What stopped the append.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a required argument is <see langword="null" />.</exception>
+    internal void RecordRefusedAppend(MailboxMutationAuditEntry entry, Exception failure)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        ArgumentNullException.ThrowIfNull(failure);
+
+        this.refusedAppendCount.Add(
+            1,
+            new KeyValuePair<string, object?>(MutationTagName, entry.Mutation.Name),
+            new KeyValuePair<string, object?>(AccountTagName, entry.AccountId.Value));
+
+        this.LogAuditEntryRefused(
+            failure,
+            entry.Mutation.Name,
+            entry.AccountId.Value,
+            entry.MutationRecordId.Value);
+    }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The audit trail did not keep the {Mutation} mutation {MutationRecordId} of {AccountId}; the change was made and this history of it is missing.")]
+    private partial void LogAuditEntryRefused(
+        Exception failure,
+        string mutation,
+        string accountId,
+        Guid mutationRecordId);
+}

--- a/src/Infrastructure/Observability/MailboxMutationAuditTelemetry.cs
+++ b/src/Infrastructure/Observability/MailboxMutationAuditTelemetry.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.Metrics;
 using MailFathom.Common.Observability;
+using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Mutations.Audit;
 using Microsoft.Extensions.Logging;
 
@@ -65,6 +66,16 @@ public sealed partial class MailboxMutationAuditTelemetry
             entry.MutationRecordId.Value);
     }
 
+    /// <summary>Says that a page left out entries this build cannot interpret.</summary>
+    /// <param name="accountId">The account whose trail was read.</param>
+    /// <param name="unreadableCount">How many rows of the page were left out.</param>
+    /// <remarks>
+    /// The rows are still in the trail and a later build reads them; what is reported is that this build's answer is
+    /// short of them, because an audit page that quietly omits entries is worse than one that says it did.
+    /// </remarks>
+    internal void RecordUnreadableEntries(MailAccountId accountId, int unreadableCount) =>
+        this.LogAuditEntriesUnreadable(accountId.Value, unreadableCount);
+
     [LoggerMessage(
         Level = LogLevel.Warning,
         Message = "The audit trail did not keep the {Mutation} mutation {MutationRecordId} of {AccountId}; the change was made and this history of it is missing.")]
@@ -73,4 +84,9 @@ public sealed partial class MailboxMutationAuditTelemetry
         string mutation,
         string accountId,
         Guid mutationRecordId);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Account {AccountId} holds {UnreadableCount} audit entries this build cannot interpret, which were left out of the page it served; a build that permits the mutation they name reads them.")]
+    private partial void LogAuditEntriesUnreadable(string accountId, int unreadableCount);
 }

--- a/src/Infrastructure/Persistence/Entities/MailboxMutationAuditEntryEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/MailboxMutationAuditEntryEntity.cs
@@ -1,0 +1,87 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+
+namespace MailFathom.Infrastructure.Persistence.Entities;
+
+/// <summary>One finished change to a remote mailbox, kept for as long as its account's retention says.</summary>
+/// <remarks>
+/// Every association this row could have carried is a plain value instead, and that is the whole design: an entry that
+/// hung on the stored email would be erased by that email's deletion, which is exactly the entry an audit of deletions
+/// exists to hold. The same reasoning keeps the account and the folder out — the trail describes an act, and an act
+/// stays true after the things it acted on are gone.
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class MailboxMutationAuditEntryEntity
+{
+    /// <summary>The longest remote folder path stored, matching the bound the folder binding's own path column carries.</summary>
+    internal const int MaximumFolderPathLength = 512;
+
+    public Guid Id { get; set; }
+
+    /// <summary>Gets or sets the mutation record this entry was written from.</summary>
+    /// <remarks>
+    /// Unique, which is what makes an append idempotent: one mutation has one ending, so a retried append after a commit
+    /// whose answer was lost is refused by the index rather than producing a second entry for the same act.
+    /// </remarks>
+    public Guid MutationRecordId { get; set; }
+
+    /// <summary>Gets or sets the account whose mailbox was changed, as a value rather than as an association.</summary>
+    public required string MailboxAccountId { get; set; }
+
+    /// <summary>Gets or sets the local email the change was about, as a value rather than as an association.</summary>
+    public Guid StoredEmailId { get; set; }
+
+    /// <summary>Gets or sets the mutation's own name, which is the identity the closed enumeration publishes.</summary>
+    public required string Mutation { get; set; }
+
+    /// <summary>Gets or sets the remote path of the folder the email was in when the change was asked for.</summary>
+    /// <remarks>
+    /// The path is stored rather than the folder key, because a key resolves through a binding that a later rebinding
+    /// replaces and a deleted account removes. What an operator asks months later is which folder the mail was in, and
+    /// the answer has to be readable without anything else still existing.
+    /// </remarks>
+    public required string SourceFolderPath { get; set; }
+
+    /// <summary>Gets or sets the hierarchy delimiter the source path was read with, where one is known.</summary>
+    public string? SourceHierarchyDelimiter { get; set; }
+
+    public uint SourceUidValidity { get; set; }
+
+    public uint SourceUid { get; set; }
+
+    /// <summary>Gets or sets the folder a relocation or a copy named, and <see langword="null" /> for every other mutation.</summary>
+    public string? DestinationFolderPath { get; set; }
+
+    /// <summary>Gets or sets the hierarchy delimiter the destination path was created with, where one is known.</summary>
+    public string? DestinationHierarchyDelimiter { get; set; }
+
+    /// <summary>Gets or sets the UIDVALIDITY a <c>COPYUID</c> response named, where the server supplied one.</summary>
+    public uint? PlacementUidValidity { get; set; }
+
+    /// <summary>Gets or sets the UID a <c>COPYUID</c> response named, where the server supplied one.</summary>
+    public uint? PlacementUid { get; set; }
+
+    /// <summary>Gets or sets which way a <c>\Seen</c> change was asked for, and <see langword="null" /> for every other mutation.</summary>
+    public bool? DesiredSeenState { get; set; }
+
+    public MailboxMutationOrigin RequesterOrigin { get; set; }
+
+    /// <summary>Gets or sets the requester identity, which carries a rule's revision where a rule asked.</summary>
+    public required string RequesterIdentity { get; set; }
+
+    /// <summary>Gets or sets when the change was written down, which is when somebody asked for it.</summary>
+    public DateTimeOffset RequestedAt { get; set; }
+
+    /// <summary>Gets or sets when the change reached the ending this entry records.</summary>
+    public DateTimeOffset CompletedAt { get; set; }
+
+    public MailboxMutationAuditOutcome Outcome { get; set; }
+
+    /// <summary>Gets or sets the code of the failure an abandoned change was given up on for, and <see langword="null" /> for one that was performed.</summary>
+    public int? FailureCode { get; set; }
+}

--- a/src/Infrastructure/Persistence/Entities/MailboxMutationEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/MailboxMutationEntity.cs
@@ -71,6 +71,15 @@ internal sealed class MailboxMutationEntity
     /// </remarks>
     public AuthoredDeleteEmailDisposition? LocalDisposition { get; set; }
 
+    /// <summary>Gets or sets whether this mutation leaves an entry in the account's audit trail when it ends.</summary>
+    /// <remarks>
+    /// Resolved from the account's configuration when the row is written and never rewritten, which is the whole reason
+    /// it is stored rather than read where the mutation ends. A mutation ends in a later run — sometimes days later —
+    /// and reading the setting there would apply whatever the operator had changed it to in the meantime, producing a
+    /// history whose gaps look like changes that never happened.
+    /// </remarks>
+    public bool AuditTrailEnabled { get; set; }
+
     public MailboxMutationStage Stage { get; set; }
 
     /// <summary>Gets or sets whether the placement left a source occurrence that still has to be removed separately.</summary>

--- a/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -92,6 +92,14 @@ internal sealed class MailFathomDbContext : DbContext
 
     internal const string MailboxMutationPlacementIndexName = "ix_mailbox_mutations_placement";
 
+    /// <summary>The constraint that keeps one audit entry per mutation ending, whatever a repeated append attempts.</summary>
+    internal const string MailboxMutationAuditEntryMutationUniqueIndexName =
+        "ix_mailbox_mutation_audit_entries_mutation";
+
+    /// <summary>The index the trail is both read and aged through.</summary>
+    internal const string MailboxMutationAuditEntryTimelineIndexName =
+        "ix_mailbox_mutation_audit_entries_account_completed";
+
     private readonly PostgresTextSearchConfiguration textSearchConfiguration;
 
     /// <summary>Initializes a new MailFathom EF Core context.</summary>
@@ -139,6 +147,9 @@ internal sealed class MailFathomDbContext : DbContext
     internal DbSet<MailboxRefreshTokenEntity> MailboxRefreshTokens => this.Set<MailboxRefreshTokenEntity>();
 
     internal DbSet<MailboxMutationEntity> MailboxMutations => this.Set<MailboxMutationEntity>();
+
+    internal DbSet<MailboxMutationAuditEntryEntity> MailboxMutationAuditEntries =>
+        this.Set<MailboxMutationAuditEntryEntity>();
 
     /// <inheritdoc />
     /// <remarks>
@@ -332,7 +343,65 @@ internal sealed class MailFathomDbContext : DbContext
         });
 
         ConfigureMailboxMutation(modelBuilder);
+        ConfigureMailboxMutationAuditEntry(modelBuilder);
     }
+
+    /// <summary>Declares the history a finished change to a remote mailbox leaves behind.</summary>
+    /// <remarks>
+    /// <para>
+    /// The row hangs on nothing. Every identity it carries — the account, the local email, the source and destination
+    /// folders — is a value rather than an association, so no cascade reaches it and the entry outlives everything it
+    /// describes. That is the whole reason the table exists separately from <c>mailbox_mutations</c>, which deliberately
+    /// does cascade from the email: a trail that inherited the mail's deletion path would erase the record that
+    /// MailFathom deleted it, which is exactly the entry an audit of deletions exists to hold.
+    /// </para>
+    /// <para>
+    /// It is append-only. Nothing amends an entry, so the row carries no concurrency token: there is no second writer
+    /// for one to protect against, and the uniqueness below is what makes a repeated append leave the trail as it was.
+    /// </para>
+    /// <para>
+    /// Nothing here is mail content. A folder path, a UID, a mutation name, and a requester identity are the server's own
+    /// or MailFathom's own names for things — which is what lets the act be recorded without the message.
+    /// </para>
+    /// </remarks>
+    private static void ConfigureMailboxMutationAuditEntry(ModelBuilder modelBuilder) =>
+        modelBuilder.Entity<MailboxMutationAuditEntryEntity>(entity =>
+        {
+            entity.ToTable("mailbox_mutation_audit_entries");
+            entity.HasKey(entry => entry.Id);
+            entity.Property(entry => entry.Id).ValueGeneratedNever();
+            entity.Property(entry => entry.MailboxAccountId).HasMaxLength(128).IsRequired();
+            entity.Property(entry => entry.Mutation).HasMaxLength(64).IsRequired();
+            entity.Property(entry => entry.SourceFolderPath)
+                .HasMaxLength(MailboxMutationAuditEntryEntity.MaximumFolderPathLength)
+                .IsRequired();
+            entity.Property(entry => entry.SourceHierarchyDelimiter).HasMaxLength(1);
+            entity.Property(entry => entry.DestinationFolderPath)
+                .HasMaxLength(MailboxMutationAuditEntryEntity.MaximumFolderPathLength);
+            entity.Property(entry => entry.DestinationHierarchyDelimiter).HasMaxLength(1);
+            entity.Property(entry => entry.RequesterIdentity)
+                .HasMaxLength(MailboxMutationRequester.MaximumIdentityLength)
+                .IsRequired();
+
+            // Stored as text for the reason every other enum in this model is: both stay readable in the ad-hoc query
+            // an audit is answered from, and survive any later reordering of their enum.
+            entity.Property(entry => entry.RequesterOrigin).HasConversion<string>().HasMaxLength(64).IsRequired();
+            entity.Property(entry => entry.Outcome).HasConversion<string>().HasMaxLength(64).IsRequired();
+
+            // One ending per mutation, enforced by the database rather than checked before the insert: an append
+            // repeated after a commit whose answer was lost passes any application check and only the constraint
+            // closes that window.
+            entity.HasIndex(entry => entry.MutationRecordId)
+                .IsUnique()
+                .HasDatabaseName(MailboxMutationAuditEntryMutationUniqueIndexName);
+
+            // The one index the trail is worked through, and it serves both readers: a page is the account's entries
+            // ordered by when they ended, and retention erases the same account's entries that ended before a cutoff.
+            // A data-subject erasure by local email is a rare, deliberate operator act and reads the table rather than
+            // an index of its own, which keeps the write cost of an append to one index beyond the key.
+            entity.HasIndex(entry => new { entry.MailboxAccountId, entry.CompletedAt, entry.Id })
+                .HasDatabaseName(MailboxMutationAuditEntryTimelineIndexName);
+        });
 
     /// <summary>Declares the durable record every change to a remote mailbox is written to before it is issued.</summary>
     /// <remarks>

--- a/src/Infrastructure/Persistence/Migrations/20260808113315_AddMailboxMutationAuditEntries.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260808113315_AddMailboxMutationAuditEntries.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260808113315_AddMailboxMutationAuditEntries")]
+    partial class AddMailboxMutationAuditEntries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260808113315_AddMailboxMutationAuditEntries.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260808113315_AddMailboxMutationAuditEntries.cs
@@ -1,0 +1,78 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMailboxMutationAuditEntries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AuditTrailEnabled",
+                table: "mailbox_mutations",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateTable(
+                name: "mailbox_mutation_audit_entries",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    MutationRecordId = table.Column<Guid>(type: "uuid", nullable: false),
+                    MailboxAccountId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    StoredEmailId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Mutation = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    SourceFolderPath = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false),
+                    SourceHierarchyDelimiter = table.Column<string>(type: "character varying(1)", maxLength: 1, nullable: true),
+                    SourceUidValidity = table.Column<long>(type: "bigint", nullable: false),
+                    SourceUid = table.Column<long>(type: "bigint", nullable: false),
+                    DestinationFolderPath = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    DestinationHierarchyDelimiter = table.Column<string>(type: "character varying(1)", maxLength: 1, nullable: true),
+                    PlacementUidValidity = table.Column<long>(type: "bigint", nullable: true),
+                    PlacementUid = table.Column<long>(type: "bigint", nullable: true),
+                    DesiredSeenState = table.Column<bool>(type: "boolean", nullable: true),
+                    RequesterOrigin = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    RequesterIdentity = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    RequestedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CompletedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Outcome = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    FailureCode = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mailbox_mutation_audit_entries", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mailbox_mutation_audit_entries_account_completed",
+                table: "mailbox_mutation_audit_entries",
+                columns: new[] { "MailboxAccountId", "CompletedAt", "Id" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mailbox_mutation_audit_entries_mutation",
+                table: "mailbox_mutation_audit_entries",
+                column: "MutationRecordId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "mailbox_mutation_audit_entries");
+
+            migrationBuilder.DropColumn(
+                name: "AuditTrailEnabled",
+                table: "mailbox_mutations");
+        }
+    }
+}

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryMapping.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryMapping.cs
@@ -1,0 +1,123 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+using MailFathom.Infrastructure.Persistence.Entities;
+
+namespace MailFathom.Infrastructure.Persistence.Mutations;
+
+/// <summary>Turns one audit entry into the row that keeps it, and back.</summary>
+internal static class MailboxMutationAuditEntryMapping
+{
+    /// <summary>Builds the row one entry is kept as.</summary>
+    /// <param name="entry">The entry to keep.</param>
+    /// <returns>The row to append.</returns>
+    internal static MailboxMutationAuditEntryEntity ToEntity(MailboxMutationAuditEntry entry) => new()
+    {
+        Id = entry.Id.Value,
+        MutationRecordId = entry.MutationRecordId.Value,
+        MailboxAccountId = entry.AccountId.Value,
+        StoredEmailId = entry.StoredEmailId.Value,
+        Mutation = entry.Mutation.Name,
+        SourceFolderPath = entry.SourceFolderPath.Value,
+        SourceHierarchyDelimiter = entry.SourceFolderPath.HierarchyDelimiter?.ToString(),
+        SourceUidValidity = entry.SourceUidValidity.Value,
+        SourceUid = entry.SourceUid.Value,
+        DestinationFolderPath = entry.DestinationFolderPath?.Value,
+        DestinationHierarchyDelimiter = entry.DestinationFolderPath?.HierarchyDelimiter?.ToString(),
+        PlacementUidValidity = entry.Placement.UidValidity?.Value,
+        PlacementUid = entry.Placement.Uid?.Value,
+        DesiredSeenState = entry.DesiredSeenState,
+        RequesterOrigin = entry.Requester.Origin,
+        RequesterIdentity = entry.Requester.Identity,
+        RequestedAt = entry.RequestedAt,
+        CompletedAt = entry.CompletedAt,
+        Outcome = entry.Outcome,
+        FailureCode = entry.Failure?.Value,
+    };
+
+    /// <summary>Rebuilds the entry one stored row states.</summary>
+    /// <param name="entity">The stored row.</param>
+    /// <returns>The entry that row states.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the row names a mutation or a folder path that no longer parses.</exception>
+    internal static MailboxMutationAuditEntry ToEntry(MailboxMutationAuditEntryEntity entity)
+    {
+        if (!MailboxMutation.TryParseName(entity.Mutation, out var mutation))
+        {
+            throw new InvalidOperationException(
+                $"Mailbox mutation audit entry {entity.Id} names '{entity.Mutation}', which is not a permitted mutation.");
+        }
+
+        return new MailboxMutationAuditEntry
+        {
+            Id = MailboxMutationAuditEntryId.Create(entity.Id),
+            MutationRecordId = MailboxMutationRecordId.Create(entity.MutationRecordId),
+            AccountId = MailAccountId.Create(entity.MailboxAccountId),
+            StoredEmailId = StoredEmailId.Create(entity.StoredEmailId),
+            Mutation = mutation,
+            SourceFolderPath = ToFolderPath(
+                entity.Id,
+                entity.SourceFolderPath,
+                entity.SourceHierarchyDelimiter),
+            SourceUidValidity = ImapUidValidity.Create(entity.SourceUidValidity),
+            SourceUid = ImapUid.Create(entity.SourceUid),
+            DestinationFolderPath = ToOptionalFolderPath(
+                entity.Id,
+                entity.DestinationFolderPath,
+                entity.DestinationHierarchyDelimiter),
+            Placement = ToPlacement(entity),
+            DesiredSeenState = entity.DesiredSeenState,
+            Requester = MailboxMutationRequester.Create(entity.RequesterOrigin, entity.RequesterIdentity),
+            RequestedAt = entity.RequestedAt,
+            CompletedAt = entity.CompletedAt,
+            Outcome = entity.Outcome,
+            Failure = ToFailure(entity),
+        };
+    }
+
+    /// <summary>Restores a stored folder path exactly as it was written.</summary>
+    /// <remarks>
+    /// The text is not trimmed on the way back, for the reason it was not trimmed on the way in: IMAP permits a quoted
+    /// mailbox name bounded by a space, and normalizing one would name a different mailbox or none at all.
+    /// </remarks>
+    private static RemoteFolderPath ToFolderPath(Guid entryId, string storedPath, string? storedDelimiter)
+    {
+        return RemoteFolderPath.TryCreate(
+            storedPath,
+            storedDelimiter is { Length: > 0 } delimiter ? delimiter[0] : null,
+            out var folderPath)
+            ? folderPath
+            : throw new InvalidOperationException(
+                $"Mailbox mutation audit entry {entryId} carries a folder path that names no folder.");
+    }
+
+    /// <summary>Restores a folder path only a relocation or a copy carries.</summary>
+    private static RemoteFolderPath? ToOptionalFolderPath(Guid entryId, string? storedPath, string? storedDelimiter) =>
+        storedPath is null ? null : ToFolderPath(entryId, storedPath, storedDelimiter);
+
+    private static RemoteEmailPlacement ToPlacement(MailboxMutationAuditEntryEntity entity) =>
+        entity is { PlacementUidValidity: { } uidValidity, PlacementUid: { } uid }
+            ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(uidValidity), ImapUid.Create(uid))
+            : RemoteEmailPlacement.NotReported();
+
+    /// <summary>Reads back the code an abandoned change was given up on for.</summary>
+    /// <remarks>
+    /// A number this build does not recognize is a row written by one that allocated a code since. It is diagnostic
+    /// detail rather than something acted on, so it is reported as absent instead of failing the read of the whole page.
+    /// </remarks>
+    private static MailFathomErrorCode? ToFailure(MailboxMutationAuditEntryEntity entity)
+    {
+        if (entity.FailureCode is not { } failureCode)
+        {
+            return null;
+        }
+
+        return MailFathomErrorCode.TryParse(failureCode, out var failure) ? failure : null;
+    }
+}

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryMapping.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryMapping.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Diagnostics.CodeAnalysis;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
@@ -42,35 +43,49 @@ internal static class MailboxMutationAuditEntryMapping
         FailureCode = entry.Failure?.Value,
     };
 
-    /// <summary>Rebuilds the entry one stored row states.</summary>
+    /// <summary>Rebuilds the entry one stored row states, or reports a row this build cannot interpret.</summary>
     /// <param name="entity">The stored row.</param>
-    /// <returns>The entry that row states.</returns>
-    /// <exception cref="InvalidOperationException">Thrown when the row names a mutation or a folder path that no longer parses.</exception>
-    internal static MailboxMutationAuditEntry ToEntry(MailboxMutationAuditEntryEntity entity)
+    /// <param name="entry">The entry that row states, when this build can read it.</param>
+    /// <returns><see langword="true" /> when the row was rebuilt; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// <para>
+    /// A row is refused rather than approximated when it names a mutation or a folder path this build does not
+    /// recognize — which is version skew rather than corruption: a later build that permits a fifth mutation writes
+    /// entries this one has no value for, and a rollback then reads them.
+    /// </para>
+    /// <para>
+    /// It is reported rather than thrown for the reason <see cref="ToFailure" /> degrades an unrecognized failure code:
+    /// this trail is read a page at a time and paginated by position, so one unreadable row thrown out of the mapping
+    /// would fail the whole page and every page after it. The caller leaves the row out, says so, and walks on.
+    /// </para>
+    /// </remarks>
+    internal static bool TryToEntry(
+        MailboxMutationAuditEntryEntity entity,
+        [NotNullWhen(true)] out MailboxMutationAuditEntry? entry)
     {
-        if (!MailboxMutation.TryParseName(entity.Mutation, out var mutation))
+        entry = null;
+
+        if (!MailboxMutation.TryParseName(entity.Mutation, out var mutation)
+            || !TryToFolderPath(entity.SourceFolderPath, entity.SourceHierarchyDelimiter, out var sourceFolderPath)
+            || !TryToOptionalFolderPath(
+                entity.DestinationFolderPath,
+                entity.DestinationHierarchyDelimiter,
+                out var destinationFolderPath))
         {
-            throw new InvalidOperationException(
-                $"Mailbox mutation audit entry {entity.Id} names '{entity.Mutation}', which is not a permitted mutation.");
+            return false;
         }
 
-        return new MailboxMutationAuditEntry
+        entry = new MailboxMutationAuditEntry
         {
             Id = MailboxMutationAuditEntryId.Create(entity.Id),
             MutationRecordId = MailboxMutationRecordId.Create(entity.MutationRecordId),
             AccountId = MailAccountId.Create(entity.MailboxAccountId),
             StoredEmailId = StoredEmailId.Create(entity.StoredEmailId),
             Mutation = mutation,
-            SourceFolderPath = ToFolderPath(
-                entity.Id,
-                entity.SourceFolderPath,
-                entity.SourceHierarchyDelimiter),
+            SourceFolderPath = sourceFolderPath,
             SourceUidValidity = ImapUidValidity.Create(entity.SourceUidValidity),
             SourceUid = ImapUid.Create(entity.SourceUid),
-            DestinationFolderPath = ToOptionalFolderPath(
-                entity.Id,
-                entity.DestinationFolderPath,
-                entity.DestinationHierarchyDelimiter),
+            DestinationFolderPath = destinationFolderPath,
             Placement = ToPlacement(entity),
             DesiredSeenState = entity.DesiredSeenState,
             Requester = MailboxMutationRequester.Create(entity.RequesterOrigin, entity.RequesterIdentity),
@@ -79,6 +94,8 @@ internal static class MailboxMutationAuditEntryMapping
             Outcome = entity.Outcome,
             Failure = ToFailure(entity),
         };
+
+        return true;
     }
 
     /// <summary>Restores a stored folder path exactly as it was written.</summary>
@@ -86,20 +103,30 @@ internal static class MailboxMutationAuditEntryMapping
     /// The text is not trimmed on the way back, for the reason it was not trimmed on the way in: IMAP permits a quoted
     /// mailbox name bounded by a space, and normalizing one would name a different mailbox or none at all.
     /// </remarks>
-    private static RemoteFolderPath ToFolderPath(Guid entryId, string storedPath, string? storedDelimiter)
-    {
-        return RemoteFolderPath.TryCreate(
+    private static bool TryToFolderPath(string storedPath, string? storedDelimiter, out RemoteFolderPath folderPath) =>
+        RemoteFolderPath.TryCreate(
             storedPath,
             storedDelimiter is { Length: > 0 } delimiter ? delimiter[0] : null,
-            out var folderPath)
-            ? folderPath
-            : throw new InvalidOperationException(
-                $"Mailbox mutation audit entry {entryId} carries a folder path that names no folder.");
-    }
+            out folderPath);
 
     /// <summary>Restores a folder path only a relocation or a copy carries.</summary>
-    private static RemoteFolderPath? ToOptionalFolderPath(Guid entryId, string? storedPath, string? storedDelimiter) =>
-        storedPath is null ? null : ToFolderPath(entryId, storedPath, storedDelimiter);
+    private static bool TryToOptionalFolderPath(
+        string? storedPath,
+        string? storedDelimiter,
+        out RemoteFolderPath? folderPath)
+    {
+        if (storedPath is null)
+        {
+            folderPath = null;
+
+            return true;
+        }
+
+        var parsed = TryToFolderPath(storedPath, storedDelimiter, out var storedFolderPath);
+        folderPath = parsed ? storedFolderPath : null;
+
+        return parsed;
+    }
 
     private static RemoteEmailPlacement ToPlacement(MailboxMutationAuditEntryEntity entity) =>
         entity is { PlacementUidValidity: { } uidValidity, PlacementUid: { } uid }

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryStore.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryStore.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Persistence;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Mutations.Audit;
+using MailFathom.Infrastructure.Observability;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
 using Microsoft.EntityFrameworkCore;
@@ -26,7 +27,10 @@ namespace MailFathom.Infrastructure.Persistence.Mutations;
 /// </para>
 /// </remarks>
 [RequiresIntegrationCoverage]
-internal sealed class MailboxMutationAuditEntryStore(MailFathomDbContext readContext) : IMailboxMutationAuditEntryStore
+internal sealed class MailboxMutationAuditEntryStore(
+    MailFathomDbContext readContext,
+    MailboxMutationAuditTelemetry telemetry)
+    : IMailboxMutationAuditEntryStore
 {
     /// <inheritdoc />
     public async Task AppendAsync(
@@ -78,12 +82,35 @@ internal sealed class MailboxMutationAuditEntryStore(MailFathomDbContext readCon
             .ToArrayAsync(cancellationToken);
 
         var pageEntities = entities.Take(query.PageSize).ToArray();
-        var entries = pageEntities.Select(MailboxMutationAuditEntryMapping.ToEntry).ToArray();
+        var entries = new List<MailboxMutationAuditEntry>(pageEntities.Length);
+        var unreadableCount = 0;
 
+        foreach (var entity in pageEntities)
+        {
+            if (MailboxMutationAuditEntryMapping.TryToEntry(entity, out var entry))
+            {
+                entries.Add(entry);
+            }
+            else
+            {
+                unreadableCount++;
+            }
+        }
+
+        if (unreadableCount > 0)
+        {
+            telemetry.RecordUnreadableEntries(query.AccountId, unreadableCount);
+        }
+
+        // The boundary is the last row read rather than the last entry presented, so a row this build cannot interpret
+        // costs its own place in the page and nothing else: the walk neither stalls on it nor repeats the rows around it.
         return new MailboxMutationAuditPage(
             entries,
-            entities.Length > query.PageSize && entries.Length > 0
-                ? MailboxMutationAuditCursor.After(entries[^1], query.FilterFingerprint)
+            entities.Length > query.PageSize && pageEntities.Length > 0
+                ? MailboxMutationAuditCursor.After(
+                    pageEntities[^1].CompletedAt,
+                    MailboxMutationAuditEntryId.Create(pageEntities[^1].Id),
+                    query.FilterFingerprint)
                 : null);
     }
 

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryStore.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryStore.cs
@@ -1,0 +1,164 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Application.Persistence;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Mutations.Audit;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Sessions;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailFathom.Infrastructure.Persistence.Mutations;
+
+/// <summary>Keeps the audit trail of every change MailFathom made to a remote mailbox, in PostgreSQL.</summary>
+/// <remarks>
+/// <para>
+/// The append uses the context enlisted in the caller's session; the page read uses the scoped context, because it joins
+/// no transaction. The erasure uses neither: it is a set-based delete that composes with nothing a caller is holding.
+/// </para>
+/// <para>
+/// Nothing here updates a row. An entry states an ending that already happened, so the trail only ever grows and
+/// shrinks, and the one uniqueness it enforces — one entry per mutation record — is what makes a repeated append leave
+/// the trail as it was.
+/// </para>
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class MailboxMutationAuditEntryStore(MailFathomDbContext readContext) : IMailboxMutationAuditEntryStore
+{
+    /// <inheritdoc />
+    public async Task AppendAsync(
+        IPersistenceSession session,
+        MailboxMutationAuditEntry entry,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var writeContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
+        var mutationRecordId = entry.MutationRecordId.Value;
+
+        // Looked up by the mutation rather than by the key, because a retried append generates a fresh key and the
+        // thing that must not happen twice is an entry for one ending. The change-tracker pass is explicit for the
+        // reason the mutation record's own lookup makes it explicit: an append staged earlier in this same uncommitted
+        // session would be invisible to a query.
+        var existing = await TrackedEntityLookup.SinglePendingOrPersistedAsync(
+            writeContext.MailboxMutationAuditEntries,
+            writeContext.MailboxMutationAuditEntries,
+            candidate => candidate.MutationRecordId == mutationRecordId,
+            cancellationToken);
+
+        if (existing is not null)
+        {
+            return;
+        }
+
+        writeContext.MailboxMutationAuditEntries.Add(MailboxMutationAuditEntryMapping.ToEntity(entry));
+    }
+
+    /// <inheritdoc />
+    public async Task<MailboxMutationAuditPage> ReadPageAsync(
+        MailboxMutationAuditQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var accountValue = query.AccountId.Value;
+
+        var entities = await this.Filter(query)
+            .Where(entry => entry.MailboxAccountId == accountValue)
+            .OrderByDescending(entry => entry.CompletedAt)
+            .ThenByDescending(entry => entry.Id)
+
+            // One more than the page holds, which is how the answer says whether a following page exists without a
+            // second count query over the same filtered set.
+            .Take(query.PageSize + 1)
+            .ToArrayAsync(cancellationToken);
+
+        var pageEntities = entities.Take(query.PageSize).ToArray();
+        var entries = pageEntities.Select(MailboxMutationAuditEntryMapping.ToEntry).ToArray();
+
+        return new MailboxMutationAuditPage(
+            entries,
+            entities.Length > query.PageSize && entries.Length > 0
+                ? MailboxMutationAuditCursor.After(entries[^1], query.FilterFingerprint)
+                : null);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> EraseCompletedBeforeAsync(
+        MailAccountId accountId,
+        DateTimeOffset completedBefore,
+        int limit,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+
+        var accountValue = accountId.Value;
+
+        // The bounded set is read first and deleted by key, rather than bounding the delete itself: PostgreSQL has no
+        // `DELETE ... LIMIT`, so a bound expressed on the delete either fails to translate or becomes a subquery whose
+        // shape depends on the provider. Two statements over the same index cost one extra round trip and keep the
+        // statement that takes row locks small enough to state.
+        var expiringIds = await readContext.MailboxMutationAuditEntries
+            .AsNoTracking()
+            .Where(entry => entry.MailboxAccountId == accountValue && entry.CompletedAt < completedBefore)
+            .OrderBy(entry => entry.CompletedAt)
+            .ThenBy(entry => entry.Id)
+            .Take(limit)
+            .Select(entry => entry.Id)
+            .ToArrayAsync(cancellationToken);
+
+        if (expiringIds.Length == 0)
+        {
+            return 0;
+        }
+
+        return await readContext.MailboxMutationAuditEntries
+            .Where(entry => expiringIds.Contains(entry.Id))
+            .ExecuteDeleteAsync(cancellationToken);
+    }
+
+    /// <summary>Applies the filters a query names, leaving the account and the ordering to the caller.</summary>
+    /// <remarks>
+    /// The mutation is compared by its stored name rather than through the closed enumeration, because a value object's
+    /// member inside a translated lambda either fails to translate or forces client evaluation.
+    /// </remarks>
+    private IQueryable<MailboxMutationAuditEntryEntity> Filter(MailboxMutationAuditQuery query)
+    {
+        var entries = readContext.MailboxMutationAuditEntries.AsNoTracking();
+
+        if (query.Mutation.IsSpecified)
+        {
+            var mutationName = query.Mutation.Name;
+            entries = entries.Where(entry => entry.Mutation == mutationName);
+        }
+
+        if (query.CompletedFrom is { } completedFrom)
+        {
+            entries = entries.Where(entry => entry.CompletedAt >= completedFrom);
+        }
+
+        if (query.CompletedBefore is { } completedBefore)
+        {
+            entries = entries.Where(entry => entry.CompletedAt < completedBefore);
+        }
+
+        // The keyset boundary is the pair the order is taken on, so an entry that finished in the same instant as the
+        // last one of the previous page is served exactly once rather than skipped or repeated. The identifier
+        // comparison is evaluated by PostgreSQL as a `uuid` comparison, which is what the index is ordered by, so it
+        // never has to agree with how the CLR happens to compare two `Guid` values.
+        if (query.Cursor is { } cursor)
+        {
+            var boundaryCompletedAt = cursor.CompletedAt;
+            var boundaryId = cursor.EntryId.Value;
+
+            entries = entries.Where(entry => entry.CompletedAt < boundaryCompletedAt
+                || (entry.CompletedAt == boundaryCompletedAt && entry.Id < boundaryId));
+        }
+
+        return entries;
+    }
+}

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditTrail.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditTrail.cs
@@ -1,0 +1,103 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+using MailFathom.Infrastructure.Observability;
+
+namespace MailFathom.Infrastructure.Persistence.Mutations;
+
+/// <summary>Appends one finished mutation to its account's audit trail, and never lets that append cost the mutation.</summary>
+/// <remarks>
+/// <para>
+/// The append is a commit of its own, made after the mutation's terminal stage is already durable. That ordering is what
+/// the guarantee rests on: by the time this runs, somebody's mailbox has already been changed and the record already
+/// says so, so nothing here can roll a change back and nothing here may fail the operation that made it.
+/// </para>
+/// <para>
+/// A failure is therefore swallowed, and swallowing it is only defensible because it is reported — which
+/// <see cref="MailboxMutationAuditTelemetry" /> is what does. A cancellation the caller raised is reported the same way
+/// and then travels on, because the entry it left unwritten is just as missing as one a database refused and the stage
+/// it was owed for is terminal, so no later attempt reaches this point again.
+/// </para>
+/// <para>
+/// What is deliberately not attempted is a retry loop of its own. The optimistic concurrency policy already repeats a
+/// conflicted commit, and anything beyond that would be a second retry policy wrapped around a write whose caller is
+/// finishing a mail-server operation.
+/// </para>
+/// </remarks>
+public sealed class MailboxMutationAuditTrail : IMailboxMutationAuditTrail
+{
+    private readonly IMailboxMutationAuditEntryStore store;
+    private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly TimeProvider timeProvider;
+    private readonly MailboxMutationAuditTelemetry telemetry;
+
+    /// <summary>Initializes the trail from the store it appends to and the channels a refused append is reported on.</summary>
+    /// <param name="store">Keeps the entries.</param>
+    /// <param name="commitPolicy">Commits the append in a transaction of its own, retrying an optimistic conflict.</param>
+    /// <param name="timeProvider">Stamps the instant the mutation ended.</param>
+    /// <param name="telemetry">Reports an append that did not happen.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
+    public MailboxMutationAuditTrail(
+        IMailboxMutationAuditEntryStore store,
+        OptimisticConcurrencyRetryPolicy commitPolicy,
+        TimeProvider timeProvider,
+        MailboxMutationAuditTelemetry telemetry)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(commitPolicy);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(telemetry);
+
+        this.store = store;
+        this.commitPolicy = commitPolicy;
+        this.timeProvider = timeProvider;
+        this.telemetry = telemetry;
+    }
+
+    /// <inheritdoc />
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "The mutation has already changed a remote mailbox and its record already says so; a trail that could fail the operation which produced it would be worse than a reported gap in the history.")]
+    public async Task RecordAsync(
+        MailboxMutationRecord record,
+        MailFolderResolution sourceFolder,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        ArgumentNullException.ThrowIfNull(sourceFolder);
+
+        if (!record.IsAudited)
+        {
+            return;
+        }
+
+        var completedAt = this.timeProvider.GetUtcNow();
+        var entry = MailboxMutationAuditEntry.Of(
+            MailboxMutationAuditEntryId.Create(Guid.CreateVersion7(completedAt)),
+            record,
+            sourceFolder,
+            completedAt);
+
+        try
+        {
+            await this.commitPolicy.CommitAsync(
+                (session, token) => this.store.AppendAsync(session, entry, token),
+                cancellationToken);
+        }
+        catch (OperationCanceledException cancellation) when (cancellationToken.IsCancellationRequested)
+        {
+            this.telemetry.RecordRefusedAppend(entry, cancellation);
+
+            throw;
+        }
+        catch (Exception failure)
+        {
+            this.telemetry.RecordRefusedAppend(entry, failure);
+        }
+    }
+}

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordMapping.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordMapping.cs
@@ -52,6 +52,7 @@ internal static class MailboxMutationRecordMapping
                 entity.DesiredSeenState,
                 ToLocalDisposition(entity, mutation)),
             Stage = entity.Stage,
+            IsAudited = entity.AuditTrailEnabled,
             RequiresSourceRemoval = entity.RequiresSourceRemoval,
             Placement = ToPlacement(entity),
             AttemptCount = entity.AttemptCount,

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordStore.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordStore.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.CodeCoverage;
@@ -30,7 +31,10 @@ namespace MailFathom.Infrastructure.Persistence.Mutations;
 /// </para>
 /// </remarks>
 [RequiresIntegrationCoverage]
-internal sealed class MailboxMutationRecordStore(MailFathomDbContext readContext, TimeProvider timeProvider)
+internal sealed class MailboxMutationRecordStore(
+    MailFathomDbContext readContext,
+    IMailboxMutationAuditSettingsReader auditSettingsReader,
+    TimeProvider timeProvider)
     : IMailboxMutationRecordStore
 {
     /// <inheritdoc />
@@ -77,6 +81,10 @@ internal sealed class MailboxMutationRecordStore(MailFathomDbContext readContext
             DestinationHierarchyDelimiter = request.DestinationPath?.HierarchyDelimiter?.ToString(),
             DesiredSeenState = request.DesiredSeenState,
             LocalDisposition = request.LocalDisposition,
+
+            // Resolved here, with the row, so a trail switched on or off while this mutation is in flight decides
+            // nothing about a change already begun.
+            AuditTrailEnabled = auditSettingsReader.GetAuditSettings(request.Occurrence.AccountId).IsEnabled,
             Stage = MailboxMutationStage.Recorded,
             RequiresSourceRemoval = false,
             AttemptCount = 0,

--- a/src/Infrastructure/Persistence/Sessions/PersistenceSessionFactory.cs
+++ b/src/Infrastructure/Persistence/Sessions/PersistenceSessionFactory.cs
@@ -46,7 +46,7 @@ internal sealed class PersistenceSessionFactory(MailFathomDbContext dbContext) :
         public Task RollbackTransactionAsync(CancellationToken cancellationToken) =>
             transaction.RollbackAsync(cancellationToken);
 
-        /// <summary>Recognizes the four inserts a competing writer can win, and nothing else.</summary>
+        /// <summary>Recognizes the five inserts a competing writer can win, and nothing else.</summary>
         /// <remarks>
         /// <para>
         /// Each names a constraint whose violation means "another run got here first" rather than "this data is
@@ -63,6 +63,13 @@ internal sealed class PersistenceSessionFactory(MailFathomDbContext dbContext) :
         /// and the retry reads back the record the winner wrote — which is exactly how the same request twice performs
         /// one mutation.
         /// </para>
+        /// <para>
+        /// The fifth is one audit entry per mutation ending, and it is listed for a reason the others do not have: what
+        /// reads the answer is a trail that swallows a failed append and counts it. An append repeated after a commit
+        /// whose answer was lost is the benign case that constraint exists for, and leaving it unrecognized would report
+        /// it as an entry the trail could not keep — on the very counter that makes swallowing defensible — while the
+        /// trail in fact holds exactly the one entry it should.
+        /// </para>
         /// </remarks>
         public bool IsConcurrencyConflict(DbUpdateException exception) =>
             exception.InnerException is PostgresException
@@ -71,7 +78,8 @@ internal sealed class PersistenceSessionFactory(MailFathomDbContext dbContext) :
                 ConstraintName: MailFathomDbContext.SynchronizationCheckpointPrimaryKeyConstraintName
                     or MailFathomDbContext.MailFolderBindingUniqueIndexName
                     or MailFathomDbContext.MailboxAccountPrimaryKeyConstraintName
-                    or MailFathomDbContext.MailboxMutationIdentityUniqueIndexName,
+                    or MailFathomDbContext.MailboxMutationIdentityUniqueIndexName
+                    or MailFathomDbContext.MailboxMutationAuditEntryMutationUniqueIndexName,
             };
 
         public void ClearTrackedState() => dbContext.ChangeTracker.Clear();

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ using MailFathom.Application.Emails.SearchEmails;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
@@ -324,6 +325,13 @@ public static class ServiceCollectionExtensions
         // Read by synchronization rather than by the performer, so that a relocation coming back through an ordinary
         // run is recognized as MailFathom's own instead of being stored as a second email.
         services.AddScoped<IMailboxMutationReconciliationStore, MailboxMutationReconciliationStore>();
+        // The history a finished change leaves behind, which is a second table with a lifetime of its own rather than
+        // the operational record above: that one ends with the mutation, and this one is kept for as long as the
+        // account's retention says and is erased by the pass beside it.
+        services.AddScoped<IMailboxMutationAuditEntryStore, MailboxMutationAuditEntryStore>();
+        services.AddSingleton<MailboxMutationAuditTelemetry>();
+        services.AddScoped<IMailboxMutationAuditTrail, MailboxMutationAuditTrail>();
+        services.AddScoped<MailboxMutationAuditTrailRetention>();
         services.AddScoped<IMailboxMutationPerformer, MailboxMutationPerformer>();
         // A singleton, because the gauges it publishes are the process's and the account snapshots behind them outlive
         // any one run; the pass that fills them is scoped like everything else that reaches a mail server.

--- a/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditCursorTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditCursorTests.cs
@@ -1,0 +1,106 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Mail.Mutations.Audit;
+
+/// <summary>Covers the boundary one page of an audit trail hands to the next.</summary>
+public sealed class MailboxMutationAuditCursorTests
+{
+    private const string Fingerprint = "0123456789abcdef";
+
+    private static readonly DateTimeOffset CompletedAt = new(2026, 8, 7, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>A cursor survives the round trip through the opaque text a caller presents.</summary>
+    [Fact]
+    public void TryDecode_TextThisVersionEncoded_RestoresTheBoundary()
+    {
+        // Arrange
+        var entry = Entry();
+        var encoded = MailboxMutationAuditCursor.After(entry, Fingerprint).Encode();
+
+        // Act
+        var decoded = MailboxMutationAuditCursor.TryDecode(encoded, out var cursor);
+
+        // Assert
+        Assert.Equal(
+            (true, entry.CompletedAt, entry.Id, Fingerprint),
+            (decoded, cursor.CompletedAt, cursor.EntryId, cursor.FilterFingerprint));
+    }
+
+    /// <summary>An instant written in another offset encodes identically, so a boundary never depends on the offset.</summary>
+    [Fact]
+    public void Encode_SameInstantInAnotherOffset_ProducesTheSameCursor()
+    {
+        // Arrange
+        var entry = Entry();
+        var shifted = entry with { CompletedAt = entry.CompletedAt.ToOffset(TimeSpan.FromHours(2)) };
+
+        // Act
+        var encodings = new[]
+        {
+            MailboxMutationAuditCursor.After(entry, Fingerprint).Encode(),
+            MailboxMutationAuditCursor.After(shifted, Fingerprint).Encode(),
+        };
+
+        // Assert
+        Assert.Equal(encodings[0], encodings[1]);
+    }
+
+    /// <summary>Text this system never issued names no boundary, and is reported rather than partly decoded.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("not a cursor")]
+    [InlineData("MC5ub3BlLm5vcGUubm9wZQ")]
+    public void TryDecode_TextThisSystemNeverIssued_IsRefused(string text)
+    {
+        // Act
+        var decoded = MailboxMutationAuditCursor.TryDecode(text, out _);
+
+        // Assert
+        Assert.False(decoded);
+    }
+
+    /// <summary>A cursor longer than any this version issues is refused before it is decoded at all.</summary>
+    [Fact]
+    public void TryDecode_TextLongerThanAnyCursorThisVersionIssues_IsRefusedUnread()
+    {
+        // Arrange
+        var overlong = new string('A', MailboxMutationAuditCursor.MaximumEncodedLength + 1);
+
+        // Act
+        var decoded = MailboxMutationAuditCursor.TryDecode(overlong, out _);
+
+        // Assert
+        Assert.False(decoded);
+    }
+
+    private static MailboxMutationAuditEntry Entry() => new()
+    {
+        Id = MailboxMutationAuditEntryId.Create(Guid.CreateVersion7(CompletedAt)),
+        MutationRecordId = MailboxMutationRecordId.Create(Guid.CreateVersion7(CompletedAt)),
+        AccountId = MailAccountId.Create("work"),
+        StoredEmailId = StoredEmailId.Create(Guid.CreateVersion7(CompletedAt)),
+        Mutation = MailboxMutation.Relocate,
+        SourceFolderPath = RemoteFolderPath.Create("INBOX"),
+        SourceUidValidity = ImapUidValidity.Create(1),
+        SourceUid = ImapUid.Create(41),
+        DestinationFolderPath = RemoteFolderPath.Create("Archive", '/'),
+        Placement = RemoteEmailPlacement.NotReported(),
+        DesiredSeenState = null,
+        Requester = MailboxMutationRequester.Rule("file-newsletters", 3),
+        RequestedAt = CompletedAt.AddMinutes(-1),
+        CompletedAt = CompletedAt,
+        Outcome = MailboxMutationAuditOutcome.Performed,
+        Failure = (MailFathomErrorCode?)null,
+    };
+}

--- a/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditQueryTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditQueryTests.cs
@@ -1,0 +1,156 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Mail.Mutations.Audit;
+
+/// <summary>Covers what a request for one page of an audit trail is accepted and refused for.</summary>
+public sealed class MailboxMutationAuditQueryTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+
+    private static readonly DateTimeOffset CompletedAt = new(2026, 8, 7, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>A request that names no page size is served the default rather than the whole trail.</summary>
+    [Fact]
+    public void Create_WithoutAPageSize_UsesTheDefault()
+    {
+        // Act
+        var result = Create(pageSize: null);
+
+        // Assert
+        Assert.Equal(MailboxMutationAuditQuery.DefaultPageSize, result.Query?.PageSize);
+    }
+
+    /// <summary>A page size outside the served range is refused rather than clamped, so nothing is silently dropped.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(MailboxMutationAuditQuery.MaximumPageSize + 1)]
+    public void Create_PageSizeOutsideTheServedRange_IsRefused(int pageSize)
+    {
+        // Act
+        var result = Create(pageSize);
+
+        // Assert
+        Assert.Equal(MailboxMutationAuditQueryOutcome.PageSizeOutOfRange, result.Outcome);
+    }
+
+    /// <summary>A range that ends where it begins names no entries, and saying so beats serving an empty page.</summary>
+    [Fact]
+    public void Create_TimeRangeThatEndsWhereItBegins_IsRefused()
+    {
+        // Act
+        var result = MailboxMutationAuditQuery.Create(
+            Account,
+            mutation: default,
+            CompletedAt,
+            CompletedAt,
+            pageSize: null,
+            cursor: null);
+
+        // Assert
+        Assert.Equal(MailboxMutationAuditQueryOutcome.TimeRangeEmpty, result.Outcome);
+    }
+
+    /// <summary>A cursor from one walk names no boundary in another, so presenting it to different filters is refused.</summary>
+    [Fact]
+    public void Create_CursorIssuedForOtherFilters_IsRefused()
+    {
+        // Arrange
+        var issuingQuery = Create(pageSize: null).Query!;
+        var cursor = MailboxMutationAuditCursor.After(Entry(), issuingQuery.FilterFingerprint);
+
+        // Act
+        var result = MailboxMutationAuditQuery.Create(
+            Account,
+            MailboxMutation.Delete,
+            completedFrom: null,
+            completedBefore: null,
+            pageSize: null,
+            cursor);
+
+        // Assert
+        Assert.Equal(MailboxMutationAuditQueryOutcome.CursorFilterMismatch, result.Outcome);
+    }
+
+    /// <summary>The same filters read under a different page size continue the same walk, because pacing is not a filter.</summary>
+    [Fact]
+    public void Create_CursorPresentedWithADifferentPageSize_IsAccepted()
+    {
+        // Arrange
+        var issuingQuery = Create(pageSize: 10).Query!;
+        var cursor = MailboxMutationAuditCursor.After(Entry(), issuingQuery.FilterFingerprint);
+
+        // Act
+        var result = MailboxMutationAuditQuery.Create(
+            Account,
+            mutation: default,
+            completedFrom: null,
+            completedBefore: null,
+            pageSize: 25,
+            cursor);
+
+        // Assert
+        Assert.Equal(MailboxMutationAuditQueryOutcome.Accepted, result.Outcome);
+    }
+
+    /// <summary>Two accounts never share a fingerprint, so a cursor cannot walk into another mailbox's history.</summary>
+    [Fact]
+    public void FilterFingerprint_DiffersByAccount()
+    {
+        // Arrange
+        var mine = Create(pageSize: null).Query!;
+
+        var theirs = MailboxMutationAuditQuery.Create(
+            MailAccountId.Create("personal"),
+            mutation: default,
+            completedFrom: null,
+            completedBefore: null,
+            pageSize: null,
+            cursor: null).Query!;
+
+        // Act
+        var fingerprints = new[] { mine.FilterFingerprint, theirs.FilterFingerprint };
+
+        // Assert
+        Assert.Distinct(fingerprints);
+    }
+
+    private static MailboxMutationAuditQueryResult Create(int? pageSize) => MailboxMutationAuditQuery.Create(
+        Account,
+        mutation: default,
+        completedFrom: null,
+        completedBefore: null,
+        pageSize,
+        cursor: null);
+
+    private static MailboxMutationAuditEntry Entry() => new()
+    {
+        Id = MailboxMutationAuditEntryId.Create(Guid.CreateVersion7(CompletedAt)),
+        MutationRecordId = MailboxMutationRecordId.Create(Guid.CreateVersion7(CompletedAt)),
+        AccountId = Account,
+        StoredEmailId = StoredEmailId.Create(Guid.CreateVersion7(CompletedAt)),
+        Mutation = MailboxMutation.Relocate,
+        SourceFolderPath = RemoteFolderPath.Create("INBOX"),
+        SourceUidValidity = ImapUidValidity.Create(1),
+        SourceUid = ImapUid.Create(41),
+        DestinationFolderPath = RemoteFolderPath.Create("Archive", '/'),
+        Placement = RemoteEmailPlacement.NotReported(),
+        DesiredSeenState = null,
+        Requester = MailboxMutationRequester.Rule("file-newsletters", 3),
+        RequestedAt = CompletedAt.AddMinutes(-1),
+        CompletedAt = CompletedAt,
+        Outcome = MailboxMutationAuditOutcome.Performed,
+        Failure = (MailFathomErrorCode?)null,
+    };
+}

--- a/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditTrailRetentionTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditTrailRetentionTests.cs
@@ -1,0 +1,87 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Domain.Accounts;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Mail.Mutations.Audit;
+
+/// <summary>Covers how far back one account's audit trail is allowed to reach.</summary>
+public sealed class MailboxMutationAuditTrailRetentionTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+
+    private static readonly DateTimeOffset RunInstant = new(2026, 8, 7, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>Everything that ended before the configured window is erased, and nothing inside it is.</summary>
+    [Fact]
+    public async Task EraseExpiredAsync_ConfiguredWindow_ErasesWhatEndedBeforeIt()
+    {
+        // Arrange
+        var store = Substitute.For<IMailboxMutationAuditEntryStore>();
+        var retention = CreateRetention(store, new MailboxMutationAuditSettings(IsEnabled: true, TimeSpan.FromDays(30)));
+
+        // Act
+        await retention.EraseExpiredAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        await store.Received(1).EraseCompletedBeforeAsync(
+            Account,
+            RunInstant.AddDays(-30),
+            MailboxMutationAuditTrailRetention.MaximumEntriesErasedPerPass,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>An account that has just turned the trail off still ages out what it wrote while it was on.</summary>
+    [Fact]
+    public async Task EraseExpiredAsync_TrailSwitchedOff_StillAgesOutWhatItAlreadyHolds()
+    {
+        // Arrange
+        var store = Substitute.For<IMailboxMutationAuditEntryStore>();
+        var retention = CreateRetention(store, new MailboxMutationAuditSettings(IsEnabled: false, TimeSpan.FromDays(30)));
+
+        // Act
+        await retention.EraseExpiredAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        await store.Received(1).EraseCompletedBeforeAsync(
+            Account,
+            RunInstant.AddDays(-30),
+            MailboxMutationAuditTrailRetention.MaximumEntriesErasedPerPass,
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>An account this deployment no longer configures names no window, so nothing of its history is destroyed.</summary>
+    [Fact]
+    public async Task EraseExpiredAsync_AccountThatNamesNoWindow_ErasesNothing()
+    {
+        // Arrange
+        var store = Substitute.For<IMailboxMutationAuditEntryStore>();
+        var retention = CreateRetention(store, MailboxMutationAuditSettings.Disabled);
+
+        // Act
+        var erasedCount = await retention.EraseExpiredAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        await store.DidNotReceive().EraseCompletedBeforeAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<DateTimeOffset>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+        Assert.Equal(0, erasedCount);
+    }
+
+    private static MailboxMutationAuditTrailRetention CreateRetention(
+        IMailboxMutationAuditEntryStore store,
+        MailboxMutationAuditSettings settings)
+    {
+        var settingsReader = Substitute.For<IMailboxMutationAuditSettingsReader>();
+        settingsReader.GetAuditSettings(Account).Returns(settings);
+
+        return new MailboxMutationAuditTrailRetention(settingsReader, store, new FakeTimeProvider(RunInstant));
+    }
+}

--- a/tests/Application.UnitTests/Mail/Mutations/Convergence/MailboxMutationConvergerTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Convergence/MailboxMutationConvergerTests.cs
@@ -440,6 +440,7 @@ public sealed class MailboxMutationConvergerTests
                 this.Store,
                 this.WriteSessionFactory,
                 commitPolicy,
+                this.AuditTrail,
                 new MailboxMutationOptions { MaximumAttempts = maximumAttempts });
 
             var transportSecurityPolicyReader = Substitute.For<IMailTransportSecurityPolicyReader>();
@@ -450,6 +451,7 @@ public sealed class MailboxMutationConvergerTests
                 this.Performer,
                 transportSecurityPolicyReader,
                 commitPolicy,
+                this.AuditTrail,
                 new MailboxConvergenceOptions
                 {
                     MaxMutationsPerPass = maxMutationsPerPass,
@@ -459,6 +461,8 @@ public sealed class MailboxMutationConvergerTests
         }
 
         internal InMemoryMailboxMutationRecordStore Store { get; } = new();
+
+        internal RecordingMailboxMutationAuditTrail AuditTrail { get; } = new();
 
         internal FakeTimeProvider Clock { get; } = new(new DateTimeOffset(2026, 8, 7, 12, 0, 0, TimeSpan.Zero));
 

--- a/tests/Application.UnitTests/Mail/Mutations/MailboxMutationPerformerTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/MailboxMutationPerformerTests.cs
@@ -11,6 +11,7 @@ using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
 using MailFathom.Domain.Transport;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -434,6 +435,139 @@ public sealed class MailboxMutationPerformerTests
         Assert.Equal(0, context.Store.OpenedRecordCount);
     }
 
+    /// <summary>Every change MailFathom is permitted to make leaves one entry behind on an account that asked for a trail.</summary>
+    [Theory]
+    [InlineData("relocate")]
+    [InlineData("delete")]
+    [InlineData("set-seen")]
+    [InlineData("copy")]
+    public async Task PerformAsync_OnAnAuditedAccount_LeavesOneEntryPerFinishedMutation(string mutationName)
+    {
+        // Arrange
+        var context = new PerformerContext();
+        context.Store.AuditsMutations = true;
+        var request = RequestFor(mutationName);
+
+        // Act
+        await context.Performer.PerformAsync(request, InboxFolder, TransportPolicy, CancellationToken.None);
+
+        // Assert
+        var entry = Assert.Single(context.AuditTrail.Entries);
+        Assert.Equal(
+            (request.Mutation, request.StoredEmailId, InboxFolder.RemotePath, MailboxMutationAuditOutcome.Performed),
+            (entry.Mutation, entry.StoredEmailId, entry.SourceFolderPath, entry.Outcome));
+    }
+
+    /// <summary>An account that never asked for a history accumulates none, which is what off by default has to mean.</summary>
+    [Fact]
+    public async Task PerformAsync_OnAnAccountWithoutTheTrail_LeavesNothingBehind()
+    {
+        // Arrange
+        var context = new PerformerContext();
+
+        // Act
+        await context.Performer.PerformAsync(
+            RelocationRequest(),
+            InboxFolder,
+            TransportPolicy,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Empty(context.AuditTrail.Entries);
+    }
+
+    /// <summary>A change nothing will attempt again is recorded as given up on, with the code it was given up on for.</summary>
+    [Fact]
+    public async Task PerformAsync_MutationTheServerRefuses_RecordsTheEndingItWasGivenUpOnFor()
+    {
+        // Arrange
+        var context = new PerformerContext();
+        context.Store.AuditsMutations = true;
+        context.FailRelocationWith(new MailboxDestinationFolderMissingException(
+            Account,
+            InboxFolder.Alias,
+            MailboxMutation.Relocate,
+            new InvalidOperationException("The folder could not be found.")));
+
+        // Act
+        await Assert.ThrowsAsync<MailboxDestinationFolderMissingException>(
+            () => context.Performer.PerformAsync(
+                RelocationRequest(),
+                InboxFolder,
+                TransportPolicy,
+                CancellationToken.None));
+
+        // Assert
+        var entry = Assert.Single(context.AuditTrail.Entries);
+        Assert.Equal(
+            (MailboxMutationAuditOutcome.Abandoned,
+                (MailFathomErrorCode?)MailFathomErrorCode.MailboxMutationDestinationMissing),
+            (entry.Outcome, entry.Failure));
+    }
+
+    /// <summary>A trail that cannot be written costs the history and never the change that had already been made.</summary>
+    [Fact]
+    public async Task PerformAsync_TrailThatRefusesEveryAppend_StillPerformsTheMutation()
+    {
+        // Arrange
+        var context = new PerformerContext();
+        context.Store.AuditsMutations = true;
+        context.AuditTrail.FailsEveryAppend = true;
+        var request = RelocationRequest();
+
+        // Act
+        var outcome = await context.Performer.PerformAsync(
+            request,
+            InboxFolder,
+            TransportPolicy,
+            CancellationToken.None);
+
+        // Assert
+        Assert.Equal(MailboxMutationStatus.Performed, outcome.Status);
+        Assert.Equal(MailboxMutationStage.Completed, context.Store.RecordOf(request).Stage);
+    }
+
+    /// <summary>The answer is resolved when the change is written down, so switching the trail on later leaves it out.</summary>
+    [Fact]
+    public async Task PerformAsync_TrailSwitchedOnAfterTheRecordWasOpened_LeavesThatMutationOut()
+    {
+        // Arrange
+        var context = new PerformerContext(maximumAttempts: 3);
+        var request = RelocationRequest();
+        context.FailRelocationWith(
+            new MailboxUnavailableException(Account, InboxFolder.Alias, new TimeoutException()));
+
+        await Assert.ThrowsAsync<MailboxUnavailableException>(
+            () => context.Performer.PerformAsync(request, InboxFolder, TransportPolicy, CancellationToken.None));
+
+        // Act
+        context.Store.AuditsMutations = true;
+        context.AnswerRelocationWith(ArchivedAt);
+        await context.Performer.PerformAsync(request, InboxFolder, TransportPolicy, CancellationToken.None);
+
+        // Assert
+        Assert.Empty(context.AuditTrail.Entries);
+    }
+
+    private static MailboxMutationRequest RequestFor(string mutationName)
+    {
+        var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
+        var occurrence = Occurrence(42U);
+        var requester = MailboxMutationRequester.Rule("file-newsletters", 3);
+
+        return mutationName switch
+        {
+            "relocate" => MailboxMutationRequest.Relocate(storedEmailId, occurrence, requester, ArchivePath),
+            "copy" => MailboxMutationRequest.Copy(storedEmailId, occurrence, requester, ArchivePath),
+            "set-seen" => MailboxMutationRequest.SetSeen(storedEmailId, occurrence, requester, isSeen: true),
+            _ => MailboxMutationRequest.Delete(
+                storedEmailId,
+                occurrence,
+                requester,
+                AuthoredDeleteEmailDisposition.RetainLocalCopy),
+        };
+    }
+
     private static EmailOccurrenceId Occurrence(uint uid) => EmailOccurrenceId.Create(
         Account,
         InboxFolder.Id,
@@ -485,10 +619,13 @@ public sealed class MailboxMutationPerformerTests
                     sessionFactory,
                     new PersistenceConcurrencyOptions { MaximumCommitAttempts = 1 },
                     TimeProvider.System),
+                this.AuditTrail,
                 new MailboxMutationOptions { MaximumAttempts = maximumAttempts });
         }
 
         internal InMemoryMailboxMutationRecordStore Store { get; } = new();
+
+        internal RecordingMailboxMutationAuditTrail AuditTrail { get; } = new();
 
         internal IMailboxWriteSession WriteSession { get; }
 

--- a/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -2026,6 +2026,7 @@ public sealed class MailboxSynchronizerTests
                 MailboxMutationRequester.Rule("file-newsletters", 1),
                 InboxFolder.RemotePath),
             Stage = MailboxMutationStage.Completed,
+            IsAudited = false,
             RequiresSourceRemoval = true,
             Placement = RemoteEmailPlacement.Reported(placedUidValidity, placedUid),
             AttemptCount = 1,

--- a/tests/Application.UnitTests/Synchronization/Reconciliation/MailboxReconcilerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/Reconciliation/MailboxReconcilerTests.cs
@@ -1121,6 +1121,7 @@ public sealed class MailboxReconcilerTests
                     requester,
                     localDisposition),
             Stage = MailboxMutationStage.Completed,
+            IsAudited = false,
             RequiresSourceRemoval = isRelocation,
             Placement = isRelocation
                 ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(99), ImapUid.Create(4))
@@ -1152,6 +1153,7 @@ public sealed class MailboxReconcilerTests
                 MailboxMutationRequester.Rule("mark-newsletters-read", 1),
                 isSeen),
             Stage = stage,
+            IsAudited = false,
             RequiresSourceRemoval = false,
             Placement = RemoteEmailPlacement.NotReported(),
             AttemptCount = 1,

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationRecordStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationRecordStore.cs
@@ -28,6 +28,13 @@ internal sealed class InMemoryMailboxMutationRecordStore : IMailboxMutationRecor
     /// <summary>Gets how many requests were written down, which is one per idempotency identity however often it was asked.</summary>
     internal int OpenedRecordCount => this.recordsById.Count;
 
+    /// <summary>Gets or sets what the account's audit trail setting resolves to when a record is opened.</summary>
+    /// <remarks>
+    /// It is a property of the store because that is where the real one resolves it: the answer is written onto the row
+    /// once and never re-read, so a test arranges it here rather than by changing a setting mid-run.
+    /// </remarks>
+    internal bool AuditsMutations { get; set; }
+
     /// <inheritdoc />
     public Task<MailboxMutationRecord> OpenAsync(
         IPersistenceSession session,
@@ -46,6 +53,7 @@ internal sealed class InMemoryMailboxMutationRecordStore : IMailboxMutationRecor
             Id = MailboxMutationRecordId.Create(Guid.CreateVersion7(this.Advance())),
             Request = request,
             Stage = MailboxMutationStage.Recorded,
+            IsAudited = this.AuditsMutations,
             RequiresSourceRemoval = false,
             Placement = RemoteEmailPlacement.NotReported(),
             AttemptCount = 0,

--- a/tests/Application.UnitTests/TestDoubles/RecordingMailboxMutationAuditTrail.cs
+++ b/tests/Application.UnitTests/TestDoubles/RecordingMailboxMutationAuditTrail.cs
@@ -1,0 +1,57 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+
+namespace MailFathom.Application.UnitTests.TestDoubles;
+
+/// <summary>Keeps the audit entries a run appended, and reproduces the one rule the trail decides for itself.</summary>
+/// <remarks>
+/// That rule is whether an entry is owed at all, which the record carries and no caller re-reads. Everything else the
+/// real trail does — committing in a transaction of its own and swallowing a failure — belongs to the adapter and is
+/// proven against a real database, so the double appends in memory and, when a test asks it to, refuses in the same way
+/// the real one absorbs a refusal.
+/// </remarks>
+internal sealed class RecordingMailboxMutationAuditTrail : IMailboxMutationAuditTrail
+{
+    private readonly List<MailboxMutationAuditEntry> entries = [];
+    private DateTimeOffset completedAt = new(2026, 8, 7, 13, 0, 0, TimeSpan.Zero);
+
+    /// <summary>Gets the entries appended, in the order the mutations ended.</summary>
+    internal IReadOnlyList<MailboxMutationAuditEntry> Entries => this.entries;
+
+    /// <summary>Gets or sets whether every append fails, as a trail whose database is unreachable would.</summary>
+    internal bool FailsEveryAppend { get; set; }
+
+    /// <inheritdoc />
+    public Task RecordAsync(
+        MailboxMutationRecord record,
+        MailFolderResolution sourceFolder,
+        CancellationToken cancellationToken)
+    {
+        if (!record.IsAudited)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (this.FailsEveryAppend)
+        {
+            // Swallowed exactly as the adapter swallows it: the change has already been made and the trail may not
+            // fail the operation that made it.
+            return Task.CompletedTask;
+        }
+
+        this.completedAt = this.completedAt.AddSeconds(1);
+        this.entries.Add(MailboxMutationAuditEntry.Of(
+            MailboxMutationAuditEntryId.Create(Guid.CreateVersion7(this.completedAt)),
+            record,
+            sourceFolder,
+            this.completedAt));
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Domain.UnitTests/Mutations/Audit/MailboxMutationAuditEntryTests.cs
+++ b/tests/Domain.UnitTests/Mutations/Audit/MailboxMutationAuditEntryTests.cs
@@ -1,0 +1,279 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Mutations.Audit;
+
+/// <summary>Covers what one finished mutation states in the history it leaves behind.</summary>
+public sealed class MailboxMutationAuditEntryTests
+{
+    private static readonly DateTimeOffset RecordedAt = new(2026, 8, 7, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly DateTimeOffset CompletedAt = RecordedAt.AddMinutes(4);
+
+    private static readonly RemoteFolderPath Inbox = RemoteFolderPath.Create("INBOX");
+
+    private static readonly RemoteFolderPath Archive = RemoteFolderPath.Create("Archive", '/');
+
+    private static readonly StoredEmailId LocalEmail = StoredEmailId.Create(Guid.CreateVersion7(RecordedAt));
+
+    private static readonly MailboxMutationRequester Requester = MailboxMutationRequester.Rule("file-newsletters", 3);
+
+    private static readonly MailFolderResolution SourceFolder = MailFolderResolution.FirstBindingOf(
+        MailFolderAlias.Create("inbox"),
+        Inbox);
+
+    private static readonly ImapUidValidity DestinationUidValidity = ImapUidValidity.Create(9001);
+
+    private static readonly ImapUid PlacedUid = ImapUid.Create(77);
+
+    private static readonly MailboxMutationAuditEntryId EntryId =
+        MailboxMutationAuditEntryId.Create(Guid.CreateVersion7(CompletedAt));
+
+    /// <summary>Everything a person needs to reconstruct a relocation without reading the mail is on the entry.</summary>
+    [Fact]
+    public void Of_CompletedRelocation_StatesTheActInFull()
+    {
+        // Arrange
+        var record = CompletedRelocation();
+
+        // Act
+        var entry = MailboxMutationAuditEntry.Of(EntryId, record, SourceFolder, CompletedAt);
+
+        // Assert
+        Assert.Equal(
+            (MailboxMutation.Relocate,
+                LocalEmail,
+                Inbox,
+                ImapUidValidity.Create(1),
+                ImapUid.Create(41),
+                (RemoteFolderPath?)Archive,
+                (ImapUid?)PlacedUid,
+                Requester,
+                RecordedAt,
+                CompletedAt,
+                MailboxMutationAuditOutcome.Performed,
+                (MailFathomErrorCode?)null),
+            (entry.Mutation,
+                entry.StoredEmailId,
+                entry.SourceFolderPath,
+                entry.SourceUidValidity,
+                entry.SourceUid,
+                entry.DestinationFolderPath,
+                entry.Placement.Uid,
+                entry.Requester,
+                entry.RequestedAt,
+                entry.CompletedAt,
+                entry.Outcome,
+                entry.Failure));
+    }
+
+    /// <summary>A delete names no destination and no flag direction, and still names the folder the mail was taken out of.</summary>
+    [Fact]
+    public void Of_CompletedDelete_NamesTheSourceAndNoDestination()
+    {
+        // Arrange
+        var record = CompletedRelocation() with
+        {
+            Request = MailboxMutationRequest.Delete(
+                LocalEmail,
+                SourceOccurrence(),
+                Requester,
+                AuthoredDeleteEmailDisposition.RetainLocalCopy),
+            Placement = RemoteEmailPlacement.NotReported(),
+        };
+
+        // Act
+        var entry = MailboxMutationAuditEntry.Of(EntryId, record, SourceFolder, CompletedAt);
+
+        // Assert
+        Assert.Equal(
+            (MailboxMutation.Delete, Inbox, (RemoteFolderPath?)null, (bool?)null),
+            (entry.Mutation, entry.SourceFolderPath, entry.DestinationFolderPath, entry.DesiredSeenState));
+    }
+
+    /// <summary>A flag change records which way it was asked for, because reading it back is the whole question.</summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Of_CompletedSeenStateChange_RecordsTheDirection(bool isSeen)
+    {
+        // Arrange
+        var record = CompletedRelocation() with
+        {
+            Request = MailboxMutationRequest.SetSeen(LocalEmail, SourceOccurrence(), Requester, isSeen),
+            Placement = RemoteEmailPlacement.NotReported(),
+        };
+
+        // Act
+        var entry = MailboxMutationAuditEntry.Of(EntryId, record, SourceFolder, CompletedAt);
+
+        // Assert
+        Assert.Equal(
+            (MailboxMutation.SetSeen, (bool?)isSeen),
+            (entry.Mutation, entry.DesiredSeenState));
+    }
+
+    /// <summary>A copy records where the second occurrence landed, which is what tells it from the relocation it looks like.</summary>
+    [Fact]
+    public void Of_CompletedCopy_RecordsThePlacementTheServerNamed()
+    {
+        // Arrange
+        var record = CompletedRelocation() with
+        {
+            Request = MailboxMutationRequest.Copy(LocalEmail, SourceOccurrence(), Requester, Archive),
+        };
+
+        // Act
+        var entry = MailboxMutationAuditEntry.Of(EntryId, record, SourceFolder, CompletedAt);
+
+        // Assert
+        Assert.Equal(
+            (MailboxMutation.Copy, (RemoteFolderPath?)Archive, (ImapUidValidity?)DestinationUidValidity, (ImapUid?)PlacedUid),
+            (entry.Mutation, entry.DestinationFolderPath, entry.Placement.UidValidity, entry.Placement.Uid));
+    }
+
+    /// <summary>A change that was given up on says so, and carries the code it was given up on for.</summary>
+    [Fact]
+    public void Of_AbandonedMutation_CarriesTheFailureItEndedOn()
+    {
+        // Arrange
+        var record = CompletedRelocation() with
+        {
+            Stage = MailboxMutationStage.Abandoned,
+            LastFailure = MailFathomErrorCode.MailboxMutationDestinationMissing,
+        };
+
+        // Act
+        var entry = MailboxMutationAuditEntry.Of(EntryId, record, SourceFolder, CompletedAt);
+
+        // Assert
+        Assert.Equal(
+            (MailboxMutationAuditOutcome.Abandoned, (MailFathomErrorCode?)MailFathomErrorCode.MailboxMutationDestinationMissing),
+            (entry.Outcome, entry.Failure));
+    }
+
+    /// <summary>A change that succeeded after a failed attempt records the ending, not what it survived on the way.</summary>
+    [Fact]
+    public void Of_CompletedMutationThatFailedOnce_CarriesNoFailure()
+    {
+        // Arrange
+        var record = CompletedRelocation() with
+        {
+            LastFailure = MailFathomErrorCode.MailboxUnavailable,
+        };
+
+        // Act
+        var entry = MailboxMutationAuditEntry.Of(EntryId, record, SourceFolder, CompletedAt);
+
+        // Assert
+        Assert.Equal(
+            (MailboxMutationAuditOutcome.Performed, (MailFathomErrorCode?)null),
+            (entry.Outcome, entry.Failure));
+    }
+
+    /// <summary>A mutation still in flight states no ending, so no entry is written from one.</summary>
+    [Theory]
+    [InlineData(MailboxMutationStage.Recorded)]
+    [InlineData(MailboxMutationStage.PlacementIssued)]
+    [InlineData(MailboxMutationStage.PlacementConfirmed)]
+    [InlineData(MailboxMutationStage.SourceFlaggedDeleted)]
+    public void Of_MutationThatHasNotEnded_IsRefused(MailboxMutationStage stage)
+    {
+        // Arrange
+        var record = CompletedRelocation() with { Stage = stage };
+
+        // Act
+        var refusal = Record.Exception(() =>
+            MailboxMutationAuditEntry.Of(EntryId, record, SourceFolder, CompletedAt));
+
+        // Assert
+        Assert.IsType<ArgumentException>(refusal);
+    }
+
+    /// <summary>A binding that is not the one the change was aimed at would put the act in the wrong folder.</summary>
+    [Fact]
+    public void Of_FolderBindingTheOccurrenceDoesNotName_IsRefused()
+    {
+        // Arrange
+        var otherFolder = MailFolderResolution.FirstBindingOf(MailFolderAlias.Create("later"), Archive);
+
+        // Act
+        var refusal = Record.Exception(() =>
+            MailboxMutationAuditEntry.Of(EntryId, CompletedRelocation(), otherFolder, CompletedAt));
+
+        // Assert
+        Assert.IsType<ArgumentException>(refusal);
+    }
+
+    /// <summary>The entry holds identifiers, folder paths, and MailFathom's own names — and nothing that could be mail.</summary>
+    /// <remarks>
+    /// Asserted against the declared members rather than against one entry's values, because what has to stay true is
+    /// that no subject, address, body fragment, or filename is ever added here. A member arriving without a decision
+    /// fails this and forces one.
+    /// </remarks>
+    [Fact]
+    public void DeclaredMembers_AreOnlyIdentitiesTimestampsAndOutcome()
+    {
+        // Arrange
+        string[] expectedMembers =
+        [
+            nameof(MailboxMutationAuditEntry.Id),
+            nameof(MailboxMutationAuditEntry.MutationRecordId),
+            nameof(MailboxMutationAuditEntry.AccountId),
+            nameof(MailboxMutationAuditEntry.StoredEmailId),
+            nameof(MailboxMutationAuditEntry.Mutation),
+            nameof(MailboxMutationAuditEntry.SourceFolderPath),
+            nameof(MailboxMutationAuditEntry.SourceUidValidity),
+            nameof(MailboxMutationAuditEntry.SourceUid),
+            nameof(MailboxMutationAuditEntry.DestinationFolderPath),
+            nameof(MailboxMutationAuditEntry.Placement),
+            nameof(MailboxMutationAuditEntry.DesiredSeenState),
+            nameof(MailboxMutationAuditEntry.Requester),
+            nameof(MailboxMutationAuditEntry.RequestedAt),
+            nameof(MailboxMutationAuditEntry.CompletedAt),
+            nameof(MailboxMutationAuditEntry.Outcome),
+            nameof(MailboxMutationAuditEntry.Failure),
+        ];
+
+        // Act
+        var declaredMembers = typeof(MailboxMutationAuditEntry)
+            .GetProperties()
+            .Select(property => property.Name)
+            .Where(name => !string.Equals(name, "EqualityContract", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal);
+
+        // Assert
+        Assert.Equal(expectedMembers.Order(StringComparer.Ordinal), declaredMembers);
+    }
+
+    private static EmailOccurrenceId SourceOccurrence() => EmailOccurrenceId.Create(
+        MailAccountId.Create("work"),
+        SourceFolder.Id,
+        ImapUidValidity.Create(1),
+        ImapUid.Create(41));
+
+    private static MailboxMutationRecord CompletedRelocation() => new()
+    {
+        Id = MailboxMutationRecordId.Create(Guid.CreateVersion7(RecordedAt)),
+        Request = MailboxMutationRequest.Relocate(LocalEmail, SourceOccurrence(), Requester, Archive),
+        Stage = MailboxMutationStage.Completed,
+        IsAudited = true,
+        RequiresSourceRemoval = true,
+        Placement = RemoteEmailPlacement.Reported(DestinationUidValidity, PlacedUid),
+        AttemptCount = 1,
+        RecordedAt = RecordedAt,
+        StageChangedAt = CompletedAt,
+        LastFailure = null,
+        PlacementObservedAt = null,
+        SourceRemovalObservedAt = null,
+    };
+}

--- a/tests/Domain.UnitTests/Mutations/MailboxMutationRecordTests.cs
+++ b/tests/Domain.UnitTests/Mutations/MailboxMutationRecordTests.cs
@@ -510,6 +510,7 @@ public sealed class MailboxMutationRecordTests
         Id = MailboxMutationRecordId.Create(Guid.CreateVersion7(RecordedAt)),
         Request = MailboxMutationRequest.Relocate(LocalEmail, SourceOccurrence(), Requester, Archive),
         Stage = MailboxMutationStage.Completed,
+        IsAudited = false,
         RequiresSourceRemoval = true,
         Placement = RemoteEmailPlacement.Reported(DestinationUidValidity, PlacedUid),
         AttemptCount = 1,

--- a/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Accounts;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Host.Api;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Transport;
@@ -77,9 +78,9 @@ public sealed class AdminApiEndpointsTests
         Assert.All(mapped, endpoint => Assert.Empty(endpoint.Metadata.GetOrderedMetadata<IAuthorizeData>()));
     }
 
-    /// <summary>Both routes are the group's, and the write route is the one whose absence from it would matter most.</summary>
+    /// <summary>Every route is the group's, and the write route is the one whose absence from it would matter most.</summary>
     [Fact]
-    public void MapAdminApi_Always_ServesBothRoutesBeneathTheAdministrativePrefix()
+    public void MapAdminApi_Always_ServesEveryRouteBeneathTheAdministrativePrefix()
     {
         // Arrange
         var endpoints = BuildRouteBuilder();
@@ -95,6 +96,7 @@ public sealed class AdminApiEndpointsTests
 
         Assert.Equal(
             [
+                $"{AdminEndpointOptions.RoutePrefix}{MailboxMutationAuditEndpoint.Route}",
                 $"{AdminEndpointOptions.RoutePrefix}{MailboxRefreshTokenEndpoint.Route}",
                 $"{AdminEndpointOptions.RoutePrefix}/session",
             ],
@@ -155,6 +157,8 @@ public sealed class AdminApiEndpointsTests
         services.AddScoped(_ => new MailboxRefreshTokenRecorder(
             Substitute.For<IMailAccountCatalog>(),
             Substitute.For<IMailboxRefreshTokenStore>()));
+        services.AddScoped(_ => Substitute.For<IMailAccountCatalog>());
+        services.AddScoped(_ => Substitute.For<IMailboxMutationAuditEntryStore>());
 
         return new TestEndpointRouteBuilder(services.BuildServiceProvider());
     }

--- a/tests/Host.UnitTests/Configuration/Mail/MailSynchronizationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailSynchronizationOptionsTests.cs
@@ -263,6 +263,60 @@ public sealed class MailSynchronizationOptionsTests
         Assert.Contains(messages, message => message!.Contains("no password secret reference", StringComparison.Ordinal));
     }
 
+    /// <summary>The block decides when personal data is destroyed, so a typo in it fails startup rather than binding away.</summary>
+    [Fact]
+    public void ValidateForSynchronization_AccountWhoseAuditTrailBlockIsNotABlock_ReportsIt()
+    {
+        // Arrange
+        var account = CreateAccount("primary");
+        account.AuditTrail = null!;
+        var options = new MailSynchronizationOptions { Enabled = true, Accounts = [account] };
+
+        // Act
+        var messages = options.ValidateForSynchronization().Select(result => result.ErrorMessage).ToArray();
+
+        // Assert
+        Assert.Contains(messages, message => message!.Contains("Account 'primary'", StringComparison.Ordinal)
+            && message.Contains("audit trail configuration must be a block", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A window shorter than a run would erase entries before the run that would have shown them, and one beyond the
+    /// ceiling stops being a retention anybody could justify. Both fail startup rather than being clamped.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(23)]
+    [InlineData(3650 * 24 + 1)]
+    public void ValidateForSynchronization_AuditTrailRetentionOutsideTheAcceptedRange_ReportsIt(int retentionHours)
+    {
+        // Arrange
+        var account = CreateAccount("primary");
+        account.AuditTrail.Retention = TimeSpan.FromHours(retentionHours);
+        var options = new MailSynchronizationOptions { Enabled = true, Accounts = [account] };
+
+        // Act
+        var messages = options.ValidateForSynchronization().Select(result => result.ErrorMessage).ToArray();
+
+        // Assert
+        Assert.Contains(messages, message => message!.Contains("Account 'primary'", StringComparison.Ordinal)
+            && message.Contains("audit trail retention must be between", StringComparison.Ordinal));
+    }
+
+    /// <summary>The control for the two above: the default block an account that configures nothing gets is accepted.</summary>
+    [Fact]
+    public void ValidateForSynchronization_AccountThatConfiguresNoAuditTrail_ReportsNoAuditTrailError()
+    {
+        // Arrange
+        var options = new MailSynchronizationOptions { Enabled = true, Accounts = [CreateAccount("primary")] };
+
+        // Act
+        var messages = options.ValidateForSynchronization().Select(result => result.ErrorMessage).ToArray();
+
+        // Assert
+        Assert.DoesNotContain(messages, message => message!.Contains("audit trail", StringComparison.Ordinal));
+    }
+
     [Fact]
     public void ValidateForSynchronization_UnsafeTransportSecurity_NamesTheAccountAndTheViolationIdentity()
     {

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
@@ -123,6 +124,14 @@ internal static class SynchronizationTestHost
         services.AddSingleton<MailboxConvergenceTelemetry>();
         services.AddScoped<IMailboxMutationPerformer, MailboxMutationPerformer>();
         services.AddScoped<MailboxMutationConverger>();
+
+        // The trail and its retention pass are composed here for the same reason convergence is: a supervisor resolves
+        // both from its scope. Neither is what these tests are about — the trail is off for every account they
+        // configure, so both answer that there is nothing to keep and nothing to erase.
+        services.AddSingleton(CreateTrailThatKeepsNothing());
+        services.AddSingleton(CreateAuditStoreWithNothingToErase());
+        services.AddScoped<IMailboxMutationAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
+        services.AddScoped<MailboxMutationAuditTrailRetention>();
         services.AddLogging();
 
         // Each run hands its own snapshot to the scopes it opens, and every per-account reader answers from that
@@ -259,6 +268,35 @@ internal static class SynchronizationTestHost
             .Returns(Task.FromResult<IReadOnlyList<MailboxMutationLifecycleCount>>([]));
 
         return recordStore;
+    }
+
+    /// <summary>Answers every append, because the accounts these tests configure keep no trail and owe none.</summary>
+    private static IMailboxMutationAuditTrail CreateTrailThatKeepsNothing()
+    {
+        var auditTrail = Substitute.For<IMailboxMutationAuditTrail>();
+        auditTrail
+            .RecordAsync(
+                Arg.Any<MailboxMutationRecord>(),
+                Arg.Any<MailFolderResolution>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+
+        return auditTrail;
+    }
+
+    /// <summary>Answers a retention pass that the account's trail holds nothing that has outlived its window.</summary>
+    private static IMailboxMutationAuditEntryStore CreateAuditStoreWithNothingToErase()
+    {
+        var auditStore = Substitute.For<IMailboxMutationAuditEntryStore>();
+        auditStore
+            .EraseCompletedBeforeAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<DateTimeOffset>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(0));
+
+        return auditStore;
     }
 
     private static IMailboxMutationReconciliationStore CreateMutationStoreWithNothingRecorded()

--- a/tests/Infrastructure.UnitTests/Persistence/Mutations/MailboxMutationAuditEntryMappingTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Mutations/MailboxMutationAuditEntryMappingTests.cs
@@ -1,0 +1,115 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Mutations;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Mutations;
+
+/// <summary>Covers which stored audit rows this build can present, and which it declines rather than approximates.</summary>
+/// <remarks>
+/// The trail is read a page at a time and paginated by position, so a row this build cannot interpret has to be a
+/// reported answer rather than an exception: thrown out of the mapping it would fail the whole page and every page after
+/// it, which would wedge an account's history from the first row a later build wrote.
+/// </remarks>
+public sealed class MailboxMutationAuditEntryMappingTests
+{
+    private static readonly DateTimeOffset RecordedAt = new(2026, 8, 7, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>A row this build wrote reads back as the act it recorded.</summary>
+    [Fact]
+    public void TryToEntry_RowThisBuildWrote_RebuildsTheEntry()
+    {
+        // Arrange
+        var entity = StoredRelocation();
+
+        // Act
+        var rebuilt = MailboxMutationAuditEntryMapping.TryToEntry(entity, out var entry);
+
+        // Assert
+        Assert.True(rebuilt);
+        Assert.Equal(
+            (MailboxMutation.Relocate,
+                RemoteFolderPath.Create("INBOX"),
+                (RemoteFolderPath?)RemoteFolderPath.Create("Archive", '/'),
+                MailboxMutationAuditOutcome.Performed),
+            (entry!.Mutation, entry.SourceFolderPath, entry.DestinationFolderPath, entry.Outcome));
+    }
+
+    /// <summary>A mutation kind this build does not permit is a later build's row, and it costs its own place and nothing else.</summary>
+    [Fact]
+    public void TryToEntry_RowNamingAMutationThisBuildDoesNotPermit_IsDeclined()
+    {
+        // Arrange
+        var entity = StoredRelocation();
+        entity.Mutation = "archive-forever";
+
+        // Act
+        var rebuilt = MailboxMutationAuditEntryMapping.TryToEntry(entity, out var entry);
+
+        // Assert
+        Assert.False(rebuilt);
+        Assert.Null(entry);
+    }
+
+    /// <summary>A stored path that names no folder is declined the same way, rather than throwing out of the page.</summary>
+    [Fact]
+    public void TryToEntry_RowCarryingAPathThatNamesNoFolder_IsDeclined()
+    {
+        // Arrange
+        var entity = StoredRelocation();
+        entity.SourceFolderPath = "  ";
+
+        // Act
+        var rebuilt = MailboxMutationAuditEntryMapping.TryToEntry(entity, out var entry);
+
+        // Assert
+        Assert.False(rebuilt);
+        Assert.Null(entry);
+    }
+
+    /// <summary>A failure code this build has not allocated is diagnostic detail, so it is dropped rather than declining the row.</summary>
+    [Fact]
+    public void TryToEntry_RowNamingAFailureCodeThisBuildHasNotAllocated_KeepsTheEntryWithoutIt()
+    {
+        // Arrange
+        var entity = StoredRelocation();
+        entity.Outcome = MailboxMutationAuditOutcome.Abandoned;
+        entity.FailureCode = 99999;
+
+        // Act
+        var rebuilt = MailboxMutationAuditEntryMapping.TryToEntry(entity, out var entry);
+
+        // Assert
+        Assert.True(rebuilt);
+        Assert.Equal(
+            (MailboxMutationAuditOutcome.Abandoned, (MailFathomErrorCode?)null),
+            (entry!.Outcome, entry.Failure));
+    }
+
+    private static MailboxMutationAuditEntryEntity StoredRelocation() => new()
+    {
+        Id = Guid.CreateVersion7(RecordedAt),
+        MutationRecordId = Guid.CreateVersion7(RecordedAt),
+        MailboxAccountId = "work",
+        StoredEmailId = Guid.CreateVersion7(RecordedAt),
+        Mutation = MailboxMutation.Relocate.Name,
+        SourceFolderPath = "INBOX",
+        SourceHierarchyDelimiter = null,
+        SourceUidValidity = 1,
+        SourceUid = 41,
+        DestinationFolderPath = "Archive",
+        DestinationHierarchyDelimiter = "/",
+        RequesterOrigin = MailboxMutationOrigin.Rule,
+        RequesterIdentity = "file-newsletters@3",
+        RequestedAt = RecordedAt,
+        CompletedAt = RecordedAt.AddMinutes(4),
+        Outcome = MailboxMutationAuditOutcome.Performed,
+    };
+}

--- a/tests/Infrastructure.UnitTests/Persistence/Mutations/MailboxMutationAuditTrailTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Mutations/MailboxMutationAuditTrailTests.cs
@@ -1,0 +1,183 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+using MailFathom.Infrastructure.Observability;
+using MailFathom.Infrastructure.Persistence.Mutations;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Mutations;
+
+/// <summary>Covers the one rule that decides whether a finished mutation's history is kept, and what a lost entry costs.</summary>
+/// <remarks>
+/// The append itself is a database write and is proven against real PostgreSQL. What is here is the part above it: an
+/// account that never asked for a trail is written nothing, and an append that does not happen may not fail the mutation
+/// that has already changed somebody's mailbox — but has to be visible.
+/// </remarks>
+public sealed class MailboxMutationAuditTrailTests : IDisposable
+{
+    private static readonly DateTimeOffset RecordedAt = new(2026, 8, 7, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+
+    private static readonly MailFolderResolution Inbox = MailFolderResolution.FirstBindingOf(
+        MailFolderAlias.Create("inbox"),
+        RemoteFolderPath.Create("INBOX"));
+
+    private static readonly RemoteFolderPath ArchivePath = RemoteFolderPath.Create("Archive", '/');
+
+    private readonly RecordingLoggerProvider logs = new();
+    private readonly ILoggerFactory loggerFactory;
+    private readonly IMailboxMutationAuditEntryStore store = Substitute.For<IMailboxMutationAuditEntryStore>();
+    private readonly MailboxMutationAuditTrail trail;
+
+    public MailboxMutationAuditTrailTests()
+    {
+        this.loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(this.logs));
+
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        persistenceSession.CommitAsync(Arg.Any<CancellationToken>()).Returns(PersistenceCommitResult.Committed);
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(persistenceSession);
+
+        this.trail = new MailboxMutationAuditTrail(
+            this.store,
+            new OptimisticConcurrencyRetryPolicy(
+                sessionFactory,
+                new PersistenceConcurrencyOptions { MaximumCommitAttempts = 1 },
+                TimeProvider.System),
+            new FakeTimeProvider(RecordedAt.AddMinutes(4)),
+            new MailboxMutationAuditTelemetry(
+                this.loggerFactory.CreateLogger<MailboxMutationAuditTelemetry>()));
+    }
+
+    public void Dispose()
+    {
+        this.loggerFactory.Dispose();
+        this.logs.Dispose();
+    }
+
+    /// <summary>An account that never asked for a history accumulates none, which is what off by default has to mean.</summary>
+    [Fact]
+    public async Task RecordAsync_MutationOfAnUnauditedAccount_AppendsNothing()
+    {
+        // Act
+        await this.trail.RecordAsync(
+            CompletedRelocation() with { IsAudited = false },
+            Inbox,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await this.store.DidNotReceive().AppendAsync(
+            Arg.Any<IPersistenceSession>(),
+            Arg.Any<MailboxMutationAuditEntry>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>An audited mutation states its whole act to the store, once.</summary>
+    [Fact]
+    public async Task RecordAsync_AuditedMutation_AppendsTheEntryThatMutationStates()
+    {
+        // Arrange
+        var appended = new List<MailboxMutationAuditEntry>();
+        this.store
+            .When(candidate => candidate.AppendAsync(
+                Arg.Any<IPersistenceSession>(),
+                Arg.Any<MailboxMutationAuditEntry>(),
+                Arg.Any<CancellationToken>()))
+            .Do(call => appended.Add(call.ArgAt<MailboxMutationAuditEntry>(1)!));
+
+        // Act
+        await this.trail.RecordAsync(CompletedRelocation(), Inbox, TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(appended);
+        Assert.Equal(
+            (MailboxMutation.Relocate, Account, Inbox.RemotePath, MailboxMutationAuditOutcome.Performed, RecordedAt),
+            (entry.Mutation, entry.AccountId, entry.SourceFolderPath, entry.Outcome, entry.RequestedAt));
+    }
+
+    /// <summary>A trail that cannot be written costs the history and never the change that had already been made.</summary>
+    [Fact]
+    public async Task RecordAsync_StoreThatRefusesTheAppend_CompletesAndReportsTheLostEntry()
+    {
+        // Arrange
+        this.store.AppendAsync(
+                Arg.Any<IPersistenceSession>(),
+                Arg.Any<MailboxMutationAuditEntry>(),
+                Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("The trail is not reachable."));
+
+        // Act
+        var failure = await Record.ExceptionAsync(
+            () => this.trail.RecordAsync(CompletedRelocation(), Inbox, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Null(failure);
+        Assert.Contains(
+            this.logs.Records,
+            record => record.Level == LogLevel.Warning
+                && record.Message.Contains("audit trail did not keep", StringComparison.Ordinal));
+    }
+
+    /// <summary>A cancellation leaves the entry just as missing, so it is reported before it travels on.</summary>
+    [Fact]
+    public async Task RecordAsync_CallerCancelsTheAppend_ReportsTheLostEntryAndRethrows()
+    {
+        // Arrange
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => this.trail.RecordAsync(CompletedRelocation(), Inbox, cancellation.Token));
+
+        // Assert
+        Assert.Contains(
+            this.logs.Records,
+            record => record.Level == LogLevel.Warning
+                && record.Message.Contains("audit trail did not keep", StringComparison.Ordinal));
+    }
+
+    private static MailboxMutationRecord CompletedRelocation()
+    {
+        var occurrence = EmailOccurrenceId.Create(
+            Account,
+            Inbox.Id,
+            ImapUidValidity.Create(1),
+            ImapUid.Create(41));
+
+        return new MailboxMutationRecord
+        {
+            Id = MailboxMutationRecordId.Create(Guid.CreateVersion7(RecordedAt)),
+            Request = MailboxMutationRequest.Relocate(
+                StoredEmailId.Create(Guid.CreateVersion7(RecordedAt)),
+                occurrence,
+                MailboxMutationRequester.Rule("file-newsletters", 3),
+                ArchivePath),
+            Stage = MailboxMutationStage.Completed,
+            IsAudited = true,
+            RequiresSourceRemoval = true,
+            Placement = RemoteEmailPlacement.NotReported(),
+            AttemptCount = 1,
+            RecordedAt = RecordedAt,
+            StageChangedAt = RecordedAt.AddMinutes(4),
+            LastFailure = (MailFathomErrorCode?)null,
+            PlacementObservedAt = null,
+            SourceRemovalObservedAt = null,
+        };
+    }
+}

--- a/tests/Infrastructure.UnitTests/Persistence/Mutations/MailboxMutationAuditTrailTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Mutations/MailboxMutationAuditTrailTests.cs
@@ -106,8 +106,18 @@ public sealed class MailboxMutationAuditTrailTests : IDisposable
         // Assert
         var entry = Assert.Single(appended);
         Assert.Equal(
-            (MailboxMutation.Relocate, Account, Inbox.RemotePath, MailboxMutationAuditOutcome.Performed, RecordedAt),
-            (entry.Mutation, entry.AccountId, entry.SourceFolderPath, entry.Outcome, entry.RequestedAt));
+            (MailboxMutation.Relocate,
+                Account,
+                Inbox.RemotePath,
+                MailboxMutationAuditOutcome.Performed,
+                RecordedAt,
+                RecordedAt.AddMinutes(4)),
+            (entry.Mutation,
+                entry.AccountId,
+                entry.SourceFolderPath,
+                entry.Outcome,
+                entry.RequestedAt,
+                entry.CompletedAt));
     }
 
     /// <summary>A trail that cannot be written costs the history and never the change that had already been made.</summary>

--- a/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
+++ b/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
@@ -71,15 +72,24 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
     /// everywhere but the one class proving that this setting does not decide the outcome of a deletion MailFathom
     /// itself performed.
     /// </param>
+    /// <param name="auditTrailEnabled">
+    /// Whether the account keeps a durable record of the changes MailFathom made to it. Off everywhere but the class
+    /// proving what the trail holds, which is the deployed default and keeps every other test from accumulating a
+    /// history it never asked about.
+    /// </param>
     /// <returns>The composed services, which the caller owns and must dispose.</returns>
     internal static async Task<OrchestratedMailFathomServices> StartAsync(
         MailFathomOrchestrationFixture orchestration,
         CancellationToken cancellationToken,
         RemotelyDeletedEmailDisposition remotelyDeletedEmailDisposition =
-            RemotelyDeletedEmailDisposition.RetainTombstone)
+            RemotelyDeletedEmailDisposition.RetainTombstone,
+        bool auditTrailEnabled = false)
     {
         var builder = new HostApplicationBuilder();
-        var account = new SyntheticMailAccount(orchestration.MailServer, remotelyDeletedEmailDisposition);
+        var account = new SyntheticMailAccount(
+            orchestration.MailServer,
+            remotelyDeletedEmailDisposition,
+            auditTrailEnabled);
 
         builder.Services.AddSingleton(TimeProvider.System);
         builder.Services.AddSecretResolution(SecretValueInterpretation.ReferenceOnly);
@@ -90,6 +100,7 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
         builder.Services.AddSingleton<IMailSynchronizationWindowReader>(account);
         builder.Services.AddSingleton<IRemotelyDeletedEmailDispositionReader>(account);
         builder.Services.AddSingleton<IAuthoredDeleteEmailDispositionReader>(account);
+        builder.Services.AddSingleton<IMailboxMutationAuditSettingsReader>(account);
         builder.Services.AddSingleton(new MailboxSynchronizationOptions
         {
             MaxMetadataBatchSize = 50,

--- a/tests/IntegrationTests/Orchestration/SyntheticMailAccount.cs
+++ b/tests/IntegrationTests/Orchestration/SyntheticMailAccount.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using MailFathom.AppHost;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.Synchronization.Reconciliation;
 using MailFathom.Domain.Accounts;
@@ -35,15 +36,26 @@ namespace MailFathom.IntegrationTests.Orchestration;
 internal sealed class SyntheticMailAccount(
     OrchestratedMailServerEndpoints endpoints,
     RemotelyDeletedEmailDisposition remotelyDeletedEmailDisposition =
-        RemotelyDeletedEmailDisposition.RetainTombstone)
+        RemotelyDeletedEmailDisposition.RetainTombstone,
+    bool auditTrailEnabled = false)
     : IImapAccountSettingsProvider,
     IMailTransportSecurityPolicyReader,
     IMailSynchronizationWindowReader,
     IRemotelyDeletedEmailDispositionReader,
-    IAuthoredDeleteEmailDispositionReader
+    IAuthoredDeleteEmailDispositionReader,
+    IMailboxMutationAuditSettingsReader
 {
     /// <summary>Gets the account identifier every occurrence this suite stores belongs to.</summary>
     public static MailAccountId AccountId { get; } = MailAccountId.Create("integration");
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Off unless a test asks for it, which is the deployed default and the state every other test needs: an audit
+    /// entry per finished mutation would otherwise accumulate across a suite that authors many of them. The retention
+    /// is long enough that no orchestrated run erases what it just wrote.
+    /// </remarks>
+    public MailboxMutationAuditSettings GetAuditSettings(MailAccountId accountId) =>
+        new(auditTrailEnabled, TimeSpan.FromDays(90));
 
     /// <inheritdoc />
     /// <remarks>

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxConvergenceTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxConvergenceTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
@@ -239,9 +240,11 @@ public sealed class OrchestratedMailboxConvergenceTests(MailFathomOrchestrationF
                 store,
                 scope.GetRequiredService<IMailboxWriteSessionFactory>(),
                 commitPolicy,
+                scope.GetRequiredService<IMailboxMutationAuditTrail>(),
                 new MailboxMutationOptions()),
             scope.GetRequiredService<IMailTransportSecurityPolicyReader>(),
             commitPolicy,
+            scope.GetRequiredService<IMailboxMutationAuditTrail>(),
             new MailboxConvergenceOptions { UnknownOutcomeGrace = TimeSpan.Zero },
             TimeProvider.System);
 
@@ -312,9 +315,11 @@ public sealed class OrchestratedMailboxConvergenceTests(MailFathomOrchestrationF
                 store,
                 new MailKitImapWriteSessionFactory(pool, CreateTelemetry()),
                 commitPolicy,
+                scope.GetRequiredService<IMailboxMutationAuditTrail>(),
                 new MailboxMutationOptions()),
             scope.GetRequiredService<IMailTransportSecurityPolicyReader>(),
             commitPolicy,
+            scope.GetRequiredService<IMailboxMutationAuditTrail>(),
             new MailboxConvergenceOptions(),
             TimeProvider.System);
 

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationAuditTrailTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationAuditTrailTests.cs
@@ -1,0 +1,296 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.IntegrationTests.Mailbox;
+using MailFathom.IntegrationTests.Orchestration;
+using MailFathom.IntegrationTests.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Synchronization;
+
+/// <summary>Proves the audit trail against real PostgreSQL and a real mail server together.</summary>
+/// <remarks>
+/// <para>
+/// Two tests, because there are two claims no substitute can establish. The first is that a finished mutation of every
+/// permitted kind leaves one entry that outlives the email it describes — which needs a real cascade to survive, since
+/// what an in-memory double proves about a foreign key is only what it was written to prove. The second is that an
+/// account with the trail off writes nothing at all, which is the default the privacy posture rests on and which the
+/// same database has to show as an absence beside the presences above.
+/// </para>
+/// <para>
+/// Everything else about the trail — what each entry states, what it deliberately omits, when retention erases one —
+/// is a rule the unit suite exercises against substitutes and buys nothing here.
+/// </para>
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedMailboxMutationAuditTrailTests(MailFathomOrchestrationFixture orchestration)
+{
+    private const string ArchiveFolderName = "AuditTrailArchive";
+
+    /// <summary>The alias this class owns, bound to the real inbox so a write session selects it.</summary>
+    private static readonly MailFolderResolution Inbox = MailFolderResolution.FirstBindingOf(
+        MailFolderAlias.Create("audit-trail-inbox"),
+        RemoteFolderPath.Create(OrchestratedMailbox.InboxPath, hierarchyDelimiter: '.'));
+
+    private static readonly RemoteFolderPath ArchivePath =
+        RemoteFolderPath.Create(ArchiveFolderName, hierarchyDelimiter: '.');
+
+    private static readonly MailboxMutationRequester Requester =
+        MailboxMutationRequester.Rule("keep-an-audit-trail", 1);
+
+    /// <summary>
+    /// Every change MailFathom is permitted to make leaves exactly one entry on an account that asked for a trail, and
+    /// every one of those entries is still there after the email it describes has been erased — including the entry for
+    /// the deletion itself, which is the one an audit of deletions exists to hold.
+    /// </summary>
+    [Fact]
+    public async Task AuditTrail_EveryMutationKind_KeepsOneEntryEachThatOutlivesTheEmail()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mailbox = new OrchestratedMailbox(orchestration.MailServer);
+        await mailbox.RecreateFolderAsync(ArchiveFolderName, cancellationToken);
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(
+            orchestration,
+            cancellationToken,
+            auditTrailEnabled: true);
+
+        await CommitInboxBindingAsync(services, cancellationToken);
+
+        var requests = await ArrangeOneOfEachMutationAsync(services, mailbox, cancellationToken);
+
+        // Act
+        foreach (var request in requests)
+        {
+            await PerformAsync(services, request, cancellationToken);
+        }
+
+        var performedEntries = await ReadTrailAsync(services, cancellationToken);
+
+        await EraseStoredEmailsAsync(services, requests, cancellationToken);
+
+        // Assert
+        var survivingEntries = await ReadTrailAsync(services, cancellationToken);
+
+        Assert.Equal(
+            MailboxMutation.All.Select(mutation => mutation.Name).Order(StringComparer.Ordinal),
+            performedEntries
+                .Where(entry => entry.Requester == Requester)
+                .Select(entry => entry.Mutation.Name)
+                .Order(StringComparer.Ordinal));
+
+        Assert.All(
+            performedEntries.Where(entry => entry.Requester == Requester),
+            entry => Assert.Equal(MailboxMutationAuditOutcome.Performed, entry.Outcome));
+
+        // The trail hangs on nothing the erasure reached, so the same entries are still readable afterwards.
+        Assert.Equal(
+            performedEntries.Select(entry => entry.Id).Order(),
+            survivingEntries.Select(entry => entry.Id).Order());
+
+        // The source folder is the remote path rather than a key into a binding, which is what makes the entry
+        // readable once the mail it describes is gone.
+        Assert.All(
+            survivingEntries.Where(entry => entry.Requester == Requester),
+            entry => Assert.Equal(Inbox.RemotePath, entry.SourceFolderPath));
+    }
+
+    /// <summary>An account that never asked for a history accumulates none, which is what off by default has to mean.</summary>
+    [Fact]
+    public async Task AuditTrail_AccountWithTheTrailOff_KeepsNothing()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mailbox = new OrchestratedMailbox(orchestration.MailServer);
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await CommitInboxBindingAsync(services, cancellationToken);
+
+        var subject = $"audit-trail-off-{Guid.NewGuid():N}";
+        var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
+        var storedEmailId = await StoreMetadataAsync(services, occurrence, subject, cancellationToken);
+        var unauditedRequester = MailboxMutationRequester.Command($"trail-off-{Guid.NewGuid():N}");
+        var request = MailboxMutationRequest.SetSeen(storedEmailId, occurrence, unauditedRequester, isSeen: true);
+
+        // Act
+        var outcome = await PerformAsync(services, request, cancellationToken);
+
+        // Assert
+        Assert.Equal(MailboxMutationStatus.Performed, outcome.Status);
+
+        var entries = await ReadTrailAsync(services, cancellationToken);
+        Assert.DoesNotContain(entries, entry => entry.Requester == unauditedRequester);
+    }
+
+    /// <summary>Delivers one message per permitted mutation and builds the request that performs it.</summary>
+    /// <remarks>
+    /// Each mutation gets its own message, because a relocation and a delete both take their message out of the inbox
+    /// and one request must not be aimed at an occurrence another has already moved.
+    /// </remarks>
+    private static async Task<IReadOnlyList<MailboxMutationRequest>> ArrangeOneOfEachMutationAsync(
+        OrchestratedMailFathomServices services,
+        OrchestratedMailbox mailbox,
+        CancellationToken cancellationToken)
+    {
+        var requests = new List<MailboxMutationRequest>();
+
+        foreach (var mutation in MailboxMutation.All)
+        {
+            var subject = $"audit-trail-{mutation.Name}-{Guid.NewGuid():N}";
+            var occurrence = await DeliverAndLocateAsync(mailbox, subject, cancellationToken);
+            var storedEmailId = await StoreMetadataAsync(services, occurrence, subject, cancellationToken);
+
+            requests.Add(RequestFor(mutation, storedEmailId, occurrence));
+        }
+
+        return requests;
+    }
+
+    private static MailboxMutationRequest RequestFor(
+        MailboxMutation mutation,
+        StoredEmailId storedEmailId,
+        EmailOccurrenceId occurrence)
+    {
+        if (mutation == MailboxMutation.Relocate)
+        {
+            return MailboxMutationRequest.Relocate(storedEmailId, occurrence, Requester, ArchivePath);
+        }
+
+        if (mutation == MailboxMutation.Copy)
+        {
+            return MailboxMutationRequest.Copy(storedEmailId, occurrence, Requester, ArchivePath);
+        }
+
+        if (mutation == MailboxMutation.Delete)
+        {
+            return MailboxMutationRequest.Delete(
+                storedEmailId,
+                occurrence,
+                Requester,
+                AuthoredDeleteEmailDisposition.RetainLocalCopy);
+        }
+
+        return MailboxMutationRequest.SetSeen(storedEmailId, occurrence, Requester, isSeen: true);
+    }
+
+    private static Task<MailboxMutationOutcome> PerformAsync(
+        OrchestratedMailFathomServices services,
+        MailboxMutationRequest request,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IMailboxMutationPerformer>().PerformAsync(
+                request,
+                Inbox,
+                scope.GetRequiredService<IMailTransportSecurityPolicyReader>()
+                    .GetPolicy(SyntheticMailAccount.AccountId),
+                token),
+            cancellationToken);
+
+    /// <summary>Reads the whole of this account's trail through the port an operator's page is served from.</summary>
+    private static Task<IReadOnlyList<MailboxMutationAuditEntry>> ReadTrailAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) =>
+            {
+                var queryResult = MailboxMutationAuditQuery.Create(
+                    SyntheticMailAccount.AccountId,
+                    mutation: default,
+                    completedFrom: null,
+                    completedBefore: null,
+                    MailboxMutationAuditQuery.MaximumPageSize,
+                    cursor: null);
+
+                var page = await scope.GetRequiredService<IMailboxMutationAuditEntryStore>()
+                    .ReadPageAsync(queryResult.Query!, token);
+
+                return page.Entries;
+            },
+            cancellationToken);
+
+    /// <summary>Erases the stored emails the entries describe, which is the cascade the trail has to survive.</summary>
+    /// <remarks>
+    /// Deleted through the context rather than through a disposition, because what is under test is the schema: the
+    /// mutation records cascade from the email by design and the audit entries must not, and a set-based delete is the
+    /// bluntest form of that question.
+    /// </remarks>
+    private static Task<int> EraseStoredEmailsAsync(
+        OrchestratedMailFathomServices services,
+        IReadOnlyList<MailboxMutationRequest> requests,
+        CancellationToken cancellationToken)
+    {
+        var erasedIds = requests.Select(request => request.StoredEmailId.Value).ToArray();
+
+        return services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailFathomDbContext>()
+                .StoredEmails
+                .Where(email => erasedIds.Contains(email.Id))
+                .ExecuteDeleteAsync(token),
+            cancellationToken);
+    }
+
+    private static async Task CommitInboxBindingAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken) => Assert.Equal(
+            PersistenceCommitResult.Committed,
+            await services.CommitAsync(
+                (scope, session, token) => scope.GetRequiredService<IMailFolderResolutionStore>().SaveResolutionAsync(
+                    session,
+                    SyntheticMailAccount.AccountId,
+                    Inbox,
+                    token),
+                cancellationToken));
+
+    private static Task<StoredEmailId> StoreMetadataAsync(
+        OrchestratedMailFathomServices services,
+        EmailOccurrenceId occurrence,
+        string subject,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) =>
+            {
+                await using var session = await scope.GetRequiredService<IPersistenceSessionFactory>()
+                    .BeginSessionAsync(token);
+
+                var storedEmailId = await scope.GetRequiredService<IEmailMetadataRepository>().UpsertMetadataAsync(
+                    session,
+                    SyntheticEmail.RemoteMetadataOf(occurrence, subject),
+                    extractedMetadata: null,
+                    StoredEmailContentAvailability.ExceededSizeLimit,
+                    token);
+
+                Assert.Equal(PersistenceCommitResult.Committed, await session.CommitAsync(token));
+
+                return storedEmailId;
+            },
+            cancellationToken);
+
+    private static async Task<EmailOccurrenceId> DeliverAndLocateAsync(
+        OrchestratedMailbox mailbox,
+        string subject,
+        CancellationToken cancellationToken)
+    {
+        await mailbox.DeliverAsync(subject, cancellationToken);
+
+        var inbox = await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken);
+        var delivered = Assert.Single(inbox, email => email.Subject == subject);
+
+        return EmailOccurrenceId.Create(
+            SyntheticMailAccount.AccountId,
+            Inbox.Id,
+            await mailbox.ReadUidValidityAsync(OrchestratedMailbox.InboxPath, cancellationToken),
+            delivered.Uid);
+    }
+}

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationAuditTrailTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationAuditTrailTests.cs
@@ -98,10 +98,11 @@ public sealed class OrchestratedMailboxMutationAuditTrailTests(MailFathomOrchest
             performedEntries.Where(entry => entry.Requester == Requester),
             entry => Assert.Equal(MailboxMutationAuditOutcome.Performed, entry.Outcome));
 
-        // The trail hangs on nothing the erasure reached, so the same entries are still readable afterwards.
+        // The trail hangs on nothing the erasure reached, so the same entries are still readable afterwards. Ordered by
+        // the identifier's own value rather than by the identity, which is a record struct and carries no comparison.
         Assert.Equal(
-            performedEntries.Select(entry => entry.Id).Order(),
-            survivingEntries.Select(entry => entry.Id).Order());
+            performedEntries.Select(entry => entry.Id.Value).Order(),
+            survivingEntries.Select(entry => entry.Id.Value).Order());
 
         // The source folder is the remote path rather than a key into a binding, which is what makes the entry
         // readable once the mail it describes is gone.

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationRecordTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationRecordTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
 using MailFathom.Application.Synchronization;
@@ -241,6 +242,7 @@ public sealed class OrchestratedMailboxMutationRecordTests(MailFathomOrchestrati
             scope.GetRequiredService<IMailboxMutationRecordStore>(),
             new MailKitImapWriteSessionFactory(pool, CreateTelemetry()),
             scope.GetRequiredService<OptimisticConcurrencyRetryPolicy>(),
+            scope.GetRequiredService<IMailboxMutationAuditTrail>(),
             new MailboxMutationOptions());
 
         return await performer.PerformAsync(


### PR DESCRIPTION
Every mutation under #452 changes somebody's mailbox, and the record that makes that change correct is not the thing that explains it afterwards. `mailbox_mutations` carries the idempotency identity, the stage a retry resumes from, and the provenance that stops a rule reacting to its own effect — and its useful life ends when the mutation reaches a terminal state. This adds the opposite artifact beside it: `mailbox_mutation_audit_entries`, written once when a mutation ends, read by nothing the mechanism depends on, and kept for as long as its account says.

## Off by default, enabled per account

An audit trail of mail movements is derived personal data — it says where a person's mail has been, when, and at whose instruction — so an installation that never asked for one never accumulates it:

```yaml
Mail:
  Synchronization:
    Accounts:
      - AccountId: work
        AuditTrail:
          Enabled: true
          Retention: 90.00:00:00
```

The answer is resolved when the mutation is written down and stored on its record, so a trail switched on or off mid-flight decides nothing about a change already begun — which is what stops a toggle producing a history whose gaps look like changes nobody made.

## It outlives the mail it describes

Every identity on an entry is a value rather than an association, and no foreign key leaves the row. That is the design rather than an omission: a trail that inherited the deletion path of the email it describes would erase the record that MailFathom deleted it, which is exactly the entry an audit of deletions exists to hold. What replaces the cascade is a bound of its own — each account states how long its entries are kept, and every account run erases what has outlived that window, at most five thousand entries a pass so a shortened window cannot turn one delete into a lock on the table.

An entry names the mutation, the local email, the source folder path with its UIDVALIDITY and UID, the destination path and the UID the server reported, the flag direction, who asked with their rule revision, both timestamps, and whether it was performed or given up on with the code. It holds no subject, address, body fragment, or filename.

## Writing it never costs a change

The append is a commit of its own made after the terminal stage is already durable, so it can neither roll back a mailbox somebody's server has changed nor fail the operation that changed it. An entry that does not get written — including one a cancellation left unwritten — raises a warning naming the account and the mutation and increments `mailfathom.mailbox.mutation.audit.refused_appends`, which is what makes swallowing the failure defensible rather than silent.

## Reading it

`GET /api/admin/mailbox/mutations/audit` serves bounded, keyset-paginated pages filterable by account, mutation, and time. The account is required rather than optional: a surface over this data is better for making a caller name whose history they are reading. The data-subject erasure path is documented against the table, because the trail deliberately has no cascade to ride.

## Breaking changes

**Database schema** — additive only, in one reviewed migration: the new table plus an `AuditTrailEnabled` column on `mailbox_mutations` defaulting to `FALSE`. A release is deployable over the previous release's data, and an existing row reads as unaudited.

**Configuration schema** — additive only: the `AuditTrail` block is optional and its absence is the previous behaviour. No operator action on upgrade.

The MCP tool contract and the deployment contract are untouched.

## Verification

- `scripts/verify-full.sh` — passed, 3609 unit tests
- Coverage — 93.74% aggregate line coverage, against the 85% gate
- Migration reviewed as SQL, applied to the orchestrated database, host reached `Running`/`Healthy` against it
- Integration tests build; the suite is dispatched separately

Closes #477
