### PR TITLE
[#569] Clear the base image's ASPNETCORE_HTTP_PORTS so the published container starts

### DIFF
--- a/.github/workflows/publish-container-image.yml
+++ b/.github/workflows/publish-container-image.yml
@@ -330,6 +330,21 @@ jobs:
           [[ "$image_ports" == *'8080/tcp'* && "$image_ports" == *'8081/tcp'* ]] || { echo "::error::The image exposes '${image_ports}' rather than 8080 and 8081."; exit 1; }
           [[ "$image_channel" == "$EXPECTED_CHANNEL" ]] || { echo "::error::The image is labelled channel '${image_channel}' rather than '${EXPECTED_CHANNEL}'."; exit 1; }
 
+          # Where a surface is served is its own section's question, so MailFathom refuses the host's URL-shaped
+          # addresses rather than ignoring them — and the aspnet base image ships one of them, ASPNETCORE_HTTP_PORTS, in
+          # its own config. An image that carries a value under any of the three therefore fails every container it
+          # produces, before it serves anything, against a variable no operator wrote. The runtime stage clears the one
+          # the base image sets; this reads the built image back instead of reading that file, which is what also sees a
+          # variable arriving from a base-image bump rather than from a line somebody could be asked about in review.
+          # The startup line asserted above is logged before configuration is validated, so it is no evidence of this.
+          image_listener_variables="$(docker image inspect mailfathom:gate --format '{{ json .Config.Env }}' |
+            jq -r '(. // [])[] | select(test("^ASPNETCORE_(URLS|HTTP_PORTS|HTTPS_PORTS)=."))')"
+
+          if [[ -n "$image_listener_variables" ]]; then
+            echo "::error::The image carries a listener-shaped variable MailFathom refuses at startup: $(printf '%s' "$image_listener_variables" | paste -sd ' ' -). Every container started from it would fail before serving anything. Clear it in the runtime stage of deploy/docker/Dockerfile, where ASPNETCORE_HTTP_PORTS already is."
+            exit 1
+          fi
+
           echo "The image starts, reports ${EXPECTED_VERSION} from ${EXPECTED_REVISION}, and publishes the documented runtime contract."
 
       # A release publishes nothing when this finds something fixable; a nightly reports and publishes anyway, because a

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -150,6 +150,15 @@ LABEL org.opencontainers.image.licenses="Apache-2.0" \
 # terminates at the ingress or the reverse proxy in front of it, which is also the only place a certificate needs to
 # exist.
 ENV McpEndpoint__Port=8080 \
+    # Cleared rather than omitted, and this line is load-bearing. The aspnet base image sets ASPNETCORE_HTTP_PORTS=8080
+    # in its own config, and the refusal above is a refusal rather than an "ignore" — so an image that inherits the
+    # value fails every container it produces, against a variable no operator wrote and no deployment asset sets. A
+    # Dockerfile cannot unset an inherited variable, and an empty value is what the guard treats as absent, so this is
+    # the whole of the fix. Do not delete it as redundant with the refusal: the refusal is what it exists to keep from
+    # firing. `ASPNETCORE_URLS` and `ASPNETCORE_HTTPS_PORTS` are absent from the base image and are deliberately not
+    # cleared here — the smoke test in .github/workflows/publish-container-image.yml reads all three back off the built
+    # image, so a base-image bump that introduces one fails the publication instead of being neutralized unnoticed.
+    ASPNETCORE_HTTP_PORTS= \
     # No diagnostic IPC socket. It would be the one thing this process writes outside /tmp's tmpfs, and a socket that
     # can request a process dump is a way to read secret material out of managed memory — the exposure
     # docs/operations/secret-provisioning.md documents and asks deployments to close. Set it back to 1 deliberately,

--- a/docs/operations/container-image.md
+++ b/docs/operations/container-image.md
@@ -63,6 +63,14 @@ until you name that proxy in `ReverseProxy:TrustedProxies`, which is what stops 
 network from setting them — see
 [behind a TLS-terminating reverse proxy](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy).
 
+**The image carries no listener-shaped variable of its own.** Where a surface is served is its own section's question,
+so the host refuses `ASPNETCORE_URLS`, `ASPNETCORE_HTTP_PORTS`, and `ASPNETCORE_HTTPS_PORTS` rather than ignoring them —
+and the aspnet base image sets `ASPNETCORE_HTTP_PORTS=8080` in its own config. The runtime stage clears that variable to
+an empty value, which is what the refusal treats as absent, so a container serves what `McpEndpoint:Port` and
+`HealthEndpoints:Port` say and no deployment has to unset anything. The other two are absent. [Where each surface is
+served](configuration-reference.md#where-each-surface-is-served) is the contract, and [Verification](#verification) is
+the gate that reads all three back off the built image so a base-image bump cannot reintroduce one unnoticed.
+
 `DOTNET_EnableDiagnostics=0` is set, so no diagnostic IPC socket is created. That socket can request a process dump,
 and a dump is a way to read secret material out of managed memory — the residual exposure
 [secret provisioning](secret-provisioning.md#secret-material-in-process-memory) documents and asks deployments to
@@ -276,9 +284,16 @@ Publication runs the gates instead, in an order that spends the cheap ones first
    baseline migration, and asserts against the result, which is minutes of container time no commit a unit test would
    have rejected is worth. A nightly does not run it.
 3. **The image gates.** The image is built for one architecture, started, and required to report the version and
-   revision its labels claim, to run as the unprivileged `1654` account, and to expose both listeners; then Trivy scans
-   it, which refuses to publish a release carrying a fixable `HIGH` or `CRITICAL` finding and only reports one on a
-   nightly.
+   revision its labels claim, to run as the unprivileged `1654` account, to expose both listeners, and to carry none of
+   the three listener-shaped variables the host refuses; then Trivy scans it, which refuses to publish a release
+   carrying a fixable `HIGH` or `CRITICAL` finding and only reports one on a nightly.
+
+   The listener check reads `ASPNETCORE_URLS`, `ASPNETCORE_HTTP_PORTS`, and `ASPNETCORE_HTTPS_PORTS` back off the built
+   image's config rather than reading the Dockerfile, because a value under any of them can arrive from the base image
+   as well as from a line somebody wrote — the base image sets one today, and a bump can introduce another. The startup
+   line the same step waits for is no evidence here: it is logged before configuration is validated, so a container that
+   reports it can still fail on the next line. What this does not cover is a pull request: the gate runs where the image
+   is built, so a change that put a variable back is caught by the next nightly rather than by the branch that made it.
 
 **Nothing is built from the commit until the first two have passed** — not the image, not the schema script, and not
 the command binaries. They are jobs in `Release` and `Nightly` themselves rather than steps inside the workflow that


### PR DESCRIPTION
Closes #569

The published image could not start. Its runtime stage is built on `mcr.microsoft.com/dotnet/aspnet:10.0.10-noble-chiseled-extra`, which sets `ASPNETCORE_HTTP_PORTS=8080` in its own config, and `ExternalListenerConfiguration` refuses that variable rather than ignoring it — so every container the image produced failed startup against a value no operator wrote and no deployment asset sets. The refusal is correct and is untouched here; what was wrong is that the image shipped the value it refuses.

## What changed

**`deploy/docker/Dockerfile`** clears `ASPNETCORE_HTTP_PORTS` to an empty value in the runtime stage. Empty is what the guard treats as absent, and a Dockerfile has no other way to unset an inherited variable. The comment beside it says what the line is for and that deleting it as redundant with the refusal is exactly what reintroduces the defect.

`ASPNETCORE_URLS` and `ASPNETCORE_HTTPS_PORTS` are absent from the base image and are deliberately *not* cleared, so a base-image bump that introduces one fails the gate below rather than being neutralized where nobody sees it.

**`.github/workflows/publish-container-image.yml`** — the smoke test now reads all three listener-shaped variables back off the built image's config and refuses to publish an image carrying any of them with a value.

**`docs/operations/container-image.md`** states that the image carries no listener-shaped variable of its own, and records what the gate reads and what it does not cover.

## Which check was chosen, and what it does not cover

The issue offered two: an assertion over the built image's config, or one over the Dockerfile's runtime stage in `scripts/test-agent-workflow.sh`. **The image-config assertion is the honest one for the stated purpose.** A value under one of these names can arrive from the base image as well as from a line somebody wrote, and the user story is about a base-image bump — which a text assertion over the Dockerfile cannot evaluate at all. Reading the artifact also covers the case a text assertion would miss entirely: the variable arriving from a layer nobody edited.

It also replaces a false negative. The startup line the same step already waits for is logged before configuration is validated, so today's broken image passes the smoke test and dies immediately afterwards.

**What it does not cover:** it runs where the image is built — `Nightly` and `Release` — and not on a pull request. A change that puts a variable back is caught by the next nightly, before any user pulls it, rather than by the branch that made it. `Container image` (manual dispatch) builds without starting or inspecting, so it does not catch it either. Adding a Dockerfile-text check to `scripts/test-agent-workflow.sh` beside this one would close that window for a deleted `ENV` line only, and was left out rather than carried as a second mechanism that answers a narrower question than the one it sits next to.

## Verification

The image was built locally from this branch and run.

`docker image inspect` on the built image:

```
McpEndpoint__Port=8080
ASPNETCORE_HTTP_PORTS=
DOTNET_EnableDiagnostics=0
```

The gate's own expression reports nothing against that image, and reports `ASPNETCORE_HTTP_PORTS=8080` against the unmodified base image — so both paths were exercised rather than only the passing one.

Started with the variable forced back to `8080`, the container reproduces the reported failure verbatim (`OptionsValidationException: ASPNETCORE_HTTP_PORTS — MailFathom serves no listener of its own from this variable.`). Started as built, it gets past configuration and stops at the database it was given none for.

The Compose deployment was then brought up from `deploy/compose/` unchanged — own project name, own volume, own ports — against a schema generated by `scripts/build-schema-artifact.sh`:

```
/started -> 200 Healthy
/health  -> 200 Healthy
/alive   -> 200 Healthy
```

No workaround entry was added to `compose.yaml`, `.env.example`, or the chart, and none is needed.

`scripts/verify-full.sh`: green — 126/126 workflow contracts, 3630 tests, 94.89% line coverage.

## Two things found while verifying, neither fixed here

- **The schema step in the Compose docs is run as the wrong role**, which leaves `permission denied for table __EFMigrationsHistory` and a restart loop. That is #571 and is not touched here; the run above applied the schema as the `mailfathom` role to get past it.
- **`deploy/compose/.env.example` still says "No MailFathom release has been published yet."** That is stale rather than wrong-in-this-change, and correcting it needs a decision about which tag to name.

## Contracts

No public surface moves. The MCP tool contract, the configuration schema, the database schema, and the deployment contract are all unchanged: the variable this clears is one MailFathom already refused, so nothing that worked before stops working.

**Operator action on upgrade: none.** A deployment carrying the `ASPNETCORE_HTTP_PORTS: ""` workaround keeps working — an empty value and an absent one are the same thing to the guard — and the entry can be dropped whenever convenient.
