### PR TITLE
[#582] Make the generation-lifecycle integration test independent of class order

### DIFF
--- a/tests/IntegrationTests/Persistence/OrchestratedEmbeddingGenerationLifecycleTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmbeddingGenerationLifecycleTests.cs
@@ -51,17 +51,18 @@ public sealed class OrchestratedEmbeddingGenerationLifecycleTests(MailFathomOrch
         var cancellationToken = TestContext.Current.CancellationToken;
         await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
         var chunkIds = await StorePassagesAsync(services, uid: 9301, cancellationToken);
-
-        // Every claim below reads a question the database answers about the whole instance — which superseded
-        // generation is still holding vectors — while what this test is about is the one generation it supersedes
-        // itself. Another class that embedded under the deterministic profile leaves exactly such a row behind, and
-        // the switch below is what supersedes it, so the reading would name that class's generation rather than this
-        // one's for no reason except the order xUnit chose. Draining first states the precondition instead of
-        // inheriting it.
-        await DrainSupersededVectorsAsync(services, cancellationToken);
-
         var previous = await RegisterAsync(services, "generation-previous", cancellationToken);
         await SwitchToAsync(services, previous.Id, cancellationToken);
+
+        // Drained after this switch rather than before it, because the residue this test has to be free of is not
+        // superseded until the switch supersedes it. Any class that embedded under the deterministic profile leaves it
+        // serving and holding vectors, and the claims below read a question the database answers about the whole
+        // instance — which superseded generation still holds vectors — while what this test is about is the one
+        // generation it supersedes itself. Without this, the reading names that class's generation rather than this
+        // one's, for no reason except the order xUnit chose. Nothing this test created can be taken by it: `previous`
+        // is serving here and holds no vector yet.
+        await DrainSupersededVectorsAsync(services, cancellationToken);
+
         await StoreVectorsAsync(services, chunkIds, previous.Id, cancellationToken);
 
         // Act


### PR DESCRIPTION
Closes #582

`TheGenerationLifecycle_AReindexThatCompletes_SwitchesOnceAndEmptiesWhatItReplaced` has been failing on branches whose diff has nothing to do with it. On 2026-08-08 it failed identically — same assertion, same line, unmodified test — on `agent/bound-embedding-cost` and on `agent/bound-aggregate-content-volume` within half an hour, while an earlier run that day passed.

## What was wrong

The test asserts that `FindSupersededProfileHoldingVectorsAsync()` returns the generation it superseded itself. That query answers a question about the whole instance, and the suite shares one database with no worker to clear anything: any class that embedded under the deterministic profile leaves that profile **serving** and holding vectors, and this test's own `SwitchToAsync(previous.Id)` is what supersedes it. The reading then names that class's generation — older by a few seconds, which is exactly what the two GUID v7 values in the failure differ by.

So the test passed only when it happened to run before every class that embeds, and xUnit guarantees no such order.

The production contract is not at fault and does not change here. It promises *some* superseded generation holding vectors, which is what the upkeep needs and what it returns; the test was asserting more than that.

## What changed

A drain of that residue already existed, added while chasing this from the other branch, but it ran **before** the switch — where the residue is still active and the query cannot see it, which made it a no-op. It now runs immediately after the switch to the first generation. By then the residue is superseded and visible, and nothing this test created can be taken by it: `previous` is serving at that moment and holds no vector yet.

The drain is bounded and fails the test rather than looping when a generation reported as holding vectors gives none up.

## Verification

- `scripts/verify-full.sh` — green.
- The integration suite is not run locally; it will be dispatched against this branch, and the reading that matters is this test passing in a run where an embedding class went first.