### PR TITLE
[#571] Correct the Compose deployment instructions that produce an unstartable deployment

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -8,6 +8,7 @@
 #   mkdir -p secrets/mailfathom
 #   chmod 700 secrets
 #   chmod 711 secrets/mailfathom
+#   chmod 755 config
 #   openssl rand -base64 33 | tr -d '\n' > secrets/postgres-superuser-password
 #   openssl rand -base64 33 | tr -d '\n' > secrets/mailfathom-database-password
 #   chmod 444 secrets/postgres-superuser-password secrets/mailfathom-database-password
@@ -32,9 +33,10 @@
 # mount, so that account needs the execute bit on it — at 0700 every secret reference fails to resolve however the files
 # inside are permissioned — while ./secrets is mounted nowhere and its 0700 is what keeps other users on the host out.
 # The files are read rather than listed, so 0444 is right and 0600 reads to MailFathom as an unresolvable reference.
-# ./config is mounted the same way and is listed rather than opened by name, so it needs read as well as execute (0755,
-# which the checkout carries) and its *.json files need to be readable (0644). A umask of 077 produces a deployment that
-# does not start. See docs/operations/deployment-compose.md for the whole reasoning.
+# ./config is mounted the same way and is listed rather than opened by name, so it needs read as well as execute (0755)
+# and its *.json files need to be readable (0644). Git records no directory mode, so that one is set rather than assumed:
+# a clone made under a strict umask leaves a directory the container cannot list, and a umask of 077 produces a
+# deployment that does not start. See docs/operations/deployment-compose.md for the whole reasoning.
 
 ### The image
 #

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -6,7 +6,8 @@
 # permissioned and never appears in another process's environment block. Create these three before the first start:
 #
 #   mkdir -p secrets/mailfathom
-#   chmod 700 secrets secrets/mailfathom
+#   chmod 700 secrets
+#   chmod 711 secrets/mailfathom
 #   openssl rand -base64 33 | tr -d '\n' > secrets/postgres-superuser-password
 #   openssl rand -base64 33 | tr -d '\n' > secrets/mailfathom-database-password
 #   chmod 444 secrets/postgres-superuser-password secrets/mailfathom-database-password
@@ -25,9 +26,15 @@
 # whose mailboxes all authenticate with a password needs no key and starts without one. See
 # docs/operations/secret-provisioning.md for the whole contract.
 #
-# The directory restricts access and the files are readable, not the other way round: MailFathom runs as an unprivileged
-# account that is nobody's host user, and Compose bind-mounts a secret with the host's own permissions rather than
-# applying `mode`. A 0600 file reads to MailFathom as an unresolvable secret reference.
+# What is mounted has to be reachable by the container's own account; what is not mounted is what restricts access.
+# MailFathom runs as an unprivileged account that is nobody's host user and holds no capability to override a mode with,
+# and Compose bind-mounts with the host's own permissions rather than applying `mode`. ./secrets/mailfathom is a bind
+# mount, so that account needs the execute bit on it — at 0700 every secret reference fails to resolve however the files
+# inside are permissioned — while ./secrets is mounted nowhere and its 0700 is what keeps other users on the host out.
+# The files are read rather than listed, so 0444 is right and 0600 reads to MailFathom as an unresolvable reference.
+# ./config is mounted the same way and is listed rather than opened by name, so it needs read as well as execute (0755,
+# which the checkout carries) and its *.json files need to be readable (0644). A umask of 077 produces a deployment that
+# does not start. See docs/operations/deployment-compose.md for the whole reasoning.
 
 ### The image
 #

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -58,13 +58,15 @@ cd MailFathom/deploy/compose
 cp .env.example .env
 
 mkdir -p secrets/mailfathom
-chmod 700 secrets secrets/mailfathom
+chmod 700 secrets                # not mounted anywhere; this is what keeps other host users out
+chmod 711 secrets/mailfathom     # bind-mounted, so uid 1654 needs to traverse it
 openssl rand -base64 33 | tr -d '\n' > secrets/postgres-superuser-password
 openssl rand -base64 33 | tr -d '\n' > secrets/mailfathom-database-password
 chmod 444 secrets/postgres-superuser-password secrets/mailfathom-database-password
 
 cp config/10-mailfathom.json.example config/10-mailfathom.json
 $EDITOR config/10-mailfathom.json
+chmod 644 config/10-mailfathom.json          # after the editor, which may rewrite it under your umask
 
 docker compose up -d postgres    # creates the role, the database, and the vector extension
 # apply mailfathom-schema-<version>.sql — the guide below has the command

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -60,6 +60,7 @@ cp .env.example .env
 mkdir -p secrets/mailfathom
 chmod 700 secrets                # not mounted anywhere; this is what keeps other host users out
 chmod 711 secrets/mailfathom     # bind-mounted, so uid 1654 needs to traverse it
+chmod 755 config                 # bind-mounted and listed, so it needs read too — a clone's umask decides this
 openssl rand -base64 33 | tr -d '\n' > secrets/postgres-superuser-password
 openssl rand -base64 33 | tr -d '\n' > secrets/mailfathom-database-password
 chmod 444 secrets/postgres-superuser-password secrets/mailfathom-database-password

--- a/docs/operations/container-image.md
+++ b/docs/operations/container-image.md
@@ -163,12 +163,13 @@ database with DDL. What a released installation applies is a file beside the ima
 `mailfathom-schema-<version>.sql`, attached to the release — and running it is an explicit operator action each
 deployment page describes.
 
-The role that applies it needs more privilege than the service's: the schema installs the `vector` extension, which
-PostgreSQL does not permit an ordinary role to create. That asymmetry is why the step is separate, and why a command
-inside this image would be the wrong shape for it whatever else it cost — the credentials this process runs with are
-not the ones that may run DDL. Grant the service a role that can read and write rows and nothing more, and give the
-schema step a role that can do the rest. The Compose deployment installs the extension during initialization, while a
-superuser is still connected, so neither of its roles has to be one.
+Applying it can need more privilege than serving does: the schema installs the `vector` extension, which PostgreSQL
+does not permit an ordinary role to create. That asymmetry is why the step is separate, and why a command inside this
+image would be the wrong shape for it whatever else it cost — the credentials this process runs with are not the ones
+that decide what may run DDL. Where the extension is installed out of band the asymmetry disappears and one role can
+both apply the schema and serve, which is what the Compose deployment does during initialization while a superuser is
+still connected; where it is not, give the schema step a role that may create an extension and grant the service one
+that can read and write rows and nothing more.
 
 [Applying the database schema](database-schema.md) is the whole path, including the ownership grants a separate role
 leaves behind and the three startup failures a schema problem reports.

--- a/docs/operations/database-schema.md
+++ b/docs/operations/database-schema.md
@@ -44,8 +44,7 @@ redirection, and no page here has to be rewritten when a release is cut.
 
 ## The role that applies it
 
-**It needs privileges the service's role does not, and it should not be the service's role.** Two facts drive that,
-and both outlive whatever runs the SQL.
+**Two facts decide which role runs the SQL, and both outlive whatever does.**
 
 **The `vector` extension.** The schema installs it, and PostgreSQL does not permit an ordinary role to create an
 extension. Either install it out of band, while a superuser is connected — which is what the Compose deployment's
@@ -53,9 +52,22 @@ initialization script does, so its `CREATE EXTENSION IF NOT EXISTS vector` then 
 schema step as a role that may.
 
 **Ownership follows whoever runs the DDL.** PostgreSQL makes the role that created a table, sequence, or index its
-owner, and ownership grants nothing to anybody else. A schema applied by `mailfathom_migrator` therefore leaves
-MailFathom failing on permission errors against a schema that plainly exists. Grant the service's role the privileges
-it needs, and set default privileges so the next migration's objects are covered too:
+owner, and ownership grants nothing to anybody else. A schema applied by any role but the one MailFathom connects as
+therefore leaves it failing on permission errors against a schema that plainly exists — the superuser included, which
+is the easiest version of this mistake to make.
+
+That leaves two arrangements, and a deployment is one or the other.
+
+**One role applies and serves.** The extension is installed out of band, the serving role owns everything the script
+created, and no grant is needed. This is the Docker Compose deployment:
+`postgres/10-create-mailfathom-database.sh` creates the database owned by `mailfathom` and installs `vector` while a
+superuser is still connected, precisely so that the schema step afterwards is an ordinary role's work. [Applying it
+there](#docker-compose) is the command, and it connects as `mailfathom`.
+
+**A separate migrator applies it.** `mailfathom_migrator` owns what it created and `mailfathom` serves, which is the
+shape to reach for wherever the privilege to alter the schema and the privilege to serve requests are meant to differ.
+It costs the grants below: grant the service's role the privileges it needs, and set default privileges so the next
+migration's objects are covered too.
 
 ```sql
 GRANT USAGE ON SCHEMA public TO mailfathom;
@@ -123,18 +135,23 @@ Do not add `--single-transaction`. The script issues its own transaction stateme
 
 ### Docker Compose
 
-The database publishes no port, and the superuser password is already mounted inside its container, so the shortest
-route is to run psql there and hand it the script on standard input. Nothing puts the credential on a command line
-that another process could read:
+The database publishes no port, and both database credentials are already mounted inside its container, so the
+shortest route is to run psql there and hand it the script on standard input. Nothing puts the credential on a command
+line that another process could read:
 
 ```bash
 cd deploy/compose
 
 docker compose exec --no-TTY postgres sh -c \
-  'PGPASSWORD="$(cat /run/secrets/postgres-superuser-password)" exec psql \
-     --username postgres --dbname "$MAILFATHOM_DATABASE" --set ON_ERROR_STOP=on' \
+  'PGPASSWORD="$(cat /run/secrets/mailfathom-database-password)" exec psql \
+     --username "$MAILFATHOM_DATABASE_ROLE" --dbname "$MAILFATHOM_DATABASE" --set ON_ERROR_STOP=on' \
   < 'mailfathom-schema-<version>.sql'
 ```
+
+**As `mailfathom`, never as `postgres`.** This is the single-role arrangement above, so the role that applies the
+schema is the role that serves requests, and it is the one the objects have to end up owned by. Applying the script as
+the superuser instead leaves MailFathom refusing to start with `42501: permission denied for table
+__EFMigrationsHistory` — the schema is there and unreadable to the only role that needs it.
 
 [Deploying with Docker Compose](deployment-compose.md#starting) is where that step sits in the sequence.
 

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -33,6 +33,7 @@ cp .env.example .env
 mkdir -p secrets/mailfathom
 chmod 700 secrets
 chmod 711 secrets/mailfathom
+chmod 755 config
 
 openssl rand -base64 33 | tr -d '\n' > secrets/postgres-superuser-password
 openssl rand -base64 33 | tr -d '\n' > secrets/mailfathom-database-password
@@ -56,7 +57,9 @@ startup failure when it is missed:
   quotes the path it was handed — which makes a mode the least visible way to break this deployment. `0711` is what
   the secrets directory takes: traversable by that account, and still not listable by anything but you. The
   configuration directory is *listed* rather than opened by name, because MailFathom layers in every `*.json` it finds
-  there, so that one needs read as well — `0755`, which is what the checkout already carries.
+  there, so that one needs read as well, which is the `0755` above. It is set rather than assumed because Git records
+  no directory mode: `config/` arrives with whatever `umask` the clone ran under, and a strict one leaves a directory
+  the container cannot list.
 - **The files inside both are read, so they have to be readable.** `0444` for a secret and `0644` for a configuration
   file. A `0600` or `0400` file presents to MailFathom as a secret reference that cannot be resolved, or crashes
   startup naming the configuration file it could not open, so a `umask` of `077` produces a deployment that will not

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -7,6 +7,19 @@ runs when an operator asks for it. It is the shape to use for self-hosting on on
 
 Everything below assumes `deploy/compose/` as the working directory.
 
+**Every command here is `docker compose`, and Docker is what this deployment is verified on.** Nothing in
+`compose.yaml` is Docker-specific and the same file runs under `podman compose`, with two rootless-Podman facts worth
+knowing before you start, because neither announces itself:
+
+- The account inside the container maps to a subordinate uid rather than to yours, so the file modes below are what
+  makes the deployment start rather than a hardening preference. They are the modes Docker needs as well and for the
+  same reason — the account is nobody's host user in either runtime — and getting them right is also what keeps a
+  `--userns` mapping out of it, which matters because `podman-compose` puts a project's services in one pod and
+  `--userns` cannot be combined with a pod.
+- Rootless Podman publishes no port below 1024 until `net.ipv4.ip_unprivileged_port_start` allows it. This deployment
+  publishes 8080 and 8081, so what meets that limit is a reverse proxy terminating TLS on 443 in front of MailFathom
+  rather than MailFathom itself.
+
 ## Before the first start
 
 Three files have to exist. Two are database credentials the Compose file mounts as secrets; the third is the
@@ -18,7 +31,8 @@ cd deploy/compose
 cp .env.example .env
 
 mkdir -p secrets/mailfathom
-chmod 700 secrets secrets/mailfathom
+chmod 700 secrets
+chmod 711 secrets/mailfathom
 
 openssl rand -base64 33 | tr -d '\n' > secrets/postgres-superuser-password
 openssl rand -base64 33 | tr -d '\n' > secrets/mailfathom-database-password
@@ -26,14 +40,32 @@ chmod 444 secrets/postgres-superuser-password secrets/mailfathom-database-passwo
 
 cp config/10-mailfathom.json.example config/10-mailfathom.json
 $EDITOR config/10-mailfathom.json
+chmod 644 config/10-mailfathom.json          # after the editor, which may have rewritten the file under your umask
 ```
 
-**The directory restricts access and the files are readable — not the other way round.** MailFathom runs as an
-unprivileged account inside the container that corresponds to no user on the host, and Compose bind-mounts a secret
-with the host's own permissions: outside Swarm it ignores `mode`, `uid`, and `gid`. A `0600` file therefore presents
-to MailFathom as a secret reference that cannot be resolved, and startup fails naming the setting. The `0700` directory
-is what keeps other users on the host out; only root and you can reach through it at all. Every file you add under
-`secrets/mailfathom/` needs the same treatment.
+**What is mounted has to be reachable by the container's own account; what is not mounted is what restricts access.**
+MailFathom runs as an unprivileged account inside the container that corresponds to no user on the host — uid 1654,
+with every capability dropped, so it holds no `DAC_OVERRIDE` to override a mode with. Compose bind-mounts with the
+host's own permissions: outside Swarm it ignores `mode`, `uid`, and `gid`. Three consequences follow, and each is a
+startup failure when it is missed:
+
+- **`secrets/mailfathom` and `config` are the bind mounts, so that account needs the execute bit on both.** At `0700`
+  it has none, and a directory is checked before the files inside it are, so every secret reference under it fails to
+  resolve however those files are permissioned. What startup reports is material that could not be found rather than a
+  permission error, because MailFathom collapses every file-system failure into one result so that no diagnostic
+  quotes the path it was handed — which makes a mode the least visible way to break this deployment. `0711` is what
+  the secrets directory takes: traversable by that account, and still not listable by anything but you. The
+  configuration directory is *listed* rather than opened by name, because MailFathom layers in every `*.json` it finds
+  there, so that one needs read as well — `0755`, which is what the checkout already carries.
+- **The files inside both are read, so they have to be readable.** `0444` for a secret and `0644` for a configuration
+  file. A `0600` or `0400` file presents to MailFathom as a secret reference that cannot be resolved, or crashes
+  startup naming the configuration file it could not open, so a `umask` of `077` produces a deployment that will not
+  start.
+- **`secrets/` itself is mounted nowhere**, so its `0700` is the whole of the access control: only root and you reach
+  through it at all, and that holds for `secrets/mailfathom/` underneath it whatever the mount needs. Loosening the
+  mounted directory by one bit therefore costs nothing on the host.
+
+Every file you add under `secrets/mailfathom/` needs the same `0444`.
 
 `.env`, `secrets/`, and `config/*.json` are all ignored by Git. The two `.example` files are tracked and contain
 placeholders only.
@@ -104,15 +136,24 @@ build defines: 20260731132336_Initial.
 ```
 
 The step is `mailfathom-schema-<version>.sql`, attached to the release you are installing. The database publishes no
-port, and the superuser password is already mounted inside its container, so the shortest route is to run psql there
-and hand it the script on standard input — which also keeps the credential off a command line:
+port, and both database credentials are already mounted inside its container, so the shortest route is to run psql
+there and hand it the script on standard input — which also keeps the credential off a command line:
 
 ```bash
 docker compose exec --no-TTY postgres sh -c \
-  'PGPASSWORD="$(cat /run/secrets/postgres-superuser-password)" exec psql \
-     --username postgres --dbname "$MAILFATHOM_DATABASE" --set ON_ERROR_STOP=on' \
+  'PGPASSWORD="$(cat /run/secrets/mailfathom-database-password)" exec psql \
+     --username "$MAILFATHOM_DATABASE_ROLE" --dbname "$MAILFATHOM_DATABASE" --set ON_ERROR_STOP=on' \
   < 'mailfathom-schema-<version>.sql'
 ```
+
+**As `mailfathom`, never as `postgres`.** PostgreSQL makes the role that ran the DDL the owner of everything it
+created, and ownership grants nothing to anybody else, so a schema applied by the superuser leaves MailFathom refusing
+to start against a schema that plainly exists — `42501: permission denied for table __EFMigrationsHistory`, reported
+as a schema of unknown shape. This deployment has one role that both applies the schema and serves requests, which is
+exactly what the initialization script's out-of-band `CREATE EXTENSION` buys: the schema artifact's own
+`CREATE EXTENSION IF NOT EXISTS vector` then finds the extension already present rather than needing a privilege
+`mailfathom` does not have. [The role that applies it](database-schema.md#the-role-that-applies-it) states the other
+arrangement and what it costs.
 
 Read the SQL before applying it, and take a backup first. The script is idempotent, so running it against a database
 that already carries some of its migrations applies only what is missing. [Applying the database
@@ -179,8 +220,8 @@ running one keeps serving against a schema that is ahead.
 
 ```bash
 docker compose exec --no-TTY postgres sh -c \
-  'PGPASSWORD="$(cat /run/secrets/postgres-superuser-password)" exec psql \
-     --username postgres --dbname "$MAILFATHOM_DATABASE" --set ON_ERROR_STOP=on' \
+  'PGPASSWORD="$(cat /run/secrets/mailfathom-database-password)" exec psql \
+     --username "$MAILFATHOM_DATABASE_ROLE" --dbname "$MAILFATHOM_DATABASE" --set ON_ERROR_STOP=on' \
   < 'mailfathom-schema-<version>.sql'                            # the version being upgraded to
 
 docker compose pull                                        # or: docker compose build


### PR DESCRIPTION
Closes #571

Two operator-facing instructions in the Compose deployment were wrong, and following them as written produced a
deployment that could not start. Neither is a code change; `compose.yaml`, the Helm chart, and the source are untouched.

## The schema was applied as the wrong role

`deployment-compose.md` § *Starting* and § *Upgrading*, and `database-schema.md` § *Docker Compose*, all connected as the
superuser. PostgreSQL makes the role that ran the DDL the owner and ownership grants nothing to anybody else, so every
table belonged to `postgres` while MailFathom connects as `mailfathom`, and the host failed its own startup gate.

All three copies now apply the schema as `$MAILFATHOM_DATABASE_ROLE` with the database password the `postgres` container
already mounts — no new plumbing, because `compose.yaml` already puts both the role name and that secret in that
container.

`database-schema.md` § *The role that applies it* stated the two-role arrangement as the only one and then said two
sections later that Compose is single-role. It now presents both arrangements and names which one this deployment is,
and `container-image.md`'s paragraph on the same privilege asymmetry follows it.

## The documented directory mode was unreachable — confirmed, not predicted

`chmod 700 secrets secrets/mailfathom` makes the bind mount unreachable. The process inside runs as uid 1654 with
`cap_drop: ALL`, so it holds no `DAC_OVERRIDE`, and a directory owned by the host user with no execute bit for others
cannot be traversed however the files inside are permissioned — the directory is checked first.

The mounted directory is now `0711`; the unmounted `secrets/` keeps its `0700`, which is where the host-side access
control actually lives, so nothing is loosened that was protecting anything. The configuration file gets an explicit
`0644` for the same reason — it is bind-mounted too, and a `umask` of `077` otherwise crashes startup on a file it
cannot open. `.env.example` and `deploy/docker/README.md` carry the same modes, since both repeat them.

Worth naming because it is what makes this hard to diagnose: a mode failure is reported as **material that could not be
found**, not as a permission error, because `FileSystemSecretFileReader` deliberately collapses every file-system
failure into one result so that no diagnostic quotes the path it was handed. The page now says so.

## The Podman claim

Narrowed rather than expanded. `deployment-compose.md` now opens by saying every command is `docker compose` and that
Docker is what the deployment is verified on, and names the two rootless-Podman facts that actually bite: the container
account is a subordinate uid — which is *why* the modes above matter and what keeps a `--userns` mapping out of it,
given that `podman-compose` puts a project in a pod and `--userns` cannot be combined with one — and the sub-1024 port
limit, which the reverse proxy meets rather than MailFathom. `secret-provisioning.md` § *Docker or Podman Compose* is
left alone: its claim is that Compose mounts a secret at `/run/secrets/<name>`, which is true of both.

## Verification

Run end to end on **Docker 29.7.2**, `deploy/compose/` from an empty state, using only what the page says. Three
values were appended to `.env` so the run would not collide with anything else on a shared daemon
(`COMPOSE_PROJECT_NAME`, the two published ports, the volume name); nothing else deviates.

Both defects were reproduced first, against the instructions as they read before this change:

| | |
| --- | --- |
| `0700` on `secrets/mailfathom` | both references fail — `MailSynchronization:Accounts:0:Secrets:Password — the secret reference could not be resolved [MaterialNotFound]` |
| `0711`, schema applied as `postgres` | `DatabaseSchemaStateUnreadableException` → `Npgsql.PostgresException 42501: permission denied for table __EFMigrationsHistory` |
| `0600` on `config/10-mailfathom.json` | `System.UnauthorizedAccessException: Access to the path '/etc/mailfathom/config/10-mailfathom.json' is denied` |

And with the corrected instructions, from `cp .env.example .env` to a serving container:

- schema applied as `mailfathom`, exit 0, `CREATE EXTENSION IF NOT EXISTS vector` finding the extension already present
- all 14 `public` tables owned by `mailfathom`
- `/started`, `/health`, and `/alive` all `Healthy`

The first pass needed a local `compose.override.yaml` clearing `ASPNETCORE_HTTP_PORTS`, because #569 was still open.
That merged as #575 while this was in progress, so the final run above was made on a branch rebased onto it, with **no
override file at all**.

`scripts/verify-full.sh` green — 3630 tests, 0 failed, line coverage 94.8%. `scripts/build-docs-site.sh` reports no new
link warning.

## Operator action

**None.** Nothing shipped changes and a running deployment is unaffected. One built from the previous pages is repaired
by re-applying the schema as the service's role, or by granting it the privileges § *The role that applies it* lists.
