### PR TITLE
[#433] Reindex into a new vector generation without a search outage

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -74,7 +74,7 @@ Only a message that yielded text has rows here, and deleting a message cascades 
 
 ## Embedding profiles
 
-`embedding_profiles` holds one row per vector space this deployment has embedded into. Nothing writes one yet — the row is created by the activation that takes a declared model up and starts spending against it — but the columns are what a stored vector's attribution will point at, and they are permanent from this migration onwards.
+`embedding_profiles` holds one row per vector space this deployment has embedded into. The row is written by the activation that takes a declared model up and starts spending against it, and its columns are what a stored vector's attribution points at.
 
 A profile is **the geometry of a vector space and nothing else**: `Provider`, `ModelIdentifier`, `ModelVersion` where the provider exposes one, `Dimension`, `DistanceMetric`, and the three columns that make up the input preparation — `InputCharacterLimit`, `PassageInstruction`, and `NormalizesVector`. Those are exactly the properties that decide whether two vectors can be compared. [ADR 0006](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md) is where each of them was argued.
 
@@ -89,6 +89,8 @@ Three things about that list are decisions rather than defaults.
 `IdentityFingerprint` is a SHA-256 digest over every column above, written as sixty-four lowercase hexadecimal characters, and `ix_embedding_profiles_identity_fingerprint` is unique over it. That index is what makes activation idempotent: re-declaring a geometry that is already registered resolves to the row that exists rather than inserting a second one whose vectors would be produced from scratch for nothing, so returning to a previous model is a switch rather than a duplicate. Every field of the digest is length-prefixed and every number is big-endian, and an absent optional value is written as a presence marker rather than skipped, so the encoding is one-to-one.
 
 What stays mutable is the lifecycle: `LifecycleState` — building, active, or superseded — with `RegisteredAt`, and `ActivatedAt` and `SupersededAt`, each null until its event has happened. **There is no generation counter.** The profile *is* the generation, so two generations coexisting while a new one is built are two rows, and no read path has a second field it must remember to consult.
+
+`ix_embedding_profiles_lifecycle_state` is unique over `LifecycleState` and partial to the two states that admit one row each, which is how one index expresses both halves of that: at most one generation being built, and at most one being read. Superseded rows are outside its predicate, because a deployment accumulates one for every model it has ever used. It is enforced by the database rather than by the code that writes, for the same reason the vector's width is: two rows claiming to serve would leave retrieval reading whichever one a query returned, with half the vectors in the table unreachable and nothing about the answers saying so. The one consequence for a writer is that the switch has to supersede the old row before it promotes the new one, which is why those two statements are issued in order rather than staged together. [Changing the embedding model](../operations/embedding-profiles.md) is the operator's view of that transition.
 
 Nothing operational reaches this table. The endpoint address, the credential, the batch size, the request rate, the concurrency, and the spending ceilings are configuration, which is what makes rotating a key or raising a rate limit an edit rather than a re-embed — and what means no column here can be edited into disagreeing with the vectors it describes.
 
@@ -283,6 +285,7 @@ of the message it came from.
 | `ix_email_search_documents_search_vector` | `(search_vector)`, GIN | Lexical search over subject, participants, and body text |
 | `ix_email_chunks_email_ordinal` | `(StoredEmailId, Ordinal)`, unique | One message's passages in reading order, and the constraint a re-cut cannot write an ordinal twice past |
 | `ix_embedding_profiles_identity_fingerprint` | `(IdentityFingerprint)`, unique | One row per vector space, which is what makes activation idempotent |
+| `ix_embedding_profiles_lifecycle_state` | `(LifecycleState)`, unique, where the state is building or active | At most one generation being built and at most one being read |
 | `ix_email_embeddings_profile` | `(EmbeddingProfileId, Dimension)` | Reading a whole generation, which is how a superseded one is removed |
 | `ix_mailbox_mutations_identity` | `(MailFolderId, UidValidity, Uid, RequesterOrigin, RequesterIdentity, Mutation)`, unique | A mutation's idempotency identity, which is what makes the same request twice perform one change |
 | `ix_mailbox_mutations_outstanding` | `(MailboxAccountId, RecordedAt)` where the stage is not `Completed` | The changes an operator asks about: those in flight and those given up on |

--- a/docs/features/automatic-embedding.md
+++ b/docs/features/automatic-embedding.md
@@ -40,15 +40,20 @@ question a restart, a repeat, and the backfill all ask.
 
 The worker takes one message at a time and, for that message:
 
-1. reads the active profile, and stops if there is none;
+1. reads the generation searches are answered from, and stops if there is none;
 2. refuses to write if the configured model is not the one that was activated — see below;
-3. reads the passages that have no vector under that profile, at most one provider call's worth;
+3. reads the passages that have no vector under that generation, at most one provider call's worth;
 4. asks the generator for their vectors;
 5. commits those vectors, and repeats from step 3 until nothing is outstanding or the turn's calls run out.
 
 Each call's vectors are committed together, so a crash leaves a whole page of passages embedded or none of it — never a
 message that looks finished and is not. Nothing about the message is remembered between turns, which is what makes
 offering one twice free: a message already current reads no passages, calls no provider, and writes nothing.
+
+**While a model change is under way, this path keeps writing into the generation that is serving** rather than into the
+one being built, so mail arriving during a reindex is searchable the moment it is stored. The reindex reaches the same
+message for the new generation before the count that completes it can read zero, so nothing is lost by leaving that to
+the sweep. [Changing the embedding model](../operations/embedding-profiles.md) describes the rest of the sequence.
 
 One turn is allowed a bounded number of provider calls. The bound exists so that a store reporting passages as
 outstanding and then storing nothing for them ends the turn instead of spending in a loop, and it is not claimed to be

--- a/docs/features/embedding-backfill.md
+++ b/docs/features/embedding-backfill.md
@@ -1,6 +1,6 @@
 # Embedding backfill
 
-<!-- describes: src/Application/Emails/Embeddings/Backfill/**, src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs, src/Infrastructure/Observability/EmailEmbeddingBackfillTelemetry.cs, src/Host/Configuration/Embeddings/EmbeddingBackfillOptions.cs, src/Host/Hosting/Workers/MailEmbeddingBackfillWorker.cs -->
+<!-- describes: src/Application/Emails/Embeddings/Backfill/**, src/Application/Emails/Embeddings/Generations/EmbeddingGenerationUpkeep.cs, src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs, src/Infrastructure/Observability/EmailEmbeddingBackfillTelemetry.cs, src/Host/Configuration/Embeddings/EmbeddingBackfillOptions.cs, src/Host/Hosting/Workers/MailEmbeddingBackfillWorker.cs -->
 
 [Automatic embedding](automatic-embedding.md) covers mail as it arrives. An instance that has been synchronizing for
 months has everything else, and for that mail the live path never runs at all — nothing revisits a message that was
@@ -9,6 +9,18 @@ provider was full.
 
 This is the walk that reaches it. Nothing here is a command anybody runs either: activating a profile is what starts
 it, the same fact that starts the live path.
+
+## Which generation it walks towards
+
+One, and the caller decides which: the generation being built where a model change is under way, and otherwise the one
+searches are answered from. The same walk therefore does both jobs — filling the gaps in the generation that is serving,
+and building a new one from nothing beside it — because they are the same question asked of two profiles.
+[Changing the embedding model](../operations/embedding-profiles.md) is the operator's view of the second.
+
+Two more things ride the same pass, in the same order every time it runs. When the sweep finishes and nothing is
+outstanding for a generation that is being built, that generation becomes the one searches are answered from, in one
+transaction. And a generation that a switch replaced has its vectors removed, a bounded batch per pass, until it holds
+none.
 
 ## What it reaches, and in which order
 
@@ -19,9 +31,9 @@ Two conditions select a message, and they are the two halves of what a pre-exist
   already stored, which costs a database write and no provider call and reaches no mail server. The rules applied are
   the ones synchronization applies, so a message this walk reaches ends up cut exactly as the same message arriving
   today would be.
-- **A message with a passage that carries no vector** under the active profile was stored before the profile was
-  activated, or was turned away by `Embeddings:MaxQueuedEmails`, or was left part-way through by a provider call that
-  failed.
+- **A message with a passage that carries no vector** under the generation being walked towards was stored before that
+  generation existed, or was turned away by `Embeddings:MaxQueuedEmails`, or was left part-way through by a provider
+  call that failed. For a generation being built from nothing, that is every message the instance holds.
 
 A message a tombstone hides is in neither group. Vectors nothing may retrieve are a provider bill with no reader. A
 message whose local copy was deliberately kept after MailFathom deleted it on the server is not that: nothing may
@@ -78,10 +90,15 @@ every passage the instance holds.
 embedded, and what has not is found again by the same question whenever it is turned back on.
 [Configuration reference](../operations/configuration-reference.md#embeddingbackfill) holds the defaults and the ranges.
 
-An instance that has activated no profile runs the walk and reaches no mail: there is no vector space for a passage to
-be missing from, so the run ends before it reads a message. An instance whose configured model is not the one the
-active profile records writes nothing and warns, for the reason
+An instance that has activated no profile reaches no mail: there is no vector space for a passage to be missing from,
+so the pass ends before it reads a message. An instance whose configured model is not the one the generation records
+writes nothing and warns, for the reason
 [an edited declaration](automatic-embedding.md#an-edited-declaration-that-nobody-activated) gives.
+
+The removal of a superseded generation's vectors is bounded too, and it is not a setting: it deletes rows nobody reads,
+reaches no provider, and costs nothing an operator has to consent to, so what paces it is the interval between passes
+rather than a number beside the ones above. A pass that removed a full batch is followed by the short interval, because
+there is more of that generation behind it.
 
 ## What an operator can see
 
@@ -93,12 +110,18 @@ active profile records writes nothing and warns, for the reason
 | `mailfathom.embedding.backfill.messages` | Messages brought up to date with the active profile |
 | `mailfathom.embedding.backfill.passages` | Passages given a vector |
 | `mailfathom.embedding.backfill.exhausted` | Messages left part-way through because one turn spent every provider call it is allowed |
+| `mailfathom.embedding.generation.switches` | Generations that finished being built and became the one searches are answered from |
+| `mailfathom.embedding.generation.removed` | Vectors of a superseded generation removed after a switch |
 
 The outstanding count is measured once at the start of a sweep and held until the next sweep measures again, so the
 gauge is a figure a sweep established rather than a live one. That is deliberate: an exact live count is an unbounded
 scan over every passage, and making it a gauge would put that scan on whatever interval a collector happened to be
 configured with. The counters beside it are what move in between, so progress is read as those rising against the
 figure the sweep started from.
+
+The switch is counted rather than published as a state, because what an operator asks of it afterwards is when it
+happened and how many have. A gauge naming the generation now serving would be a dimension of unbounded cardinality for
+a value the log line about the switch already carries.
 
 Nothing on that list is derived from mail. The tags are an outcome name and a failure classification, both of them
 MailFathom's own closed sets; no message identity, passage, or vector reaches a log, a metric, or a trace, and a log

--- a/docs/features/embedding-generation.md
+++ b/docs/features/embedding-generation.md
@@ -34,6 +34,9 @@ decision nobody was shown.
 **An operator who edits the model and expects the change to take effect has to know that it did not.** The activation
 command is what makes it so, and it is deliberately not automatic.
 
+What an activation then does — build a new generation beside the one still answering searches, switch to it once, and
+remove what it replaced — is [changing the embedding model](../operations/embedding-profiles.md).
+
 ## What a declaration says
 
 Each entry of `Embeddings:Endpoints` declares a whole geometry — provider, model, model version, dimension, distance

--- a/docs/operations/database-schema.md
+++ b/docs/operations/database-schema.md
@@ -112,9 +112,14 @@ index as it is stored. Building one over a generation that is already embedded t
 in it, and a non-concurrent `CREATE INDEX` blocks writes to `email_embeddings` for that time — the same caution
 [Locks and timeouts](#locks-and-timeouts) states for the script.
 
+**The same ownership covers dropping one.** A generation that a model change replaced has its index removed before its
+vectors are, so a batched deletion is not maintaining an index nothing will read. That `DROP INDEX` needs the same
+right the `CREATE INDEX` does, and a deployment that has arranged the ownership above has already granted it.
+
 **A refusal costs performance and nothing else.** Where the privilege is missing, or the build fails for any other
 reason, MailFathom reports which profile and why, and the vectors are untouched. Vector search over that profile stays
-exact until an index exists: correct, and linear in the number of vectors it reads.
+exact until an index exists: correct, and linear in the number of vectors it reads. A removal that is refused leaves an
+index occupying storage for a generation nothing reads, which the next pass over that generation tries again.
 
 ## Applying it
 

--- a/docs/operations/embedding-profiles.md
+++ b/docs/operations/embedding-profiles.md
@@ -1,0 +1,100 @@
+# Changing the embedding model without a search outage
+
+<!-- describes: src/Application/Emails/Embeddings/Generations/**, src/Infrastructure/Persistence/Embeddings/EmbeddingGenerationStore.cs -->
+
+Re-embedding a mailbox takes as long as it takes and costs what it costs. If activating a new model invalidated the
+vectors already stored, semantic search would be degraded for the whole run, and an operator who changed model on a
+Tuesday would still be answering for it on Wednesday.
+
+So it does not. A new model becomes a **generation that is built** beside the one still answering searches, and it
+takes over in a single transition once it is complete. This page is what an operator sees while that happens, what it
+costs, and what stopping or reversing it means.
+
+## A generation is a profile row
+
+There is no counter and no second record. [ADR
+0006](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md)
+makes the profile the generation, so an instance in the middle of a model change holds two rows in
+`embedding_profiles`, and every stored vector names the one it belongs to. Each row is in one of three states:
+
+| State | What it means |
+|---|---|
+| **Building** | Vectors are being produced under it. Nothing reads it, and at most one row is here |
+| **Active** | The one generation searches are answered from. At most one row is here |
+| **Superseded** | Replaced by a later generation, or abandoned before it ever served. Its vectors are being removed |
+
+"At most one" is the database's answer rather than a rule the code remembers: `ix_embedding_profiles_lifecycle_state`
+is unique over the state and partial to the first two. [Stored email
+schema](../architecture/stored-email-schema.md#embedding-profiles) holds the columns.
+
+## The sequence, and what an operator sees at each stage
+
+Configuration declares the model, and editing it starts nothing —
+[embedding generation](../features/embedding-generation.md#declaring-is-free-activating-is-what-spends) is where that
+split is argued. Activation is the explicit act that takes the declaration up, and from there the deployment runs the
+rest on its own.
+
+1. **Activation registers the generation.** The declared geometry is fingerprinted and resolved against
+   `embedding_profiles`: an identity already registered resolves to the row that exists, and a new one is inserted. The
+   row starts as *building*, and its approximate vector index is created immediately — while the generation is empty,
+   which is the cheapest moment it can be built. Activating what is already serving reports that and spends nothing;
+   activating while a *different* generation is being built is refused rather than started beside it, because one walk
+   between two partial generations would finish neither.
+2. **The reindex fills it.** The same bounded, resumable sweep that backfills mail now walks towards the new
+   generation, at the pace `EmbeddingBackfill:*` sets. [Embedding backfill](../features/embedding-backfill.md) describes
+   the walk, what one pass costs, and how to slow it down. Searches are answered from the old generation throughout,
+   and mail arriving meanwhile is embedded into that old generation by the live path, so nothing becomes unsearchable
+   while the run is on.
+3. **The switch happens once, when nothing is outstanding.** A completed sweep is not enough on its own — a message a
+   provider refused stays outstanding behind the walk's position — so the deployment counts what remains and switches
+   only at zero. Promoting the new generation and superseding the old one is one transaction, reported as
+   `The generation being built is complete and is now the one searches are answered from` and counted by
+   `mailfathom.embedding.generation.switches`.
+4. **The superseded vectors are removed in bounded batches.** The old generation's index is dropped as soon as it
+   stops being read, and its vectors go a batch per pass, counted by `mailfathom.embedding.generation.removed`. The
+   profile row itself survives: it is what a vector was once attributable to, and its identity may never move.
+
+While the reindex is running, `mailfathom.embedding.backfill.outstanding` is how much of the mailbox the new
+generation is still missing, and the counters beside it are what move in between.
+[What an operator can see](../features/embedding-backfill.md#what-an-operator-can-see) lists all of them.
+
+## What it costs
+
+**A full re-embed of the mailbox**, at whatever the declared provider charges per passage. Every passage of every
+message that a search may reach is sent again, because a vector of the old space says nothing about where that passage
+lands in the new one. Nothing about the switch is free either way: the old generation goes on occupying storage until
+its removal finishes, so an instance is briefly holding two generations of vectors at once.
+
+Nothing else changes. Chunking is not repeated — the passages are already cut and their boundary rules are not part of
+a profile's identity — so a model change pays for provider calls and local writes, not for re-reading mail.
+
+## Stopping one, and going back
+
+**Cancelling a reindex** abandons the generation being built and leaves the one serving exactly where it is. The
+abandoned row becomes superseded, its index is dropped, and whatever partial vectors it accumulated are removed in the
+same bounded batches. What was spent on those vectors is spent; nothing about the search results changes, because that
+generation was never read.
+
+A cancellation that arrives after the reindex has already completed reports that nothing was being built, and changes
+nothing: the generation it names is the one searches are now answered from, and this command never takes that out of
+service. Going back to the previous model from there is the rollback below.
+
+**Rolling back after a switch is activating the previous model again.** It is unambiguous — the row is still there and
+its identity was fixed when it was registered, so the declaration resolves to it rather than to a duplicate — and it is
+**paid**: the superseded generation's vectors were removed rather than retained, so coming back means embedding the
+mailbox a second time. ADR 0006 takes that deliberately. The alternative is doubling vector storage indefinitely for
+derived personal data whose purpose ended at the switch, and an instance that carries two full generations forever
+because nobody ran a cleanup.
+
+The one case where rolling back costs less is a rollback that catches its own removal part-way through: a generation
+activated again stops being superseded, so whatever vectors it still holds are kept and the reindex only has to produce
+the rest.
+
+## What is never affected
+
+- **Retrieval reads exactly one generation.** A partially built generation is never mixed with the one still serving,
+  which is what the lifecycle states and the index over them are for.
+- **No mail is re-read.** A reindex reaches no IMAP server, so it cannot touch a remote `\Seen` flag however long it
+  runs.
+- **Nothing is logged about the mail.** Every line and every metric here carries counts, a state name, and a profile
+  identifier; no subject, address, passage, or vector reaches any of them.

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -107,6 +107,12 @@ started are different questions about one provider bill.
 [Embedding backfill](../features/embedding-backfill.md#what-an-operator-can-see) names each of them, and says why the
 outstanding figure is a sweep old rather than live.
 
+A model change publishes two more, `mailfathom.embedding.generation.switches` and
+`mailfathom.embedding.generation.removed`: the moment a generation being built became the one searches are answered
+from, and the vectors of the one it replaced going away in bounded batches. Both are counters rather than a gauge over
+which generation is current, because an identifier is a dimension of unbounded cardinality for a value the switch's own
+log line already carries. [Changing the embedding model](embedding-profiles.md) is what those two are read against.
+
 Each outbound AI provider publishes what its last call established about it, as `mailfathom.ai.provider.health` tagged
 with `mailfathom.ai.provider.role` — `embedding` or `chat`. The two roles carry one measurement each rather than one
 combined figure, because an instance may hold a working embedding provider and a failing chat one and the two ask

--- a/docs/operations/toc.yml
+++ b/docs/operations/toc.yml
@@ -25,6 +25,8 @@
       href: deployment-kubernetes.md
     - name: Applying the database schema
       href: database-schema.md
+    - name: Changing the embedding model
+      href: embedding-profiles.md
 - name: Endpoints
   items:
     - name: The MCP endpoint

--- a/src/Application/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfill.cs
+++ b/src/Application/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfill.cs
@@ -8,7 +8,7 @@ using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Emails.Embeddings.Backfill;
 
-/// <summary>Walks the mail an instance already had, giving it the passages and the vectors the live path never produced.</summary>
+/// <summary>Walks the stored mail, giving one generation the passages and the vectors it does not yet have.</summary>
 /// <remarks>
 /// <para>
 /// The work is bounded, idempotent, and restartable, and it is deliberately the same shape as the extraction backfill:
@@ -16,6 +16,11 @@ namespace MailFathom.Application.Emails.Embeddings.Backfill;
 /// message's turn commits is what the next run resumes from. What is outstanding is decided by the absence of a vector
 /// rather than remembered anywhere, so a run interrupted between two provider calls re-embeds nothing it already paid
 /// for.
+/// </para>
+/// <para>
+/// Which generation it walks towards is the caller's decision and never this type's. The same walk fills the mail a
+/// live path never reached under the generation now serving, and fills a new generation from nothing while the old one
+/// goes on answering searches — one mechanism, because the two are the same question asked of two profiles.
 /// </para>
 /// <para>
 /// Two things are outstanding here rather than one, and the order between them is the whole point: a message stored
@@ -33,61 +38,58 @@ namespace MailFathom.Application.Emails.Embeddings.Backfill;
 /// </remarks>
 public sealed class StoredEmailEmbeddingBackfill
 {
-    private readonly IActiveEmbeddingProfileReader profileReader;
     private readonly IStoredEmailEmbeddingBackfillStore backfillStore;
     private readonly StoredEmailEmbeddingGenerator embeddingGenerator;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
     private readonly StoredEmailEmbeddingBackfillOptions options;
 
     /// <summary>Initializes a new embedding backfill.</summary>
-    /// <param name="profileReader">Answers whether this instance embeds at all, and into which vector space.</param>
     /// <param name="backfillStore">Reads what remains and writes both the passages and the position a run produced.</param>
     /// <param name="embeddingGenerator">Brings one message up to date, which is the same unit of work the live worker performs.</param>
     /// <param name="concurrencyRetryPolicy">Commits a write, retrying a conflict with a competing writer.</param>
     /// <param name="options">Bounds one run.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public StoredEmailEmbeddingBackfill(
-        IActiveEmbeddingProfileReader profileReader,
         IStoredEmailEmbeddingBackfillStore backfillStore,
         StoredEmailEmbeddingGenerator embeddingGenerator,
         OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
         StoredEmailEmbeddingBackfillOptions options)
     {
-        ArgumentNullException.ThrowIfNull(profileReader);
         ArgumentNullException.ThrowIfNull(backfillStore);
         ArgumentNullException.ThrowIfNull(embeddingGenerator);
         ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
         ArgumentNullException.ThrowIfNull(options);
 
-        this.profileReader = profileReader;
         this.backfillStore = backfillStore;
         this.embeddingGenerator = embeddingGenerator;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
         this.options = options;
     }
 
-    /// <summary>Runs one bounded pass of the backfill.</summary>
+    /// <summary>Runs one bounded pass of the backfill towards one generation.</summary>
+    /// <param name="target">The generation whose missing vectors this run produces.</param>
     /// <param name="cancellationToken">Cancels the run between messages, between batches, and inside a message's turn.</param>
     /// <returns>What this run produced, and why it ended.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="target" /> is <see langword="null" />.</exception>
     /// <exception cref="PersistenceConcurrencyConflictException">
     /// Thrown when a competing writer wins a race that the bounded retries could not resolve. Passages and vectors
     /// already committed stay durable, and the next run resumes from the committed position.
     /// </exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels. Committed passages, vectors, and positions stay durable.</exception>
-    public async Task<StoredEmailEmbeddingBackfillResult> RunAsync(CancellationToken cancellationToken)
+    /// <remarks>
+    /// The target is taken once for the whole walk rather than per message, because it is what the outstanding-work
+    /// query is expressed against: a run that changed generation half way through would leave two prefixes of two
+    /// generations and a position that describes neither.
+    /// </remarks>
+    public async Task<StoredEmailEmbeddingBackfillResult> RunAsync(
+        RegisteredEmbeddingProfile target,
+        CancellationToken cancellationToken)
     {
-        // Read before the walk rather than per message, because the profile is what the outstanding-work query is
-        // expressed against: with no active profile there is no vector space for a passage to be missing from, and the
-        // question the walk asks would have no subject.
-        var profile = await this.profileReader.FindActiveProfileAsync(cancellationToken);
-        if (profile is null)
-        {
-            return Ended(StoredEmailEmbeddingBackfillOutcome.NoActiveProfile, RunProgress.Empty);
-        }
+        ArgumentNullException.ThrowIfNull(target);
 
         var position = await this.backfillStore.FindResumePositionAsync(cancellationToken);
         var outstandingAtSweepStart = position is null
-            ? await this.backfillStore.CountEmailsAwaitingEmbeddingAsync(profile.Id, cancellationToken)
+            ? await this.backfillStore.CountEmailsAwaitingEmbeddingAsync(target.Id, cancellationToken)
             : (int?)null;
 
         var progress = RunProgress.Empty;
@@ -96,7 +98,7 @@ public sealed class StoredEmailEmbeddingBackfill
         {
             var batch = await this.backfillStore.GetEmailsAwaitingEmbeddingAsync(
                 position,
-                profile.Id,
+                target.Id,
                 this.options.BatchSize,
                 cancellationToken);
 
@@ -109,15 +111,17 @@ public sealed class StoredEmailEmbeddingBackfill
 
             foreach (var email in batch)
             {
-                var turn = await this.BringUpToDateAsync(email, cancellationToken);
+                var turn = await this.BringUpToDateAsync(email, target, cancellationToken);
                 progress = progress.Add(email, turn);
 
-                // Neither of these says anything about this message, so stepping past it would skip a message for a
-                // reason that has nothing to do with it. The position stays where it was and an operator settles it.
-                if (turn.Outcome is StoredEmailEmbeddingOutcome.NoActiveProfile
-                    or StoredEmailEmbeddingOutcome.GeneratorDisagreesWithProfile)
+                // This says nothing about the message, so stepping past it would skip one for a reason that has nothing
+                // to do with it. The position stays where it was and an operator settles it.
+                if (turn.Outcome is StoredEmailEmbeddingOutcome.GeneratorDisagreesWithProfile)
                 {
-                    return Ended(OutcomeOf(turn.Outcome), progress, outstandingAtSweepStart);
+                    return Ended(
+                        StoredEmailEmbeddingBackfillOutcome.GeneratorDisagreesWithProfile,
+                        progress,
+                        outstandingAtSweepStart);
                 }
 
                 position = email.StoredEmailId;
@@ -155,6 +159,7 @@ public sealed class StoredEmailEmbeddingBackfill
     /// </remarks>
     private async Task<StoredEmailEmbeddingRun> BringUpToDateAsync(
         StoredEmailAwaitingEmbedding email,
+        RegisteredEmbeddingProfile target,
         CancellationToken cancellationToken)
     {
         if (email.RequiresChunking)
@@ -167,7 +172,7 @@ public sealed class StoredEmailEmbeddingBackfill
                 cancellationToken);
         }
 
-        return await this.embeddingGenerator.EmbedAsync(email.StoredEmailId, cancellationToken);
+        return await this.embeddingGenerator.EmbedAsync(email.StoredEmailId, target, cancellationToken);
     }
 
     /// <summary>Commits how far the sweep has come, or that it has ended.</summary>
@@ -192,13 +197,6 @@ public sealed class StoredEmailEmbeddingBackfill
             progress.CallBudgetExhaustedEmailCount,
             outstandingAtSweepStart,
             failure);
-
-    /// <summary>Names the run's ending after the message turn that caused it.</summary>
-    private static StoredEmailEmbeddingBackfillOutcome OutcomeOf(StoredEmailEmbeddingOutcome outcome) => outcome switch
-    {
-        StoredEmailEmbeddingOutcome.NoActiveProfile => StoredEmailEmbeddingBackfillOutcome.NoActiveProfile,
-        _ => StoredEmailEmbeddingBackfillOutcome.GeneratorDisagreesWithProfile,
-    };
 
     /// <summary>What a run has produced so far, in counts alone.</summary>
     /// <remarks>

--- a/src/Application/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfillResult.cs
+++ b/src/Application/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfillResult.cs
@@ -33,6 +33,21 @@ public sealed record StoredEmailEmbeddingBackfillResult(
     int? OutstandingEmailCountAtSweepStart,
     EmbeddingGenerationFailure? Failure)
 {
+    /// <summary>The pass an instance that has registered no generation performs, which reaches nothing and spends nothing.</summary>
+    /// <remarks>
+    /// Reported by whatever decides which generation a pass walks towards rather than by the walk, which is never
+    /// started without one. It is a result rather than an absence of one because the worker records and paces every
+    /// pass alike, and a pass that found no generation is a fact about the instance an operator reads here.
+    /// </remarks>
+    public static StoredEmailEmbeddingBackfillResult NoActiveProfile { get; } = new(
+        StoredEmailEmbeddingBackfillOutcome.NoActiveProfile,
+        ChunkedEmailCount: 0,
+        EmbeddedEmailCount: 0,
+        EmbeddedChunkCount: 0,
+        CallBudgetExhaustedEmailCount: 0,
+        OutstandingEmailCountAtSweepStart: null,
+        Failure: null);
+
     /// <summary>Gets whether running again shortly would reach work this run could not.</summary>
     /// <remarks>
     /// <para>

--- a/src/Application/Emails/Embeddings/Generation/StoredEmailEmbeddingGenerator.cs
+++ b/src/Application/Emails/Embeddings/Generation/StoredEmailEmbeddingGenerator.cs
@@ -7,7 +7,7 @@ using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Emails.Embeddings.Generation;
 
-/// <summary>Gives every passage of one stored message a vector under the profile this instance embeds into.</summary>
+/// <summary>Gives every passage of one stored message a vector under one of this instance's generations.</summary>
 /// <remarks>
 /// <para>
 /// The operation reads committed state and writes committed state, and the provider call between the two happens with
@@ -47,52 +47,51 @@ public sealed class StoredEmailEmbeddingGenerator
     /// </remarks>
     private const int MaximumProviderCallsPerEmail = 512;
 
-    private readonly IActiveEmbeddingProfileReader profileReader;
     private readonly IEmailEmbeddingStore embeddingStore;
     private readonly ITextEmbeddingGenerator textEmbeddingGenerator;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
 
     /// <summary>Initializes a new generator of one message's embeddings.</summary>
-    /// <param name="profileReader">Answers which vector space this instance embeds into.</param>
     /// <param name="embeddingStore">Reads which passages lack a vector, and writes the vectors that answer.</param>
     /// <param name="textEmbeddingGenerator">Turns passages into points of that space.</param>
     /// <param name="concurrencyRetryPolicy">Commits one call's vectors, retrying a conflict with a competing writer.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public StoredEmailEmbeddingGenerator(
-        IActiveEmbeddingProfileReader profileReader,
         IEmailEmbeddingStore embeddingStore,
         ITextEmbeddingGenerator textEmbeddingGenerator,
         OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy)
     {
-        ArgumentNullException.ThrowIfNull(profileReader);
         ArgumentNullException.ThrowIfNull(embeddingStore);
         ArgumentNullException.ThrowIfNull(textEmbeddingGenerator);
         ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
 
-        this.profileReader = profileReader;
         this.embeddingStore = embeddingStore;
         this.textEmbeddingGenerator = textEmbeddingGenerator;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
     }
 
-    /// <summary>Embeds whatever of one message is not yet embedded under the active profile.</summary>
+    /// <summary>Embeds whatever of one message is not yet embedded under one generation.</summary>
     /// <param name="storedEmailId">The message to bring up to date.</param>
+    /// <param name="profile">The generation the vectors belong to, which the caller decides and this never reads.</param>
     /// <param name="cancellationToken">Cancels the turn between calls and between commits.</param>
     /// <returns>How the turn ended, and how many passages it committed vectors for.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="profile" /> is <see langword="null" />.</exception>
     /// <exception cref="PersistenceConcurrencyConflictException">
     /// Thrown when a competing writer wins a race the bounded retries could not resolve. Vectors already committed stay
     /// durable and the passages they cover are no longer outstanding.
     /// </exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels or the host is shutting down. Committed vectors stay durable.</exception>
+    /// <remarks>
+    /// The generation is a parameter rather than something read here, because the live path and a reindex write into
+    /// different ones at the same moment: mail arriving is embedded into the generation serving searches, and the sweep
+    /// fills the one being built. A generator that resolved it itself could only ever serve one of the two.
+    /// </remarks>
     public async Task<StoredEmailEmbeddingRun> EmbedAsync(
         StoredEmailId storedEmailId,
+        RegisteredEmbeddingProfile profile,
         CancellationToken cancellationToken)
     {
-        var profile = await this.profileReader.FindActiveProfileAsync(cancellationToken);
-        if (profile is null)
-        {
-            return StoredEmailEmbeddingRun.NoActiveProfile();
-        }
+        ArgumentNullException.ThrowIfNull(profile);
 
         // Compared through the fingerprint rather than property by property, because that digest is what the profile
         // table is unique on: agreeing here is the same statement as resolving to this row at activation.
@@ -154,7 +153,7 @@ public sealed class StoredEmailEmbeddingGenerator
 
     /// <summary>Commits one call's vectors, so a crash leaves a whole page of passages embedded or none of it.</summary>
     private Task CommitVectorsAsync(
-        ActiveEmbeddingProfile profile,
+        RegisteredEmbeddingProfile profile,
         IReadOnlyList<EmailChunkAwaitingEmbedding> passages,
         IReadOnlyList<EmbeddingVector> vectors,
         CancellationToken cancellationToken)

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingGenerationTransition.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingGenerationTransition.cs
@@ -1,0 +1,19 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Generations;
+
+/// <summary>Whether one upkeep pass moved a generation from being built to being read.</summary>
+/// <remarks>
+/// The switch is one recorded event rather than a gradual drift, which is what lets an operator point at the moment
+/// searches started being answered by the new model. Every other pass leaves the generations where they were.
+/// </remarks>
+public enum EmbeddingGenerationTransition
+{
+    /// <summary>The pass left the generations as it found them.</summary>
+    None = 0,
+
+    /// <summary>The generation being built became the one retrieval reads, and the one it replaced was superseded.</summary>
+    Switched = 1,
+}

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingGenerationUpkeep.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingGenerationUpkeep.cs
@@ -76,15 +76,14 @@ public sealed class EmbeddingGenerationUpkeep
     public async Task<EmbeddingGenerationUpkeepResult> RunAsync(CancellationToken cancellationToken)
     {
         var generations = await this.generationStore.ReadGenerationsAsync(cancellationToken);
-        if (generations.Target is not { } target)
-        {
-            return new EmbeddingGenerationUpkeepResult(
-                StoredEmailEmbeddingBackfillResult.NoActiveProfile,
-                EmbeddingGenerationTransition.None,
-                RemovedSupersededVectorCount: 0);
-        }
 
-        var sweep = await this.backfill.RunAsync(target, cancellationToken);
+        // The walk is what an instance with no generation has nothing to do; the removal is not. A reindex cancelled
+        // on an instance that had never served one leaves a superseded generation and no sibling, and its partial
+        // vectors are personal data that has to go whether or not anything is being embedded now.
+        var sweep = generations.Target is { } target
+            ? await this.backfill.RunAsync(target, cancellationToken)
+            : StoredEmailEmbeddingBackfillResult.NoActiveProfile;
+
         var transition = await this.CompleteBuiltGenerationAsync(generations, sweep, cancellationToken);
         var removedVectorCount = await this.RemoveSupersededVectorsAsync(cancellationToken);
 

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingGenerationUpkeep.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingGenerationUpkeep.cs
@@ -1,0 +1,173 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Backfill;
+using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Application.Persistence;
+
+namespace MailFathom.Application.Emails.Embeddings.Generations;
+
+/// <summary>One bounded pass of everything this instance's vector generations need doing to them.</summary>
+/// <remarks>
+/// <para>
+/// Three steps in one pass, in the order they depend on each other: fill whichever generation is behind, complete a
+/// generation that has stopped being behind, and remove the vectors of one that nothing reads any more. They ride one
+/// loop rather than three workers because they are one pipeline — the third step exists only because the second one
+/// happened — and because each is bounded, so a pass that finds all three outstanding still ends.
+/// </para>
+/// <para>
+/// The completion is what makes a model change an operation without an outage. A new generation is filled while the old
+/// one goes on answering searches, and the moment it is complete it takes over in one recorded transition; the old
+/// generation's vectors then go, in batches, because they are personal data whose purpose ended there. See
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md">ADR 0006</see>.
+/// </para>
+/// </remarks>
+public sealed class EmbeddingGenerationUpkeep
+{
+    /// <summary>How many superseded vectors one pass removes before it ends.</summary>
+    /// <remarks>
+    /// A constant rather than a setting, because it bounds a local delete rather than describing a deployment: nothing
+    /// here reaches a provider or costs an operator money, and what paces the removal of a large generation is the
+    /// interval between passes, which is configured. The bound exists so one statement cannot hold a transaction, a lock
+    /// set, and a write-ahead burst open for as long as a mailbox's worth of vectors takes to delete.
+    /// </remarks>
+    private const int SupersededVectorRemovalBatchSize = 10_000;
+
+    private readonly IEmbeddingGenerationStore generationStore;
+    private readonly IStoredEmailEmbeddingBackfillStore backfillStore;
+    private readonly StoredEmailEmbeddingBackfill backfill;
+    private readonly IEmbeddingProfileVectorIndex vectorIndex;
+    private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
+
+    /// <summary>Initializes a new upkeep pass.</summary>
+    /// <param name="generationStore">Reads the generations and writes the transitions between them.</param>
+    /// <param name="backfillStore">Answers how much of the target generation is still outstanding.</param>
+    /// <param name="backfill">Walks the stored mail towards the target generation.</param>
+    /// <param name="vectorIndex">Removes the approximate index of a generation nothing reads any more.</param>
+    /// <param name="concurrencyRetryPolicy">Commits a transition or a removal batch, retrying a conflict with a competing writer.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public EmbeddingGenerationUpkeep(
+        IEmbeddingGenerationStore generationStore,
+        IStoredEmailEmbeddingBackfillStore backfillStore,
+        StoredEmailEmbeddingBackfill backfill,
+        IEmbeddingProfileVectorIndex vectorIndex,
+        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy)
+    {
+        ArgumentNullException.ThrowIfNull(generationStore);
+        ArgumentNullException.ThrowIfNull(backfillStore);
+        ArgumentNullException.ThrowIfNull(backfill);
+        ArgumentNullException.ThrowIfNull(vectorIndex);
+        ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
+
+        this.generationStore = generationStore;
+        this.backfillStore = backfillStore;
+        this.backfill = backfill;
+        this.vectorIndex = vectorIndex;
+        this.concurrencyRetryPolicy = concurrencyRetryPolicy;
+    }
+
+    /// <summary>Runs one bounded pass.</summary>
+    /// <param name="cancellationToken">Cancels the pass between its steps and inside each of them.</param>
+    /// <returns>What the pass produced, and whether running again shortly would reach more.</returns>
+    /// <exception cref="PersistenceConcurrencyConflictException">Thrown when a competing writer wins a race the bounded retries could not resolve.</exception>
+    /// <exception cref="EmbeddingVectorIndexFailedException">Thrown when the database refused to remove a superseded generation's index.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels. Everything already committed stays durable.</exception>
+    public async Task<EmbeddingGenerationUpkeepResult> RunAsync(CancellationToken cancellationToken)
+    {
+        var generations = await this.generationStore.ReadGenerationsAsync(cancellationToken);
+        if (generations.Target is not { } target)
+        {
+            return new EmbeddingGenerationUpkeepResult(
+                StoredEmailEmbeddingBackfillResult.NoActiveProfile,
+                EmbeddingGenerationTransition.None,
+                RemovedSupersededVectorCount: 0);
+        }
+
+        var sweep = await this.backfill.RunAsync(target, cancellationToken);
+        var transition = await this.CompleteBuiltGenerationAsync(generations, sweep, cancellationToken);
+        var removedVectorCount = await this.RemoveSupersededVectorsAsync(cancellationToken);
+
+        return new EmbeddingGenerationUpkeepResult(sweep, transition, removedVectorCount);
+    }
+
+    /// <summary>Switches to the generation being built once nothing is outstanding for it.</summary>
+    /// <remarks>
+    /// A completed sweep is not the same statement as a complete generation, which is why the count is asked for rather
+    /// than inferred: the walk ends its sweep when nothing is outstanding <em>in front of</em> its position, and a
+    /// message a provider refused earlier stays outstanding behind it. Asking is one indexed count, and only on the pass
+    /// that finished a sweep towards a generation that is being built.
+    /// </remarks>
+    private async Task<EmbeddingGenerationTransition> CompleteBuiltGenerationAsync(
+        EmbeddingGenerations generations,
+        StoredEmailEmbeddingBackfillResult sweep,
+        CancellationToken cancellationToken)
+    {
+        if (generations.Building is not { } building
+            || sweep.Outcome != StoredEmailEmbeddingBackfillOutcome.SweepCompleted)
+        {
+            return EmbeddingGenerationTransition.None;
+        }
+
+        var outstandingEmailCount = await this.backfillStore.CountEmailsAwaitingEmbeddingAsync(
+            building.Id,
+            cancellationToken);
+        if (outstandingEmailCount > 0)
+        {
+            return EmbeddingGenerationTransition.None;
+        }
+
+        var switched = await this.concurrencyRetryPolicy.CommitAsync(
+            (persistenceSession, attemptCancellationToken) => this.generationStore.SwitchToAsync(
+                persistenceSession,
+                building.Id,
+                attemptCancellationToken),
+            cancellationToken);
+
+        // A generation somebody cancelled while this pass was finishing it is not switched to, and the store is what
+        // says so: the count above was taken against a row that has since stopped being built.
+        if (!switched)
+        {
+            return EmbeddingGenerationTransition.None;
+        }
+
+        // Dropped after the switch rather than with it, and outside its transaction: an index is not something the
+        // switch can roll back, and every batched delete below would otherwise maintain an index nothing will read.
+        if (generations.Serving is { } superseded)
+        {
+            await this.vectorIndex.RemoveAsync(superseded.Id, cancellationToken);
+        }
+
+        return EmbeddingGenerationTransition.Switched;
+    }
+
+    /// <summary>Removes one bounded batch of a superseded generation's vectors.</summary>
+    /// <remarks>
+    /// One generation per pass, and the index goes when the last batch of it does. A batch that came back short is the
+    /// generation being empty, which is also the moment an index left behind by a process that stopped mid-removal is
+    /// cleared — the call is idempotent, so paying it once per emptied generation costs nothing.
+    /// </remarks>
+    private async Task<int> RemoveSupersededVectorsAsync(CancellationToken cancellationToken)
+    {
+        if (await this.generationStore.FindSupersededProfileHoldingVectorsAsync(cancellationToken)
+            is not { } supersededProfileId)
+        {
+            return 0;
+        }
+
+        var removedVectorCount = await this.concurrencyRetryPolicy.CommitAsync(
+            (persistenceSession, attemptCancellationToken) => this.generationStore.RemoveVectorsAsync(
+                persistenceSession,
+                supersededProfileId,
+                SupersededVectorRemovalBatchSize,
+                attemptCancellationToken),
+            cancellationToken);
+
+        if (removedVectorCount < SupersededVectorRemovalBatchSize)
+        {
+            await this.vectorIndex.RemoveAsync(supersededProfileId, cancellationToken);
+        }
+
+        return removedVectorCount;
+    }
+}

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingGenerationUpkeepResult.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingGenerationUpkeepResult.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Backfill;
+
+namespace MailFathom.Application.Emails.Embeddings.Generations;
+
+/// <summary>What one upkeep pass did to this instance's generations.</summary>
+/// <remarks>
+/// Counts and classifications only, like every other result a worker reports: the messages a pass reached, the vectors
+/// it wrote, and the vectors it removed are all derived from mail, and none of them belongs in a log.
+/// </remarks>
+/// <param name="Sweep">What the walk towards the target generation produced, and why it ended.</param>
+/// <param name="Transition">Whether the generation being built became the one retrieval reads.</param>
+/// <param name="RemovedSupersededVectorCount">How many vectors of a replaced generation this pass removed.</param>
+public sealed record EmbeddingGenerationUpkeepResult(
+    StoredEmailEmbeddingBackfillResult Sweep,
+    EmbeddingGenerationTransition Transition,
+    int RemovedSupersededVectorCount)
+{
+    /// <summary>Gets whether running again shortly would reach work this pass could not.</summary>
+    /// <remarks>
+    /// Three things pace the loop rather than one. The sweep answers for the mail it is embedding; a switch means the
+    /// next pass has a whole generation to clear out, and waiting an idle interval to start it would leave a mailbox's
+    /// worth of superseded vectors in place for no reason; and a removal that reached its bound has more behind it,
+    /// which is the same argument the sweep's own budget makes.
+    /// </remarks>
+    public bool MoreWorkIsWorthTryingSoon =>
+        this.Sweep.MoreWorkIsWorthTryingSoon
+        || this.Transition == EmbeddingGenerationTransition.Switched
+        || this.RemovedSupersededVectorCount > 0;
+}

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingGenerations.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingGenerations.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Generations;
+
+/// <summary>The generations this instance holds: the one retrieval reads, and the one being built beside it.</summary>
+/// <remarks>
+/// <para>
+/// Two rather than one, because changing model must not take semantic search away for as long as a mailbox takes to
+/// re-embed. The generation being built is never read, and the one serving stays authoritative until the new one is
+/// complete — which is what
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md">ADR 0006</see>
+/// means by making the profile the generation: there is no counter beside these two rows.
+/// </para>
+/// <para>
+/// Both are absent on an instance that has activated nothing, which is a supported deployment rather than a fault.
+/// </para>
+/// </remarks>
+/// <param name="Serving">The generation retrieval reads and newly synchronized mail is embedded into, or <see langword="null" /> when this instance has activated none.</param>
+/// <param name="Building">The generation a reindex is filling, or <see langword="null" /> when no reindex is running.</param>
+public sealed record EmbeddingGenerations(
+    RegisteredEmbeddingProfile? Serving,
+    RegisteredEmbeddingProfile? Building)
+{
+    /// <summary>An instance that has registered no profile at all.</summary>
+    public static EmbeddingGenerations None { get; } = new(Serving: null, Building: null);
+
+    /// <summary>Gets the generation the sweep works towards, which is the one being built where there is one.</summary>
+    /// <remarks>
+    /// The sweep fills the new generation in preference to the old, because the old one is complete by the time a new
+    /// one exists and every passage the sweep pays for is one the switch will not have to wait for. Mail arriving while
+    /// it runs is embedded into <see cref="Serving" /> by the live path instead, so it stays searchable throughout; the
+    /// sweep reaches it for the new generation before the count that decides the switch can read zero.
+    /// </remarks>
+    public RegisteredEmbeddingProfile? Target => this.Building ?? this.Serving;
+}

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingProfileActivation.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingProfileActivation.cs
@@ -1,0 +1,123 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Application.Persistence;
+
+namespace MailFathom.Application.Emails.Embeddings.Generations;
+
+/// <summary>Turns a declared geometry into the generation this instance is building towards.</summary>
+/// <remarks>
+/// <para>
+/// This is the one writer of a profile row, and the only thing in MailFathom that starts spending against a provider on
+/// purpose. Editing configuration declares a model and costs nothing;
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md">ADR 0006</see>
+/// makes this separate act the one that materializes the declaration and pays for it.
+/// </para>
+/// <para>
+/// What it never does is take semantic search away while it works. A generation begins its life being built, is never
+/// read while it is there, and replaces whatever was serving only once it is complete — so an operator changing model
+/// on a Tuesday is not answering for it on Wednesday. The counting and the confirmation that belong in front of the
+/// spending are the command surface's, not this type's: by the time it is called, the decision has been made.
+/// </para>
+/// </remarks>
+public sealed class EmbeddingProfileActivation
+{
+    private readonly IEmbeddingGenerationStore generationStore;
+    private readonly IEmbeddingProfileVectorIndex vectorIndex;
+    private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
+
+    /// <summary>Initializes a new activation.</summary>
+    /// <param name="generationStore">Reads which generations exist and registers the one being started.</param>
+    /// <param name="vectorIndex">Builds the approximate index the new generation will be searched through.</param>
+    /// <param name="concurrencyRetryPolicy">Commits the registration, retrying a conflict with a competing writer.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public EmbeddingProfileActivation(
+        IEmbeddingGenerationStore generationStore,
+        IEmbeddingProfileVectorIndex vectorIndex,
+        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy)
+    {
+        ArgumentNullException.ThrowIfNull(generationStore);
+        ArgumentNullException.ThrowIfNull(vectorIndex);
+        ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
+
+        this.generationStore = generationStore;
+        this.vectorIndex = vectorIndex;
+        this.concurrencyRetryPolicy = concurrencyRetryPolicy;
+    }
+
+    /// <summary>Registers the declared geometry as the generation to build, unless one of it is already there.</summary>
+    /// <param name="declared">The geometry configuration declares, which the fingerprint resolves a profile through.</param>
+    /// <param name="cancellationToken">Cancels the reads and the registration.</param>
+    /// <returns>What the activation did, and which generation it did it to.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="declared" /> is <see langword="null" />.</exception>
+    /// <exception cref="EmbeddingVectorIndexFailedException">
+    /// Thrown when the registration committed but the database refused to build the generation's approximate index. The
+    /// generation is registered and the reindex will run; searching it stays exact until an activation of the same
+    /// declaration builds the index, which is why repeating the command is what repairs this.
+    /// </exception>
+    /// <exception cref="PersistenceConcurrencyConflictException">Thrown when a competing writer wins a race the bounded retries could not resolve.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    public async Task<EmbeddingProfileActivationResult> ActivateAsync(
+        EmbeddingProfileIdentity declared,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(declared);
+
+        var generations = await this.generationStore.ReadGenerationsAsync(cancellationToken);
+        var declaredFingerprint = EmbeddingProfileFingerprint.Compute(declared);
+
+        // Compared through the fingerprint rather than property by property, because that digest is what the profile
+        // table is unique on: agreeing here is the same statement as resolving to that row.
+        if (generations.Serving is { } serving && Fingerprints(serving) == declaredFingerprint)
+        {
+            return new EmbeddingProfileActivationResult(
+                EmbeddingProfileActivationOutcome.AlreadyServing,
+                serving.Id);
+        }
+
+        if (generations.Building is { } building)
+        {
+            return Fingerprints(building) == declaredFingerprint
+                ? await this.ResumeBuildingAsync(building, cancellationToken)
+                : new EmbeddingProfileActivationResult(
+                    EmbeddingProfileActivationOutcome.DifferentReindexRunning,
+                    building.Id);
+        }
+
+        var registered = await this.concurrencyRetryPolicy.CommitAsync(
+            (persistenceSession, attemptCancellationToken) => this.generationStore.RegisterBuildingAsync(
+                persistenceSession,
+                declared,
+                attemptCancellationToken),
+            cancellationToken);
+
+        // Built while the generation is empty, which is the cheapest moment it can be built and the reason no migration
+        // creates it: the index covers one profile and one width, neither of which exists before this call.
+        await this.vectorIndex.EnsureBuiltAsync(registered, cancellationToken);
+
+        return new EmbeddingProfileActivationResult(
+            EmbeddingProfileActivationOutcome.ReindexStarted,
+            registered.Id);
+    }
+
+    /// <summary>Reports the reindex already under way, having made sure it has the index it will be read through.</summary>
+    /// <remarks>
+    /// The index build is repeated rather than skipped because it is idempotent and because a failed one is exactly what
+    /// brings an operator back to this command. Skipping it would leave the only repair path doing nothing.
+    /// </remarks>
+    private async Task<EmbeddingProfileActivationResult> ResumeBuildingAsync(
+        RegisteredEmbeddingProfile building,
+        CancellationToken cancellationToken)
+    {
+        await this.vectorIndex.EnsureBuiltAsync(building, cancellationToken);
+
+        return new EmbeddingProfileActivationResult(
+            EmbeddingProfileActivationOutcome.AlreadyBuilding,
+            building.Id);
+    }
+
+    private static EmbeddingProfileFingerprint Fingerprints(RegisteredEmbeddingProfile profile) =>
+        EmbeddingProfileFingerprint.Compute(profile.Identity);
+}

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingProfileActivation.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingProfileActivation.cs
@@ -57,7 +57,11 @@ public sealed class EmbeddingProfileActivation
     /// generation is registered and the reindex will run; searching it stays exact until an activation of the same
     /// declaration builds the index, which is why repeating the command is what repairs this.
     /// </exception>
-    /// <exception cref="PersistenceConcurrencyConflictException">Thrown when a competing writer wins a race the bounded retries could not resolve.</exception>
+    /// <exception cref="PersistenceConcurrencyConflictException">
+    /// Thrown when a competing writer wins a race the bounded retries could not resolve and which was not another
+    /// activation: losing to one of those is reported as an outcome rather than raised, because what the operator has
+    /// to know is which generation is being built rather than that two commands collided.
+    /// </exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
     public async Task<EmbeddingProfileActivationResult> ActivateAsync(
         EmbeddingProfileIdentity declared,
@@ -86,12 +90,20 @@ public sealed class EmbeddingProfileActivation
                     building.Id);
         }
 
-        var registered = await this.concurrencyRetryPolicy.CommitAsync(
-            (persistenceSession, attemptCancellationToken) => this.generationStore.RegisterBuildingAsync(
-                persistenceSession,
-                declared,
-                attemptCancellationToken),
-            cancellationToken);
+        RegisteredEmbeddingProfile registered;
+        try
+        {
+            registered = await this.concurrencyRetryPolicy.CommitAsync(
+                (persistenceSession, attemptCancellationToken) => this.generationStore.RegisterBuildingAsync(
+                    persistenceSession,
+                    declared,
+                    attemptCancellationToken),
+                cancellationToken);
+        }
+        catch (PersistenceConcurrencyConflictException conflict)
+        {
+            return await this.ReportTheReindexThatWonAsync(conflict, declaredFingerprint, cancellationToken);
+        }
 
         // Built while the generation is empty, which is the cheapest moment it can be built and the reason no migration
         // creates it: the index covers one profile and one width, neither of which exists before this call.
@@ -100,6 +112,32 @@ public sealed class EmbeddingProfileActivation
         return new EmbeddingProfileActivationResult(
             EmbeddingProfileActivationOutcome.ReindexStarted,
             registered.Id);
+    }
+
+    /// <summary>Answers a lost registration race with what the winner made true, or rethrows when nothing did.</summary>
+    /// <remarks>
+    /// The check above and the write are not one act, so two activations can both find nothing being built and both try
+    /// to register. The database refuses the second — one generation may be built at a time — and where the two
+    /// geometries differ no retry resolves it, because the losing row is the same row on every attempt. Re-reading is
+    /// what turns the conflict into the answer the operator needs, and which answer that is follows from whose geometry
+    /// won. A conflict with nothing being built afterwards was not this race at all, and is raised.
+    /// </remarks>
+    private async Task<EmbeddingProfileActivationResult> ReportTheReindexThatWonAsync(
+        PersistenceConcurrencyConflictException conflict,
+        EmbeddingProfileFingerprint declaredFingerprint,
+        CancellationToken cancellationToken)
+    {
+        var generations = await this.generationStore.ReadGenerationsAsync(cancellationToken);
+        if (generations.Building is not { } building)
+        {
+            throw conflict;
+        }
+
+        return Fingerprints(building) == declaredFingerprint
+            ? await this.ResumeBuildingAsync(building, cancellationToken)
+            : new EmbeddingProfileActivationResult(
+                EmbeddingProfileActivationOutcome.DifferentReindexRunning,
+                building.Id);
     }
 
     /// <summary>Reports the reindex already under way, having made sure it has the index it will be read through.</summary>

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingProfileActivationOutcome.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingProfileActivationOutcome.cs
@@ -1,0 +1,35 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Generations;
+
+/// <summary>What activating a declared geometry did, which is what an operator is told it started.</summary>
+/// <remarks>
+/// Three of these spend nothing and the first spends a mailbox, which is why they are apart: an operator who ran the
+/// command twice has to be able to tell the run that began a reindex from the one that found it already running.
+/// </remarks>
+public enum EmbeddingProfileActivationOutcome
+{
+    /// <summary>A generation was registered for this geometry and a reindex began filling it.</summary>
+    /// <remarks>
+    /// Whatever was serving goes on serving until the new generation is complete. Where nothing was, retrieval stays
+    /// lexical until the switch rather than reading a generation that is half built.
+    /// </remarks>
+    ReindexStarted = 0,
+
+    /// <summary>This geometry is the generation already being built, and the reindex was left running.</summary>
+    /// <remarks>Repeating the command is what an operator does after an index build failed, so it re-ensures the index rather than doing nothing at all.</remarks>
+    AlreadyBuilding = 1,
+
+    /// <summary>This geometry is already the generation retrieval reads, so nothing was registered and nothing spent.</summary>
+    AlreadyServing = 2,
+
+    /// <summary>A different generation is being built, so this activation was refused rather than started beside it.</summary>
+    /// <remarks>
+    /// One reindex at a time is the whole of the guarantee: two would put two partial generations in one table with one
+    /// walk between them, and neither would ever reach the count that completes it. Cancelling the running one is what
+    /// makes this activation possible.
+    /// </remarks>
+    DifferentReindexRunning = 3,
+}

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingProfileActivationResult.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingProfileActivationResult.cs
@@ -1,0 +1,17 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Generations;
+
+/// <summary>What one activation did, and which generation it did it to.</summary>
+/// <remarks>
+/// The identifier is present on every outcome, including the refused one, because what an operator needs next differs
+/// by outcome and each answer names a row: the generation now being built, the one already serving, or the one whose
+/// reindex is in the way.
+/// </remarks>
+/// <param name="Outcome">What the activation did.</param>
+/// <param name="ProfileId">The generation the outcome is about.</param>
+public sealed record EmbeddingProfileActivationResult(
+    EmbeddingProfileActivationOutcome Outcome,
+    EmbeddingProfileId ProfileId);

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingReindexCancellation.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingReindexCancellation.cs
@@ -1,0 +1,81 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Application.Persistence;
+
+namespace MailFathom.Application.Emails.Embeddings.Generations;
+
+/// <summary>Stops a reindex, leaving the generation that was serving exactly where it was.</summary>
+/// <remarks>
+/// The operation exists because a reindex is a decision an operator can regret while it is still running — the wrong
+/// model, a bill growing faster than expected — and the honest answer to that is to stop, not to wait for the switch and
+/// then pay for a second one. Nothing about retrieval changes: the generation being abandoned was never read.
+/// </remarks>
+public sealed class EmbeddingReindexCancellation
+{
+    private readonly IEmbeddingGenerationStore generationStore;
+    private readonly IEmbeddingProfileVectorIndex vectorIndex;
+    private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
+
+    /// <summary>Initializes a new cancellation.</summary>
+    /// <param name="generationStore">Reads which generation is being built and abandons it.</param>
+    /// <param name="vectorIndex">Removes the approximate index the abandoned generation would have been searched through.</param>
+    /// <param name="concurrencyRetryPolicy">Commits the transition, retrying a conflict with a competing writer.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public EmbeddingReindexCancellation(
+        IEmbeddingGenerationStore generationStore,
+        IEmbeddingProfileVectorIndex vectorIndex,
+        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy)
+    {
+        ArgumentNullException.ThrowIfNull(generationStore);
+        ArgumentNullException.ThrowIfNull(vectorIndex);
+        ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
+
+        this.generationStore = generationStore;
+        this.vectorIndex = vectorIndex;
+        this.concurrencyRetryPolicy = concurrencyRetryPolicy;
+    }
+
+    /// <summary>Abandons the generation being built, if one is.</summary>
+    /// <param name="cancellationToken">Cancels the read and the transition.</param>
+    /// <returns>Whether a reindex was abandoned.</returns>
+    /// <exception cref="EmbeddingVectorIndexFailedException">
+    /// Thrown when the abandonment committed but the database refused to remove the generation's approximate index. The
+    /// reindex is stopped either way; the index goes on occupying storage for a generation nothing reads until the
+    /// removal of its vectors reaches the end and drops it.
+    /// </exception>
+    /// <exception cref="PersistenceConcurrencyConflictException">Thrown when a competing writer wins a race the bounded retries could not resolve.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    public async Task<EmbeddingReindexCancellationOutcome> CancelAsync(CancellationToken cancellationToken)
+    {
+        var generations = await this.generationStore.ReadGenerationsAsync(cancellationToken);
+        if (generations.Building is not { } building)
+        {
+            return EmbeddingReindexCancellationOutcome.NothingBuilding;
+        }
+
+        var abandoned = await this.concurrencyRetryPolicy.CommitAsync(
+            (persistenceSession, attemptCancellationToken) => this.generationStore.AbandonAsync(
+                persistenceSession,
+                building.Id,
+                attemptCancellationToken),
+            cancellationToken);
+
+        // A reindex that completed between the read and the write took its generation into service, and abandoning that
+        // is not what this command means. Nothing was changed, so nothing — least of all the index searches are now
+        // answered through — is removed.
+        if (!abandoned)
+        {
+            return EmbeddingReindexCancellationOutcome.NothingBuilding;
+        }
+
+        // Dropped before the vectors rather than after them, because every batched delete would otherwise maintain an
+        // index nothing will ever read. The removal drops it again when it empties the generation, which is what covers
+        // a process that stopped between these two steps.
+        await this.vectorIndex.RemoveAsync(building.Id, cancellationToken);
+
+        return EmbeddingReindexCancellationOutcome.Cancelled;
+    }
+}

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingReindexCancellationOutcome.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingReindexCancellationOutcome.cs
@@ -1,0 +1,20 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Generations;
+
+/// <summary>What cancelling a reindex did.</summary>
+public enum EmbeddingReindexCancellationOutcome
+{
+    /// <summary>The generation being built was abandoned, and whatever was serving goes on serving.</summary>
+    /// <remarks>Its partial vectors are removed in bounded batches, and its row survives so the same model can be activated again later.</remarks>
+    Cancelled = 0,
+
+    /// <summary>No generation was being built, so nothing was abandoned.</summary>
+    /// <remarks>
+    /// Not a failure, and deliberately not a way to turn semantic search off: this command ends a reindex, and the
+    /// generation that is serving is never what it reaches.
+    /// </remarks>
+    NothingBuilding = 1,
+}

--- a/src/Application/Emails/Embeddings/Generations/IEmbeddingGenerationStore.cs
+++ b/src/Application/Emails/Embeddings/Generations/IEmbeddingGenerationStore.cs
@@ -1,0 +1,105 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+
+namespace MailFathom.Application.Emails.Embeddings.Generations;
+
+/// <summary>The profile rows a generation's life is written into, and every transition between them.</summary>
+/// <remarks>
+/// <para>
+/// One contract rather than several, because these operations are one state machine: registering a generation, making
+/// it the one retrieval reads, abandoning one that never got there, and clearing out what a replaced one left. A caller
+/// holding only some of them could move a generation into a state nothing would take it out of.
+/// </para>
+/// <para>
+/// It overlaps <see cref="IActiveEmbeddingProfileReader" /> deliberately and narrowly. That port answers the one
+/// question the read path asks — which generation serves a search — and it is the only thing retrieval and the live
+/// embedding worker are allowed to know about profiles. This one is the write side of the same table, and reading both
+/// generations is part of deciding a transition rather than a second way to ask what is active.
+/// </para>
+/// </remarks>
+public interface IEmbeddingGenerationStore
+{
+    /// <summary>Reads which generation serves retrieval and which one, if any, is being built.</summary>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>Both generations, either of which may be absent.</returns>
+    Task<EmbeddingGenerations> ReadGenerationsAsync(CancellationToken cancellationToken);
+
+    /// <summary>Registers a generation to embed into, or resolves the one this geometry already has.</summary>
+    /// <param name="session">The session whose transaction this write joins.</param>
+    /// <param name="identity">The geometry the generation is fixed to.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>The registered profile, in its building state.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any reference argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Resolved through the identity fingerprint rather than inserted blindly, which is what makes returning to a
+    /// previous model a switch rather than a duplicate: the row is still there, its identity may never have moved, and
+    /// the vectors that once hung on it were attributable to exactly this geometry. What the resolution does change is
+    /// the row's lifecycle, which is the only part of a profile that moves.
+    /// </remarks>
+    Task<RegisteredEmbeddingProfile> RegisterBuildingAsync(
+        IPersistenceSession session,
+        EmbeddingProfileIdentity identity,
+        CancellationToken cancellationToken);
+
+    /// <summary>Makes a built generation the one retrieval reads, and supersedes whichever one it replaces.</summary>
+    /// <param name="session">The session whose transaction this write joins.</param>
+    /// <param name="built">The generation whose vectors are complete.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns><see langword="true" /> when the switch applied, and <see langword="false" /> when the named generation was no longer being built.</returns>
+    /// <remarks>
+    /// One operation rather than two, because the two halves are one fact: an instance that superseded its old
+    /// generation without promoting the new one would serve nothing, and one that promoted the new one first would
+    /// briefly claim two. Both are written in the caller's transaction, so the switch a reader observes is the whole of
+    /// it or none of it — and a generation somebody abandoned while the sweep was finishing it is not switched to at
+    /// all, which is what the answer reports.
+    /// </remarks>
+    Task<bool> SwitchToAsync(IPersistenceSession session, EmbeddingProfileId built, CancellationToken cancellationToken);
+
+    /// <summary>Abandons a generation that was being built, leaving whichever one is serving where it is.</summary>
+    /// <param name="session">The session whose transaction this write joins.</param>
+    /// <param name="building">The generation to abandon.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns><see langword="true" /> when the generation was abandoned, and <see langword="false" /> when it was no longer being built.</returns>
+    /// <remarks>
+    /// The row survives and its identity stays what it was, so activating the same model again later resolves to it
+    /// rather than registering a second. What does not survive is the partial vectors, which the removal below reaches
+    /// because the row is superseded like any other generation nothing reads. A generation that finished being built
+    /// and became the one serving between the read and this write is not abandoned, because abandoning what searches
+    /// are answered from is not what cancelling a reindex means.
+    /// </remarks>
+    Task<bool> AbandonAsync(IPersistenceSession session, EmbeddingProfileId building, CancellationToken cancellationToken);
+
+    /// <summary>Finds a superseded generation that still holds vectors, if one does.</summary>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The generation whose vectors are still to be removed, or <see langword="null" /> when none is.</returns>
+    /// <remarks>
+    /// One at a time, because removal is bounded and a pass empties one generation before it looks at another. A
+    /// generation activated again while its removal was in progress is no longer superseded and stops being reported
+    /// here, which is what lets a rollback keep whatever vectors it still had.
+    /// </remarks>
+    Task<EmbeddingProfileId?> FindSupersededProfileHoldingVectorsAsync(CancellationToken cancellationToken);
+
+    /// <summary>Removes a bounded batch of one superseded generation's vectors.</summary>
+    /// <param name="session">The session whose transaction this write joins.</param>
+    /// <param name="profileId">The generation whose vectors are no longer read.</param>
+    /// <param name="batchSize">The greatest number of vectors to remove in this batch.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>How many vectors this batch removed, which is zero exactly when the generation holds none.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="batchSize" /> is not positive.</exception>
+    /// <remarks>
+    /// Bounded rather than one statement, because a generation of a large mailbox is millions of rows and a single
+    /// delete would hold one transaction, one lock set, and one write-ahead burst for as long as it took. They are
+    /// removed rather than kept for a rollback window: they are personal data derived from mail whose purpose ended at
+    /// the switch, which is the trade
+    /// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md">ADR 0006</see>
+    /// makes deliberately and states the cost of.
+    /// </remarks>
+    Task<int> RemoveVectorsAsync(
+        IPersistenceSession session,
+        EmbeddingProfileId profileId,
+        int batchSize,
+        CancellationToken cancellationToken);
+}

--- a/src/Application/Emails/Embeddings/IActiveEmbeddingProfileReader.cs
+++ b/src/Application/Emails/Embeddings/IActiveEmbeddingProfileReader.cs
@@ -19,5 +19,5 @@ public interface IActiveEmbeddingProfileReader
     /// <see langword="null" /> is an ordinary answer rather than a failure. An instance that has activated no profile
     /// embeds nothing, serves lexical search, and is a supported deployment.
     /// </remarks>
-    Task<ActiveEmbeddingProfile?> FindActiveProfileAsync(CancellationToken cancellationToken);
+    Task<RegisteredEmbeddingProfile?> FindActiveProfileAsync(CancellationToken cancellationToken);
 }

--- a/src/Application/Emails/Embeddings/IEmailEmbeddingStore.cs
+++ b/src/Application/Emails/Embeddings/IEmailEmbeddingStore.cs
@@ -48,7 +48,7 @@ public interface IEmailEmbeddingStore
     /// </remarks>
     Task SaveEmbeddingsAsync(
         IPersistenceSession session,
-        ActiveEmbeddingProfile profile,
+        RegisteredEmbeddingProfile profile,
         IReadOnlyList<GeneratedChunkEmbedding> embeddings,
         CancellationToken cancellationToken);
 }

--- a/src/Application/Emails/Embeddings/Indexing/IEmbeddingProfileVectorIndex.cs
+++ b/src/Application/Emails/Embeddings/Indexing/IEmbeddingProfileVectorIndex.cs
@@ -33,7 +33,7 @@ public interface IEmbeddingProfileVectorIndex
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="profile" /> is <see langword="null" />.</exception>
     /// <exception cref="EmbeddingVectorIndexFailedException">Thrown when the database refused to build the index.</exception>
-    Task EnsureBuiltAsync(ActiveEmbeddingProfile profile, CancellationToken cancellationToken);
+    Task EnsureBuiltAsync(RegisteredEmbeddingProfile profile, CancellationToken cancellationToken);
 
     /// <summary>Removes the approximate index belonging to one profile, if it has one.</summary>
     /// <param name="profileId">The profile whose index is to go.</param>

--- a/src/Application/Emails/Embeddings/RegisteredEmbeddingProfile.cs
+++ b/src/Application/Emails/Embeddings/RegisteredEmbeddingProfile.cs
@@ -4,11 +4,13 @@
 
 namespace MailFathom.Application.Emails.Embeddings;
 
-/// <summary>The profile vectors are currently produced and read under, and the geometry it fixed when it was registered.</summary>
+/// <summary>One profile row, with the geometry it fixed when it was registered.</summary>
 /// <remarks>
 /// <para>
-/// Its absence is what "this instance does not embed" means. There is no configuration flag beside it: an active profile
-/// row exists, or it does not, and
+/// Lifecycle-neutral by design, because a profile is a generation and two of them coexist while a new one is built: the
+/// one retrieval reads and the one being embedded into are the same shape and are told apart by
+/// <see cref="EmbeddingProfileLifecycleState" /> rather than by their type. Its absence is what "this instance does not
+/// embed" means — a profile row exists, or it does not, and
 /// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md">ADR 0006</see>
 /// records why the switch is an activation rather than a setting.
 /// </para>
@@ -20,4 +22,4 @@ namespace MailFathom.Application.Emails.Embeddings;
 /// </remarks>
 /// <param name="Id">Which registered profile this is.</param>
 /// <param name="Identity">The geometry the profile fixed at registration.</param>
-public sealed record ActiveEmbeddingProfile(EmbeddingProfileId Id, EmbeddingProfileIdentity Identity);
+public sealed record RegisteredEmbeddingProfile(EmbeddingProfileId Id, EmbeddingProfileIdentity Identity);

--- a/src/Application/Emails/Search/IEmailVectorSearchIndexReader.cs
+++ b/src/Application/Emails/Search/IEmailVectorSearchIndexReader.cs
@@ -53,7 +53,7 @@ public interface IEmailVectorSearchIndexReader
     /// </remarks>
     Task<IReadOnlyList<RankedEmailCandidate>> ReadNearestCandidatesAsync(
         MailboxEmailSelection selection,
-        ActiveEmbeddingProfile profile,
+        RegisteredEmbeddingProfile profile,
         EmbeddingVector queryVector,
         int limit,
         CancellationToken cancellationToken);

--- a/src/Application/Emails/Search/SemanticEmailSearch.cs
+++ b/src/Application/Emails/Search/SemanticEmailSearch.cs
@@ -243,6 +243,6 @@ public sealed class SemanticEmailSearch
     /// </remarks>
     private sealed record SemanticSearchGate(
         SemanticSearchCapability Capability,
-        ActiveEmbeddingProfile? Profile,
+        RegisteredEmbeddingProfile? Profile,
         ITextEmbeddingGenerator? Generator);
 }

--- a/src/Application/Persistence/OptimisticConcurrencyRetryPolicy.cs
+++ b/src/Application/Persistence/OptimisticConcurrencyRetryPolicy.cs
@@ -45,8 +45,36 @@ public sealed class OptimisticConcurrencyRetryPolicy
     /// <returns>A task that completes once one attempt has committed.</returns>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when every allowed attempt conflicted.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels before or between attempts.</exception>
-    public async Task CommitAsync(
+    public Task CommitAsync(
         Func<IPersistenceSession, CancellationToken, Task> stageChangesAsync,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stageChangesAsync);
+
+        return this.CommitAsync<object?>(
+            async (session, attemptCancellationToken) =>
+            {
+                await stageChangesAsync(session, attemptCancellationToken);
+
+                return null;
+            },
+            cancellationToken);
+    }
+
+    /// <summary>Stages and commits a complete local write that answers with what it wrote.</summary>
+    /// <typeparam name="TResult">What the write answers with.</typeparam>
+    /// <param name="stageChangesAsync">Stages the complete idempotent local write in the supplied session and answers with its result.</param>
+    /// <param name="cancellationToken">Cancels session creation, staging, commit, or a subsequent retry.</param>
+    /// <returns>What the attempt that committed produced.</returns>
+    /// <exception cref="PersistenceConcurrencyConflictException">Thrown when every allowed attempt conflicted.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels before or between attempts.</exception>
+    /// <remarks>
+    /// The result of an attempt that did not commit is discarded, which is the whole reason this exists rather than a
+    /// caller assigning to a captured local: a variable written by the losing attempt keeps its value, so code reading
+    /// it after a conflict would be reading a row that was rolled back.
+    /// </remarks>
+    public async Task<TResult> CommitAsync<TResult>(
+        Func<IPersistenceSession, CancellationToken, Task<TResult>> stageChangesAsync,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(stageChangesAsync);
@@ -56,11 +84,11 @@ public sealed class OptimisticConcurrencyRetryPolicy
             cancellationToken.ThrowIfCancellationRequested();
 
             await using var session = await this.sessionFactory.BeginSessionAsync(cancellationToken);
-            await stageChangesAsync(session, cancellationToken);
+            var result = await stageChangesAsync(session, cancellationToken);
 
             if (await session.CommitAsync(cancellationToken) == PersistenceCommitResult.Committed)
             {
-                return;
+                return result;
             }
 
             if (attemptNumber < this.maximumAttempts)

--- a/src/Host/Hosting/Workers/MailEmbeddingBackfillWorker.cs
+++ b/src/Host/Hosting/Workers/MailEmbeddingBackfillWorker.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
+using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Persistence;
 using MailFathom.Host.Configuration.Embeddings;
 using MailFathom.Infrastructure.Observability;
@@ -12,8 +13,13 @@ using Microsoft.Extensions.Options;
 
 namespace MailFathom.Host.Hosting.Workers;
 
-/// <summary>Runs the embedding backfill in scoped work units, pacing itself by what the last run found.</summary>
+/// <summary>Runs the embedding upkeep pass in scoped work units, pacing itself by what the last one found.</summary>
 /// <remarks>
+/// <para>
+/// The pass is the backfill sweep and the two things that ride it: completing a generation the sweep has finished
+/// filling, and removing the vectors of one it replaced. They share this loop and its interval because they are one
+/// pipeline, and because each is bounded — the worker's job is to keep starting passes, not to decide what a pass does.
+/// </para>
 /// <para>
 /// Unlike the extraction backfill, this worker never ends itself. Its walk is a repeating sweep, because a message the
 /// live backlog's bound turned away and a message a refused provider call left part-way through both keep passages with
@@ -85,10 +91,10 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
         {
             using var scope = this.scopeFactory.CreateScope();
 
-            var backfill = scope.ServiceProvider.GetRequiredService<StoredEmailEmbeddingBackfill>();
-            var result = await backfill.RunAsync(cancellationToken);
+            var upkeep = scope.ServiceProvider.GetRequiredService<EmbeddingGenerationUpkeep>();
+            var result = await upkeep.RunAsync(cancellationToken);
 
-            this.telemetry.RecordRun(result);
+            this.telemetry.RecordPass(result);
             this.Report(result);
 
             return result.MoreWorkIsWorthTryingSoon ? this.settings.Interval : this.settings.IdleSweepInterval;
@@ -111,13 +117,33 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
         }
     }
 
-    /// <summary>Says what the run means for an operator, at the level that outcome deserves.</summary>
+    /// <summary>Says what the pass means for an operator, at the level each part of it deserves.</summary>
+    /// <remarks>
+    /// The switch and the removal are reported before the sweep, because they are the events an operator watching a
+    /// model change is waiting for and the sweep's own counters are what they have been reading in the meantime.
+    /// </remarks>
+    private void Report(EmbeddingGenerationUpkeepResult result)
+    {
+        if (result.Transition == EmbeddingGenerationTransition.Switched)
+        {
+            this.LogGenerationSwitched();
+        }
+
+        if (result.RemovedSupersededVectorCount > 0)
+        {
+            this.LogSupersededVectorsRemoved(result.RemovedSupersededVectorCount);
+        }
+
+        this.ReportSweep(result.Sweep);
+    }
+
+    /// <summary>Says what the walk part of the pass means for an operator, at the level that outcome deserves.</summary>
     /// <remarks>
     /// Progress and a completed sweep are ordinary, and an instance that has activated no profile is the state ADR 0006
     /// makes supported, so none of the three is a warning. The two that need an operator are a declaration disagreeing
     /// with what was activated and a provider that refused.
     /// </remarks>
-    private void Report(StoredEmailEmbeddingBackfillResult result)
+    private void ReportSweep(StoredEmailEmbeddingBackfillResult result)
     {
         switch (result.Outcome)
         {
@@ -199,6 +225,16 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
         Level = LogLevel.Information,
         Message = "The embedding backfill has reached the end of the stored mail; the next sweep starts from the beginning to pick up whatever a refused call or a full queue left behind.")]
     private partial void LogSweepCompleted();
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The generation being built is complete and is now the one searches are answered from; the generation it replaced is superseded and its vectors are being removed.")]
+    private partial void LogGenerationSwitched();
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Removed {RemovedVectorCount} vectors of a superseded generation; they are derived personal data whose purpose ended at the switch, so none of them is kept for a rollback.")]
+    private partial void LogSupersededVectorsRemoved(int removedVectorCount);
 
     [LoggerMessage(
         Level = LogLevel.Debug,

--- a/src/Host/Hosting/Workers/MailEmbeddingWorker.cs
+++ b/src/Host/Hosting/Workers/MailEmbeddingWorker.cs
@@ -74,8 +74,7 @@ internal sealed partial class MailEmbeddingWorker : BackgroundService
         {
             using var scope = this.scopeFactory.CreateScope();
 
-            var generator = scope.ServiceProvider.GetRequiredService<StoredEmailEmbeddingGenerator>();
-            var run = await generator.EmbedAsync(storedEmailId, cancellationToken);
+            var run = await EmbedIntoServingGenerationAsync(scope.ServiceProvider, storedEmailId, cancellationToken);
 
             this.telemetry.RecordEmbeddedMessage(run, this.timeProvider.GetElapsedTime(startingTimestamp));
             this.Report(run);
@@ -92,6 +91,29 @@ internal sealed partial class MailEmbeddingWorker : BackgroundService
         {
             this.LogMessageFailed(exception);
         }
+    }
+
+    /// <summary>Embeds one message into the generation searches are answered from, if there is one.</summary>
+    /// <remarks>
+    /// The generation serving searches rather than one being built, which is what keeps mail arriving during a reindex
+    /// searchable the moment it is stored. The reindex reaches the same message for the new generation before the count
+    /// that completes it can read zero, so nothing is lost by leaving it to the sweep.
+    /// </remarks>
+    private static async Task<StoredEmailEmbeddingRun> EmbedIntoServingGenerationAsync(
+        IServiceProvider scopedServices,
+        StoredEmailId storedEmailId,
+        CancellationToken cancellationToken)
+    {
+        var profileReader = scopedServices.GetRequiredService<IActiveEmbeddingProfileReader>();
+        var serving = await profileReader.FindActiveProfileAsync(cancellationToken);
+        if (serving is null)
+        {
+            return StoredEmailEmbeddingRun.NoActiveProfile();
+        }
+
+        var generator = scopedServices.GetRequiredService<StoredEmailEmbeddingGenerator>();
+
+        return await generator.EmbedAsync(storedEmailId, serving, cancellationToken);
     }
 
     /// <summary>Says what the outcome means for an operator, at the level that outcome deserves.</summary>

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -370,9 +370,9 @@ try
             ?? throw new InvalidOperationException(
                 "The embedding chain was declared at registration and is absent from the validated configuration."));
         builder.Services.AddEmbeddingProviderAdapter();
-        // Beside the adapter rather than inside AddInfrastructure, because these two resolve the generator that call
-        // registers. An instance that declared no chain registers neither and starts; one that declared one registers
-        // both and the workers below have something to resolve.
+        // Beside the adapter rather than inside AddInfrastructure, because the units of work it registers resolve the
+        // generator that call registers. An instance that declared no chain registers none of them and starts; one that
+        // declared a chain registers them all and the workers below have something to resolve.
         builder.Services.AddEmailEmbeddingGeneration();
         builder.Services.AddHealthChecks()
             .Add(AiProviderHealthCheck.RegistrationFor(AiProviderRole.Embedding));

--- a/src/Infrastructure/Observability/EmailEmbeddingBackfillTelemetry.cs
+++ b/src/Infrastructure/Observability/EmailEmbeddingBackfillTelemetry.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
+using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Common.Observability;
 
 namespace MailFathom.Infrastructure.Observability;
@@ -40,6 +41,8 @@ public sealed class EmailEmbeddingBackfillTelemetry
     private readonly Counter<long> embeddedEmailCount;
     private readonly Counter<long> passageCount;
     private readonly Counter<long> callBudgetExhaustedEmailCount;
+    private readonly Counter<long> generationSwitchCount;
+    private readonly Counter<long> removedSupersededVectorCount;
     private int outstandingEmailCount;
 
     /// <summary>Initializes the instruments every backfill run reports through.</summary>
@@ -65,6 +68,14 @@ public sealed class EmailEmbeddingBackfillTelemetry
             "mailfathom.embedding.backfill.exhausted",
             unit: "{message}",
             description: "Messages the backfill left part-way through because one turn spent every provider call it is allowed.");
+        this.generationSwitchCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.embedding.generation.switches",
+            unit: "{switch}",
+            description: "Generations that finished being built and became the one searches are answered from.");
+        this.removedSupersededVectorCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.embedding.generation.removed",
+            unit: "{vector}",
+            description: "Vectors of a superseded generation removed after a switch.");
         Telemetry.Meter.CreateObservableGauge(
             "mailfathom.embedding.backfill.outstanding",
             () => Volatile.Read(ref this.outstandingEmailCount),
@@ -72,13 +83,33 @@ public sealed class EmailEmbeddingBackfillTelemetry
             description: "Messages awaiting embedding when the current sweep began.");
     }
 
-    /// <summary>Records one bounded pass of the backfill.</summary>
-    /// <param name="result">What the pass produced and why it ended.</param>
+    /// <summary>Records one bounded upkeep pass: its sweep, its switch, and what it removed.</summary>
+    /// <param name="result">What the pass produced.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="result" /> is <see langword="null" />.</exception>
-    public void RecordRun(StoredEmailEmbeddingBackfillResult result)
+    /// <remarks>
+    /// The switch is a counter rather than a state, because what an operator asks of it afterwards is when it happened
+    /// and how many have — and a gauge of the current generation would publish an identifier, which is a dimension of
+    /// unbounded cardinality for a value one log line already carries.
+    /// </remarks>
+    public void RecordPass(EmbeddingGenerationUpkeepResult result)
     {
         ArgumentNullException.ThrowIfNull(result);
 
+        this.RecordSweep(result.Sweep);
+
+        if (result.Transition == EmbeddingGenerationTransition.Switched)
+        {
+            this.generationSwitchCount.Add(1);
+        }
+
+        if (result.RemovedSupersededVectorCount > 0)
+        {
+            this.removedSupersededVectorCount.Add(result.RemovedSupersededVectorCount);
+        }
+    }
+
+    private void RecordSweep(StoredEmailEmbeddingBackfillResult result)
+    {
         var tags = new TagList
         {
             { OutcomeTagName, OutcomeTagOf(result.Outcome) },

--- a/src/Infrastructure/Persistence/Embeddings/ActiveEmbeddingProfileReader.cs
+++ b/src/Infrastructure/Persistence/Embeddings/ActiveEmbeddingProfileReader.cs
@@ -8,11 +8,13 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MailFathom.Infrastructure.Persistence.Embeddings;
 
-/// <summary>Reads the one profile row this instance currently embeds into and reads from.</summary>
+/// <summary>Reads the one profile row searches are answered from, which is also where arriving mail is embedded.</summary>
 /// <remarks>
-/// At most one profile is <see cref="EmbeddingProfileLifecycleState.Active" /> at a time, which the activation command
-/// is what enforces. This reads whichever row is there and takes the most recently activated one if a defect ever left
-/// two, because serving the newer generation is the safer reading of an ambiguous state than picking arbitrarily.
+/// At most one profile is <see cref="EmbeddingProfileLifecycleState.Active" /> at a time, which a partial unique index
+/// over the lifecycle column is what enforces. The generation being built is deliberately out of reach here: a caller
+/// on this port is serving a search or embedding mail that has just arrived, and both of those belong to the
+/// generation that is complete. The ordering is what makes an ambiguous state readable anyway — serving the newer
+/// generation is the safer reading of two rows than picking arbitrarily.
 /// </remarks>
 [RequiresIntegrationCoverage]
 internal sealed class ActiveEmbeddingProfileReader(MailFathomDbContext dbContext) : IActiveEmbeddingProfileReader
@@ -23,7 +25,7 @@ internal sealed class ActiveEmbeddingProfileReader(MailFathomDbContext dbContext
     /// fingerprint are not what a caller does anything with, and the row must not be tracked by a context a write will
     /// later join.
     /// </remarks>
-    public async Task<ActiveEmbeddingProfile?> FindActiveProfileAsync(CancellationToken cancellationToken)
+    public async Task<RegisteredEmbeddingProfile?> FindActiveProfileAsync(CancellationToken cancellationToken)
     {
         var profile = await dbContext.EmbeddingProfiles
             .AsNoTracking()
@@ -44,7 +46,7 @@ internal sealed class ActiveEmbeddingProfileReader(MailFathomDbContext dbContext
         return profile is null ? null : Map(profile);
     }
 
-    private static ActiveEmbeddingProfile Map(ActiveProfileRow profile) => new(
+    private static RegisteredEmbeddingProfile Map(ActiveProfileRow profile) => new(
         EmbeddingProfileId.Create(profile.Id),
         EmbeddingProfileIdentity.Create(
             profile.Provider,

--- a/src/Infrastructure/Persistence/Embeddings/EmailEmbeddingStore.cs
+++ b/src/Infrastructure/Persistence/Embeddings/EmailEmbeddingStore.cs
@@ -55,7 +55,7 @@ internal sealed class EmailEmbeddingStore(MailFathomDbContext dbContext, TimePro
     /// </remarks>
     public async Task SaveEmbeddingsAsync(
         IPersistenceSession session,
-        ActiveEmbeddingProfile profile,
+        RegisteredEmbeddingProfile profile,
         IReadOnlyList<GeneratedChunkEmbedding> embeddings,
         CancellationToken cancellationToken)
     {

--- a/src/Infrastructure/Persistence/Embeddings/EmailVectorSearchIndexReader.cs
+++ b/src/Infrastructure/Persistence/Embeddings/EmailVectorSearchIndexReader.cs
@@ -47,7 +47,7 @@ internal sealed class EmailVectorSearchIndexReader(MailFathomDbContext dbContext
     /// <inheritdoc />
     public async Task<IReadOnlyList<RankedEmailCandidate>> ReadNearestCandidatesAsync(
         MailboxEmailSelection selection,
-        ActiveEmbeddingProfile profile,
+        RegisteredEmbeddingProfile profile,
         EmbeddingVector queryVector,
         int limit,
         CancellationToken cancellationToken)
@@ -81,7 +81,7 @@ internal sealed class EmailVectorSearchIndexReader(MailFathomDbContext dbContext
     /// </remarks>
     internal IQueryable<StoredEmailVectorHitRow> NearestHitsQuery(
         MailboxEmailSelection selection,
-        ActiveEmbeddingProfile profile,
+        RegisteredEmbeddingProfile profile,
         EmbeddingVector queryVector,
         int limit)
     {

--- a/src/Infrastructure/Persistence/Embeddings/EmbeddingGenerationStore.cs
+++ b/src/Infrastructure/Persistence/Embeddings/EmbeddingGenerationStore.cs
@@ -219,11 +219,20 @@ internal sealed class EmbeddingGenerationStore(MailFathomDbContext dbContext, Ti
 
     /// <inheritdoc />
     /// <remarks>
+    /// <para>
     /// The one statement here that is written rather than composed, and the reason is the shape of a bounded delete
     /// over a whole generation. A limit needs rows chosen, and choosing them by any column would sort every vector the
     /// generation still holds on every batch — quadratic over the run that empties a mailbox's worth of them. Selecting
     /// by <c>ctid</c> lets PostgreSQL stop at the limit while reading the profile's own index, so a batch costs what a
-    /// batch is. Both values are parameters rather than text, so nothing a caller supplies reaches the statement.
+    /// batch is. Every value is a parameter rather than text, so nothing a caller supplies reaches the statement.
+    /// </para>
+    /// <para>
+    /// The lifecycle is re-checked here rather than trusted from the read that chose this generation, because the two
+    /// are separate transactions and an activation of the same model in between is exactly the case the rollback
+    /// promise covers: a generation that stops being superseded keeps whatever vectors it still holds, and a delete
+    /// that had already been decided would charge the operator for re-embedding them. The subquery is uncorrelated, so
+    /// PostgreSQL evaluates it once for the statement rather than per row.
+    /// </para>
     /// </remarks>
     public Task<int> RemoveVectorsAsync(
         IPersistenceSession session,
@@ -235,13 +244,18 @@ internal sealed class EmbeddingGenerationStore(MailFathomDbContext dbContext, Ti
 
         var sessionContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
         var supersededProfileId = profileId.Value;
+        var supersededState = nameof(EmbeddingProfileLifecycleState.Superseded);
 
         return sessionContext.Database.ExecuteSqlAsync(
             $"""
              DELETE FROM email_embeddings
              WHERE ctid IN (
-                 SELECT ctid FROM email_embeddings
-                 WHERE "EmbeddingProfileId" = {supersededProfileId}
+                 SELECT vector.ctid FROM email_embeddings AS vector
+                 WHERE vector."EmbeddingProfileId" = {supersededProfileId}
+                   AND EXISTS (
+                       SELECT 1 FROM embedding_profiles AS generation
+                       WHERE generation."Id" = {supersededProfileId}
+                         AND generation."LifecycleState" = {supersededState})
                  LIMIT {batchSize})
              """,
             cancellationToken);

--- a/src/Infrastructure/Persistence/Embeddings/EmbeddingGenerationStore.cs
+++ b/src/Infrastructure/Persistence/Embeddings/EmbeddingGenerationStore.cs
@@ -1,0 +1,285 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Generations;
+using MailFathom.Application.Persistence;
+using MailFathom.CodeCoverage;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Sessions;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailFathom.Infrastructure.Persistence.Embeddings;
+
+/// <summary>EF Core state of the generations, and of every transition a profile row makes between them.</summary>
+/// <remarks>
+/// <para>
+/// The lifecycle transitions are issued as set-based updates rather than staged through the change tracker, which is
+/// the one place this store departs from the repositories around it and is not a preference. A partial unique index
+/// admits one building generation and one serving one, so the switch has to supersede the old row before it promotes
+/// the new one; the change tracker gives no order to two updates of one table, and either order is a coin toss that
+/// would violate that index half the time. Two statements issued in the caller's transaction are ordered by
+/// construction.
+/// </para>
+/// <para>
+/// Nothing here is personal data. A profile describes a model, and the vectors this removes are counted rather than
+/// read.
+/// </para>
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class EmbeddingGenerationStore(MailFathomDbContext dbContext, TimeProvider timeProvider)
+    : IEmbeddingGenerationStore
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// One query for both rows, projected onto the identity columns rather than materialized: the partial unique index
+    /// admits at most one of each state, so what comes back is at most two rows and neither of them is tracked by a
+    /// context a write will later join.
+    /// </remarks>
+    public async Task<EmbeddingGenerations> ReadGenerationsAsync(CancellationToken cancellationToken)
+    {
+        var rows = await dbContext.EmbeddingProfiles
+            .AsNoTracking()
+            .Where(candidate => candidate.LifecycleState == EmbeddingProfileLifecycleState.Active
+                || candidate.LifecycleState == EmbeddingProfileLifecycleState.Building)
+            .Select(candidate => new GenerationRow(
+                candidate.Id,
+                candidate.LifecycleState,
+                candidate.Provider,
+                candidate.ModelIdentifier,
+                candidate.ModelVersion,
+                candidate.Dimension,
+                candidate.DistanceMetric,
+                candidate.InputCharacterLimit,
+                candidate.PassageInstruction,
+                candidate.NormalizesVector))
+            .ToArrayAsync(cancellationToken);
+
+        return new EmbeddingGenerations(
+            Serving: Map(rows, EmbeddingProfileLifecycleState.Active),
+            Building: Map(rows, EmbeddingProfileLifecycleState.Building));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The lookup is by the identity fingerprint, which is an alternate key, so it takes the two-pass helper rather than
+    /// <c>FindAsync</c>. A row it finds is re-registered rather than replaced: its identity columns may never move, and
+    /// the lifecycle is the only thing this write touches.
+    /// </remarks>
+    public async Task<RegisteredEmbeddingProfile> RegisterBuildingAsync(
+        IPersistenceSession session,
+        EmbeddingProfileIdentity identity,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+
+        var sessionContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
+        var fingerprint = EmbeddingProfileFingerprint.Compute(identity).Value;
+
+        var registered = await TrackedEntityLookup.SinglePendingOrPersistedAsync(
+            sessionContext.EmbeddingProfiles,
+            sessionContext.EmbeddingProfiles,
+            candidate => candidate.IdentityFingerprint == fingerprint,
+            cancellationToken);
+
+        if (registered is null)
+        {
+            registered = new EmbeddingProfileEntity
+            {
+                Id = Guid.CreateVersion7(),
+                Provider = identity.Provider,
+                ModelIdentifier = identity.ModelIdentifier,
+                ModelVersion = identity.ModelVersion,
+                Dimension = identity.Dimension,
+                DistanceMetric = identity.DistanceMetric,
+                InputCharacterLimit = identity.InputPreparation.InputCharacterLimit,
+                PassageInstruction = identity.InputPreparation.PassageInstruction,
+                NormalizesVector = identity.InputPreparation.NormalizesVector,
+                IdentityFingerprint = fingerprint,
+                LifecycleState = EmbeddingProfileLifecycleState.Building,
+                RegisteredAt = timeProvider.GetUtcNow(),
+            };
+
+            sessionContext.EmbeddingProfiles.Add(registered);
+        }
+        else
+        {
+            registered.LifecycleState = EmbeddingProfileLifecycleState.Building;
+            registered.SupersededAt = null;
+        }
+
+        return new RegisteredEmbeddingProfile(EmbeddingProfileId.Create(registered.Id), identity);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SwitchToAsync(
+        IPersistenceSession session,
+        EmbeddingProfileId built,
+        CancellationToken cancellationToken)
+    {
+        var sessionContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
+        var builtId = built.Value;
+
+        if (!await LockWhileBuildingAsync(sessionContext, builtId, cancellationToken))
+        {
+            return false;
+        }
+
+        var switchedAt = timeProvider.GetUtcNow();
+
+        // Superseding first is what the partial unique index requires, and the two statements are ordered because they
+        // are issued rather than staged. The row being promoted is excluded from the first, so a switch repeated after
+        // a crash between the commit and whatever followed it changes nothing.
+        await sessionContext.EmbeddingProfiles
+            .Where(candidate => candidate.LifecycleState == EmbeddingProfileLifecycleState.Active
+                && candidate.Id != builtId)
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(candidate => candidate.LifecycleState, EmbeddingProfileLifecycleState.Superseded)
+                    .SetProperty(candidate => candidate.SupersededAt, switchedAt),
+                cancellationToken);
+
+        await sessionContext.EmbeddingProfiles
+            .Where(candidate => candidate.Id == builtId)
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(candidate => candidate.LifecycleState, EmbeddingProfileLifecycleState.Active)
+                    .SetProperty(candidate => candidate.ActivatedAt, switchedAt)
+                    .SetProperty(candidate => candidate.SupersededAt, (DateTimeOffset?)null),
+                cancellationToken);
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Narrowed to a row that is still being built, so a cancellation that arrives after the switch has taken the same
+    /// generation into service abandons nothing and says so — and one that arrives while the switch is committing waits
+    /// on the row that switch has locked rather than passing through it.
+    /// </remarks>
+    public async Task<bool> AbandonAsync(
+        IPersistenceSession session,
+        EmbeddingProfileId building,
+        CancellationToken cancellationToken)
+    {
+        var sessionContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
+        var buildingId = building.Value;
+        var abandonedAt = timeProvider.GetUtcNow();
+
+        var abandonedRowCount = await sessionContext.EmbeddingProfiles
+            .Where(candidate => candidate.Id == buildingId
+                && candidate.LifecycleState == EmbeddingProfileLifecycleState.Building)
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(candidate => candidate.LifecycleState, EmbeddingProfileLifecycleState.Superseded)
+                    .SetProperty(candidate => candidate.SupersededAt, abandonedAt),
+                cancellationToken);
+
+        return abandonedRowCount > 0;
+    }
+
+    /// <summary>Takes the row lock the switch needs, and answers whether the generation is still being built.</summary>
+    /// <remarks>
+    /// Written rather than composed, because the guard is the lock: reading the state without one would leave a
+    /// cancellation free to abandon the generation between the supersede and the promote, and the transaction would
+    /// commit with nothing serving at all. <c>FOR UPDATE</c> makes that cancellation wait for this transaction and then
+    /// find a row that is no longer building, which is the answer its own narrowed update reports.
+    /// </remarks>
+    private static async Task<bool> LockWhileBuildingAsync(
+        MailFathomDbContext sessionContext,
+        Guid builtId,
+        CancellationToken cancellationToken)
+    {
+        var lockedState = await sessionContext.Database
+            .SqlQuery<string>(
+                $"""SELECT "LifecycleState" AS "Value" FROM embedding_profiles WHERE "Id" = {builtId} FOR UPDATE""")
+            .SingleOrDefaultAsync(cancellationToken);
+
+        return lockedState == nameof(EmbeddingProfileLifecycleState.Building);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Ordered by when the generation was superseded, so the oldest is emptied first and a second replaced generation
+    /// waits its turn rather than interleaving with it.
+    /// </remarks>
+    public async Task<EmbeddingProfileId?> FindSupersededProfileHoldingVectorsAsync(CancellationToken cancellationToken)
+    {
+        var profileId = await dbContext.EmbeddingProfiles
+            .AsNoTracking()
+            .Where(candidate => candidate.LifecycleState == EmbeddingProfileLifecycleState.Superseded)
+            .Where(candidate => candidate.Embeddings.Any())
+            .OrderBy(candidate => candidate.SupersededAt)
+            .Select(candidate => (Guid?)candidate.Id)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return profileId is { } superseded ? EmbeddingProfileId.Create(superseded) : null;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The one statement here that is written rather than composed, and the reason is the shape of a bounded delete
+    /// over a whole generation. A limit needs rows chosen, and choosing them by any column would sort every vector the
+    /// generation still holds on every batch — quadratic over the run that empties a mailbox's worth of them. Selecting
+    /// by <c>ctid</c> lets PostgreSQL stop at the limit while reading the profile's own index, so a batch costs what a
+    /// batch is. Both values are parameters rather than text, so nothing a caller supplies reaches the statement.
+    /// </remarks>
+    public Task<int> RemoveVectorsAsync(
+        IPersistenceSession session,
+        EmbeddingProfileId profileId,
+        int batchSize,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(batchSize);
+
+        var sessionContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
+        var supersededProfileId = profileId.Value;
+
+        return sessionContext.Database.ExecuteSqlAsync(
+            $"""
+             DELETE FROM email_embeddings
+             WHERE ctid IN (
+                 SELECT ctid FROM email_embeddings
+                 WHERE "EmbeddingProfileId" = {supersededProfileId}
+                 LIMIT {batchSize})
+             """,
+            cancellationToken);
+    }
+
+    private static RegisteredEmbeddingProfile? Map(
+        IReadOnlyList<GenerationRow> rows,
+        EmbeddingProfileLifecycleState lifecycleState)
+    {
+        if (rows.FirstOrDefault(row => row.LifecycleState == lifecycleState) is not { } generation)
+        {
+            return null;
+        }
+
+        return new RegisteredEmbeddingProfile(
+            EmbeddingProfileId.Create(generation.Id),
+            EmbeddingProfileIdentity.Create(
+                generation.Provider,
+                generation.ModelIdentifier,
+                generation.ModelVersion,
+                generation.Dimension,
+                generation.DistanceMetric,
+                EmbeddingInputPreparation.Create(
+                    generation.InputCharacterLimit,
+                    generation.PassageInstruction,
+                    generation.NormalizesVector)));
+    }
+
+    /// <summary>One generation's row, as the projection returns it.</summary>
+    private sealed record GenerationRow(
+        Guid Id,
+        EmbeddingProfileLifecycleState LifecycleState,
+        string Provider,
+        string ModelIdentifier,
+        string? ModelVersion,
+        int Dimension,
+        EmbeddingDistanceMetric DistanceMetric,
+        int InputCharacterLimit,
+        string? PassageInstruction,
+        bool NormalizesVector);
+}

--- a/src/Infrastructure/Persistence/Embeddings/EmbeddingProfileVectorIndex.cs
+++ b/src/Infrastructure/Persistence/Embeddings/EmbeddingProfileVectorIndex.cs
@@ -35,7 +35,7 @@ internal sealed partial class EmbeddingProfileVectorIndex(
     ILogger<EmbeddingProfileVectorIndex> logger) : IEmbeddingProfileVectorIndex
 {
     /// <inheritdoc />
-    public async Task EnsureBuiltAsync(ActiveEmbeddingProfile profile, CancellationToken cancellationToken)
+    public async Task EnsureBuiltAsync(RegisteredEmbeddingProfile profile, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(profile);
 

--- a/src/Infrastructure/Persistence/Embeddings/EmbeddingVectorIndexStatements.cs
+++ b/src/Infrastructure/Persistence/Embeddings/EmbeddingVectorIndexStatements.cs
@@ -59,7 +59,7 @@ internal static class EmbeddingVectorIndexStatements
     /// <returns>A <c>CREATE INDEX</c> statement, idempotent in the profile it is for.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="profile" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when the profile records a metric pgvector has no operator class for.</exception>
-    internal static string CreateIndexFor(ActiveEmbeddingProfile profile)
+    internal static string CreateIndexFor(RegisteredEmbeddingProfile profile)
     {
         ArgumentNullException.ThrowIfNull(profile);
 

--- a/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -58,6 +58,15 @@ internal sealed class MailFathomDbContext : DbContext
     /// </remarks>
     internal const string EmbeddingProfileFingerprintUniqueIndexName = "ix_embedding_profiles_identity_fingerprint";
 
+    /// <summary>The index that admits one generation being built and one being read, and no second of either.</summary>
+    /// <remarks>
+    /// The guarantee is structural because the failure it prevents is silent: two rows claiming to serve would leave
+    /// retrieval reading whichever one a query happened to return, with half the vectors in the table unreachable and
+    /// nothing about the answers saying so. Superseded rows are outside the filter, because a deployment accumulates
+    /// one per model it has ever used.
+    /// </remarks>
+    internal const string EmbeddingProfileLifecycleUniqueIndexName = "ix_embedding_profiles_lifecycle_state";
+
     /// <summary>The alternate key a vector row's dimension is checked against.</summary>
     internal const string EmbeddingProfileDimensionAlternateKeyName = "ak_embedding_profiles_id_dimension";
 
@@ -608,6 +617,14 @@ internal sealed class MailFathomDbContext : DbContext
             entity.HasIndex(profile => profile.IdentityFingerprint)
                 .IsUnique()
                 .HasDatabaseName(EmbeddingProfileFingerprintUniqueIndexName);
+
+            // Unique over the state itself and partial to the two states that admit one row each, which is how one
+            // index expresses both halves of the invariant: at most one generation being built, and at most one being
+            // read. The literals are the enum member names because the column stores those names.
+            entity.HasIndex(profile => profile.LifecycleState)
+                .IsUnique()
+                .HasFilter($"\"LifecycleState\" IN ('{nameof(EmbeddingProfileLifecycleState.Building)}', '{nameof(EmbeddingProfileLifecycleState.Active)}')")
+                .HasDatabaseName(EmbeddingProfileLifecycleUniqueIndexName);
 
             entity.HasAlternateKey(profile => new { profile.Id, profile.Dimension })
                 .HasName(EmbeddingProfileDimensionAlternateKeyName);

--- a/src/Infrastructure/Persistence/Migrations/20260808113641_AddEmbeddingProfileLifecycleUniqueIndex.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260808113641_AddEmbeddingProfileLifecycleUniqueIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260808113641_AddEmbeddingProfileLifecycleUniqueIndex")]
+    partial class AddEmbeddingProfileLifecycleUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -330,95 +333,6 @@ namespace MailFathom.Infrastructure.Persistence.Migrations
                     b.ToTable("mailbox_accounts", (string)null);
                 });
 
-            modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.MailboxMutationAuditEntryEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTimeOffset>("CompletedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<bool?>("DesiredSeenState")
-                        .HasColumnType("boolean");
-
-                    b.Property<string>("DestinationFolderPath")
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
-
-                    b.Property<string>("DestinationHierarchyDelimiter")
-                        .HasMaxLength(1)
-                        .HasColumnType("character varying(1)");
-
-                    b.Property<int?>("FailureCode")
-                        .HasColumnType("integer");
-
-                    b.Property<string>("MailboxAccountId")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<string>("Mutation")
-                        .IsRequired()
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
-
-                    b.Property<Guid>("MutationRecordId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Outcome")
-                        .IsRequired()
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
-
-                    b.Property<long?>("PlacementUid")
-                        .HasColumnType("bigint");
-
-                    b.Property<long?>("PlacementUidValidity")
-                        .HasColumnType("bigint");
-
-                    b.Property<DateTimeOffset>("RequestedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<string>("RequesterIdentity")
-                        .IsRequired()
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<string>("RequesterOrigin")
-                        .IsRequired()
-                        .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
-
-                    b.Property<string>("SourceFolderPath")
-                        .IsRequired()
-                        .HasMaxLength(512)
-                        .HasColumnType("character varying(512)");
-
-                    b.Property<string>("SourceHierarchyDelimiter")
-                        .HasMaxLength(1)
-                        .HasColumnType("character varying(1)");
-
-                    b.Property<long>("SourceUid")
-                        .HasColumnType("bigint");
-
-                    b.Property<long>("SourceUidValidity")
-                        .HasColumnType("bigint");
-
-                    b.Property<Guid>("StoredEmailId")
-                        .HasColumnType("uuid");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("MutationRecordId")
-                        .IsUnique()
-                        .HasDatabaseName("ix_mailbox_mutation_audit_entries_mutation");
-
-                    b.HasIndex("MailboxAccountId", "CompletedAt", "Id")
-                        .HasDatabaseName("ix_mailbox_mutation_audit_entries_account_completed");
-
-                    b.ToTable("mailbox_mutation_audit_entries", (string)null);
-                });
-
             modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.MailboxMutationEntity", b =>
                 {
                     b.Property<Guid>("Id")
@@ -426,9 +340,6 @@ namespace MailFathom.Infrastructure.Persistence.Migrations
 
                     b.Property<int>("AttemptCount")
                         .HasColumnType("integer");
-
-                    b.Property<bool>("AuditTrailEnabled")
-                        .HasColumnType("boolean");
 
                     b.Property<uint>("ConcurrencyVersion")
                         .IsConcurrencyToken()

--- a/src/Infrastructure/Persistence/Migrations/20260808113641_AddEmbeddingProfileLifecycleUniqueIndex.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260808113641_AddEmbeddingProfileLifecycleUniqueIndex.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmbeddingProfileLifecycleUniqueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_embedding_profiles_lifecycle_state",
+                table: "embedding_profiles",
+                column: "LifecycleState",
+                unique: true,
+                filter: "\"LifecycleState\" IN ('Building', 'Active')");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_embedding_profiles_lifecycle_state",
+                table: "embedding_profiles");
+        }
+    }
+}

--- a/src/Infrastructure/Persistence/Sessions/PersistenceSessionFactory.cs
+++ b/src/Infrastructure/Persistence/Sessions/PersistenceSessionFactory.cs
@@ -46,7 +46,7 @@ internal sealed class PersistenceSessionFactory(MailFathomDbContext dbContext) :
         public Task RollbackTransactionAsync(CancellationToken cancellationToken) =>
             transaction.RollbackAsync(cancellationToken);
 
-        /// <summary>Recognizes the five inserts a competing writer can win, and nothing else.</summary>
+        /// <summary>Recognizes the inserts a competing writer can win, and nothing else.</summary>
         /// <remarks>
         /// <para>
         /// Each names a constraint whose violation means "another run got here first" rather than "this data is
@@ -70,6 +70,15 @@ internal sealed class PersistenceSessionFactory(MailFathomDbContext dbContext) :
         /// it as an entry the trail could not keep — on the very counter that makes swallowing defensible — while the
         /// trail in fact holds exactly the one entry it should.
         /// </para>
+        /// <para>
+        /// The last two are the embedding profile's, and both are races between two activations. A collision on the
+        /// identity fingerprint is the mutation identity's case again: the retry resolves to the profile the winner
+        /// registered, which is what makes activating one declaration twice register one row. A collision on the
+        /// lifecycle index is two activations of <em>different</em> geometries, where the retry cannot resolve it —
+        /// what recognizing it buys is that the loser meets a first-party conflict rather than a provider exception
+        /// crossing the application boundary, and the activation turns that into the answer the operator needs, which
+        /// is that a different reindex is already running.
+        /// </para>
         /// </remarks>
         public bool IsConcurrencyConflict(DbUpdateException exception) =>
             exception.InnerException is PostgresException
@@ -79,7 +88,9 @@ internal sealed class PersistenceSessionFactory(MailFathomDbContext dbContext) :
                     or MailFathomDbContext.MailFolderBindingUniqueIndexName
                     or MailFathomDbContext.MailboxAccountPrimaryKeyConstraintName
                     or MailFathomDbContext.MailboxMutationIdentityUniqueIndexName
-                    or MailFathomDbContext.MailboxMutationAuditEntryMutationUniqueIndexName,
+                    or MailFathomDbContext.MailboxMutationAuditEntryMutationUniqueIndexName
+                    or MailFathomDbContext.EmbeddingProfileFingerprintUniqueIndexName
+                    or MailFathomDbContext.EmbeddingProfileLifecycleUniqueIndexName,
             };
 
         public void ClearTrackedState() => dbContext.ChangeTracker.Clear();

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.GetEmailContent;
@@ -218,6 +219,12 @@ public static class ServiceCollectionExtensions
         // beside it.
         services.AddScoped<IEmbeddingProfileVectorIndex, EmbeddingProfileVectorIndex>();
         services.AddScoped<IStoredEmailEmbeddingBackfillStore, StoredEmailEmbeddingBackfillStore>();
+        services.AddScoped<IEmbeddingGenerationStore, EmbeddingGenerationStore>();
+        // The two operator acts on a generation, registered here rather than beside the generation work because neither
+        // resolves an `ITextEmbeddingGenerator`: they move a profile row and maintain an index, so they build in every
+        // container. What decides that there is anything to activate is the declaration the caller reads, not this.
+        services.AddScoped<EmbeddingProfileActivation>();
+        services.AddScoped<EmbeddingReindexCancellation>();
         services.AddScoped<IEmailMetadataRepository, StoredEmailMetadataRepository>();
         services.AddScoped<IDatabaseSchemaInspector, EfCoreDatabaseSchemaInspector>();
         services.AddScoped<IEmailContentStore, EmailContentStore>();
@@ -366,8 +373,9 @@ public static class ServiceCollectionExtensions
     /// registration rather than by making one that would fail.
     /// </para>
     /// <para>
-    /// The two are one call because they are one decision: the backfill's unit of work is one message brought up to
-    /// date by that same generator, so a deployment that resolves neither is the only other shape.
+    /// The three are one call because they are one decision: the backfill's unit of work is one message brought up to
+    /// date by that same generator, the upkeep pass is that walk plus the transitions it completes, so a deployment
+    /// that resolves none of them is the only other shape.
     /// </para>
     /// <para>
     /// Semantic retrieval reads the same generator and is deliberately <em>not</em> here. It is asked for through a
@@ -382,6 +390,7 @@ public static class ServiceCollectionExtensions
 
         services.AddScoped<StoredEmailEmbeddingGenerator>();
         services.AddScoped<StoredEmailEmbeddingBackfill>();
+        services.AddScoped<EmbeddingGenerationUpkeep>();
 
         return services;
     }

--- a/tests/Application.UnitTests/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfillTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfillTests.cs
@@ -29,7 +29,7 @@ public sealed class StoredEmailEmbeddingBackfillTests
         var backfill = world.CreateBackfill();
 
         // Act
-        var result = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var result = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingBackfillOutcome.SweepCompleted, result.Outcome);
@@ -53,7 +53,7 @@ public sealed class StoredEmailEmbeddingBackfillTests
         var backfill = world.CreateBackfill();
 
         // Act
-        var result = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var result = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(0, result.ChunkedEmailCount);
@@ -72,7 +72,7 @@ public sealed class StoredEmailEmbeddingBackfillTests
         var backfill = world.CreateBackfill(batchSize: 3, maxBatchesPerRun: 2);
 
         // Act
-        var result = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var result = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingBackfillOutcome.BatchBudgetSpent, result.Outcome);
@@ -91,9 +91,9 @@ public sealed class StoredEmailEmbeddingBackfillTests
         var backfill = world.CreateBackfill(batchSize: 3, maxBatchesPerRun: 1);
 
         // Act
-        var firstRun = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var firstRun = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
         var positionAfterFirstRun = world.BackfillStore.SavedPositions[^1];
-        var secondRun = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var secondRun = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(firstRun.MoreWorkIsWorthTryingSoon);
@@ -113,9 +113,9 @@ public sealed class StoredEmailEmbeddingBackfillTests
         var backfill = world.CreateBackfill();
 
         // Act
-        var firstRun = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var firstRun = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
         var callsAfterFirstRun = world.TextEmbeddingGenerator.RequestedBatches.Count;
-        var secondRun = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var secondRun = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(8, firstRun.EmbeddedChunkCount);
@@ -134,7 +134,7 @@ public sealed class StoredEmailEmbeddingBackfillTests
         var backfill = world.CreateBackfill();
 
         // Act
-        var result = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var result = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
         var resumePosition = await world.BackfillStore.FindResumePositionAsync(TestContext.Current.CancellationToken);
 
         // Assert
@@ -142,26 +142,6 @@ public sealed class StoredEmailEmbeddingBackfillTests
         Assert.False(result.MoreWorkIsWorthTryingSoon);
         Assert.Null(world.BackfillStore.SavedPositions[^1]);
         Assert.Null(resumePosition);
-    }
-
-    /// <summary>An instance that has activated no profile has no vector space to work towards, so nothing is spent.</summary>
-    [Fact]
-    public async Task RunAsync_NoActiveProfile_ReadsNoMailAndSpendsNothing()
-    {
-        // Arrange
-        var world = CreateWorld(profileActive: false);
-        AddMessagesAwaitingEmbedding(world, count: 3, passagesEach: 1);
-        var backfill = world.CreateBackfill();
-
-        // Act
-        var result = await backfill.RunAsync(TestContext.Current.CancellationToken);
-
-        // Assert
-        Assert.Equal(StoredEmailEmbeddingBackfillOutcome.NoActiveProfile, result.Outcome);
-        Assert.False(result.MoreWorkIsWorthTryingSoon);
-        Assert.Empty(world.BackfillStore.RequestedResumePositions);
-        Assert.Empty(world.TextEmbeddingGenerator.RequestedBatches);
-        Assert.Empty(world.BackfillStore.SavedPositions);
     }
 
     /// <summary>
@@ -177,7 +157,7 @@ public sealed class StoredEmailEmbeddingBackfillTests
         var backfill = world.CreateBackfill();
 
         // Act
-        var result = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var result = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingBackfillOutcome.GeneratorDisagreesWithProfile, result.Outcome);
@@ -215,7 +195,7 @@ public sealed class StoredEmailEmbeddingBackfillTests
         var backfill = world.CreateBackfill();
 
         // Act
-        var result = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var result = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingBackfillOutcome.ProviderFailed, result.Outcome);
@@ -245,7 +225,7 @@ public sealed class StoredEmailEmbeddingBackfillTests
         var backfill = world.CreateBackfill();
 
         // Act
-        var result = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var result = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(1, result.CallBudgetExhaustedEmailCount);
@@ -269,7 +249,7 @@ public sealed class StoredEmailEmbeddingBackfillTests
 
         // Act
         var cancelled = await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => backfill.RunAsync(cancellation.Token));
+            () => backfill.RunAsync(world.Target, cancellation.Token));
 
         // Assert
         Assert.Equal(cancellation.Token, cancelled.CancellationToken);
@@ -290,8 +270,8 @@ public sealed class StoredEmailEmbeddingBackfillTests
         var backfill = world.CreateBackfill(batchSize: 2, maxBatchesPerRun: 1);
 
         // Act
-        var firstRun = await backfill.RunAsync(TestContext.Current.CancellationToken);
-        var secondRun = await backfill.RunAsync(TestContext.Current.CancellationToken);
+        var firstRun = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
+        var secondRun = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(5, firstRun.OutstandingEmailCountAtSweepStart);
@@ -327,20 +307,13 @@ public sealed class StoredEmailEmbeddingBackfillTests
 
     private static BackfillWorld CreateWorld(
         string generatorModelIdentifier = "a-model",
-        bool profileActive = true,
         int maximumPassagesPerCall = 8)
     {
-        var activeProfile = profileActive
-            ? new ActiveEmbeddingProfile(ProfileId, CreateIdentity("a-model"))
-            : null;
         var embeddingStore = new InMemoryEmailEmbeddingStore();
         var backfillStore = new InMemoryStoredEmailEmbeddingBackfillStore(embeddingStore);
         var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(
             CreateIdentity(generatorModelIdentifier),
             maximumPassagesPerCall);
-
-        var profileReader = Substitute.For<IActiveEmbeddingProfileReader>();
-        profileReader.FindActiveProfileAsync(Arg.Any<CancellationToken>()).Returns(activeProfile);
 
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>())
@@ -352,29 +325,27 @@ public sealed class StoredEmailEmbeddingBackfillTests
             new FakeTimeProvider());
 
         return new BackfillWorld(
+            new RegisteredEmbeddingProfile(ProfileId, CreateIdentity("a-model")),
             embeddingStore,
             backfillStore,
             textEmbeddingGenerator,
             new StoredEmailEmbeddingGenerator(
-                profileReader,
                 embeddingStore,
                 textEmbeddingGenerator,
                 concurrencyRetryPolicy),
-            profileReader,
             concurrencyRetryPolicy);
     }
 
     /// <summary>The mail, the vectors, and the collaborators one backfill run works against.</summary>
     private sealed record BackfillWorld(
+        RegisteredEmbeddingProfile Target,
         InMemoryEmailEmbeddingStore EmbeddingStore,
         InMemoryStoredEmailEmbeddingBackfillStore BackfillStore,
         ScriptedTextEmbeddingGenerator TextEmbeddingGenerator,
         StoredEmailEmbeddingGenerator EmbeddingGenerator,
-        IActiveEmbeddingProfileReader ProfileReader,
         OptimisticConcurrencyRetryPolicy ConcurrencyRetryPolicy)
     {
         public StoredEmailEmbeddingBackfill CreateBackfill(int batchSize = 50, int maxBatchesPerRun = 10) => new(
-            this.ProfileReader,
             this.BackfillStore,
             this.EmbeddingGenerator,
             this.ConcurrencyRetryPolicy,

--- a/tests/Application.UnitTests/Emails/Embeddings/Generation/StoredEmailEmbeddingGeneratorTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generation/StoredEmailEmbeddingGeneratorTests.cs
@@ -27,10 +27,10 @@ public sealed class StoredEmailEmbeddingGeneratorTests
         var store = new InMemoryEmailEmbeddingStore();
         var passages = CreatePassages(3);
         store.AddPassages(Message, passages);
-        var generator = CreateGenerator(store, CreateProfile(), maximumPassagesPerCall: 8);
+        var generator = CreateGenerator(store, maximumPassagesPerCall: 8);
 
         // Act
-        var run = await generator.EmbedAsync(Message, TestContext.Current.CancellationToken);
+        var run = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingOutcome.Embedded, run.Outcome);
@@ -46,10 +46,10 @@ public sealed class StoredEmailEmbeddingGeneratorTests
         var store = new InMemoryEmailEmbeddingStore();
         store.AddPassages(Message, CreatePassages(5));
         var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall: 2);
-        var generator = CreateGenerator(store, CreateProfile(), textEmbeddingGenerator);
+        var generator = CreateGenerator(store, textEmbeddingGenerator);
 
         // Act
-        var run = await generator.EmbedAsync(Message, TestContext.Current.CancellationToken);
+        var run = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(5, run.EmbeddedChunkCount);
@@ -64,11 +64,11 @@ public sealed class StoredEmailEmbeddingGeneratorTests
         var store = new InMemoryEmailEmbeddingStore();
         store.AddPassages(Message, CreatePassages(2));
         var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall: 8);
-        var generator = CreateGenerator(store, CreateProfile(), textEmbeddingGenerator);
-        await generator.EmbedAsync(Message, TestContext.Current.CancellationToken);
+        var generator = CreateGenerator(store, textEmbeddingGenerator);
+        await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
 
         // Act
-        var repeat = await generator.EmbedAsync(Message, TestContext.Current.CancellationToken);
+        var repeat = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingOutcome.Embedded, repeat.Outcome);
@@ -77,23 +77,29 @@ public sealed class StoredEmailEmbeddingGeneratorTests
         Assert.Equal(2, store.StoredVectors.Count);
     }
 
+    /// <summary>
+    /// The generation is the caller's decision, which is what lets a reindex fill a new one while the live path goes on
+    /// embedding arriving mail into the one still answering searches. A generator that resolved it itself could serve
+    /// only one of the two, and the vectors of the other would silently land under the wrong attribution.
+    /// </summary>
     [Fact]
-    public async Task EmbedAsync_NoProfileActivated_EmbedsNothingAndReachesNoProvider()
+    public async Task EmbedAsync_GenerationBeingBuilt_AttributesEveryVectorToThatGenerationAlone()
     {
         // Arrange
         var store = new InMemoryEmailEmbeddingStore();
         store.AddPassages(Message, CreatePassages(2));
-        var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall: 8);
-        var generator = CreateGenerator(store, activeProfile: null, textEmbeddingGenerator);
+        var generator = CreateGenerator(store, maximumPassagesPerCall: 8);
+        var building = new RegisteredEmbeddingProfile(
+            EmbeddingProfileId.Create(Guid.CreateVersion7()),
+            CreateIdentity());
 
         // Act
-        var run = await generator.EmbedAsync(Message, TestContext.Current.CancellationToken);
+        var run = await generator.EmbedAsync(Message, building, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal(StoredEmailEmbeddingOutcome.NoActiveProfile, run.Outcome);
-        Assert.Equal(0, run.EmbeddedChunkCount);
-        Assert.Empty(textEmbeddingGenerator.RequestedBatches);
-        Assert.Equal(0, store.ReadCount);
+        Assert.Equal(StoredEmailEmbeddingOutcome.Embedded, run.Outcome);
+        Assert.Equal([building.Id, building.Id], store.StoredVectors.Keys.Select(key => key.ProfileId).ToArray());
+        Assert.DoesNotContain(ProfileId, store.StoredVectors.Keys.Select(key => key.ProfileId));
     }
 
     [Fact]
@@ -105,10 +111,10 @@ public sealed class StoredEmailEmbeddingGeneratorTests
         var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(
             CreateIdentity(modelIdentifier: "a-newer-model"),
             maximumPassagesPerCall: 8);
-        var generator = CreateGenerator(store, CreateProfile(), textEmbeddingGenerator);
+        var generator = CreateGenerator(store, textEmbeddingGenerator);
 
         // Act
-        var run = await generator.EmbedAsync(Message, TestContext.Current.CancellationToken);
+        var run = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingOutcome.GeneratorDisagreesWithProfile, run.Outcome);
@@ -133,10 +139,10 @@ public sealed class StoredEmailEmbeddingGeneratorTests
         {
             Failure = failure,
         };
-        var generator = CreateGenerator(store, CreateProfile(), textEmbeddingGenerator);
+        var generator = CreateGenerator(store, textEmbeddingGenerator);
 
         // Act
-        var run = await generator.EmbedAsync(Message, TestContext.Current.CancellationToken);
+        var run = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingOutcome.ProviderFailed, run.Outcome);
@@ -156,10 +162,10 @@ public sealed class StoredEmailEmbeddingGeneratorTests
             Failure = EmbeddingGenerationFailure.RateLimited,
             FailingCallNumber = 2,
         };
-        var generator = CreateGenerator(store, CreateProfile(), textEmbeddingGenerator);
+        var generator = CreateGenerator(store, textEmbeddingGenerator);
 
         // Act
-        var run = await generator.EmbedAsync(Message, TestContext.Current.CancellationToken);
+        var run = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingOutcome.ProviderFailed, run.Outcome);
@@ -181,10 +187,10 @@ public sealed class StoredEmailEmbeddingGeneratorTests
         var store = new InMemoryEmailEmbeddingStore();
         store.AddPassages(Message, CreatePassages(callBudget + 5));
         var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall: 1);
-        var generator = CreateGenerator(store, CreateProfile(), textEmbeddingGenerator);
+        var generator = CreateGenerator(store, textEmbeddingGenerator);
 
         // Act
-        var run = await generator.EmbedAsync(Message, TestContext.Current.CancellationToken);
+        var run = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingOutcome.CallBudgetExhausted, run.Outcome);
@@ -207,10 +213,10 @@ public sealed class StoredEmailEmbeddingGeneratorTests
         var store = new InMemoryEmailEmbeddingStore();
         store.AddPassages(Message, CreatePassages(callBudget));
         var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall: 1);
-        var generator = CreateGenerator(store, CreateProfile(), textEmbeddingGenerator);
+        var generator = CreateGenerator(store, textEmbeddingGenerator);
 
         // Act
-        var run = await generator.EmbedAsync(Message, TestContext.Current.CancellationToken);
+        var run = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Equal(StoredEmailEmbeddingOutcome.Embedded, run.Outcome);
@@ -229,11 +235,11 @@ public sealed class StoredEmailEmbeddingGeneratorTests
         {
             CancelOnCall = cancellation,
         };
-        var generator = CreateGenerator(store, CreateProfile(), textEmbeddingGenerator);
+        var generator = CreateGenerator(store, textEmbeddingGenerator);
 
         // Act
         var cancelled = await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => generator.EmbedAsync(Message, cancellation.Token));
+            () => generator.EmbedAsync(Message, CreateProfile(), cancellation.Token));
 
         // Assert
         Assert.Equal(cancellation.Token, cancelled.CancellationToken);
@@ -254,31 +260,22 @@ public sealed class StoredEmailEmbeddingGeneratorTests
             EmbeddingDistanceMetric.Cosine,
             EmbeddingInputPreparation.Create(2_000, passageInstruction: null, normalizesVector: true));
 
-    private static ActiveEmbeddingProfile CreateProfile() => new(ProfileId, CreateIdentity());
+    private static RegisteredEmbeddingProfile CreateProfile() => new(ProfileId, CreateIdentity());
 
     private static StoredEmailEmbeddingGenerator CreateGenerator(
         IEmailEmbeddingStore store,
-        ActiveEmbeddingProfile? activeProfile,
         int maximumPassagesPerCall) =>
-        CreateGenerator(
-            store,
-            activeProfile,
-            new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall));
+        CreateGenerator(store, new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall));
 
     private static StoredEmailEmbeddingGenerator CreateGenerator(
         IEmailEmbeddingStore store,
-        ActiveEmbeddingProfile? activeProfile,
         ITextEmbeddingGenerator textEmbeddingGenerator)
     {
-        var profileReader = Substitute.For<IActiveEmbeddingProfileReader>();
-        profileReader.FindActiveProfileAsync(Arg.Any<CancellationToken>()).Returns(activeProfile);
-
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>())
             .Returns(_ => Substitute.For<IPersistenceSession>());
 
         return new StoredEmailEmbeddingGenerator(
-            profileReader,
             store,
             textEmbeddingGenerator,
             new OptimisticConcurrencyRetryPolicy(

--- a/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingGenerationUpkeepTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingGenerationUpkeepTests.cs
@@ -173,6 +173,57 @@ public sealed class EmbeddingGenerationUpkeepTests
         await world.VectorIndex.Received().RemoveAsync(superseded.Id, Arg.Any<CancellationToken>());
     }
 
+    /// <summary>
+    /// A reindex cancelled on an instance that had never served a generation leaves one superseded row and no sibling,
+    /// so there is nothing to sweep towards and still something to clear out. The vectors it accumulated are personal
+    /// data derived from mail, and a pass that walked away from them because it had no target would keep them forever.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_ASupersededGenerationAndNothingElse_StillRemovesItsVectors()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var abandoned = await world.ServeAGenerationWithVectorsAsync(messageCount: 2);
+        world.GenerationStore.Supersede(abandoned.Id);
+
+        // Act
+        var result = await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(StoredEmailEmbeddingBackfillOutcome.NoActiveProfile, result.Sweep.Outcome);
+        Assert.Equal(2, result.RemovedSupersededVectorCount);
+        Assert.Equal(0, world.EmbeddingStore.CountVectors(abandoned.Id));
+    }
+
+    /// <summary>
+    /// Rolling back catches its own removal part-way through: a generation activated again stops being superseded, and
+    /// the vectors it still holds are what makes that rollback cheaper than a full re-embed. A delete decided before
+    /// the reactivation must not go through on the strength of that earlier decision.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AGenerationActivatedAgainWhileItsRemovalWasPending_KeepsTheVectorsItStillHolds()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var reactivated = await world.ServeAGenerationWithVectorsAsync(messageCount: 2);
+        world.GenerationStore.Supersede(reactivated.Id);
+        await world.GenerationStore.RegisterBuildingAsync(
+            Substitute.For<IPersistenceSession>(),
+            CreateIdentity("a-model"),
+            TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, result.RemovedSupersededVectorCount);
+        Assert.Equal(2, world.EmbeddingStore.CountVectors(reactivated.Id));
+
+        // The vectors that survived are what makes this rollback cheap: nothing was outstanding, so the generation was
+        // complete the moment it was registered again and the pass switched straight back to it.
+        Assert.Equal(EmbeddingProfileLifecycleState.Active, world.GenerationStore.StateOf(reactivated.Id));
+    }
+
     /// <summary>An instance that has registered no generation has nothing to work towards, so nothing is spent.</summary>
     [Fact]
     public async Task RunAsync_NoGenerationRegistered_ReadsNoMailAndReachesNoProvider()

--- a/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingGenerationUpkeepTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingGenerationUpkeepTests.cs
@@ -1,0 +1,323 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Backfill;
+using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Generations;
+using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Emails;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Embeddings.Generations;
+
+public sealed class EmbeddingGenerationUpkeepTests
+{
+    /// <summary>
+    /// The generation being built is what the sweep works towards, and the one serving searches keeps every vector it
+    /// had while that happens. Two generations coexisting in one table is the whole point of a reindex without an
+    /// outage.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AGenerationBeingBuilt_FillsItWhileTheServingGenerationKeepsItsOwnVectors()
+    {
+        // A pass bounded below what the mailbox holds, so the reindex is observed part-way through rather than
+        // completing and switching in the same pass — which is the state a reindex of a real mailbox is in for hours.
+        var world = CreateWorld(batchSize: 1, maxBatchesPerRun: 1);
+        var serving = await world.ServeAGenerationWithVectorsAsync(messageCount: 3);
+        var building = world.GenerationStore.Add(
+            CreateIdentity("a-model"),
+            EmbeddingProfileLifecycleState.Building);
+
+        // Act
+        var result = await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingGenerationTransition.None, result.Transition);
+        Assert.Equal(1, world.EmbeddingStore.CountVectors(building.Id));
+        Assert.Equal(3, world.EmbeddingStore.CountVectors(serving.Id));
+        Assert.Equal(EmbeddingProfileLifecycleState.Active, world.GenerationStore.StateOf(serving.Id));
+    }
+
+    /// <summary>The switch is one transition, and it is what makes the new generation the one retrieval reads.</summary>
+    [Fact]
+    public async Task RunAsync_TheGenerationBeingBuiltIsComplete_SwitchesToItAndSupersedesTheOneItReplaces()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var serving = await world.ServeAGenerationWithVectorsAsync(messageCount: 2);
+        var building = world.GenerationStore.Add(
+            CreateIdentity("a-model"),
+            EmbeddingProfileLifecycleState.Building);
+
+        // Act
+        var result = await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingGenerationTransition.Switched, result.Transition);
+        Assert.Equal(EmbeddingProfileLifecycleState.Active, world.GenerationStore.StateOf(building.Id));
+        Assert.Equal(EmbeddingProfileLifecycleState.Superseded, world.GenerationStore.StateOf(serving.Id));
+
+        var generations = await world.GenerationStore.ReadGenerationsAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(building.Id, generations.Serving?.Id);
+        Assert.Null(generations.Building);
+    }
+
+    /// <summary>
+    /// A completed sweep is not a complete generation. The walk ends its sweep when nothing is outstanding in front of
+    /// its position, and a message a provider refused stays outstanding behind it — switching there would promote a
+    /// generation that is missing mail, which no later pass would notice because it is retrievable and simply answers
+    /// worse.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_ASweepCompletedWithAMessageStillOutstanding_DoesNotSwitch()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var serving = await world.ServeAGenerationWithVectorsAsync(messageCount: 3);
+        var building = world.GenerationStore.Add(
+            CreateIdentity("a-model"),
+            EmbeddingProfileLifecycleState.Building);
+        world.TextEmbeddingGenerator.Failure = EmbeddingGenerationFailure.RateLimited;
+        world.TextEmbeddingGenerator.FailingCallNumber = world.TextEmbeddingGenerator.RequestedBatches.Count + 2;
+
+        // Act
+        var refusedPass = await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+        var completingPass = await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(StoredEmailEmbeddingBackfillOutcome.ProviderFailed, refusedPass.Sweep.Outcome);
+        Assert.Equal(StoredEmailEmbeddingBackfillOutcome.SweepCompleted, completingPass.Sweep.Outcome);
+        Assert.Equal(EmbeddingGenerationTransition.None, completingPass.Transition);
+        Assert.Equal(EmbeddingProfileLifecycleState.Building, world.GenerationStore.StateOf(building.Id));
+        Assert.Equal(EmbeddingProfileLifecycleState.Active, world.GenerationStore.StateOf(serving.Id));
+    }
+
+    /// <summary>
+    /// A cancellation that lands after the pass counted the generation complete must not be overtaken by the switch it
+    /// was cancelling. Superseding the generation that is serving and then failing to promote the one that was
+    /// abandoned would leave the instance with nothing to answer a search from, and nothing later would put it back.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_TheGenerationBeingBuiltIsAbandonedAsTheSwitchCommits_LeavesTheServingGenerationServing()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var serving = await world.ServeAGenerationWithVectorsAsync(messageCount: 2);
+        var building = world.GenerationStore.Add(
+            CreateIdentity("a-model"),
+            EmbeddingProfileLifecycleState.Building);
+        world.GenerationStore.AbandonWhenSwitched = building.Id;
+
+        // Act
+        var result = await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingGenerationTransition.None, result.Transition);
+        Assert.Equal(EmbeddingProfileLifecycleState.Active, world.GenerationStore.StateOf(serving.Id));
+        Assert.Equal(EmbeddingProfileLifecycleState.Superseded, world.GenerationStore.StateOf(building.Id));
+
+        var generations = await world.GenerationStore.ReadGenerationsAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(serving.Id, generations.Serving?.Id);
+    }
+
+    /// <summary>
+    /// The superseded generation's vectors go in bounded batches after the switch, and the generation now serving keeps
+    /// every one of its own. They are removed rather than kept for a rollback window because they are personal data
+    /// whose purpose ended at the switch.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AfterASwitch_RemovesTheSupersededVectorsAndLeavesTheServingOnesAlone()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var superseded = await world.ServeAGenerationWithVectorsAsync(messageCount: 2);
+        var building = world.GenerationStore.Add(
+            CreateIdentity("a-model"),
+            EmbeddingProfileLifecycleState.Building);
+
+        // Act
+        var result = await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, result.RemovedSupersededVectorCount);
+        Assert.Equal(0, world.EmbeddingStore.CountVectors(superseded.Id));
+        Assert.Equal(2, world.EmbeddingStore.CountVectors(building.Id));
+
+        // Bounded rather than one statement, which is what keeps a generation of a large mailbox from being deleted in
+        // a single transaction holding one lock set and one write-ahead burst for as long as it takes.
+        Assert.All(world.GenerationStore.RequestedRemovalBatchSizes, batchSize => Assert.True(batchSize > 0));
+    }
+
+    /// <summary>
+    /// The index of a generation nothing reads goes when its last vectors do, which is also what clears one left behind
+    /// by a process that stopped part-way through a removal.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_TheLastVectorsOfASupersededGeneration_RemovesItsApproximateIndexToo()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var superseded = await world.ServeAGenerationWithVectorsAsync(messageCount: 1);
+        world.GenerationStore.Add(CreateIdentity("a-model"), EmbeddingProfileLifecycleState.Building);
+
+        // Act
+        await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        await world.VectorIndex.Received().RemoveAsync(superseded.Id, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>An instance that has registered no generation has nothing to work towards, so nothing is spent.</summary>
+    [Fact]
+    public async Task RunAsync_NoGenerationRegistered_ReadsNoMailAndReachesNoProvider()
+    {
+        // Arrange
+        var world = CreateWorld();
+        world.AddMail(messageCount: 3);
+
+        // Act
+        var result = await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(StoredEmailEmbeddingBackfillOutcome.NoActiveProfile, result.Sweep.Outcome);
+        Assert.Equal(EmbeddingGenerationTransition.None, result.Transition);
+        Assert.False(result.MoreWorkIsWorthTryingSoon);
+        Assert.Empty(world.TextEmbeddingGenerator.RequestedBatches);
+        Assert.Empty(world.BackfillStore.SavedPositions);
+    }
+
+    /// <summary>
+    /// With nothing being built the sweep works towards the generation serving searches, which is the ordinary backfill
+    /// of mail the live path never reached.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_NothingBeingBuilt_SweepsTowardsTheServingGeneration()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var serving = world.GenerationStore.Add(CreateIdentity("a-model"), EmbeddingProfileLifecycleState.Active);
+        world.AddMail(messageCount: 2);
+
+        // Act
+        var result = await world.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, result.Sweep.EmbeddedEmailCount);
+        Assert.Equal(EmbeddingGenerationTransition.None, result.Transition);
+        Assert.Equal(2, world.EmbeddingStore.CountVectors(serving.Id));
+    }
+
+    private static EmbeddingProfileIdentity CreateIdentity(string modelIdentifier) =>
+        EmbeddingProfileIdentity.Create(
+            "a-provider",
+            modelIdentifier,
+            modelVersion: null,
+            dimension: 8,
+            EmbeddingDistanceMetric.Cosine,
+            EmbeddingInputPreparation.Create(2_000, passageInstruction: null, normalizesVector: true));
+
+    private static UpkeepWorld CreateWorld(int batchSize = 50, int maxBatchesPerRun = 10)
+    {
+        var embeddingStore = new InMemoryEmailEmbeddingStore();
+        var backfillStore = new InMemoryStoredEmailEmbeddingBackfillStore(embeddingStore);
+        var generationStore = new InMemoryEmbeddingGenerationStore(embeddingStore);
+
+        // One geometry for every generation in these tests, because the generator refuses to write into a profile whose
+        // fingerprint is not its own and what is under test here is the lifecycle rather than the geometry check.
+        var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(
+            CreateIdentity("a-model"),
+            maximumPassagesPerCall: 8);
+        var vectorIndex = Substitute.For<IEmbeddingProfileVectorIndex>();
+
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Substitute.For<IPersistenceSession>());
+
+        var concurrencyRetryPolicy = new OptimisticConcurrencyRetryPolicy(
+            sessionFactory,
+            new PersistenceConcurrencyOptions(),
+            new FakeTimeProvider());
+
+        var upkeep = new EmbeddingGenerationUpkeep(
+            generationStore,
+            backfillStore,
+            new StoredEmailEmbeddingBackfill(
+                backfillStore,
+                new StoredEmailEmbeddingGenerator(embeddingStore, textEmbeddingGenerator, concurrencyRetryPolicy),
+                concurrencyRetryPolicy,
+                new StoredEmailEmbeddingBackfillOptions
+                {
+                    BatchSize = batchSize,
+                    MaxBatchesPerRun = maxBatchesPerRun,
+                }),
+            vectorIndex,
+            concurrencyRetryPolicy);
+
+        return new UpkeepWorld(
+            embeddingStore,
+            backfillStore,
+            generationStore,
+            textEmbeddingGenerator,
+            vectorIndex,
+            upkeep);
+    }
+
+    /// <summary>The mail, the generations, and the collaborators one upkeep pass works against.</summary>
+    private sealed record UpkeepWorld(
+        InMemoryEmailEmbeddingStore EmbeddingStore,
+        InMemoryStoredEmailEmbeddingBackfillStore BackfillStore,
+        InMemoryEmbeddingGenerationStore GenerationStore,
+        ScriptedTextEmbeddingGenerator TextEmbeddingGenerator,
+        IEmbeddingProfileVectorIndex VectorIndex,
+        EmbeddingGenerationUpkeep Upkeep)
+    {
+        /// <summary>Adds mail that has its passages and no vector under any generation.</summary>
+        public void AddMail(int messageCount)
+        {
+            // A loop rather than a projection, because registering a message with the store is a side effect.
+            foreach (var _ in Enumerable.Range(0, messageCount))
+            {
+                this.BackfillStore.AddEmailAwaitingEmbedding(
+                    StoredEmailId.Create(Guid.CreateVersion7()),
+                    passageCount: 1);
+            }
+        }
+
+        /// <summary>Brings the world to where an instance that has been embedding for a while already is.</summary>
+        /// <remarks>
+        /// The vectors come from real passes rather than being placed by hand, so what a later pass finds is what the
+        /// production path would actually have left there. It runs until the sweep has nothing left, because a bounded
+        /// pass reaches only part of the mail and an arrangement that stopped there would leave the generation the test
+        /// calls serving with a hole in it.
+        /// </remarks>
+        public async Task<RegisteredEmbeddingProfile> ServeAGenerationWithVectorsAsync(int messageCount)
+        {
+            var serving = this.GenerationStore.Add(
+                CreateIdentity("a-model"),
+                EmbeddingProfileLifecycleState.Active);
+
+            this.AddMail(messageCount);
+
+            // Bounded rather than "until it says so", so an arrangement that stops making progress fails the test it is
+            // arranging instead of hanging it.
+            for (var pass = 0; pass < messageCount + 1; pass++)
+            {
+                var result = await this.Upkeep.RunAsync(TestContext.Current.CancellationToken);
+                if (result.Sweep.Outcome == StoredEmailEmbeddingBackfillOutcome.SweepCompleted)
+                {
+                    return serving;
+                }
+            }
+
+            Assert.Fail("The arrangement did not finish embedding the mail it stored.");
+
+            return serving;
+        }
+    }
+}

--- a/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingProfileActivationTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingProfileActivationTests.cs
@@ -1,0 +1,213 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Generations;
+using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.UnitTests.TestDoubles;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Embeddings.Generations;
+
+public sealed class EmbeddingProfileActivationTests
+{
+    /// <summary>
+    /// The whole guarantee in one assertion: the new geometry becomes a generation that is built rather than one that
+    /// is read, and the generation answering searches is left exactly where it was.
+    /// </summary>
+    [Fact]
+    public async Task ActivateAsync_ADifferentGeometryWhileOneIsServing_BuildsBesideItWithoutTakingItOutOfService()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var serving = world.GenerationStore.Add(CreateIdentity("the-old-model"), EmbeddingProfileLifecycleState.Active);
+
+        // Act
+        var result = await world.Activation.ActivateAsync(
+            CreateIdentity("a-newer-model"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingProfileActivationOutcome.ReindexStarted, result.Outcome);
+        Assert.Equal(
+            EmbeddingProfileLifecycleState.Building,
+            world.GenerationStore.StateOf(result.ProfileId));
+        Assert.Equal(EmbeddingProfileLifecycleState.Active, world.GenerationStore.StateOf(serving.Id));
+
+        var generations = await world.GenerationStore.ReadGenerationsAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(serving.Id, generations.Serving?.Id);
+        Assert.Equal(result.ProfileId, generations.Building?.Id);
+    }
+
+    /// <summary>The index is built while the generation is empty, which is the cheapest moment it can be built.</summary>
+    [Fact]
+    public async Task ActivateAsync_ANewGeometry_BuildsTheApproximateIndexForTheGenerationItRegistered()
+    {
+        // Arrange
+        var world = CreateWorld();
+
+        // Act
+        var result = await world.Activation.ActivateAsync(
+            CreateIdentity("a-model"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await world.VectorIndex.Received(1).EnsureBuiltAsync(
+            Arg.Is<RegisteredEmbeddingProfile>(profile => profile!.Id == result.ProfileId),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// An instance with nothing serving builds rather than serving immediately, so the moment searches start being
+    /// answered semantically is the same single transition every later model change produces.
+    /// </summary>
+    [Fact]
+    public async Task ActivateAsync_NothingServingYet_StillBuildsRatherThanServingAPartialGeneration()
+    {
+        // Arrange
+        var world = CreateWorld();
+
+        // Act
+        var result = await world.Activation.ActivateAsync(
+            CreateIdentity("a-model"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingProfileActivationOutcome.ReindexStarted, result.Outcome);
+
+        var generations = await world.GenerationStore.ReadGenerationsAsync(TestContext.Current.CancellationToken);
+        Assert.Null(generations.Serving);
+        Assert.Equal(result.ProfileId, generations.Building?.Id);
+    }
+
+    /// <summary>Activating what is already serving spends nothing, which is what makes the command safe to repeat.</summary>
+    [Fact]
+    public async Task ActivateAsync_TheGeometryAlreadyServing_ReportsItAndRegistersNothing()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var identity = CreateIdentity("a-model");
+        var serving = world.GenerationStore.Add(identity, EmbeddingProfileLifecycleState.Active);
+
+        // Act
+        var result = await world.Activation.ActivateAsync(identity, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingProfileActivationOutcome.AlreadyServing, result.Outcome);
+        Assert.Equal(serving.Id, result.ProfileId);
+
+        var generations = await world.GenerationStore.ReadGenerationsAsync(TestContext.Current.CancellationToken);
+        Assert.Null(generations.Building);
+    }
+
+    /// <summary>
+    /// Repeating the command against the generation already being built is what an operator does after an index build
+    /// failed, so it re-ensures the index rather than reporting the reindex and doing nothing.
+    /// </summary>
+    [Fact]
+    public async Task ActivateAsync_TheGeometryAlreadyBeingBuilt_LeavesTheReindexRunningAndReEnsuresItsIndex()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var identity = CreateIdentity("a-model");
+        var building = world.GenerationStore.Add(identity, EmbeddingProfileLifecycleState.Building);
+
+        // Act
+        var result = await world.Activation.ActivateAsync(identity, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingProfileActivationOutcome.AlreadyBuilding, result.Outcome);
+        Assert.Equal(building.Id, result.ProfileId);
+        await world.VectorIndex.Received(1).EnsureBuiltAsync(
+            Arg.Is<RegisteredEmbeddingProfile>(profile => profile!.Id == building.Id),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Two generations being built at once would leave one walk between two partial generations and neither ever
+    /// reaching the count that completes it, so the second activation is refused rather than started beside the first.
+    /// </summary>
+    [Fact]
+    public async Task ActivateAsync_ADifferentReindexAlreadyRunning_RefusesAndNamesTheGenerationInTheWay()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var building = world.GenerationStore.Add(
+            CreateIdentity("a-model-being-built"),
+            EmbeddingProfileLifecycleState.Building);
+
+        // Act
+        var result = await world.Activation.ActivateAsync(
+            CreateIdentity("yet-another-model"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingProfileActivationOutcome.DifferentReindexRunning, result.Outcome);
+        Assert.Equal(building.Id, result.ProfileId);
+        await world.VectorIndex.DidNotReceiveWithAnyArgs().EnsureBuiltAsync(null!, TestContext.Current.CancellationToken);
+
+        var generations = await world.GenerationStore.ReadGenerationsAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(building.Id, generations.Building?.Id);
+    }
+
+    /// <summary>
+    /// Rolling back is activating a previous model again, and it resolves to the row that model already has: its
+    /// identity may never move, so a second row would be a second generation of one geometry.
+    /// </summary>
+    [Fact]
+    public async Task ActivateAsync_AGeometryThatWasSuperseded_ResolvesToItsExistingRowRatherThanRegisteringASecond()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var identity = CreateIdentity("the-model-we-came-from");
+        var superseded = world.GenerationStore.Add(identity, EmbeddingProfileLifecycleState.Superseded);
+        world.GenerationStore.Add(CreateIdentity("the-model-that-replaced-it"), EmbeddingProfileLifecycleState.Active);
+
+        // Act
+        var result = await world.Activation.ActivateAsync(identity, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingProfileActivationOutcome.ReindexStarted, result.Outcome);
+        Assert.Equal(superseded.Id, result.ProfileId);
+        Assert.Equal(EmbeddingProfileLifecycleState.Building, world.GenerationStore.StateOf(superseded.Id));
+    }
+
+    private static EmbeddingProfileIdentity CreateIdentity(string modelIdentifier) =>
+        EmbeddingProfileIdentity.Create(
+            "a-provider",
+            modelIdentifier,
+            modelVersion: null,
+            dimension: 8,
+            EmbeddingDistanceMetric.Cosine,
+            EmbeddingInputPreparation.Create(2_000, passageInstruction: null, normalizesVector: true));
+
+    private static ActivationWorld CreateWorld()
+    {
+        var generationStore = new InMemoryEmbeddingGenerationStore(new InMemoryEmailEmbeddingStore());
+        var vectorIndex = Substitute.For<IEmbeddingProfileVectorIndex>();
+
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Substitute.For<IPersistenceSession>());
+
+        var activation = new EmbeddingProfileActivation(
+            generationStore,
+            vectorIndex,
+            new OptimisticConcurrencyRetryPolicy(
+                sessionFactory,
+                new PersistenceConcurrencyOptions(),
+                new FakeTimeProvider()));
+
+        return new ActivationWorld(generationStore, vectorIndex, activation);
+    }
+
+    /// <summary>The generations and the collaborators one activation works against.</summary>
+    private sealed record ActivationWorld(
+        InMemoryEmbeddingGenerationStore GenerationStore,
+        IEmbeddingProfileVectorIndex VectorIndex,
+        EmbeddingProfileActivation Activation);
+}

--- a/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingProfileActivationTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingProfileActivationTests.cs
@@ -176,6 +176,73 @@ public sealed class EmbeddingProfileActivationTests
         Assert.Equal(EmbeddingProfileLifecycleState.Building, world.GenerationStore.StateOf(superseded.Id));
     }
 
+    /// <summary>
+    /// The check for a running reindex and the registration are not one act, so two activations of different
+    /// geometries can both find nothing being built. The database refuses the second, and no retry resolves that —
+    /// what the operator needs is not that two commands collided but which generation is now being built.
+    /// </summary>
+    [Fact]
+    public async Task ActivateAsync_AnotherActivationWonTheRegistrationRace_ReportsTheReindexThatWon()
+    {
+        // Arrange
+        var winner = new RegisteredEmbeddingProfile(
+            EmbeddingProfileId.Create(Guid.CreateVersion7()),
+            CreateIdentity("the-model-that-won"));
+        var activation = CreateActivation(
+            RacedRegistrationStore(buildingAfterTheRace: winner),
+            Substitute.For<IEmbeddingProfileVectorIndex>());
+
+        // Act
+        var result = await activation.ActivateAsync(
+            CreateIdentity("the-model-that-lost"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingProfileActivationOutcome.DifferentReindexRunning, result.Outcome);
+        Assert.Equal(winner.Id, result.ProfileId);
+    }
+
+    /// <summary>
+    /// A conflict with nothing being built afterwards was some other competing writer, and reporting it as a reindex
+    /// in the way would tell an operator to cancel something that does not exist.
+    /// </summary>
+    [Fact]
+    public async Task ActivateAsync_AConflictThatWasNotAnotherActivation_RaisesItRatherThanInventingAnOutcome()
+    {
+        // Arrange
+        var activation = CreateActivation(
+            RacedRegistrationStore(buildingAfterTheRace: null),
+            Substitute.For<IEmbeddingProfileVectorIndex>());
+
+        // Act
+        var conflict = await Assert.ThrowsAsync<PersistenceConcurrencyConflictException>(
+            () => activation.ActivateAsync(CreateIdentity("a-model"), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Contains("optimistic concurrency", conflict.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>A store whose registration always loses the race, and which answers afterwards with what won it.</summary>
+    private static IEmbeddingGenerationStore RacedRegistrationStore(RegisteredEmbeddingProfile? buildingAfterTheRace)
+    {
+        var generationStore = Substitute.For<IEmbeddingGenerationStore>();
+
+        // Substituted rather than hand-written, because what this arranges is the database refusing a write, which the
+        // in-memory store has no way to do: it is the port's failure mode rather than any state it holds.
+        generationStore.ReadGenerationsAsync(Arg.Any<CancellationToken>())
+            .Returns(
+                _ => EmbeddingGenerations.None,
+                _ => new EmbeddingGenerations(Serving: null, buildingAfterTheRace));
+        generationStore.RegisterBuildingAsync(
+                Arg.Any<IPersistenceSession>(),
+                Arg.Any<EmbeddingProfileIdentity>(),
+                Arg.Any<CancellationToken>())
+            .Returns<RegisteredEmbeddingProfile>(_ => throw new PersistenceConcurrencyConflictException(
+                "A local write did not commit within the configured optimistic concurrency attempts."));
+
+        return generationStore;
+    }
+
     private static EmbeddingProfileIdentity CreateIdentity(string modelIdentifier) =>
         EmbeddingProfileIdentity.Create(
             "a-provider",
@@ -190,19 +257,27 @@ public sealed class EmbeddingProfileActivationTests
         var generationStore = new InMemoryEmbeddingGenerationStore(new InMemoryEmailEmbeddingStore());
         var vectorIndex = Substitute.For<IEmbeddingProfileVectorIndex>();
 
+        return new ActivationWorld(
+            generationStore,
+            vectorIndex,
+            CreateActivation(generationStore, vectorIndex));
+    }
+
+    private static EmbeddingProfileActivation CreateActivation(
+        IEmbeddingGenerationStore generationStore,
+        IEmbeddingProfileVectorIndex vectorIndex)
+    {
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>())
             .Returns(_ => Substitute.For<IPersistenceSession>());
 
-        var activation = new EmbeddingProfileActivation(
+        return new EmbeddingProfileActivation(
             generationStore,
             vectorIndex,
             new OptimisticConcurrencyRetryPolicy(
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
                 new FakeTimeProvider()));
-
-        return new ActivationWorld(generationStore, vectorIndex, activation);
     }
 
     /// <summary>The generations and the collaborators one activation works against.</summary>

--- a/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingReindexCancellationTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingReindexCancellationTests.cs
@@ -1,0 +1,157 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Generations;
+using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.UnitTests.TestDoubles;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Embeddings.Generations;
+
+public sealed class EmbeddingReindexCancellationTests
+{
+    /// <summary>Cancelling ends the reindex and changes nothing about what searches are answered from.</summary>
+    [Fact]
+    public async Task CancelAsync_AReindexRunning_AbandonsItAndLeavesTheServingGenerationServing()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var serving = world.GenerationStore.Add(CreateIdentity("the-old-model"), EmbeddingProfileLifecycleState.Active);
+        var building = world.GenerationStore.Add(
+            CreateIdentity("a-newer-model"),
+            EmbeddingProfileLifecycleState.Building);
+
+        // Act
+        var outcome = await world.Cancellation.CancelAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingReindexCancellationOutcome.Cancelled, outcome);
+        Assert.Equal(EmbeddingProfileLifecycleState.Superseded, world.GenerationStore.StateOf(building.Id));
+        Assert.Equal(EmbeddingProfileLifecycleState.Active, world.GenerationStore.StateOf(serving.Id));
+
+        var generations = await world.GenerationStore.ReadGenerationsAsync(TestContext.Current.CancellationToken);
+        Assert.Null(generations.Building);
+        Assert.Equal(serving.Id, generations.Serving?.Id);
+    }
+
+    /// <summary>
+    /// The abandoned generation's index goes with it, because every batched delete of its vectors would otherwise
+    /// maintain an index nothing will ever read.
+    /// </summary>
+    [Fact]
+    public async Task CancelAsync_AReindexRunning_RemovesTheApproximateIndexOfTheAbandonedGeneration()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var building = world.GenerationStore.Add(CreateIdentity("a-model"), EmbeddingProfileLifecycleState.Building);
+
+        // Act
+        await world.Cancellation.CancelAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        await world.VectorIndex.Received(1).RemoveAsync(building.Id, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// This command ends a reindex and is deliberately not a way to turn semantic search off, so an instance with only a
+    /// serving generation is left untouched.
+    /// </summary>
+    [Fact]
+    public async Task CancelAsync_NoReindexRunning_ReportsItAndTouchesNoGeneration()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var serving = world.GenerationStore.Add(CreateIdentity("a-model"), EmbeddingProfileLifecycleState.Active);
+
+        // Act
+        var outcome = await world.Cancellation.CancelAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingReindexCancellationOutcome.NothingBuilding, outcome);
+        Assert.Equal(EmbeddingProfileLifecycleState.Active, world.GenerationStore.StateOf(serving.Id));
+        await world.VectorIndex.DidNotReceiveWithAnyArgs().RemoveAsync(default, TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// A reindex that completed between the read and the write took its generation into service, and abandoning that is
+    /// not what this command means. Removing its index would be worse than the report: searches would go on being
+    /// answered, exactly and slowly, with nothing saying why.
+    /// </summary>
+    [Fact]
+    public async Task CancelAsync_TheReindexCompletedFirst_ChangesNothingAndLeavesTheIndexAlone()
+    {
+        // Arrange
+        var vectorIndex = Substitute.For<IEmbeddingProfileVectorIndex>();
+        var building = new RegisteredEmbeddingProfile(
+            EmbeddingProfileId.Create(Guid.CreateVersion7()),
+            CreateIdentity("a-model"));
+
+        var generationStore = Substitute.For<IEmbeddingGenerationStore>();
+        generationStore.ReadGenerationsAsync(Arg.Any<CancellationToken>())
+            .Returns(new EmbeddingGenerations(Serving: null, building));
+        generationStore.AbandonAsync(
+                Arg.Any<IPersistenceSession>(),
+                building.Id,
+                Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Substitute.For<IPersistenceSession>());
+
+        var cancellation = new EmbeddingReindexCancellation(
+            generationStore,
+            vectorIndex,
+            new OptimisticConcurrencyRetryPolicy(
+                sessionFactory,
+                new PersistenceConcurrencyOptions(),
+                new FakeTimeProvider()));
+
+        // Act
+        var outcome = await cancellation.CancelAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmbeddingReindexCancellationOutcome.NothingBuilding, outcome);
+        await vectorIndex.DidNotReceiveWithAnyArgs().RemoveAsync(default, TestContext.Current.CancellationToken);
+    }
+
+    private static EmbeddingProfileIdentity CreateIdentity(string modelIdentifier) =>
+        EmbeddingProfileIdentity.Create(
+            "a-provider",
+            modelIdentifier,
+            modelVersion: null,
+            dimension: 8,
+            EmbeddingDistanceMetric.Cosine,
+            EmbeddingInputPreparation.Create(2_000, passageInstruction: null, normalizesVector: true));
+
+    private static CancellationWorld CreateWorld()
+    {
+        var generationStore = new InMemoryEmbeddingGenerationStore(new InMemoryEmailEmbeddingStore());
+        var vectorIndex = Substitute.For<IEmbeddingProfileVectorIndex>();
+
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Substitute.For<IPersistenceSession>());
+
+        var cancellation = new EmbeddingReindexCancellation(
+            generationStore,
+            vectorIndex,
+            new OptimisticConcurrencyRetryPolicy(
+                sessionFactory,
+                new PersistenceConcurrencyOptions(),
+                new FakeTimeProvider()));
+
+        return new CancellationWorld(generationStore, vectorIndex, cancellation);
+    }
+
+    /// <summary>The generations and the collaborators one cancellation works against.</summary>
+    private sealed record CancellationWorld(
+        InMemoryEmbeddingGenerationStore GenerationStore,
+        IEmbeddingProfileVectorIndex VectorIndex,
+        EmbeddingReindexCancellation Cancellation);
+}

--- a/tests/Application.UnitTests/Emails/Search/SemanticEmailSearchTests.cs
+++ b/tests/Application.UnitTests/Emails/Search/SemanticEmailSearchTests.cs
@@ -304,7 +304,7 @@ public sealed class SemanticEmailSearchTests
 
     private static SemanticEmailSearch SearchOver(
         InMemoryEmailVectorSearchIndex vectorIndex,
-        ActiveEmbeddingProfile? profile,
+        RegisteredEmbeddingProfile? profile,
         ScriptedTextEmbeddingGenerator? generator,
         AiProviderHealthState providerState = AiProviderHealthState.Serving) => new(
         ProfileReaderReturning(profile),
@@ -313,9 +313,9 @@ public sealed class SemanticEmailSearchTests
         new FakeTimeProvider(Now),
         generator);
 
-    private static ActiveEmbeddingProfile ActiveProfile() => new(ProfileId, Identity());
+    private static RegisteredEmbeddingProfile ActiveProfile() => new(ProfileId, Identity());
 
-    private static IActiveEmbeddingProfileReader ProfileReaderReturning(ActiveEmbeddingProfile? profile)
+    private static IActiveEmbeddingProfileReader ProfileReaderReturning(RegisteredEmbeddingProfile? profile)
     {
         var reader = Substitute.For<IActiveEmbeddingProfileReader>();
         reader.FindActiveProfileAsync(Arg.Any<CancellationToken>()).Returns(profile);

--- a/tests/Application.UnitTests/Emails/SearchEmails/MailboxSearchReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/SearchEmails/MailboxSearchReaderTests.cs
@@ -542,7 +542,7 @@ public sealed class MailboxSearchReaderTests
         var identity = ProfileIdentity();
         var profileReader = Substitute.For<IActiveEmbeddingProfileReader>();
         profileReader.FindActiveProfileAsync(Arg.Any<CancellationToken>())
-            .Returns(new ActiveEmbeddingProfile(ProfileId, identity));
+            .Returns(new RegisteredEmbeddingProfile(ProfileId, identity));
 
         return new SemanticEmailSearch(
             profileReader,

--- a/tests/Application.UnitTests/TestDoubles/InMemoryEmailEmbeddingStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryEmailEmbeddingStore.cs
@@ -34,6 +34,28 @@ internal sealed class InMemoryEmailEmbeddingStore : IEmailEmbeddingStore
     public IReadOnlyDictionary<(EmailChunkId ChunkId, EmbeddingProfileId ProfileId), EmbeddingVector> StoredVectors =>
         this.vectors;
 
+    /// <summary>Removes a bounded batch of one generation's vectors, the way the superseded-vector sweep does.</summary>
+    /// <returns>How many vectors the batch removed.</returns>
+    public int RemoveVectors(EmbeddingProfileId profileId, int batchSize)
+    {
+        var batch = this.vectors.Keys
+            .Where(key => key.ProfileId == profileId)
+            .Take(batchSize)
+            .ToArray();
+
+        // A loop rather than a projection, because removing an entry is a side effect on the dictionary being read.
+        foreach (var key in batch)
+        {
+            this.vectors.Remove(key);
+        }
+
+        return batch.Length;
+    }
+
+    /// <summary>Counts the vectors one generation currently holds.</summary>
+    public int CountVectors(EmbeddingProfileId profileId) =>
+        this.vectors.Keys.Count(key => key.ProfileId == profileId);
+
     /// <summary>Gives one message the passages a chunker would have derived for it.</summary>
     public void AddPassages(StoredEmailId storedEmailId, params IReadOnlyList<EmailChunkAwaitingEmbedding> chunks)
     {
@@ -76,7 +98,7 @@ internal sealed class InMemoryEmailEmbeddingStore : IEmailEmbeddingStore
     /// <inheritdoc />
     public Task SaveEmbeddingsAsync(
         IPersistenceSession session,
-        ActiveEmbeddingProfile profile,
+        RegisteredEmbeddingProfile profile,
         IReadOnlyList<GeneratedChunkEmbedding> embeddings,
         CancellationToken cancellationToken)
     {

--- a/tests/Application.UnitTests/TestDoubles/InMemoryEmailVectorSearchIndex.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryEmailVectorSearchIndex.cs
@@ -40,7 +40,7 @@ internal sealed class InMemoryEmailVectorSearchIndex : IEmailVectorSearchIndexRe
     /// <inheritdoc />
     public Task<IReadOnlyList<RankedEmailCandidate>> ReadNearestCandidatesAsync(
         MailboxEmailSelection selection,
-        ActiveEmbeddingProfile profile,
+        RegisteredEmbeddingProfile profile,
         EmbeddingVector queryVector,
         int limit,
         CancellationToken cancellationToken)
@@ -82,7 +82,7 @@ internal sealed class InMemoryEmailVectorSearchIndex : IEmailVectorSearchIndexRe
     /// <param name="Limit">How many candidates the caller asked for.</param>
     internal sealed record ReadNearestCandidatesCall(
         MailboxEmailSelection Selection,
-        ActiveEmbeddingProfile Profile,
+        RegisteredEmbeddingProfile Profile,
         EmbeddingVector QueryVector,
         int Limit);
 

--- a/tests/Application.UnitTests/TestDoubles/InMemoryEmbeddingGenerationStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryEmbeddingGenerationStore.cs
@@ -54,6 +54,10 @@ internal sealed class InMemoryEmbeddingGenerationStore : IEmbeddingGenerationSto
     public EmbeddingProfileLifecycleState StateOf(EmbeddingProfileId profileId) =>
         this.rows[profileId].LifecycleState;
 
+    /// <summary>Leaves one row where a cancelled reindex leaves it, so a later pass finds what it would find.</summary>
+    public void Supersede(EmbeddingProfileId profileId) =>
+        this.rows[profileId].LifecycleState = EmbeddingProfileLifecycleState.Superseded;
+
     /// <inheritdoc />
     public Task<EmbeddingGenerations> ReadGenerationsAsync(CancellationToken cancellationToken)
     {
@@ -162,6 +166,13 @@ internal sealed class InMemoryEmbeddingGenerationStore : IEmbeddingGenerationSto
         cancellationToken.ThrowIfCancellationRequested();
 
         this.RequestedRemovalBatchSizes.Add(batchSize);
+
+        // The state is re-checked at the delete for the reason the real store re-checks it: a generation activated
+        // again between the read that chose it and this write keeps whatever vectors it still holds.
+        if (this.rows[profileId].LifecycleState != EmbeddingProfileLifecycleState.Superseded)
+        {
+            return Task.FromResult(0);
+        }
 
         return Task.FromResult(this.embeddingStore.RemoveVectors(profileId, batchSize));
     }

--- a/tests/Application.UnitTests/TestDoubles/InMemoryEmbeddingGenerationStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryEmbeddingGenerationStore.cs
@@ -1,0 +1,179 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Generations;
+using MailFathom.Application.Persistence;
+
+namespace MailFathom.Application.UnitTests.TestDoubles;
+
+/// <summary>Holds the profile rows and enforces the invariant the partial unique index enforces in PostgreSQL.</summary>
+/// <remarks>
+/// Hand-written rather than substituted because what the tests are about is the state machine: a switch has to promote
+/// one row and supersede another together, a second generation may never be building, and a row that stops being
+/// superseded has to stop being reported for removal. A substitute answering each call from a script could not be wrong
+/// about any of that. Its vectors are the ones the generator actually wrote, so removal is observed rather than
+/// asserted.
+/// </remarks>
+internal sealed class InMemoryEmbeddingGenerationStore : IEmbeddingGenerationStore
+{
+    private readonly InMemoryEmailEmbeddingStore embeddingStore;
+    private readonly Dictionary<EmbeddingProfileId, GenerationRow> rows = [];
+
+    /// <summary>Initializes a store over the vectors the generator writes.</summary>
+    public InMemoryEmbeddingGenerationStore(InMemoryEmailEmbeddingStore embeddingStore) =>
+        this.embeddingStore = embeddingStore;
+
+    /// <summary>Gets the batch sizes removal was asked for, in order.</summary>
+    public List<int> RequestedRemovalBatchSizes { get; } = [];
+
+    /// <summary>Gets or sets a generation abandoned the moment a switch to it is attempted.</summary>
+    /// <remarks>
+    /// The one way to arrange the race the switch guards against: a cancellation that lands after a pass counted the
+    /// generation complete and before it committed the transition. Against a real database that ordering is settled by
+    /// a row lock; here it is settled by this hook, so the guard is exercised rather than assumed.
+    /// </remarks>
+    public EmbeddingProfileId? AbandonWhenSwitched { get; set; }
+
+    /// <summary>Registers a row in the state a test needs it in, the way an earlier activation would have left it.</summary>
+    public RegisteredEmbeddingProfile Add(
+        EmbeddingProfileIdentity identity,
+        EmbeddingProfileLifecycleState lifecycleState)
+    {
+        var profile = new RegisteredEmbeddingProfile(
+            EmbeddingProfileId.Create(Guid.CreateVersion7()),
+            identity);
+
+        this.rows[profile.Id] = new GenerationRow(profile) { LifecycleState = lifecycleState };
+
+        return profile;
+    }
+
+    /// <summary>Reads what state one row is in, which is what a transition is asserted against.</summary>
+    public EmbeddingProfileLifecycleState StateOf(EmbeddingProfileId profileId) =>
+        this.rows[profileId].LifecycleState;
+
+    /// <inheritdoc />
+    public Task<EmbeddingGenerations> ReadGenerationsAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(new EmbeddingGenerations(
+            Serving: this.SingleIn(EmbeddingProfileLifecycleState.Active),
+            Building: this.SingleIn(EmbeddingProfileLifecycleState.Building)));
+    }
+
+    /// <inheritdoc />
+    public Task<RegisteredEmbeddingProfile> RegisterBuildingAsync(
+        IPersistenceSession session,
+        EmbeddingProfileIdentity identity,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var fingerprint = EmbeddingProfileFingerprint.Compute(identity);
+        var registered = this.rows.Values.SingleOrDefault(
+            row => EmbeddingProfileFingerprint.Compute(row.Profile.Identity) == fingerprint);
+
+        if (registered is null)
+        {
+            var profile = this.Add(identity, EmbeddingProfileLifecycleState.Building);
+
+            return Task.FromResult(profile);
+        }
+
+        registered.LifecycleState = EmbeddingProfileLifecycleState.Building;
+
+        return Task.FromResult(registered.Profile);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SwitchToAsync(
+        IPersistenceSession session,
+        EmbeddingProfileId built,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (this.AbandonWhenSwitched is { } cancelled)
+        {
+            this.rows[cancelled].LifecycleState = EmbeddingProfileLifecycleState.Superseded;
+        }
+
+        if (this.rows[built].LifecycleState != EmbeddingProfileLifecycleState.Building)
+        {
+            return Task.FromResult(false);
+        }
+
+        // A loop rather than a projection, because every match is a state change on the row it names.
+        foreach (var row in this.rows.Values.Where(candidate =>
+            candidate.LifecycleState == EmbeddingProfileLifecycleState.Active && candidate.Profile.Id != built))
+        {
+            row.LifecycleState = EmbeddingProfileLifecycleState.Superseded;
+        }
+
+        this.rows[built].LifecycleState = EmbeddingProfileLifecycleState.Active;
+
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> AbandonAsync(
+        IPersistenceSession session,
+        EmbeddingProfileId building,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (this.rows[building].LifecycleState != EmbeddingProfileLifecycleState.Building)
+        {
+            return Task.FromResult(false);
+        }
+
+        this.rows[building].LifecycleState = EmbeddingProfileLifecycleState.Superseded;
+
+        return Task.FromResult(true);
+    }
+
+    /// <inheritdoc />
+    public Task<EmbeddingProfileId?> FindSupersededProfileHoldingVectorsAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var superseded = this.rows.Values
+            .Where(row => row.LifecycleState == EmbeddingProfileLifecycleState.Superseded)
+            .Select(row => row.Profile.Id)
+            .Where(profileId => this.embeddingStore.CountVectors(profileId) > 0)
+            .Cast<EmbeddingProfileId?>()
+            .FirstOrDefault();
+
+        return Task.FromResult(superseded);
+    }
+
+    /// <inheritdoc />
+    public Task<int> RemoveVectorsAsync(
+        IPersistenceSession session,
+        EmbeddingProfileId profileId,
+        int batchSize,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(batchSize);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        this.RequestedRemovalBatchSizes.Add(batchSize);
+
+        return Task.FromResult(this.embeddingStore.RemoveVectors(profileId, batchSize));
+    }
+
+    /// <summary>Answers with the one row in a state, refusing two the way the partial unique index does.</summary>
+    private RegisteredEmbeddingProfile? SingleIn(EmbeddingProfileLifecycleState lifecycleState) => this.rows.Values
+        .SingleOrDefault(row => row.LifecycleState == lifecycleState)
+        ?.Profile;
+
+    /// <summary>One profile row: an identity that never moves and a lifecycle that does.</summary>
+    private sealed record GenerationRow(RegisteredEmbeddingProfile Profile)
+    {
+        public EmbeddingProfileLifecycleState LifecycleState { get; set; }
+    }
+}

--- a/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingBackfillWorkerTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingBackfillWorkerTests.cs
@@ -6,6 +6,8 @@ using MailFathom.Application.Emails.Chunking;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Generations;
+using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Emails;
 using MailFathom.Host.Configuration.Embeddings;
@@ -187,9 +189,9 @@ public sealed class MailEmbeddingBackfillWorkerTests
     private static WorkerWorld CreateWorld(EmbeddingBackfillOptions settings) =>
         CreateWorld(
             settings,
-            new ActiveEmbeddingProfile(EmbeddingProfileId.Create(Guid.CreateVersion7()), CreateIdentity()));
+            new RegisteredEmbeddingProfile(EmbeddingProfileId.Create(Guid.CreateVersion7()), CreateIdentity()));
 
-    private static WorkerWorld CreateWorld(EmbeddingBackfillOptions settings, ActiveEmbeddingProfile? activeProfile)
+    private static WorkerWorld CreateWorld(EmbeddingBackfillOptions settings, RegisteredEmbeddingProfile? activeProfile)
     {
         settings.IdleSweepInterval = IdleSweepInterval;
 
@@ -203,8 +205,11 @@ public sealed class MailEmbeddingBackfillWorkerTests
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<StoredEmailAwaitingEmbedding>>([]));
 
-        var profileReader = Substitute.For<IActiveEmbeddingProfileReader>();
-        profileReader.FindActiveProfileAsync(Arg.Any<CancellationToken>()).Returns(activeProfile);
+        // Only a serving generation, because what a reindex adds beside it is the upkeep pass's own behavior and is
+        // covered where that lives; these tests are about the loop the worker runs around it.
+        var generationStore = Substitute.For<IEmbeddingGenerationStore>();
+        generationStore.ReadGenerationsAsync(Arg.Any<CancellationToken>())
+            .Returns(new EmbeddingGenerations(activeProfile, Building: null));
 
         var textEmbeddingGenerator = Substitute.For<ITextEmbeddingGenerator>();
         textEmbeddingGenerator.Identity.Returns(CreateIdentity());
@@ -213,7 +218,8 @@ public sealed class MailEmbeddingBackfillWorkerTests
         var services = new ServiceCollection();
         services.AddSingleton<TimeProvider>(world.TimeProvider);
         services.AddSingleton(world.BackfillStore);
-        services.AddSingleton(profileReader);
+        services.AddSingleton(generationStore);
+        services.AddSingleton(Substitute.For<IEmbeddingProfileVectorIndex>());
         services.AddSingleton(world.EmbeddingStore);
         services.AddSingleton(textEmbeddingGenerator);
         services.AddSingleton(Substitute.For<IPersistenceSessionFactory>());
@@ -226,6 +232,7 @@ public sealed class MailEmbeddingBackfillWorkerTests
         services.AddScoped<OptimisticConcurrencyRetryPolicy>();
         services.AddScoped<StoredEmailEmbeddingGenerator>();
         services.AddScoped<StoredEmailEmbeddingBackfill>();
+        services.AddScoped<EmbeddingGenerationUpkeep>();
 
         var serviceProvider = services.BuildServiceProvider();
         world.Attach(
@@ -268,10 +275,17 @@ public sealed class MailEmbeddingBackfillWorkerTests
         /// A loop rather than a single advance, because a run's delay is created after the line that ends it is written:
         /// an advance that arrives before the delay exists is simply lost, and the next one fires it. What the loop
         /// proves is that the worker starts another sweep at all, which is the claim this worker's shape rests on.
+        /// <para>
+        /// Each attempt waits on the line as well as on a short window rather than merely yielding, because yielding
+        /// hands the loop straight back to itself on a busy machine: every advance would then be spent while the pass
+        /// that creates the next delay is still running, and the worker would be left waiting on a clock nothing moves
+        /// again. The window bounds one attempt and never the wait — the line completing ends it immediately.
+        /// </para>
         /// </remarks>
         public async Task AdvanceUntilLogged(string fragment, int occurrences)
         {
-            const int advanceAttempts = 1000;
+            const int advanceAttempts = 200;
+            var passObservationWindow = TimeSpan.FromMilliseconds(20);
 
             var logged = this.Logger.WaitForOccurrences(fragment, occurrences);
 
@@ -279,7 +293,7 @@ public sealed class MailEmbeddingBackfillWorkerTests
             {
                 this.TimeProvider.Advance(IdleSweepInterval);
 
-                await Task.Yield();
+                await Task.WhenAny(logged, Task.Delay(passObservationWindow, TestContext.Current.CancellationToken));
             }
 
             await logged;

--- a/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingWorkerTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingWorkerTests.cs
@@ -50,7 +50,7 @@ public sealed class MailEmbeddingWorkerTests
         profileReader.FindActiveProfileAsync(Arg.Any<CancellationToken>())
             .Returns(
                 _ => throw new InvalidOperationException("the database is unavailable"),
-                _ => Task.FromResult<ActiveEmbeddingProfile?>(CreateProfile()));
+                _ => Task.FromResult<RegisteredEmbeddingProfile?>(CreateProfile()));
         var embeddingStore = CreateStoreWithNothingOutstanding();
         using var worker = CreateWorker(messages, profileReader, embeddingStore, out var logger);
 
@@ -102,10 +102,10 @@ public sealed class MailEmbeddingWorkerTests
         EmbeddingDistanceMetric.Cosine,
         EmbeddingInputPreparation.Create(2_000, passageInstruction: null, normalizesVector: true));
 
-    private static ActiveEmbeddingProfile CreateProfile() =>
+    private static RegisteredEmbeddingProfile CreateProfile() =>
         new(EmbeddingProfileId.Create(Guid.CreateVersion7()), Identity);
 
-    private static IActiveEmbeddingProfileReader CreateProfileReader(ActiveEmbeddingProfile? profile)
+    private static IActiveEmbeddingProfileReader CreateProfileReader(RegisteredEmbeddingProfile? profile)
     {
         var reader = Substitute.For<IActiveEmbeddingProfileReader>();
         reader.FindActiveProfileAsync(Arg.Any<CancellationToken>()).Returns(profile);

--- a/tests/Infrastructure.UnitTests/Observability/EmailEmbeddingBackfillTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/EmailEmbeddingBackfillTelemetryTests.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
+using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Infrastructure.Observability;
 using MailFathom.Infrastructure.UnitTests.TestDoubles;
 using Xunit;
@@ -24,13 +25,17 @@ public sealed class EmailEmbeddingBackfillTelemetryTests
 
     private const string OutstandingGauge = "mailfathom.embedding.backfill.outstanding";
 
+    private const string SwitchCountInstrument = "mailfathom.embedding.generation.switches";
+
+    private const string RemovedVectorInstrument = "mailfathom.embedding.generation.removed";
+
     /// <summary>
     /// The tag strings are what an operator splits the series on to tell a sweep that finished from one a provider
     /// refused, so a swapped or mistyped value would mislabel that split rather than fail. Every value of both closed
     /// sets is driven through the mapping here.
     /// </summary>
     [Fact]
-    public void RecordRun_EveryOutcomeAndFailure_TagsTheSeriesWithTheNameThatOutcomeIsReadBy()
+    public void RecordPass_EveryOutcomeAndFailure_TagsTheSeriesWithTheNameThatOutcomeIsReadBy()
     {
         // Arrange
         var telemetry = new EmailEmbeddingBackfillTelemetry();
@@ -58,7 +63,7 @@ public sealed class EmailEmbeddingBackfillTelemetryTests
 
     /// <summary>Every run counts as exactly one, whatever it produced, or the series would count work instead of runs.</summary>
     [Fact]
-    public void RecordRun_AnyOutcome_CountsTheRunOnce()
+    public void RecordPass_AnyOutcome_CountsTheRunOnce()
     {
         // Arrange
         var telemetry = new EmailEmbeddingBackfillTelemetry();
@@ -77,7 +82,7 @@ public sealed class EmailEmbeddingBackfillTelemetryTests
     /// that is working through a mailbox.
     /// </summary>
     [Fact]
-    public void RecordRun_ProgressCounters_RecordWhatMovedAndNothingForARunThatProducedNone()
+    public void RecordPass_ProgressCounters_RecordWhatMovedAndNothingForARunThatProducedNone()
     {
         // Arrange
         var telemetry = new EmailEmbeddingBackfillTelemetry();
@@ -88,13 +93,13 @@ public sealed class EmailEmbeddingBackfillTelemetryTests
             ExhaustedCountInstrument);
 
         // Act
-        telemetry.RecordRun(CreateResult(
+        RecordSweep(telemetry, CreateResult(
             StoredEmailEmbeddingBackfillOutcome.BatchBudgetSpent,
             chunkedEmailCount: 2,
             embeddedEmailCount: 5,
             embeddedChunkCount: 31,
             callBudgetExhaustedEmailCount: 1));
-        telemetry.RecordRun(CreateResult(StoredEmailEmbeddingBackfillOutcome.SweepCompleted));
+        RecordSweep(telemetry, CreateResult(StoredEmailEmbeddingBackfillOutcome.SweepCompleted));
 
         // Assert
         Assert.Equal([2], measurements.ValuesOf(ChunkedCountInstrument));
@@ -110,19 +115,19 @@ public sealed class EmailEmbeddingBackfillTelemetryTests
     /// established and a run resuming one leaves it alone rather than publishing nothing.
     /// </summary>
     [Fact]
-    public void RecordRun_ASweepStarts_HoldsItsOutstandingCountUntilTheNextSweepMeasuresAgain()
+    public void RecordPass_ASweepStarts_HoldsItsOutstandingCountUntilTheNextSweepMeasuresAgain()
     {
         // Arrange
         var telemetry = new EmailEmbeddingBackfillTelemetry();
         using var measurements = new RecordedMailFathomMeasurements(OutstandingGauge);
 
         // Act
-        telemetry.RecordRun(CreateResult(
+        RecordSweep(telemetry, CreateResult(
             StoredEmailEmbeddingBackfillOutcome.BatchBudgetSpent,
             outstandingEmailCountAtSweepStart: 412));
         measurements.ObserveGauges();
 
-        telemetry.RecordRun(CreateResult(StoredEmailEmbeddingBackfillOutcome.BatchBudgetSpent));
+        RecordSweep(telemetry, CreateResult(StoredEmailEmbeddingBackfillOutcome.BatchBudgetSpent));
         measurements.ObserveGauges();
 
         // Assert
@@ -130,6 +135,33 @@ public sealed class EmailEmbeddingBackfillTelemetryTests
         // of this name that is still alive on the process-wide meter and still answers for its own sweep, so one
         // observation records several numbers and only this one's is the figure under test.
         Assert.Equal(2, measurements.ValuesOf(OutstandingGauge).Count(outstanding => outstanding == 412));
+    }
+
+    /// <summary>
+    /// The switch and the removal are what an operator watching a model change reads, and they are counted rather than
+    /// published as a state: a gauge naming the current generation would be a dimension of unbounded cardinality for a
+    /// value one log line already carries.
+    /// </summary>
+    [Fact]
+    public void RecordPass_APassThatSwitchedAndRemoved_CountsBothAgainstTheirOwnInstruments()
+    {
+        // Arrange
+        var telemetry = new EmailEmbeddingBackfillTelemetry();
+        using var measurements = new RecordedMailFathomMeasurements(SwitchCountInstrument, RemovedVectorInstrument);
+
+        // Act
+        telemetry.RecordPass(new EmbeddingGenerationUpkeepResult(
+            CreateResult(StoredEmailEmbeddingBackfillOutcome.SweepCompleted),
+            EmbeddingGenerationTransition.Switched,
+            RemovedSupersededVectorCount: 4_000));
+        telemetry.RecordPass(new EmbeddingGenerationUpkeepResult(
+            CreateResult(StoredEmailEmbeddingBackfillOutcome.SweepCompleted),
+            EmbeddingGenerationTransition.None,
+            RemovedSupersededVectorCount: 0));
+
+        // Assert
+        Assert.Equal([1], measurements.ValuesOf(SwitchCountInstrument));
+        Assert.Equal([4_000], measurements.ValuesOf(RemovedVectorInstrument));
     }
 
     /// <summary>Drives one run of every shape the backfill can end in, in the order the outcomes are declared.</summary>
@@ -149,9 +181,22 @@ public sealed class EmailEmbeddingBackfillTelemetryTests
 
         foreach (var result in results)
         {
-            telemetry.RecordRun(result);
+            RecordSweep(telemetry, result);
         }
     }
+
+    /// <summary>Records a pass whose sweep is the one under test and which changed no generation.</summary>
+    /// <remarks>
+    /// The sweep's own instruments are what most of these tests are about, and wrapping the result here keeps each of
+    /// them stating the sweep it drives rather than the two fields it does not care about.
+    /// </remarks>
+    private static void RecordSweep(
+        EmailEmbeddingBackfillTelemetry telemetry,
+        StoredEmailEmbeddingBackfillResult sweep) =>
+        telemetry.RecordPass(new EmbeddingGenerationUpkeepResult(
+            sweep,
+            EmbeddingGenerationTransition.None,
+            RemovedSupersededVectorCount: 0));
 
     private static StoredEmailEmbeddingBackfillResult CreateResult(
         StoredEmailEmbeddingBackfillOutcome outcome,

--- a/tests/Infrastructure.UnitTests/Persistence/Embeddings/EmailVectorSearchIndexReaderCommandTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Embeddings/EmailVectorSearchIndexReaderCommandTests.cs
@@ -142,7 +142,7 @@ public sealed class EmailVectorSearchIndexReaderCommandTests
         return reader
             .NearestHitsQuery(
                 selection ?? UnfilteredSelection,
-                new ActiveEmbeddingProfile(ProfileId, IdentityWith(distanceMetric)),
+                new RegisteredEmbeddingProfile(ProfileId, IdentityWith(distanceMetric)),
                 EmbeddingVector.Create([0.1f, 0.2f, 0.3f, 0.4f, 0.5f, 0.6f, 0.7f, 0.8f]),
                 limit: 20)
             .ToQueryString();

--- a/tests/Infrastructure.UnitTests/Persistence/Embeddings/EmbeddingVectorIndexStatementsTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Embeddings/EmbeddingVectorIndexStatementsTests.cs
@@ -143,7 +143,7 @@ public sealed class EmbeddingVectorIndexStatementsTests
             statement);
     }
 
-    private static ActiveEmbeddingProfile ProfileOf(
+    private static RegisteredEmbeddingProfile ProfileOf(
         int dimension,
         EmbeddingDistanceMetric distanceMetric,
         string provider = "mailfathom-test-vendor",

--- a/tests/Infrastructure.UnitTests/Persistence/Entities/EmbeddingSchemaModelTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Entities/EmbeddingSchemaModelTests.cs
@@ -175,6 +175,36 @@ public sealed class EmbeddingSchemaModelTests
             index.Properties.Select(property => property.Name));
     }
 
+    /// <summary>
+    /// Two rows claiming to serve would leave retrieval reading whichever one a query returned, with half the vectors
+    /// in the table unreachable and nothing about the answers saying so. The index is partial to the two states that
+    /// admit one row each, because a deployment accumulates one superseded row per model it has ever used.
+    /// </summary>
+    [Fact]
+    public void EmbeddingProfileModel_Lifecycle_AdmitsOneGenerationBeingBuiltAndOneBeingRead()
+    {
+        // Arrange
+        using var context = CreateContext();
+
+        // Act
+        var index = EntityType<EmbeddingProfileEntity>(context)
+            .GetIndexes()
+            .FirstOrDefault(candidate =>
+                candidate.GetDatabaseName() == MailFathomDbContext.EmbeddingProfileLifecycleUniqueIndexName);
+
+        // Assert
+        Assert.NotNull(index);
+        Assert.True(index.IsUnique);
+        Assert.Equal(
+            [nameof(EmbeddingProfileEntity.LifecycleState)],
+            index.Properties.Select(property => property.Name));
+
+        // The filter names the values the column stores, which are the enum member names rather than their numbers.
+        Assert.Equal(
+            "\"LifecycleState\" IN ('Building', 'Active')",
+            index.GetFilter());
+    }
+
     /// <summary>The fingerprint column is the digest's own shape, so a value of any other width cannot be written at all.</summary>
     [Fact]
     public void EmbeddingProfileModel_Fingerprint_IsFixedAtTheDigestLength()

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingBackfillTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingBackfillTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Emails;
@@ -152,17 +153,22 @@ public sealed class OrchestratedEmailEmbeddingBackfillTests(MailFathomOrchestrat
         CancellationToken cancellationToken,
         int batchSize = 20,
         int maxBatchesPerRun = 25) => services.InScopeAsync(
-            (scope, token) => new StoredEmailEmbeddingBackfill(
-                scope.GetRequiredService<IActiveEmbeddingProfileReader>(),
-                scope.GetRequiredService<IStoredEmailEmbeddingBackfillStore>(),
-                scope.GetRequiredService<StoredEmailEmbeddingGenerator>(),
-                scope.GetRequiredService<OptimisticConcurrencyRetryPolicy>(),
-                new StoredEmailEmbeddingBackfillOptions
-                {
-                    BatchSize = batchSize,
-                    MaxBatchesPerRun = maxBatchesPerRun,
-                })
-                .RunAsync(token),
+            async (scope, token) =>
+            {
+                var generations = await scope.GetRequiredService<IEmbeddingGenerationStore>()
+                    .ReadGenerationsAsync(token);
+
+                return await new StoredEmailEmbeddingBackfill(
+                    scope.GetRequiredService<IStoredEmailEmbeddingBackfillStore>(),
+                    scope.GetRequiredService<StoredEmailEmbeddingGenerator>(),
+                    scope.GetRequiredService<OptimisticConcurrencyRetryPolicy>(),
+                    new StoredEmailEmbeddingBackfillOptions
+                    {
+                        BatchSize = batchSize,
+                        MaxBatchesPerRun = maxBatchesPerRun,
+                    })
+                    .RunAsync(Assert.IsType<RegisteredEmbeddingProfile>(generations.Target), token);
+            },
             cancellationToken);
 
     private static Task<StoredEmailId?> ReadResumePositionAsync(

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingGenerationTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingGenerationTests.cs
@@ -94,9 +94,16 @@ public sealed class OrchestratedEmailEmbeddingGenerationTests(MailFathomOrchestr
         OrchestratedMailFathomServices services,
         StoredEmailId storedEmailId,
         CancellationToken cancellationToken) => services.InScopeAsync(
-            (scope, token) => scope.GetRequiredService<StoredEmailEmbeddingGenerator>().EmbedAsync(
-                storedEmailId,
-                token),
+            async (scope, token) =>
+            {
+                var serving = await scope.GetRequiredService<IActiveEmbeddingProfileReader>()
+                    .FindActiveProfileAsync(token);
+
+                return await scope.GetRequiredService<StoredEmailEmbeddingGenerator>().EmbedAsync(
+                    storedEmailId,
+                    Assert.IsType<RegisteredEmbeddingProfile>(serving),
+                    token);
+            },
             cancellationToken);
 
     private static Task<IReadOnlyList<EmailChunkAwaitingEmbedding>> ReadOutstandingAsync(
@@ -186,7 +193,7 @@ public sealed class OrchestratedEmailEmbeddingGenerationTests(MailFathomOrchestr
                     OrchestratedMailFathomServices.DeterministicEmbeddingInputCharacterLimit,
                     passageInstruction: null,
                     normalizesVector: true)),
-            EmbeddingProfileLifecycleState.Building,
+            EmbeddingProfileLifecycleState.Superseded,
             cancellationToken);
 
     private static Task<EmbeddingProfileId> InsertProfileAsync(

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingTests.cs
@@ -213,7 +213,7 @@ public sealed class OrchestratedEmailEmbeddingTests(MailFathomOrchestrationFixtu
                     PassageInstruction = identity.InputPreparation.PassageInstruction,
                     NormalizesVector = identity.InputPreparation.NormalizesVector,
                     IdentityFingerprint = EmbeddingProfileFingerprint.Compute(identity).Value,
-                    LifecycleState = EmbeddingProfileLifecycleState.Building,
+                    LifecycleState = EmbeddingProfileLifecycleState.Superseded,
                     RegisteredAt = TimeProvider.System.GetUtcNow(),
                 });
 

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailVectorSearchTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailVectorSearchTests.cs
@@ -49,7 +49,7 @@ public sealed class OrchestratedEmailVectorSearchTests(MailFathomOrchestrationFi
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
         var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
         var profileId = await OrchestratedEmbeddingProfile.EnsureActiveDeterministicAsync(services, cancellationToken);
-        var profile = new ActiveEmbeddingProfile(profileId, await ActiveIdentityAsync(services, cancellationToken));
+        var profile = new RegisteredEmbeddingProfile(profileId, await ActiveIdentityAsync(services, cancellationToken));
 
         var nearest = await StoreOneMessageAsync(services, binding, uid: 9601, cancellationToken);
         var farther = await StoreOneMessageAsync(services, binding, uid: 9602, cancellationToken);

--- a/tests/IntegrationTests/Persistence/OrchestratedEmbeddingGenerationLifecycleTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmbeddingGenerationLifecycleTests.cs
@@ -1,0 +1,321 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Generations;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Emails;
+using MailFathom.Infrastructure.Persistence;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Pgvector;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Persistence;
+
+/// <summary>
+/// Proves the generation lifecycle against a real schema: that a generation being built and one being read coexist,
+/// that the switch between them is one transaction the partial unique index accepts, and that the superseded
+/// generation's vectors are removed in bounded batches.
+/// </summary>
+/// <remarks>
+/// None of it is reachable without a real server. The invariant under test is a partial unique index, so it is
+/// PostgreSQL that decides whether two rows may claim to serve and PostgreSQL that decides whether the switch's two
+/// statements are accepted in the order they are issued — a substitute would report every ordering as fine, including
+/// the one that violates the index half the time. What a unit test already covers, which is what each transition means
+/// and when it is taken, is deliberately not repeated here.
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedEmbeddingGenerationLifecycleTests(MailFathomOrchestrationFixture orchestration)
+{
+    private const string FolderAlias = "embedding-generations";
+
+    private const int GenerationDimension = 2;
+
+    /// <summary>The point every stored vector here is placed at, its value being irrelevant to what is under test.</summary>
+    private static readonly float[] VectorComponents = [1f, 2f];
+
+    /// <summary>
+    /// One run over the whole lifecycle, because each step is what makes the next one meaningful: a generation that is
+    /// serving is what a second one has to be built beside, the switch is what makes the first one superseded, and a
+    /// superseded generation holding vectors is what the bounded removal is asked to empty.
+    /// </summary>
+    [Fact]
+    public async Task TheGenerationLifecycle_AReindexThatCompletes_SwitchesOnceAndEmptiesWhatItReplaced()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var chunkIds = await StorePassagesAsync(services, uid: 9301, cancellationToken);
+        var previous = await RegisterAsync(services, "generation-previous", cancellationToken);
+        await SwitchToAsync(services, previous.Id, cancellationToken);
+        await StoreVectorsAsync(services, chunkIds, previous.Id, cancellationToken);
+
+        // Act
+        var next = await RegisterAsync(services, "generation-next", cancellationToken);
+        var whileBuilding = await ReadGenerationsAsync(services, cancellationToken);
+        await SwitchToAsync(services, next.Id, cancellationToken);
+        var afterSwitch = await ReadGenerationsAsync(services, cancellationToken);
+
+        // Assert
+        Assert.Equal(previous.Id, whileBuilding.Serving?.Id);
+        Assert.Equal(next.Id, whileBuilding.Building?.Id);
+        Assert.Equal(next.Id, afterSwitch.Serving?.Id);
+        Assert.Null(afterSwitch.Building);
+
+        // The generation that was serving keeps its vectors until the removal reaches them, which is what makes the
+        // switch itself an operation with nothing to wait for.
+        Assert.Equal(chunkIds.Count, await CountVectorsAsync(services, previous.Id, cancellationToken));
+        Assert.Equal(previous.Id, await FindSupersededHoldingVectorsAsync(services, cancellationToken));
+
+        var firstBatch = await RemoveVectorsAsync(services, previous.Id, batchSize: 1, cancellationToken);
+        var remainingBatch = await RemoveVectorsAsync(services, previous.Id, batchSize: 100, cancellationToken);
+
+        Assert.Equal(1, firstBatch);
+        Assert.Equal(chunkIds.Count - 1, remainingBatch);
+        Assert.Equal(0, await CountVectorsAsync(services, previous.Id, cancellationToken));
+        Assert.Null(await FindSupersededHoldingVectorsAsync(services, cancellationToken));
+    }
+
+    /// <summary>
+    /// A second row claiming to serve is refused by the database rather than by the code that writes it, because the
+    /// failure it prevents is silent: retrieval would read whichever row a query returned, leaving half the vectors in
+    /// the table unreachable and nothing about the answers saying so.
+    /// </summary>
+    [Fact]
+    public async Task RegisteringAGeneration_ASecondRowClaimingToServe_IsRefusedByTheDatabase()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var serving = await RegisterAsync(services, "generation-serving", cancellationToken);
+        await SwitchToAsync(services, serving.Id, cancellationToken);
+
+        // Act
+        var refusal = await InsertServingRowAsync(services, "generation-intruder", cancellationToken);
+
+        // Assert
+        Assert.NotNull(refusal);
+        Assert.Contains(
+            MailFathomDbContext.EmbeddingProfileLifecycleUniqueIndexName,
+            refusal.InnerException?.Message,
+            StringComparison.Ordinal);
+
+        // The control the refusal needs: the same row is accepted once it claims nothing the serving generation claims.
+        Assert.Null(await InsertSupersededRowAsync(services, "generation-bystander", cancellationToken));
+    }
+
+    private static EmbeddingProfileIdentity IdentityOf(string modelIdentifier) => EmbeddingProfileIdentity.Create(
+        "mailfathom-test-vendor",
+        modelIdentifier,
+        modelVersion: null,
+        GenerationDimension,
+        EmbeddingDistanceMetric.Cosine,
+        EmbeddingInputPreparation.Create(8_000, passageInstruction: null, normalizesVector: true));
+
+    private static async Task<RegisteredEmbeddingProfile> RegisterAsync(
+        OrchestratedMailFathomServices services,
+        string modelIdentifier,
+        CancellationToken cancellationToken)
+    {
+        RegisteredEmbeddingProfile? registered = null;
+
+        var commitResult = await services.CommitAsync(
+            async (scope, session, token) => registered = await scope.GetRequiredService<IEmbeddingGenerationStore>()
+                .RegisterBuildingAsync(session, IdentityOf(modelIdentifier), token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+
+        return Assert.IsType<RegisteredEmbeddingProfile>(registered);
+    }
+
+    private static async Task SwitchToAsync(
+        OrchestratedMailFathomServices services,
+        EmbeddingProfileId built,
+        CancellationToken cancellationToken)
+    {
+        var switched = false;
+
+        var commitResult = await services.CommitAsync(
+            async (scope, session, token) => switched = await scope.GetRequiredService<IEmbeddingGenerationStore>()
+                .SwitchToAsync(session, built, token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+
+        // The store refuses to switch to a generation that is no longer being built, so a false here would mean the
+        // arrangement never registered one rather than that the switch merely did nothing.
+        Assert.True(switched);
+    }
+
+    private static Task<EmbeddingGenerations> ReadGenerationsAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IEmbeddingGenerationStore>().ReadGenerationsAsync(token),
+            cancellationToken);
+
+    private static Task<EmbeddingProfileId?> FindSupersededHoldingVectorsAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IEmbeddingGenerationStore>()
+                .FindSupersededProfileHoldingVectorsAsync(token),
+            cancellationToken);
+
+    private static async Task<int> RemoveVectorsAsync(
+        OrchestratedMailFathomServices services,
+        EmbeddingProfileId profileId,
+        int batchSize,
+        CancellationToken cancellationToken)
+    {
+        var removedVectorCount = 0;
+
+        var commitResult = await services.CommitAsync(
+            async (scope, session, token) => removedVectorCount = await scope
+                .GetRequiredService<IEmbeddingGenerationStore>()
+                .RemoveVectorsAsync(session, profileId, batchSize, token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+
+        return removedVectorCount;
+    }
+
+    /// <summary>Stores one synthetic message and answers with the passages the chunk writer derived for it.</summary>
+    private static async Task<IReadOnlyList<Guid>> StorePassagesAsync(
+        OrchestratedMailFathomServices services,
+        uint uid,
+        CancellationToken cancellationToken)
+    {
+        var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
+        var occurrenceId = SyntheticEmail.OccurrenceIn(binding, uid);
+        var subject = $"generation-{uid}";
+
+        var commitResult = await services.CommitAsync(
+            (scope, session, token) => scope.GetRequiredService<IEmailMetadataRepository>().UpsertMetadataAsync(
+                session,
+                SyntheticEmail.RemoteMetadataOf(occurrenceId, subject),
+                SyntheticEmail.ExtractionOf(
+                    occurrenceId,
+                    subject,
+                    SyntheticEmail.BodyTextContaining(subject, wordCount: 400),
+                    "recipient@mailfathom.test"),
+                StoredEmailContentAvailability.Available,
+                token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+
+        var alias = occurrenceId.FolderResolutionId.Alias.Value;
+        IReadOnlyList<Guid> chunkIds = await services.InScopeAsync(
+            async (scope, token) => await scope.GetRequiredService<MailFathomDbContext>().EmailChunks
+                .AsNoTracking()
+                .Where(chunk => chunk.StoredEmail.MailFolder.MailboxAccountId == occurrenceId.AccountId.Value
+                    && chunk.StoredEmail.MailFolder.Alias == alias
+                    && chunk.StoredEmail.Uid == occurrenceId.Uid.Value)
+                .OrderBy(chunk => chunk.Ordinal)
+                .Select(chunk => chunk.Id)
+                .ToArrayAsync(token),
+            cancellationToken);
+
+        Assert.NotEmpty(chunkIds);
+
+        return chunkIds;
+    }
+
+    /// <summary>Gives one generation a vector for every passage, which is what a completed reindex leaves behind.</summary>
+    private static Task<int> StoreVectorsAsync(
+        OrchestratedMailFathomServices services,
+        IReadOnlyList<Guid> chunkIds,
+        EmbeddingProfileId profileId,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) =>
+            {
+                var context = scope.GetRequiredService<MailFathomDbContext>();
+
+                context.EmailEmbeddings.AddRange(chunkIds.Select(chunkId => new EmailEmbeddingEntity
+                {
+                    EmailChunkId = chunkId,
+                    EmbeddingProfileId = profileId.Value,
+                    Dimension = GenerationDimension,
+                    Embedding = new Vector(VectorComponents),
+                    GeneratedAt = TimeProvider.System.GetUtcNow(),
+                }));
+
+                return await context.SaveChangesAsync(token);
+            },
+            cancellationToken);
+
+    private static Task<int> CountVectorsAsync(
+        OrchestratedMailFathomServices services,
+        EmbeddingProfileId profileId,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailFathomDbContext>().EmailEmbeddings
+                .AsNoTracking()
+                .CountAsync(vector => vector.EmbeddingProfileId == profileId.Value, token),
+            cancellationToken);
+
+    private static Task<DbUpdateException?> InsertServingRowAsync(
+        OrchestratedMailFathomServices services,
+        string modelIdentifier,
+        CancellationToken cancellationToken) => InsertRowAsync(
+            services,
+            modelIdentifier,
+            EmbeddingProfileLifecycleState.Active,
+            cancellationToken);
+
+    private static Task<DbUpdateException?> InsertSupersededRowAsync(
+        OrchestratedMailFathomServices services,
+        string modelIdentifier,
+        CancellationToken cancellationToken) => InsertRowAsync(
+            services,
+            modelIdentifier,
+            EmbeddingProfileLifecycleState.Superseded,
+            cancellationToken);
+
+    /// <summary>Inserts a profile row directly, and answers with what the database refused or <see langword="null" />.</summary>
+    private static Task<DbUpdateException?> InsertRowAsync(
+        OrchestratedMailFathomServices services,
+        string modelIdentifier,
+        EmbeddingProfileLifecycleState lifecycleState,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) =>
+            {
+                var identity = IdentityOf(modelIdentifier);
+                var context = scope.GetRequiredService<MailFathomDbContext>();
+                var registeredAt = TimeProvider.System.GetUtcNow();
+
+                context.EmbeddingProfiles.Add(new EmbeddingProfileEntity
+                {
+                    Id = Guid.CreateVersion7(),
+                    Provider = identity.Provider,
+                    ModelIdentifier = identity.ModelIdentifier,
+                    ModelVersion = identity.ModelVersion,
+                    Dimension = identity.Dimension,
+                    DistanceMetric = identity.DistanceMetric,
+                    InputCharacterLimit = identity.InputPreparation.InputCharacterLimit,
+                    PassageInstruction = identity.InputPreparation.PassageInstruction,
+                    NormalizesVector = identity.InputPreparation.NormalizesVector,
+                    IdentityFingerprint = EmbeddingProfileFingerprint.Compute(identity).Value,
+                    LifecycleState = lifecycleState,
+                    RegisteredAt = registeredAt,
+                    ActivatedAt = lifecycleState == EmbeddingProfileLifecycleState.Active ? registeredAt : null,
+                });
+
+                try
+                {
+                    await context.SaveChangesAsync(token);
+
+                    return null;
+                }
+                catch (DbUpdateException refusal)
+                {
+                    return refusal;
+                }
+            },
+            cancellationToken);
+}

--- a/tests/IntegrationTests/Persistence/OrchestratedEmbeddingGenerationLifecycleTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmbeddingGenerationLifecycleTests.cs
@@ -72,6 +72,15 @@ public sealed class OrchestratedEmbeddingGenerationLifecycleTests(MailFathomOrch
         Assert.Equal(chunkIds.Count, await CountVectorsAsync(services, previous.Id, cancellationToken));
         Assert.Equal(previous.Id, await FindSupersededHoldingVectorsAsync(services, cancellationToken));
 
+        // A rollback that catches its own removal part-way through keeps what the generation still holds, and the
+        // delete is what has to know that: the read that chose this generation happened in an earlier transaction, so
+        // the statement re-checks the state rather than trusting the decision it was given.
+        await RegisterAsync(services, "generation-previous", cancellationToken);
+        Assert.Equal(0, await RemoveVectorsAsync(services, previous.Id, batchSize: 100, cancellationToken));
+        Assert.Equal(chunkIds.Count, await CountVectorsAsync(services, previous.Id, cancellationToken));
+
+        await AbandonAsync(services, previous.Id, cancellationToken);
+
         var firstBatch = await RemoveVectorsAsync(services, previous.Id, batchSize: 1, cancellationToken);
         var remainingBatch = await RemoveVectorsAsync(services, previous.Id, batchSize: 100, cancellationToken);
 
@@ -151,6 +160,22 @@ public sealed class OrchestratedEmbeddingGenerationLifecycleTests(MailFathomOrch
         // The store refuses to switch to a generation that is no longer being built, so a false here would mean the
         // arrangement never registered one rather than that the switch merely did nothing.
         Assert.True(switched);
+    }
+
+    private static async Task AbandonAsync(
+        OrchestratedMailFathomServices services,
+        EmbeddingProfileId building,
+        CancellationToken cancellationToken)
+    {
+        var abandoned = false;
+
+        var commitResult = await services.CommitAsync(
+            async (scope, session, token) => abandoned = await scope.GetRequiredService<IEmbeddingGenerationStore>()
+                .AbandonAsync(session, building, token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+        Assert.True(abandoned);
     }
 
     private static Task<EmbeddingGenerations> ReadGenerationsAsync(

--- a/tests/IntegrationTests/Persistence/OrchestratedEmbeddingGenerationLifecycleTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmbeddingGenerationLifecycleTests.cs
@@ -116,6 +116,14 @@ public sealed class OrchestratedEmbeddingGenerationLifecycleTests(MailFathomOrch
 
         // The control the refusal needs: the same row is accepted once it claims nothing the serving generation claims.
         Assert.Null(await InsertSupersededRowAsync(services, "generation-bystander", cancellationToken));
+
+        // And the refusal reaches an application writer as a conflict rather than as a provider exception: two
+        // activations of different geometries collide on this index, and the session is what classifies that.
+        await RegisterAsync(services, "generation-first-to-build", cancellationToken);
+
+        Assert.Equal(
+            PersistenceCommitResult.ConcurrencyConflict,
+            await TryRegisterAsync(services, "generation-second-to-build", cancellationToken));
     }
 
     private static EmbeddingProfileIdentity IdentityOf(string modelIdentifier) => EmbeddingProfileIdentity.Create(
@@ -161,6 +169,19 @@ public sealed class OrchestratedEmbeddingGenerationLifecycleTests(MailFathomOrch
         // arrangement never registered one rather than that the switch merely did nothing.
         Assert.True(switched);
     }
+
+    /// <summary>Registers a generation through the real session, and answers with what the commit reported.</summary>
+    /// <remarks>
+    /// Unlike <c>RegisterAsync</c>, this one asserts nothing about the outcome: it exists to observe a refusal arriving
+    /// as a classified conflict rather than as the provider exception underneath it.
+    /// </remarks>
+    private static Task<PersistenceCommitResult> TryRegisterAsync(
+        OrchestratedMailFathomServices services,
+        string modelIdentifier,
+        CancellationToken cancellationToken) => services.CommitAsync(
+            (scope, session, token) => scope.GetRequiredService<IEmbeddingGenerationStore>()
+                .RegisterBuildingAsync(session, IdentityOf(modelIdentifier), token),
+            cancellationToken);
 
     private static async Task AbandonAsync(
         OrchestratedMailFathomServices services,

--- a/tests/IntegrationTests/Persistence/OrchestratedEmbeddingProfile.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmbeddingProfile.cs
@@ -30,6 +30,19 @@ internal static class OrchestratedEmbeddingProfile
                 var context = scope.GetRequiredService<MailFathomDbContext>();
                 var activatedAt = TimeProvider.System.GetUtcNow();
 
+                // The partial unique index admits one serving generation and one being built, so whatever an earlier
+                // class left in either state is stood down before this one takes the position. Issued as a set-based
+                // update ahead of the tracked write below, because the index is checked per statement and promoting
+                // this row first would collide with the row it is replacing.
+                await context.EmbeddingProfiles
+                    .Where(profile => profile.IdentityFingerprint != fingerprint)
+                    .Where(profile => profile.LifecycleState != EmbeddingProfileLifecycleState.Superseded)
+                    .ExecuteUpdateAsync(
+                        setters => setters
+                            .SetProperty(profile => profile.LifecycleState, EmbeddingProfileLifecycleState.Superseded)
+                            .SetProperty(profile => profile.SupersededAt, activatedAt),
+                        token);
+
                 var registered = await context.EmbeddingProfiles
                     .SingleOrDefaultAsync(profile => profile.IdentityFingerprint == fingerprint, token);
 
@@ -57,11 +70,11 @@ internal static class OrchestratedEmbeddingProfile
                 else
                 {
                     // Re-activated rather than left alone even when it is already active, because other classes in this
-                    // suite register active profiles of their own and the reader serves whichever was activated last.
-                    // Without this, a caller would get the deterministic geometry only when nothing else had claimed
-                    // that position since — which is a dependency on the order xUnit happened to choose.
+                    // suite move this row through its lifecycle and a caller must get the deterministic geometry
+                    // serving whatever the order xUnit happened to choose.
                     registered.LifecycleState = EmbeddingProfileLifecycleState.Active;
                     registered.ActivatedAt = activatedAt;
+                    registered.SupersededAt = null;
                 }
 
                 await context.SaveChangesAsync(token);

--- a/tests/IntegrationTests/Persistence/OrchestratedEmbeddingVectorIndexTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmbeddingVectorIndexTests.cs
@@ -78,7 +78,7 @@ public sealed class OrchestratedEmbeddingVectorIndexTests(MailFathomOrchestratio
 
     private static async Task EnsureBuiltAsync(
         OrchestratedMailFathomServices services,
-        ActiveEmbeddingProfile profile,
+        RegisteredEmbeddingProfile profile,
         CancellationToken cancellationToken) => await services.InScopeAsync(
             async (scope, token) =>
             {
@@ -100,7 +100,7 @@ public sealed class OrchestratedEmbeddingVectorIndexTests(MailFathomOrchestratio
             },
             cancellationToken);
 
-    private static async Task<ActiveEmbeddingProfile> RegisterProfileAsync(
+    private static async Task<RegisteredEmbeddingProfile> RegisterProfileAsync(
         OrchestratedMailFathomServices services,
         int dimension,
         string modelIdentifier,
@@ -132,16 +132,15 @@ public sealed class OrchestratedEmbeddingVectorIndexTests(MailFathomOrchestratio
                     PassageInstruction = identity.InputPreparation.PassageInstruction,
                     NormalizesVector = identity.InputPreparation.NormalizesVector,
                     IdentityFingerprint = EmbeddingProfileFingerprint.Compute(identity).Value,
-                    LifecycleState = EmbeddingProfileLifecycleState.Active,
+                    LifecycleState = EmbeddingProfileLifecycleState.Superseded,
                     RegisteredAt = TimeProvider.System.GetUtcNow(),
-                    ActivatedAt = TimeProvider.System.GetUtcNow(),
                 });
 
                 return await context.SaveChangesAsync(token);
             },
             cancellationToken);
 
-        return new ActiveEmbeddingProfile(EmbeddingProfileId.Create(profileId), identity);
+        return new RegisteredEmbeddingProfile(EmbeddingProfileId.Create(profileId), identity);
     }
 
     /// <summary>Reads what PostgreSQL says the index is, which is the only account of it a test can trust.</summary>


### PR DESCRIPTION
Changing the embedding model no longer costs a search outage. Activation registers a **generation that is built** beside the one still answering searches, the switch happens once and only when the new generation is complete, and the generation it replaced is cleared out afterwards.

## What this adds

- **`EmbeddingProfileActivation`** — resolves the declared geometry through its fingerprint, registers it as *building*, and creates its approximate index while the generation is still empty. Activating what is already serving spends nothing; activating while a *different* generation is being built is refused rather than started beside it.
- **`EmbeddingGenerationUpkeep`** — one bounded pass that rides the existing backfill loop: sweep towards the target generation, complete it when nothing is outstanding, then remove a bounded batch of a superseded generation's vectors.
- **`EmbeddingReindexCancellation`** — abandons the generation being built and leaves the one serving exactly where it is.
- **`IEmbeddingGenerationStore`** and its EF Core adapter — the profile rows and every transition between them.

## Decisions worth reviewing

- **The switch is guarded by the database.** A new partial unique index, `ix_embedding_profiles_lifecycle_state`, admits at most one *building* row and at most one *active* row. That forces the switch to supersede before it promotes, and the two statements are therefore issued in order rather than staged through the change tracker; a `SELECT ... FOR UPDATE` on the row being promoted is what keeps a cancellation from landing between them and leaving nothing serving.
- **The first activation builds too.** An instance with nothing serving does not get a half-built generation to search: retrieval stays lexical until the first generation is complete, so every model change — the first included — is the same single observable transition.
- **The live path writes into the generation that is serving** while a reindex runs, so mail arriving meanwhile stays searchable. The sweep reaches it for the new generation before the count that completes it can read zero.
- **A superseded generation's vectors are removed in bounded batches** and not kept for a rollback window, per ADR 0006. Rolling back is activating the previous profile again, which is unambiguous and paid.
- **`ActiveEmbeddingProfile` is renamed `RegisteredEmbeddingProfile`**, because the same shape now names a generation that is being built as well as the one being read.
- The bounded delete is the one hand-written statement here: a `ctid` subquery with a limit, because ordering by any column would sort the whole remaining generation on every batch.

## Breaking changes

None to the configuration schema, the MCP tool contract, or the deployment contract. The database schema gains one additive migration, `AddEmbeddingProfileLifecycleUniqueIndex`; it is deployable over existing data, and no deployment can currently hold a second active or building profile because nothing activates one yet.

## Verification

- `scripts/verify-full.sh`: 3650 tests, 0 failed; aggregate line coverage 94.97%.
- Migration applied to the orchestrated database, schema dumped, and `mailfathom-host` reached Running/Healthy against it.
- The integration suite gains `OrchestratedEmbeddingGenerationLifecycleTests` (two generations coexisting, the switch, bounded removal, and the index refusing a second serving row) — it has not been run here.

Closes #433