### PR TITLE
[#627] Refuse a deployment mfctl cannot be sure it speaks to, and warn when the two builds merely differ

### DIFF
--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -70,7 +70,7 @@ reverse proxy, write the public URL and keep the path: `https://mail.example.tes
 
 | Route | What it does |
 | --- | --- |
-| `GET /api/admin/session` | Reports the credential that authenticated and the running version. This is what `login` and `status` ask. |
+| `GET /api/admin/session` | Reports the credential that authenticated and the running version. `login` and `status` report what it answers; every other command reads it first to [check the two versions against each other](#take-the-command-from-the-deployments-own-release-line). |
 | `POST /api/admin/mailbox/refresh-token` | Stores a mailbox refresh token for one configured account, sealed under the deployment's data-encryption key. This is what [`mfctl mailbox authorize --account`](mailbox-oauth.md#sending-the-token-to-the-deployment) sends. |
 | `GET /api/admin/mailbox/mutations/audit` | Reads one account's record of the changes MailFathom made to its mailbox, where that account [keeps one](../features/imap-synchronization.md#an-account-can-keep-a-record-of-what-was-done-to-it-and-none-does-by-default). |
 | `GET /api/admin/answering/audit` | Reads one account's record of the questions answered from its mailbox, where that account [keeps one](../features/mail-answering.md#an-account-can-keep-a-record-of-what-a-question-read-and-none-does-by-default). |
@@ -400,6 +400,39 @@ install above, because a release newer than what the review has accepted is the 
 this page cannot know which. Whenever the answer is none,
 [the releases page](https://github.com/Krzysztof318/MailFathom/releases) is where the command comes from on every
 platform.
+
+### Take the command from the deployment's own release line
+
+**`mfctl` and the deployment it administers have to agree on `major.minor`.** Every command that reaches a deployment
+reads `GET /api/admin/session` before it asks for anything else, compares the version that comes back with its own, and
+stops there when the two name different release lines:
+
+```console
+$ mfctl embedding status
+mfctl is 0.5.0 and the deployment is 0.4.2. A minor release is permitted to change the administrative contract, so a
+command is refused rather than sent to a deployment from another release line. Run the mfctl published with that
+deployment's release, or upgrade the deployment to this one.
+```
+
+Nothing is sent when that happens, which is the point: the refusal lands before the request it is protecting, so a
+command that would have started a provider bill starts none.
+
+The rule follows the version's own promise rather than adding one. Within `0.x` a minor release may change any public
+surface and a patch may change none, so the release line is the whole of what the two builds have to share —
+[ADR 0004](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0004-versioning-and-release-policy.md)
+records that policy.
+
+Everything below the line is a difference the command reports and carries on past:
+
+| The pair | What happens |
+| --- | --- |
+| Identical versions | Nothing is said. |
+| Same `major.minor`, different patch — `0.5.0` and `0.5.1` | The command runs, and writes one line to standard error saying the builds differ and problems may occur. |
+| Same `major.minor`, one of them a nightly — `0.5.0` and `0.5.0-nightly.41` | The same. A nightly is a preview of the release it will become, not a line of its own. |
+| A version either side cannot read | The command runs and says which of the two it could not read. A build reporting `unknown` is an unstamped one rather than an incompatible one, so it is never refused on that alone. |
+
+The warning is written once per command rather than once per request, and it goes to standard error, so a command whose
+output you redirect still captures the result alone.
 
 ## Signing in
 
@@ -731,6 +764,9 @@ encryption answers the copy. Holding the credential in the platform's own secret
 | `The deployment refused the grant without saying why.` | The request was refused with no reason in the answer, which is what something in front of the endpoint answering `400` looks like. Check that `--endpoint` reaches the deployment itself. |
 | `rather than storing the token` | The endpoint answered with neither an acceptance nor an explained refusal. The token was not stored and the account is unchanged. A `500` here is most often a deployment with no `DataEncryption` key ring, which is what a stored token is sealed under; its own log names the cause. |
 | `did not identify itself as MailFathom` | Something else is answering on that port — a proxy, or another service. |
+| `refused rather than sent to a deployment from another release line` | The command and the deployment are from different `major.minor` releases, and [nothing was sent](#take-the-command-from-the-deployments-own-release-line). Take the command from the deployment's own release, or upgrade the deployment. |
+| `not the same build and problems may occur` | The two share a release line and so agree on the administrative contract, but are different builds of it — a patch apart, or one of them a nightly. The command ran. |
+| `is unchecked` | One of the two reported a version that could not be read, which is what an unstamped or locally built binary looks like. The command ran, and whether the two agree is unknown. |
 | `could not be reached` | Nothing is listening, or a firewall is in the way. The endpoint binds only what `BindAddress` names; `127.0.0.1` is unreachable from another machine by design. |
 | `presented a certificate this machine does not trust` | On `login`, the question described in [when the connection is weaker than the default](#when-the-connection-is-weaker-than-the-default). On any other command, a profile that holds no pin met a certificate that stopped validating — sign in again to review it. Nothing was sent either way. |
 | `presented a certificate this profile has not pinned` | The deployment's certificate is not the one this profile accepted. Both fingerprints are named. A renewal is the ordinary cause and `mfctl login` is the answer; anything else is worth finding out about before you accept it. |

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -63,12 +63,18 @@ Four things about that block are worth understanding before you copy it:
 
 ## Getting the command
 
-A release attaches a self-contained binary per platform, with nothing to install beside it — the .NET runtime is inside
-the file. Which release starts attaching them, the asset names, and how to build the command from a checkout until then
-are all on [getting the command](../operations/admin-endpoint.md#getting-the-command).
+Every release attaches a self-contained binary per platform, with nothing to install beside it — the .NET runtime is
+inside the file. The asset names, the checksum that tells a genuine download from a tampered one, and the Windows
+Package Manager path are all on [getting the command](../operations/admin-endpoint.md#getting-the-command).
 
 Download the one for the machine you administer *from*. The command talks to a deployment over HTTP, so it does not
 have to run where the service runs — that is the whole point of it being a client.
+
+**Take it from the release your deployment is running.** The command and the deployment have to agree on `major.minor`,
+because a minor release is allowed to change what they say to each other; a pair that does not agree is refused rather
+than attempted, and a pair that differs only in patch or nightly warns and carries on.
+[Take the command from the deployment's own release line](../operations/admin-endpoint.md#take-the-command-from-the-deployments-own-release-line)
+is the rule in full.
 
 ## Signing in
 

--- a/src/Cli/Administration/AdminApiClient.cs
+++ b/src/Cli/Administration/AdminApiClient.cs
@@ -9,27 +9,46 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using MailFathom.Cli.Administration.Embeddings;
 using MailFathom.Cli.Transport;
+using MailFathom.Versioning;
 
 namespace MailFathom.Cli.Administration;
 
 /// <summary>Reaches the administrative endpoint of one deployment.</summary>
 /// <remarks>
+/// <para>
 /// Every operation the command performs is a request through here. There is no second path to a deployment — no
 /// configuration file it reads, no database it opens — so what this class can do is the whole of what the command can
 /// do, and the endpoint's own authentication is what bounds it.
+/// </para>
+/// <para>
+/// Being that one path is also what makes it the place the two versions are settled. The session is read before the
+/// first operation whichever command is running, so a deployment this build cannot be sure it speaks to is refused
+/// before anything is asked of it rather than after — an activation that would start a provider bill is the case that
+/// decides where the check belongs. It happens once per client, and a client is made once per command, so an operator
+/// running a command whose builds merely differ is told once rather than once per request.
+/// </para>
 /// </remarks>
 internal sealed class AdminApiClient
 {
+    private static readonly string CommandVersion =
+        StampedAssemblyVersion.ReadFrom(typeof(AdminApiClient).Assembly).Version;
+
     private readonly DeploymentTransport transport;
+    private readonly ICliConsole console;
+
+    private AdminSession? settledSession;
 
     /// <summary>Initializes a client over a transport the caller owns.</summary>
     /// <param name="transport">The transport, whose base address names the deployment.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transport" /> is <see langword="null" />.</exception>
-    internal AdminApiClient(DeploymentTransport transport)
+    /// <param name="console">The terminal a version difference the command carries on past is reported to.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal AdminApiClient(DeploymentTransport transport, ICliConsole console)
     {
         ArgumentNullException.ThrowIfNull(transport);
+        ArgumentNullException.ThrowIfNull(console);
 
         this.transport = transport;
+        this.console = console;
     }
 
     /// <summary>Asks the deployment who the presented credential makes the caller.</summary>
@@ -68,7 +87,11 @@ internal sealed class AdminApiClient
             throw new CliFailure($"The deployment answered {(int)response.StatusCode} rather than a session.");
         }
 
-        return await ReadSessionBodyAsync(response, cancellationToken);
+        var session = await ReadSessionBodyAsync(response, cancellationToken);
+
+        this.Settle(session);
+
+        return session;
     }
 
     /// <summary>Hands a deployment the refresh token it should keep for one of its mail accounts.</summary>
@@ -93,6 +116,8 @@ internal sealed class AdminApiClient
         ArgumentNullException.ThrowIfNull(token);
         ArgumentNullException.ThrowIfNull(account);
         ArgumentNullException.ThrowIfNull(refreshToken);
+
+        await this.EnsureSettledAsync(token, cancellationToken);
 
         using var request = new HttpRequestMessage(HttpMethod.Post, AdminEndpointRoutes.MailboxRefreshTokenPath)
         {
@@ -220,6 +245,8 @@ internal sealed class AdminApiClient
     {
         ArgumentNullException.ThrowIfNull(token);
 
+        await this.EnsureSettledAsync(token, cancellationToken);
+
         using var request = new HttpRequestMessage(method, path);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
@@ -259,6 +286,44 @@ internal sealed class AdminApiClient
             throw new CliFailure(
                 "The address answered, but not with anything MailFathom would send. Check that it is the administrative endpoint rather than another service on the same host.",
                 failure);
+        }
+    }
+
+    /// <summary>Reads the session where the command has not asked for one, so every operation is preceded by the version check.</summary>
+    /// <remarks>
+    /// One request, before the first operation and never again on the same client. <c>login</c> and <c>status</c> ask
+    /// for the session themselves and therefore reach this having already settled, which is what keeps the check at one
+    /// request per command whichever command is running.
+    /// </remarks>
+    private async Task EnsureSettledAsync(string token, CancellationToken cancellationToken)
+    {
+        if (this.settledSession is null)
+        {
+            _ = await this.ReadSessionAsync(token, cancellationToken);
+        }
+    }
+
+    /// <summary>Applies what the deployment's version means for this command, and reports it where it means anything.</summary>
+    /// <exception cref="CliFailure">Thrown when the deployment is from another release line, which no command is sent to.</exception>
+    private void Settle(AdminSession session)
+    {
+        if (this.settledSession is not null)
+        {
+            return;
+        }
+
+        this.settledSession = session;
+
+        var agreement = DeploymentVersionAgreement.Settle(CommandVersion, session.Version);
+
+        if (agreement is { PermitsCommands: false, Concern: { } refusal })
+        {
+            throw new CliFailure(refusal);
+        }
+
+        if (agreement.Concern is { } warning)
+        {
+            this.console.WriteError(warning);
         }
     }
 

--- a/src/Cli/Administration/DeploymentVersionAgreement.cs
+++ b/src/Cli/Administration/DeploymentVersionAgreement.cs
@@ -1,0 +1,126 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Commands;
+
+namespace MailFathom.Cli.Administration;
+
+/// <summary>Settles what the version a deployment reports means for the command about to act on it.</summary>
+/// <remarks>
+/// <para>
+/// The version pair already answers whether the two builds agree, so nothing further has to be published for this:
+/// within <c>0.x</c> a minor release may break any public surface and a patch may break none, which makes the
+/// <c>major.minor</c> line the whole of the compatibility statement. A command from another line is therefore refused
+/// rather than sent, and one from the same line carrying a different patch or prerelease identifier is a build
+/// difference worth naming and nothing more. See
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0004-versioning-and-release-policy.md">ADR 0004</see>.
+/// </para>
+/// <para>
+/// A version that cannot be read warns instead of refusing. The refusal reports an incompatibility that was observed,
+/// and an unstamped or locally built binary is an absence of evidence rather than evidence of a break — refusing on it
+/// would make a build nobody can identify a build nobody can administer.
+/// </para>
+/// </remarks>
+internal sealed record DeploymentVersionAgreement
+{
+    private DeploymentVersionAgreement(bool permitsCommands, string? concern)
+    {
+        this.PermitsCommands = permitsCommands;
+        this.Concern = concern;
+    }
+
+    /// <summary>Gets a value indicating whether the command may act on the deployment at all.</summary>
+    internal bool PermitsCommands { get; }
+
+    /// <summary>Gets the sentence the operator is told, which is <see langword="null" /> only where the two report the same version.</summary>
+    /// <remarks>It is the refusal's own message where <see cref="PermitsCommands" /> is <see langword="false" />, and a warning the command carries on past where it is <see langword="true" />.</remarks>
+    internal string? Concern { get; }
+
+    /// <summary>Settles a command's own version against the one a deployment reports.</summary>
+    /// <param name="commandVersion">The version this command was stamped with.</param>
+    /// <param name="deploymentVersion">The version the deployment reports, which is <see langword="null" /> where it reported none.</param>
+    /// <returns>What that pair permits, and what the operator is told about it.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="commandVersion" /> is <see langword="null" />.</exception>
+    internal static DeploymentVersionAgreement Settle(string commandVersion, string? deploymentVersion)
+    {
+        ArgumentNullException.ThrowIfNull(commandVersion);
+
+        var command = commandVersion.Trim();
+        var deployment = deploymentVersion?.Trim() ?? string.Empty;
+
+        var commandLine = LineOf(command);
+        var deploymentLine = LineOf(deployment);
+
+        if (commandLine is null || deploymentLine is null)
+        {
+            return Permitting(Unreadable(command, deployment, commandLine is null, deploymentLine is null));
+        }
+
+        if (commandLine != deploymentLine)
+        {
+            return Refusing(command, deployment);
+        }
+
+        return string.Equals(command, deployment, StringComparison.Ordinal)
+            ? new DeploymentVersionAgreement(permitsCommands: true, concern: null)
+            : Permitting(DifferingBuilds(command, deployment));
+    }
+
+    private static DeploymentVersionAgreement Permitting(string concern) => new(permitsCommands: true, concern);
+
+    private static DeploymentVersionAgreement Refusing(string command, string deployment) =>
+        new(
+            permitsCommands: false,
+            $"{CliRootCommand.CommandName} is {Reported(command)} and the deployment is {Reported(deployment)}. A minor release is permitted to change the administrative contract, so a command is refused rather than sent to a deployment from another release line. Run the {CliRootCommand.CommandName} published with that deployment's release, or upgrade the deployment to this one.");
+
+    private static string DifferingBuilds(string command, string deployment) =>
+        $"{CliRootCommand.CommandName} is {Reported(command)} and the deployment is {Reported(deployment)}. They are the same release line and so agree on the administrative contract, but they are not the same build and problems may occur.";
+
+    /// <summary>Says which of the two could not be read, because that is what decides where the operator looks.</summary>
+    private static string Unreadable(
+        string command,
+        string deployment,
+        bool commandUnreadable,
+        bool deploymentUnreadable)
+    {
+        var subject = (commandUnreadable, deploymentUnreadable) switch
+        {
+            (true, true) => "Neither version is one",
+            (true, false) => $"{CliRootCommand.CommandName}'s own version is not one",
+            _ => "The deployment's version is not one",
+        };
+
+        return $"{subject} this command can compare: {CliRootCommand.CommandName} is {Reported(command)} and the deployment is {Reported(deployment)}. Whether the two agree on the administrative contract is unchecked, so problems may occur.";
+    }
+
+    /// <summary>Reads the release line a version belongs to, which is the whole of what the comparison acts on.</summary>
+    /// <remarks>
+    /// A stamped version carries a prerelease identifier, and — before
+    /// <see cref="Versioning.StampedAssemblyVersion" /> has split one off — build metadata as well:
+    /// <c>0.5.0-nightly.41</c> is the same line as <c>0.5.0</c>, because a nightly is a preview of the release it will
+    /// become rather than a version of its own. Both are cut away before the numeric part is read, and anything left
+    /// that is not a version — <c>unknown</c> above all — reads as no line at all rather than as a line that differs
+    /// from every other. What remains needs the two components that name the line and no more, so a value stating
+    /// exactly that is read rather than refused on a formality.
+    /// </remarks>
+    private static (int Major, int Minor)? LineOf(string version)
+    {
+        if (string.IsNullOrEmpty(version))
+        {
+            return null;
+        }
+
+        var core = version.AsSpan();
+        var identifierStart = core.IndexOfAny('-', '+');
+
+        if (identifierStart >= 0)
+        {
+            core = core[..identifierStart];
+        }
+
+        return Version.TryParse(core, out var parsed) ? (parsed.Major, parsed.Minor) : null;
+    }
+
+    private static string Reported(string version) => version.Length == 0 ? "reporting none" : version;
+}

--- a/src/Cli/Commands/ActivateEmbeddingCommand.cs
+++ b/src/Cli/Commands/ActivateEmbeddingCommand.cs
@@ -66,7 +66,7 @@ internal static class ActivateEmbeddingCommand
         var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
 
         using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
-        var client = new AdminApiClient(transport);
+        var client = new AdminApiClient(transport, context.Console);
 
         var assessment = await client.ReadEmbeddingActivationAsync(profile.Token, cancellationToken);
 

--- a/src/Cli/Commands/AuthorizeMailboxCommand.cs
+++ b/src/Cli/Commands/AuthorizeMailboxCommand.cs
@@ -382,7 +382,7 @@ internal static class AuthorizeMailboxCommand
             destination.Deployment.Endpoint,
             destination.Deployment.Trust);
 
-        await new AdminApiClient(transport).StoreMailboxRefreshTokenAsync(
+        await new AdminApiClient(transport, context.Console).StoreMailboxRefreshTokenAsync(
             destination.Deployment.Token,
             destination.AccountId,
             grant.RefreshToken,

--- a/src/Cli/Commands/CancelEmbeddingReindexCommand.cs
+++ b/src/Cli/Commands/CancelEmbeddingReindexCommand.cs
@@ -54,7 +54,7 @@ internal static class CancelEmbeddingReindexCommand
         var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
 
         using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
-        var cancellation = await new AdminApiClient(transport)
+        var cancellation = await new AdminApiClient(transport, context.Console)
             .CancelEmbeddingReindexAsync(profile.Token, cancellationToken);
 
         context.Console.WriteLine(cancellation.Describe());

--- a/src/Cli/Commands/EmbeddingStatusCommand.cs
+++ b/src/Cli/Commands/EmbeddingStatusCommand.cs
@@ -48,7 +48,7 @@ internal static class EmbeddingStatusCommand
         var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
 
         using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
-        var status = await new AdminApiClient(transport).ReadEmbeddingStatusAsync(profile.Token, cancellationToken);
+        var status = await new AdminApiClient(transport, context.Console).ReadEmbeddingStatusAsync(profile.Token, cancellationToken);
 
         context.Console.WriteLine($"{profile.Name} ({profile.Endpoint.GetLeftPart(UriPartial.Authority)})");
         context.Console.WriteLine($"Declared:  {DescribeDeclaration(status)}");

--- a/src/Cli/Commands/LoginCommand.cs
+++ b/src/Cli/Commands/LoginCommand.cs
@@ -167,7 +167,7 @@ internal static class LoginCommand
         // accepted would turn a wrong client registration or a narrow scope into a failure at some later command. For a
         // key pair it also proves the deployment holds the matching public key, which nothing else on this machine can.
         var deploymentSession = await connection.RunAsync(
-            transport => new AdminApiClient(transport).ReadSessionAsync(token, cancellationToken));
+            transport => new AdminApiClient(transport, context.Console).ReadSessionAsync(token, cancellationToken));
         var credentialName = deploymentSession.Credential ?? "unnamed";
 
         // The minted assertion is deliberately not the stored token: it is spent within the minute and every later

--- a/src/Cli/Commands/StatusCommand.cs
+++ b/src/Cli/Commands/StatusCommand.cs
@@ -46,7 +46,7 @@ internal static class StatusCommand
         var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
 
         using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
-        var session = await new AdminApiClient(transport).ReadSessionAsync(profile.Token, cancellationToken);
+        var session = await new AdminApiClient(transport, context.Console).ReadSessionAsync(profile.Token, cancellationToken);
 
         context.Console.WriteLine(
             $"'{profile.Name}' ({profile.Endpoint.GetLeftPart(UriPartial.Authority)}) accepts the stored credential as '{session.Credential}' (MailFathom {session.Version}).");

--- a/tests/Cli.UnitTests/AuthorizeMailboxCommandTests.cs
+++ b/tests/Cli.UnitTests/AuthorizeMailboxCommandTests.cs
@@ -299,6 +299,35 @@ public sealed class AuthorizeMailboxCommandTests : IDisposable
         Assert.DoesNotContain(this.console.Lines, line => line.Contains("a-refresh-token", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// A deployment from another release line is sent nothing at all. This is the request that carries somebody else's
+    /// long-lived credential, so the refusal has to land before it goes out — and the token is not printed as a
+    /// fallback either, which would put it in the scrollback the <c>--account</c> path exists to keep it out of.
+    /// </summary>
+    [Fact]
+    public async Task Authorize_ADeploymentFromAnotherReleaseLine_SendsItNoTokenAndPrintsNone()
+    {
+        // Arrange
+        this.SignInTo("production", "https://mail.example.test:8443", "an-admin-key");
+        using var handler = ProviderIssuingAGrantAndDeploymentAnswering(
+            HttpStatusCode.NoContent,
+            FakeAdminEndpoint.AnotherReleaseLine);
+
+        // Act
+        var exitCode = await this.RunAsync(
+            handler,
+            FakeMailboxRedirect.ApprovingWhenAsked("an-authorization-code", this.StateTheCommandGenerated),
+            "mailbox", "authorize", "--provider", "google", "--client-id", "app", "--account", "workspace");
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.DoesNotContain(
+            handler.RecordedRequests,
+            recorded => recorded.RequestUri?.AbsolutePath == AdminEndpointRoutes.MailboxRefreshTokenPath);
+        Assert.Contains(this.console.Errors, line => line.Contains("another release line", StringComparison.Ordinal));
+        Assert.DoesNotContain(this.console.Lines, line => line.Contains("a-refresh-token", StringComparison.Ordinal));
+    }
+
     /// <summary>A deployment that refuses the administrative credential is reported as that rather than as a stored grant.</summary>
     [Fact]
     public async Task Authorize_ADeploymentRefusingTheAdministrativeCredential_SaysSoAndStoresNothing()
@@ -428,8 +457,10 @@ public sealed class AuthorizeMailboxCommandTests : IDisposable
     /// answer differently. Routing on the administrative prefix is also what lets a test assert that the grant reached
     /// the write route rather than merely that two requests happened.
     /// </remarks>
-    private static FakeHttpMessageHandler ProviderIssuingAGrantAndDeploymentAnswering(HttpStatusCode deploymentStatus) =>
-        ProviderIssuingAGrantAndDeploymentRefusing(deploymentStatus, string.Empty);
+    private static FakeHttpMessageHandler ProviderIssuingAGrantAndDeploymentAnswering(
+        HttpStatusCode deploymentStatus,
+        string? deploymentVersion = null) =>
+        ProviderIssuingAGrantAndDeploymentRefusing(deploymentStatus, string.Empty, deploymentVersion);
 
     /// <summary>The provider, and a deployment that answers its session route before whatever it does with the grant.</summary>
     /// <remarks>
@@ -439,13 +470,16 @@ public sealed class AuthorizeMailboxCommandTests : IDisposable
     /// </remarks>
     private static FakeHttpMessageHandler ProviderIssuingAGrantAndDeploymentRefusing(
         HttpStatusCode deploymentStatus,
-        string deploymentBody) =>
+        string deploymentBody,
+        string? deploymentVersion = null) =>
         new((request, _) => Task.FromResult(request.RequestUri?.AbsolutePath switch
         {
             AdminEndpointRoutes.SessionPath => new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent(
-                    FakeAdminEndpoint.SessionBody("workstation", FakeAdminEndpoint.CommandVersion),
+                    FakeAdminEndpoint.SessionBody(
+                        "workstation",
+                        deploymentVersion ?? FakeAdminEndpoint.CommandVersion),
                     Encoding.UTF8,
                     "application/json"),
             },

--- a/tests/Cli.UnitTests/AuthorizeMailboxCommandTests.cs
+++ b/tests/Cli.UnitTests/AuthorizeMailboxCommandTests.cs
@@ -431,22 +431,37 @@ public sealed class AuthorizeMailboxCommandTests : IDisposable
     private static FakeHttpMessageHandler ProviderIssuingAGrantAndDeploymentAnswering(HttpStatusCode deploymentStatus) =>
         ProviderIssuingAGrantAndDeploymentRefusing(deploymentStatus, string.Empty);
 
+    /// <summary>The provider, and a deployment that answers its session route before whatever it does with the grant.</summary>
+    /// <remarks>
+    /// The session is answered separately from the rest of the administrative prefix because the command reads it
+    /// before storing anything: that is where the two versions are settled, and letting the status under test answer it
+    /// as well would test the version check rather than what the deployment did with the grant.
+    /// </remarks>
     private static FakeHttpMessageHandler ProviderIssuingAGrantAndDeploymentRefusing(
         HttpStatusCode deploymentStatus,
         string deploymentBody) =>
-        new((request, _) => Task.FromResult(
-            request.RequestUri?.AbsolutePath.StartsWith(AdminEndpointRoutes.Prefix, StringComparison.Ordinal) == true
-                ? new HttpResponseMessage(deploymentStatus)
+        new((request, _) => Task.FromResult(request.RequestUri?.AbsolutePath switch
+        {
+            AdminEndpointRoutes.SessionPath => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    FakeAdminEndpoint.SessionBody("workstation", FakeAdminEndpoint.CommandVersion),
+                    Encoding.UTF8,
+                    "application/json"),
+            },
+            { } path when path.StartsWith(AdminEndpointRoutes.Prefix, StringComparison.Ordinal) =>
+                new HttpResponseMessage(deploymentStatus)
                 {
                     Content = new StringContent(deploymentBody, Encoding.UTF8, "application/problem+json"),
-                }
-                : new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent(
-                        """{"access_token":"an-access-token","refresh_token":"a-refresh-token","expires_in":3600}""",
-                        Encoding.UTF8,
-                        "application/json"),
-                }));
+                },
+            _ => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"access_token":"an-access-token","refresh_token":"a-refresh-token","expires_in":3600}""",
+                    Encoding.UTF8,
+                    "application/json"),
+            },
+        }));
 
     /// <summary>A token endpoint that refuses everything, so a test reaching it fails loudly rather than passing quietly.</summary>
     private static FakeHttpMessageHandler TokenEndpointRefusing() =>

--- a/tests/Cli.UnitTests/DeploymentVersionAgreementTests.cs
+++ b/tests/Cli.UnitTests/DeploymentVersionAgreementTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Globalization;
 using System.Net;
 using MailFathom.Cli.Administration;
 using MailFathom.Cli.Credentials;
@@ -149,7 +148,7 @@ public sealed class DeploymentVersionAgreementTests : IDisposable
         using var deployment = FakeEmbeddingDeployment.Answering(
             assessment: SpendingAssessment,
             activation: (HttpStatusCode.OK, ActivationAnswer),
-            version: AnotherReleaseLine());
+            version: FakeAdminEndpoint.AnotherReleaseLine);
 
         // Act
         var exitCode = await this.RunAsync(deployment, "embedding", "activate", "--endpoint", Endpoint, "--yes");
@@ -170,7 +169,7 @@ public sealed class DeploymentVersionAgreementTests : IDisposable
     public async Task Status_ADeploymentBuiltDifferentlyOnTheSameLine_WarnsAndReportsAnyway()
     {
         // Arrange
-        using var deployment = FakeAdminEndpoint.Accepting("workstation", AnotherBuildOfThisLine());
+        using var deployment = FakeAdminEndpoint.Accepting("workstation", FakeAdminEndpoint.AnotherBuildOfThisLine);
 
         // Act
         var exitCode = await this.RunAsync(deployment, "status", "--endpoint", Endpoint);
@@ -194,7 +193,7 @@ public sealed class DeploymentVersionAgreementTests : IDisposable
         using var deployment = FakeEmbeddingDeployment.Answering(
             assessment: SpendingAssessment,
             activation: (HttpStatusCode.OK, ActivationAnswer),
-            version: AnotherBuildOfThisLine());
+            version: FakeAdminEndpoint.AnotherBuildOfThisLine);
 
         // Act
         var exitCode = await this.RunAsync(deployment, "embedding", "activate", "--endpoint", Endpoint, "--yes");
@@ -238,19 +237,6 @@ public sealed class DeploymentVersionAgreementTests : IDisposable
             Directory.Delete(this.storeDirectory, recursive: true);
         }
     }
-
-    /// <summary>A version on the release line after this build's, whatever this build's is.</summary>
-    private static string AnotherReleaseLine()
-    {
-        var line = System.Version.Parse(CoreOf(FakeAdminEndpoint.CommandVersion));
-
-        return string.Create(CultureInfo.InvariantCulture, $"{line.Major}.{line.Minor + 1}.0");
-    }
-
-    /// <summary>A different build of this build's own line, which is what a nightly of the same release is.</summary>
-    private static string AnotherBuildOfThisLine() => $"{CoreOf(FakeAdminEndpoint.CommandVersion)}-nightly.41";
-
-    private static string CoreOf(string version) => version.Split('-', '+')[0];
 
     private Task<int> RunAsync(FakeHttpMessageHandler deployment, params string[] args)
     {

--- a/tests/Cli.UnitTests/DeploymentVersionAgreementTests.cs
+++ b/tests/Cli.UnitTests/DeploymentVersionAgreementTests.cs
@@ -1,0 +1,306 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using System.Net;
+using MailFathom.Cli.Administration;
+using MailFathom.Cli.Credentials;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers what a version pair permits, and what a command does with the answer.</summary>
+/// <remarks>
+/// The decision is asserted against literal pairs, because it is a rule about release lines rather than about this
+/// build. What a command does with it is asserted against the version this assembly was actually stamped with, since
+/// that is the only version a deployment can report for the two to agree and a literal would fail the release that
+/// moves the declared prefix.
+/// </remarks>
+public sealed class DeploymentVersionAgreementTests : IDisposable
+{
+    private const string Endpoint = "https://mail.example.test:8443";
+
+    private static readonly Uri EndpointAddress = new(Endpoint);
+
+    private readonly string storeDirectory =
+        Path.Combine(Path.GetTempPath(), $"mailfathom-version-tests-{Guid.NewGuid():N}");
+
+    private readonly RecordingCliConsole console = new();
+
+    private readonly FakeTimeProvider clock = new(new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero));
+
+    /// <summary>The same version on both sides is the ordinary case, and it says nothing at all.</summary>
+    [Fact]
+    public void Settle_TheSameVersionOnBothSides_PermitsCommandsAndSaysNothing()
+    {
+        // Act
+        var agreement = DeploymentVersionAgreement.Settle("0.5.0", "0.5.0");
+
+        // Assert
+        Assert.True(agreement.PermitsCommands);
+        Assert.Null(agreement.Concern);
+    }
+
+    /// <summary>A patch and a prerelease identifier are both within the line, which ADR 0004 makes a compatible pair.</summary>
+    [Theory]
+    [InlineData("0.5.0", "0.5.1")]
+    [InlineData("0.5.3", "0.5.0")]
+    [InlineData("0.5.0", "0.5.0-nightly.41")]
+    [InlineData("0.5.0-nightly.41", "0.5.0-nightly.42")]
+    [InlineData("0.5.0", "0.5.0+3f1c9ab")]
+    [InlineData("1.2.0", "1.2.9")]
+    public void Settle_TheSameReleaseLineBuiltDifferently_PermitsCommandsAndWarns(
+        string commandVersion,
+        string deploymentVersion)
+    {
+        // Act
+        var agreement = DeploymentVersionAgreement.Settle(commandVersion, deploymentVersion);
+
+        // Assert
+        Assert.True(agreement.PermitsCommands);
+        Assert.Contains("not the same build and problems may occur", agreement.Concern, StringComparison.Ordinal);
+        Assert.Contains(commandVersion, agreement.Concern, StringComparison.Ordinal);
+        Assert.Contains(deploymentVersion, agreement.Concern, StringComparison.Ordinal);
+    }
+
+    /// <summary>A minor may break any surface below <c>1.0.0</c>, so another line is refused rather than attempted.</summary>
+    [Theory]
+    [InlineData("0.5.0", "0.4.0")]
+    [InlineData("0.5.0", "0.6.0")]
+    [InlineData("0.5.0", "1.5.0")]
+    [InlineData("1.0.0", "0.9.9")]
+    [InlineData("0.5.0", "0.6.0-nightly.3")]
+    public void Settle_AnotherReleaseLine_RefusesAndNamesBothVersions(
+        string commandVersion,
+        string deploymentVersion)
+    {
+        // Act
+        var agreement = DeploymentVersionAgreement.Settle(commandVersion, deploymentVersion);
+
+        // Assert
+        Assert.False(agreement.PermitsCommands);
+        Assert.Contains("another release line", agreement.Concern, StringComparison.Ordinal);
+        Assert.Contains(commandVersion, agreement.Concern, StringComparison.Ordinal);
+        Assert.Contains(deploymentVersion, agreement.Concern, StringComparison.Ordinal);
+    }
+
+    /// <summary>A version nothing can read is an absence of evidence, so it warns and names the side it could not read.</summary>
+    [Theory]
+    [InlineData("0.5.0", "unknown", "The deployment's version is not one")]
+    [InlineData("0.5.0", null, "The deployment's version is not one")]
+    [InlineData("0.5.0", "", "The deployment's version is not one")]
+    [InlineData("0.5.0", "0.5.0.1.2", "The deployment's version is not one")]
+    [InlineData("unknown", "0.5.0", "mfctl's own version is not one")]
+    [InlineData("unknown", "unknown", "Neither version is one")]
+    public void Settle_AVersionNeitherSideCanRead_PermitsCommandsAndSaysWhichOne(
+        string commandVersion,
+        string? deploymentVersion,
+        string expectedSubject)
+    {
+        // Act
+        var agreement = DeploymentVersionAgreement.Settle(commandVersion, deploymentVersion);
+
+        // Assert
+        Assert.True(agreement.PermitsCommands);
+        Assert.StartsWith(expectedSubject, agreement.Concern, StringComparison.Ordinal);
+        Assert.Contains("is unchecked", agreement.Concern, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A version carrying only the two components that name the line is read as that line rather than as unreadable.
+    /// Nothing here publishes one — Helm alone would refuse it — but the line is the whole of what the comparison acts
+    /// on, and refusing a value that states it exactly would be refusing on a formality.
+    /// </summary>
+    [Fact]
+    public void Settle_ADeploymentReportingTheLineAlone_ReadsItAsThatLine()
+    {
+        // Act
+        var agreement = DeploymentVersionAgreement.Settle("0.5.0", "0.5");
+
+        // Assert
+        Assert.True(agreement.PermitsCommands);
+        Assert.Contains("not the same build", agreement.Concern, StringComparison.Ordinal);
+    }
+
+    /// <summary>Whitespace around a stamped version is not a version difference, and reading it as one would warn on every command.</summary>
+    [Fact]
+    public void Settle_AVersionSurroundedByWhitespace_ReadsAsTheSameVersion()
+    {
+        // Act
+        var agreement = DeploymentVersionAgreement.Settle("0.5.0", "  0.5.0  ");
+
+        // Assert
+        Assert.True(agreement.PermitsCommands);
+        Assert.Null(agreement.Concern);
+    }
+
+    /// <summary>
+    /// The refusal has to land before the request it is protecting, and this is the command that decides it: an
+    /// activation is what starts a provider bill, so a deployment this build cannot be sure it speaks to must never be
+    /// asked to perform one.
+    /// </summary>
+    [Fact]
+    public async Task Activate_ADeploymentFromAnotherReleaseLine_RefusesWithoutAskingItForAnything()
+    {
+        // Arrange
+        using var deployment = FakeEmbeddingDeployment.Answering(
+            assessment: SpendingAssessment,
+            activation: (HttpStatusCode.OK, ActivationAnswer),
+            version: AnotherReleaseLine());
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "embedding", "activate", "--endpoint", Endpoint, "--yes");
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.False(deployment.WasAskedToActivate());
+        Assert.DoesNotContain(
+            deployment.RecordedRequests,
+            recorded => recorded.RequestUri?.AbsolutePath == AdminEndpointRoutes.EmbeddingActivationPath);
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains("another release line", StringComparison.Ordinal));
+    }
+
+    /// <summary>A build difference is a sentence and not a refusal, so the command it was reported on still runs.</summary>
+    [Fact]
+    public async Task Status_ADeploymentBuiltDifferentlyOnTheSameLine_WarnsAndReportsAnyway()
+    {
+        // Arrange
+        using var deployment = FakeAdminEndpoint.Accepting("workstation", AnotherBuildOfThisLine());
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "status", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains("not the same build and problems may occur", StringComparison.Ordinal));
+        Assert.Contains(this.console.Lines, line => line.Contains("accepts the stored credential", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// One warning per command rather than one per request. The activation sends two, and an operator told the same
+    /// thing twice about one invocation learns to read past it.
+    /// </summary>
+    [Fact]
+    public async Task Activate_ADeploymentBuiltDifferently_WarnsOnceForTheWholeCommand()
+    {
+        // Arrange
+        using var deployment = FakeEmbeddingDeployment.Answering(
+            assessment: SpendingAssessment,
+            activation: (HttpStatusCode.OK, ActivationAnswer),
+            version: AnotherBuildOfThisLine());
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "embedding", "activate", "--endpoint", Endpoint, "--yes");
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.True(deployment.WasAskedToActivate());
+        Assert.Single(
+            this.console.Errors,
+            line => line.Contains("not the same build and problems may occur", StringComparison.Ordinal));
+    }
+
+    /// <summary>The check costs one session request per command, whether or not the command reads a session of its own.</summary>
+    [Theory]
+    [InlineData("status")]
+    [InlineData("embedding")]
+    public async Task ACommandAgainstAnAgreeingDeployment_ReadsTheSessionOnceAndSaysNothingAboutVersions(
+        string command)
+    {
+        // Arrange
+        using var deployment = FakeEmbeddingDeployment.Answering(status: EmbeddingStatusAnswer);
+
+        // Act
+        var exitCode = command == "status"
+            ? await this.RunAsync(deployment, "status", "--endpoint", Endpoint)
+            : await this.RunAsync(deployment, "embedding", "status", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Single(
+            deployment.RecordedRequests,
+            recorded => recorded.RequestUri?.AbsolutePath == AdminEndpointRoutes.SessionPath);
+        Assert.DoesNotContain(this.console.Errors, line => line.Contains("problems may occur", StringComparison.Ordinal));
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Directory.Exists(this.storeDirectory))
+        {
+            Directory.Delete(this.storeDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>A version on the release line after this build's, whatever this build's is.</summary>
+    private static string AnotherReleaseLine()
+    {
+        var line = System.Version.Parse(CoreOf(FakeAdminEndpoint.CommandVersion));
+
+        return string.Create(CultureInfo.InvariantCulture, $"{line.Major}.{line.Minor + 1}.0");
+    }
+
+    /// <summary>A different build of this build's own line, which is what a nightly of the same release is.</summary>
+    private static string AnotherBuildOfThisLine() => $"{CoreOf(FakeAdminEndpoint.CommandVersion)}-nightly.41";
+
+    private static string CoreOf(string version) => version.Split('-', '+')[0];
+
+    private Task<int> RunAsync(FakeHttpMessageHandler deployment, params string[] args)
+    {
+        var store = new CredentialStore(
+            Path.Combine(this.storeDirectory, "credentials.json"),
+            new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key")));
+
+        store.Save("production", EndpointAddress, "not-a-real-key", "workstation");
+
+        var context = new CliContext(
+            this.console,
+            store,
+            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
+            FakeMailboxRedirect.Silent(),
+            _ => false,
+            this.clock);
+
+        return CliRunner.RunAsync(context, args);
+    }
+
+    private const string SpendingAssessment = """
+        {
+          "declared": {"fingerprint":"a1b2c3","provider":"a-provider","model":"a-model","modelVersion":null,"dimension":1536,"distanceMetric":"Cosine"},
+          "forecast": "AlreadyServing",
+          "estimate": null,
+          "spend": null,
+          "exceedsSpendCeiling": false
+        }
+        """;
+
+    private const string ActivationAnswer = """
+        {
+          "outcome": "AlreadyServing",
+          "profileId": "0199c3d0-0000-7000-8000-000000000001",
+          "estimate": null
+        }
+        """;
+
+    private const string EmbeddingStatusAnswer = """
+        {
+          "declared": {"fingerprint":"a1b2c3","provider":"a-provider","model":"a-model","modelVersion":null,"dimension":1536,"distanceMetric":"Cosine"},
+          "activationOutstanding": false,
+          "serving": {
+            "profileId": "0199c3d0-0000-7000-8000-000000000001",
+            "geometry": {"fingerprint":"a1b2c3","provider":"a-provider","model":"a-model","modelVersion":null,"dimension":1536,"distanceMetric":"Cosine"},
+            "progress": {"searchableEmailCount":10,"embeddedEmailCount":10,"outstandingEmailCount":0,"outstandingPassageCount":0,"outstandingCharacterCount":0,"approximateTokenCount":0}
+          },
+          "building": null,
+          "provider": {"state":"Serving","observedAt":"2026-08-09T11:59:00+00:00"},
+          "spend": null
+        }
+        """;
+}

--- a/tests/Cli.UnitTests/FakeAdminEndpoint.cs
+++ b/tests/Cli.UnitTests/FakeAdminEndpoint.cs
@@ -5,7 +5,9 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
+using MailFathom.Cli.Administration;
 using MailFathom.TestSupport;
+using MailFathom.Versioning;
 
 namespace MailFathom.Cli.UnitTests;
 
@@ -17,13 +19,36 @@ namespace MailFathom.Cli.UnitTests;
 /// </remarks>
 internal static class FakeAdminEndpoint
 {
+    /// <summary>Gets the version this command was stamped with, which is what a deployment reports for the two to agree.</summary>
+    /// <remarks>
+    /// Read from the assembly rather than written as a literal, because the declared prefix moves every release and a
+    /// literal would turn the release that moves it into a suite that refuses its own deployment. A test that is about
+    /// the version difference names the version it wants; every other one takes this and meets no warning.
+    /// </remarks>
+    internal static string CommandVersion { get; } =
+        StampedAssemblyVersion.ReadFrom(typeof(AdminApiClient).Assembly).Version;
+
+    /// <summary>Builds an endpoint that accepts whatever credential it is given, reporting this command's own version.</summary>
+    /// <param name="credentialName">The name it reports for the credential.</param>
+    /// <returns>The endpoint.</returns>
+    internal static FakeHttpMessageHandler Accepting(string credentialName) =>
+        Accepting(credentialName, CommandVersion);
+
     /// <summary>Builds an endpoint that accepts whatever credential it is given.</summary>
     /// <param name="credentialName">The name it reports for the credential.</param>
     /// <param name="version">The version it reports.</param>
     /// <returns>The endpoint.</returns>
     internal static FakeHttpMessageHandler Accepting(string credentialName, string version) => AnsweringBody(
         HttpStatusCode.OK,
-        $$"""{"service":"MailFathom","version":"{{version}}","credential":"{{credentialName}}"}""");
+        SessionBody(credentialName, version));
+
+    /// <summary>Builds the body the session route answers with.</summary>
+    /// <param name="credentialName">The name it reports for the credential.</param>
+    /// <param name="version">The version it reports.</param>
+    /// <returns>The JSON body.</returns>
+    /// <remarks>Shared with the doubles that route by path, so every one of them reports a session the same way and a change to that shape lands in one place.</remarks>
+    internal static string SessionBody(string credentialName, string version) =>
+        $$"""{"service":"MailFathom","version":"{{version}}","credential":"{{credentialName}}"}""";
 
     /// <summary>Builds an endpoint that answers with a status and no usable body.</summary>
     /// <param name="status">The status it answers with.</param>

--- a/tests/Cli.UnitTests/FakeAdminEndpoint.cs
+++ b/tests/Cli.UnitTests/FakeAdminEndpoint.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
@@ -27,6 +28,12 @@ internal static class FakeAdminEndpoint
     /// </remarks>
     internal static string CommandVersion { get; } =
         StampedAssemblyVersion.ReadFrom(typeof(AdminApiClient).Assembly).Version;
+
+    /// <summary>Gets a version on the release line after this command's, which is the pair every command refuses.</summary>
+    internal static string AnotherReleaseLine { get; } = LineAfter(CommandVersion);
+
+    /// <summary>Gets a different build of this command's own line, which is what a nightly of the same release is.</summary>
+    internal static string AnotherBuildOfThisLine { get; } = $"{CoreOf(CommandVersion)}-nightly.41";
 
     /// <summary>Builds an endpoint that accepts whatever credential it is given, reporting this command's own version.</summary>
     /// <param name="credentialName">The name it reports for the credential.</param>
@@ -97,6 +104,15 @@ internal static class FakeAdminEndpoint
             && presented.Count > 0
                 ? AuthenticationHeaderValue.Parse(presented[0])
                 : null;
+
+    private static string LineAfter(string version)
+    {
+        var line = Version.Parse(CoreOf(version));
+
+        return string.Create(CultureInfo.InvariantCulture, $"{line.Major}.{line.Minor + 1}.0");
+    }
+
+    private static string CoreOf(string version) => version.Split('-', '+')[0];
 
     private static RecordedHttpRequest? LastRequest(FakeHttpMessageHandler endpoint)
     {

--- a/tests/Cli.UnitTests/FakeEmbeddingDeployment.cs
+++ b/tests/Cli.UnitTests/FakeEmbeddingDeployment.cs
@@ -22,13 +22,21 @@ internal static class FakeEmbeddingDeployment
     /// <param name="assessment">The body the activation route answers a read with.</param>
     /// <param name="activation">The body the activation route answers a write with, or a refusal.</param>
     /// <param name="cancellation">The body the reindex cancellation route answers with.</param>
+    /// <param name="version">The version it reports, which defaults to the one the command was built as.</param>
     /// <returns>The deployment.</returns>
+    /// <remarks>
+    /// The session route is answered whatever the test asked for, because every command reads it before its own
+    /// operation: that is where the two versions are settled, and a double that served the embedding routes alone
+    /// would report a deployment nothing can be administered on.
+    /// </remarks>
     internal static FakeHttpMessageHandler Answering(
         string? status = null,
         string? assessment = null,
         (HttpStatusCode Status, string Body)? activation = null,
-        string? cancellation = null) =>
-        new((request, _) => Task.FromResult(Answer(request, status, assessment, activation, cancellation)));
+        string? cancellation = null,
+        string? version = null) =>
+        new((request, _) => Task.FromResult(
+            Answer(request, status, assessment, activation, cancellation, version ?? FakeAdminEndpoint.CommandVersion)));
 
     /// <summary>Reports whether the command asked the deployment to activate anything.</summary>
     /// <param name="deployment">The deployment the command was pointed at.</param>
@@ -48,9 +56,15 @@ internal static class FakeEmbeddingDeployment
         string? status,
         string? assessment,
         (HttpStatusCode Status, string Body)? activation,
-        string? cancellation)
+        string? cancellation,
+        string version)
     {
         var path = request.RequestUri?.AbsolutePath;
+
+        if (path == AdminEndpointRoutes.SessionPath)
+        {
+            return Json(HttpStatusCode.OK, FakeAdminEndpoint.SessionBody("workstation", version));
+        }
 
         if (path == AdminEndpointRoutes.EmbeddingStatusPath && status is { } statusBody)
         {

--- a/tests/Cli.UnitTests/FakeOAuthDeployment.cs
+++ b/tests/Cli.UnitTests/FakeOAuthDeployment.cs
@@ -118,7 +118,7 @@ internal sealed class FakeOAuthDeployment
                 $$"""{"device_code":"a-device-code","user_code":"WDJB-MJHT","verification_uri":"{{this.VerificationUri}}","expires_in":600,"interval":1}"""),
             "/api/admin/session" => Json(
                 HttpStatusCode.OK,
-                """{"service":"MailFathom","version":"0.2.0","credential":"kasia"}"""),
+                FakeAdminEndpoint.SessionBody("kasia", FakeAdminEndpoint.CommandVersion)),
             _ => new HttpResponseMessage(HttpStatusCode.NotFound),
         };
     }

--- a/tests/Cli.UnitTests/KeyPairSignInTests.cs
+++ b/tests/Cli.UnitTests/KeyPairSignInTests.cs
@@ -38,7 +38,7 @@ public sealed class KeyPairSignInTests : IDisposable
         // Arrange
         var store = this.CreateStore();
         var privateKeyPath = this.WriteKeyPair();
-        using var handler = FakeAdminEndpoint.Accepting("nightly-digest", "0.4.0");
+        using var handler = FakeAdminEndpoint.Accepting("nightly-digest");
 
         // Act
         var exitCode = await RunAsync(
@@ -65,7 +65,7 @@ public sealed class KeyPairSignInTests : IDisposable
     {
         // Arrange
         var privateKeyPath = this.WriteKeyPair();
-        using var handler = FakeAdminEndpoint.Accepting("nightly-digest", "0.4.0");
+        using var handler = FakeAdminEndpoint.Accepting("nightly-digest");
 
         // Act
         await RunAsync(
@@ -92,7 +92,7 @@ public sealed class KeyPairSignInTests : IDisposable
         // Arrange
         var store = this.CreateStore();
         var privateKeyPath = this.WriteKeyPair();
-        using var handler = FakeAdminEndpoint.Accepting("nightly-digest", "0.4.0");
+        using var handler = FakeAdminEndpoint.Accepting("nightly-digest");
 
         await RunAsync(
             this.Context(store, handler),
@@ -128,7 +128,7 @@ public sealed class KeyPairSignInTests : IDisposable
         // Arrange
         var store = this.CreateStore();
         var privateKeyPath = this.WriteKeyPair();
-        using var handler = FakeAdminEndpoint.Accepting("nightly-digest", "0.4.0");
+        using var handler = FakeAdminEndpoint.Accepting("nightly-digest");
 
         // Act
         await RunAsync(
@@ -150,7 +150,7 @@ public sealed class KeyPairSignInTests : IDisposable
     public async Task Login_WithAKeyPairAndNoKey_SaysWhatToPassWithoutReachingTheDeployment()
     {
         // Arrange
-        using var handler = FakeAdminEndpoint.Accepting("nightly-digest", "0.4.0");
+        using var handler = FakeAdminEndpoint.Accepting("nightly-digest");
 
         // Act
         var exitCode = await RunAsync(
@@ -167,7 +167,7 @@ public sealed class KeyPairSignInTests : IDisposable
     public async Task Login_WithThePublicHalfOfTheKeyPair_SaysWhichHalfToPass()
     {
         // Arrange
-        using var handler = FakeAdminEndpoint.Accepting("nightly-digest", "0.4.0");
+        using var handler = FakeAdminEndpoint.Accepting("nightly-digest");
         var publicKeyPath = this.WriteKeyPair().Replace(".key", ".pub", StringComparison.Ordinal);
 
         // Act
@@ -191,7 +191,7 @@ public sealed class KeyPairSignInTests : IDisposable
     public async Task Login_WithAKeyThatIsNotThere_ReportsTheFileRatherThanCrashing()
     {
         // Arrange
-        using var handler = FakeAdminEndpoint.Accepting("nightly-digest", "0.4.0");
+        using var handler = FakeAdminEndpoint.Accepting("nightly-digest");
 
         // Act
         var exitCode = await RunAsync(

--- a/tests/Cli.UnitTests/LoginCommandTests.cs
+++ b/tests/Cli.UnitTests/LoginCommandTests.cs
@@ -33,7 +33,7 @@ public sealed class LoginCommandTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
 
         // Act
@@ -49,7 +49,7 @@ public sealed class LoginCommandTests : IDisposable
     public async Task Login_ThePresentedCredential_IsSentAsABearerCredential()
     {
         // Arrange
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
 
         // Act
@@ -178,7 +178,7 @@ public sealed class LoginCommandTests : IDisposable
     public async Task Login_NoCredentialSupplied_FailsWithoutReachingTheDeployment()
     {
         // Arrange
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = string.Empty;
 
         // Act
@@ -195,7 +195,7 @@ public sealed class LoginCommandTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
 
         // Act
@@ -210,7 +210,7 @@ public sealed class LoginCommandTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
 
         // Act
@@ -229,7 +229,7 @@ public sealed class LoginCommandTests : IDisposable
         // Arrange
         var store = this.CreateStore();
         store.Save("production", EndpointAddress, "the-old-key", "workstation");
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "the-new-key";
 
         // Act
@@ -246,7 +246,7 @@ public sealed class LoginCommandTests : IDisposable
     public async Task Login_AnUnknownNameThatIsNotAnAddress_SaysToPassAnAddressInstead()
     {
         // Arrange
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
 
         // Act
@@ -265,7 +265,7 @@ public sealed class LoginCommandTests : IDisposable
     public async Task Login_ANameThatIsAnAddress_IsRefused()
     {
         // Arrange
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
 
         // Act
@@ -285,7 +285,7 @@ public sealed class LoginCommandTests : IDisposable
         store.Save("production", EndpointAddress, "not-a-real-key", "workstation");
 
         // Act
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         var exitCode = await RunAsync(this.Context(store, handler), "logout", "--endpoint", Endpoint);
 
@@ -304,7 +304,7 @@ public sealed class LoginCommandTests : IDisposable
     public async Task ACommandNeedingACredential_WhenNotSignedIn_SaysHowToSignIn(string commandName)
     {
         // Arrange
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         // Act
         var exitCode = await RunAsync(this.Context(this.CreateStore(), handler), commandName);
@@ -324,7 +324,7 @@ public sealed class LoginCommandTests : IDisposable
         // Arrange
         var store = this.CreateStore();
         store.Save("production", EndpointAddress, "not-a-real-key", "workstation");
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         // Act
         var exitCode = await RunAsync(this.Context(store, handler), "status");
@@ -343,7 +343,7 @@ public sealed class LoginCommandTests : IDisposable
         var store = this.CreateStore();
         store.Save("staging", new Uri("https://staging.example.test:8443"), "staging-key", "workstation");
         store.Save("production", EndpointAddress, "production-key", "workstation");
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         // Act
         var exitCode = await RunAsync(this.Context(store, handler), "status", "--endpoint", "staging");
@@ -361,7 +361,7 @@ public sealed class LoginCommandTests : IDisposable
         var store = this.CreateStore();
         store.Save("staging", new Uri("https://staging.example.test:8443"), "staging-key", "workstation");
         store.Save("production", EndpointAddress, "production-key", "workstation");
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         // Act
         var exitCode = await RunAsync(this.Context(store, handler), "switch", "staging");
@@ -378,7 +378,7 @@ public sealed class LoginCommandTests : IDisposable
         // Arrange
         var store = this.CreateStore();
         store.Save("production", EndpointAddress, "production-key", "workstation");
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         // Act
         var exitCode = await RunAsync(this.Context(store, handler), "switch", "qa");
@@ -395,7 +395,7 @@ public sealed class LoginCommandTests : IDisposable
         var store = this.CreateStore();
         store.Save("production", EndpointAddress, "production-key", "workstation");
         store.Save("staging", new Uri("https://staging.example.test:8443"), "staging-key", "workstation");
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         // Act
         var exitCode = await RunAsync(this.Context(store, handler), "profiles");
@@ -411,7 +411,7 @@ public sealed class LoginCommandTests : IDisposable
     public async Task Profiles_NoneStored_SaysSoRatherThanFailing()
     {
         // Arrange
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.2.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         // Act
         var exitCode = await RunAsync(this.Context(this.CreateStore(), handler), "profiles");

--- a/tests/Cli.UnitTests/LoginCommandTests.cs
+++ b/tests/Cli.UnitTests/LoginCommandTests.cs
@@ -80,6 +80,30 @@ public sealed class LoginCommandTests : IDisposable
     }
 
     /// <summary>
+    /// A deployment from another release line must not reach the store either. The credential itself is fine there —
+    /// what is wrong is the deployment, and a profile saved for one every later command would refuse is a sign-in that
+    /// succeeded into nothing.
+    /// </summary>
+    [Fact]
+    public async Task Login_ADeploymentFromAnotherReleaseLine_StoresNothingAndFails()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        using var handler = FakeAdminEndpoint.Accepting("workstation", FakeAdminEndpoint.AnotherReleaseLine);
+        this.console.SecretToSupply = "not-a-real-key";
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "login", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(1, exitCode);
+        Assert.Empty(store.Read().Profiles);
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains("another release line", StringComparison.Ordinal));
+    }
+
+    /// <summary>
     /// A success status is not by itself a MailFathom deployment: a proxy or an unrelated service on the same host can
     /// return one. Requiring the body to name the service is what keeps a stored credential from being one nothing saw.
     /// </summary>

--- a/tests/Cli.UnitTests/TransportTrustSignInTests.cs
+++ b/tests/Cli.UnitTests/TransportTrustSignInTests.cs
@@ -70,7 +70,7 @@ public sealed class TransportTrustSignInTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
         this.console.AnswerToGive = true;
 
@@ -91,7 +91,7 @@ public sealed class TransportTrustSignInTests : IDisposable
     public async Task Login_AnUntrustedCertificate_ShowsItsSubjectIssuerFingerprintValidityAndWhyItFailed()
     {
         // Arrange
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
         this.console.AnswerToGive = true;
 
@@ -118,7 +118,7 @@ public sealed class TransportTrustSignInTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
         this.console.AnswerToGive = false;
 
@@ -139,7 +139,7 @@ public sealed class TransportTrustSignInTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
         this.console.AnswersQuestions = false;
 
@@ -161,7 +161,7 @@ public sealed class TransportTrustSignInTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
         this.console.AnswersQuestions = false;
 
@@ -187,7 +187,7 @@ public sealed class TransportTrustSignInTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
 
         // Act
@@ -204,7 +204,7 @@ public sealed class TransportTrustSignInTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
         this.console.AnswerToGive = true;
 
@@ -248,7 +248,7 @@ public sealed class TransportTrustSignInTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
         this.console.AnswerToGive = false;
 
@@ -268,7 +268,7 @@ public sealed class TransportTrustSignInTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
         this.console.AnswersQuestions = false;
 
@@ -287,7 +287,7 @@ public sealed class TransportTrustSignInTests : IDisposable
     {
         // Arrange
         var store = this.CreateStore();
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "not-a-real-key";
         this.console.AnswersQuestions = false;
 
@@ -313,7 +313,7 @@ public sealed class TransportTrustSignInTests : IDisposable
             "not-a-real-key",
             "workstation",
             trust: new StoredTransportTrust(PinnedCertificateFingerprint: null, AcceptsClearText: true));
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         // Act
         var exitCode = await RunAsync(this.Context(store, handler), "status");
@@ -336,7 +336,7 @@ public sealed class TransportTrustSignInTests : IDisposable
             "not-a-real-key",
             "workstation",
             trust: new StoredTransportTrust(pinned));
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         // Act
         var exitCode = await RunAsync(
@@ -364,7 +364,7 @@ public sealed class TransportTrustSignInTests : IDisposable
             "not-a-real-key",
             "workstation",
             trust: new StoredTransportTrust(PresentedCertificate.FingerprintOf(this.deploymentCertificate)));
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
 
         // Act
         var exitCode = await RunAsync(
@@ -387,7 +387,7 @@ public sealed class TransportTrustSignInTests : IDisposable
             "the-old-key",
             "workstation",
             trust: new StoredTransportTrust(PresentedCertificate.FingerprintOf(this.deploymentCertificate)));
-        using var handler = FakeAdminEndpoint.Accepting("workstation", "0.5.0");
+        using var handler = FakeAdminEndpoint.Accepting("workstation");
         this.console.SecretToSupply = "the-new-key";
         this.console.AnswerToGive = true;
 


### PR DESCRIPTION
Closes #627

`mfctl` already read the version a deployment reports and did nothing with it but print it — the only value it checked was `service`, which tells MailFathom from something else answering the port. So a command from one release talking to a deployment from another arrived as a `404` whose message pointed at the port, a refusal repeated from the deployment, or a request that succeeded against a field that had changed meaning.

The version pair already answers that question, so nothing new is published for it. Within `0.x` a minor release may break any public surface and a patch may break none, which makes the `major.minor` line the whole of the compatibility statement — [ADR 0004](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0004-versioning-and-release-policy.md) is the policy this reads.

## What it does

| The pair | What happens |
| --- | --- |
| Identical versions | Nothing is said. |
| Same `major.minor`, different patch or prerelease | The command runs; one line on standard error names both versions and says problems may occur. |
| Different `major` or `minor` | The command is refused and **nothing operational is sent**. |
| A version either side cannot read | The command runs and says which side could not be read. |

The refusal landing *before* the request is what decided where the check lives. `AdminApiClient` is the one path to a deployment, so it reads `GET /api/admin/session` before the first operation whichever command is running — which means `embedding activate` against a deployment this build cannot be sure it speaks to never reaches the route that starts a provider bill. `login` and `status` already read the session, so they settle on the answer they were fetching anyway and the check costs one request per command run rather than two. It is settled once per client and a client is made once per command, so the warning appears once per invocation and not once per request.

A version that cannot be read warns rather than refusing. The refusal reports an incompatibility that was *observed*, and an unstamped or locally built binary reporting `unknown` is an absence of evidence — refusing on it would make a build nobody can identify a build nobody can administer.

## Break to record

**Deployment contract.** An `mfctl` and a deployment from different `major.minor` lines now refuse each other rather than attempting the command. The operator's action is to run the `mfctl` published with the deployment's own release, which every release attaches beside the image.

## Notes

- The test doubles stopped writing version literals: `FakeAdminEndpoint.CommandVersion` reads the stamped version off the assembly, so the release that moves `VersionPrefix` cannot leave the suite refusing its own deployment. Three fakes now answer the session route, because every command reads it.
- `docs/users/administering.md` lost a sentence left from before the first release — "which release *starts* attaching them … how to build the command from a checkout *until then*" — which had outlived the releases that attach the binaries.

## Verification

- `scripts/verify-full.sh` — pass. 4424 tests, 0 failed; aggregate line coverage 95.20% (12948/13601), required 85%; `Formatted 0 of 1511 files`.
- `scripts/review-obligations.sh` — every row answered; `docs/operations/mailbox-oauth.md` read and owes nothing, since what it states about the store request did not move.
- `$check-docs-licenses` — Docs pass, Changelog n/a, Licenses n/a (no package, tool, service, image, model or copied source added).
