### PR TITLE
[#572] Let the MCP challenge scheme authenticate nobody

### DIFF
--- a/src/Host/Security/Mcp/McpTransportSecurityExtensions.cs
+++ b/src/Host/Security/Mcp/McpTransportSecurityExtensions.cs
@@ -99,7 +99,19 @@ internal static class McpTransportSecurityExtensions
     }
 
     /// <summary>Names the registered scheme that answers a request presenting no credential at all.</summary>
-    /// <remarks>It has to be a scheme this endpoint actually registered, or the challenge forwards to nothing. All three challenge with a bearer scheme, so which one answers decides what a client is told only in the OAuth case, where the challenge carries the metadata document.</remarks>
+    /// <remarks>
+    /// <para>
+    /// It has to be a scheme this endpoint actually registered, or the challenge forwards to nothing. All three
+    /// challenge with a bearer scheme, so which one answers decides what a client is told only in the OAuth case, where
+    /// the challenge carries the metadata document.
+    /// </para>
+    /// <para>
+    /// It is also what a credential this endpoint cannot place authenticates against, so whichever scheme is named here
+    /// must authenticate nobody rather than judge something. All three do: the API key and assertion handlers read no
+    /// credential out of such a request, and the MCP scheme performs no authentication at all once
+    /// <see cref="AddProtectedResourceMetadataScheme" /> has cleared the forwarding the SDK sets by default.
+    /// </para>
+    /// </remarks>
     private static string ChallengeSchemeFor(McpEndpointOptions endpointSettings)
     {
         if (endpointSettings.AllowsOAuth)
@@ -126,6 +138,14 @@ internal static class McpTransportSecurityExtensions
 
         authentication.AddMcp(mcpOptions =>
         {
+            // This scheme answers the challenge and publishes the document; it judges no credential, and its handler
+            // authenticates nobody by design. The SDK's options nevertheless forward authentication to JwtBearer's own
+            // default scheme name, which this host never registers — its validators are named for the authorization
+            // server each one speaks for. Every request that presents nothing this endpoint can place is routed here,
+            // starting with the unauthenticated request every MCP client opens with, so leaving the forwarding in place
+            // answers discovery with a fault instead of the refusal that carries the pointer below.
+            mcpOptions.ForwardAuthenticate = null;
+
             // Absolute and configured, never derived from the request. Left unset, the SDK composes both this address
             // and the resource it advertises from the request's scheme and Host header, so a deployment behind a proxy
             // would tell each client to authenticate for whichever name that client arrived under.

--- a/src/Host/Security/Transport/TransportSecurityExtensions.cs
+++ b/src/Host/Security/Transport/TransportSecurityExtensions.cs
@@ -45,7 +45,7 @@ internal static class TransportSecurityExtensions
     /// <param name="apiKeys">The keys a request may present one of, empty where the surface accepts none.</param>
     /// <param name="publicKeys">The client public keys a signed assertion may be verified against, empty where the surface accepts no assertion.</param>
     /// <param name="oauthMethods">What a token must prove, one entry per configured OAuth block, empty where the surface accepts no access token.</param>
-    /// <param name="challengeSchemeName">The scheme answering a request that presented no credential at all.</param>
+    /// <param name="challengeSchemeName">The scheme answering a request that presented no credential this surface can place, which is both what authenticates it and what challenges it.</param>
     /// <returns>The authentication builder, so a surface can add schemes only it needs.</returns>
     /// <exception cref="ArgumentNullException">Thrown when any reference argument is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="surface" /> is the struct default.</exception>
@@ -204,6 +204,9 @@ internal static class TransportSecurityExtensions
 
                 // A challenge is answered by one scheme whichever credential was presented, because a request that has
                 // nothing to authenticate with has told us nothing about which kind of credential it was going to use.
+                // That is the same scheme the selector above routes such a request to, which is what obliges it to
+                // authenticate nobody: authenticating and challenging are different jobs, and a scheme that forwarded
+                // the first somewhere would answer a fault where the pipeline expects a refusal it can challenge.
                 policyOptions.ForwardChallenge = challengeSchemeName;
             });
     }

--- a/tests/Host.UnitTests/Security/Endpoints/AdminTransportSecurityExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Endpoints/AdminTransportSecurityExtensionsTests.cs
@@ -1,0 +1,73 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Access;
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Security.Endpoints;
+using MailFathom.Host.Security.Transport;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Security.Endpoints;
+
+/// <summary>Covers what the administrative endpoint's composition decides about the credentials it accepts.</summary>
+/// <remarks>
+/// This surface reaches the same routing scheme through the same abstraction the MCP endpoint does, so the question a
+/// credential-less request raises there is a question here too — and it is answered by a different scheme, which is why
+/// it is asserted rather than inferred from the other surface passing.
+/// </remarks>
+public sealed class AdminTransportSecurityExtensionsTests
+{
+    /// <summary>
+    /// Every <c>mfctl login</c> begins with a request holding nothing, and so does every probe of a running deployment.
+    /// The scheme such a request reaches has to authenticate nobody, so the pipeline can challenge; a scheme forwarding
+    /// the question elsewhere answers a fault instead, and a fault is not a posture an operator can log in through.
+    /// This surface names one of its own token validators, which reads no credential out of such a request and forwards
+    /// nothing — but that is a property of the scheme it happens to name rather than of naming one, so it is asserted.
+    /// </summary>
+    [Fact]
+    public async Task AddAdminTransportSecurity_AnOAuthOnlyEndpoint_AuthenticatesNobodyForARequestCarryingNoCredential()
+    {
+        // Arrange
+        using var composed = ComposeOAuthOnlyEndpoint();
+
+        var request = new DefaultHttpContext { RequestServices = composed };
+        request.Request.Scheme = "https";
+        request.Request.Host = new HostString("mail.example.test");
+
+        // Act
+        var result = await composed
+            .GetRequiredService<IAuthenticationService>()
+            .AuthenticateAsync(request, TransportSurface.Admin.RoutingSchemeName);
+
+        // Assert
+        Assert.True(result.None);
+    }
+
+    private static ServiceProvider ComposeOAuthOnlyEndpoint()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var endpointSettings = new AdminEndpointOptions { Enabled = true };
+        var oauthSettings = new OAuthValidationOptions
+        {
+            Resource = $"https://mail.example.test:8090{AdminEndpointOptions.RoutePrefix}",
+        };
+
+        oauthSettings.AuthorizationServers.Add(new AuthorizationServerOptions
+        {
+            Name = "workforce",
+            Issuer = "https://sso.example.test",
+        });
+
+        endpointSettings.Authentication.Add(new TransportAuthenticationOptions { OAuth = oauthSettings });
+
+        services.AddAdminTransportSecurity(endpointSettings);
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/tests/Host.UnitTests/Security/Mcp/McpTransportSecurityExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Mcp/McpTransportSecurityExtensionsTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Buffers.Text;
+using System.Text;
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Mcp;
@@ -9,6 +11,7 @@ using MailFathom.Host.Security.Transport;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Cors.Infrastructure;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
@@ -23,6 +26,8 @@ namespace MailFathom.Host.UnitTests.Security.Mcp;
 /// </remarks>
 public sealed class McpTransportSecurityExtensionsTests
 {
+    private const string McpResource = "https://mail.example.test/mcp";
+
     /// <summary>
     /// The challenge names where to authorize and which scopes are required, and a browser cannot read a response header
     /// the policy does not expose. Without it the one answer that tells a page how to proceed is the one it cannot see.
@@ -76,6 +81,128 @@ public sealed class McpTransportSecurityExtensionsTests
         Assert.Contains(schemes, scheme => scheme.Name == TransportSurface.Mcp.ClientAssertionSchemeName);
         Assert.DoesNotContain(schemes, scheme => scheme.Name == TransportSurface.Mcp.ApiKeySchemeName);
     }
+
+    /// <summary>
+    /// The first request every MCP client makes carries no credential, and so does every request that presents something
+    /// this endpoint cannot place. Both reach the scheme that answers the challenge, so that scheme has to authenticate
+    /// nobody rather than forward the question somewhere. Forwarded, an OAuth-only endpoint answers a fault instead of a
+    /// refusal, which is the whole of what a client sees: discovery never starts and no client reaches the point of being
+    /// told how to authorize.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("Bearer an-opaque-credential-nobody-issued")]
+    [InlineData("Bearer not.a.token")]
+    public async Task AddMcpTransportSecurity_AnOAuthOnlyEndpoint_AuthenticatesNobodyForACredentialItCannotPlace(
+        string? authorizationHeaderValue)
+    {
+        // Arrange
+        using var composed = ComposeOAuthOnlyEndpoint();
+        var request = RequestTo(composed, authorizationHeaderValue);
+
+        // Act
+        var result = await composed
+            .GetRequiredService<IAuthenticationService>()
+            .AuthenticateAsync(request, TransportSurface.Mcp.RoutingSchemeName);
+
+        // Assert
+        Assert.True(result.None);
+    }
+
+    /// <summary>
+    /// And what that request is answered with. The pointer is how a client finds the authorization server at all, so a
+    /// challenge carrying anything else leaves an endpoint that refuses correctly and is still unreachable.
+    /// </summary>
+    [Fact]
+    public async Task AddMcpTransportSecurity_AnOAuthOnlyEndpoint_ChallengesWithThePointerToItsMetadataDocument()
+    {
+        // Arrange
+        using var composed = ComposeOAuthOnlyEndpoint();
+        var request = RequestTo(composed, authorizationHeaderValue: null);
+
+        // Act
+        await composed
+            .GetRequiredService<IAuthenticationService>()
+            .ChallengeAsync(request, TransportSurface.Mcp.RoutingSchemeName, properties: null);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status401Unauthorized, request.Response.StatusCode);
+        Assert.Equal(
+            $"Bearer resource_metadata=\"{ProtectedResourceMetadataAddress.AddressFor(McpResource)}\"",
+            request.Response.Headers.WWWAuthenticate);
+    }
+
+    /// <summary>
+    /// A token naming a configured authorization server is judged by that server's validator rather than by the scheme
+    /// answering the challenge, which is what keeps the routing above from swallowing the credentials the endpoint does
+    /// accept. The validator is asked for by name and reached by name, so both halves are read: a scheme the routing
+    /// names and the registration never added is the shape this whole defect took.
+    /// </summary>
+    [Fact]
+    public async Task AddMcpTransportSecurity_AnOAuthOnlyEndpoint_RoutesAConfiguredIssuersTokenToThatIssuersValidator()
+    {
+        // Arrange
+        using var composed = ComposeOAuthOnlyEndpoint();
+        var routing = composed
+            .GetRequiredService<IOptionsMonitor<PolicySchemeOptions>>()
+            .Get(TransportSurface.Mcp.RoutingSchemeName);
+
+        var request = RequestTo(composed, TokenIssuedBy("https://sso.example.test"));
+
+        // Act
+        var selectedScheme = routing.ForwardDefaultSelector?.Invoke(request);
+
+        // Assert
+        Assert.Equal(TransportSurface.Mcp.OAuthSchemeNameFor("workforce"), selectedScheme);
+        Assert.NotNull(await composed
+            .GetRequiredService<IAuthenticationSchemeProvider>()
+            .GetSchemeAsync(selectedScheme!));
+    }
+
+    private static ServiceProvider ComposeOAuthOnlyEndpoint()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var endpointSettings = new McpEndpointOptions { Enabled = true };
+        var oauthSettings = new OAuthValidationOptions { Resource = McpResource };
+        oauthSettings.AuthorizationServers.Add(new AuthorizationServerOptions
+        {
+            Name = "workforce",
+            Issuer = "https://sso.example.test",
+        });
+
+        endpointSettings.Authentication.Add(new TransportAuthenticationOptions { OAuth = oauthSettings });
+
+        services.AddMcpTransportSecurity(endpointSettings);
+
+        return services.BuildServiceProvider();
+    }
+
+    private static DefaultHttpContext RequestTo(IServiceProvider composed, string? authorizationHeaderValue)
+    {
+        var request = new DefaultHttpContext { RequestServices = composed };
+        request.Request.Scheme = "https";
+        request.Request.Host = new HostString("mail.example.test");
+
+        if (authorizationHeaderValue is not null)
+        {
+            request.Request.Headers.Authorization = authorizationHeaderValue;
+        }
+
+        return request;
+    }
+
+    /// <summary>Composes a token naming an issuer, which is all the routing reads of one before a validator is chosen.</summary>
+    private static string TokenIssuedBy(string issuer)
+    {
+        var payload = Encode($$"""{"iss":"{{issuer}}","sub":"9f2c"}""");
+
+        return $"Bearer {Encode("""{"alg":"RS256","typ":"JWT"}""")}.{payload}.signature";
+    }
+
+    private static string Encode(string document) =>
+        Base64Url.EncodeToString(Encoding.UTF8.GetBytes(document));
 
     private static McpEndpointOptions BrowserFacingEndpoint()
     {


### PR DESCRIPTION
## What this fixes

An MCP endpoint configured with `OAuth` and no other method threw `500` on every request that carried
no credential it could place — the unauthenticated request every MCP client opens with, and every
health probe on the process. OAuth on `/mcp` was therefore unusable end to end: discovery never
started, so no client reached the point of being told how to authorize.

## The cause, confirmed against the package

The issue asked for the third hop to be verified before fixing, because the fix depends on whether the
forwarding default is the SDK's or something this repository sets. **It is the SDK's**, in
`ModelContextProtocol.AspNetCore` 2.0.0:

```csharp
public McpAuthenticationOptions()
{
    // "Bearer" is JwtBearerDefaults.AuthenticationScheme, but we don't have a reference to the JwtBearer package here.
    ForwardAuthenticate = "Bearer";
    Events = new McpAuthenticationEvents();
}
```

The same file's handler already answers the question correctly on its own — `HandleAuthenticateAsync`
returns `AuthenticateResult.NoResult()` under the comment *"if no forwarding is configured, this
handler doesn't perform authentication"*. The constructor then configures forwarding over it, to a
scheme this host never registers: its validators are named `MailFathom:Mcp:OAuth:<name>`, one per
authorization server.

So the defect was where the issue placed it — a scheme chosen for its **challenge** being used as the
**authenticate** target — and the smallest correct correction is to stop the scheme forwarding a
question it was never meant to answer.

## The change

One line where the scheme is registered, plus the reasoning recorded in the two places a reader would
look:

- `McpTransportSecurityExtensions.AddProtectedResourceMetadataScheme` clears `ForwardAuthenticate`.
- `ChallengeSchemeFor` now states the second obligation the challenge scheme carries — it is also what
  an unplaceable credential authenticates against, so it must authenticate nobody.
- `TransportSecurityExtensions.AddRoutingScheme` records the same invariant beside `ForwardChallenge`,
  which is where the two jobs meet.

`CredentialSchemeSelector`'s own remarks already claimed this was true — *"the request reaches a scheme
that authenticates nobody and answers with the challenge"*. The claim now holds.

## Surfaces covered

Both, and the administrative one was **checked rather than assumed**, as the acceptance asked.

| Surface, OAuth-only | Scheme an unplaceable credential reaches | Before | After |
|---|---|---|---|
| MCP | `McpAuth` (carries the RFC 9728 pointer) | throws | no result, then `401` with the pointer |
| Admin | its own first token validator | no result | unchanged |

The administrative endpoint was never affected: `AdminTransportSecurityExtensions.ChallengeSchemeFor`
names one of its own JWT validators, which reads no credential out of a credential-less request and
forwards nothing. That is a property of the scheme it happens to name rather than of naming one, so it
is now pinned by a test instead of left to inspection.

**The probes come back with the MCP endpoint.** They carry no credential by design and are
authenticated against the application default scheme — pinned to the MCP surface's routing scheme —
so they took the same path on the same process. That is the `null` case of the first test below.

## Tests, and where they live

`Host.UnitTests`, driving the **composed authentication pipeline** through the real
`IAuthenticationService` over the container `AddMcpTransportSecurity` builds — not
`CredentialSchemeSelector` in isolation. That distinction is the point: the selector test passes today
and passed through the release, because the selector returns exactly what it should; what no test
reached was what the scheme it named did next. Before the fix the three MCP cases failed with the
deployment's exact exception:

```
System.InvalidOperationException : No authentication handler is registered for the scheme 'Bearer'.
The registered schemes are: MailFathom:Mcp:Transport, MailFathom:Mcp:OAuth:workforce, McpAuth.
```

- an OAuth-only MCP endpoint authenticates nobody for no credential, an opaque bearer, and a
  token-shaped credential naming no configured issuer;
- it challenges with `Bearer resource_metadata="…/.well-known/oauth-protected-resource/mcp"`;
- a token naming a configured issuer still routes to that issuer's validator, and that scheme is one
  the registration actually added — a name the routing produces and the registration never added is
  the shape this whole defect took;
- an OAuth-only administrative endpoint authenticates nobody for a credential-less request.

**Where the discovery test belongs — the call this pull request was asked to make and state:** at host
level, not in the integration suite. The MailFathom half of discovery — the `401`, the pointer, the
metadata document's contents — needs no authorization server, and it is covered here and in
`PublishedOAuthMetadataTests`. The remaining half, an authorized call, is a signature check against a
real issuer's key set: reaching it would mean a third composed host resource plus a stand-in
authorization server, for a per-run container cost, to prove a token validator that is not what broke.
`tests/AGENTS.md` asks that each integration test be justified by what only real infrastructure can
prove, and this one would not survive that question.

The same reasoning bounds the unit tests: an opaque bearer on the *administrative* surface routes to a
JWT validator and provokes a real metadata fetch, so that case is deliberately absent rather than
overlooked — it would put a network call in the unit suite.

## Documentation

No correction needed, which the issue anticipated and which was verified rather than assumed.
`docs/operations/mcp-endpoint.md` § *OAuth* describes the posture this restores, and
`docs/operations/health-endpoints.md` § *No credential, no origin gate, no rate limit* promises probes
that answer — both now describe what the code does.

## Operator action

**None.** A deployment carrying the unused-`ApiKey` workaround may drop that entry after upgrading; it
was a routing fix rather than a credential anybody presented, and it is no longer needed. No
configuration key, database column, MCP tool contract, or deployment contract changes.

## Not done here, deliberately

Reporting the SDK default upstream, which the issue scopes out of this change. Nothing in
`ModelContextProtocol.AspNetCore` is modified.

Closes #572
