### PR TITLE
[#621] Wake the embedding backfill when an operator acts, and report when its next pass is due

### DIFF
--- a/docs/features/embedding-backfill.md
+++ b/docs/features/embedding-backfill.md
@@ -109,6 +109,31 @@ reaches no provider, and costs nothing an operator has to consent to, so what pa
 rather than a number beside the ones above. A pass that removed a full batch is followed by the short interval, because
 there is more of that generation behind it.
 
+## An operator's act does not wait for the pause to expire
+
+Every pause above is chosen by the pass that just ended, which means it was chosen without knowing what an operator
+would do next. That is most visible on a first activation. Every pass before one ends with no generation to walk
+towards, so the walk is always sleeping the long interval, and the row the activation commits is one the sleeping
+worker has no way to observe — leaving the first vectors of a mailbox to arrive whenever a quarter-hour timer unrelated
+to the activation happens to expire.
+
+So the acts that create the work say so. **Activating a profile** and **cancelling a reindex** each ask for a pass now,
+and a worker waiting out a pause takes it immediately; the second matters for the same reason the first does, because
+what a cancellation leaves behind is a generation nothing reads whose partial vectors are personal data with no purpose
+left. An act arriving while a pass is already running is held rather than dropped, so the pass after it is the one that
+picks the work up, and two acts in a row ask for one pass rather than two. Nothing else brings a pass forward: a
+message arriving is the [live path](automatic-embedding.md)'s, not this walk's.
+
+The pause itself is unchanged and so is its purpose. `EmbeddingBackfill:IdleSweepInterval` still governs an instance
+with nothing to do, which is exactly the instance that should stop asking the database about nothing.
+
+**When the next pass is due is readable while it is being waited for.** `mfctl embedding status` reports it on the
+`Next pass` line, and that line is what separates a deployment that is waiting from one that is failing — every other
+reading in that output says the same thing during a pause as it does on a broken instance: nothing serving, nothing
+embedded, and a provider nothing has been asked of. A deployment reporting no pass at all has scheduled none, which is
+what `EmbeddingBackfill:Enabled` set to `false` leaves behind. The log says the same at `Debug` after every pass, and
+says at `Information` when an act cut a pause short.
+
 ## What an operator can see
 
 | Signal | What it answers |

--- a/docs/features/embedding-backfill.md
+++ b/docs/features/embedding-backfill.md
@@ -130,9 +130,11 @@ with nothing to do, which is exactly the instance that should stop asking the da
 **When the next pass is due is readable while it is being waited for.** `mfctl embedding status` reports it on the
 `Next pass` line, and that line is what separates a deployment that is waiting from one that is failing — every other
 reading in that output says the same thing during a pause as it does on a broken instance: nothing serving, nothing
-embedded, and a provider nothing has been asked of. A deployment reporting no pass at all has scheduled none, which is
-what `EmbeddingBackfill:Enabled` set to `false` leaves behind. The log says the same at `Debug` after every pass, and
-says at `Information` when an act cut a pause short.
+embedded, and a provider nothing has been asked of. A deployment reporting no pass at all has scheduled none, which
+happens for two reasons and neither is a fault: it has only just started, or `EmbeddingBackfill:Enabled` is `false` and
+its worker reports outright that it will take no pass — which is also what keeps an activation on such a deployment
+from recording a pass nothing would ever reach. The log says the same at `Debug` after every pass, and says at
+`Information` when an act cut a pause short.
 
 ## What an operator can see
 

--- a/docs/features/embedding-generation.md
+++ b/docs/features/embedding-generation.md
@@ -38,7 +38,10 @@ status` is where they find out — it says outright that a declaration is waitin
 both are documented, with the estimate the second one states before it spends.
 
 What an activation then does — build a new generation beside the one still answering searches, switch to it once, and
-remove what it replaced — is [changing the embedding model](../operations/embedding-profiles.md).
+remove what it replaced — is [changing the embedding model](../operations/embedding-profiles.md). It also starts:
+the walk over the mail an instance already had takes its next pass as soon as the activation commits rather than
+whenever an interval chosen while there was nothing to embed happens to expire, which
+[embedding backfill](embedding-backfill.md#an-operators-act-does-not-wait-for-the-pause-to-expire) records.
 
 ## What a declaration says
 

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -205,16 +205,25 @@ production (https://mail.example.test:8443)
 Declared:  openai text-embedding-3-small, 1536 dimensions, Cosine
 Serving:   openai text-embedding-3-small, 1536 dimensions, Cosine — 4,120 of 4,120 messages embedded; nothing outstanding
 Reindex:   none running.
+Next pass: due at 2026-08-08 12:14:30Z
 Provider:  Serving, as of 2026-08-08 11:59:00Z
 Spend:     1,200 of 50,000,000 characters; the period rolls over at 2026-08-09 00:00:00Z
 ```
 
 **`mfctl embedding status` is the command to run when semantic search is not returning what you expected.** It answers
-that question five ways at once, because it has five answers that look nothing alike: no provider declared, a
-declaration nobody activated, a provider refusing the credential, a reindex still running, and a budget period spent.
-The line to read first is `Declared`, which says so outright when an activation is outstanding — an edited
-configuration file changes nothing until one happens, and this is where you find that out rather than from search
-results that stayed the same.
+that question six ways at once, because it has six answers that look nothing alike: no provider declared, a
+declaration nobody activated, a provider refusing the credential, a reindex still running, a budget period spent, and a
+walk whose next pass is simply not due yet. The line to read first is `Declared`, which says so outright when an
+activation is outstanding — an edited configuration file changes nothing until one happens, and this is where you find
+that out rather than from search results that stayed the same.
+
+`Next pass` is the line for the minutes just after an activation, when a deployment that is waiting and one that is
+failing read identically everywhere else: nothing serving, nothing embedded, and a provider nothing has been asked of.
+An activation asks for a pass immediately, so the instant it names is normally the one now or a moment away rather than
+the end of an interval an earlier pass chose; `none scheduled` means the walk is scheduling nothing at all, which is
+what `EmbeddingBackfill:Enabled` set to `false` leaves. [Embedding
+backfill](../features/embedding-backfill.md#an-operators-act-does-not-wait-for-the-pause-to-expire) holds the pacing
+this line reports.
 
 **`mfctl embedding activate` reads the estimate, states it, and asks.** The deployment counts the passages the run
 would send and expresses them as characters and approximate tokens, weighs them against `Embeddings:MaxInputCharactersPerPeriod`,

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -220,8 +220,8 @@ that out rather than from search results that stayed the same.
 `Next pass` is the line for the minutes just after an activation, when a deployment that is waiting and one that is
 failing read identically everywhere else: nothing serving, nothing embedded, and a provider nothing has been asked of.
 An activation asks for a pass immediately, so the instant it names is normally the one now or a moment away rather than
-the end of an interval an earlier pass chose; `none scheduled` means the walk is scheduling nothing at all, which is
-what `EmbeddingBackfill:Enabled` set to `false` leaves. [Embedding
+the end of an interval an earlier pass chose; `none scheduled` means the deployment has only just started, or that
+`EmbeddingBackfill:Enabled` is `false` and it walks no stored mail at all. [Embedding
 backfill](../features/embedding-backfill.md#an-operators-act-does-not-wait-for-the-pause-to-expire) holds the pacing
 this line reports.
 

--- a/docs/operations/embedding-profiles.md
+++ b/docs/operations/embedding-profiles.md
@@ -44,11 +44,14 @@ rest on its own.
    refused rather than started beside it, because one walk between two partial generations would finish neither.
    [Administering the embedding profile](admin-endpoint.md#administering-the-embedding-profile) holds the command, its
    flag, and each refusal.
-2. **The reindex fills it.** The same bounded, resumable sweep that backfills mail now walks towards the new
-   generation, at the pace `EmbeddingBackfill:*` sets. [Embedding backfill](../features/embedding-backfill.md) describes
-   the walk, what one pass costs, and how to slow it down. Searches are answered from the old generation throughout,
-   and mail arriving meanwhile is embedded into that old generation by the live path, so nothing becomes unsearchable
-   while the run is on.
+2. **The reindex fills it, starting at once.** The same bounded, resumable sweep that backfills mail now walks towards
+   the new generation, at the pace `EmbeddingBackfill:*` sets. The activation asks for a pass immediately rather than
+   letting the run begin whenever the pause the previous pass chose happens to expire — which on a first activation is
+   the whole of `EmbeddingBackfill:IdleSweepInterval`, chosen while there was nothing to embed;
+   [an operator's act does not wait for the pause to
+   expire](../features/embedding-backfill.md#an-operators-act-does-not-wait-for-the-pause-to-expire) is why. Searches
+   are answered from the old generation throughout, and mail arriving meanwhile is embedded into that old generation by
+   the live path, so nothing becomes unsearchable while the run is on.
 3. **The switch happens once, when nothing is outstanding.** A completed sweep is not enough on its own — a message a
    provider refused stays outstanding behind the walk's position — so the deployment counts what remains and switches
    only at zero. Promoting the new generation and superseding the old one is one transaction, reported as
@@ -62,7 +65,8 @@ While the reindex is running, `mailfathom.embedding.backfill.outstanding` is how
 generation is still missing, and the counters beside it are what move in between.
 [What an operator can see](../features/embedding-backfill.md#what-an-operator-can-see) lists all of them.
 `mfctl embedding status` is the same picture without a metrics backend: it names both generations, how much of the
-mailbox each covers, what the provider last did, and what the budget period has spent.
+mailbox each covers, what the provider last did, what the budget period has spent, and when the next pass is due —
+which is the line to read in the seconds after an activation, while the first pass has yet to write anything.
 
 ## What it costs
 
@@ -78,8 +82,9 @@ a profile's identity — so a model change pays for provider calls and local wri
 
 **Cancelling a reindex** — `mfctl embedding cancel-reindex` — abandons the generation being built and leaves the one
 serving exactly where it is. The abandoned row becomes superseded, its index is dropped, and whatever partial vectors it
-accumulated are removed in the same bounded batches. What was spent on those vectors is spent; nothing about the search
-results changes, because that generation was never read.
+accumulated are removed in the same bounded batches, beginning with a pass the cancellation asks for rather than one an
+earlier pause happened to schedule. What was spent on those vectors is spent; nothing about the search results changes,
+because that generation was never read.
 
 A cancellation that arrives after the reindex has already completed reports that nothing was being built, and changes
 nothing: the generation it names is the one searches are now answered from, and this command never takes that out of

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -210,7 +210,9 @@ before it starts. `--yes` agrees up front, for a scripted run.
 
 `mfctl embedding status` is the one to reach for first. It answers, in one output, whether a model is active, whether
 that model is still the one your configuration declares, whether your provider is answering, how much of the mailbox
-is embedded, and what the current budget period has spent.
+is embedded, what the current budget period has spent, and when the walk that embeds your existing mail next runs. That
+last line is the one to read in the minutes after an activation: until the first passages have gone out, a deployment
+that is simply between passes looks exactly like one that is broken.
 
 [Administering the embedding profile](../operations/admin-endpoint.md#administering-the-embedding-profile) is the
 operator's reference for all three, and [changing the embedding model](../operations/embedding-profiles.md) is what a

--- a/src/Application/Emails/Embeddings/Administration/EmbeddingStatus.cs
+++ b/src/Application/Emails/Embeddings/Administration/EmbeddingStatus.cs
@@ -10,11 +10,11 @@ namespace MailFathom.Application.Emails.Embeddings.Administration;
 /// <summary>Whether semantic search is working on this instance, and where it is if it is not yet.</summary>
 /// <remarks>
 /// <para>
-/// One value rather than four readings an operator has to combine, because the question it answers is one question.
+/// One value rather than five readings an operator has to combine, because the question it answers is one question.
 /// Semantic search can be absent for reasons that look nothing alike — no provider declared, a declaration nobody
-/// activated, a provider refusing the credential, a reindex still running, a budget period spent — and each of them is
-/// answered by a different member here. Reading them apart would leave an operator checking four things to learn that
-/// the fifth was the problem.
+/// activated, a provider refusing the credential, a reindex still running, a budget period spent, a pass that is
+/// simply not due yet — and each of them is answered by a different member here. Reading them apart would leave an
+/// operator checking five things to learn that the sixth was the problem.
 /// </para>
 /// <para>
 /// Nothing here is mail. Model names, counts, timestamps, and a health state are what it holds, which is what makes it
@@ -26,12 +26,18 @@ namespace MailFathom.Application.Emails.Embeddings.Administration;
 /// <param name="Building">The generation a reindex is filling, or <see langword="null" /> when no reindex is running.</param>
 /// <param name="ProviderHealth">What the last call to the embedding provider established about it.</param>
 /// <param name="Period">Where the deployment's budget period stands.</param>
+/// <param name="NextBackfillPassDueAt">
+/// When the backfill's next pass is due, or <see langword="null" /> while none is scheduled. An instant already past is
+/// a pass that is running or about to be taken, and the absence is an instance whose backfill worker has scheduled
+/// nothing — which is what <c>EmbeddingBackfill:Enabled</c> set to <see langword="false" /> leaves behind.
+/// </param>
 public sealed record EmbeddingStatus(
     EmbeddingProfileIdentity? Declared,
     EmbeddingGenerationProgress? Serving,
     EmbeddingGenerationProgress? Building,
     AiProviderHealth ProviderHealth,
-    EmbeddingSpendPeriod Period)
+    EmbeddingSpendPeriod Period,
+    DateTimeOffset? NextBackfillPassDueAt)
 {
     /// <summary>Gets whether a declaration is waiting for an activation nobody has performed.</summary>
     /// <remarks>

--- a/src/Application/Emails/Embeddings/Administration/EmbeddingStatus.cs
+++ b/src/Application/Emails/Embeddings/Administration/EmbeddingStatus.cs
@@ -28,8 +28,8 @@ namespace MailFathom.Application.Emails.Embeddings.Administration;
 /// <param name="Period">Where the deployment's budget period stands.</param>
 /// <param name="NextBackfillPassDueAt">
 /// When the backfill's next pass is due, or <see langword="null" /> while none is scheduled. An instant already past is
-/// a pass that is running or about to be taken, and the absence is an instance whose backfill worker has scheduled
-/// nothing — which is what <c>EmbeddingBackfill:Enabled</c> set to <see langword="false" /> leaves behind.
+/// a pass that is running or about to be taken; the absence is an instance that has only just started, or one whose
+/// walk is turned off and will schedule nothing at all.
 /// </param>
 public sealed record EmbeddingStatus(
     EmbeddingProfileIdentity? Declared,

--- a/src/Application/Emails/Embeddings/Administration/EmbeddingStatusReader.cs
+++ b/src/Application/Emails/Embeddings/Administration/EmbeddingStatusReader.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.AiProviders;
+using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Limits;
 
@@ -11,9 +12,9 @@ namespace MailFathom.Application.Emails.Embeddings.Administration;
 /// <summary>Answers, in one read, whether semantic search is working on this instance and how far behind it is.</summary>
 /// <remarks>
 /// Composed here rather than by whatever surface asks, because the composition is the answer: which generation serves,
-/// how much each one still owes, what the provider last did, and what the budget period has spent are four sources that
-/// only mean something together. Assembling them in the endpoint would put that reasoning in the composition root and
-/// would leave a second caller to reassemble it differently.
+/// how much each one still owes, what the provider last did, what the budget period has spent, and when the walk next
+/// runs are five sources that only mean something together. Assembling them in the endpoint would put that reasoning in
+/// the composition root and would leave a second caller to reassemble it differently.
 /// </remarks>
 public sealed class EmbeddingStatusReader
 {
@@ -21,28 +22,33 @@ public sealed class EmbeddingStatusReader
     private readonly IEmbeddingWorkloadReader workloadReader;
     private readonly EmbeddingSpendGate spendGate;
     private readonly IAiProviderHealthReader providerHealth;
+    private readonly EmbeddingBackfillSchedule backfillSchedule;
 
     /// <summary>Initializes a new reader over the state one status answer is composed from.</summary>
     /// <param name="generationStore">Reads which generations this instance holds.</param>
     /// <param name="workloadReader">Counts what each generation still owes.</param>
     /// <param name="spendGate">Reads where the budget period stands.</param>
     /// <param name="providerHealth">Reports what the last call to the embedding provider established.</param>
+    /// <param name="backfillSchedule">Reports when the walk's next pass is due.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public EmbeddingStatusReader(
         IEmbeddingGenerationStore generationStore,
         IEmbeddingWorkloadReader workloadReader,
         EmbeddingSpendGate spendGate,
-        IAiProviderHealthReader providerHealth)
+        IAiProviderHealthReader providerHealth,
+        EmbeddingBackfillSchedule backfillSchedule)
     {
         ArgumentNullException.ThrowIfNull(generationStore);
         ArgumentNullException.ThrowIfNull(workloadReader);
         ArgumentNullException.ThrowIfNull(spendGate);
         ArgumentNullException.ThrowIfNull(providerHealth);
+        ArgumentNullException.ThrowIfNull(backfillSchedule);
 
         this.generationStore = generationStore;
         this.workloadReader = workloadReader;
         this.spendGate = spendGate;
         this.providerHealth = providerHealth;
+        this.backfillSchedule = backfillSchedule;
     }
 
     /// <summary>Reads where semantic search stands on this instance.</summary>
@@ -65,7 +71,8 @@ public sealed class EmbeddingStatusReader
             await this.DescribeAsync(generations.Serving, cancellationToken),
             await this.DescribeAsync(generations.Building, cancellationToken),
             this.providerHealth.Read(AiProviderRole.Embedding),
-            await this.spendGate.ReadCurrentPeriodAsync(cancellationToken));
+            await this.spendGate.ReadCurrentPeriodAsync(cancellationToken),
+            this.backfillSchedule.NextPassDueAt);
     }
 
     /// <summary>Counts what one generation still owes, where there is a generation to count for.</summary>

--- a/src/Application/Emails/Embeddings/Backfill/EmbeddingBackfillSchedule.cs
+++ b/src/Application/Emails/Embeddings/Backfill/EmbeddingBackfillSchedule.cs
@@ -1,0 +1,153 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Embeddings.Backfill;
+
+/// <summary>When the embedding upkeep pass is next due, and the one way an operator's act brings it forward.</summary>
+/// <remarks>
+/// <para>
+/// The pause between passes is chosen by the pass that just ended, so nothing a later act writes can shorten it. An
+/// instance that has activated no profile ends every pass having found no generation to walk towards, which is the long
+/// idle interval; the activation that gives it one then commits a row a sleeping worker has no way to observe, and the
+/// first vectors of a reindex arrive whenever that unrelated interval happens to expire. This is the signal that closes
+/// that gap — the act that creates the work says so, and the worker waiting out the pause takes the next pass at once.
+/// </para>
+/// <para>
+/// The instant is the other half of the same fact and is held here for the same reason: nothing else in the process
+/// knows it. An operator reading a deployment during that pause sees no vectors, no provider call, and no log line, and
+/// what tells a wait apart from a failure is being able to read when the wait ends.
+/// </para>
+/// <para>
+/// One instance per process, because a pass is one thing the process does. It is deliberately not durable: what it
+/// carries is a decision the running worker has already made, so a restart correctly forgets it and the first pass of
+/// the new process schedules the next one.
+/// </para>
+/// </remarks>
+public sealed class EmbeddingBackfillSchedule
+{
+    private readonly Lock gate = new();
+    private readonly TimeProvider timeProvider;
+
+    private TaskCompletionSource? waitingWorker;
+    private bool passRequested;
+
+    /// <summary>Initializes a schedule holding no pass.</summary>
+    /// <param name="timeProvider">Dates the pause the worker is taking and the moment an act brings a pass forward to.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeProvider" /> is <see langword="null" />.</exception>
+    public EmbeddingBackfillSchedule(TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.timeProvider = timeProvider;
+    }
+
+    /// <summary>Gets when the next pass is due, or <see langword="null" /> while no pass has been scheduled.</summary>
+    /// <remarks>
+    /// <para>
+    /// An instant already past is a pass that is due now — either running, or about to be taken by a worker that has
+    /// finished waiting. The absence is an instance whose backfill worker has scheduled nothing, which is what
+    /// <c>EmbeddingBackfill:Enabled</c> set to <see langword="false" /> leaves behind and what a process that has only
+    /// just started shows for as long as its first pass takes.
+    /// </para>
+    /// <para>
+    /// A nullable <see cref="DateTimeOffset" /> is wider than one atomic write, so the read holds the gate and every
+    /// assignment below is made while already holding it. The setter does not take the gate itself, because both
+    /// writers do so for the rest of what they change as well and a re-entrant acquisition would say the two facts were
+    /// separable.
+    /// </para>
+    /// </remarks>
+    public DateTimeOffset? NextPassDueAt
+    {
+        get
+        {
+            lock (this.gate)
+            {
+                return field;
+            }
+        }
+
+        private set;
+    }
+
+    /// <summary>Asks for a pass now, releasing a worker that is waiting out the pause the last pass chose.</summary>
+    /// <remarks>
+    /// Called by the act that made a pass worth running rather than by anything watching for one, because the state it
+    /// reacts to is a row that act has just committed. A request arriving while a pass is already running is held in the
+    /// flag rather than dropped, so work an operator asked for is never lost to a worker that was busy instead of
+    /// waiting; a second request against a first nobody has taken yet asks for the same single pass.
+    /// </remarks>
+    public void BringForward()
+    {
+        TaskCompletionSource? waiting;
+
+        lock (this.gate)
+        {
+            this.NextPassDueAt = this.timeProvider.GetUtcNow();
+            this.passRequested = true;
+            waiting = this.waitingWorker;
+            this.waitingWorker = null;
+        }
+
+        // Completed outside the lock, so nothing a released worker goes on to do runs while this one holds it.
+        waiting?.TrySetResult();
+    }
+
+    /// <summary>Records that the next pass is due after the given pause, and waits for it.</summary>
+    /// <param name="pause">How long the pass that just ended asked to wait.</param>
+    /// <param name="cancellationToken">Ends the wait when the process is stopping.</param>
+    /// <returns><see langword="true" /> when the wait ended because a pass was brought forward, <see langword="false" /> when the pause simply elapsed.</returns>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    /// <remarks>
+    /// Recording and waiting are one call so that a pause cannot be taken without the instant that ends it being
+    /// readable, which is the whole of what an operator is missing while a deployment sits quiet.
+    /// </remarks>
+    public async Task<bool> WaitForNextPassAsync(TimeSpan pause, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        TaskCompletionSource broughtForward;
+
+        lock (this.gate)
+        {
+            // Taken before the pause is recorded, because a request made while the last pass was running is a pass that
+            // is already due: recording an instant for it would report a wait that is not going to happen.
+            if (this.passRequested)
+            {
+                this.passRequested = false;
+
+                return true;
+            }
+
+            this.NextPassDueAt = this.timeProvider.GetUtcNow() + pause;
+
+            // Asynchronous continuations, so completing this never runs the worker's next pass on the thread of the
+            // request that activated a profile.
+            broughtForward = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            this.waitingWorker = broughtForward;
+        }
+
+        using var pauseEnded = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var elapsing = Task.Delay(pause, this.timeProvider, pauseEnded.Token);
+        var ended = await Task.WhenAny(broughtForward.Task, elapsing);
+
+        lock (this.gate)
+        {
+            this.waitingWorker = null;
+            this.passRequested = false;
+        }
+
+        if (ended == elapsing)
+        {
+            // Awaited rather than discarded, so a stopping process ends the loop here instead of taking one more pass.
+            await elapsing;
+
+            return false;
+        }
+
+        // Ends the timer the pause created, which would otherwise outlive a wait it no longer bounds.
+        await pauseEnded.CancelAsync();
+
+        return true;
+    }
+}

--- a/src/Application/Emails/Embeddings/Backfill/EmbeddingBackfillSchedule.cs
+++ b/src/Application/Emails/Embeddings/Backfill/EmbeddingBackfillSchedule.cs
@@ -31,6 +31,7 @@ public sealed class EmbeddingBackfillSchedule
 
     private TaskCompletionSource? waitingWorker;
     private bool passRequested;
+    private bool passesRun = true;
 
     /// <summary>Initializes a schedule holding no pass.</summary>
     /// <param name="timeProvider">Dates the pause the worker is taking and the moment an act brings a pass forward to.</param>
@@ -46,9 +47,9 @@ public sealed class EmbeddingBackfillSchedule
     /// <remarks>
     /// <para>
     /// An instant already past is a pass that is due now — either running, or about to be taken by a worker that has
-    /// finished waiting. The absence is an instance whose backfill worker has scheduled nothing, which is what
-    /// <c>EmbeddingBackfill:Enabled</c> set to <see langword="false" /> leaves behind and what a process that has only
-    /// just started shows for as long as its first pass takes.
+    /// finished waiting. The absence has two causes and neither is a fault: a process that has only just started shows
+    /// it until its first pass schedules the next one, and a deployment whose walk is turned off shows it for good,
+    /// because <see cref="NoPassWillRun" /> is what its worker reports instead of ever waiting.
     /// </para>
     /// <para>
     /// A nullable <see cref="DateTimeOffset" /> is wider than one atomic write, so the read holds the gate and every
@@ -70,12 +71,38 @@ public sealed class EmbeddingBackfillSchedule
         private set;
     }
 
+    /// <summary>Reports that this process runs no pass at all, so nothing is scheduled and nothing can be asked for.</summary>
+    /// <remarks>
+    /// <para>
+    /// Called by the worker in place of ever waiting, because whether the walk runs is a configuration value the worker
+    /// reads and nothing here can see. Without it an activation would record a due instant on a deployment where no
+    /// pass will ever be taken, and the status surface would report an overdue pass for as long as the process lived —
+    /// which is the reading this whole type exists to prevent, arrived at from the other direction.
+    /// </para>
+    /// <para>
+    /// It also clears a request that got in first, because an activation can reach the process before its worker has
+    /// run far enough to say this. There is no way back: whether the walk runs is read once at startup, so a schedule
+    /// told this keeps saying it until the process ends.
+    /// </para>
+    /// </remarks>
+    public void NoPassWillRun()
+    {
+        lock (this.gate)
+        {
+            this.passesRun = false;
+            this.passRequested = false;
+            this.NextPassDueAt = null;
+        }
+    }
+
     /// <summary>Asks for a pass now, releasing a worker that is waiting out the pause the last pass chose.</summary>
     /// <remarks>
     /// Called by the act that made a pass worth running rather than by anything watching for one, because the state it
     /// reacts to is a row that act has just committed. A request arriving while a pass is already running is held in the
     /// flag rather than dropped, so work an operator asked for is never lost to a worker that was busy instead of
-    /// waiting; a second request against a first nobody has taken yet asks for the same single pass.
+    /// waiting; a second request against a first nobody has taken yet asks for the same single pass. Where
+    /// <see cref="NoPassWillRun" /> has been reported it does nothing at all, because there is no worker to release and
+    /// recording a pass nothing will take would be a worse answer than recording none.
     /// </remarks>
     public void BringForward()
     {
@@ -83,6 +110,11 @@ public sealed class EmbeddingBackfillSchedule
 
         lock (this.gate)
         {
+            if (!this.passesRun)
+            {
+                return;
+            }
+
             this.NextPassDueAt = this.timeProvider.GetUtcNow();
             this.passRequested = true;
             waiting = this.waitingWorker;

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingProfileActivation.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingProfileActivation.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Persistence;
 
@@ -27,24 +28,29 @@ public sealed class EmbeddingProfileActivation
     private readonly IEmbeddingGenerationStore generationStore;
     private readonly IEmbeddingProfileVectorIndex vectorIndex;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
+    private readonly EmbeddingBackfillSchedule backfillSchedule;
 
     /// <summary>Initializes a new activation.</summary>
     /// <param name="generationStore">Reads which generations exist and registers the one being started.</param>
     /// <param name="vectorIndex">Builds the approximate index the new generation will be searched through.</param>
     /// <param name="concurrencyRetryPolicy">Commits the registration, retrying a conflict with a competing writer.</param>
+    /// <param name="backfillSchedule">Brings the next upkeep pass forward once there is a generation for it to walk towards.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public EmbeddingProfileActivation(
         IEmbeddingGenerationStore generationStore,
         IEmbeddingProfileVectorIndex vectorIndex,
-        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy)
+        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
+        EmbeddingBackfillSchedule backfillSchedule)
     {
         ArgumentNullException.ThrowIfNull(generationStore);
         ArgumentNullException.ThrowIfNull(vectorIndex);
         ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
+        ArgumentNullException.ThrowIfNull(backfillSchedule);
 
         this.generationStore = generationStore;
         this.vectorIndex = vectorIndex;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
+        this.backfillSchedule = backfillSchedule;
     }
 
     /// <summary>Registers the declared geometry as the generation to build, unless one of it is already there.</summary>
@@ -109,6 +115,8 @@ public sealed class EmbeddingProfileActivation
         // creates it: the index covers one profile and one width, neither of which exists before this call.
         await this.vectorIndex.EnsureBuiltAsync(registered, cancellationToken);
 
+        this.AskForAPassNow();
+
         return new EmbeddingProfileActivationResult(
             EmbeddingProfileActivationOutcome.ReindexStarted,
             registered.Id);
@@ -151,10 +159,23 @@ public sealed class EmbeddingProfileActivation
     {
         await this.vectorIndex.EnsureBuiltAsync(building, cancellationToken);
 
+        this.AskForAPassNow();
+
         return new EmbeddingProfileActivationResult(
             EmbeddingProfileActivationOutcome.AlreadyBuilding,
             building.Id);
     }
+
+    /// <summary>Brings the next upkeep pass forward, because this call is what made one worth running.</summary>
+    /// <remarks>
+    /// The row committed above is the whole of the signal, and a sleeping worker cannot observe it: a pass is paced by
+    /// what the previous one found, and every pass before an activation found no generation to walk towards and took
+    /// the long idle interval. Without this, the first passages of a reindex go out whenever that unrelated interval
+    /// happens to expire rather than because an operator asked for them. The two refusals ask for nothing — an
+    /// activation of what is already serving changed no row, and one refused for a different running reindex is not the
+    /// activation that happened.
+    /// </remarks>
+    private void AskForAPassNow() => this.backfillSchedule.BringForward();
 
     private static EmbeddingProfileFingerprint Fingerprints(RegisteredEmbeddingProfile profile) =>
         EmbeddingProfileFingerprint.Compute(profile.Identity);

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingReindexCancellation.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingReindexCancellation.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Persistence;
 
@@ -18,24 +19,29 @@ public sealed class EmbeddingReindexCancellation
     private readonly IEmbeddingGenerationStore generationStore;
     private readonly IEmbeddingProfileVectorIndex vectorIndex;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
+    private readonly EmbeddingBackfillSchedule backfillSchedule;
 
     /// <summary>Initializes a new cancellation.</summary>
     /// <param name="generationStore">Reads which generation is being built and abandons it.</param>
     /// <param name="vectorIndex">Removes the approximate index the abandoned generation would have been searched through.</param>
     /// <param name="concurrencyRetryPolicy">Commits the transition, retrying a conflict with a competing writer.</param>
+    /// <param name="backfillSchedule">Brings the next upkeep pass forward, which is the pass that removes what the abandoned generation holds.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public EmbeddingReindexCancellation(
         IEmbeddingGenerationStore generationStore,
         IEmbeddingProfileVectorIndex vectorIndex,
-        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy)
+        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
+        EmbeddingBackfillSchedule backfillSchedule)
     {
         ArgumentNullException.ThrowIfNull(generationStore);
         ArgumentNullException.ThrowIfNull(vectorIndex);
         ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
+        ArgumentNullException.ThrowIfNull(backfillSchedule);
 
         this.generationStore = generationStore;
         this.vectorIndex = vectorIndex;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
+        this.backfillSchedule = backfillSchedule;
     }
 
     /// <summary>Abandons the generation being built, if one is.</summary>
@@ -75,6 +81,11 @@ public sealed class EmbeddingReindexCancellation
         // index nothing will ever read. The removal drops it again when it empties the generation, which is what covers
         // a process that stopped between these two steps.
         await this.vectorIndex.RemoveAsync(building.Id, cancellationToken);
+
+        // What this leaves behind is a generation nothing reads whose partial vectors are personal data with no purpose
+        // left, and the pass that removes them is the one an idle interval has just put as much as a quarter of an hour
+        // away. The worker cannot observe the row this changed, so the removal is asked for here.
+        this.backfillSchedule.BringForward();
 
         return EmbeddingReindexCancellationOutcome.Cancelled;
     }

--- a/src/Cli/Administration/Embeddings/EmbeddingStatus.cs
+++ b/src/Cli/Administration/Embeddings/EmbeddingStatus.cs
@@ -20,13 +20,15 @@ namespace MailFathom.Cli.Administration.Embeddings;
 /// <param name="Building">The generation a reindex is filling, or <see langword="null" /> when no reindex is running.</param>
 /// <param name="Provider">What the deployment's last call to its embedding provider established.</param>
 /// <param name="Spend">Where the deployment's budget period stands.</param>
+/// <param name="NextBackfillPassDueAt">When the deployment's backfill runs its next pass, or <see langword="null" /> while it has scheduled none.</param>
 internal sealed record EmbeddingStatus(
     [property: JsonPropertyName("declared")] EmbeddingGeometry? Declared,
     [property: JsonPropertyName("activationOutstanding")] bool ActivationOutstanding,
     [property: JsonPropertyName("serving")] EmbeddingGeneration? Serving,
     [property: JsonPropertyName("building")] EmbeddingGeneration? Building,
     [property: JsonPropertyName("provider")] EmbeddingProviderHealth? Provider,
-    [property: JsonPropertyName("spend")] EmbeddingSpend? Spend);
+    [property: JsonPropertyName("spend")] EmbeddingSpend? Spend,
+    [property: JsonPropertyName("nextBackfillPassDueAt")] DateTimeOffset? NextBackfillPassDueAt);
 
 /// <summary>One vector space, as a deployment names it.</summary>
 /// <param name="Fingerprint">The digest the deployment's profile row is unique on.</param>

--- a/src/Cli/Commands/EmbeddingStatusCommand.cs
+++ b/src/Cli/Commands/EmbeddingStatusCommand.cs
@@ -54,6 +54,7 @@ internal static class EmbeddingStatusCommand
         context.Console.WriteLine($"Declared:  {DescribeDeclaration(status)}");
         context.Console.WriteLine($"Serving:   {DescribeServing(status.Serving)}");
         context.Console.WriteLine($"Reindex:   {DescribeReindex(status.Building)}");
+        context.Console.WriteLine($"Next pass: {DescribeNextPass(status.NextBackfillPassDueAt)}");
         context.Console.WriteLine($"Provider:  {DescribeProvider(status.Provider)}");
         context.Console.WriteLine($"Spend:     {status.Spend?.Describe() ?? "not reported"}");
 
@@ -85,6 +86,17 @@ internal static class EmbeddingStatusCommand
     private static string DescribeReindex(EmbeddingGeneration? building) => building is { } present
         ? $"{present.Geometry?.Describe() ?? "an unreported model"} — {present.Progress?.DescribeProgress() ?? "progress not reported"}"
         : "none running.";
+
+    /// <summary>States when the walk next runs, which is what tells a deployment that is waiting from one that is failing.</summary>
+    /// <remarks>
+    /// The line this command was missing. A deployment between passes reports nothing served, nothing outstanding
+    /// moving, and a provider nothing has been asked of — three readings an operator has no way to tell apart from a
+    /// broken instance until one of them says a pass is simply not due yet. The instant is absolute rather than a
+    /// countdown, because it is the deployment's clock rather than this terminal's that decides when the pass runs.
+    /// </remarks>
+    private static string DescribeNextPass(DateTimeOffset? dueAt) => dueAt is { } moment
+        ? $"due at {moment:u}"
+        : "none scheduled. The deployment's backfill has scheduled no pass, which is what 'EmbeddingBackfill:Enabled' set to false leaves.";
 
     /// <summary>States what the last call to the provider established, and when.</summary>
     /// <remarks>

--- a/src/Cli/Commands/EmbeddingStatusCommand.cs
+++ b/src/Cli/Commands/EmbeddingStatusCommand.cs
@@ -93,10 +93,15 @@ internal static class EmbeddingStatusCommand
     /// moving, and a provider nothing has been asked of — three readings an operator has no way to tell apart from a
     /// broken instance until one of them says a pass is simply not due yet. The instant is absolute rather than a
     /// countdown, because it is the deployment's clock rather than this terminal's that decides when the pass runs.
+    /// <para>
+    /// The absence names both of its causes and asserts neither, because a deployment that has only just started shows
+    /// it as truthfully as one whose walk is turned off, and a line claiming the second would send an operator to a
+    /// setting that is already what they want it to be.
+    /// </para>
     /// </remarks>
     private static string DescribeNextPass(DateTimeOffset? dueAt) => dueAt is { } moment
         ? $"due at {moment:u}"
-        : "none scheduled. The deployment's backfill has scheduled no pass, which is what 'EmbeddingBackfill:Enabled' set to false leaves.";
+        : "none scheduled — either the deployment has only just started, or 'EmbeddingBackfill:Enabled' is false and it walks no stored mail.";
 
     /// <summary>States what the last call to the provider established, and when.</summary>
     /// <remarks>

--- a/src/Host/Api/EmbeddingAdministrationResponses.cs
+++ b/src/Host/Api/EmbeddingAdministrationResponses.cs
@@ -159,13 +159,19 @@ internal sealed record EmbeddingSpendResponse(
 /// <param name="Building">The generation a reindex is filling, or <see langword="null" /> when no reindex is running.</param>
 /// <param name="Provider">What the last call to the embedding provider established.</param>
 /// <param name="Spend">Where the budget period stands.</param>
+/// <param name="NextBackfillPassDueAt">
+/// When the backfill's next pass is due, or <see langword="null" /> while none is scheduled. It is what tells a
+/// deployment that is waiting apart from one that is failing, which every other member here reads alike: an instance
+/// between passes reports no vectors, no provider call, and no reason.
+/// </param>
 internal sealed record EmbeddingStatusResponse(
     EmbeddingGeometryResponse? Declared,
     bool ActivationOutstanding,
     EmbeddingGenerationResponse? Serving,
     EmbeddingGenerationResponse? Building,
     EmbeddingProviderHealthResponse Provider,
-    EmbeddingSpendResponse Spend)
+    EmbeddingSpendResponse Spend,
+    DateTimeOffset? NextBackfillPassDueAt)
 {
     /// <summary>Describes one instance's embedding state for the wire.</summary>
     /// <param name="status">The state.</param>
@@ -181,7 +187,8 @@ internal sealed record EmbeddingStatusResponse(
             EmbeddingGenerationResponse.For(status.Serving),
             EmbeddingGenerationResponse.For(status.Building),
             EmbeddingProviderHealthResponse.For(status.ProviderHealth),
-            EmbeddingSpendResponse.For(status.Period));
+            EmbeddingSpendResponse.For(status.Period),
+            status.NextBackfillPassDueAt);
     }
 }
 

--- a/src/Host/Hosting/Workers/MailEmbeddingBackfillWorker.cs
+++ b/src/Host/Hosting/Workers/MailEmbeddingBackfillWorker.cs
@@ -72,6 +72,10 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
     {
         if (!this.settings.Enabled)
         {
+            // Said before returning, because this is the one loop that would ever take a pass: without it an
+            // activation would record a due instant nothing is going to reach, and the status surface would report an
+            // overdue pass for the life of the process.
+            this.schedule.NoPassWillRun();
             this.LogBackfillDisabled();
 
             return;

--- a/src/Host/Hosting/Workers/MailEmbeddingBackfillWorker.cs
+++ b/src/Host/Hosting/Workers/MailEmbeddingBackfillWorker.cs
@@ -31,12 +31,19 @@ namespace MailFathom.Host.Hosting.Workers;
 /// in front of it is followed by the short interval, and one that reached the end of the stored mail — or that an
 /// operator has to settle before anything can be embedded at all — by the long one.
 /// </para>
+/// <para>
+/// The pause is chosen by the pass that just ended, so a wait can be sitting out an interval an operator's act has made
+/// stale — most visibly the first activation on an instance, where every pass before it found nothing to do and took
+/// the long one. <see cref="EmbeddingBackfillSchedule" /> is where the wait is taken for that reason: the act that
+/// creates the work releases it, and the instant it would otherwise end at is readable while it lasts.
+/// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this hosted service.")]
 internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
 {
     private readonly IServiceScopeFactory scopeFactory;
     private readonly EmailEmbeddingBackfillTelemetry telemetry;
+    private readonly EmbeddingBackfillSchedule schedule;
     private readonly EmbeddingBackfillOptions settings;
     private readonly ILogger<MailEmbeddingBackfillWorker> logger;
     private readonly TimeProvider timeProvider;
@@ -45,6 +52,7 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
     public MailEmbeddingBackfillWorker(
         IServiceScopeFactory scopeFactory,
         EmailEmbeddingBackfillTelemetry telemetry,
+        EmbeddingBackfillSchedule schedule,
         IOptions<EmbeddingBackfillOptions> settings,
         ILogger<MailEmbeddingBackfillWorker> logger,
         TimeProvider timeProvider)
@@ -53,6 +61,7 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
 
         this.scopeFactory = scopeFactory;
         this.telemetry = telemetry;
+        this.schedule = schedule;
         this.settings = settings.Value;
         this.logger = logger;
         this.timeProvider = timeProvider;
@@ -72,9 +81,14 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            var delay = await this.RunOnceAsync(stoppingToken);
+            var pause = await this.RunOnceAsync(stoppingToken);
 
-            await Task.Delay(delay, this.timeProvider, stoppingToken);
+            this.LogNextPassScheduled(pause);
+
+            if (await this.schedule.WaitForNextPassAsync(pause, stoppingToken))
+            {
+                this.LogNextPassBroughtForward();
+            }
         }
     }
 
@@ -238,6 +252,25 @@ internal sealed partial class MailEmbeddingBackfillWorker : BackgroundService
         Level = LogLevel.Information,
         Message = "An embedding backfill sweep began with {OutstandingEmailCount} messages awaiting embedding.")]
     private partial void LogSweepStarted(int outstandingEmailCount);
+
+    /// <summary>Says how long the pause the last pass chose lasts, which is the one thing a quiet deployment never stated.</summary>
+    /// <remarks>
+    /// At <see cref="LogLevel.Debug" /> because it is written after every pass, including the thirty-second ones a busy
+    /// instance takes. What an operator reads instead is <c>mfctl embedding status</c>, which reports the instant this
+    /// pause ends at from <see cref="EmbeddingBackfillSchedule" /> without a level being turned up first. A line
+    /// following it saying the pass was brought forward is not a contradiction: this one names the pause that act cut
+    /// short.
+    /// </remarks>
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "The next embedding backfill pass is due in {Pause}.")]
+    private partial void LogNextPassScheduled(TimeSpan pause);
+
+    /// <summary>Says that an operator's act cut the pause short, which happens only when one has been performed.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Activating or cancelling a generation brought the next embedding backfill pass forward, so it starts now rather than when the pause the last pass chose would have ended.")]
+    private partial void LogNextPassBroughtForward();
 
     /// <summary>Reports one run in counts only; no subject, address, passage, or vector may reach a log.</summary>
     [LoggerMessage(

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -233,6 +233,11 @@ public static class ServiceCollectionExtensions
         // The only registration here that changes the schema. It is scoped like every other store so that a caller
         // which has opened a persistence session gets its statement inside that session's transaction rather than
         // beside it.
+        // A singleton because the pass it schedules is one thing the process does: a scoped schedule would let an
+        // activation bring forward a pass nothing is waiting on, and would report a due instant whichever request
+        // happened to create it last. Registered whether or not this deployment embeds, because the status surface
+        // reads it on every instance and an act that never happens simply never brings anything forward.
+        services.AddSingleton<EmbeddingBackfillSchedule>();
         services.AddScoped<IEmbeddingProfileVectorIndex, EmbeddingProfileVectorIndex>();
         services.AddScoped<IStoredEmailEmbeddingBackfillStore, StoredEmailEmbeddingBackfillStore>();
         services.AddScoped<IEmbeddingGenerationStore, EmbeddingGenerationStore>();

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -230,14 +230,15 @@ public static class ServiceCollectionExtensions
         // Where a period stands is what an activation weighs its estimate against and what a status command reports,
         // and both are asked of an instance that has declared nothing at all.
         services.AddScoped<EmbeddingSpendGate>();
-        // The only registration here that changes the schema. It is scoped like every other store so that a caller
-        // which has opened a persistence session gets its statement inside that session's transaction rather than
-        // beside it.
         // A singleton because the pass it schedules is one thing the process does: a scoped schedule would let an
         // activation bring forward a pass nothing is waiting on, and would report a due instant whichever request
         // happened to create it last. Registered whether or not this deployment embeds, because the status surface
-        // reads it on every instance and an act that never happens simply never brings anything forward.
+        // reads it on every instance; what decides that no pass is ever scheduled is the worker saying so, not the
+        // absence of anything to embed.
         services.AddSingleton<EmbeddingBackfillSchedule>();
+        // The only registration here that changes the schema. It is scoped like every other store so that a caller
+        // which has opened a persistence session gets its statement inside that session's transaction rather than
+        // beside it.
         services.AddScoped<IEmbeddingProfileVectorIndex, EmbeddingProfileVectorIndex>();
         services.AddScoped<IStoredEmailEmbeddingBackfillStore, StoredEmailEmbeddingBackfillStore>();
         services.AddScoped<IEmbeddingGenerationStore, EmbeddingGenerationStore>();

--- a/tests/Application.UnitTests/Emails/Embeddings/Administration/CountedEmbeddingActivationTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Administration/CountedEmbeddingActivationTests.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Administration;
+using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Emails.Embeddings.Limits;
@@ -233,7 +234,8 @@ public sealed class CountedEmbeddingActivationTests
                 new OptimisticConcurrencyRetryPolicy(
                     sessionFactory,
                     new PersistenceConcurrencyOptions(),
-                    timeProvider)));
+                    timeProvider),
+                new EmbeddingBackfillSchedule(timeProvider)));
 
         return new ActivationWorld(generationStore, workloadReader, ledger, activation);
     }

--- a/tests/Application.UnitTests/Emails/Embeddings/Administration/EmbeddingStatusReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Administration/EmbeddingStatusReaderTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Administration;
+using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.UnitTests.TestDoubles;
 using Microsoft.Extensions.Time.Testing;
@@ -117,6 +118,39 @@ public sealed class EmbeddingStatusReaderTests
         Assert.Equal(60_000, status.Period.RemainingInputCharacterCount);
     }
 
+    /// <summary>
+    /// The reading that tells a deployment which is waiting apart from one which is failing. Everything else in this
+    /// answer reads the same during a pause between passes as it does on a broken instance: nothing serving, no vector
+    /// written, and a provider nothing has been asked of.
+    /// </summary>
+    [Fact]
+    public async Task ReadAsync_ABackfillPassScheduled_ReportsWhenItIsDue()
+    {
+        // Arrange
+        var world = CreateWorld();
+        world.BackfillSchedule.BringForward();
+
+        // Act
+        var status = await world.Reader.ReadAsync(CreateIdentity("a-model"), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(Now, status.NextBackfillPassDueAt);
+    }
+
+    /// <summary>An instance whose backfill worker has scheduled nothing says so, which is what a disabled walk looks like.</summary>
+    [Fact]
+    public async Task ReadAsync_NoBackfillPassScheduled_ReportsNone()
+    {
+        // Arrange
+        var world = CreateWorld();
+
+        // Act
+        var status = await world.Reader.ReadAsync(CreateIdentity("a-model"), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(status.NextBackfillPassDueAt);
+    }
+
     private static EmbeddingProfileIdentity CreateIdentity(string modelIdentifier) =>
         EmbeddingProfileIdentity.Create(
             "a-provider",
@@ -135,6 +169,7 @@ public sealed class EmbeddingStatusReaderTests
         providerHealth.Read(Arg.Any<AiProviderRole>()).Returns(callInfo =>
             new AiProviderHealth(callInfo.Arg<AiProviderRole>(), AiProviderHealthState.Unobserved, ObservedAt: null));
 
+        var backfillSchedule = new EmbeddingBackfillSchedule(new FakeTimeProvider(Now));
         var reader = new EmbeddingStatusReader(
             generationStore,
             workloadReader,
@@ -142,9 +177,10 @@ public sealed class EmbeddingStatusReaderTests
                 ledger,
                 EmbeddingSpendBudget.Create(maxInputCharactersPerPeriod, TimeSpan.FromDays(1)),
                 new FakeTimeProvider(Now)),
-            providerHealth);
+            providerHealth,
+            backfillSchedule);
 
-        return new StatusWorld(generationStore, workloadReader, ledger, providerHealth, reader);
+        return new StatusWorld(generationStore, workloadReader, ledger, providerHealth, backfillSchedule, reader);
     }
 
     /// <summary>The state and the collaborators one status answer is composed from.</summary>
@@ -153,5 +189,6 @@ public sealed class EmbeddingStatusReaderTests
         InMemoryEmbeddingWorkloadReader WorkloadReader,
         InMemoryEmbeddingSpendLedger Ledger,
         IAiProviderHealthReader ProviderHealth,
+        EmbeddingBackfillSchedule BackfillSchedule,
         EmbeddingStatusReader Reader);
 }

--- a/tests/Application.UnitTests/Emails/Embeddings/Backfill/EmbeddingBackfillScheduleTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Backfill/EmbeddingBackfillScheduleTests.cs
@@ -1,0 +1,125 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Backfill;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Embeddings.Backfill;
+
+/// <summary>Covers the pause between upkeep passes: when it ends, and the one act that ends it early.</summary>
+public sealed class EmbeddingBackfillScheduleTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 9, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly TimeSpan IdleSweepInterval = TimeSpan.FromMinutes(15);
+
+    /// <summary>The ordinary pause: nothing asked for a pass, so the wait lasts exactly as long as it was given.</summary>
+    [Fact]
+    public async Task WaitForNextPassAsync_ThePauseElapses_ReportsThatNothingBroughtThePassForward()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(Now);
+        var schedule = new EmbeddingBackfillSchedule(clock);
+
+        // Act
+        var waiting = schedule.WaitForNextPassAsync(IdleSweepInterval, TestContext.Current.CancellationToken);
+        clock.Advance(IdleSweepInterval);
+
+        // Assert
+        Assert.False(await waiting);
+    }
+
+    /// <summary>
+    /// The whole point of the type. An activation writes a row the sleeping worker cannot observe, so without this the
+    /// first pass of a reindex waits out an idle interval an earlier pass chose while there was nothing to embed.
+    /// </summary>
+    [Fact]
+    public async Task WaitForNextPassAsync_BroughtForwardWhileWaiting_EndsTheWaitWithoutTheClockMoving()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(Now);
+        var schedule = new EmbeddingBackfillSchedule(clock);
+
+        // Act
+        var waiting = schedule.WaitForNextPassAsync(IdleSweepInterval, TestContext.Current.CancellationToken);
+        schedule.BringForward();
+
+        // Assert
+        Assert.True(await waiting);
+        Assert.Equal(Now, schedule.NextPassDueAt);
+    }
+
+    /// <summary>
+    /// An activation that lands while a pass is already running has nobody to release, and dropping it would leave the
+    /// work it created waiting for the next pause to expire — which is the delay this type exists to remove.
+    /// </summary>
+    [Fact]
+    public async Task WaitForNextPassAsync_BroughtForwardWhileAPassWasRunning_IsTakenByTheNextWaitRatherThanLost()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(Now);
+        var schedule = new EmbeddingBackfillSchedule(clock);
+        schedule.BringForward();
+
+        // Act
+        var broughtForward = await schedule.WaitForNextPassAsync(
+            IdleSweepInterval,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(broughtForward);
+    }
+
+    /// <summary>One request is one pass, so a request nobody has taken is not answered twice.</summary>
+    [Fact]
+    public async Task WaitForNextPassAsync_TheWaitAfterOneBroughtForward_PausesAgainRatherThanEndingImmediately()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(Now);
+        var schedule = new EmbeddingBackfillSchedule(clock);
+        schedule.BringForward();
+        await schedule.WaitForNextPassAsync(IdleSweepInterval, TestContext.Current.CancellationToken);
+
+        // Act
+        var waiting = schedule.WaitForNextPassAsync(IdleSweepInterval, TestContext.Current.CancellationToken);
+        var dueAtWhileWaiting = schedule.NextPassDueAt;
+        clock.Advance(IdleSweepInterval);
+
+        // Assert
+        Assert.False(await waiting);
+        Assert.Equal(Now + IdleSweepInterval, dueAtWhileWaiting);
+    }
+
+    /// <summary>An instance whose worker has scheduled nothing reports no pass, which is what a disabled backfill looks like.</summary>
+    [Fact]
+    public void NextPassDueAt_NoPassEverScheduled_ReportsNone()
+    {
+        // Arrange
+        var schedule = new EmbeddingBackfillSchedule(new FakeTimeProvider(Now));
+
+        // Act
+        var dueAt = schedule.NextPassDueAt;
+
+        // Assert
+        Assert.Null(dueAt);
+    }
+
+    /// <summary>A stopping process ends the wait rather than taking one more pass on the way out.</summary>
+    [Fact]
+    public async Task WaitForNextPassAsync_TheProcessStopping_EndsTheWaitAsCancelled()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(Now);
+        var schedule = new EmbeddingBackfillSchedule(clock);
+        using var stopping = new CancellationTokenSource();
+
+        // Act
+        var waiting = schedule.WaitForNextPassAsync(IdleSweepInterval, stopping.Token);
+        await stopping.CancelAsync();
+
+        // Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiting);
+    }
+}

--- a/tests/Application.UnitTests/Emails/Embeddings/Backfill/EmbeddingBackfillScheduleTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Backfill/EmbeddingBackfillScheduleTests.cs
@@ -106,6 +106,61 @@ public sealed class EmbeddingBackfillScheduleTests
         Assert.Null(dueAt);
     }
 
+    /// <summary>
+    /// A deployment whose walk is turned off has no worker to release, so recording a due instant for an activation
+    /// would leave the status surface reporting a pass that is overdue for the life of the process — the same
+    /// unreadable state this type exists to remove, arrived at from the other side.
+    /// </summary>
+    [Fact]
+    public void BringForward_WhereNoPassWillRun_SchedulesNothing()
+    {
+        // Arrange
+        var schedule = new EmbeddingBackfillSchedule(new FakeTimeProvider(Now));
+        schedule.NoPassWillRun();
+
+        // Act
+        schedule.BringForward();
+
+        // Assert
+        Assert.Null(schedule.NextPassDueAt);
+    }
+
+    /// <summary>
+    /// An activation can reach the process before its worker has run far enough to report that it takes no pass, so
+    /// the report clears what got in first rather than leaving one stale instant behind.
+    /// </summary>
+    [Fact]
+    public void NoPassWillRun_APassAlreadyAskedFor_ClearsIt()
+    {
+        // Arrange
+        var schedule = new EmbeddingBackfillSchedule(new FakeTimeProvider(Now));
+        schedule.BringForward();
+
+        // Act
+        schedule.NoPassWillRun();
+
+        // Assert
+        Assert.Null(schedule.NextPassDueAt);
+    }
+
+    /// <summary>The latched request goes with the instant, so a walk that runs no pass cannot answer one either.</summary>
+    [Fact]
+    public async Task WaitForNextPassAsync_AfterNoPassWillRunClearedARequest_PausesRatherThanReturningImmediately()
+    {
+        // Arrange
+        var clock = new FakeTimeProvider(Now);
+        var schedule = new EmbeddingBackfillSchedule(clock);
+        schedule.BringForward();
+        schedule.NoPassWillRun();
+
+        // Act
+        var waiting = schedule.WaitForNextPassAsync(IdleSweepInterval, TestContext.Current.CancellationToken);
+        clock.Advance(IdleSweepInterval);
+
+        // Assert
+        Assert.False(await waiting);
+    }
+
     /// <summary>A stopping process ends the wait rather than taking one more pass on the way out.</summary>
     [Fact]
     public async Task WaitForNextPassAsync_TheProcessStopping_EndsTheWaitAsCancelled()

--- a/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingProfileActivationTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingProfileActivationTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Persistence;
@@ -15,6 +16,8 @@ namespace MailFathom.Application.UnitTests.Emails.Embeddings.Generations;
 
 public sealed class EmbeddingProfileActivationTests
 {
+    private static readonly DateTimeOffset Now = new(2026, 8, 9, 12, 0, 0, TimeSpan.Zero);
+
     /// <summary>
     /// The whole guarantee in one assertion: the new geometry becomes a generation that is built rather than one that
     /// is read, and the generation answering searches is left exactly where it was.
@@ -128,6 +131,60 @@ public sealed class EmbeddingProfileActivationTests
     }
 
     /// <summary>
+    /// The row this registers is the whole signal the backfill worker has, and it is asleep on a pause chosen by a pass
+    /// that found nothing to embed. Without the request, the first passages of the reindex go out whenever that
+    /// unrelated interval happens to expire rather than because an operator asked for them.
+    /// </summary>
+    [Fact]
+    public async Task ActivateAsync_ANewGeometry_AsksForTheNextBackfillPassNow()
+    {
+        // Arrange
+        var world = CreateWorld();
+
+        // Act
+        await world.Activation.ActivateAsync(CreateIdentity("a-model"), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(Now, world.BackfillSchedule.NextPassDueAt);
+    }
+
+    /// <summary>
+    /// Repeating the command against a reindex already running is the repair path for a failed index build, and it is
+    /// also what an operator reaches for when a sweep that completed left messages a refused call had stepped past. The
+    /// pass that reaches them is the one the long interval has just put a quarter of an hour away.
+    /// </summary>
+    [Fact]
+    public async Task ActivateAsync_TheGeometryAlreadyBeingBuilt_AsksForTheNextBackfillPassNow()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var identity = CreateIdentity("a-model");
+        world.GenerationStore.Add(identity, EmbeddingProfileLifecycleState.Building);
+
+        // Act
+        await world.Activation.ActivateAsync(identity, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(Now, world.BackfillSchedule.NextPassDueAt);
+    }
+
+    /// <summary>An activation that changed no row created no work, so it does not spend a pass asking about none.</summary>
+    [Fact]
+    public async Task ActivateAsync_TheGeometryAlreadyServing_LeavesTheBackfillPaceAlone()
+    {
+        // Arrange
+        var world = CreateWorld();
+        var identity = CreateIdentity("a-model");
+        world.GenerationStore.Add(identity, EmbeddingProfileLifecycleState.Active);
+
+        // Act
+        await world.Activation.ActivateAsync(identity, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(world.BackfillSchedule.NextPassDueAt);
+    }
+
+    /// <summary>
     /// Two generations being built at once would leave one walk between two partial generations and neither ever
     /// reaching the count that completes it, so the second activation is refused rather than started beside the first.
     /// </summary>
@@ -149,6 +206,7 @@ public sealed class EmbeddingProfileActivationTests
         Assert.Equal(EmbeddingProfileActivationOutcome.DifferentReindexRunning, result.Outcome);
         Assert.Equal(building.Id, result.ProfileId);
         await world.VectorIndex.DidNotReceiveWithAnyArgs().EnsureBuiltAsync(null!, TestContext.Current.CancellationToken);
+        Assert.Null(world.BackfillSchedule.NextPassDueAt);
 
         var generations = await world.GenerationStore.ReadGenerationsAsync(TestContext.Current.CancellationToken);
         Assert.Equal(building.Id, generations.Building?.Id);
@@ -190,7 +248,8 @@ public sealed class EmbeddingProfileActivationTests
             CreateIdentity("the-model-that-won"));
         var activation = CreateActivation(
             RacedRegistrationStore(buildingAfterTheRace: winner),
-            Substitute.For<IEmbeddingProfileVectorIndex>());
+            Substitute.For<IEmbeddingProfileVectorIndex>(),
+            new EmbeddingBackfillSchedule(new FakeTimeProvider(Now)));
 
         // Act
         var result = await activation.ActivateAsync(
@@ -212,7 +271,8 @@ public sealed class EmbeddingProfileActivationTests
         // Arrange
         var activation = CreateActivation(
             RacedRegistrationStore(buildingAfterTheRace: null),
-            Substitute.For<IEmbeddingProfileVectorIndex>());
+            Substitute.For<IEmbeddingProfileVectorIndex>(),
+            new EmbeddingBackfillSchedule(new FakeTimeProvider(Now)));
 
         // Act
         var conflict = await Assert.ThrowsAsync<PersistenceConcurrencyConflictException>(
@@ -256,16 +316,19 @@ public sealed class EmbeddingProfileActivationTests
     {
         var generationStore = new InMemoryEmbeddingGenerationStore(new InMemoryEmailEmbeddingStore());
         var vectorIndex = Substitute.For<IEmbeddingProfileVectorIndex>();
+        var backfillSchedule = new EmbeddingBackfillSchedule(new FakeTimeProvider(Now));
 
         return new ActivationWorld(
             generationStore,
             vectorIndex,
-            CreateActivation(generationStore, vectorIndex));
+            backfillSchedule,
+            CreateActivation(generationStore, vectorIndex, backfillSchedule));
     }
 
     private static EmbeddingProfileActivation CreateActivation(
         IEmbeddingGenerationStore generationStore,
-        IEmbeddingProfileVectorIndex vectorIndex)
+        IEmbeddingProfileVectorIndex vectorIndex,
+        EmbeddingBackfillSchedule backfillSchedule)
     {
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>())
@@ -277,12 +340,14 @@ public sealed class EmbeddingProfileActivationTests
             new OptimisticConcurrencyRetryPolicy(
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
-                new FakeTimeProvider()));
+                new FakeTimeProvider()),
+            backfillSchedule);
     }
 
     /// <summary>The generations and the collaborators one activation works against.</summary>
     private sealed record ActivationWorld(
         InMemoryEmbeddingGenerationStore GenerationStore,
         IEmbeddingProfileVectorIndex VectorIndex,
+        EmbeddingBackfillSchedule BackfillSchedule,
         EmbeddingProfileActivation Activation);
 }

--- a/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingReindexCancellationTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingReindexCancellationTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Persistence;
@@ -15,6 +16,8 @@ namespace MailFathom.Application.UnitTests.Emails.Embeddings.Generations;
 
 public sealed class EmbeddingReindexCancellationTests
 {
+    private static readonly DateTimeOffset Now = new(2026, 8, 9, 12, 0, 0, TimeSpan.Zero);
+
     /// <summary>Cancelling ends the reindex and changes nothing about what searches are answered from.</summary>
     [Fact]
     public async Task CancelAsync_AReindexRunning_AbandonsItAndLeavesTheServingGenerationServing()
@@ -58,6 +61,25 @@ public sealed class EmbeddingReindexCancellationTests
     }
 
     /// <summary>
+    /// What a cancellation leaves is a generation nothing reads whose partial vectors are personal data with no purpose
+    /// left, and the pass that removes them is the one the interval before it chose while there was still a reindex to
+    /// pace. Asking for it here is what keeps that removal from waiting out as much as a quarter of an hour.
+    /// </summary>
+    [Fact]
+    public async Task CancelAsync_AReindexRunning_AsksForTheNextBackfillPassNowSoTheAbandonedVectorsGo()
+    {
+        // Arrange
+        var world = CreateWorld();
+        world.GenerationStore.Add(CreateIdentity("a-model"), EmbeddingProfileLifecycleState.Building);
+
+        // Act
+        await world.Cancellation.CancelAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(Now, world.BackfillSchedule.NextPassDueAt);
+    }
+
+    /// <summary>
     /// This command ends a reindex and is deliberately not a way to turn semantic search off, so an instance with only a
     /// serving generation is left untouched.
     /// </summary>
@@ -75,6 +97,7 @@ public sealed class EmbeddingReindexCancellationTests
         Assert.Equal(EmbeddingReindexCancellationOutcome.NothingBuilding, outcome);
         Assert.Equal(EmbeddingProfileLifecycleState.Active, world.GenerationStore.StateOf(serving.Id));
         await world.VectorIndex.DidNotReceiveWithAnyArgs().RemoveAsync(default, TestContext.Current.CancellationToken);
+        Assert.Null(world.BackfillSchedule.NextPassDueAt);
     }
 
     /// <summary>
@@ -110,7 +133,8 @@ public sealed class EmbeddingReindexCancellationTests
             new OptimisticConcurrencyRetryPolicy(
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
-                new FakeTimeProvider()));
+                new FakeTimeProvider()),
+            new EmbeddingBackfillSchedule(new FakeTimeProvider(Now)));
 
         // Act
         var outcome = await cancellation.CancelAsync(TestContext.Current.CancellationToken);
@@ -138,20 +162,23 @@ public sealed class EmbeddingReindexCancellationTests
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>())
             .Returns(_ => Substitute.For<IPersistenceSession>());
 
+        var backfillSchedule = new EmbeddingBackfillSchedule(new FakeTimeProvider(Now));
         var cancellation = new EmbeddingReindexCancellation(
             generationStore,
             vectorIndex,
             new OptimisticConcurrencyRetryPolicy(
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
-                new FakeTimeProvider()));
+                new FakeTimeProvider()),
+            backfillSchedule);
 
-        return new CancellationWorld(generationStore, vectorIndex, cancellation);
+        return new CancellationWorld(generationStore, vectorIndex, backfillSchedule, cancellation);
     }
 
     /// <summary>The generations and the collaborators one cancellation works against.</summary>
     private sealed record CancellationWorld(
         InMemoryEmbeddingGenerationStore GenerationStore,
         IEmbeddingProfileVectorIndex VectorIndex,
+        EmbeddingBackfillSchedule BackfillSchedule,
         EmbeddingReindexCancellation Cancellation);
 }

--- a/tests/Cli.UnitTests/EmbeddingCommandTests.cs
+++ b/tests/Cli.UnitTests/EmbeddingCommandTests.cs
@@ -156,7 +156,7 @@ public sealed class EmbeddingCommandTests : IDisposable
 
     /// <summary>A deployment whose walk is turned off schedules nothing, and the line says which setting does that.</summary>
     [Fact]
-    public async Task Status_ADeploymentSchedulingNoBackfillPass_NamesTheSettingThatTurnsTheWalkOff()
+    public async Task Status_ADeploymentSchedulingNoBackfillPass_NamesBothCausesWithoutAssertingEither()
     {
         // Arrange
         using var deployment = FakeEmbeddingDeployment.Answering(status: """
@@ -176,9 +176,14 @@ public sealed class EmbeddingCommandTests : IDisposable
 
         // Assert
         Assert.Equal(CliExitCode.Success, exitCode);
-        Assert.Contains(
+        var nextPass = Assert.Single(
             this.console.Lines,
-            line => line.Contains("EmbeddingBackfill:Enabled", StringComparison.Ordinal));
+            line => line.StartsWith("Next pass:", StringComparison.Ordinal));
+        Assert.Contains("EmbeddingBackfill:Enabled", nextPass, StringComparison.Ordinal);
+
+        // Both causes, because a deployment that has only just started reports the absence as truthfully as one whose
+        // walk is turned off, and naming only the setting sends an operator to a value that is already what they want.
+        Assert.Contains("only just started", nextPass, StringComparison.Ordinal);
     }
 
     /// <summary>The estimate is written before the question is asked, so what is agreed to is a number rather than a word.</summary>

--- a/tests/Cli.UnitTests/EmbeddingCommandTests.cs
+++ b/tests/Cli.UnitTests/EmbeddingCommandTests.cs
@@ -119,6 +119,68 @@ public sealed class EmbeddingCommandTests : IDisposable
         Assert.Contains(this.console.Lines, line => line.Contains("answered lexically", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// The line an operator reads when a freshly activated deployment looks broken. Nothing serving, nothing embedded,
+    /// and a provider nothing has been asked of are the same three readings a failing instance gives, and the scheduled
+    /// pass is what separates them.
+    /// </summary>
+    [Fact]
+    public async Task Status_ADeploymentWaitingForItsNextBackfillPass_ReportsWhenThatPassIsDue()
+    {
+        // Arrange
+        using var deployment = FakeEmbeddingDeployment.Answering(status: """
+            {
+              "declared": {"fingerprint":"a1b2c3","provider":"a-provider","model":"a-model","modelVersion":null,"dimension":1536,"distanceMetric":"Cosine"},
+              "activationOutstanding": false,
+              "serving": null,
+              "building": {
+                "profileId": "0199c3d0-0000-7000-8000-000000000002",
+                "geometry": {"fingerprint":"a1b2c3","provider":"a-provider","model":"a-model","modelVersion":null,"dimension":1536,"distanceMetric":"Cosine"},
+                "progress": {"searchableEmailCount":12,"embeddedEmailCount":0,"outstandingEmailCount":12,"outstandingPassageCount":40,"outstandingCharacterCount":8000,"approximateTokenCount":2000}
+              },
+              "provider": {"state":"Unobserved","observedAt":null},
+              "spend": {"periodStartsAt":"2026-08-08T00:00:00+00:00","periodEndsAt":"2026-08-09T00:00:00+00:00","consumedInputCharacterCount":0,"ceilingInputCharacterCount":null,"remainingInputCharacterCount":null},
+              "nextBackfillPassDueAt": "2026-08-08T12:00:30+00:00"
+            }
+            """);
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "embedding", "status", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("Next pass: due at 2026-08-08 12:00:30Z", StringComparison.Ordinal));
+    }
+
+    /// <summary>A deployment whose walk is turned off schedules nothing, and the line says which setting does that.</summary>
+    [Fact]
+    public async Task Status_ADeploymentSchedulingNoBackfillPass_NamesTheSettingThatTurnsTheWalkOff()
+    {
+        // Arrange
+        using var deployment = FakeEmbeddingDeployment.Answering(status: """
+            {
+              "declared": {"fingerprint":"a1b2c3","provider":"a-provider","model":"a-model","modelVersion":null,"dimension":1536,"distanceMetric":"Cosine"},
+              "activationOutstanding": false,
+              "serving": null,
+              "building": null,
+              "provider": {"state":"Unobserved","observedAt":null},
+              "spend": {"periodStartsAt":"2026-08-08T00:00:00+00:00","periodEndsAt":"2026-08-09T00:00:00+00:00","consumedInputCharacterCount":0,"ceilingInputCharacterCount":null,"remainingInputCharacterCount":null},
+              "nextBackfillPassDueAt": null
+            }
+            """);
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "embedding", "status", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("EmbeddingBackfill:Enabled", StringComparison.Ordinal));
+    }
+
     /// <summary>The estimate is written before the question is asked, so what is agreed to is a number rather than a word.</summary>
     [Fact]
     public async Task Activate_ATerminalThatAgrees_ReportsTheEstimateFirstAndThenStartsTheReindex()

--- a/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Emails.Embeddings.Administration;
+using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Emails.Embeddings.Limits;
@@ -200,18 +201,25 @@ public sealed class AdminApiEndpointsTests
             new PersistenceConcurrencyOptions(),
             timeProvider);
 
+        var backfillSchedule = new EmbeddingBackfillSchedule(timeProvider);
+
         services.AddSingleton(new DeclaredEmbeddingGeometry(Identity: null));
         services.AddScoped(_ => new EmbeddingStatusReader(
             generationStore,
             workloadReader,
             spendGate,
-            Substitute.For<IAiProviderHealthReader>()));
+            Substitute.For<IAiProviderHealthReader>(),
+            backfillSchedule));
         services.AddScoped(_ => new CountedEmbeddingActivation(
             generationStore,
             workloadReader,
             spendGate,
-            new EmbeddingProfileActivation(generationStore, vectorIndex, retryPolicy)));
-        services.AddScoped(_ => new EmbeddingReindexCancellation(generationStore, vectorIndex, retryPolicy));
+            new EmbeddingProfileActivation(generationStore, vectorIndex, retryPolicy, backfillSchedule)));
+        services.AddScoped(_ => new EmbeddingReindexCancellation(
+            generationStore,
+            vectorIndex,
+            retryPolicy,
+            backfillSchedule));
     }
 
     private static IReadOnlyList<Endpoint> MaterializeEndpoints(IEndpointRouteBuilder endpoints) =>

--- a/tests/Host.UnitTests/Api/EmbeddingProfileEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/EmbeddingProfileEndpointsTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Administration;
+using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Emails.Embeddings.Limits;
@@ -83,6 +84,27 @@ public sealed class EmbeddingProfileEndpointsTests
         Assert.Equal(
             EmbeddingProfileFingerprint.Compute(declared).Value,
             result.Value?.Declared?.Fingerprint);
+    }
+
+    /// <summary>
+    /// The scheduled pass travels with the rest of the answer, because it is what a caller reads a quiet deployment
+    /// against: every other member of this body says the same thing during a pause as it does on a broken instance.
+    /// </summary>
+    [Fact]
+    public async Task ReadStatusAsync_ABackfillPassScheduled_CarriesWhenItIsDue()
+    {
+        // Arrange
+        var world = CreateWorld();
+        world.BackfillSchedule.BringForward();
+
+        // Act
+        var result = await EmbeddingProfileEndpoints.ReadStatusAsync(
+            new DeclaredEmbeddingGeometry(CreateIdentity("a-model")),
+            world.StatusReader,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(Now, result.Value?.NextBackfillPassDueAt);
     }
 
     /// <summary>There is nothing to activate where nothing is declared, and the answer names the setting that would declare one.</summary>
@@ -259,23 +281,26 @@ public sealed class EmbeddingProfileEndpointsTests
             new PersistenceConcurrencyOptions(),
             timeProvider);
         var vectorIndex = Substitute.For<IEmbeddingProfileVectorIndex>();
+        var backfillSchedule = new EmbeddingBackfillSchedule(timeProvider);
 
         return new EndpointWorld(
             generationStore,
             workloadReader,
+            backfillSchedule,
             new CountedEmbeddingActivation(
                 generationStore,
                 workloadReader,
                 spendGate,
-                new EmbeddingProfileActivation(generationStore, vectorIndex, retryPolicy)),
-            new EmbeddingStatusReader(generationStore, workloadReader, spendGate, providerHealth),
-            new EmbeddingReindexCancellation(generationStore, vectorIndex, retryPolicy));
+                new EmbeddingProfileActivation(generationStore, vectorIndex, retryPolicy, backfillSchedule)),
+            new EmbeddingStatusReader(generationStore, workloadReader, spendGate, providerHealth, backfillSchedule),
+            new EmbeddingReindexCancellation(generationStore, vectorIndex, retryPolicy, backfillSchedule));
     }
 
     /// <summary>The ports one request runs against, and the three services the routes resolve.</summary>
     private sealed record EndpointWorld(
         IEmbeddingGenerationStore GenerationStore,
         IEmbeddingWorkloadReader WorkloadReader,
+        EmbeddingBackfillSchedule BackfillSchedule,
         CountedEmbeddingActivation Activation,
         EmbeddingStatusReader StatusReader,
         EmbeddingReindexCancellation Cancellation)

--- a/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingBackfillWorkerTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingBackfillWorkerTests.cs
@@ -68,6 +68,38 @@ public sealed class MailEmbeddingBackfillWorkerTests
         await world.Worker.StopAsync(CancellationToken.None);
     }
 
+    /// <summary>
+    /// The wait this worker used to make an operator sit through. Every pass before an activation ends with no
+    /// generation to walk towards and takes the long interval, so the row an activation commits is one the sleeping
+    /// worker cannot observe — and the clock is deliberately never advanced here, because what is being proved is that
+    /// the pass no longer waits for it.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_APassBroughtForwardWhileIdle_TakesItWithoutWaitingOutTheIdleInterval()
+    {
+        // Arrange
+        using var world = CreateWorld(new EmbeddingBackfillOptions(), activeProfile: null);
+        await world.Worker.StartAsync(CancellationToken.None);
+        await world.Logger.WaitForOccurrences(
+            "No embedding profile is active",
+            occurrences: 1,
+            TestContext.Current.CancellationToken);
+
+        // Act
+        world.Schedule.BringForward();
+        await world.Logger.WaitForOccurrences(
+            "brought the next embedding backfill pass forward",
+            occurrences: 1,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await world.Logger.WaitForOccurrences(
+            "No embedding profile is active",
+            occurrences: 2,
+            TestContext.Current.CancellationToken);
+        await world.Worker.StopAsync(CancellationToken.None);
+    }
+
     /// <summary>An instance that has activated no profile is a supported state, so it is reported without a warning and costs no walk.</summary>
     [Fact]
     public async Task ExecuteAsync_NoActiveProfile_ReportsItWithoutWalkingTheMail()
@@ -330,6 +362,7 @@ public sealed class MailEmbeddingBackfillWorkerTests
             new MailEmbeddingBackfillWorker(
                 serviceProvider.GetRequiredService<IServiceScopeFactory>(),
                 new EmailEmbeddingBackfillTelemetry(),
+                world.Schedule,
                 Options.Create(settings),
                 world.Logger,
                 world.TimeProvider));
@@ -343,9 +376,13 @@ public sealed class MailEmbeddingBackfillWorkerTests
         private ServiceProvider? serviceProvider;
         private MailEmbeddingBackfillWorker? worker;
 
+        public WorkerWorld() => this.Schedule = new EmbeddingBackfillSchedule(this.TimeProvider);
+
         public AwaitingLogger<MailEmbeddingBackfillWorker> Logger { get; } = new();
 
         public FakeTimeProvider TimeProvider { get; } = new();
+
+        public EmbeddingBackfillSchedule Schedule { get; }
 
         public IStoredEmailEmbeddingBackfillStore BackfillStore { get; } =
             Substitute.For<IStoredEmailEmbeddingBackfillStore>();

--- a/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingBackfillWorkerTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/MailEmbeddingBackfillWorkerTests.cs
@@ -45,6 +45,26 @@ public sealed class MailEmbeddingBackfillWorkerTests
     }
 
     /// <summary>
+    /// This loop is the only thing that ever takes a pass, so a worker that never runs one has to say so: otherwise an
+    /// activation records a due instant nothing will reach, and every later status read reports a pass overdue by
+    /// however long the process has been up.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_BackfillDisabled_LeavesAnActivationUnableToScheduleAPassNothingWouldTake()
+    {
+        // Arrange
+        using var world = CreateWorld(new EmbeddingBackfillOptions { Enabled = false });
+
+        // Act
+        await world.Worker.StartAsync(CancellationToken.None);
+        await world.Worker.ExecuteTask!;
+        world.Schedule.BringForward();
+
+        // Assert
+        Assert.Null(world.Schedule.NextPassDueAt);
+    }
+
+    /// <summary>
     /// The walk is a repeating sweep rather than one that finishes, so reaching the end starts another pass instead of
     /// ending the worker — which is what makes the promise that a refused call and a full live queue are reached later
     /// something this keeps.

--- a/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -130,6 +130,31 @@ public sealed class ServiceCollectionExtensionsTests
     }
 
     /// <summary>
+    /// The pass the schedule paces is one thing the process does, so a scoped registration would let an activation
+    /// release a waiter that does not exist and would report a due instant belonging to whichever request created the
+    /// scope last. It is registered whether or not a chain was declared, because the status surface reads it on every
+    /// deployment and an act that never happens simply never brings anything forward.
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_OnAnyDeployment_RegistersTheBackfillScheduleAsOneInstancePerProcess()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddInfrastructure(
+            _ => new PostgresConnectionSettings("Host=localhost;Database=mailfathom", null, null),
+            PostgresTextSearchConfiguration.Default,
+            MailAnsweringBudget.Default);
+
+        // Assert
+        Assert.Contains(
+            services,
+            descriptor => descriptor.ServiceType == typeof(EmbeddingBackfillSchedule)
+                && descriptor.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    /// <summary>
     /// The retrieval an answering run reaches mail through is a reading of the search above, so it is registered for
     /// every deployment rather than only where a chat endpoint was declared: an instance that answers no questions
     /// resolves it and never calls it, while one that does would otherwise fail to compose its agent.


### PR DESCRIPTION
`mfctl embedding activate` succeeded, reported its forecast, and then the deployment sat for up to fifteen minutes
reporting a state indistinguishable from a broken one. This closes both halves of that: the wait, and the silence.

## Why the wait was that long

The pause between upkeep passes is chosen by the pass that just ended, so nothing a later act writes can shorten it.
Before an activation every pass ends `NoActiveProfile`, which is `MoreWorkIsWorthTryingSoon == false`, which is
`EmbeddingBackfill:IdleSweepInterval` — fifteen minutes by default. The row the activation then commits is one the
sleeping worker has no way to observe, so the first vectors of a mailbox arrived whenever that unrelated timer happened
to expire.

## What this does

`EmbeddingBackfillSchedule` holds the two halves of one fact: **when the next pass is due**, and **a request the acts
that create the work raise**.

- **Activating a profile** asks for a pass now, on the two outcomes that mean there is work — `ReindexStarted` and
  `AlreadyBuilding`. The two refusals ask for nothing: an activation of what is already serving changed no row, and one
  refused for a different running reindex is not the activation that happened.
- **Cancelling a reindex** asks for one too, for the same reason and one more: what it leaves behind is a generation
  nothing reads whose partial vectors are personal data with no purpose left, and the pass that removes them was
  likewise a quarter of an hour away.
- A request arriving **while a pass is running** is latched rather than dropped, so nothing an operator asked for is
  lost to a worker that was busy instead of waiting. Two requests ask for one pass.

**The pause itself is unchanged and is not the defect.** `EmbeddingBackfill:IdleSweepInterval` keeps its meaning and its
default, because an instance with nothing to do should stop asking the database about nothing.

## Saying what is happening

`mfctl embedding status` gains a `Next pass` line:

```console
Reindex:   none running.
Next pass: due at 2026-08-08 12:14:30Z
Provider:  Serving, as of 2026-08-08 11:59:00Z
```

That line is what separates a deployment which is waiting from one which is failing, because every other reading in
that output is identical between the two: nothing serving, nothing embedded, and `Provider: Unobserved. No call has
been made yet`. `none scheduled` names `EmbeddingBackfill:Enabled` as what leaves the walk scheduling nothing.

The log says the same at `Debug` after every pass, and at `Information` when an act cut a pause short — rare, because
only an operator's act raises it.

## Breaking change

**None.** `GET /api/admin/embeddings` gains `nextBackfillPassDueAt`, which is additive; an older `mfctl` reads the
absence as no scheduled pass. No configuration key, database column, or MCP tool contract moves.

## Verification

`scripts/verify-full.sh` — 4342 tests, 0 failures, aggregate line coverage 95.13%.

New tests cover the schedule's four interleavings (pause elapses, brought forward while waiting, brought forward while
a pass was running, one request is one pass), both acts raising and the two refusals not raising it, the status field
through the reader and the endpoint, the CLI line in both states, the singleton lifetime the registration depends on,
and the worker taking a brought-forward pass **without the test clock advancing at all**.

Closes #621
