### PR TITLE
[#434] Bound embedding cost, rate, and volume per instance

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -72,6 +72,8 @@ The key is a surrogate UUIDv7 rather than the email and the ordinal together, be
 
 Only a message that yielded text has rows here, and deleting a message cascades to them.
 
+`stored_emails.ChunkedTextTruncatedFromCharacterCount` is where the cut records what it left out: the length the extracted text had when the per-message ceiling stopped the cut short of its end, and null when no ceiling reached that message. It lives on the message rather than on a chunk because it is a fact about the message, and it is stored rather than inferred because a message cut whole and one cut to a ceiling are indistinguishable from their passages alone. [Message chunks](../features/message-chunks.md#the-per-message-ceiling) records what the ceiling is for.
+
 ## Embedding profiles
 
 `embedding_profiles` holds one row per vector space this deployment has embedded into. The row is written by the activation that takes a declared model up and starts spending against it, and its columns are what a stored vector's attribution points at.
@@ -112,6 +114,14 @@ Neither half works alone. PostgreSQL evaluates a check constraint against one ro
 The two references behave differently on delete, and that is the whole erasure story. **The chunk cascades**: a vector hangs on a chunk, a chunk hangs on a stored email, so deleting a message reaches every vector derived from it without a rule anybody has to remember. **The profile restricts**: a profile is what a stored vector's attribution points at, so the schema refuses to remove one while a vector still names it. `ix_email_embeddings_profile` is what a whole generation is read by when a superseded one is removed in bounded batches; without it that read would scan every vector in the table.
 
 `GeneratedAt` records when the vector was produced, which tells a re-embed from an original one apart.
+
+## What a budget period has spent
+
+`embedding_spend_periods` holds one row per budget period, keyed by `PeriodStartsAt` — the instant that period began, which every process derives from the configured period length and the Unix epoch rather than reading from anywhere. `ConsumedInputCharacterCount` is a `bigint` because a period of a mailbox's initial embedding passes a billion characters without difficulty. Nothing allocates a period: the first spend inside one inserts its row and every later spend adds to it.
+
+The table exists rather than the count being derived from the stored vectors, which would need no table at all. A superseded generation has its vectors removed in bounded batches, so a count taken over them would erase the record of a spend that genuinely happened — and the period in which a model change is paid for is exactly the period an operator is watching. It is durable rather than held in memory for the reason the ceiling exists: a process crashing and restarting in a loop would otherwise begin every period again from zero and spend the whole ceiling on each attempt.
+
+The one write is an increment issued as an upsert, in the same transaction as the vectors it paid for. That makes the charge and the vectors one durable fact, and it means two workers spending inside one period add to each other rather than each overwriting a total that was already stale when it was read — which is why the row carries no concurrency token. Nothing hangs off it and nothing cascades into it: a character count and an instant name no message, passage, or vector, so the record of a cost outlives every vector that cost paid for.
 
 ## Outstanding content repair requests
 
@@ -342,6 +352,8 @@ The derived search document is not a lesser classification of the same data. Bod
 The same holds for `email_chunks`, and one thing about it is deliberate: a chunk records the message it came from and the span inside it, and nothing else. The account, folder, sender, recipients, date, and subject a retrieval will want to cite are reached through that message rather than copied onto the passage, so cutting mail into chunks widens no access, export, or erasure surface — it only adds rows the same cascade erases.
 
 `email_embeddings` is the same again, one step further out. A vector is derived from mail content and inherits the source message's classification, retention, access, export, and erasure obligations whole; nothing about being a list of numbers makes it a lesser copy of the words it stands for, and it is not anonymous because it cannot be read back by eye. It carries no text and no coordinates of its own — the chunk it hangs on answers both — and the cascade from that chunk is what makes erasure structural rather than a rule somebody has to remember. No vector, no chunk text, and no digest reaches a log, a metric, a trace, or an error message.
+
+`embedding_spend_periods` holds no personal data either, and its shape is what makes that true rather than a claim about it: a character count and an instant say how much a deployment spent and when, and neither names a message, a passage, or a vector. That is also why it outlives what it recorded — nothing cascades into it, and erasing the mail a period paid to embed leaves the record that the period was paid for.
 
 `embedding_profiles` is the exception on this page: it holds no personal data at all. It describes a model, and the credential that reaches that model is configuration rather than a column here, so nothing in this table is a secret or is derived from anybody's mail.
 

--- a/docs/features/automatic-embedding.md
+++ b/docs/features/automatic-embedding.md
@@ -68,6 +68,23 @@ the resilience pipeline's concurrency budget; the bound that decides whether the
 how many passages one request carries, which
 [embedding generation](embedding-generation.md#bounds-every-call-carries) already applies.
 
+## What a reached ceiling does
+
+Before every provider call the turn asks what the current budget period still admits, and a period that admits nothing
+ends the turn without sending anything. The worker then **pauses until that period rolls over** rather than carrying on
+to the next message: without the pause it would take every waiting message in turn, learn the same thing from the same
+read, and drain a backlog at the speed of a database query. What it waits for is the roll-over instant the turn itself
+reported, so it neither polls a ceiling already known to bind nor sleeps past the moment it lifts.
+
+Nothing is dropped by waiting, and nothing has to be done to release it. The message whose turn met the ceiling keeps
+its outstanding passages, which is the condition the [backfill](embedding-backfill.md#why-it-sweeps-rather-than-finishes)
+selects on; the messages behind it stay in the backlog until its bound turns one away, at which point the same promise
+covers those too. The pause is logged as a warning naming how long it will last and which key raises the ceiling, and
+it is counted like any other outcome.
+
+[Embedding generation](embedding-generation.md#what-an-instance-is-willing-to-spend) states the three ceilings, what
+each is counted in, and why a batch that crosses one is paid for whole.
+
 ## An edited declaration that nobody activated
 
 Configuration can be changed to name a different model without activating it, and the vectors already stored belong to
@@ -100,9 +117,12 @@ declining to try again here.
 | --- | --- |
 | `mailfathom.embedding.backlog.depth` | How far behind embedding is right now |
 | `mailfathom.embedding.backlog.refused` | How many messages the bound turned away, which the backfill will have to reach |
-| `mailfathom.embedding.messages` | Messages taken from the backlog, by outcome — embedded, no active profile, declaration disagrees, provider failed, or one turn's calls exhausted |
+| `mailfathom.embedding.messages` | Messages taken from the backlog, by outcome — embedded, no active profile, declaration disagrees, provider failed, one turn's calls exhausted, or the spend ceiling reached |
 | `mailfathom.embedding.message.duration` | How long embedding one message took, by the same outcome |
 | `mailfathom.embedding.passages` | Passages given a vector |
+| `mailfathom.embedding.budget.consumed` | Characters sent to a provider and charged against the spend ceiling |
+| `mailfathom.embedding.input.truncated` | Messages the per-message ceiling cut short |
+| `mailfathom.embedding.input.omitted` | Characters that ceiling left out of the passages it cut |
 
 Falling behind is therefore visible as a rising depth rather than as search results that quietly stay lexical.
 

--- a/docs/features/embedding-backfill.md
+++ b/docs/features/embedding-backfill.md
@@ -95,6 +95,15 @@ so the pass ends before it reads a message. An instance whose configured model i
 writes nothing and warns, for the reason
 [an edited declaration](automatic-embedding.md#an-edited-declaration-that-nobody-activated) gives.
 
+Neither interval applies to a run the deployment's spend ceiling stopped. That ending names the instant it stops
+applying — the moment the budget period rolls over — so the worker waits for exactly that: the short interval would
+re-read a ceiling already known to bind, and the long one would leave a rolled-over period idle for as much as a quarter
+of an hour. The run also stops **without advancing its position**, unlike a run a refused call ended, because a reached
+ceiling says nothing about the message in hand and the passages it did not reach are the ones a fresh period should pay
+for first. [Embedding generation](embedding-generation.md#what-an-instance-is-willing-to-spend) holds the ceiling
+itself, and an initial backfill of a large mailbox is the case for raising it deliberately rather than being paced by
+it.
+
 The removal of a superseded generation's vectors is bounded too, and it is not a setting: it deletes rows nobody reads,
 reaches no provider, and costs nothing an operator has to consent to, so what paces it is the interval between passes
 rather than a number beside the ones above. A pass that removed a full batch is followed by the short interval, because
@@ -105,7 +114,7 @@ there is more of that generation behind it.
 | Signal | What it answers |
 | --- | --- |
 | `mailfathom.embedding.backfill.outstanding` | How many messages awaited embedding when the current sweep began |
-| `mailfathom.embedding.backfill.runs` | Bounded passes, by how each ended — budget spent, sweep completed, no active profile, declaration disagrees, or provider failed |
+| `mailfathom.embedding.backfill.runs` | Bounded passes, by how each ended — batch budget spent, sweep completed, no active profile, declaration disagrees, provider failed, or the spend ceiling reached |
 | `mailfathom.embedding.backfill.chunked` | Messages that had to be cut into passages first, which is how much of the mailbox predates chunking |
 | `mailfathom.embedding.backfill.messages` | Messages brought up to date with the active profile |
 | `mailfathom.embedding.backfill.passages` | Passages given a vector |

--- a/docs/features/embedding-generation.md
+++ b/docs/features/embedding-generation.md
@@ -178,6 +178,44 @@ rather than a row the database rejects later with no provider in sight.
 - **A bounded response.** The transport refuses a body larger than the declared geometry could fill, and refuses
   redirects — a moved endpoint answering with one would carry the key or the bearer token to whatever host it named.
 
+## What an instance is willing to spend
+
+The bounds above are about one call. Three more are about the deployment, and they exist because embedding is the first
+thing MailFathom does that costs money per unit of mail: a runaway loop somewhere else costs CPU, and a runaway
+embedding loop is an invoice that arrives a month later. Each is configuration, each is validated at startup, and none
+of them is part of an embedding profile — they decide how many vectors exist, never what any vector means, so moving
+one leaves every stored vector exactly as comparable as it was.
+
+- **What one message may cost.** `MaxCharactersPerEmail` is how much of a message's extracted text is cut into
+  passages. Raw MIME is bounded in megabytes, so one message can carry more text than an ordinary mailbox does in a
+  month; beyond this ceiling the message is bounded rather than refused — its opening is embedded and retrievable, and
+  [message chunks](message-chunks.md#the-per-message-ceiling) records what the cut left out, on the message.
+- **How fast requests may go out.** `MaxRequestsPerMinute` spaces requests so a deployment never sends faster than it
+  declared. It paces nothing by default, and it is for a provider whose quota is stated per minute: being refused for
+  exceeding one costs an attempt, a retry, and a place in a circuit-breaker window other work is measured in. A caller
+  takes the next free slot and waits for it; nothing polls and nothing spins.
+- **What one period may cost.** `MaxInputCharactersPerPeriod` and `SpendPeriod` are the aggregate ceiling, counted in
+  the characters actually sent to a provider — the one quantity a price is approximately proportional to that this
+  deployment can count exactly without carrying a model's own tokenizer. The period is a fixed window anchored at the
+  Unix epoch, so every restart agrees on where one begins without anything being stored to say so, and what each period
+  has spent is kept in the database rather than in memory: a process crashing and restarting in a loop would otherwise
+  begin every period again from zero.
+
+Reaching the aggregate ceiling pauses embedding until the period rolls over, and nothing is lost by the pause: a
+passage with no vector is exactly the condition the [backfill](embedding-backfill.md) selects on. The wait is the
+roll-over rather than an interval, so work resumes without anybody acting. [Automatic
+embedding](automatic-embedding.md#what-a-reached-ceiling-does) describes what the pause looks like from the worker.
+
+The ceiling binds to within one batch. A batch is admitted whenever anything at all is left in the period and is then
+paid for whole, because weighing a batch against what remains would stall a deployment whose ceiling is smaller than one
+batch for ever — it would refuse the same request at every roll-over. The overshoot is therefore at most one batch per
+call in flight.
+
+**Concurrency is not one of these keys.** How many provider calls may be in flight at once is
+`Resilience:AiProviderInvocation:ConcurrencyLimit`, which is the one mechanism that owns that question; [outbound
+resilience](../architecture/outbound-resilience.md) holds it. A second limiter counting in-flight calls here would make
+two settings answer for one behaviour.
+
 ## What never reaches a log
 
 No passage, no vector, no credential, and no provider response body. A provider's own error text quotes the request

--- a/docs/features/message-chunks.md
+++ b/docs/features/message-chunks.md
@@ -108,6 +108,11 @@ later hangs on a passage hanging on the same row.
 Anything else replaces the message's passages whole rather than reconciling them one by one, because a boundary change
 shifts every ordinal after the first difference and a row-by-row merge would only make that look survivable.
 
+One thing is compared outside that decision: what the [per-message ceiling](#the-per-message-ceiling) left out. Text
+that grew past the ceiling while everything up to it stayed identical yields exactly the same passages and a different
+truncation, so the record is written from the current derivation rather than from whether any passage moved. An
+unchanged message still writes nothing — the value it would be given is the value it already has.
+
 ## The rule-set version
 
 Every chunk records the version of the rules it was cut to, in a column beside its hash. Nothing reads it to decide

--- a/docs/features/message-chunks.md
+++ b/docs/features/message-chunks.md
@@ -57,6 +57,30 @@ by a few characters, because refusing it would leave the walk with nowhere to go
 The cut consults no clock, no random source, and no culture, and every comparison is ordinal. The same text under the
 same rules produces the same passages, with the same offsets and the same hashes, on any machine and in any order.
 
+## The per-message ceiling
+
+A message is cut only as far as `Embeddings:MaxCharactersPerEmail`, which is 200 000 characters unless a deployment
+says otherwise. That is a long report with its quoted history and far beyond what ordinary correspondence reaches; what
+it excludes is the log dump, the exported table, and the machine-generated transcript — none of which anybody asks a
+question about, and any of which would otherwise become hundreds of passages and hundreds of paid vectors. Raw MIME is
+bounded in megabytes, so without a ceiling here one message's cost would be whatever a sender attached.
+
+The message is **bounded rather than refused**. Its opening is cut, embedded, and retrievable, which is the part the
+rest of a message elaborates, and the cut lands on the nearest text-element boundary at or below the ceiling like every
+other boundary here. What the ceiling left out is recorded on the message itself — the length its text had when the cut
+stopped short — so the question "could the answer have been in the part nobody embedded" is answered from a stored fact
+rather than guessed at from a chunk count. Two metrics carry the same thing across a deployment: how many messages the
+ceiling reached, and how much text it left out.
+
+The ceiling is deliberately **not one of the boundary rules above**, and therefore not part of the hash. The rules
+decide what a passage says; the ceiling decides only how many passages there are, and a passage the ceiling leaves in
+place keeps exactly the digest it had. So moving the ceiling changes nothing about a message it does not reach, and
+leaves every stored vector as comparable as it was. What it does cost is the messages it *does* reach: those are
+re-cut, and a re-cut replaces a message's passages whole for the reason below, so an oversized message a moved ceiling
+reaches is embedded again from its first passage. [Embedding
+generation](embedding-generation.md#what-an-instance-is-willing-to-spend) states the ceiling beside the two that bound
+a deployment rather than a message.
+
 ## What the hash covers
 
 Each chunk carries a SHA-256 digest, written as sixty-four lowercase hexadecimal characters. It is computed over:

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -236,6 +236,36 @@ next, never what a search is currently able to do; only an activation does that.
 | `Embeddings:RequestTimeout` | TimeSpan | `00:01:00` | positive; one request to one endpoint | restart |
 | `Embeddings:MaxQueuedEmails` | int | `1024` | 1 – 1000000; newly synchronized messages that may wait to be embedded at once, beyond which synchronization stops offering and the backfill reaches the rest | restart |
 
+### What an instance is willing to spend
+
+The four keys below bound cost rather than correctness, and they are validated whether or not a chain is declared:
+passages are cut for every synchronized message on an instance that has chosen no provider, so a ceiling left
+unvalidated would be one already applying. None of them is part of an embedding profile — they decide how many vectors
+exist and never what one means, so moving any of them leaves every stored vector as comparable as it was. [Embedding
+generation](../features/embedding-generation.md#what-an-instance-is-willing-to-spend) records what each bounds and why.
+
+| Key | Type | Default | Constraint | Change |
+| --- | --- | --- | --- | --- |
+| `Embeddings:MaxCharactersPerEmail` | int | `200000` | 1000 – 10000000; how much of one message's extracted text is cut into passages. A message beyond it is bounded rather than refused — its opening is embedded and the length its text had is recorded on the message | restart |
+| `Embeddings:MaxRequestsPerMinute` | int | `0` | 0 – 100000; `0` paces nothing, which is the default. For a provider whose quota is stated per minute; a caller takes the next free slot and waits for it | restart |
+| `Embeddings:MaxInputCharactersPerPeriod` | long | `50000000` | zero or positive; the characters one period may send a provider, counted as sent rather than as stored. `0` declares no ceiling at all, which is supported and means an enabled feature can produce a bill nobody agreed to | restart |
+| `Embeddings:SpendPeriod` | TimeSpan | `1.00:00:00` | 1 min – 31 days; the fixed window the ceiling is counted over, anchored at the Unix epoch so every restart places it identically | restart |
+
+Reaching `MaxInputCharactersPerPeriod` pauses embedding until the period rolls over, and resumes without anybody
+acting; nothing is dropped, because a passage with no vector is what the backfill selects on. The ceiling binds to
+within one batch: a batch is admitted whenever anything at all is left and is then paid for whole, because weighing it
+against what remains would stall a deployment whose ceiling is smaller than one batch for ever.
+
+The default is chosen to bind. Fifty million characters a day is roughly twelve million tokens and embeds something
+like sixteen thousand ordinary messages, so an instance keeping up with arriving mail never meets it and one working
+through a decade of archive is paced rather than surprised — raise it deliberately for an initial backfill, having seen
+the number.
+
+**Concurrency is not here.** How many provider calls may be in flight at once is
+`Resilience:AiProviderInvocation:ConcurrencyLimit`, which is the one setting that owns that question; [outbound
+resilience](../architecture/outbound-resilience.md) holds it, and a second limiter beside it would make two keys answer
+for one behaviour.
+
 ### One endpoint — `Embeddings:Endpoints:<n>`
 
 An ordered chain. Every entry declares the same geometry and reaches the same vector space, so a failing endpoint

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -99,6 +99,17 @@ passages it embedded and how long that took, broken down by outcome and by the c
 [Automatic embedding](../features/automatic-embedding.md#what-an-operator-can-see) names each instrument and what it
 answers; the depth is the one an instance falling behind shows up in first.
 
+Three counters beside those answer what embedding is costing rather than how it is going.
+`mailfathom.embedding.budget.consumed` is the characters sent to a provider and charged against the spend ceiling,
+which summed over a period is what that period spent and summed over any other window is a question a ceiling cannot
+answer; `mailfathom.embedding.input.truncated` and `mailfathom.embedding.input.omitted` are how many messages the
+per-message ceiling cut short and how much text it left out. The consumed figure is a counter rather than a gauge of
+what is left, because a remaining figure would have to be read from the database inside a callback a meter invokes on
+its own schedule. Two instruments carry the truncation rather than one, because one enormous message and a thousand
+slightly oversized ones need different answers from an operator: how often the ceiling binds, and what raising it would
+cost. [Embedding generation](../features/embedding-generation.md#what-an-instance-is-willing-to-spend) records what each
+ceiling bounds.
+
 The backfill over mail stored before a profile existed publishes its own family beside that one, under
 `mailfathom.embedding.backfill.*`: how many messages awaited embedding when the current sweep began, how each bounded
 run ended, and how many messages it cut into passages, brought up to date, and gave vectors to. The instruments are

--- a/src/AI/Chunking/DeterministicEmailTextChunker.cs
+++ b/src/AI/Chunking/DeterministicEmailTextChunker.cs
@@ -4,6 +4,7 @@
 
 using System.Globalization;
 using MailFathom.Application.Emails.Chunking;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Emails.Extraction;
 
 namespace MailFathom.AI.Chunking;
@@ -30,16 +31,22 @@ namespace MailFathom.AI.Chunking;
 internal sealed class DeterministicEmailTextChunker : IEmailTextChunker
 {
     /// <inheritdoc />
-    public IReadOnlyList<EmailTextChunk> DeriveChunks(ExtractedEmailText text, EmailChunkingRules rules)
+    public EmailChunkingResult DeriveChunks(
+        ExtractedEmailText text,
+        EmailChunkingRules rules,
+        EmbeddingInputBound bound)
     {
         ArgumentNullException.ThrowIfNull(text);
         ArgumentNullException.ThrowIfNull(rules);
+        ArgumentNullException.ThrowIfNull(bound);
 
-        var source = SelectSourceForm(text, rules);
-        if (string.IsNullOrEmpty(source))
+        var selected = SelectSourceForm(text, rules);
+        if (string.IsNullOrEmpty(selected))
         {
-            return [];
+            return EmailChunkingResult.NoText;
         }
+
+        var (source, truncatedFrom) = CutToBound(selected, bound);
 
         var chunks = new List<EmailTextChunk>();
         var start = 0;
@@ -70,7 +77,23 @@ internal sealed class DeterministicEmailTextChunker : IEmailTextChunker
             start = FindNextStart(source, start, end, rules.OverlapCharacterCount);
         }
 
-        return chunks;
+        return new EmailChunkingResult(chunks, truncatedFrom);
+    }
+
+    /// <summary>Cuts the text down to what one message may cost, and reports the length it had when that happened.</summary>
+    /// <remarks>
+    /// The cut lands on a text-element boundary for the reason every boundary here does: a ceiling that fell inside a
+    /// surrogate pair or a combining sequence would hand the last chunk a character its author never wrote, and
+    /// PostgreSQL would refuse the write rather than store it.
+    /// </remarks>
+    private static (string Source, int? TruncatedFrom) CutToBound(string source, EmbeddingInputBound bound)
+    {
+        if (source.Length <= bound.MaximumCharacterCount)
+        {
+            return (source, null);
+        }
+
+        return (source[..BoundaryAtOrBefore(source, knownBoundary: 0, bound.MaximumCharacterCount)], source.Length);
     }
 
     private static string? SelectSourceForm(ExtractedEmailText text, EmailChunkingRules rules) => rules.SourceForm switch

--- a/src/Application/Emails/Chunking/EmailChunkingResult.cs
+++ b/src/Application/Emails/Chunking/EmailChunkingResult.cs
@@ -1,0 +1,24 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Chunking;
+
+/// <summary>The passages one message's text was cut into, and how much of that text the cut reached.</summary>
+/// <param name="Chunks">The passages in reading order, empty for a message whose body yielded no text.</param>
+/// <param name="TruncatedFromCharacterCount">
+/// The length the text had when the per-message ceiling stopped the cut short of its end, or <see langword="null" />
+/// when the whole text was cut.
+/// </param>
+/// <remarks>
+/// The truncation travels with the chunks rather than being inferred from them, because a chunk count says nothing
+/// about what is missing: a message cut whole and one cut to a ceiling look identical from the passages alone, and the
+/// difference is exactly what a reader deciding whether an answer could have been in the part nobody embedded needs.
+/// </remarks>
+public sealed record EmailChunkingResult(
+    IReadOnlyList<EmailTextChunk> Chunks,
+    int? TruncatedFromCharacterCount)
+{
+    /// <summary>The result of cutting a message whose body yielded no text at all.</summary>
+    public static EmailChunkingResult NoText { get; } = new([], TruncatedFromCharacterCount: null);
+}

--- a/src/Application/Emails/Chunking/IEmailTextChunker.cs
+++ b/src/Application/Emails/Chunking/IEmailTextChunker.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Emails.Extraction;
 
 namespace MailFathom.Application.Emails.Chunking;
@@ -22,14 +23,21 @@ namespace MailFathom.Application.Emails.Chunking;
 /// </remarks>
 public interface IEmailTextChunker
 {
-    /// <summary>Cuts extracted text into chunks, in reading order.</summary>
+    /// <summary>Cuts extracted text into chunks, in reading order, stopping at what one message may cost.</summary>
     /// <param name="text">The text extraction derived from one message's body.</param>
     /// <param name="rules">The boundaries to cut along.</param>
-    /// <returns>The chunks in reading order, or an empty list when the message yielded no text to cut.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="text" /> or <paramref name="rules" /> is <see langword="null" />.</exception>
+    /// <param name="bound">How much of the text to cut, beyond which the message's remainder yields no passage.</param>
+    /// <returns>The chunks in reading order and what the ceiling left out, or an empty result when the message yielded no text to cut.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     /// <remarks>
-    /// The same text and the same rules produce the same chunks and the same hashes on every call, on any machine, and
-    /// in any order, which is what lets a caller decide by hash alone whether anything downstream has to be re-done.
+    /// The same text, the same rules, and the same bound produce the same chunks and the same hashes on every call, on
+    /// any machine, and in any order, which is what lets a caller decide by hash alone whether anything downstream has
+    /// to be re-done. The bound is a parameter rather than a member of the rules deliberately: the rules are covered by
+    /// each chunk's content hash because they decide what a passage says, while the bound decides only how many
+    /// passages there are and must not make an unchanged passage look like a different one.
     /// </remarks>
-    IReadOnlyList<EmailTextChunk> DeriveChunks(ExtractedEmailText text, EmailChunkingRules rules);
+    EmailChunkingResult DeriveChunks(
+        ExtractedEmailText text,
+        EmailChunkingRules rules,
+        EmbeddingInputBound bound);
 }

--- a/src/Application/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfill.cs
+++ b/src/Application/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfill.cs
@@ -124,6 +124,18 @@ public sealed class StoredEmailEmbeddingBackfill
                         outstandingAtSweepStart);
                 }
 
+                // The ceiling stops the run before the position steps past this message, because unlike a refused
+                // provider call it says nothing about the message and the passages it did not reach are the ones the
+                // rolled-over period should pay for first.
+                if (turn.Outcome is StoredEmailEmbeddingOutcome.SpendCeilingReached)
+                {
+                    return Ended(
+                        StoredEmailEmbeddingBackfillOutcome.SpendCeilingReached,
+                        progress,
+                        outstandingAtSweepStart,
+                        spendPeriodEndsAt: turn.SpendPeriodEndsAt);
+                }
+
                 position = email.StoredEmailId;
                 await this.CommitPositionAsync(position, cancellationToken);
 
@@ -188,7 +200,8 @@ public sealed class StoredEmailEmbeddingBackfill
         StoredEmailEmbeddingBackfillOutcome outcome,
         RunProgress progress,
         int? outstandingAtSweepStart = null,
-        EmbeddingGenerationFailure? failure = null) =>
+        EmbeddingGenerationFailure? failure = null,
+        DateTimeOffset? spendPeriodEndsAt = null) =>
         new(
             outcome,
             progress.ChunkedEmailCount,
@@ -196,7 +209,8 @@ public sealed class StoredEmailEmbeddingBackfill
             progress.EmbeddedChunkCount,
             progress.CallBudgetExhaustedEmailCount,
             outstandingAtSweepStart,
-            failure);
+            failure,
+            spendPeriodEndsAt);
 
     /// <summary>What a run has produced so far, in counts alone.</summary>
     /// <remarks>

--- a/src/Application/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfillOutcome.cs
+++ b/src/Application/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfillOutcome.cs
@@ -26,4 +26,13 @@ public enum StoredEmailEmbeddingBackfillOutcome
 
     /// <summary>A provider call ended without vectors, which ends the run rather than the next message's turn.</summary>
     ProviderFailed = 4,
+
+    /// <summary>The period's spend ceiling is reached, so the run ended and the next one waits for the period to roll over.</summary>
+    /// <remarks>
+    /// The one ending that names its own resumption. Every other reason to stop is either settled by an operator or
+    /// retried on an interval chosen by how likely work is to be there; this one has an exact instant after which
+    /// sweeping is worth doing again, and <see cref="StoredEmailEmbeddingBackfillResult.SpendPeriodEndsAt" /> carries
+    /// it so the worker waits for that rather than polling a ceiling it already knows binds.
+    /// </remarks>
+    SpendCeilingReached = 5,
 }

--- a/src/Application/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfillResult.cs
+++ b/src/Application/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfillResult.cs
@@ -12,6 +12,7 @@ namespace MailFathom.Application.Emails.Embeddings.Backfill;
 /// <param name="CallBudgetExhaustedEmailCount">How many messages this run left part-way through because one turn spent every provider call a turn is allowed.</param>
 /// <param name="OutstandingEmailCountAtSweepStart">How many messages awaited embedding when this sweep began, or <see langword="null" /> when the run resumed a sweep somebody else measured.</param>
 /// <param name="Failure">Why a provider call produced nothing, present exactly when <paramref name="Outcome" /> is <see cref="StoredEmailEmbeddingBackfillOutcome.ProviderFailed" />.</param>
+/// <param name="SpendPeriodEndsAt">When the budget period rolls over, present exactly when <paramref name="Outcome" /> is <see cref="StoredEmailEmbeddingBackfillOutcome.SpendCeilingReached" />.</param>
 /// <remarks>
 /// <para>
 /// Counts and classifications only. Every message this run touched, every passage it cut, and every vector it stored is
@@ -31,7 +32,8 @@ public sealed record StoredEmailEmbeddingBackfillResult(
     int EmbeddedChunkCount,
     int CallBudgetExhaustedEmailCount,
     int? OutstandingEmailCountAtSweepStart,
-    EmbeddingGenerationFailure? Failure)
+    EmbeddingGenerationFailure? Failure,
+    DateTimeOffset? SpendPeriodEndsAt)
 {
     /// <summary>The pass an instance that has registered no generation performs, which reaches nothing and spends nothing.</summary>
     /// <remarks>
@@ -46,7 +48,8 @@ public sealed record StoredEmailEmbeddingBackfillResult(
         EmbeddedChunkCount: 0,
         CallBudgetExhaustedEmailCount: 0,
         OutstandingEmailCountAtSweepStart: null,
-        Failure: null);
+        Failure: null,
+        SpendPeriodEndsAt: null);
 
     /// <summary>Gets whether running again shortly would reach work this run could not.</summary>
     /// <remarks>
@@ -60,6 +63,12 @@ public sealed record StoredEmailEmbeddingBackfillResult(
     /// a refused request, and a vector the declared geometry does not describe all answer a repetition identically while
     /// counting against the account's request budget, so asking again in half a minute buys the same refusal at the same
     /// price. The sweep still reaches those messages later, because it starts again from the beginning.
+    /// </para>
+    /// <para>
+    /// A reached spend ceiling answers <see langword="false" /> here and is paced by neither interval. It is the one
+    /// ending that names the instant it stops applying, so the worker waits for that instead — a short interval would
+    /// re-read a ceiling already known to bind, and the long one would leave a rolled-over period idle for as much as a
+    /// quarter of an hour.
     /// </para>
     /// </remarks>
     public bool MoreWorkIsWorthTryingSoon => this.Outcome switch

--- a/src/Application/Emails/Embeddings/EmbeddingInputPreparation.cs
+++ b/src/Application/Emails/Embeddings/EmbeddingInputPreparation.cs
@@ -57,6 +57,25 @@ public sealed class EmbeddingInputPreparation
     /// <summary>Gets whether the vector is normalized to unit length before it is stored.</summary>
     public bool NormalizesVector { get; }
 
+    /// <summary>Counts the characters one passage occupies once this preparation has been applied to it.</summary>
+    /// <param name="passage">The passage as a caller supplied it.</param>
+    /// <returns>The length of the text a provider would be sent for it.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="passage" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// What a spend ceiling is counted in. It answers without preparing the passage, because the ceiling is consulted
+    /// before a batch is assembled and building the text to measure it would allocate a copy of every passage for a
+    /// number the lengths already give. The instruction is added before the cut for the reason the preparation applies
+    /// it there, so the two agree by construction rather than by coincidence.
+    /// </remarks>
+    public int CountBilledCharacters(string passage)
+    {
+        ArgumentNullException.ThrowIfNull(passage);
+
+        var preparedLength = passage.Length + (this.PassageInstruction?.Length ?? 0);
+
+        return Math.Min(preparedLength, this.InputCharacterLimit);
+    }
+
     /// <summary>Builds a preparation, refusing one that could not produce a passage to send.</summary>
     /// <param name="inputCharacterLimit">The width a passage is cut to before it is sent.</param>
     /// <param name="passageInstruction">The instruction a model requires of a passage, or <see langword="null" />.</param>

--- a/src/Application/Emails/Embeddings/Generation/StoredEmailEmbeddingGenerator.cs
+++ b/src/Application/Emails/Embeddings/Generation/StoredEmailEmbeddingGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Emails;
 
@@ -50,24 +51,34 @@ public sealed class StoredEmailEmbeddingGenerator
     private readonly IEmailEmbeddingStore embeddingStore;
     private readonly ITextEmbeddingGenerator textEmbeddingGenerator;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
+    private readonly EmbeddingSpendGate spendGate;
+    private readonly EmbeddingRequestPacer requestPacer;
 
     /// <summary>Initializes a new generator of one message's embeddings.</summary>
     /// <param name="embeddingStore">Reads which passages lack a vector, and writes the vectors that answer.</param>
     /// <param name="textEmbeddingGenerator">Turns passages into points of that space.</param>
     /// <param name="concurrencyRetryPolicy">Commits one call's vectors, retrying a conflict with a competing writer.</param>
+    /// <param name="spendGate">Says whether the period still admits a request, and is charged for the ones it does.</param>
+    /// <param name="requestPacer">Holds a call back until this deployment is allowed to send its next one.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public StoredEmailEmbeddingGenerator(
         IEmailEmbeddingStore embeddingStore,
         ITextEmbeddingGenerator textEmbeddingGenerator,
-        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy)
+        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
+        EmbeddingSpendGate spendGate,
+        EmbeddingRequestPacer requestPacer)
     {
         ArgumentNullException.ThrowIfNull(embeddingStore);
         ArgumentNullException.ThrowIfNull(textEmbeddingGenerator);
         ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
+        ArgumentNullException.ThrowIfNull(spendGate);
+        ArgumentNullException.ThrowIfNull(requestPacer);
 
         this.embeddingStore = embeddingStore;
         this.textEmbeddingGenerator = textEmbeddingGenerator;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
+        this.spendGate = spendGate;
+        this.requestPacer = requestPacer;
     }
 
     /// <summary>Embeds whatever of one message is not yet embedded under one generation.</summary>
@@ -102,6 +113,7 @@ public sealed class StoredEmailEmbeddingGenerator
         }
 
         var embeddedChunkCount = 0;
+        var sentCharacterCount = 0;
 
         for (var call = 0; call < MaximumProviderCallsPerEmail; call++)
         {
@@ -115,8 +127,23 @@ public sealed class StoredEmailEmbeddingGenerator
             // loop instead means the budget ran out with passages still outstanding, which is a different answer.
             if (passages.Count == 0)
             {
-                return StoredEmailEmbeddingRun.Embedded(embeddedChunkCount);
+                return StoredEmailEmbeddingRun.Embedded(embeddedChunkCount, sentCharacterCount);
             }
+
+            // Asked before every call rather than once per message, because a long message spends across many calls and
+            // a ceiling consulted only at the start would be one a single message could walk straight through.
+            var period = await this.spendGate.ReadCurrentPeriodAsync(cancellationToken);
+            if (!period.AdmitsRequest)
+            {
+                return StoredEmailEmbeddingRun.SpendCeilingReached(
+                    embeddedChunkCount,
+                    sentCharacterCount,
+                    period.EndsAt);
+            }
+
+            var billedCharacterCount = CountBilledCharacters(profile, passages);
+
+            await this.requestPacer.WaitForSlotAsync(cancellationToken);
 
             IReadOnlyList<EmbeddingVector> vectors;
             try
@@ -127,12 +154,16 @@ public sealed class StoredEmailEmbeddingGenerator
             }
             catch (EmbeddingGenerationFailedException generationFailure)
             {
-                return StoredEmailEmbeddingRun.ProviderFailed(embeddedChunkCount, generationFailure.Failure);
+                return StoredEmailEmbeddingRun.ProviderFailed(
+                    embeddedChunkCount,
+                    generationFailure.Failure,
+                    sentCharacterCount);
             }
 
-            await this.CommitVectorsAsync(profile, passages, vectors, cancellationToken);
+            await this.CommitVectorsAsync(profile, passages, vectors, billedCharacterCount, cancellationToken);
 
             embeddedChunkCount += passages.Count;
+            sentCharacterCount += billedCharacterCount;
         }
 
         // The budget is spent, and that alone does not say the message is unfinished: the last call may have taken the
@@ -147,26 +178,53 @@ public sealed class StoredEmailEmbeddingGenerator
             cancellationToken);
 
         return outstanding.Count == 0
-            ? StoredEmailEmbeddingRun.Embedded(embeddedChunkCount)
-            : StoredEmailEmbeddingRun.CallBudgetExhausted(embeddedChunkCount);
+            ? StoredEmailEmbeddingRun.Embedded(embeddedChunkCount, sentCharacterCount)
+            : StoredEmailEmbeddingRun.CallBudgetExhausted(embeddedChunkCount, sentCharacterCount);
     }
 
-    /// <summary>Commits one call's vectors, so a crash leaves a whole page of passages embedded or none of it.</summary>
+    /// <summary>Counts what one batch will cost, in the characters a provider is about to be sent.</summary>
+    /// <remarks>
+    /// Measured through the profile's own input preparation rather than from the passage lengths, because the
+    /// preparation is what decides the text a provider actually receives: a passage beyond the model's input limit is
+    /// cut before it is sent, and charging a budget for characters nobody was sent would make a long-passage deployment
+    /// look like an expensive one.
+    /// </remarks>
+    private static int CountBilledCharacters(
+        RegisteredEmbeddingProfile profile,
+        IReadOnlyList<EmailChunkAwaitingEmbedding> passages) =>
+        passages.Sum(passage => profile.Identity.InputPreparation.CountBilledCharacters(passage.Text));
+
+    /// <summary>Commits one call's vectors and its cost together, so a crash leaves a whole page embedded or none of it.</summary>
+    /// <remarks>
+    /// The charge joins the same transaction as the vectors it paid for, which is what makes the ledger unable to
+    /// disagree with what was stored. A call whose commit then fails outright is the one case the ledger under-counts,
+    /// and it is left that way deliberately: the alternative is a charge in its own transaction, which would over-count
+    /// every ordinary conflict the retry policy goes on to resolve.
+    /// </remarks>
     private Task CommitVectorsAsync(
         RegisteredEmbeddingProfile profile,
         IReadOnlyList<EmailChunkAwaitingEmbedding> passages,
         IReadOnlyList<EmbeddingVector> vectors,
+        int billedCharacterCount,
         CancellationToken cancellationToken)
     {
         GeneratedChunkEmbedding[] embeddings =
             [.. passages.Zip(vectors, (passage, vector) => new GeneratedChunkEmbedding(passage.Id, vector))];
 
         return this.concurrencyRetryPolicy.CommitAsync(
-            (persistenceSession, attemptCancellationToken) => this.embeddingStore.SaveEmbeddingsAsync(
-                persistenceSession,
-                profile,
-                embeddings,
-                attemptCancellationToken),
+            async (persistenceSession, attemptCancellationToken) =>
+            {
+                await this.embeddingStore.SaveEmbeddingsAsync(
+                    persistenceSession,
+                    profile,
+                    embeddings,
+                    attemptCancellationToken);
+
+                await this.spendGate.RecordSpendAsync(
+                    persistenceSession,
+                    billedCharacterCount,
+                    attemptCancellationToken);
+            },
             cancellationToken);
     }
 }

--- a/src/Application/Emails/Embeddings/Generation/StoredEmailEmbeddingOutcome.cs
+++ b/src/Application/Emails/Embeddings/Generation/StoredEmailEmbeddingOutcome.cs
@@ -43,4 +43,16 @@ public enum StoredEmailEmbeddingOutcome
     /// far below what a message of that length needs.
     /// </remarks>
     CallBudgetExhausted = 4,
+
+    /// <summary>The period's spend ceiling is reached, so nothing further is sent until it rolls over.</summary>
+    /// <remarks>
+    /// A condition of the instance rather than of the message, and the only one of them that resolves itself: the
+    /// period rolls over at <see cref="StoredEmailEmbeddingRun.SpendPeriodEndsAt" /> and work continues, with no
+    /// operator having to do anything. It is deliberately not the same outcome as
+    /// <see cref="CallBudgetExhausted" /> beside it, which bounds how many calls one message's turn may make and says
+    /// something about that message's length; this says the deployment has spent what it agreed to spend, and says
+    /// nothing about the message at all. What was committed stays durable and the rest stays outstanding, which is the
+    /// condition the backfill selects on.
+    /// </remarks>
+    SpendCeilingReached = 5,
 }

--- a/src/Application/Emails/Embeddings/Generation/StoredEmailEmbeddingRun.cs
+++ b/src/Application/Emails/Embeddings/Generation/StoredEmailEmbeddingRun.cs
@@ -11,55 +11,110 @@ namespace MailFathom.Application.Emails.Embeddings.Generation;
 /// </remarks>
 /// <param name="Outcome">How the turn ended.</param>
 /// <param name="EmbeddedChunkCount">How many passages were given a vector and committed during this turn.</param>
+/// <param name="InputCharacterCount">How many characters this turn sent to a provider, which is what its spend was counted in.</param>
 /// <param name="Failure">Why a provider call produced nothing, present exactly when <paramref name="Outcome" /> is <see cref="StoredEmailEmbeddingOutcome.ProviderFailed" />.</param>
+/// <param name="SpendPeriodEndsAt">When the budget period rolls over, present exactly when <paramref name="Outcome" /> is <see cref="StoredEmailEmbeddingOutcome.SpendCeilingReached" />.</param>
 public sealed record StoredEmailEmbeddingRun(
     StoredEmailEmbeddingOutcome Outcome,
     int EmbeddedChunkCount,
-    EmbeddingGenerationFailure? Failure)
+    int InputCharacterCount,
+    EmbeddingGenerationFailure? Failure,
+    DateTimeOffset? SpendPeriodEndsAt)
 {
     /// <summary>Reports a message every passage of which now carries a vector.</summary>
     /// <param name="embeddedChunkCount">How many passages this turn produced a vector for.</param>
+    /// <param name="inputCharacterCount">How many characters the turn sent to produce them.</param>
     /// <returns>The result.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the count is negative.</exception>
-    public static StoredEmailEmbeddingRun Embedded(int embeddedChunkCount)
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a count is negative.</exception>
+    public static StoredEmailEmbeddingRun Embedded(int embeddedChunkCount, int inputCharacterCount = 0)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(embeddedChunkCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(inputCharacterCount);
 
-        return new StoredEmailEmbeddingRun(StoredEmailEmbeddingOutcome.Embedded, embeddedChunkCount, Failure: null);
+        return new StoredEmailEmbeddingRun(
+            StoredEmailEmbeddingOutcome.Embedded,
+            embeddedChunkCount,
+            inputCharacterCount,
+            Failure: null,
+            SpendPeriodEndsAt: null);
     }
 
     /// <summary>Reports a message whose turn spent every provider call it is allowed with passages still outstanding.</summary>
     /// <param name="embeddedChunkCount">How many passages the turn did commit a vector for.</param>
+    /// <param name="inputCharacterCount">How many characters the turn sent before it ran out of calls.</param>
     /// <returns>The result.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the count is negative.</exception>
-    public static StoredEmailEmbeddingRun CallBudgetExhausted(int embeddedChunkCount)
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a count is negative.</exception>
+    public static StoredEmailEmbeddingRun CallBudgetExhausted(int embeddedChunkCount, int inputCharacterCount = 0)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(embeddedChunkCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(inputCharacterCount);
 
         return new StoredEmailEmbeddingRun(
             StoredEmailEmbeddingOutcome.CallBudgetExhausted,
             embeddedChunkCount,
-            Failure: null);
+            inputCharacterCount,
+            Failure: null,
+            SpendPeriodEndsAt: null);
+    }
+
+    /// <summary>Reports a turn stopped by the period's spend ceiling, after whatever it had already committed.</summary>
+    /// <param name="embeddedChunkCount">How many passages the turn committed a vector for before the ceiling bound.</param>
+    /// <param name="inputCharacterCount">How many characters the turn sent before it stopped.</param>
+    /// <param name="spendPeriodEndsAt">When the period rolls over, which is when work resumes without anyone acting.</param>
+    /// <returns>The result.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a count is negative.</exception>
+    public static StoredEmailEmbeddingRun SpendCeilingReached(
+        int embeddedChunkCount,
+        int inputCharacterCount,
+        DateTimeOffset spendPeriodEndsAt)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(embeddedChunkCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(inputCharacterCount);
+
+        return new StoredEmailEmbeddingRun(
+            StoredEmailEmbeddingOutcome.SpendCeilingReached,
+            embeddedChunkCount,
+            inputCharacterCount,
+            Failure: null,
+            spendPeriodEndsAt);
     }
 
     /// <summary>Reports an instance that has activated no profile.</summary>
     /// <returns>The result.</returns>
-    public static StoredEmailEmbeddingRun NoActiveProfile() =>
-        new(StoredEmailEmbeddingOutcome.NoActiveProfile, EmbeddedChunkCount: 0, Failure: null);
+    public static StoredEmailEmbeddingRun NoActiveProfile() => new(
+        StoredEmailEmbeddingOutcome.NoActiveProfile,
+        EmbeddedChunkCount: 0,
+        InputCharacterCount: 0,
+        Failure: null,
+        SpendPeriodEndsAt: null);
 
     /// <summary>Reports a generator whose vector space is not the one the active profile records.</summary>
     /// <returns>The result.</returns>
-    public static StoredEmailEmbeddingRun GeneratorDisagreesWithProfile() =>
-        new(StoredEmailEmbeddingOutcome.GeneratorDisagreesWithProfile, EmbeddedChunkCount: 0, Failure: null);
+    public static StoredEmailEmbeddingRun GeneratorDisagreesWithProfile() => new(
+        StoredEmailEmbeddingOutcome.GeneratorDisagreesWithProfile,
+        EmbeddedChunkCount: 0,
+        InputCharacterCount: 0,
+        Failure: null,
+        SpendPeriodEndsAt: null);
 
     /// <summary>Reports a provider call that ended without vectors, after whatever this turn had already committed.</summary>
     /// <param name="embeddedChunkCount">How many passages were committed before the failing call.</param>
     /// <param name="failure">Why the call produced nothing.</param>
+    /// <param name="inputCharacterCount">How many characters the turn had sent before the failing call.</param>
     /// <returns>The result.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the count is negative, or the failure is not a defined member.</exception>
-    public static StoredEmailEmbeddingRun ProviderFailed(int embeddedChunkCount, EmbeddingGenerationFailure failure)
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a count is negative, or the failure is not a defined member.</exception>
+    /// <remarks>
+    /// The failing call's own characters are deliberately not counted. A provider that answered with a refusal, a
+    /// timeout, or a transport fault produced no vectors, and charging a budget for it would let an unreachable endpoint
+    /// spend a period's ceiling on nothing.
+    /// </remarks>
+    public static StoredEmailEmbeddingRun ProviderFailed(
+        int embeddedChunkCount,
+        EmbeddingGenerationFailure failure,
+        int inputCharacterCount = 0)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(embeddedChunkCount);
+        ArgumentOutOfRangeException.ThrowIfNegative(inputCharacterCount);
 
         if (!Enum.IsDefined(failure))
         {
@@ -69,6 +124,11 @@ public sealed record StoredEmailEmbeddingRun(
                 "A provider failure is reported through a defined classification.");
         }
 
-        return new StoredEmailEmbeddingRun(StoredEmailEmbeddingOutcome.ProviderFailed, embeddedChunkCount, failure);
+        return new StoredEmailEmbeddingRun(
+            StoredEmailEmbeddingOutcome.ProviderFailed,
+            embeddedChunkCount,
+            inputCharacterCount,
+            failure,
+            SpendPeriodEndsAt: null);
     }
 }

--- a/src/Application/Emails/Embeddings/Limits/EmbeddingInputBound.cs
+++ b/src/Application/Emails/Embeddings/Limits/EmbeddingInputBound.cs
@@ -1,0 +1,56 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Limits;
+
+/// <summary>How much of one message's extracted text is cut into passages, and therefore what one message may cost.</summary>
+/// <remarks>
+/// <para>
+/// Per-item cost is not uniform: raw MIME is bounded at tens of megabytes, so a single message can carry more text than
+/// an ordinary mailbox does in a month, and every character of it would otherwise become a passage and a paid vector.
+/// This is the ceiling that makes one message's cost bounded rather than proportional to whatever a sender attached.
+/// </para>
+/// <para>
+/// It bounds rather than refuses. A message beyond the ceiling is still cut, still embedded, and still retrievable on
+/// its opening — which is the part the rest of a message elaborates — and the length its text had is recorded on the
+/// message so that what was left out is a stored fact rather than something inferred later from a chunk count.
+/// </para>
+/// <para>
+/// It is not the input preparation an embedding profile records, although both are limits on text.
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md">ADR 0006</see>
+/// draws the line: preparation decides what one passage means and belongs to the profile's identity, while this decides
+/// how many passages exist and changes the meaning of none of them. Raising it therefore cuts new passages for the
+/// messages it reaches and leaves every stored vector exactly as comparable as it was.
+/// </para>
+/// </remarks>
+public sealed class EmbeddingInputBound
+{
+    /// <summary>The characters of one message that are cut into passages where a deployment declares nothing.</summary>
+    /// <remarks>
+    /// Two hundred thousand characters is a long report with its quoted history, and far beyond what ordinary
+    /// correspondence reaches; what it excludes is the log dump, the exported table, and the machine-generated
+    /// attachment transcript, none of which a person asks a question about.
+    /// </remarks>
+    public const int DefaultMaximumCharacterCount = 200_000;
+
+    private EmbeddingInputBound(int maximumCharacterCount) =>
+        this.MaximumCharacterCount = maximumCharacterCount;
+
+    /// <summary>Gets the bound a deployment that declared none is cut to.</summary>
+    public static EmbeddingInputBound Default { get; } = new(DefaultMaximumCharacterCount);
+
+    /// <summary>Gets the characters of one message's text that are cut into passages.</summary>
+    public int MaximumCharacterCount { get; }
+
+    /// <summary>Builds a bound from what a deployment declared.</summary>
+    /// <param name="maximumCharacterCount">The characters of one message's text to cut into passages.</param>
+    /// <returns>The bound.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the count is not positive.</exception>
+    public static EmbeddingInputBound Create(int maximumCharacterCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maximumCharacterCount);
+
+        return new EmbeddingInputBound(maximumCharacterCount);
+    }
+}

--- a/src/Application/Emails/Embeddings/Limits/EmbeddingRequestPacer.cs
+++ b/src/Application/Emails/Embeddings/Limits/EmbeddingRequestPacer.cs
@@ -1,0 +1,91 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Limits;
+
+/// <summary>Spaces embedding requests out so a deployment never sends faster than it declared it would.</summary>
+/// <remarks>
+/// <para>
+/// A rate ceiling and the spend ceiling beside it bound different things and neither substitutes for the other: the
+/// budget decides how much a period may cost, this decides how quickly that cost is allowed to accumulate. It exists
+/// because a provider quota is stated per minute rather than per month, and because being refused with a rate-limit
+/// response costs an attempt, a retry, and a place in a circuit-breaker window that other work is measured in.
+/// </para>
+/// <para>
+/// It is also not the concurrency limit. How many calls may be in flight at once is the resilience pipeline's
+/// <c>AiProviderInvocation</c> budget, which is the one mechanism that owns that question; a second limiter counting
+/// in-flight calls here would make two settings answer for one behaviour.
+/// </para>
+/// <para>
+/// The pacing is a slot reservation rather than a token bucket that refills on a timer: a caller takes the next free
+/// slot, moves the marker forward by one interval, and waits for its own slot to arrive. Nothing polls, nothing spins,
+/// and every wait is a single cancellable delay measured on the injected <see cref="TimeProvider" /> — which is what
+/// lets a test prove that the ceiling binds and then releases, rather than proving it against a wall clock.
+/// </para>
+/// </remarks>
+public sealed class EmbeddingRequestPacer
+{
+    private readonly Lock reservation = new();
+    private readonly TimeSpan interval;
+    private readonly TimeProvider timeProvider;
+
+    private DateTimeOffset nextSlotAt;
+
+    private EmbeddingRequestPacer(TimeSpan interval, TimeProvider timeProvider)
+    {
+        this.interval = interval;
+        this.timeProvider = timeProvider;
+        this.nextSlotAt = DateTimeOffset.MinValue;
+    }
+
+    /// <summary>Gets whether this pacer delays nothing, which is what a rate of zero asked for.</summary>
+    public bool IsUnpaced => this.interval == TimeSpan.Zero;
+
+    /// <summary>Builds a pacer from the rate a deployment declared.</summary>
+    /// <param name="maxRequestsPerMinute">The requests one minute may carry, or zero to pace nothing.</param>
+    /// <param name="timeProvider">Measures the waits and decides when a slot has arrived.</param>
+    /// <returns>The pacer.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeProvider" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the rate is negative.</exception>
+    public static EmbeddingRequestPacer Create(int maxRequestsPerMinute, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentOutOfRangeException.ThrowIfNegative(maxRequestsPerMinute);
+
+        return new EmbeddingRequestPacer(
+            maxRequestsPerMinute == 0 ? TimeSpan.Zero : TimeSpan.FromMinutes(1) / maxRequestsPerMinute,
+            timeProvider);
+    }
+
+    /// <summary>Waits until this deployment is allowed to send its next embedding request.</summary>
+    /// <param name="cancellationToken">Abandons the wait when the caller stops or the host shuts down.</param>
+    /// <returns>A task that completes when the slot has arrived, immediately where nothing is paced.</returns>
+    /// <exception cref="OperationCanceledException">Thrown when the wait is cancelled, which leaves the reservation spent and the next caller no worse off than one slot.</exception>
+    /// <remarks>
+    /// The slot is reserved under the lock and waited for outside it, so a caller that has to wait a second does not
+    /// hold every other caller behind it for that second — they take the slots after it and wait for their own.
+    /// </remarks>
+    public Task WaitForSlotAsync(CancellationToken cancellationToken)
+    {
+        if (this.IsUnpaced)
+        {
+            return Task.CompletedTask;
+        }
+
+        TimeSpan wait;
+
+        lock (this.reservation)
+        {
+            var now = this.timeProvider.GetUtcNow();
+            var slot = this.nextSlotAt > now ? this.nextSlotAt : now;
+
+            this.nextSlotAt = slot + this.interval;
+            wait = slot - now;
+        }
+
+        return wait <= TimeSpan.Zero
+            ? Task.CompletedTask
+            : Task.Delay(wait, this.timeProvider, cancellationToken);
+    }
+}

--- a/src/Application/Emails/Embeddings/Limits/EmbeddingSpendBudget.cs
+++ b/src/Application/Emails/Embeddings/Limits/EmbeddingSpendBudget.cs
@@ -1,0 +1,85 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Limits;
+
+/// <summary>The aggregate ceiling an instance is willing to spend on embedding, and the period it is counted over.</summary>
+/// <remarks>
+/// <para>
+/// Embedding is the first thing MailFathom does that costs money per unit of mail, so what bounds it is a figure an
+/// operator agreed to rather than one this system inferred. The unit is the characters actually sent to a provider,
+/// because that is what every provider prices from — approximately, since a token is not a character — and because it
+/// is the one quantity this deployment can count exactly without carrying a model's own tokenizer.
+/// </para>
+/// <para>
+/// The period is a fixed window anchored at the Unix epoch rather than a rolling one. A fixed window has a start an
+/// operator can name, a roll-over instant work can wait for, and one row per period to count against; a rolling window
+/// would need every spend event retained for the length of the window and would never give a paused worker a moment to
+/// wake up at.
+/// </para>
+/// <para>
+/// Configuration alone, and deliberately never part of an embedding profile.
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md">ADR 0006</see>
+/// keeps the profile row to what a stored vector means; a ceiling decides how many vectors exist and changes the
+/// meaning of none of them, so raising it re-embeds nothing.
+/// </para>
+/// </remarks>
+public sealed class EmbeddingSpendBudget
+{
+    private EmbeddingSpendBudget(long maxInputCharactersPerPeriod, TimeSpan period)
+    {
+        this.MaxInputCharactersPerPeriod = maxInputCharactersPerPeriod;
+        this.Period = period;
+    }
+
+    /// <summary>Gets a budget that bounds nothing, which is what an operator writing a ceiling of zero asked for.</summary>
+    public static EmbeddingSpendBudget Unbounded { get; } = new(maxInputCharactersPerPeriod: 0, TimeSpan.FromDays(1));
+
+    /// <summary>Gets the characters one period may send to a provider, or zero where the operator declared no ceiling.</summary>
+    public long MaxInputCharactersPerPeriod { get; }
+
+    /// <summary>Gets the length of the window the ceiling is counted over.</summary>
+    public TimeSpan Period { get; }
+
+    /// <summary>Gets whether this budget refuses nothing.</summary>
+    public bool IsUnbounded => this.MaxInputCharactersPerPeriod == 0;
+
+    /// <summary>Builds a budget from what a deployment declared.</summary>
+    /// <param name="maxInputCharactersPerPeriod">The characters one period may send, or zero for no ceiling at all.</param>
+    /// <param name="period">The window the ceiling is counted over.</param>
+    /// <returns>The budget.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the ceiling is negative, or the period is not positive.</exception>
+    public static EmbeddingSpendBudget Create(long maxInputCharactersPerPeriod, TimeSpan period)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(maxInputCharactersPerPeriod);
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(period, TimeSpan.Zero);
+
+        return maxInputCharactersPerPeriod == 0
+            ? Unbounded
+            : new EmbeddingSpendBudget(maxInputCharactersPerPeriod, period);
+    }
+
+    /// <summary>Finds the start of the period an instant falls in, which is the key the consumed total is counted under.</summary>
+    /// <param name="instant">The moment to place in a period.</param>
+    /// <returns>The period's start, in UTC.</returns>
+    /// <remarks>
+    /// Anchored at the Unix epoch so that every process of a deployment, and every restart of one, agrees on where a
+    /// period begins without anything having to be stored to say so.
+    /// </remarks>
+    public DateTimeOffset PeriodStartAt(DateTimeOffset instant)
+    {
+        var elapsedTicks = instant.ToUniversalTime().Ticks - DateTimeOffset.UnixEpoch.Ticks;
+
+        // Floored rather than truncated, so an instant before the epoch — which no clock this runs on reports, but which
+        // a test may hand it — lands on the start of its period rather than on the end of the one before.
+        var periodsElapsed = (long)Math.Floor((double)elapsedTicks / this.Period.Ticks);
+
+        return DateTimeOffset.UnixEpoch.AddTicks(periodsElapsed * this.Period.Ticks);
+    }
+
+    /// <summary>Finds when the period an instant falls in rolls over, which is when paused work resumes.</summary>
+    /// <param name="instant">The moment to place in a period.</param>
+    /// <returns>The instant the next period begins, in UTC.</returns>
+    public DateTimeOffset PeriodEndAt(DateTimeOffset instant) => this.PeriodStartAt(instant) + this.Period;
+}

--- a/src/Application/Emails/Embeddings/Limits/EmbeddingSpendGate.cs
+++ b/src/Application/Emails/Embeddings/Limits/EmbeddingSpendGate.cs
@@ -1,0 +1,88 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+
+namespace MailFathom.Application.Emails.Embeddings.Limits;
+
+/// <summary>Answers whether embedding may spend right now, and records what it did spend.</summary>
+/// <remarks>
+/// <para>
+/// One type owns both halves because they are one decision: what a period admits is decided by what the same period has
+/// been charged, and splitting the question from the answer would let a reader consult one clock and a writer another.
+/// </para>
+/// <para>
+/// The reading is deliberately cheap and unconditional rather than cached. A period's total is one indexed row, the
+/// read happens beside a network call that costs orders of magnitude more, and a cached figure would be wrong exactly
+/// when it matters — after a restart, or while a second worker is spending against the same period.
+/// </para>
+/// </remarks>
+public sealed class EmbeddingSpendGate
+{
+    private readonly IEmbeddingSpendLedger ledger;
+    private readonly EmbeddingSpendBudget budget;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes a new gate over one deployment's budget.</summary>
+    /// <param name="ledger">Keeps the durable count of what each period has spent.</param>
+    /// <param name="budget">The ceiling and the period it is counted over.</param>
+    /// <param name="timeProvider">Decides which period the present moment belongs to.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public EmbeddingSpendGate(
+        IEmbeddingSpendLedger ledger,
+        EmbeddingSpendBudget budget,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(ledger);
+        ArgumentNullException.ThrowIfNull(budget);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.ledger = ledger;
+        this.budget = budget;
+        this.timeProvider = timeProvider;
+    }
+
+    /// <summary>Reads where the current period stands, which is what a run consults before it starts spending.</summary>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The period, its consumption, and what it still admits.</returns>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    /// <remarks>
+    /// This is the reading an activation weighs its estimate against, so it answers for a deployment with no ceiling
+    /// too: the period is still named and still counted, and only the ceiling is absent.
+    /// </remarks>
+    public async Task<EmbeddingSpendPeriod> ReadCurrentPeriodAsync(CancellationToken cancellationToken)
+    {
+        var now = this.timeProvider.GetUtcNow();
+        var periodStart = this.budget.PeriodStartAt(now);
+        var consumed = await this.ledger.ReadConsumedInputCharactersAsync(periodStart, cancellationToken);
+
+        return new EmbeddingSpendPeriod(
+            periodStart,
+            periodStart + this.budget.Period,
+            consumed,
+            this.budget.IsUnbounded ? null : this.budget.MaxInputCharactersPerPeriod);
+    }
+
+    /// <summary>Charges one provider call to the period it happened in.</summary>
+    /// <param name="session">The session committing the vectors that call produced.</param>
+    /// <param name="inputCharacterCount">The characters the call sent.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>A task that completes when the charge has been issued inside the caller's transaction.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="session" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the count is negative.</exception>
+    /// <remarks>
+    /// A deployment with no ceiling is charged exactly as one with a ceiling is. The count is what an operator watches
+    /// to decide whether to declare a ceiling at all, so leaving it unwritten would make the figure appear only once it
+    /// was already too late to be useful.
+    /// </remarks>
+    public Task RecordSpendAsync(
+        IPersistenceSession session,
+        long inputCharacterCount,
+        CancellationToken cancellationToken)
+    {
+        var periodStart = this.budget.PeriodStartAt(this.timeProvider.GetUtcNow());
+
+        return this.ledger.RecordSpendAsync(session, periodStart, inputCharacterCount, cancellationToken);
+    }
+}

--- a/src/Application/Emails/Embeddings/Limits/EmbeddingSpendPeriod.cs
+++ b/src/Application/Emails/Embeddings/Limits/EmbeddingSpendPeriod.cs
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Limits;
+
+/// <summary>What one budget period has spent so far, and what it still admits.</summary>
+/// <param name="StartsAt">When the period began, which is the key its total is counted under.</param>
+/// <param name="EndsAt">When the period rolls over, which is the instant paused work resumes at.</param>
+/// <param name="ConsumedInputCharacterCount">The characters already sent to a provider inside this period.</param>
+/// <param name="CeilingInputCharacterCount">The characters the period admits, or <see langword="null" /> where the deployment declared no ceiling.</param>
+/// <remarks>
+/// <para>
+/// This is the value the whole ceiling is readable through: a worker asks it whether to start, a paused one asks it
+/// when to wake, and an activation asks it whether the estimate it is about to confirm fits in what is left. Counts and
+/// instants only — no message, passage, or vector is describable from it.
+/// </para>
+/// <para>
+/// A ceiling of <see langword="null" /> is a deployment that declared none, which is a supported state rather than an
+/// unbounded one by omission: it is what an operator writing a ceiling of zero asked for, and the documentation says
+/// what it costs.
+/// </para>
+/// </remarks>
+public sealed record EmbeddingSpendPeriod(
+    DateTimeOffset StartsAt,
+    DateTimeOffset EndsAt,
+    long ConsumedInputCharacterCount,
+    long? CeilingInputCharacterCount)
+{
+    /// <summary>Gets the characters this period still admits, or <see langword="null" /> where nothing is being counted against.</summary>
+    /// <remarks>Never negative: a batch that crossed the ceiling is paid for, and what is left after it is nothing rather than a debt.</remarks>
+    public long? RemainingInputCharacterCount => this.CeilingInputCharacterCount is { } ceiling
+        ? Math.Max(0, ceiling - this.ConsumedInputCharacterCount)
+        : null;
+
+    /// <summary>Gets whether this period has reached its ceiling and admits no further request.</summary>
+    public bool IsExhausted => this.CeilingInputCharacterCount is { } ceiling
+        && this.ConsumedInputCharacterCount >= ceiling;
+
+    /// <summary>Gets whether a request may be sent under this period.</summary>
+    /// <remarks>
+    /// Asked of the period rather than of the request, because a batch is admitted whenever anything at all is left and
+    /// is then paid for whole. Weighing the batch against what remains instead would stall a deployment whose ceiling is
+    /// smaller than one batch forever — it would refuse the same request at every roll-over — and the overshoot the
+    /// simpler rule allows is bounded by one batch per concurrent call, which is the tolerance the configuration
+    /// reference states.
+    /// </remarks>
+    public bool AdmitsRequest => !this.IsExhausted;
+}

--- a/src/Application/Emails/Embeddings/Limits/IEmbeddingSpendLedger.cs
+++ b/src/Application/Emails/Embeddings/Limits/IEmbeddingSpendLedger.cs
@@ -1,0 +1,50 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+
+namespace MailFathom.Application.Emails.Embeddings.Limits;
+
+/// <summary>Keeps the durable count of what each budget period has already sent to a provider.</summary>
+/// <remarks>
+/// <para>
+/// Durable rather than held in memory, because the failure a spend ceiling exists to prevent is precisely the one an
+/// in-process counter cannot see: a process that crashes and restarts in a loop would begin every period again from
+/// zero and spend the whole ceiling on each attempt.
+/// </para>
+/// <para>
+/// It is also deliberately not derived from the stored vectors, which would need no table at all. A generation that is
+/// superseded has its vectors removed in bounded batches, so a count taken over them would erase the record of a spend
+/// that genuinely happened — and the period in which a model change is paid for is exactly the period an operator is
+/// watching.
+/// </para>
+/// </remarks>
+public interface IEmbeddingSpendLedger
+{
+    /// <summary>Reads what one period has consumed so far.</summary>
+    /// <param name="periodStart">The period's start, as the budget places it.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The characters already sent inside that period, which is zero for a period nothing has spent in yet.</returns>
+    Task<long> ReadConsumedInputCharactersAsync(DateTimeOffset periodStart, CancellationToken cancellationToken);
+
+    /// <summary>Adds what one provider call sent to the period it belongs to.</summary>
+    /// <param name="session">The session whose transaction this write joins.</param>
+    /// <param name="periodStart">The period's start, as the budget places it.</param>
+    /// <param name="inputCharacterCount">The characters the call sent.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>A task that completes when the increment has been issued inside the caller's transaction.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="session" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the count is negative.</exception>
+    /// <remarks>
+    /// Written inside the transaction that commits the vectors the call produced, so the two are one durable fact: a
+    /// crash between them cannot leave vectors nothing was charged for, or a charge for vectors that were never stored.
+    /// The increment is expressed as an increment rather than as a read followed by a write, so two workers spending
+    /// against one period add to each other instead of overwriting one another's total.
+    /// </remarks>
+    Task RecordSpendAsync(
+        IPersistenceSession session,
+        DateTimeOffset periodStart,
+        long inputCharacterCount,
+        CancellationToken cancellationToken);
+}

--- a/src/Host/Configuration/Embeddings/EmbeddingOptions.cs
+++ b/src/Host/Configuration/Embeddings/EmbeddingOptions.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.AI.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Limits;
 
 namespace MailFathom.Host.Configuration.Embeddings;
 
@@ -27,6 +28,27 @@ namespace MailFathom.Host.Configuration.Embeddings;
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
 internal sealed class EmbeddingOptions : IValidatableObject
 {
+    /// <summary>The characters one period may send where a deployment declares no ceiling of its own.</summary>
+    /// <remarks>
+    /// Fifty million characters a day is roughly twelve million tokens, which at the price of a small embedding model
+    /// is small change and at the price of a large one is a figure worth noticing — which is the point of a default
+    /// that binds. It embeds something like sixteen thousand ordinary messages a day, so an instance keeping up with
+    /// arriving mail never meets it and one embedding a decade of archive is paced rather than surprised. An operator
+    /// who wants an initial backfill finished sooner raises it deliberately, having seen the number.
+    /// </remarks>
+    public const long DefaultMaxInputCharactersPerPeriod = 50_000_000;
+
+    /// <summary>The longest window the aggregate ceiling may be counted over.</summary>
+    /// <remarks>
+    /// A period longer than a month would let one burst spend a ceiling and leave embedding paused for weeks, which is
+    /// a budget nobody would recognize as one from the outside.
+    /// </remarks>
+    private static readonly TimeSpan LongestSpendPeriod = TimeSpan.FromDays(31);
+
+    /// <summary>The shortest window the aggregate ceiling may be counted over.</summary>
+    /// <remarks>Below a minute the roll-over is faster than the pause it causes, so the ceiling would pace work instead of bounding it.</remarks>
+    private static readonly TimeSpan ShortestSpendPeriod = TimeSpan.FromMinutes(1);
+
     /// <summary>Gets the endpoints in the order they are tried, all of them reaching one vector space.</summary>
     /// <remarks>
     /// An ordered chain rather than one endpoint, because an endpoint failing and a vector space changing are
@@ -63,12 +85,53 @@ internal sealed class EmbeddingOptions : IValidatableObject
     [Range(1, 1_000_000)]
     public int MaxQueuedEmails { get; set; } = EmailEmbeddingBacklogOptions.DefaultCapacity;
 
+    /// <summary>Gets or sets how much of one message's extracted text is cut into passages.</summary>
+    /// <remarks>
+    /// The ceiling on what one message may cost. Per-item cost is not uniform — raw MIME is bounded in megabytes, so a
+    /// single message can carry more text than a mailbox does in a month — and a message beyond this is bounded rather
+    /// than refused: its opening is embedded and retrievable, and the length its text had is recorded on the message so
+    /// that what was left out is a stored fact rather than something inferred from a chunk count.
+    /// </remarks>
+    [Range(1_000, 10_000_000)]
+    public int MaxCharactersPerEmail { get; set; } = EmbeddingInputBound.DefaultMaximumCharacterCount;
+
+    /// <summary>Gets or sets how many embedding requests one minute may carry, or zero to pace none.</summary>
+    /// <remarks>
+    /// The rate ceiling, which bounds neither cost nor concurrency. What one period may spend is
+    /// <see cref="MaxInputCharactersPerPeriod" /> and how many calls may be in flight at once is the
+    /// <c>AiProviderInvocation</c> resilience budget; this exists because a provider quota is stated per minute, and
+    /// being refused for exceeding one costs an attempt, a retry, and a place in a circuit-breaker window.
+    /// </remarks>
+    [Range(0, 100_000)]
+    public int MaxRequestsPerMinute { get; set; }
+
+    /// <summary>Gets or sets the characters one period may send to a provider, or zero to bound nothing.</summary>
+    /// <remarks>
+    /// The aggregate ceiling, counted in the characters actually sent because that is what a provider's price is
+    /// approximately proportional to and the one quantity this deployment can count exactly without carrying a model's
+    /// own tokenizer. Reaching it pauses embedding until the period rolls over; nothing is dropped, because a passage
+    /// with no vector is exactly what the backfill selects on.
+    /// </remarks>
+    public long MaxInputCharactersPerPeriod { get; set; } = DefaultMaxInputCharactersPerPeriod;
+
+    /// <summary>Gets or sets the window the aggregate ceiling is counted over.</summary>
+    /// <remarks>A fixed window anchored at the Unix epoch, so every restart agrees on where a period begins without anything being stored to say so.</remarks>
+    public TimeSpan SpendPeriod { get; set; } = TimeSpan.FromDays(1);
+
     /// <summary>Gets whether the deployment declared an embedding provider at all.</summary>
     public bool IsConfigured => this.Endpoints.Count > 0;
 
     /// <inheritdoc />
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
+        // The ceilings are checked whether or not a chain was declared, unlike everything below them. Passages are cut
+        // for every synchronized message on an instance that has chosen no provider — they are what a later activation
+        // embeds — so a per-message ceiling nobody validated would be one an instance is already applying.
+        foreach (var error in this.FindSpendCeilingErrors())
+        {
+            yield return error;
+        }
+
         if (!this.IsConfigured)
         {
             yield break;
@@ -94,6 +157,26 @@ internal sealed class EmbeddingOptions : IValidatableObject
         foreach (var error in this.FindGeometryErrors())
         {
             yield return error;
+        }
+    }
+
+    /// <summary>Refuses an aggregate ceiling that could not bound a spend, or a period that could not carry one.</summary>
+    private IEnumerable<ValidationResult> FindSpendCeilingErrors()
+    {
+        if (this.MaxInputCharactersPerPeriod < 0)
+        {
+            yield return new ValidationResult(
+                "Embeddings MaxInputCharactersPerPeriod is zero or positive. Zero declares no aggregate ceiling at all, "
+                + "which is a supported deployment; a negative one describes no budget.",
+                [nameof(this.MaxInputCharactersPerPeriod)]);
+        }
+
+        if (this.SpendPeriod < ShortestSpendPeriod || this.SpendPeriod > LongestSpendPeriod)
+        {
+            yield return new ValidationResult(
+                $"Embeddings SpendPeriod is between {ShortestSpendPeriod} and {LongestSpendPeriod}. Below that a "
+                + "ceiling paces work rather than bounding it, and above it one burst leaves embedding paused for weeks.",
+                [nameof(this.SpendPeriod)]);
         }
     }
 

--- a/src/Host/Hosting/Workers/MailEmbeddingBackfillWorker.cs
+++ b/src/Host/Hosting/Workers/MailEmbeddingBackfillWorker.cs
@@ -97,7 +97,7 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
             this.telemetry.RecordPass(result);
             this.Report(result);
 
-            return result.MoreWorkIsWorthTryingSoon ? this.settings.Interval : this.settings.IdleSweepInterval;
+            return this.PaceAfter(result);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -115,6 +115,30 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
 
             return this.settings.Interval;
         }
+    }
+
+    /// <summary>Chooses how long to wait before the next pass, which the spend ceiling answers exactly.</summary>
+    /// <remarks>
+    /// Neither interval applies to a pass the ceiling stopped. The short one would re-read a ceiling already known to
+    /// bind, over and over until the period ended; the long one would leave a rolled-over period idle for as much as a
+    /// quarter of an hour. The roll-over is an instant the run itself reported, so the wait is exactly it. The removal
+    /// of a superseded generation is deliberately not exempted — it reaches no provider, but it rides this same pass,
+    /// and the alternative is a loop that spends the pause deleting rows nobody is waiting for.
+    /// </remarks>
+    private TimeSpan PaceAfter(EmbeddingGenerationUpkeepResult result)
+    {
+        if (result.Sweep.SpendPeriodEndsAt is { } periodEndsAt)
+        {
+            var wait = periodEndsAt - this.timeProvider.GetUtcNow();
+            if (wait > TimeSpan.Zero)
+            {
+                this.LogSpendCeilingReached(wait);
+
+                return wait;
+            }
+        }
+
+        return result.MoreWorkIsWorthTryingSoon ? this.settings.Interval : this.settings.IdleSweepInterval;
     }
 
     /// <summary>Says what the pass means for an operator, at the level each part of it deserves.</summary>
@@ -255,6 +279,11 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
         Level = LogLevel.Warning,
         Message = "{CallBudgetExhaustedEmailCount} messages each spent every provider call a turn is allowed and are still not fully embedded; a later sweep reaches the rest. A message needing that many calls means Embeddings:MaxPassagesPerRequest is far below what one message of this length carries.")]
     private partial void LogCallBudgetExhausted(int callBudgetExhaustedEmailCount);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The embedding spend ceiling for this period is reached, so the backfill is paused for {Wait} until the period rolls over; the position it committed is where it resumes and nothing is lost by the wait. Raise Embeddings:MaxInputCharactersPerPeriod to spend more per period.")]
+    private partial void LogSpendCeilingReached(TimeSpan wait);
 
     [LoggerMessage(
         Level = LogLevel.Warning,

--- a/src/Host/Hosting/Workers/MailEmbeddingWorker.cs
+++ b/src/Host/Hosting/Workers/MailEmbeddingWorker.cs
@@ -55,8 +55,43 @@ internal sealed partial class MailEmbeddingWorker : BackgroundService
 
         await foreach (var storedEmailId in this.backlog.ReadAllAsync(stoppingToken))
         {
-            await this.EmbedOneAsync(storedEmailId, stoppingToken);
+            var run = await this.EmbedOneAsync(storedEmailId, stoppingToken);
+
+            await this.PauseUntilTheCeilingLiftsAsync(run, stoppingToken);
         }
+    }
+
+    /// <summary>Holds the worker until the budget period rolls over, when a turn ended on the spend ceiling.</summary>
+    /// <remarks>
+    /// <para>
+    /// The pause belongs here rather than inside a message's turn, because without it the ceiling would be met once per
+    /// waiting message: every one of them would be taken from the backlog, read the ledger, learn the same thing, and be
+    /// left for the backfill — a queue drained at the speed of a database read instead of work that waits.
+    /// </para>
+    /// <para>
+    /// Nothing is dropped by waiting. The message whose turn met the ceiling keeps its outstanding passages, which is
+    /// exactly the condition the backfill selects on, and the messages behind it stay in the backlog until the bound it
+    /// carries turns one away — at which point the same promise covers those too.
+    /// </para>
+    /// </remarks>
+    private async Task PauseUntilTheCeilingLiftsAsync(
+        StoredEmailEmbeddingRun? run,
+        CancellationToken cancellationToken)
+    {
+        if (run?.SpendPeriodEndsAt is not { } periodEndsAt)
+        {
+            return;
+        }
+
+        var wait = periodEndsAt - this.timeProvider.GetUtcNow();
+        if (wait <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        this.LogSpendCeilingReached(wait, this.backlog.Depth);
+
+        await Task.Delay(wait, this.timeProvider, cancellationToken);
     }
 
     /// <summary>Embeds one message and reports it, isolating whatever goes wrong from the messages behind it.</summary>
@@ -66,7 +101,9 @@ internal sealed partial class MailEmbeddingWorker : BackgroundService
     /// again here would put a second retry layer around a call that already runs under one.
     /// </remarks>
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "The hosted worker isolates one message's failure so the messages waiting behind it are still embedded.")]
-    private async Task EmbedOneAsync(StoredEmailId storedEmailId, CancellationToken cancellationToken)
+    private async Task<StoredEmailEmbeddingRun?> EmbedOneAsync(
+        StoredEmailId storedEmailId,
+        CancellationToken cancellationToken)
     {
         var startingTimestamp = this.timeProvider.GetTimestamp();
 
@@ -78,6 +115,8 @@ internal sealed partial class MailEmbeddingWorker : BackgroundService
 
             this.telemetry.RecordEmbeddedMessage(run, this.timeProvider.GetElapsedTime(startingTimestamp));
             this.Report(run);
+
+            return run;
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -91,6 +130,9 @@ internal sealed partial class MailEmbeddingWorker : BackgroundService
         {
             this.LogMessageFailed(exception);
         }
+
+        // A turn nobody has a result for says nothing about the ceiling, so the loop carries on to the next message.
+        return null;
     }
 
     /// <summary>Embeds one message into the generation searches are answered from, if there is one.</summary>
@@ -146,6 +188,11 @@ internal sealed partial class MailEmbeddingWorker : BackgroundService
 
                 break;
 
+            // Reported by the pause that follows rather than here, which is what says how long the wait is; saying it
+            // twice about one turn would read as two events.
+            case StoredEmailEmbeddingOutcome.SpendCeilingReached:
+                break;
+
             // The classification is matched rather than defaulted, because inventing one would report a failure the
             // provider never gave. A ProviderFailed result without it is unconstructible, so the case simply does not
             // arise.
@@ -189,6 +236,11 @@ internal sealed partial class MailEmbeddingWorker : BackgroundService
         Level = LogLevel.Warning,
         Message = "One message spent every provider call a turn is allowed after {EmbeddedChunkCount} passages and is still not fully embedded; the rest stay outstanding for the backfill. A message needing that many calls means Embeddings:MaxPassagesPerRequest is far below what one message of this length carries.")]
     private partial void LogCallBudgetExhausted(int embeddedChunkCount);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The embedding spend ceiling for this period is reached, so embedding is paused for {Wait} until the period rolls over; {BacklogDepth} messages are waiting and nothing is lost by the wait. Raise Embeddings:MaxInputCharactersPerPeriod to spend more per period.")]
+    private partial void LogSpendCeilingReached(TimeSpan wait, int backlogDepth);
 
     [LoggerMessage(
         Level = LogLevel.Warning,

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.AiProviders;
 using MailFathom.Application.EmailContent;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Mail;
@@ -337,6 +338,25 @@ try
     {
         Capacity = provider.GetRequiredService<IOptions<EmbeddingOptions>>().Value.MaxQueuedEmails,
     });
+
+    // The three ceilings, registered the same way and for the same reason the backlog bound is: each of them applies to
+    // an instance rather than to an activation. Passages are cut for every synchronized message whether or not a
+    // provider was ever declared, and what a period has spent is a figure an operator reads before deciding to declare
+    // one — so registering these behind the declaration would leave the chunker without a bound and the ledger without
+    // a budget to be read against.
+    builder.Services.AddSingleton(provider => EmbeddingInputBound.Create(
+        provider.GetRequiredService<IOptions<EmbeddingOptions>>().Value.MaxCharactersPerEmail));
+    builder.Services.AddSingleton(provider =>
+    {
+        var settings = provider.GetRequiredService<IOptions<EmbeddingOptions>>().Value;
+
+        return EmbeddingSpendBudget.Create(settings.MaxInputCharactersPerPeriod, settings.SpendPeriod);
+    });
+    // A singleton because the reservation it hands out is what makes one process's requests add up to the declared
+    // rate; one per scope would let every worker send at the full rate on its own.
+    builder.Services.AddSingleton(provider => EmbeddingRequestPacer.Create(
+        provider.GetRequiredService<IOptions<EmbeddingOptions>>().Value.MaxRequestsPerMinute,
+        provider.GetRequiredService<TimeProvider>()));
 
     // Read the same way and for the same reason as the embedding declaration: whether this deployment generates text
     // decides which services exist, and that decision is taken before the container that would resolve an options

--- a/src/Infrastructure/Observability/EmailEmbeddingBackfillTelemetry.cs
+++ b/src/Infrastructure/Observability/EmailEmbeddingBackfillTelemetry.cs
@@ -153,6 +153,7 @@ public sealed class EmailEmbeddingBackfillTelemetry
         StoredEmailEmbeddingBackfillOutcome.NoActiveProfile => "no_active_profile",
         StoredEmailEmbeddingBackfillOutcome.GeneratorDisagreesWithProfile => "generator_disagrees_with_profile",
         StoredEmailEmbeddingBackfillOutcome.ProviderFailed => "provider_failed",
+        StoredEmailEmbeddingBackfillOutcome.SpendCeilingReached => "spend_ceiling_reached",
         _ => "unknown",
     };
 

--- a/src/Infrastructure/Observability/EmailEmbeddingTelemetry.cs
+++ b/src/Infrastructure/Observability/EmailEmbeddingTelemetry.cs
@@ -31,6 +31,9 @@ public sealed class EmailEmbeddingTelemetry
     private readonly Counter<long> messageCount;
     private readonly Counter<long> passageCount;
     private readonly Histogram<double> messageDuration;
+    private readonly Counter<long> consumedInputCharacterCount;
+    private readonly Counter<long> truncatedMessageCount;
+    private readonly Counter<long> omittedInputCharacterCount;
 
     /// <summary>Initializes the instruments every embedded message reports through.</summary>
     public EmailEmbeddingTelemetry()
@@ -47,6 +50,22 @@ public sealed class EmailEmbeddingTelemetry
             "mailfathom.embedding.message.duration",
             unit: "s",
             description: "How long embedding one message took, by outcome.");
+
+        // A counter rather than a gauge of what is left, because the ledger's remaining figure would have to be read
+        // from the database inside a callback the meter invokes on its own schedule. Summed over a period this answers
+        // the same question, and summed over any other window it answers one a ceiling cannot.
+        this.consumedInputCharacterCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.embedding.budget.consumed",
+            unit: "{character}",
+            description: "Characters sent to an embedding provider and charged against the spend ceiling.");
+        this.truncatedMessageCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.embedding.input.truncated",
+            unit: "{message}",
+            description: "Messages whose text the per-message embedding ceiling cut short.");
+        this.omittedInputCharacterCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.embedding.input.omitted",
+            unit: "{character}",
+            description: "Characters the per-message embedding ceiling left out of the passages it cut.");
     }
 
     /// <summary>Records one message's turn at being embedded.</summary>
@@ -70,6 +89,29 @@ public sealed class EmailEmbeddingTelemetry
         {
             this.passageCount.Add(run.EmbeddedChunkCount);
         }
+
+        // Recorded for every outcome that sent anything, including the two that stopped part-way: what a turn spent is
+        // spent whether or not the message it was for is now whole.
+        if (run.InputCharacterCount > 0)
+        {
+            this.consumedInputCharacterCount.Add(run.InputCharacterCount);
+        }
+    }
+
+    /// <summary>Records one message the per-message input ceiling cut short.</summary>
+    /// <param name="omittedCharacterCount">The characters the ceiling left out of the passages.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the count is negative.</exception>
+    /// <remarks>
+    /// Two instruments rather than one, because the two questions differ: how many messages are being cut says whether
+    /// the ceiling is set where an operator meant it, and how much text is being left out says what raising it would
+    /// cost. A count alone would make one enormous message and a thousand slightly oversized ones look the same.
+    /// </remarks>
+    public void RecordTruncatedEmbeddingInput(int omittedCharacterCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(omittedCharacterCount);
+
+        this.truncatedMessageCount.Add(1);
+        this.omittedInputCharacterCount.Add(omittedCharacterCount);
     }
 
     private static string OutcomeTagOf(StoredEmailEmbeddingOutcome outcome) => outcome switch
@@ -79,6 +121,7 @@ public sealed class EmailEmbeddingTelemetry
         StoredEmailEmbeddingOutcome.GeneratorDisagreesWithProfile => "generator_disagrees_with_profile",
         StoredEmailEmbeddingOutcome.ProviderFailed => "provider_failed",
         StoredEmailEmbeddingOutcome.CallBudgetExhausted => "call_budget_exhausted",
+        StoredEmailEmbeddingOutcome.SpendCeilingReached => "spend_ceiling_reached",
         _ => "unknown",
     };
 

--- a/src/Infrastructure/Persistence/Emails/EmailChunkWriter.cs
+++ b/src/Infrastructure/Persistence/Emails/EmailChunkWriter.cs
@@ -55,6 +55,13 @@ internal sealed class EmailChunkWriter(
         var cut = chunker.DeriveChunks(text, rules, inputBound);
         var chunks = cut.Chunks;
 
+        // Recorded before the passages are compared, because the two answers are independent: text that grew past the
+        // ceiling while everything up to it stayed identical yields the same passages and a different truncation, and a
+        // record written only where rows changed would go on reporting the length the text used to have. Assigning an
+        // unchanged value marks nothing modified, so the promise below — that an unchanged message writes nothing at
+        // all — survives it.
+        this.RecordTruncation(storedEmail, cut);
+
         // The change-tracker pass comes first for the reason the search document's does: passages staged earlier in
         // this same uncommitted session are invisible to a set-based delete, and inserting beside them would violate
         // the ordinal index at commit rather than replace them.
@@ -109,20 +116,15 @@ internal sealed class EmailChunkWriter(
                 pair.First.Ordinal == pair.Second.Ordinal
                 && string.Equals(pair.First.ContentHash, pair.Second.ContentHash.Value, StringComparison.Ordinal));
 
-    /// <summary>Writes the passages a cut produced, and what that cut left out of the message.</summary>
+    /// <summary>Records what this cut left out of the message, on the message.</summary>
     /// <remarks>
-    /// The truncation is written on the message beside its passages rather than reported only as a metric, because a
-    /// counter says how often the ceiling bound across a deployment and this says which message it bound on. Written on
-    /// every insert, including as a clearing of a value a previous cut left behind: a message whose text shrank, or one
+    /// Written on the row beside its passages rather than reported only as a metric, because a counter says how often
+    /// the ceiling bound across a deployment and this says which message it bound on. It is written on every
+    /// derivation, including as a clearing of a value a previous cut left behind: a message whose text shrank, or one
     /// re-cut after the ceiling was raised past it, is no longer truncated and its row must not go on saying it is.
     /// </remarks>
-    private void Insert(
-        MailFathomDbContext dbContext,
-        StoredEmailEntity storedEmail,
-        EmailChunkingResult cut)
+    private void RecordTruncation(StoredEmailEntity storedEmail, EmailChunkingResult cut)
     {
-        var derivedAt = timeProvider.GetUtcNow();
-
         storedEmail.ChunkedTextTruncatedFromCharacterCount = cut.TruncatedFromCharacterCount;
 
         // Measured against the ceiling rather than against the text that was kept, which the passages overlap and
@@ -132,6 +134,14 @@ internal sealed class EmailChunkWriter(
         {
             telemetry.RecordTruncatedEmbeddingInput(truncatedFrom - inputBound.MaximumCharacterCount);
         }
+    }
+
+    private void Insert(
+        MailFathomDbContext dbContext,
+        StoredEmailEntity storedEmail,
+        EmailChunkingResult cut)
+    {
+        var derivedAt = timeProvider.GetUtcNow();
 
         dbContext.EmailChunks.AddRange(cut.Chunks.Select(chunk => new EmailChunkEntity
         {

--- a/src/Infrastructure/Persistence/Emails/EmailChunkWriter.cs
+++ b/src/Infrastructure/Persistence/Emails/EmailChunkWriter.cs
@@ -3,8 +3,10 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Emails.Chunking;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.CodeCoverage;
+using MailFathom.Infrastructure.Observability;
 using MailFathom.Infrastructure.Persistence.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -22,6 +24,8 @@ namespace MailFathom.Infrastructure.Persistence.Emails;
 internal sealed class EmailChunkWriter(
     IEmailTextChunker chunker,
     EmailChunkingRules rules,
+    EmbeddingInputBound inputBound,
+    EmailEmbeddingTelemetry telemetry,
     TimeProvider timeProvider)
 {
     /// <summary>Saves the passages one extraction yields, leaving an unchanged message's rows untouched.</summary>
@@ -48,7 +52,8 @@ internal sealed class EmailChunkWriter(
         ArgumentNullException.ThrowIfNull(storedEmail);
         ArgumentNullException.ThrowIfNull(text);
 
-        var chunks = chunker.DeriveChunks(text, rules);
+        var cut = chunker.DeriveChunks(text, rules, inputBound);
+        var chunks = cut.Chunks;
 
         // The change-tracker pass comes first for the reason the search document's does: passages staged earlier in
         // this same uncommitted session are invisible to a set-based delete, and inserting beside them would violate
@@ -62,7 +67,7 @@ internal sealed class EmailChunkWriter(
             }
 
             dbContext.EmailChunks.RemoveRange(staged);
-            this.Insert(dbContext, storedEmail, chunks);
+            this.Insert(dbContext, storedEmail, cut);
 
             return;
         }
@@ -87,7 +92,7 @@ internal sealed class EmailChunkWriter(
                 .ExecuteDeleteAsync(cancellationToken);
         }
 
-        this.Insert(dbContext, storedEmail, chunks);
+        this.Insert(dbContext, storedEmail, cut);
     }
 
     private static EmailChunkEntity[] FindStaged(MailFathomDbContext dbContext, Guid storedEmailId) =>
@@ -104,14 +109,31 @@ internal sealed class EmailChunkWriter(
                 pair.First.Ordinal == pair.Second.Ordinal
                 && string.Equals(pair.First.ContentHash, pair.Second.ContentHash.Value, StringComparison.Ordinal));
 
+    /// <summary>Writes the passages a cut produced, and what that cut left out of the message.</summary>
+    /// <remarks>
+    /// The truncation is written on the message beside its passages rather than reported only as a metric, because a
+    /// counter says how often the ceiling bound across a deployment and this says which message it bound on. Written on
+    /// every insert, including as a clearing of a value a previous cut left behind: a message whose text shrank, or one
+    /// re-cut after the ceiling was raised past it, is no longer truncated and its row must not go on saying it is.
+    /// </remarks>
     private void Insert(
         MailFathomDbContext dbContext,
         StoredEmailEntity storedEmail,
-        IReadOnlyList<EmailTextChunk> chunks)
+        EmailChunkingResult cut)
     {
         var derivedAt = timeProvider.GetUtcNow();
 
-        dbContext.EmailChunks.AddRange(chunks.Select(chunk => new EmailChunkEntity
+        storedEmail.ChunkedTextTruncatedFromCharacterCount = cut.TruncatedFromCharacterCount;
+
+        // Measured against the ceiling rather than against the text that was kept, which the passages overlap and
+        // therefore cannot be summed to. The cut lands on the nearest text-element boundary at or below the ceiling, so
+        // the figure is short by at most one grapheme — irrelevant beside a message this ceiling reaches at all.
+        if (cut.TruncatedFromCharacterCount is { } truncatedFrom)
+        {
+            telemetry.RecordTruncatedEmbeddingInput(truncatedFrom - inputBound.MaximumCharacterCount);
+        }
+
+        dbContext.EmailChunks.AddRange(cut.Chunks.Select(chunk => new EmailChunkEntity
         {
             // Version 7 for the reason every other identifier MailFathom generates is: the passages of one message are
             // written together, so an identifier ordered by creation time keeps them on neighbouring index pages.

--- a/src/Infrastructure/Persistence/Embeddings/EmbeddingSpendLedger.cs
+++ b/src/Infrastructure/Persistence/Embeddings/EmbeddingSpendLedger.cs
@@ -1,0 +1,73 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Limits;
+using MailFathom.Application.Persistence;
+using MailFathom.CodeCoverage;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Sessions;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailFathom.Infrastructure.Persistence.Embeddings;
+
+/// <summary>EF Core ledger of what each budget period has spent against an embedding provider.</summary>
+[RequiresIntegrationCoverage]
+internal sealed class EmbeddingSpendLedger(MailFathomDbContext dbContext) : IEmbeddingSpendLedger
+{
+    /// <summary>Adds a period's spend, inserting the period's row the first time anything is charged to it.</summary>
+    /// <remarks>
+    /// One statement rather than a read and a write, because the two workers that spend do so in separate transactions
+    /// and a read-modify-write would let each of them overwrite the other's increment with a total that was already
+    /// stale when it was read. PostgreSQL's upsert makes the whole thing one atomic addition, and the column and table
+    /// names come from the entity so the statement and the mapping cannot drift apart.
+    /// </remarks>
+    private const string RecordSpendStatement = $$"""
+        INSERT INTO {{EmbeddingSpendPeriodEntity.TableName}}
+            ("{{EmbeddingSpendPeriodEntity.PeriodStartsAtColumnName}}", "{{EmbeddingSpendPeriodEntity.ConsumedInputCharacterCountColumnName}}")
+        VALUES ({0}, {1})
+        ON CONFLICT ("{{EmbeddingSpendPeriodEntity.PeriodStartsAtColumnName}}") DO UPDATE
+        SET "{{EmbeddingSpendPeriodEntity.ConsumedInputCharacterCountColumnName}}" =
+            {{EmbeddingSpendPeriodEntity.TableName}}."{{EmbeddingSpendPeriodEntity.ConsumedInputCharacterCountColumnName}}"
+            + EXCLUDED."{{EmbeddingSpendPeriodEntity.ConsumedInputCharacterCountColumnName}}"
+        """;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// A period nobody has spent in has no row, and reads as zero rather than as an absence. That is what makes the
+    /// first call of a new period ordinary: nothing has to create a period before work may begin in it.
+    /// </remarks>
+    public async Task<long> ReadConsumedInputCharactersAsync(
+        DateTimeOffset periodStart,
+        CancellationToken cancellationToken) =>
+        await dbContext.EmbeddingSpendPeriods
+            .AsNoTracking()
+            .Where(period => period.PeriodStartsAt == periodStart)
+            .Select(period => period.ConsumedInputCharacterCount)
+            .SingleOrDefaultAsync(cancellationToken);
+
+    /// <inheritdoc />
+    public Task RecordSpendAsync(
+        IPersistenceSession session,
+        DateTimeOffset periodStart,
+        long inputCharacterCount,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentOutOfRangeException.ThrowIfNegative(inputCharacterCount);
+
+        if (inputCharacterCount == 0)
+        {
+            return Task.CompletedTask;
+        }
+
+        var sessionDbContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
+
+        // Both values are parameters rather than composed text; only the identifiers, which come from the entity's own
+        // constants, are part of the statement.
+        return sessionDbContext.Database.ExecuteSqlRawAsync(
+            RecordSpendStatement,
+            [periodStart, inputCharacterCount],
+            cancellationToken);
+    }
+}

--- a/src/Infrastructure/Persistence/Entities/EmbeddingSpendPeriodEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/EmbeddingSpendPeriodEntity.cs
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.CodeCoverage;
+
+namespace MailFathom.Infrastructure.Persistence.Entities;
+
+/// <summary>What one budget period has already sent to an embedding provider.</summary>
+/// <remarks>
+/// <para>
+/// One row per period, keyed by the instant the period began, which every process derives from the configured period
+/// length and the Unix epoch rather than reading from anywhere. Nothing allocates a period: the first spend inside one
+/// inserts its row and every later spend adds to it.
+/// </para>
+/// <para>
+/// Nothing here is mail or derived from it. A character count and an instant say how much this deployment spent and
+/// when, and neither names a message, a passage, or a vector — which is what lets the row outlive every generation
+/// whose cost it recorded.
+/// </para>
+/// <para>
+/// It carries no concurrency token, and that is deliberate rather than an omission. The one write is an increment
+/// issued as an upsert, so two workers spending inside one period add to each other instead of racing to overwrite a
+/// total each of them read.
+/// </para>
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class EmbeddingSpendPeriodEntity
+{
+    /// <summary>The table these rows live in, named here because the increment is a composed statement.</summary>
+    internal const string TableName = "embedding_spend_periods";
+
+    /// <summary>The key column, named here for the same reason the table is.</summary>
+    internal const string PeriodStartsAtColumnName = "PeriodStartsAt";
+
+    /// <summary>The counted column, named here for the same reason the table is.</summary>
+    internal const string ConsumedInputCharacterCountColumnName = "ConsumedInputCharacterCount";
+
+    /// <summary>Gets or sets when the period began, in UTC.</summary>
+    public DateTimeOffset PeriodStartsAt { get; set; }
+
+    /// <summary>Gets or sets the characters this period has sent to a provider.</summary>
+    /// <remarks>
+    /// Characters rather than tokens or requests, because it is the one quantity a provider's price is approximately
+    /// proportional to that this deployment can count exactly without carrying the model's own tokenizer. Sixty-four
+    /// bits because a period of a mailbox's initial embedding passes a billion characters without difficulty.
+    /// </remarks>
+    public long ConsumedInputCharacterCount { get; set; }
+}

--- a/src/Infrastructure/Persistence/Entities/StoredEmailEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/StoredEmailEntity.cs
@@ -173,6 +173,18 @@ internal sealed class StoredEmailEntity
     public EmailContentRepairRequestEntity? ContentRepairRequest { get; set; }
 
     /// <summary>
+    /// Gets or sets the length this email's extracted text had when the per-message embedding ceiling stopped the cut
+    /// short of its end, or <see langword="null" /> when no ceiling reached it.
+    /// </summary>
+    /// <remarks>
+    /// Recorded rather than inferred. A message cut whole and one cut to a ceiling are indistinguishable from their
+    /// passages alone, so without this column the question "could the answer have been in the part nobody embedded"
+    /// would be answered by guessing from a chunk count. The value is the length of the text, which against the ceiling
+    /// in force says exactly how much was left out.
+    /// </remarks>
+    public int? ChunkedTextTruncatedFromCharacterCount { get; set; }
+
+    /// <summary>
     /// Gets or sets the retrievable passages this email's extracted text was cut into, which are empty until chunking
     /// has run for it and stay empty for a message whose body yielded no text.
     /// </summary>

--- a/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -147,6 +147,8 @@ internal sealed class MailFathomDbContext : DbContext
 
     internal DbSet<EmailEmbeddingEntity> EmailEmbeddings => this.Set<EmailEmbeddingEntity>();
 
+    internal DbSet<EmbeddingSpendPeriodEntity> EmbeddingSpendPeriods => this.Set<EmbeddingSpendPeriodEntity>();
+
     internal DbSet<EmailContentRepairRequestEntity> EmailContentRepairRequests => this.Set<EmailContentRepairRequestEntity>();
 
     internal DbSet<BackfillPositionEntity> BackfillPositions => this.Set<BackfillPositionEntity>();
@@ -288,6 +290,21 @@ internal sealed class MailFathomDbContext : DbContext
 
         ConfigureEmbeddingProfile(modelBuilder);
         ConfigureEmailEmbedding(modelBuilder);
+
+        // One row per budget period, keyed by the instant that period began. Nothing hangs off it and nothing cascades
+        // into it: what it records is a cost this deployment incurred, which stays true after every vector that cost
+        // paid for has been superseded and removed. The column names are the entity's own constants because the one
+        // write is a composed upsert, so the statement and this mapping name the same things by construction.
+        modelBuilder.Entity<EmbeddingSpendPeriodEntity>(entity =>
+        {
+            entity.ToTable(EmbeddingSpendPeriodEntity.TableName);
+            entity.HasKey(period => period.PeriodStartsAt);
+            entity.Property(period => period.PeriodStartsAt)
+                .HasColumnName(EmbeddingSpendPeriodEntity.PeriodStartsAtColumnName)
+                .ValueGeneratedNever();
+            entity.Property(period => period.ConsumedInputCharacterCount)
+                .HasColumnName(EmbeddingSpendPeriodEntity.ConsumedInputCharacterCountColumnName);
+        });
 
         // One row per email whose stored content a read found unusable, keyed by that email so a reader meeting the
         // same damage repeatedly leaves one outstanding request rather than a row per attempt. It is deliberately a

--- a/src/Infrastructure/Persistence/Migrations/20260808150849_AddEmbeddingSpendPeriodsAndChunkedTextTruncation.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260808150849_AddEmbeddingSpendPeriodsAndChunkedTextTruncation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260808150849_AddEmbeddingSpendPeriodsAndChunkedTextTruncation")]
+    partial class AddEmbeddingSpendPeriodsAndChunkedTextTruncation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260808150849_AddEmbeddingSpendPeriodsAndChunkedTextTruncation.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260808150849_AddEmbeddingSpendPeriodsAndChunkedTextTruncation.cs
@@ -1,0 +1,48 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmbeddingSpendPeriodsAndChunkedTextTruncation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "ChunkedTextTruncatedFromCharacterCount",
+                table: "stored_emails",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "embedding_spend_periods",
+                columns: table => new
+                {
+                    PeriodStartsAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ConsumedInputCharacterCount = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_embedding_spend_periods", x => x.PeriodStartsAt);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "embedding_spend_periods");
+
+            migrationBuilder.DropColumn(
+                name: "ChunkedTextTruncatedFromCharacterCount",
+                table: "stored_emails");
+        }
+    }
+}

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.GetEmailContent;
 using MailFathom.Application.Emails.ListEmails;
@@ -215,6 +216,10 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<EmailEmbeddingBackfillTelemetry>();
         services.AddScoped<IActiveEmbeddingProfileReader, ActiveEmbeddingProfileReader>();
         services.AddScoped<IEmailEmbeddingStore, EmailEmbeddingStore>();
+        // Registered whether or not this deployment embeds, for the reason the backlog is: what a period spent is a
+        // fact about the instance rather than about an activation, and an operator deciding whether to declare a
+        // ceiling reads it before there is anything to bound.
+        services.AddScoped<IEmbeddingSpendLedger, EmbeddingSpendLedger>();
         // The only registration here that changes the schema. It is scoped like every other store so that a caller
         // which has opened a persistence session gets its statement inside that session's transaction rather than
         // beside it.
@@ -403,6 +408,10 @@ public static class ServiceCollectionExtensions
     {
         ArgumentNullException.ThrowIfNull(services);
 
+        // Scoped like the generator that asks it, because the ledger it reads through is the scoped persistence
+        // context. The budget and the pacer behind it are singletons: one is a configured value and the other holds the
+        // reservation every caller of this process takes its slot from.
+        services.AddScoped<EmbeddingSpendGate>();
         services.AddScoped<StoredEmailEmbeddingGenerator>();
         services.AddScoped<StoredEmailEmbeddingBackfill>();
         services.AddScoped<EmbeddingGenerationUpkeep>();

--- a/tests/AI.UnitTests/Chunking/DeterministicEmailTextChunkerTests.cs
+++ b/tests/AI.UnitTests/Chunking/DeterministicEmailTextChunkerTests.cs
@@ -5,6 +5,7 @@
 using System.Globalization;
 using MailFathom.AI.Chunking;
 using MailFathom.Application.Emails.Chunking;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Emails.Extraction;
 using Xunit;
 
@@ -21,7 +22,7 @@ public sealed class DeterministicEmailTextChunkerTests
     public void DeriveChunks_TextWithoutABody_YieldsNoChunks(ExtractedEmailText text)
     {
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.Empty(chunks);
@@ -36,7 +37,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         var chunk = Assert.Single(chunks);
@@ -58,7 +59,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.Equal(
@@ -75,7 +76,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.True(chunks.Count > 1, "The sample has to be long enough to be cut into several passages.");
@@ -94,7 +95,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.All(chunks, chunk => Assert.InRange(chunk.Text.Length, 1, EmailChunkingRules.Current.TargetCharacterCount));
@@ -109,7 +110,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.All(
@@ -127,7 +128,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.EndsWith("\n\n", chunks[0].Text, StringComparison.Ordinal);
@@ -146,7 +147,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.True(
@@ -163,7 +164,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.Equal(EmailChunkingRules.Current.TargetCharacterCount, chunks[0].Text.Length);
@@ -183,7 +184,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.All(chunks, chunk => Assert.Equal(0, chunk.Text.Length % element.Length));
@@ -210,7 +211,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, rules);
+        var chunks = this.Chunk(text, rules);
 
         // Assert
         Assert.All(chunks, chunk => Assert.Equal(0, chunk.Text.Length % element.Length));
@@ -226,8 +227,10 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var first = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
-        var second = new DeterministicEmailTextChunker().DeriveChunks(text, EmailChunkingRules.Current);
+        var first = this.Chunk(text, EmailChunkingRules.Current);
+        var second = new DeterministicEmailTextChunker()
+            .DeriveChunks(text, EmailChunkingRules.Current, EmbeddingInputBound.Default)
+            .Chunks;
 
         // Assert
         Assert.Equal(first, second);
@@ -241,7 +244,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody("Quoted history.\n\nThe answer.", "The answer.");
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.Equal("The answer.", Assert.Single(chunks).Text);
@@ -262,7 +265,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody("Quoted history.\n\nThe answer.", "The answer.");
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, rules);
+        var chunks = this.Chunk(text, rules);
 
         // Assert
         Assert.Equal("Quoted history.\n\nThe answer.", Assert.Single(chunks).Text);
@@ -277,7 +280,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.DerivedFromHtmlBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.All(chunks, chunk => Assert.True(chunk.IsDerivedFromLossyHtml));
@@ -292,7 +295,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, EmailChunkingRules.Current);
+        var chunks = this.Chunk(text, EmailChunkingRules.Current);
 
         // Assert
         Assert.All(chunks, chunk => Assert.Equal(EmailChunkingRules.Current.RuleSetVersion, chunk.RuleSetVersion));
@@ -314,7 +317,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody(body, body);
 
         // Act
-        var chunks = this.chunker.DeriveChunks(text, rules);
+        var chunks = this.Chunk(text, rules);
 
         // Assert
         Assert.All(chunks, chunk => Assert.False(string.IsNullOrWhiteSpace(chunk.Text)));
@@ -335,7 +338,7 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody("Body.", "Body.");
 
         // Act, Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => this.chunker.DeriveChunks(text, rules));
+        Assert.Throws<ArgumentOutOfRangeException>(() => this.Chunk(text, rules));
     }
 
     /// <summary>Nothing may be cut from arguments that are not there.</summary>
@@ -346,8 +349,72 @@ public sealed class DeterministicEmailTextChunkerTests
         var text = ExtractedEmailText.FromPlainTextBody("Body.", "Body.");
 
         // Act, Assert
-        Assert.Throws<ArgumentNullException>(() => this.chunker.DeriveChunks(null!, EmailChunkingRules.Current));
-        Assert.Throws<ArgumentNullException>(() => this.chunker.DeriveChunks(text, null!));
+        Assert.Throws<ArgumentNullException>(() => this.Chunk(null!, EmailChunkingRules.Current));
+        Assert.Throws<ArgumentNullException>(() => this.Chunk(text, null!));
+        Assert.Throws<ArgumentNullException>(
+            () => this.chunker.DeriveChunks(text, EmailChunkingRules.Current, null!));
+    }
+
+    /// <summary>A message inside the ceiling is cut whole and its record says nothing was left out.</summary>
+    [Fact]
+    public void DeriveChunks_TextInsideTheInputBound_ReportsNoTruncation()
+    {
+        // Arrange
+        var body = Paragraphs(4);
+        var text = ExtractedEmailText.FromPlainTextBody(body, body);
+
+        // Act
+        var cut = this.chunker.DeriveChunks(
+            text,
+            EmailChunkingRules.Current,
+            EmbeddingInputBound.Create(body.Length));
+
+        // Assert
+        Assert.Null(cut.TruncatedFromCharacterCount);
+        Assert.Equal(body.Length, cut.Chunks[^1].EndOffset);
+    }
+
+    /// <summary>An oversized message is bounded rather than refused, and the length it had is what the cut reports.</summary>
+    [Fact]
+    public void DeriveChunks_TextBeyondTheInputBound_CutsToItAndReportsTheLengthItHad()
+    {
+        // Arrange
+        var body = Paragraphs(20);
+        var text = ExtractedEmailText.FromPlainTextBody(body, body);
+        var bound = EmbeddingInputBound.Create(body.Length / 2);
+
+        // Act
+        var cut = this.chunker.DeriveChunks(text, EmailChunkingRules.Current, bound);
+
+        // Assert
+        Assert.Equal(body.Length, cut.TruncatedFromCharacterCount);
+        Assert.NotEmpty(cut.Chunks);
+        Assert.True(cut.Chunks[^1].EndOffset <= bound.MaximumCharacterCount);
+    }
+
+    /// <summary>
+    /// A ceiling decides how many passages exist and never what one says, so every passage the bound leaves in place
+    /// keeps the hash it had — which is what stops a raised or lowered ceiling from re-embedding text nothing changed.
+    /// </summary>
+    [Fact]
+    public void DeriveChunks_TextBeyondTheInputBound_LeavesTheHashesOfTheRetainedPassagesUnchanged()
+    {
+        // Arrange
+        var body = Paragraphs(20);
+        var text = ExtractedEmailText.FromPlainTextBody(body, body);
+
+        // Act
+        var whole = this.chunker.DeriveChunks(text, EmailChunkingRules.Current, EmbeddingInputBound.Default);
+        var bounded = this.chunker.DeriveChunks(
+            text,
+            EmailChunkingRules.Current,
+            EmbeddingInputBound.Create(body.Length / 2));
+
+        // Assert
+        Assert.NotEqual(whole.Chunks.Count, bounded.Chunks.Count);
+        Assert.Equal(
+            whole.Chunks.Take(bounded.Chunks.Count - 1).Select(chunk => chunk.ContentHash),
+            bounded.Chunks.Take(bounded.Chunks.Count - 1).Select(chunk => chunk.ContentHash));
     }
 
     public static TheoryData<ExtractedEmailText> TextsWithoutABody() =>
@@ -356,6 +423,15 @@ public sealed class DeterministicEmailTextChunkerTests
         ExtractedEmailText.EncryptedBody,
         ExtractedEmailText.FromPlainTextBody(string.Empty, string.Empty),
     ];
+
+    /// <summary>Cuts through the chunker under a ceiling deliberately beyond anything these bodies reach.</summary>
+    /// <remarks>
+    /// Every test but the three about the ceiling itself is written about the boundary rules, and passing the default
+    /// bound keeps them saying what they said before one existed: the cut is decided by the separators and the target
+    /// length alone.
+    /// </remarks>
+    private IReadOnlyList<EmailTextChunk> Chunk(ExtractedEmailText text, EmailChunkingRules rules) =>
+        this.chunker.DeriveChunks(text, rules, EmbeddingInputBound.Default).Chunks;
 
     /// <summary>Builds a body of numbered sentences, long enough to be cut and varied enough that no two chunks match.</summary>
     private static string Paragraphs(int count) => string.Join(

--- a/tests/AI.UnitTests/Embeddings/EmbeddingPassagePreparationTests.cs
+++ b/tests/AI.UnitTests/Embeddings/EmbeddingPassagePreparationTests.cs
@@ -1,0 +1,88 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.AI.Embeddings;
+using MailFathom.Application.Emails.Embeddings;
+using Xunit;
+
+namespace MailFathom.AI.UnitTests.Embeddings;
+
+/// <summary>Covers what a model is shown, and that a spend ceiling counts exactly that.</summary>
+public sealed class EmbeddingPassagePreparationTests
+{
+    [Fact]
+    public void Prepare_APassageInsideTheLimit_SendsItWithTheInstructionInFront()
+    {
+        // Arrange
+        var preparation = EmbeddingInputPreparation.Create(
+            inputCharacterLimit: 100,
+            passageInstruction: "passage: ",
+            normalizesVector: true);
+
+        // Act
+        var prepared = EmbeddingPassagePreparation.Prepare("the west stairwell", preparation);
+
+        // Assert
+        Assert.Equal("passage: the west stairwell", prepared);
+    }
+
+    [Fact]
+    public void Prepare_APassageBeyondTheLimit_KeepsItsBeginning()
+    {
+        // Arrange
+        var preparation = EmbeddingInputPreparation.Create(
+            inputCharacterLimit: 8,
+            passageInstruction: null,
+            normalizesVector: true);
+
+        // Act
+        var prepared = EmbeddingPassagePreparation.Prepare("the west stairwell", preparation);
+
+        // Assert
+        Assert.Equal("the west", prepared);
+    }
+
+    /// <summary>
+    /// The spend ceiling counts what a provider is sent, and it counts it without building the text. That is only safe
+    /// while the two agree exactly, so the agreement is asserted rather than assumed — a preparation rule changed in one
+    /// of the two places would otherwise charge a budget for characters nobody sent, or send some it never charged for.
+    /// </summary>
+    [Theory]
+    [InlineData("", null, 100)]
+    [InlineData("short", null, 100)]
+    [InlineData("a passage that is longer than the limit allows", null, 12)]
+    [InlineData("short", "passage: ", 100)]
+    [InlineData("a passage that is longer than the limit allows", "passage: ", 12)]
+    [InlineData("exactly at the limit", null, 20)]
+    public void CountBilledCharacters_AnyPassage_AgreesWithWhatPreparationWouldSend(
+        string passage,
+        string? passageInstruction,
+        int inputCharacterLimit)
+    {
+        // Arrange
+        var preparation = EmbeddingInputPreparation.Create(
+            inputCharacterLimit,
+            passageInstruction,
+            normalizesVector: true);
+
+        // Act
+        var counted = preparation.CountBilledCharacters(passage);
+
+        // Assert
+        Assert.Equal(EmbeddingPassagePreparation.Prepare(passage, preparation).Length, counted);
+    }
+
+    [Fact]
+    public void CountBilledCharacters_AMissingPassage_IsRefused()
+    {
+        // Arrange
+        var preparation = EmbeddingInputPreparation.Create(
+            inputCharacterLimit: 100,
+            passageInstruction: null,
+            normalizesVector: true);
+
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => preparation.CountBilledCharacters(null!));
+    }
+}

--- a/tests/Application.UnitTests/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfillTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Backfill/StoredEmailEmbeddingBackfillTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Emails;
@@ -17,6 +18,9 @@ namespace MailFathom.Application.UnitTests.Emails.Embeddings.Backfill;
 public sealed class StoredEmailEmbeddingBackfillTests
 {
     private static readonly EmbeddingProfileId ProfileId = EmbeddingProfileId.Create(Guid.CreateVersion7());
+
+    /// <summary>A moment the daily period places on a whole day, so an expected roll-over is arithmetic rather than a guess.</summary>
+    private static readonly DateTimeOffset PeriodStart = new(2026, 8, 8, 0, 0, 0, TimeSpan.Zero);
 
     /// <summary>A message stored before chunking existed is cut into passages before anything is asked of a provider.</summary>
     [Fact]
@@ -168,6 +172,32 @@ public sealed class StoredEmailEmbeddingBackfillTests
     }
 
     /// <summary>
+    /// A reached spend ceiling ends the run without advancing the position, unlike a refused call: it says nothing
+    /// about the message in hand, and the passages it did not reach are the ones a rolled-over period should pay for
+    /// first. The run names the instant the ceiling lifts, which is what a worker waits for instead of an interval.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_TheSpendCeilingIsReached_EndsTheRunWithoutAdvancingThePosition()
+    {
+        // Arrange
+        var world = CreateWorld(
+            spendBudget: EmbeddingSpendBudget.Create(maxInputCharactersPerPeriod: 1, TimeSpan.FromDays(1)));
+        AddMessagesAwaitingEmbedding(world, count: 3, passagesEach: 1);
+        var backfill = world.CreateBackfill();
+
+        // Act
+        var result = await backfill.RunAsync(world.Target, TestContext.Current.CancellationToken);
+
+        // Assert
+        // The first message is paid for whole and the ceiling binds on the second, so the run stops having embedded one.
+        Assert.Equal(StoredEmailEmbeddingBackfillOutcome.SpendCeilingReached, result.Outcome);
+        Assert.False(result.MoreWorkIsWorthTryingSoon);
+        Assert.Equal(PeriodStart.AddDays(1), result.SpendPeriodEndsAt);
+        Assert.Equal(1, result.EmbeddedEmailCount);
+        Assert.Single(world.BackfillStore.SavedPositions);
+    }
+
+    /// <summary>
     /// A refused call ends the run rather than the next message's turn, and the position steps past the message so
     /// nothing blocks the walk; what that turn did not reach is what the next sweep selects on.
     /// </summary>
@@ -307,7 +337,8 @@ public sealed class StoredEmailEmbeddingBackfillTests
 
     private static BackfillWorld CreateWorld(
         string generatorModelIdentifier = "a-model",
-        int maximumPassagesPerCall = 8)
+        int maximumPassagesPerCall = 8,
+        EmbeddingSpendBudget? spendBudget = null)
     {
         var embeddingStore = new InMemoryEmailEmbeddingStore();
         var backfillStore = new InMemoryStoredEmailEmbeddingBackfillStore(embeddingStore);
@@ -332,7 +363,12 @@ public sealed class StoredEmailEmbeddingBackfillTests
             new StoredEmailEmbeddingGenerator(
                 embeddingStore,
                 textEmbeddingGenerator,
-                concurrencyRetryPolicy),
+                concurrencyRetryPolicy,
+                new EmbeddingSpendGate(
+                    new InMemoryEmbeddingSpendLedger(),
+                    spendBudget ?? EmbeddingSpendBudget.Unbounded,
+                    new FakeTimeProvider(PeriodStart)),
+                EmbeddingRequestPacer.Create(maxRequestsPerMinute: 0, new FakeTimeProvider())),
             concurrencyRetryPolicy);
     }
 

--- a/tests/Application.UnitTests/Emails/Embeddings/Generation/StoredEmailEmbeddingGeneratorTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generation/StoredEmailEmbeddingGeneratorTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Emails.Chunking;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Emails;
@@ -19,6 +20,9 @@ public sealed class StoredEmailEmbeddingGeneratorTests
     private static readonly StoredEmailId Message = StoredEmailId.Create(Guid.CreateVersion7());
 
     private static readonly EmbeddingProfileId ProfileId = EmbeddingProfileId.Create(Guid.CreateVersion7());
+
+    /// <summary>A moment the daily period places on a whole day, so a test's expected roll-over is arithmetic rather than a guess.</summary>
+    private static readonly DateTimeOffset PeriodStart = new(2026, 8, 8, 0, 0, 0, TimeSpan.Zero);
 
     [Fact]
     public async Task EmbedAsync_ActiveProfileAndOutstandingPassages_EmbedsEveryPassage()
@@ -246,6 +250,112 @@ public sealed class StoredEmailEmbeddingGeneratorTests
         Assert.Single(textEmbeddingGenerator.RequestedBatches);
     }
 
+    /// <summary>A turn asks the ceiling before every call, so an exhausted period buys no provider request at all.</summary>
+    [Fact]
+    public async Task EmbedAsync_ThePeriodIsAlreadySpent_SendsNothingAndSaysWhenTheCeilingLifts()
+    {
+        // Arrange
+        var store = new InMemoryEmailEmbeddingStore();
+        store.AddPassages(Message, CreatePassages(3));
+        var ledger = new InMemoryEmbeddingSpendLedger();
+        ledger.Seed(PeriodStart, inputCharacterCount: 500);
+        var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall: 8);
+        var generator = CreateGenerator(
+            store,
+            textEmbeddingGenerator,
+            CreateSpendGate(ledger, EmbeddingSpendBudget.Create(500, TimeSpan.FromDays(1))));
+
+        // Act
+        var run = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(StoredEmailEmbeddingOutcome.SpendCeilingReached, run.Outcome);
+        Assert.Equal(0, run.EmbeddedChunkCount);
+        Assert.Equal(PeriodStart.AddDays(1), run.SpendPeriodEndsAt);
+        Assert.Empty(textEmbeddingGenerator.RequestedBatches);
+        Assert.Empty(store.EmbeddedPassages);
+    }
+
+    /// <summary>
+    /// A batch is admitted whenever anything at all is left and is then paid for whole, so the ceiling binds on the
+    /// call after the one that crossed it. Weighing a batch against what remains instead would stall a deployment whose
+    /// ceiling is smaller than one batch for ever.
+    /// </summary>
+    [Fact]
+    public async Task EmbedAsync_TheCeilingIsCrossedMidTurn_PaysForThatBatchAndStopsBeforeTheNext()
+    {
+        // Arrange
+        var store = new InMemoryEmailEmbeddingStore();
+        store.AddPassages(Message, CreatePassages(4));
+        var ledger = new InMemoryEmbeddingSpendLedger();
+        var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall: 2);
+        var generator = CreateGenerator(
+            store,
+            textEmbeddingGenerator,
+            CreateSpendGate(ledger, EmbeddingSpendBudget.Create(1, TimeSpan.FromDays(1))));
+
+        // Act
+        var run = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(StoredEmailEmbeddingOutcome.SpendCeilingReached, run.Outcome);
+        Assert.Equal(2, run.EmbeddedChunkCount);
+        Assert.Single(textEmbeddingGenerator.RequestedBatches);
+        Assert.Equal(run.InputCharacterCount, ledger.ConsumedByPeriod[PeriodStart]);
+    }
+
+    /// <summary>What a turn sent is charged to the period beside the vectors it produced, in the characters sent.</summary>
+    [Fact]
+    public async Task EmbedAsync_APassageIsEmbedded_ChargesThePeriodWhatThePreparationWouldHaveSent()
+    {
+        // Arrange
+        var store = new InMemoryEmailEmbeddingStore();
+        var passages = CreatePassages(3);
+        store.AddPassages(Message, passages);
+        var ledger = new InMemoryEmbeddingSpendLedger();
+        var profile = CreateProfile();
+        var generator = CreateGenerator(
+            store,
+            new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall: 8),
+            CreateSpendGate(ledger, EmbeddingSpendBudget.Unbounded));
+
+        // Act
+        var run = await generator.EmbedAsync(Message, profile, TestContext.Current.CancellationToken);
+
+        // Assert
+        var expected = passages.Sum(passage =>
+            profile.Identity.InputPreparation.CountBilledCharacters(passage.Text));
+        Assert.Equal(StoredEmailEmbeddingOutcome.Embedded, run.Outcome);
+        Assert.Equal(expected, run.InputCharacterCount);
+        Assert.Equal(expected, ledger.ConsumedByPeriod[PeriodStart]);
+    }
+
+    /// <summary>A refused call produced no vectors, so charging a period for it would let an outage spend the ceiling.</summary>
+    [Fact]
+    public async Task EmbedAsync_TheProviderRefuses_ChargesThePeriodNothingForTheFailedCall()
+    {
+        // Arrange
+        var store = new InMemoryEmailEmbeddingStore();
+        store.AddPassages(Message, CreatePassages(2));
+        var ledger = new InMemoryEmbeddingSpendLedger();
+        var textEmbeddingGenerator = new ScriptedTextEmbeddingGenerator(CreateIdentity(), maximumPassagesPerCall: 8)
+        {
+            Failure = EmbeddingGenerationFailure.RateLimited,
+        };
+        var generator = CreateGenerator(
+            store,
+            textEmbeddingGenerator,
+            CreateSpendGate(ledger, EmbeddingSpendBudget.Unbounded));
+
+        // Act
+        var run = await generator.EmbedAsync(Message, CreateProfile(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(StoredEmailEmbeddingOutcome.ProviderFailed, run.Outcome);
+        Assert.Equal(0, run.InputCharacterCount);
+        Assert.Empty(ledger.ConsumedByPeriod);
+    }
+
     private static IReadOnlyList<EmailChunkAwaitingEmbedding> CreatePassages(int count) =>
         [.. Enumerable.Range(0, count).Select(ordinal => new EmailChunkAwaitingEmbedding(
             EmailChunkId.Create(Guid.CreateVersion7()),
@@ -269,7 +379,8 @@ public sealed class StoredEmailEmbeddingGeneratorTests
 
     private static StoredEmailEmbeddingGenerator CreateGenerator(
         IEmailEmbeddingStore store,
-        ITextEmbeddingGenerator textEmbeddingGenerator)
+        ITextEmbeddingGenerator textEmbeddingGenerator,
+        EmbeddingSpendGate? spendGate = null)
     {
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>())
@@ -281,6 +392,13 @@ public sealed class StoredEmailEmbeddingGeneratorTests
             new OptimisticConcurrencyRetryPolicy(
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
-                new FakeTimeProvider()));
+                new FakeTimeProvider()),
+            spendGate ?? CreateSpendGate(new InMemoryEmbeddingSpendLedger(), EmbeddingSpendBudget.Unbounded),
+            EmbeddingRequestPacer.Create(maxRequestsPerMinute: 0, new FakeTimeProvider()));
     }
+
+    private static EmbeddingSpendGate CreateSpendGate(
+        IEmbeddingSpendLedger ledger,
+        EmbeddingSpendBudget budget) =>
+        new(ledger, budget, new FakeTimeProvider(PeriodStart));
 }

--- a/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingGenerationUpkeepTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingGenerationUpkeepTests.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Emails;
@@ -300,7 +301,15 @@ public sealed class EmbeddingGenerationUpkeepTests
             backfillStore,
             new StoredEmailEmbeddingBackfill(
                 backfillStore,
-                new StoredEmailEmbeddingGenerator(embeddingStore, textEmbeddingGenerator, concurrencyRetryPolicy),
+                new StoredEmailEmbeddingGenerator(
+                    embeddingStore,
+                    textEmbeddingGenerator,
+                    concurrencyRetryPolicy,
+                    new EmbeddingSpendGate(
+                        new InMemoryEmbeddingSpendLedger(),
+                        EmbeddingSpendBudget.Unbounded,
+                        new FakeTimeProvider()),
+                    EmbeddingRequestPacer.Create(maxRequestsPerMinute: 0, new FakeTimeProvider())),
                 concurrencyRetryPolicy,
                 new StoredEmailEmbeddingBackfillOptions
                 {

--- a/tests/Application.UnitTests/Emails/Embeddings/Limits/EmbeddingInputBoundTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Limits/EmbeddingInputBoundTests.cs
@@ -1,0 +1,41 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Limits;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Embeddings.Limits;
+
+/// <summary>Covers the per-message ceiling's own contract; what it does to a cut is proved where the chunker is.</summary>
+public sealed class EmbeddingInputBoundTests
+{
+    [Fact]
+    public void Default_ADeploymentThatDeclaredNothing_CarriesTheShippedCeiling()
+    {
+        // Act, Assert
+        Assert.Equal(
+            EmbeddingInputBound.DefaultMaximumCharacterCount,
+            EmbeddingInputBound.Default.MaximumCharacterCount);
+    }
+
+    [Fact]
+    public void Create_APositiveCeiling_CarriesIt()
+    {
+        // Act
+        var bound = EmbeddingInputBound.Create(12_345);
+
+        // Assert
+        Assert.Equal(12_345, bound.MaximumCharacterCount);
+    }
+
+    /// <summary>A ceiling that admits no character would embed nothing at all, which is a misconfiguration rather than a choice.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Create_ACeilingThatCouldCutNothing_IsRefused(int maximumCharacterCount)
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => EmbeddingInputBound.Create(maximumCharacterCount));
+    }
+}

--- a/tests/Application.UnitTests/Emails/Embeddings/Limits/EmbeddingRequestPacerTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Limits/EmbeddingRequestPacerTests.cs
@@ -1,0 +1,122 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Limits;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Embeddings.Limits;
+
+/// <summary>Covers the rate ceiling binding on a caller and releasing it once its slot arrives.</summary>
+public sealed class EmbeddingRequestPacerTests
+{
+    [Fact]
+    public async Task WaitForSlotAsync_NoRateIsDeclared_LetsEveryCallerThroughAtOnce()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var pacer = EmbeddingRequestPacer.Create(maxRequestsPerMinute: 0, timeProvider);
+
+        // Act
+        var waits = Enumerable
+            .Range(0, 10)
+            .Select(_ => pacer.WaitForSlotAsync(TestContext.Current.CancellationToken))
+            .ToArray();
+
+        // Assert
+        Assert.True(pacer.IsUnpaced);
+        Assert.All(waits, wait => Assert.True(wait.IsCompletedSuccessfully));
+        await Task.WhenAll(waits);
+    }
+
+    /// <summary>The first caller of an idle pacer is not held back; a rate bounds a burst rather than every request.</summary>
+    [Fact]
+    public async Task WaitForSlotAsync_TheFirstCaller_IsNotHeldBack()
+    {
+        // Arrange
+        var pacer = EmbeddingRequestPacer.Create(maxRequestsPerMinute: 60, new FakeTimeProvider());
+
+        // Act
+        var wait = pacer.WaitForSlotAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(wait.IsCompletedSuccessfully);
+        await wait;
+    }
+
+    /// <summary>
+    /// The ceiling is reached and then released by the clock alone: the second caller waits exactly one interval and
+    /// completes when it has passed, with nobody having released anything.
+    /// </summary>
+    [Fact]
+    public async Task WaitForSlotAsync_ASecondCallerInsideTheInterval_WaitsForItsOwnSlotAndThenProceeds()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var pacer = EmbeddingRequestPacer.Create(maxRequestsPerMinute: 60, timeProvider);
+        await pacer.WaitForSlotAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var second = pacer.WaitForSlotAsync(TestContext.Current.CancellationToken);
+        var pendingBeforeTheSlot = second.IsCompleted;
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        // Assert
+        Assert.False(pendingBeforeTheSlot);
+        await second;
+    }
+
+    /// <summary>
+    /// Slots are handed out in order rather than to whoever asks after the wait, so a burst of callers is spread across
+    /// the rate instead of every one of them waking on the first interval.
+    /// </summary>
+    [Fact]
+    public async Task WaitForSlotAsync_ABurstOfCallers_TakesOneSlotEachRatherThanSharingOne()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var pacer = EmbeddingRequestPacer.Create(maxRequestsPerMinute: 60, timeProvider);
+
+        // Act
+        var waits = Enumerable
+            .Range(0, 3)
+            .Select(_ => pacer.WaitForSlotAsync(TestContext.Current.CancellationToken))
+            .ToArray();
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+        var completedAfterOneInterval = waits.Count(wait => wait.IsCompleted);
+        timeProvider.Advance(TimeSpan.FromSeconds(1));
+
+        // Assert
+        Assert.Equal(2, completedAfterOneInterval);
+        await Task.WhenAll(waits);
+    }
+
+    /// <summary>A wait the host abandons ends as a cancellation rather than holding the shutdown open.</summary>
+    [Fact]
+    public async Task WaitForSlotAsync_TheCallerIsCancelledWhileWaiting_EndsTheWait()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var pacer = EmbeddingRequestPacer.Create(maxRequestsPerMinute: 60, timeProvider);
+        await pacer.WaitForSlotAsync(TestContext.Current.CancellationToken);
+        using var cancellation = new CancellationTokenSource();
+
+        // Act
+        var second = pacer.WaitForSlotAsync(cancellation.Token);
+        await cancellation.CancelAsync();
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => second);
+    }
+
+    [Fact]
+    public void Create_ARateThatCouldNotPaceAnything_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => EmbeddingRequestPacer.Create(maxRequestsPerMinute: -1, new FakeTimeProvider()));
+        Assert.Throws<ArgumentNullException>(
+            () => EmbeddingRequestPacer.Create(maxRequestsPerMinute: 60, null!));
+    }
+}

--- a/tests/Application.UnitTests/Emails/Embeddings/Limits/EmbeddingSpendBudgetTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Limits/EmbeddingSpendBudgetTests.cs
@@ -1,0 +1,87 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Limits;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Embeddings.Limits;
+
+/// <summary>Covers the window a ceiling is counted over, which every process has to place identically.</summary>
+public sealed class EmbeddingSpendBudgetTests
+{
+    [Fact]
+    public void Create_ACeilingOfZero_BoundsNothing()
+    {
+        // Act
+        var budget = EmbeddingSpendBudget.Create(maxInputCharactersPerPeriod: 0, TimeSpan.FromHours(1));
+
+        // Assert
+        Assert.True(budget.IsUnbounded);
+    }
+
+    [Fact]
+    public void Create_APositiveCeiling_Bounds()
+    {
+        // Act
+        var budget = EmbeddingSpendBudget.Create(maxInputCharactersPerPeriod: 1_000, TimeSpan.FromHours(6));
+
+        // Assert
+        Assert.False(budget.IsUnbounded);
+        Assert.Equal(1_000, budget.MaxInputCharactersPerPeriod);
+        Assert.Equal(TimeSpan.FromHours(6), budget.Period);
+    }
+
+    [Theory]
+    [InlineData(-1, 3600)]
+    [InlineData(1_000, 0)]
+    [InlineData(1_000, -1)]
+    public void Create_ABudgetThatCouldNotBoundASpend_IsRefused(long ceiling, int periodSeconds)
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => EmbeddingSpendBudget.Create(ceiling, TimeSpan.FromSeconds(periodSeconds)));
+    }
+
+    /// <summary>
+    /// Every process and every restart has to agree on where a period begins without anything being stored to say so,
+    /// which is what anchoring the window at the epoch buys: two instants inside one window place on the same start.
+    /// </summary>
+    [Fact]
+    public void PeriodStartAt_TwoInstantsInsideOneWindow_PlaceOnTheSameStart()
+    {
+        // Arrange
+        var budget = EmbeddingSpendBudget.Create(maxInputCharactersPerPeriod: 1_000, TimeSpan.FromDays(1));
+        var morning = new DateTimeOffset(2026, 8, 8, 6, 30, 0, TimeSpan.Zero);
+        var evening = new DateTimeOffset(2026, 8, 8, 23, 59, 59, TimeSpan.Zero);
+
+        // Act, Assert
+        Assert.Equal(new DateTimeOffset(2026, 8, 8, 0, 0, 0, TimeSpan.Zero), budget.PeriodStartAt(morning));
+        Assert.Equal(budget.PeriodStartAt(morning), budget.PeriodStartAt(evening));
+    }
+
+    /// <summary>An instant read from another offset is the same instant, so it belongs to the same period.</summary>
+    [Fact]
+    public void PeriodStartAt_AnInstantWrittenInAnotherOffset_PlacesOnTheSameStart()
+    {
+        // Arrange
+        var budget = EmbeddingSpendBudget.Create(maxInputCharactersPerPeriod: 1_000, TimeSpan.FromDays(1));
+        var utc = new DateTimeOffset(2026, 8, 8, 6, 30, 0, TimeSpan.Zero);
+        var elsewhere = utc.ToOffset(TimeSpan.FromHours(5));
+
+        // Act, Assert
+        Assert.Equal(budget.PeriodStartAt(utc), budget.PeriodStartAt(elsewhere));
+    }
+
+    [Fact]
+    public void PeriodEndAt_AnInstantInsideAWindow_IsWhenTheNextPeriodBegins()
+    {
+        // Arrange
+        var budget = EmbeddingSpendBudget.Create(maxInputCharactersPerPeriod: 1_000, TimeSpan.FromHours(6));
+        var instant = new DateTimeOffset(2026, 8, 8, 7, 15, 0, TimeSpan.Zero);
+
+        // Act, Assert
+        Assert.Equal(new DateTimeOffset(2026, 8, 8, 12, 0, 0, TimeSpan.Zero), budget.PeriodEndAt(instant));
+        Assert.Equal(budget.PeriodStartAt(instant) + budget.Period, budget.PeriodEndAt(instant));
+    }
+}

--- a/tests/Application.UnitTests/Emails/Embeddings/Limits/EmbeddingSpendGateTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Limits/EmbeddingSpendGateTests.cs
@@ -1,0 +1,132 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Limits;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.UnitTests.TestDoubles;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Embeddings.Limits;
+
+/// <summary>Covers what a period admits, what charging it does, and what a rolled-over period admits again.</summary>
+public sealed class EmbeddingSpendGateTests
+{
+    private static readonly DateTimeOffset Midday = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task ReadCurrentPeriodAsync_NothingSpentYet_ReportsTheWholeCeilingAsRemaining()
+    {
+        // Arrange
+        var gate = CreateGate(new InMemoryEmbeddingSpendLedger(), Bounded(1_000), new FakeTimeProvider(Midday));
+
+        // Act
+        var period = await gate.ReadCurrentPeriodAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(new DateTimeOffset(2026, 8, 8, 0, 0, 0, TimeSpan.Zero), period.StartsAt);
+        Assert.Equal(new DateTimeOffset(2026, 8, 9, 0, 0, 0, TimeSpan.Zero), period.EndsAt);
+        Assert.Equal(0, period.ConsumedInputCharacterCount);
+        Assert.Equal(1_000, period.RemainingInputCharacterCount);
+        Assert.True(period.AdmitsRequest);
+    }
+
+    /// <summary>The ceiling being reached is what a run reads before it spends, and it reads it from what was charged.</summary>
+    [Fact]
+    public async Task ReadCurrentPeriodAsync_TheCeilingHasBeenCharged_ReportsThePeriodAsAdmittingNothing()
+    {
+        // Arrange
+        var ledger = new InMemoryEmbeddingSpendLedger();
+        var gate = CreateGate(ledger, Bounded(1_000), new FakeTimeProvider(Midday));
+        await gate.RecordSpendAsync(
+            Substitute.For<IPersistenceSession>(),
+            inputCharacterCount: 1_000,
+            TestContext.Current.CancellationToken);
+
+        // Act
+        var period = await gate.ReadCurrentPeriodAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1_000, period.ConsumedInputCharacterCount);
+        Assert.Equal(0, period.RemainingInputCharacterCount);
+        Assert.False(period.AdmitsRequest);
+    }
+
+    /// <summary>
+    /// The ceiling releases itself. Nothing acts on the ledger between the two reads below and nothing resets it — the
+    /// clock reaching the next period is the whole mechanism, which is why a paused worker only has to wait.
+    /// </summary>
+    [Fact]
+    public async Task ReadCurrentPeriodAsync_ThePeriodRollsOver_AdmitsRequestsAgainWithoutAnybodyClearingAnything()
+    {
+        // Arrange
+        var ledger = new InMemoryEmbeddingSpendLedger();
+        var timeProvider = new FakeTimeProvider(Midday);
+        var gate = CreateGate(ledger, Bounded(1_000), timeProvider);
+        await gate.RecordSpendAsync(
+            Substitute.For<IPersistenceSession>(),
+            inputCharacterCount: 1_200,
+            TestContext.Current.CancellationToken);
+        var exhausted = await gate.ReadCurrentPeriodAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        timeProvider.Advance(exhausted.EndsAt - Midday);
+        var rolledOver = await gate.ReadCurrentPeriodAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(exhausted.AdmitsRequest);
+        Assert.True(rolledOver.AdmitsRequest);
+        Assert.Equal(exhausted.EndsAt, rolledOver.StartsAt);
+        Assert.Equal(0, rolledOver.ConsumedInputCharacterCount);
+
+        // The period that was spent keeps its record: a roll-over is a new window rather than a cleared counter.
+        Assert.Equal(1_200, ledger.ConsumedByPeriod[exhausted.StartsAt]);
+    }
+
+    /// <summary>A deployment with no ceiling is counted all the same, because the figure is what an operator sets one from.</summary>
+    [Fact]
+    public async Task RecordSpendAsync_NoCeilingIsDeclared_StillChargesThePeriodAndAdmitsTheNextRequest()
+    {
+        // Arrange
+        var ledger = new InMemoryEmbeddingSpendLedger();
+        var gate = CreateGate(ledger, EmbeddingSpendBudget.Unbounded, new FakeTimeProvider(Midday));
+
+        // Act
+        await gate.RecordSpendAsync(
+            Substitute.For<IPersistenceSession>(),
+            inputCharacterCount: 5_000,
+            TestContext.Current.CancellationToken);
+        var period = await gate.ReadCurrentPeriodAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(5_000, period.ConsumedInputCharacterCount);
+        Assert.Null(period.CeilingInputCharacterCount);
+        Assert.Null(period.RemainingInputCharacterCount);
+        Assert.True(period.AdmitsRequest);
+    }
+
+    [Fact]
+    public void Constructor_AMissingCollaborator_IsRefused()
+    {
+        // Arrange
+        var ledger = new InMemoryEmbeddingSpendLedger();
+        var budget = EmbeddingSpendBudget.Unbounded;
+        var timeProvider = new FakeTimeProvider();
+
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => new EmbeddingSpendGate(null!, budget, timeProvider));
+        Assert.Throws<ArgumentNullException>(() => new EmbeddingSpendGate(ledger, null!, timeProvider));
+        Assert.Throws<ArgumentNullException>(() => new EmbeddingSpendGate(ledger, budget, null!));
+    }
+
+    private static EmbeddingSpendBudget Bounded(long ceiling) =>
+        EmbeddingSpendBudget.Create(ceiling, TimeSpan.FromDays(1));
+
+    private static EmbeddingSpendGate CreateGate(
+        IEmbeddingSpendLedger ledger,
+        EmbeddingSpendBudget budget,
+        TimeProvider timeProvider) =>
+        new(ledger, budget, timeProvider);
+}

--- a/tests/Application.UnitTests/TestDoubles/InMemoryEmbeddingSpendLedger.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryEmbeddingSpendLedger.cs
@@ -1,0 +1,54 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Limits;
+using MailFathom.Application.Persistence;
+
+namespace MailFathom.Application.UnitTests.TestDoubles;
+
+/// <summary>Keeps what each period has spent in memory, adding to a period exactly as the real upsert does.</summary>
+/// <remarks>
+/// Hand-written rather than substituted, because what the gate is asked and what it later writes have to agree: a
+/// substitute answering the read from a script would report a period as admitting a request after the same test had
+/// already spent it, and every ceiling assertion would then be about the script instead of about the ledger.
+/// </remarks>
+internal sealed class InMemoryEmbeddingSpendLedger : IEmbeddingSpendLedger
+{
+    private readonly Dictionary<DateTimeOffset, long> consumedByPeriod = [];
+
+    /// <summary>Gets what each period has been charged so far.</summary>
+    public IReadOnlyDictionary<DateTimeOffset, long> ConsumedByPeriod => this.consumedByPeriod;
+
+    /// <summary>Charges a period before the test begins, which is how a test starts against a partly spent ceiling.</summary>
+    /// <param name="periodStart">The period to charge.</param>
+    /// <param name="inputCharacterCount">The characters to charge it.</param>
+    public void Seed(DateTimeOffset periodStart, long inputCharacterCount) =>
+        this.consumedByPeriod[periodStart] =
+            this.consumedByPeriod.GetValueOrDefault(periodStart) + inputCharacterCount;
+
+    /// <inheritdoc />
+    public Task<long> ReadConsumedInputCharactersAsync(
+        DateTimeOffset periodStart,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(this.consumedByPeriod.GetValueOrDefault(periodStart));
+    }
+
+    /// <inheritdoc />
+    public Task RecordSpendAsync(
+        IPersistenceSession session,
+        DateTimeOffset periodStart,
+        long inputCharacterCount,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        this.Seed(periodStart, inputCharacterCount);
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Host.UnitTests/Configuration/Embeddings/EmbeddingOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Embeddings/EmbeddingOptionsTests.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.DataAnnotations;
 using MailFathom.AI.Embeddings;
 using MailFathom.AI.Providers;
 using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Host.Configuration.Embeddings;
 using MailFathom.Host.Configuration.Providers;
 using MailFathom.Infrastructure.Secrets.Discovery;
@@ -370,6 +371,93 @@ public sealed class EmbeddingOptionsTests
             Address = address,
             ApiKey = new ConfiguredSecret { Name = $"{alias}-key", SecretReference = "env:PROVIDER_KEY" },
         };
+
+    /// <summary>The shipped ceilings bound a message and a period, and pace no request at all.</summary>
+    [Fact]
+    public void Validate_NoCeilingsDeclared_AcceptsTheShippedDefaults()
+    {
+        // Arrange
+        var settings = new EmbeddingOptions();
+
+        // Act
+        var errors = ValidateEveryProperty(settings);
+
+        // Assert
+        Assert.Empty(errors);
+        Assert.Equal(EmbeddingInputBound.DefaultMaximumCharacterCount, settings.MaxCharactersPerEmail);
+        Assert.Equal(EmbeddingOptions.DefaultMaxInputCharactersPerPeriod, settings.MaxInputCharactersPerPeriod);
+        Assert.Equal(TimeSpan.FromDays(1), settings.SpendPeriod);
+        Assert.Equal(0, settings.MaxRequestsPerMinute);
+    }
+
+    /// <summary>
+    /// The ceilings are checked whether or not a chain was declared, because passages are cut for every synchronized
+    /// message on an instance that has chosen no provider — so one of these left unvalidated is one already applying.
+    /// </summary>
+    [Fact]
+    public void Validate_APerMessageOrRateCeilingThatCouldBoundNothing_IsRefusedWithNoChainDeclared()
+    {
+        // Arrange
+        var settings = new EmbeddingOptions { MaxCharactersPerEmail = 0, MaxRequestsPerMinute = -1 };
+
+        // Act
+        var errors = ValidateEveryProperty(settings);
+
+        // Assert
+        Assert.False(settings.IsConfigured);
+        Assert.Contains(errors, error => error.MemberNames.Contains(nameof(EmbeddingOptions.MaxCharactersPerEmail)));
+        Assert.Contains(errors, error => error.MemberNames.Contains(nameof(EmbeddingOptions.MaxRequestsPerMinute)));
+    }
+
+    /// <summary>A negative ceiling describes no budget, and a period below a minute paces work rather than bounding it.</summary>
+    [Fact]
+    public void Validate_AnAggregateCeilingThatCouldBoundNothing_IsRefusedWithNoChainDeclared()
+    {
+        // Arrange
+        var settings = new EmbeddingOptions
+        {
+            MaxInputCharactersPerPeriod = -1,
+            SpendPeriod = TimeSpan.FromSeconds(1),
+        };
+
+        // Act
+        var errors = ValidateEveryProperty(settings);
+
+        // Assert
+        Assert.False(settings.IsConfigured);
+        Assert.Contains(
+            errors,
+            error => error.MemberNames.Contains(nameof(EmbeddingOptions.MaxInputCharactersPerPeriod)));
+        Assert.Contains(errors, error => error.MemberNames.Contains(nameof(EmbeddingOptions.SpendPeriod)));
+    }
+
+    /// <summary>A ceiling of zero declares none, which the documentation states and the operator chose.</summary>
+    [Fact]
+    public void Validate_AnAggregateCeilingOfZero_IsAccepted()
+    {
+        // Arrange
+        var settings = new EmbeddingOptions { MaxInputCharactersPerPeriod = 0 };
+
+        // Act
+        var errors = ValidateEveryProperty(settings);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>A period longer than a month would leave embedding paused for weeks after one burst.</summary>
+    [Fact]
+    public void Validate_ASpendPeriodBeyondTheLongestAllowed_IsRefused()
+    {
+        // Arrange
+        var settings = new EmbeddingOptions { SpendPeriod = TimeSpan.FromDays(60) };
+
+        // Act
+        var errors = ValidateEveryProperty(settings);
+
+        // Assert
+        Assert.Contains(errors, error => error.MemberNames.Contains(nameof(EmbeddingOptions.SpendPeriod)));
+    }
 
     private static IReadOnlyList<ValidationResult> Validate(EmbeddingOptions settings) =>
         [.. settings.Validate(new ValidationContext(settings))];

--- a/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingBackfillWorkerTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingBackfillWorkerTests.cs
@@ -8,13 +8,14 @@ using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Emails;
 using MailFathom.Host.Configuration.Embeddings;
 using MailFathom.Host.Hosting.Workers;
+using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.Infrastructure.Observability;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
@@ -24,9 +25,6 @@ namespace MailFathom.Host.UnitTests.Hosting.Workers;
 
 public sealed class MailEmbeddingBackfillWorkerTests
 {
-    /// <summary>Guards against a hung worker. No assertion depends on how long the run actually takes.</summary>
-    private static readonly TimeSpan DeadlockGuard = TimeSpan.FromSeconds(30);
-
     private static readonly TimeSpan IdleSweepInterval = TimeSpan.FromMinutes(15);
 
     [Fact]
@@ -59,7 +57,10 @@ public sealed class MailEmbeddingBackfillWorkerTests
 
         // Act
         await world.Worker.StartAsync(CancellationToken.None);
-        await world.Logger.WaitForOccurrences("reached the end of the stored mail", occurrences: 1);
+        await world.Logger.WaitForOccurrences(
+            "reached the end of the stored mail",
+            occurrences: 1,
+            TestContext.Current.CancellationToken);
         await world.AdvanceUntilLogged("reached the end of the stored mail", occurrences: 2);
 
         // Assert
@@ -76,7 +77,10 @@ public sealed class MailEmbeddingBackfillWorkerTests
 
         // Act
         await world.Worker.StartAsync(CancellationToken.None);
-        await world.Logger.WaitForOccurrences("No embedding profile is active", occurrences: 1);
+        await world.Logger.WaitForOccurrences(
+            "No embedding profile is active",
+            occurrences: 1,
+            TestContext.Current.CancellationToken);
         await world.Worker.StopAsync(CancellationToken.None);
 
         // Assert
@@ -121,7 +125,10 @@ public sealed class MailEmbeddingBackfillWorkerTests
 
         // Act
         await world.Worker.StartAsync(CancellationToken.None);
-        await world.Logger.WaitForOccurrences("spent every provider call a turn is allowed", occurrences: 1);
+        await world.Logger.WaitForOccurrences(
+            "spent every provider call a turn is allowed",
+            occurrences: 1,
+            TestContext.Current.CancellationToken);
         await world.Worker.StopAsync(CancellationToken.None);
 
         // Assert
@@ -148,7 +155,10 @@ public sealed class MailEmbeddingBackfillWorkerTests
 
         // Act
         await world.Worker.StartAsync(CancellationToken.None);
-        await world.Logger.WaitForOccurrences("backfill run failed", occurrences: 1);
+        await world.Logger.WaitForOccurrences(
+            "backfill run failed",
+            occurrences: 1,
+            TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(world.Worker.ExecuteTask!.IsCompleted);
@@ -168,13 +178,66 @@ public sealed class MailEmbeddingBackfillWorkerTests
 
         // Act
         await world.Worker.StartAsync(CancellationToken.None);
-        await world.Logger.WaitForOccurrences("optimistic concurrency conflict", occurrences: 1);
+        await world.Logger.WaitForOccurrences(
+            "optimistic concurrency conflict",
+            occurrences: 1,
+            TestContext.Current.CancellationToken);
         await world.Worker.StopAsync(CancellationToken.None);
 
         // Assert
         Assert.Contains(
             world.Logger.Messages,
             message => message.Contains("optimistic concurrency conflict", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A reached spend ceiling is neither interval's business: the run named the instant it stops applying, and the
+    /// worker waits for exactly that rather than re-reading a ceiling it already knows binds.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_TheSpendCeilingIsReached_WaitsForThePeriodToRollOverRatherThanForAnInterval()
+    {
+        // Arrange
+        using var world = CreateWorld(
+            new EmbeddingBackfillOptions { BatchSize = 1, MaxBatchesPerRun = 1 },
+            EmbeddingSpendBudget.Create(maxInputCharactersPerPeriod: 100, TimeSpan.FromDays(1)),
+            consumedInputCharacterCount: 100);
+        var message = StoredEmailId.Create(Guid.CreateVersion7());
+
+        world.BackfillStore
+            .GetEmailsAwaitingEmbeddingAsync(
+                Arg.Any<StoredEmailId?>(),
+                Arg.Any<EmbeddingProfileId>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<StoredEmailAwaitingEmbedding>>(
+                [new StoredEmailAwaitingEmbedding(message, RequiresChunking: false)]));
+        world.EmbeddingStore
+            .GetChunksAwaitingEmbeddingAsync(
+                Arg.Any<StoredEmailId>(),
+                Arg.Any<EmbeddingProfileId>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<EmailChunkAwaitingEmbedding>>(
+                [new EmailChunkAwaitingEmbedding(EmailChunkId.Create(Guid.CreateVersion7()), "a passage")]));
+
+        // Act
+        await world.Worker.StartAsync(CancellationToken.None);
+        await world.Logger.WaitForOccurrences(
+            "spend ceiling for this period is reached",
+            occurrences: 1,
+            TestContext.Current.CancellationToken);
+        await world.Worker.StopAsync(CancellationToken.None);
+
+        // Assert
+        Assert.Contains(
+            world.Logger.Messages,
+            line => line.Contains("MaxInputCharactersPerPeriod", StringComparison.Ordinal));
+        await world.EmbeddingStore.DidNotReceiveWithAnyArgs().SaveEmbeddingsAsync(
+            Arg.Any<IPersistenceSession>(),
+            Arg.Any<RegisteredEmbeddingProfile>(),
+            Arg.Any<IReadOnlyList<GeneratedChunkEmbedding>>(),
+            Arg.Any<CancellationToken>());
     }
 
     private static EmbeddingProfileIdentity CreateIdentity() =>
@@ -186,12 +249,35 @@ public sealed class MailEmbeddingBackfillWorkerTests
             EmbeddingDistanceMetric.Cosine,
             EmbeddingInputPreparation.Create(2_000, passageInstruction: null, normalizesVector: true));
 
-    private static WorkerWorld CreateWorld(EmbeddingBackfillOptions settings) =>
+    /// <summary>Reports a period as already having spent a given amount, which is what puts a run against a ceiling.</summary>
+    /// <remarks>
+    /// Substituted rather than kept in a fake ledger, because these tests are about how the worker paces itself after a
+    /// run reports the ceiling; that the ledger adds up is proved where the ledger's own arithmetic lives.
+    /// </remarks>
+    private static IEmbeddingSpendLedger CreateLedgerReporting(long consumedInputCharacterCount)
+    {
+        var ledger = Substitute.For<IEmbeddingSpendLedger>();
+        ledger.ReadConsumedInputCharactersAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(consumedInputCharacterCount);
+
+        return ledger;
+    }
+
+    private static WorkerWorld CreateWorld(
+        EmbeddingBackfillOptions settings,
+        EmbeddingSpendBudget? spendBudget = null,
+        long consumedInputCharacterCount = 0) =>
         CreateWorld(
             settings,
-            new RegisteredEmbeddingProfile(EmbeddingProfileId.Create(Guid.CreateVersion7()), CreateIdentity()));
+            new RegisteredEmbeddingProfile(EmbeddingProfileId.Create(Guid.CreateVersion7()), CreateIdentity()),
+            spendBudget,
+            consumedInputCharacterCount);
 
-    private static WorkerWorld CreateWorld(EmbeddingBackfillOptions settings, RegisteredEmbeddingProfile? activeProfile)
+    private static WorkerWorld CreateWorld(
+        EmbeddingBackfillOptions settings,
+        RegisteredEmbeddingProfile? activeProfile,
+        EmbeddingSpendBudget? spendBudget = null,
+        long consumedInputCharacterCount = 0)
     {
         settings.IdleSweepInterval = IdleSweepInterval;
 
@@ -229,6 +315,10 @@ public sealed class MailEmbeddingBackfillWorkerTests
             BatchSize = settings.BatchSize,
             MaxBatchesPerRun = settings.MaxBatchesPerRun,
         });
+        services.AddSingleton(spendBudget ?? EmbeddingSpendBudget.Unbounded);
+        services.AddSingleton(CreateLedgerReporting(consumedInputCharacterCount));
+        services.AddSingleton(EmbeddingRequestPacer.Create(maxRequestsPerMinute: 0, world.TimeProvider));
+        services.AddScoped<EmbeddingSpendGate>();
         services.AddScoped<OptimisticConcurrencyRetryPolicy>();
         services.AddScoped<StoredEmailEmbeddingGenerator>();
         services.AddScoped<StoredEmailEmbeddingBackfill>();
@@ -287,7 +377,10 @@ public sealed class MailEmbeddingBackfillWorkerTests
             const int advanceAttempts = 200;
             var passObservationWindow = TimeSpan.FromMilliseconds(20);
 
-            var logged = this.Logger.WaitForOccurrences(fragment, occurrences);
+            var logged = this.Logger.WaitForOccurrences(
+                fragment,
+                occurrences,
+                TestContext.Current.CancellationToken);
 
             for (var attempt = 0; attempt < advanceAttempts && !logged.IsCompleted; attempt++)
             {
@@ -304,85 +397,5 @@ public sealed class MailEmbeddingBackfillWorkerTests
             this.worker?.Dispose();
             this.serviceProvider?.Dispose();
         }
-    }
-
-    /// <summary>A logger a test can wait on, so an assertion never races the run that produces the line.</summary>
-    /// <remarks>
-    /// The recording logger beside this one answers what was written once a test already knows the work is done. A
-    /// worker that never ends offers no such moment, so the log line itself is the signal here.
-    /// </remarks>
-    private sealed class AwaitingLogger<TCategory> : ILogger<TCategory>
-    {
-        private readonly Lock recordedMessages = new();
-        private readonly List<string> messages = [];
-        private readonly List<Expectation> expectations = [];
-
-        public IReadOnlyList<string> Messages
-        {
-            get
-            {
-                lock (this.recordedMessages)
-                {
-                    return [.. this.messages];
-                }
-            }
-        }
-
-        public IDisposable? BeginScope<TState>(TState state)
-            where TState : notnull => null;
-
-        public bool IsEnabled(LogLevel logLevel) => true;
-
-        public void Log<TState>(
-            LogLevel logLevel,
-            EventId eventId,
-            TState state,
-            Exception? exception,
-            Func<TState, Exception?, string> formatter)
-        {
-            ArgumentNullException.ThrowIfNull(formatter);
-
-            List<Expectation> satisfied;
-
-            lock (this.recordedMessages)
-            {
-                this.messages.Add(formatter(state, exception));
-                satisfied = [.. this.expectations.Where(this.IsSatisfied)];
-                this.expectations.RemoveAll(satisfied.Contains);
-            }
-
-            // Completed outside the lock, so a continuation that logs cannot re-enter it.
-            foreach (var expectation in satisfied)
-            {
-                expectation.Signal.TrySetResult();
-            }
-        }
-
-        /// <summary>Waits until a message containing the fragment has been logged the given number of times.</summary>
-        public Task WaitForOccurrences(string fragment, int occurrences)
-        {
-            var expectation = new Expectation(
-                fragment,
-                occurrences,
-                new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
-
-            lock (this.recordedMessages)
-            {
-                if (this.IsSatisfied(expectation))
-                {
-                    return Task.CompletedTask;
-                }
-
-                this.expectations.Add(expectation);
-            }
-
-            return expectation.Signal.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
-        }
-
-        private bool IsSatisfied(Expectation expectation) => this.messages
-            .Count(message => message.Contains(expectation.Fragment, StringComparison.Ordinal))
-            >= expectation.Occurrences;
-
-        private sealed record Expectation(string Fragment, int Occurrences, TaskCompletionSource Signal);
     }
 }

--- a/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingWorkerTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingWorkerTests.cs
@@ -2,14 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Chunking;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Emails;
 using MailFathom.Host.Hosting.Workers;
 using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.Infrastructure.Observability;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -91,6 +94,80 @@ public sealed class MailEmbeddingWorkerTests
             Arg.Any<CancellationToken>());
     }
 
+    /// <summary>
+    /// A reached ceiling pauses the worker rather than letting it drain the backlog one refusal at a time, and the
+    /// period rolling over is what releases it — with nobody having acted, because nothing about the ceiling was wrong.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_TheSpendCeilingIsReached_PausesUntilThePeriodRollsOverAndThenCarriesOn()
+    {
+        // Arrange
+        var period = TimeSpan.FromDays(1);
+        var timeProvider = new FakeTimeProvider();
+        var embeddingStore = CreateStoreWithOnePassageOutstanding();
+        var logger = new AwaitingLogger<MailEmbeddingWorker>();
+        using var worker = CreateWorker(
+            CreateMessages(2),
+            CreateProfileReader(CreateProfile()),
+            embeddingStore,
+            logger,
+            EmbeddingSpendBudget.Create(maxInputCharactersPerPeriod: 10, period),
+            consumedInputCharacterCount: 10,
+            timeProvider);
+
+        // Act
+        await worker.StartAsync(CancellationToken.None);
+        await logger.WaitForOccurrences(
+            "embedding is paused",
+            occurrences: 1,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        // Exactly one message has been taken while the clock stands still: the worker is waiting rather than working
+        // through what is behind it.
+        await embeddingStore.Received(1).GetChunksAwaitingEmbeddingAsync(
+            Arg.Any<StoredEmailId>(),
+            Arg.Any<EmbeddingProfileId>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+
+        await AdvanceUntilLogged(timeProvider, logger, period, "embedding is paused", occurrences: 2);
+        await worker.StopAsync(CancellationToken.None);
+
+        await embeddingStore.Received(2).GetChunksAwaitingEmbeddingAsync(
+            Arg.Any<StoredEmailId>(),
+            Arg.Any<EmbeddingProfileId>(),
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Moves the clock on until the worker has logged the line the given number of times.</summary>
+    /// <remarks>
+    /// A loop rather than a single advance, because the wait is created after the line that announces it is written:
+    /// an advance that arrives before the delay exists is simply lost, and the next one fires it.
+    /// </remarks>
+    private static async Task AdvanceUntilLogged(
+        FakeTimeProvider timeProvider,
+        AwaitingLogger<MailEmbeddingWorker> logger,
+        TimeSpan step,
+        string fragment,
+        int occurrences)
+    {
+        const int advanceAttempts = 200;
+        var passObservationWindow = TimeSpan.FromMilliseconds(20);
+
+        var logged = logger.WaitForOccurrences(fragment, occurrences, TestContext.Current.CancellationToken);
+
+        for (var attempt = 0; attempt < advanceAttempts && !logged.IsCompleted; attempt++)
+        {
+            timeProvider.Advance(step);
+
+            await Task.WhenAny(logged, Task.Delay(passObservationWindow, TestContext.Current.CancellationToken));
+        }
+
+        await logged;
+    }
+
     private static IReadOnlyList<StoredEmailId> CreateMessages(int count) =>
         [.. Enumerable.Range(0, count).Select(_ => StoredEmailId.Create(Guid.CreateVersion7()))];
 
@@ -126,18 +203,55 @@ public sealed class MailEmbeddingWorkerTests
         return store;
     }
 
+    private static IEmailEmbeddingStore CreateStoreWithOnePassageOutstanding()
+    {
+        var store = Substitute.For<IEmailEmbeddingStore>();
+        store.GetChunksAwaitingEmbeddingAsync(
+                Arg.Any<StoredEmailId>(),
+                Arg.Any<EmbeddingProfileId>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<EmailChunkAwaitingEmbedding>>(
+                [new EmailChunkAwaitingEmbedding(EmailChunkId.Create(Guid.CreateVersion7()), "a passage")]));
+
+        return store;
+    }
+
     private static MailEmbeddingWorker CreateWorker(
         IReadOnlyList<StoredEmailId> messages,
         IActiveEmbeddingProfileReader profileReader,
         IEmailEmbeddingStore embeddingStore,
         out RecordingLogger<MailEmbeddingWorker> logger)
     {
-        logger = new RecordingLogger<MailEmbeddingWorker>();
-        var timeProvider = new FakeTimeProvider();
+        var recordingLogger = new RecordingLogger<MailEmbeddingWorker>();
+        logger = recordingLogger;
 
+        return CreateWorker(
+            messages,
+            profileReader,
+            embeddingStore,
+            recordingLogger,
+            EmbeddingSpendBudget.Unbounded,
+            consumedInputCharacterCount: 0,
+            new FakeTimeProvider());
+    }
+
+    private static MailEmbeddingWorker CreateWorker(
+        IReadOnlyList<StoredEmailId> messages,
+        IActiveEmbeddingProfileReader profileReader,
+        IEmailEmbeddingStore embeddingStore,
+        ILogger<MailEmbeddingWorker> logger,
+        EmbeddingSpendBudget spendBudget,
+        long consumedInputCharacterCount,
+        FakeTimeProvider timeProvider)
+    {
         var textEmbeddingGenerator = Substitute.For<ITextEmbeddingGenerator>();
         textEmbeddingGenerator.Identity.Returns(Identity);
         textEmbeddingGenerator.MaximumPassagesPerCall.Returns(8);
+
+        var spendLedger = Substitute.For<IEmbeddingSpendLedger>();
+        spendLedger.ReadConsumedInputCharactersAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(consumedInputCharacterCount);
 
         var services = new ServiceCollection();
         services.AddSingleton<TimeProvider>(timeProvider);
@@ -146,6 +260,10 @@ public sealed class MailEmbeddingWorkerTests
         services.AddSingleton(textEmbeddingGenerator);
         services.AddSingleton(Substitute.For<IPersistenceSessionFactory>());
         services.AddSingleton(new PersistenceConcurrencyOptions());
+        services.AddSingleton(spendBudget);
+        services.AddSingleton(spendLedger);
+        services.AddSingleton(EmbeddingRequestPacer.Create(maxRequestsPerMinute: 0, timeProvider));
+        services.AddScoped<EmbeddingSpendGate>();
         services.AddScoped<OptimisticConcurrencyRetryPolicy>();
         services.AddScoped<StoredEmailEmbeddingGenerator>();
 

--- a/tests/Host.UnitTests/TestDoubles/AwaitingLogger.cs
+++ b/tests/Host.UnitTests/TestDoubles/AwaitingLogger.cs
@@ -1,0 +1,94 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.Host.UnitTests.TestDoubles;
+
+/// <summary>A logger a test can wait on, so an assertion never races the run that produces the line.</summary>
+/// <remarks>
+/// <see cref="RecordingLogger{TCategory}" /> beside this one answers what was written once a test already knows the
+/// work is done. A worker that never ends offers no such moment, so the log line itself is the signal here.
+/// </remarks>
+internal sealed class AwaitingLogger<TCategory> : ILogger<TCategory>
+{
+    /// <summary>Guards against a line that never arrives. No assertion depends on how long a run actually takes.</summary>
+    private static readonly TimeSpan DeadlockGuard = TimeSpan.FromSeconds(30);
+
+    private readonly Lock recordedMessages = new();
+    private readonly List<string> messages = [];
+    private readonly List<Expectation> expectations = [];
+
+    public IReadOnlyList<string> Messages
+    {
+        get
+        {
+            lock (this.recordedMessages)
+            {
+                return [.. this.messages];
+            }
+        }
+    }
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        ArgumentNullException.ThrowIfNull(formatter);
+
+        List<Expectation> satisfied;
+
+        lock (this.recordedMessages)
+        {
+            this.messages.Add(formatter(state, exception));
+            satisfied = [.. this.expectations.Where(this.IsSatisfied)];
+            this.expectations.RemoveAll(satisfied.Contains);
+        }
+
+        // Completed outside the lock, so a continuation that logs cannot re-enter it.
+        foreach (var expectation in satisfied)
+        {
+            expectation.Signal.TrySetResult();
+        }
+    }
+
+    /// <summary>Waits until a message containing the fragment has been logged the given number of times.</summary>
+    /// <param name="fragment">The text the awaited line contains.</param>
+    /// <param name="occurrences">How many such lines to wait for.</param>
+    /// <param name="cancellationToken">Ends the wait when the test does.</param>
+    /// <returns>A task that completes once the lines have been written.</returns>
+    public Task WaitForOccurrences(string fragment, int occurrences, CancellationToken cancellationToken)
+    {
+        var expectation = new Expectation(
+            fragment,
+            occurrences,
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously));
+
+        lock (this.recordedMessages)
+        {
+            if (this.IsSatisfied(expectation))
+            {
+                return Task.CompletedTask;
+            }
+
+            this.expectations.Add(expectation);
+        }
+
+        return expectation.Signal.Task.WaitAsync(DeadlockGuard, cancellationToken);
+    }
+
+    private bool IsSatisfied(Expectation expectation) => this.messages
+        .Count(message => message.Contains(expectation.Fragment, StringComparison.Ordinal))
+        >= expectation.Occurrences;
+
+    private sealed record Expectation(string Fragment, int Occurrences, TaskCompletionSource Signal);
+}

--- a/tests/Infrastructure.UnitTests/Observability/EmailEmbeddingBackfillTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/EmailEmbeddingBackfillTelemetryTests.cs
@@ -205,7 +205,8 @@ public sealed class EmailEmbeddingBackfillTelemetryTests
         int embeddedChunkCount = 0,
         int callBudgetExhaustedEmailCount = 0,
         int? outstandingEmailCountAtSweepStart = null,
-        EmbeddingGenerationFailure? failure = null) =>
+        EmbeddingGenerationFailure? failure = null,
+        DateTimeOffset? spendPeriodEndsAt = null) =>
         new(
             outcome,
             chunkedEmailCount,
@@ -213,5 +214,6 @@ public sealed class EmailEmbeddingBackfillTelemetryTests
             embeddedChunkCount,
             callBudgetExhaustedEmailCount,
             outstandingEmailCountAtSweepStart,
-            failure);
+            failure,
+            spendPeriodEndsAt);
 }

--- a/tests/Infrastructure.UnitTests/Observability/EmailEmbeddingTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/EmailEmbeddingTelemetryTests.cs
@@ -18,6 +18,12 @@ public sealed class EmailEmbeddingTelemetryTests
 
     private const string PassageCountInstrument = "mailfathom.embedding.passages";
 
+    private const string ConsumedBudgetInstrument = "mailfathom.embedding.budget.consumed";
+
+    private const string TruncatedMessageInstrument = "mailfathom.embedding.input.truncated";
+
+    private const string OmittedCharacterInstrument = "mailfathom.embedding.input.omitted";
+
     /// <summary>
     /// The tag strings are the whole value of the instrument: an operator diagnoses a falling-behind instance by
     /// splitting these series on the outcome and, when the provider refused, on the classification. A swapped or
@@ -41,6 +47,7 @@ public sealed class EmailEmbeddingTelemetryTests
                 "no_active_profile/none",
                 "generator_disagrees_with_profile/none",
                 "call_budget_exhausted/none",
+                "spend_ceiling_reached/none",
                 "provider_failed/credential_rejected",
                 "provider_failed/rate_limited",
                 "provider_failed/request_timed_out",
@@ -114,6 +121,80 @@ public sealed class EmailEmbeddingTelemetryTests
         Assert.Equal([4, 9], measurements.ValuesOf(PassageCountInstrument));
     }
 
+    /// <summary>
+    /// What a turn spent is charged whether or not the message it was for is now whole, because the characters were
+    /// sent either way. A counter that skipped the two endings that stop part-way would under-report exactly the
+    /// periods an operator watching a ceiling is looking at.
+    /// </summary>
+    [Fact]
+    public void RecordEmbeddedMessage_ATurnThatSentSomething_CountsItAgainstTheBudgetWhateverTheOutcome()
+    {
+        // Arrange
+        var telemetry = new EmailEmbeddingTelemetry();
+        using var measurements = new RecordedMailFathomMeasurements(ConsumedBudgetInstrument);
+
+        // Act
+        telemetry.RecordEmbeddedMessage(
+            StoredEmailEmbeddingRun.Embedded(3, inputCharacterCount: 30),
+            TimeSpan.FromSeconds(1));
+        telemetry.RecordEmbeddedMessage(
+            StoredEmailEmbeddingRun.SpendCeilingReached(1, inputCharacterCount: 12, DateTimeOffset.UnixEpoch),
+            TimeSpan.FromSeconds(1));
+        telemetry.RecordEmbeddedMessage(
+            StoredEmailEmbeddingRun.CallBudgetExhausted(2, inputCharacterCount: 20),
+            TimeSpan.FromSeconds(1));
+
+        // Assert
+        Assert.Equal(62, measurements.ValuesOf(ConsumedBudgetInstrument).Sum());
+    }
+
+    /// <summary>A turn that sent nothing charges nothing, so a period with no work opens no series of zeroes.</summary>
+    [Fact]
+    public void RecordEmbeddedMessage_ATurnThatSentNothing_ChargesTheBudgetNothing()
+    {
+        // Arrange
+        var telemetry = new EmailEmbeddingTelemetry();
+        using var measurements = new RecordedMailFathomMeasurements(ConsumedBudgetInstrument);
+
+        // Act
+        telemetry.RecordEmbeddedMessage(StoredEmailEmbeddingRun.NoActiveProfile(), TimeSpan.FromSeconds(1));
+
+        // Assert
+        Assert.Equal(0, measurements.ValuesOf(ConsumedBudgetInstrument).Sum());
+    }
+
+    /// <summary>
+    /// Two instruments rather than one, because one enormous message and a thousand slightly oversized ones need
+    /// different answers from an operator: how often the ceiling binds, and what raising it would cost.
+    /// </summary>
+    [Fact]
+    public void RecordTruncatedEmbeddingInput_AMessageTheCeilingCut_CountsTheMessageAndTheTextItLeftOut()
+    {
+        // Arrange
+        var telemetry = new EmailEmbeddingTelemetry();
+        using var measurements = new RecordedMailFathomMeasurements(
+            TruncatedMessageInstrument,
+            OmittedCharacterInstrument);
+
+        // Act
+        telemetry.RecordTruncatedEmbeddingInput(omittedCharacterCount: 4_000);
+        telemetry.RecordTruncatedEmbeddingInput(omittedCharacterCount: 1_000);
+
+        // Assert
+        Assert.Equal(2, measurements.ValuesOf(TruncatedMessageInstrument).Sum());
+        Assert.Equal(5_000, measurements.ValuesOf(OmittedCharacterInstrument).Sum());
+    }
+
+    [Fact]
+    public void RecordTruncatedEmbeddingInput_ANegativeCount_IsRefused()
+    {
+        // Arrange
+        var telemetry = new EmailEmbeddingTelemetry();
+
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => telemetry.RecordTruncatedEmbeddingInput(-1));
+    }
+
     /// <summary>Drives one turn of every shape a run can end in, in the order the outcomes are declared.</summary>
     private static void RecordEveryOutcome(EmailEmbeddingTelemetry telemetry)
     {
@@ -123,6 +204,7 @@ public sealed class EmailEmbeddingTelemetryTests
             StoredEmailEmbeddingRun.NoActiveProfile(),
             StoredEmailEmbeddingRun.GeneratorDisagreesWithProfile(),
             StoredEmailEmbeddingRun.CallBudgetExhausted(7),
+            StoredEmailEmbeddingRun.SpendCeilingReached(2, inputCharacterCount: 40, DateTimeOffset.UnixEpoch),
             .. Enum.GetValues<EmbeddingGenerationFailure>()
                 .Select(failure => StoredEmailEmbeddingRun.ProviderFailed(1, failure)),
         ];

--- a/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
+++ b/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
@@ -6,6 +6,7 @@ using MailFathom.AI;
 using MailFathom.Application.EmailContent;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
@@ -59,6 +60,14 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
 
     /// <summary>The width a passage is cut to before the deterministic generator hashes it.</summary>
     internal const int DeterministicEmbeddingInputCharacterLimit = 8_000;
+
+    /// <summary>How much of one message's text this suite cuts into passages.</summary>
+    /// <remarks>
+    /// Small on purpose, for the reason the backfill's batch sizes are: a test that proves a message is cut to the
+    /// ceiling needs the ceiling to be reachable inside a body it can store. It stays well above the bodies the other
+    /// tests write, so their cuts are unchanged by it.
+    /// </remarks>
+    internal const int EmbeddingInputCharacterCeiling = 5_000;
 
     private readonly IHost host;
 
@@ -123,6 +132,15 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
         // The bound a composition root reads from the Embeddings section. The backlog itself is registered by
         // AddInfrastructure, because every committed message is offered into it whether or not this deployment embeds.
         builder.Services.AddSingleton(new EmailEmbeddingBacklogOptions());
+        // The three ceilings a composition root reads from the same section. The suite embeds against a deterministic
+        // in-repository generator that reaches no provider, so two of them are nothing to bound here: the budget bounds
+        // nothing and the pacer delays nothing, which keeps a suite that starts a container from also waiting out a
+        // rate. The per-message bound is reachable rather than shipped, for the reason its constant states.
+        builder.Services.AddSingleton(EmbeddingInputBound.Create(EmbeddingInputCharacterCeiling));
+        builder.Services.AddSingleton(EmbeddingSpendBudget.Unbounded);
+        builder.Services.AddSingleton(EmbeddingRequestPacer.Create(
+            maxRequestsPerMinute: 0,
+            TimeProvider.System));
         // The bounds a composition root reads from the EmbeddingBackfill section. Small here on purpose: a test that
         // proves a walk is bounded needs the bound to be reachable within the mail it stored.
         builder.Services.AddSingleton(new StoredEmailEmbeddingBackfillOptions

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailChunkTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailChunkTests.cs
@@ -134,6 +134,16 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
         Assert.True(
             passages[^1].StartOffset < OrchestratedMailFathomServices.EmbeddingInputCharacterCeiling,
             "The cut has to stop at the ceiling rather than run to the end of the body.");
+
+        // Text that grew only past the ceiling yields exactly the passages already stored, so the write the hashes
+        // decide is skipped — and the record of what was left out still has to follow the text rather than the rows.
+        var longer = BodyOfSeveralPassages("oversized", paragraphs: 30);
+        Assert.StartsWith(body, longer, StringComparison.Ordinal);
+
+        await StoreAsync(services, occurrenceId, "chunks-truncated", longer, cancellationToken);
+
+        Assert.Equal(passages, await ReadPassagesAsync(services, occurrenceId, cancellationToken));
+        Assert.Equal(longer.Length, await ReadTruncatedFromAsync(services, occurrenceId, cancellationToken));
     }
 
     /// <summary>Builds a body long enough to be cut into several passages, distinct per term so no two chunks match.</summary>

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailChunkTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailChunkTests.cs
@@ -97,11 +97,69 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
         Assert.Empty(await ReadPassagesAsync(services, occurrenceId, cancellationToken));
     }
 
+    /// <summary>
+    /// An oversized message is bounded rather than refused, and what the ceiling left out is written on the message in
+    /// the same transaction as the passages it did cut.
+    /// </summary>
+    /// <remarks>
+    /// Only a real database establishes the half this is about. The chunker's own truncation is proved by a unit test;
+    /// what cannot be seen through a substitute is that the column on <c>stored_emails</c> is written from inside the
+    /// session that writes the passages, so a message and the record of what was left out of it are durable together.
+    /// </remarks>
+    [Fact]
+    public async Task UpsertMetadataAsync_ABodyBeyondThePerMessageCeiling_CutsToItAndRecordsTheLengthItHad()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
+        var occurrenceId = SyntheticEmail.OccurrenceIn(binding, uid: 9003);
+        var body = BodyOfSeveralPassages("oversized", paragraphs: 24);
+
+        // Act
+        await StoreAsync(services, occurrenceId, "chunks-truncated", body, cancellationToken);
+
+        // Assert
+        var truncatedFrom = await ReadTruncatedFromAsync(services, occurrenceId, cancellationToken);
+        var passages = await ReadPassagesAsync(services, occurrenceId, cancellationToken);
+
+        Assert.Equal(body.Length, truncatedFrom);
+        Assert.True(
+            body.Length > OrchestratedMailFathomServices.EmbeddingInputCharacterCeiling,
+            "The body has to exceed the ceiling the orchestrated services declare, or nothing was truncated.");
+
+        // Bounded rather than refused: the opening is stored as passages, and the last of them begins inside the
+        // ceiling rather than anywhere in the text beyond it.
+        Assert.NotEmpty(passages);
+        Assert.True(
+            passages[^1].StartOffset < OrchestratedMailFathomServices.EmbeddingInputCharacterCeiling,
+            "The cut has to stop at the ceiling rather than run to the end of the body.");
+    }
+
     /// <summary>Builds a body long enough to be cut into several passages, distinct per term so no two chunks match.</summary>
-    private static string BodyOfSeveralPassages(string term) => string.Join(
+    private static string BodyOfSeveralPassages(string term, int paragraphs = 8) => string.Join(
         "\n\n",
-        Enumerable.Range(0, 8).Select(paragraph =>
+        Enumerable.Range(0, paragraphs).Select(paragraph =>
             SyntheticEmail.BodyTextContaining($"{term}{paragraph}", wordCount: 60)));
+
+    private static Task<int?> ReadTruncatedFromAsync(
+        OrchestratedMailFathomServices services,
+        EmailOccurrenceId occurrenceId,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) =>
+            {
+                var alias = occurrenceId.FolderResolutionId.Alias.Value;
+
+                return await scope.GetRequiredService<MailFathomDbContext>().StoredEmails
+                    .AsNoTracking()
+                    .Where(email => email.MailFolder.MailboxAccountId == occurrenceId.AccountId.Value
+                        && email.MailFolder.Alias == alias
+                        && email.UidValidity == occurrenceId.UidValidity.Value
+                        && email.Uid == occurrenceId.Uid.Value)
+                    .Select(email => email.ChunkedTextTruncatedFromCharacterCount)
+                    .SingleAsync(token);
+            },
+            cancellationToken);
 
     private static async Task StoreAsync(
         OrchestratedMailFathomServices services,
@@ -140,6 +198,7 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
                     .Select(chunk => new StoredPassage(
                         chunk.Id,
                         chunk.Ordinal,
+                        chunk.StartOffset,
                         chunk.ContentHash,
                         chunk.RuleSetVersion))
                     .ToArrayAsync(token);
@@ -163,5 +222,10 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
             cancellationToken);
 
     /// <summary>What a stored passage has to report for this class's claims to be decidable.</summary>
-    private sealed record StoredPassage(Guid Id, int Ordinal, string ContentHash, int RuleSetVersion);
+    private sealed record StoredPassage(
+        Guid Id,
+        int Ordinal,
+        int StartOffset,
+        string ContentHash,
+        int RuleSetVersion);
 }

--- a/tests/IntegrationTests/Persistence/OrchestratedEmbeddingGenerationLifecycleTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmbeddingGenerationLifecycleTests.cs
@@ -51,6 +51,15 @@ public sealed class OrchestratedEmbeddingGenerationLifecycleTests(MailFathomOrch
         var cancellationToken = TestContext.Current.CancellationToken;
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
         var chunkIds = await StorePassagesAsync(services, uid: 9301, cancellationToken);
+
+        // Every claim below reads a question the database answers about the whole instance — which superseded
+        // generation is still holding vectors — while what this test is about is the one generation it supersedes
+        // itself. Another class that embedded under the deterministic profile leaves exactly such a row behind, and
+        // the switch below is what supersedes it, so the reading would name that class's generation rather than this
+        // one's for no reason except the order xUnit chose. Draining first states the precondition instead of
+        // inheriting it.
+        await DrainSupersededVectorsAsync(services, cancellationToken);
+
         var previous = await RegisterAsync(services, "generation-previous", cancellationToken);
         await SwitchToAsync(services, previous.Id, cancellationToken);
         await StoreVectorsAsync(services, chunkIds, previous.Id, cancellationToken);
@@ -204,6 +213,32 @@ public sealed class OrchestratedEmbeddingGenerationLifecycleTests(MailFathomOrch
         CancellationToken cancellationToken) => services.InScopeAsync(
             (scope, token) => scope.GetRequiredService<IEmbeddingGenerationStore>().ReadGenerationsAsync(token),
             cancellationToken);
+
+    /// <summary>Empties whatever superseded generation another class left holding vectors.</summary>
+    /// <remarks>
+    /// Bounded rather than looped until the query is quiet on its own: a removal that reports nothing removed while the
+    /// same generation is still named would be an unbounded loop, so it fails the test instead of hanging it.
+    /// </remarks>
+    private static async Task DrainSupersededVectorsAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken)
+    {
+        const int maximumBatches = 100;
+
+        for (var batch = 0; batch < maximumBatches; batch++)
+        {
+            if (await FindSupersededHoldingVectorsAsync(services, cancellationToken) is not { } leftover)
+            {
+                return;
+            }
+
+            Assert.True(
+                await RemoveVectorsAsync(services, leftover, batchSize: 500, cancellationToken) > 0,
+                "A superseded generation reported as holding vectors has to give some up when it is asked.");
+        }
+
+        Assert.Fail("A superseded generation went on holding vectors after every batch this test is allowed.");
+    }
 
     private static Task<EmbeddingProfileId?> FindSupersededHoldingVectorsAsync(
         OrchestratedMailFathomServices services,


### PR DESCRIPTION
Closes #434

Embedding is the first thing MailFathom does that costs money per unit of mail, and nothing bounded what an instance was willing to spend on it. Three ceilings now do. Each is configuration validated at startup, and none is part of an embedding profile — they decide how many vectors exist and never what one means, so moving any of them leaves every stored vector exactly as comparable as it was.

## What one message may cost

`Embeddings:MaxCharactersPerEmail` (default 200 000) is how much of a message's extracted text is cut into passages. Raw MIME is bounded in megabytes, so one message could otherwise carry more text than a mailbox does in a month. A message beyond the ceiling is **bounded rather than refused** — its opening is embedded and retrievable — and `stored_emails.ChunkedTextTruncatedFromCharacterCount` records the length its text had when the cut stopped short, so what was left out is a stored fact rather than a guess from a chunk count.

The ceiling is a parameter of `IEmailTextChunker` rather than a chunking rule, deliberately: the rules are covered by each passage's content hash because they decide what a passage says, while the ceiling decides only how many passages there are. A passage the ceiling leaves in place keeps the digest it had.

## How fast requests may go out

`Embeddings:MaxRequestsPerMinute` spaces requests so a deployment never sends faster than it declared. It paces nothing by default and exists for a provider whose quota is stated per minute. A caller reserves the next free slot and waits for its own; nothing polls and nothing spins, and the wait is measured on the injected `TimeProvider` so a test can prove the ceiling binding and then releasing.

**Concurrency deliberately gains no key.** `Resilience:AiProviderInvocation:ConcurrencyLimit` already owns how many calls may be in flight; a second limiter would make two settings answer for one behaviour.

## What one period may cost

`Embeddings:MaxInputCharactersPerPeriod` (default 50 000 000) and `Embeddings:SpendPeriod` (default one day) are the aggregate ceiling, counted in the characters actually sent — the one quantity a price is approximately proportional to that this deployment can count exactly without carrying a model's tokenizer.

What each period has spent is durable, in a new `embedding_spend_periods` table, and the charge joins the same transaction as the vectors it paid for. In memory it would be worthless against the failure it exists to prevent: a process crashing and restarting in a loop would begin every period again from zero. It is also not derived from the stored vectors, because a superseded generation's vectors are removed in bounded batches and the count would erase a spend that genuinely happened.

Reaching the ceiling pauses both the live worker and the backfill **until the period rolls over**, which is an observable state that releases itself with nobody acting. Nothing is dropped: the outstanding passages are exactly what the backfill selects on, the same promise a refused call already relies on. The backfill also stops without advancing its position, unlike a run a refused call ended, because a reached ceiling says nothing about the message in hand.

The ceiling binds to within one batch. A batch is admitted whenever anything at all is left and is then paid for whole, because weighing a batch against what remains would stall a deployment whose ceiling is smaller than one batch for ever.

## What an operator sees

Queue depth, processing duration, failure counts by classification, and retry counts were already exported. Three counters join them: the characters charged against the ceiling, the messages the per-message ceiling cut, and the text it left out. None carries mail, a passage, a vector, or a credential — the tags stay MailFathom's own closed sets.

## Database schema

Additive, and deployable over the previous release's data: one nullable `integer` column on `stored_emails` and one new table. No existing migration is touched.

## Verification

- `scripts/verify-full.sh` — green.
- 3 839 unit tests pass; aggregate line coverage 94.80% against the 85% gate.
- The migration was applied to the orchestrated database over existing data, and `mailfathom-host` reached `Running`/`Healthy` against the resulting schema.
- The integration suite is not run locally; it will be dispatched against this branch.

Documentation updated: configuration reference, embedding generation, automatic embedding, embedding backfill, message chunks, telemetry, and the stored-email schema.