### PR TITLE
[#623] Read the chat declaration again after an edit, so changing the model costs no restart

### DIFF
--- a/docs/features/chat-generation.md
+++ b/docs/features/chat-generation.md
@@ -52,9 +52,9 @@ credential, and neither may be written down — an address identifies a tenant a
 line, a metric tag, a resilience circuit, and a failure message carry instead.
 
 **An alias names one endpoint across the whole deployment.** A chat endpoint reusing an embedding endpoint's alias is
-refused at startup, because the alias is what a credential is resolved by, what a resilience circuit is keyed by, and
-what every log line naming an endpoint carries. Two endpoints answering to one name would share all three, so a chat
-outage would open the circuit the embeddings were being served through.
+refused at startup and again on every reloaded declaration, because the alias is what a credential is resolved by, what
+a resilience circuit is keyed by, and what every log line naming an endpoint carries. Two endpoints answering to one
+name would share all three, so a chat outage would open the circuit the embeddings were being served through.
 
 ## Two providers, one client
 
@@ -104,7 +104,8 @@ both sections, keyed by the alias, which is what the deployment-wide uniqueness 
 ## The model and its parameters come from configuration
 
 None of them is a compile-time constant, so changing model is an edit rather than a rebuild and a model released after
-this version can be declared without one.
+this version can be declared without one. Nor is any of them read once: the declaration in force is read again for
+every question, which the section below states in full.
 
 - `Model` is what a request is routed to. For a cloud deployment that is the name the operator gave the deployment
   rather than the vendor's model identifier, because that is the string the endpoint recognizes.
@@ -133,6 +134,35 @@ this version can be declared without one.
 requires it to call them, so a model that cannot be given tools cannot answer a question here whatever else is declared.
 Where a reasoning model refuses tools beside a stated effort, `Api` is the setting that resolves it, and the two are
 therefore chosen together rather than independently.
+
+## Changing the model does not restart the host
+
+The declaration is read again after an edit rather than once while the host composes itself, and the reason is the case
+an operator actually hits. A model the provider will not serve is only discovered from a refusal on a real question, so
+correcting one is the ordinary path rather than a rare one — and the process being corrected is synchronizing mailboxes
+and holding an IMAP IDLE connection. Restarting it to change a string is a cost paid on every correction.
+
+What that means in practice:
+
+- **The next question uses the edited declaration.** Every key of the endpoint is in this — the model, the address, the
+  API, the parameters, the bounds, the deadline, the credential reference, and the relevance filter's two numbers.
+- **A question already in flight keeps the declaration it began with.** A run resolves the declaration once and holds it
+  until it answers, so a reload landing mid-run cannot answer half of one question in one model's voice and half in
+  another's — which is the same thing the one-endpoint rule above exists to prevent.
+- **A candidate that breaks a rule is refused whole.** Everything startup checks is checked again: the bounds, the
+  section's own rules, the deployment-wide alias uniqueness, the filter's agreement with what a retrieval hands over,
+  and whether the credential reference still resolves. A refused candidate is logged with the key an operator has to
+  fix, the previous declaration goes on answering, and the process stays up — which is what makes correcting a mistake
+  in a correction possible at all.
+- **Two things still take a restart**, because each decided which services this deployment registered: whether `Alias`
+  names an endpoint at all, and whether the relevance filter runs. Going from no chat section to one is therefore a
+  restart, and so is turning the second pass on or off. Both are refused with that message rather than adopted and
+  quietly ignored. *Renaming* a declared alias is not one of them — the credential and the circuit are looked up by
+  whatever the declaration in force calls the endpoint.
+
+[ADR 0002](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0002-configuration-reading-mapping-and-reload-boundary.md)
+classifies this group as reloadable for new operations and states the rules a reloadable group follows;
+[configuration reference § `Chat`](../operations/configuration-reference.md#chat) marks each key.
 
 ## Bounds every call carries
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -332,18 +332,29 @@ endpoint.
 
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
-| `Chat:Alias` | string | *(empty)* | writing one is what configures a chat provider at all; unique across every AI endpoint the deployment declares, embedding endpoints included. A section carrying other settings without it is refused rather than ignored | restart |
-| `Chat:Model` | string | — | required once an alias is written; what a request is routed to, which for a cloud deployment is the deployment's own name rather than the vendor's model identifier | restart |
-| `Chat:Address` | string | *(empty)* | absolute HTTPS; empty uses the provider library's default. A cloud resource's OpenAI-compatible address ends in `/openai/v1/` | restart |
-| `Chat:Api` | enum | `ChatCompletions` | `ChatCompletions` or `Responses`; which of the provider's two request APIs a call goes to under the declared address. Declared rather than derived, because the routed model name is the operator's own deployment name and nothing about it says which paths the server serves. State `Responses` for a reasoning model that refuses function tools beside a stated effort; a server that does not serve that path answers *request refused* | restart |
-| `Chat:MaxOutputTokens` | int | `1024` | 1 – 200000; what one answer may occupy. Reaching it is not a failure — the answer arrives marked as cut short | restart |
-| `Chat:Temperature` | float | *(unset)* | 0 – 2; left unset sends nothing, which is required by the models that reject the parameter outright | restart |
-| `Chat:TopP` | float | *(unset)* | 0 – 1; unset the same way, and for the same reason | restart |
-| `Chat:ReasoningEffort` | string | *(unset)* | the level the model documents, written as the provider spells it — `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or whatever a later model adds. Unset sends no reasoning parameter at all, which a model that does not reason requires. `none` is not the same as unset — it states an effort of none and sends it, which is what a provider refusing tools beside an unstated effort asks for. Startup checks the shape and not the vocabulary, because which levels exist belongs to the model; a level this deployment's model does not accept refuses the request rather than falling back | restart |
-| `Chat:MaxMessagesPerRequest` | int | `64` | 1 – 512; the turns one request carries, refused rather than truncated | restart |
-| `Chat:MaxRequestCharacters` | int | `120000` | 1 – 4000000; what those turns may add up to. Stated in characters rather than tokens because counting tokens would mean carrying the model's own tokenizer; set it below what the model's context window allows | restart |
-| `Chat:RequestTimeout` | TimeSpan | `00:02:00` | positive; one request. Longer than an embedding request's by default, because generating an answer takes as long as the answer is | restart |
-| `Chat:ApiKey` | secret block | *(absent)* | the provider key. Exactly one of this and `EntraCredential` is declared | restart, value read per request |
+| `Chat:Alias` | string | *(empty)* | writing one is what configures a chat provider at all; unique across every AI endpoint the deployment declares, embedding endpoints included. A section carrying other settings without it is refused rather than ignored | reload to rename, restart to declare or remove |
+| `Chat:Model` | string | — | required once an alias is written; what a request is routed to, which for a cloud deployment is the deployment's own name rather than the vendor's model identifier | reload |
+| `Chat:Address` | string | *(empty)* | absolute HTTPS; empty uses the provider library's default. A cloud resource's OpenAI-compatible address ends in `/openai/v1/` | reload |
+| `Chat:Api` | enum | `ChatCompletions` | `ChatCompletions` or `Responses`; which of the provider's two request APIs a call goes to under the declared address. Declared rather than derived, because the routed model name is the operator's own deployment name and nothing about it says which paths the server serves. State `Responses` for a reasoning model that refuses function tools beside a stated effort; a server that does not serve that path answers *request refused* | reload |
+| `Chat:MaxOutputTokens` | int | `1024` | 1 – 200000; what one answer may occupy. Reaching it is not a failure — the answer arrives marked as cut short | reload |
+| `Chat:Temperature` | float | *(unset)* | 0 – 2; left unset sends nothing, which is required by the models that reject the parameter outright | reload |
+| `Chat:TopP` | float | *(unset)* | 0 – 1; unset the same way, and for the same reason | reload |
+| `Chat:ReasoningEffort` | string | *(unset)* | the level the model documents, written as the provider spells it — `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, or whatever a later model adds. Unset sends no reasoning parameter at all, which a model that does not reason requires. `none` is not the same as unset — it states an effort of none and sends it, which is what a provider refusing tools beside an unstated effort asks for. Startup checks the shape and not the vocabulary, because which levels exist belongs to the model; a level this deployment's model does not accept refuses the request rather than falling back | reload |
+| `Chat:MaxMessagesPerRequest` | int | `64` | 1 – 512; the turns one request carries, refused rather than truncated | reload |
+| `Chat:MaxRequestCharacters` | int | `120000` | 1 – 4000000; what those turns may add up to. Stated in characters rather than tokens because counting tokens would mean carrying the model's own tokenizer; set it below what the model's context window allows | reload |
+| `Chat:RequestTimeout` | TimeSpan | `00:02:00` | positive; one request. Longer than an embedding request's by default, because generating an answer takes as long as the answer is | reload |
+| `Chat:ApiKey` | secret block | *(absent)* | the provider key. Exactly one of this and `EntraCredential` is declared | reload, value read per request |
+
+**What a reload changes here, and what it does not.** Everything the declared endpoint says is read again per
+question, so correcting a model the provider refused — the ordinary case, because a wrong model is only discovered from
+a refusal — costs an edit rather than a restart of a process that is synchronizing mailboxes and holding an IMAP IDLE
+connection. A run already in flight keeps the declaration it began with, so a reload landing mid-question changes the
+next question and not that one. A candidate that breaks any rule in the table is refused whole, logged with the key to
+fix, and leaves the previous declaration answering; the process stays up either way. What stays a restart is the pair
+that decides which services this deployment registered at all: whether `Chat:Alias` names an endpoint, and whether
+`Chat:RelevanceFilter:Enabled` turns the second pass on. Renaming a declared alias reloads, because the credential and
+the resilience circuit are both looked up by whatever the declaration in force calls it; going from no chat section to
+one, or the reverse, does not, and is refused with that message rather than silently ignored.
 
 **What the declared model has to be able to do.** `ask_mail` answers by offering the model a retrieval tool and requiring it to call one, so a model that cannot be given function tools cannot answer a question here whatever else is written above. That is what the two settings in the middle of the table exist for: a current reasoning model refuses function tools beside an *unstated* reasoning effort and names the responses API as the way to have both, so such a model needs `Chat:Api` set to `Responses` and `Chat:ReasoningEffort` written — including written as `none`, which states an effort rather than omitting the parameter. A model this deployment cannot use is not detected at startup, because nothing here can ask a provider what a routed name supports without paying for a call; it surfaces as *request refused* on the first question. [Chat generation](../features/chat-generation.md#two-apis-and-the-deployment-says-which) holds the whole reasoning, and [Mail answering](../features/mail-answering.md) describes the run that imposes the requirement.
 
@@ -351,7 +362,9 @@ endpoint.
 
 The same block, with the same keys, defaults, and rules as
 [`Embeddings:Endpoints:<n>:EntraCredential`](#microsoft-entra-credential--embeddingsendpointsnentracredential) above.
-One credential source resolves both sections, which is why the alias uniqueness rule spans them.
+One credential source resolves both sections, which is why the alias uniqueness rule spans them. Its keys reload here
+and take a restart there, for the reason the table above gives: this section is read again per question and the
+embedding chain is read once while the host composes itself.
 
 ### Relevance filter — `Chat:RelevanceFilter`
 
@@ -368,8 +381,8 @@ describes what it drops, what it keeps, and what it does when the provider canno
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
 | `Chat:RelevanceFilter:Enabled` | bool | `false` | turning it on requires a declared `Chat:Alias`, and a `Chat:MaxMessagesPerRequest` of at least 2, because a judgement is an instruction and a candidate | restart |
-| `Chat:RelevanceFilter:MaxCandidates` | int | *(unset)* | 1 – [`MailAnswering:MaxPassagesPerRetrieval`](#mailanswering), which is everything one retrieval hands over; a higher value would name candidates that never exist and is refused at startup rather than accepted and never met. Unset judges every passage the retrieval hands over, which is why there is no literal default here: one would go on saying 8 after the retrieval it follows was narrowed. The ceiling on what one lookup spends and how long it takes; set below what retrieval returns it buys a weaker filter rather than a shorter result, because a passage nobody judged keeps its place | restart |
-| `Chat:RelevanceFilter:MinimumRelevance` | int | `50` | 1 – 100, on the scale the model answers a judgement on. A threshold of 0 is refused: it would pay for a judgement that can drop nothing | restart |
+| `Chat:RelevanceFilter:MaxCandidates` | int | *(unset)* | 1 – [`MailAnswering:MaxPassagesPerRetrieval`](#mailanswering), which is everything one retrieval hands over; a higher value would name candidates that never exist and is refused at startup rather than accepted and never met. Unset judges every passage the retrieval hands over, which is why there is no literal default here: one would go on saying 8 after the retrieval it follows was narrowed. The ceiling on what one lookup spends and how long it takes; set below what retrieval returns it buys a weaker filter rather than a shorter result, because a passage nobody judged keeps its place | reload |
+| `Chat:RelevanceFilter:MinimumRelevance` | int | `50` | 1 – 100, on the scale the model answers a judgement on. A threshold of 0 is refused: it would pay for a judgement that can drop nothing | reload |
 
 ## `MailAnswering`
 

--- a/src/AI/AiServiceCollectionExtensions.cs
+++ b/src/AI/AiServiceCollectionExtensions.cs
@@ -120,10 +120,15 @@ public static class AiServiceCollectionExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="services" /> is <see langword="null" />.</exception>
     /// <remarks>
     /// <para>
-    /// The caller registers the <see cref="ChatGenerationPlan" /> and the
-    /// <see cref="IProviderEndpointCredentialSource" /> itself, because binding configuration and resolving a secret
-    /// reference both belong to the composition root. Nothing here reads configuration or knows what a secret reference
-    /// is.
+    /// The caller registers the <see cref="IChatGenerationPlanSource" />, the scoped <see cref="ChatGenerationPlan" />
+    /// it publishes, and the <see cref="IProviderEndpointCredentialSource" /> itself, because binding configuration and
+    /// resolving a secret reference both belong to the composition root. Nothing here reads configuration or knows what
+    /// a secret reference is.
+    /// </para>
+    /// <para>
+    /// The client is scoped rather than a singleton because the plan it runs against is: the declaration behind it
+    /// reloads, and a client built once would go on calling the model the process started with. One scope is one
+    /// operation, so the plan a call uses is the one its operation began with.
     /// </para>
     /// <para>
     /// Independent of <see cref="AddEmbeddingProviderAdapter" /> in both directions, and that is the point rather than
@@ -137,7 +142,7 @@ public static class AiServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         services.TryAddSingleton<OpenAiCompatibleClientFactory>();
-        services.AddSingleton<IChatModelClient, ProviderChatModelClient>();
+        services.AddScoped<IChatModelClient, ProviderChatModelClient>();
 
         AddChatProviderTransport(services);
 
@@ -258,6 +263,12 @@ public static class AiServiceCollectionExtensions
     /// surfaces as this deployment's own timeout — which is classified, logged, and retried under a budget — rather
     /// than as a transport exception from underneath it.
     /// </para>
+    /// <para>
+    /// The bounds are read from the plan source rather than from a resolved plan, because this runs on the root
+    /// provider whenever the factory builds a client and the plan itself is scoped to an operation. A client opened
+    /// after a reload therefore carries the reloaded ceilings, which is the same answer the operation holding the plan
+    /// gets.
+    /// </para>
     /// </remarks>
     private static void AddChatProviderTransport(IServiceCollection services)
     {
@@ -265,7 +276,7 @@ public static class AiServiceCollectionExtensions
             .ConfigurePrimaryHttpMessageHandler(static () => new SocketsHttpHandler { AllowAutoRedirect = false })
             .ConfigureHttpClient(static (provider, client) =>
             {
-                var plan = provider.GetRequiredService<ChatGenerationPlan>();
+                var plan = provider.GetRequiredService<IChatGenerationPlanSource>().Current;
 
                 client.Timeout = plan.RequestTimeout + TimeSpan.FromSeconds(30);
                 client.MaxResponseContentBufferSize =

--- a/src/AI/Chat/IChatGenerationPlanSource.cs
+++ b/src/AI/Chat/IChatGenerationPlanSource.cs
@@ -1,0 +1,30 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.AI.Chat;
+
+/// <summary>Supplies the chat plan a new operation runs against.</summary>
+/// <remarks>
+/// <para>
+/// The declaration behind a plan is reloadable, so the plan an operation runs against is a value with a publication
+/// time rather than a constant of the process. Reading it here is what lets a corrected model reach the next question
+/// instead of the next restart.
+/// </para>
+/// <para>
+/// Read once per operation and use that instance for its duration. A run that re-read this mid-flight could answer half
+/// a question with one model and half with another, which is the one thing the single-endpoint rule exists to prevent —
+/// so a run resolves the plan from its own scope and the plan is what it holds.
+/// </para>
+/// <para>
+/// Declared here and implemented by the composition root, for the reason
+/// <see cref="Providers.IProviderEndpointCredentialSource" /> is: binding configuration, validating a
+/// reloaded candidate, and deciding when one becomes current all belong to the host, and nothing in this boundary knows
+/// what a configuration section is.
+/// </para>
+/// </remarks>
+public interface IChatGenerationPlanSource
+{
+    /// <summary>Gets the plan built from the most recent declaration proven usable.</summary>
+    ChatGenerationPlan Current { get; }
+}

--- a/src/Host/Configuration/Chat/ChatDeclarationRules.cs
+++ b/src/Host/Configuration/Chat/ChatDeclarationRules.cs
@@ -1,0 +1,137 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.ComponentModel.DataAnnotations;
+using MailFathom.Host.Configuration.Answering;
+using MailFathom.Host.Configuration.Embeddings;
+using MailFathom.Host.Configuration.Providers;
+
+namespace MailFathom.Host.Configuration.Chat;
+
+/// <summary>Holds every rule a chat declaration must satisfy, so composition and a reload judge one by the same reading.</summary>
+/// <remarks>
+/// <para>
+/// The section is read twice in the life of a process: once while the host composes itself, and again for every
+/// candidate a configuration reload produces. A second copy of the rules would drift into a value startup accepted and
+/// a reload refused, or the reverse — and the reverse is the worse of the two, because it publishes a declaration
+/// nothing proved.
+/// </para>
+/// <para>
+/// Two of the rules span sections and neither options type can see both sides, which is why they are reached from here
+/// rather than from <see cref="ChatModelOptions.Validate" />: the alias must not repeat one an embedding endpoint
+/// declares, and the relevance filter must not name more candidates than a retrieval hands over.
+/// </para>
+/// </remarks>
+internal static class ChatDeclarationRules
+{
+    /// <summary>Reports everything an operator must fix before a chat declaration can be used.</summary>
+    /// <param name="candidate">The bound declaration, or <see langword="null" /> when the deployment wrote no section.</param>
+    /// <param name="embeddings">The bound embedding declaration, or <see langword="null" /> when the deployment wrote no section.</param>
+    /// <param name="answering">The bound answering ceilings, which supply the retrieval count the filter is judged against.</param>
+    /// <returns>One message per rule the declaration breaks, empty when it is usable.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="answering" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// An absent section is a supported deployment rather than a failure, so it reports nothing at all — the capability
+    /// is simply not offered, exactly as an absent embedding section serves lexical search.
+    /// </remarks>
+    public static IReadOnlyList<string> FindDeclarationErrors(
+        ChatModelOptions? candidate,
+        EmbeddingOptions? embeddings,
+        MailAnsweringOptions answering)
+    {
+        ArgumentNullException.ThrowIfNull(answering);
+
+        if (candidate is null)
+        {
+            return [];
+        }
+
+        var errors = new List<string>(FindSectionErrors(candidate));
+
+        if (PassageRelevanceCandidateAgreement.FindUnreachableCandidateCount(candidate, answering) is { } unreachableCandidateCount)
+        {
+            errors.Add(PassageRelevanceCandidateAgreement.DescribeUnreachableCandidateCount(
+                unreachableCandidateCount,
+                answering.MaxPassagesPerRetrieval));
+        }
+
+        if (ProviderEndpointAliases.FindReusedAlias(embeddings, candidate) is { } reusedAlias)
+        {
+            errors.Add(ProviderEndpointAliases.DescribeReusedAlias(reusedAlias));
+        }
+
+        return errors;
+    }
+
+    /// <summary>Reports what a reloaded declaration changed that composition already acted on.</summary>
+    /// <param name="candidate">The reloaded declaration.</param>
+    /// <param name="composed">The declaration the host was built from.</param>
+    /// <returns>One message per change that cannot take effect, empty when the candidate moves nothing composition read.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Both settings decide which services exist rather than what a request carries, and the container is built once.
+    /// Publishing such a change would report it as adopted while the process went on offering exactly the capabilities
+    /// it started with, which is worse than refusing it: an operator who turned answering on would watch the setting
+    /// take and the tool go on reporting itself inactive.
+    /// </para>
+    /// <para>
+    /// Refused rather than merely ignored, for the reason the composed database command timeout is refused: a rejected
+    /// candidate is logged with the path an operator edits, and a silently dropped one is not.
+    /// </para>
+    /// </remarks>
+    public static IReadOnlyList<string> FindChangesNeedingRestart(ChatModelOptions candidate, ChatModelOptions composed)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+        ArgumentNullException.ThrowIfNull(composed);
+
+        var errors = new List<string>();
+
+        if (candidate.IsConfigured != composed.IsConfigured)
+        {
+            errors.Add(
+                $"{ChatModelOptions.SectionName}:{nameof(ChatModelOptions.Alias)} — whether this deployment declares a chat endpoint decides which services it registers, so declaring or removing one needs a restart rather than a configuration reload. Everything the endpoint itself says reloads.");
+        }
+
+        if (candidate.RelevanceFilter.Enabled != composed.RelevanceFilter.Enabled)
+        {
+            errors.Add(
+                $"{ChatModelOptions.SectionName}:{nameof(ChatModelOptions.RelevanceFilter)}:{nameof(PassageRelevanceFilterOptions.Enabled)} — whether retrieval judges its candidates decides which retrieval is registered, so turning the pass on or off needs a restart rather than a configuration reload. The two numbers beside it reload.");
+        }
+
+        return errors;
+    }
+
+    /// <summary>Runs the section's own rules: the attribute bounds and everything <see cref="ChatModelOptions.Validate" /> reports.</summary>
+    /// <remarks>
+    /// Invoked rather than left to <c>ValidateDataAnnotations</c>, because the options framework raises a rejected
+    /// reload on the thread that reported the configuration change, where the failure has nowhere to be reported and
+    /// the candidate is dropped without a word. Running the same validator here is what turns a mistyped bound into a
+    /// logged refusal beside every other reason a candidate was not adopted.
+    /// <para>
+    /// Each message is prefixed with the key it is about, because an attribute's own text names the property and not
+    /// the setting an operator edits, and because that is the shape every other rejected reload is reported in.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<string> FindSectionErrors(ChatModelOptions candidate)
+    {
+        var results = new List<ValidationResult>();
+
+        Validator.TryValidateObject(
+            candidate,
+            new ValidationContext(candidate),
+            results,
+            validateAllProperties: true);
+
+        return results
+            .Where(result => !string.IsNullOrWhiteSpace(result.ErrorMessage))
+            .Select(result => $"{DescribeConfigurationPath(result)} — {result.ErrorMessage}");
+    }
+
+    /// <summary>Names the configuration key a validation result is about, falling back to the section when it names no member.</summary>
+    private static string DescribeConfigurationPath(ValidationResult result) =>
+        result.MemberNames.FirstOrDefault() is { Length: > 0 } memberName
+            ? $"{ChatModelOptions.SectionName}:{memberName}"
+            : ChatModelOptions.SectionName;
+}

--- a/src/Host/Configuration/Chat/ChatGenerationPlanSource.cs
+++ b/src/Host/Configuration/Chat/ChatGenerationPlanSource.cs
@@ -1,0 +1,63 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.AI.Chat;
+
+namespace MailFathom.Host.Configuration.Chat;
+
+/// <summary>Publishes the chat plan built from the declaration currently in force.</summary>
+/// <remarks>
+/// <para>
+/// The mapping is the same one composition used; what this adds is when it runs. Mapping once at registration froze the
+/// plan for the life of the process, so every key under <c>Chat</c> cost a restart of a host that is synchronizing
+/// mailboxes and holding an IMAP IDLE connection — and picking a model is exactly the setting an operator iterates on,
+/// because a model the provider refuses is only discovered from a refusal.
+/// </para>
+/// <para>
+/// The plan is cached against the settings instance it was mapped from, so a published declaration has one plan and
+/// reading it costs no allocation until a reload lands. Two threads reaching an uncached instance both map it and one
+/// wins the write: the two plans describe the same declaration, so which one wins decides nothing.
+/// </para>
+/// <para>
+/// Only the plan itself is republished. A run reads it once from its own scope and holds it for the run, so a
+/// reload landing mid-question changes the next question rather than that one.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this plan source.")]
+internal sealed class ChatGenerationPlanSource(ISettingsSnapshot<ChatModelOptions> publishedSettings)
+    : IChatGenerationPlanSource
+{
+    private MappedPlan? mapped;
+
+    /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">Thrown when the published declaration carries no chat endpoint, which composition registers this only against.</exception>
+    public ChatGenerationPlan Current
+    {
+        get
+        {
+            var settings = publishedSettings.Current;
+
+            if (Volatile.Read(ref this.mapped) is { } existing && ReferenceEquals(existing.Settings, settings))
+            {
+                return existing.Plan;
+            }
+
+            // Reached only where the endpoint was declared at registration, and a reload that would remove it is
+            // refused before it is published, so the absence is a contradiction rather than a configuration state.
+            var plan = ChatGenerationPlanMapper.Map(settings)
+                ?? throw new InvalidOperationException(
+                    "The chat endpoint was declared at registration and is absent from the configuration in force.");
+
+            Volatile.Write(ref this.mapped, new MappedPlan(settings, plan));
+
+            return plan;
+        }
+    }
+
+    /// <summary>The plan a published declaration maps to, kept beside the declaration it came from.</summary>
+    /// <param name="Settings">The published declaration, held to recognize the next one by reference.</param>
+    /// <param name="Plan">What that declaration maps to.</param>
+    private sealed record MappedPlan(ChatModelOptions Settings, ChatGenerationPlan Plan);
+}

--- a/src/Host/Configuration/Chat/ChatModelOptions.cs
+++ b/src/Host/Configuration/Chat/ChatModelOptions.cs
@@ -29,10 +29,20 @@ namespace MailFathom.Host.Configuration.Chat;
 /// parameters are all read from configuration, so changing model is an edit rather than a rebuild, and so a model
 /// released after this version can be declared without one.
 /// </para>
+/// <para>
+/// The declaration is read again after an edit rather than once at startup, so correcting a model the provider refused
+/// costs an edit rather than a restart of a process that is mid-synchronization. Two things it says are read while the
+/// host composes itself and cannot follow a reload: whether the section declares an endpoint at all, and whether the
+/// relevance filter runs, because each decides which services exist.
+/// <see cref="ChatDeclarationRules.FindChangesNeedingRestart" /> refuses a candidate that moves either.
+/// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
 internal sealed class ChatModelOptions : IValidatableObject
 {
+    /// <summary>The configuration section this declaration is bound from.</summary>
+    public const string SectionName = "Chat";
+
     /// <summary>Gets or sets the deployment's own name for the chat endpoint.</summary>
     /// <remarks>
     /// Everything else here is an address or a credential and neither may be written down, so this is the name a log

--- a/src/Host/Configuration/Chat/ChatSettingsReloadValidator.cs
+++ b/src/Host/Configuration/Chat/ChatSettingsReloadValidator.cs
@@ -1,0 +1,58 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Host.Configuration.Answering;
+using MailFathom.Host.Configuration.Embeddings;
+
+namespace MailFathom.Host.Configuration.Chat;
+
+/// <summary>Proves a reloaded chat declaration before it becomes the one new questions are answered through.</summary>
+/// <remarks>
+/// <para>
+/// The sections it is judged against arrive as the values composition actually used rather than as settings to be read
+/// again, for the reason the composed database command timeout does: what a candidate has to agree with is what the
+/// running process was built from, and reading both sides afresh would compare a candidate against itself.
+/// </para>
+/// <para>
+/// A candidate that fails leaves the previous declaration serving. That is what keeps a mistyped model, a bound outside
+/// its range, or a repointed key that resolves to nothing from taking the answering capability offline — the operator's
+/// next edit is the correction, and the process has to still be there to read it.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this validator.")]
+internal sealed class ChatSettingsReloadValidator(
+    SecretConfigurationValidator secretValidator,
+    ChatModelOptions composedSettings,
+    EmbeddingOptions? declaredEmbeddings,
+    MailAnsweringOptions declaredAnswering)
+{
+    /// <summary>Finds everything an operator must fix before a reloaded chat declaration can be published.</summary>
+    /// <param name="candidate">The reloaded declaration.</param>
+    /// <param name="cancellationToken">Cancels the secret resolution.</param>
+    /// <returns>One message per unusable setting, empty when the candidate is usable.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="candidate" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The credential is proven here and resolved again per request, on the same terms every other reloadable section's
+    /// secrets are: a reference an operator repoints to nothing would otherwise publish cleanly and then refuse every
+    /// question.
+    /// </remarks>
+    internal async Task<IReadOnlyList<string>> FindConfigurationErrorsAsync(
+        ChatModelOptions candidate,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        var errors = new List<string>(
+            await secretValidator.FindSecretReferenceErrorsAsync(
+                ChatModelOptions.SectionName,
+                candidate,
+                cancellationToken));
+
+        errors.AddRange(ChatDeclarationRules.FindDeclarationErrors(candidate, declaredEmbeddings, declaredAnswering));
+        errors.AddRange(ChatDeclarationRules.FindChangesNeedingRestart(candidate, composedSettings));
+
+        return errors;
+    }
+}

--- a/src/Host/Configuration/Providers/ConfiguredProviderEndpointCredentialSource.cs
+++ b/src/Host/Configuration/Providers/ConfiguredProviderEndpointCredentialSource.cs
@@ -22,15 +22,21 @@ namespace MailFathom.Host.Configuration.Providers;
 /// </para>
 /// <para>
 /// One source for both declared sections, keyed by the alias alone. Startup refuses a chat endpoint whose alias an
-/// embedding endpoint already uses, which is what lets the lookup stay a search over one name rather than a name paired
-/// with the section it came from — and the same rule is what keeps two endpoints from sharing one resilience circuit
-/// and one log identity.
+/// embedding endpoint already uses, and so does every reloaded chat declaration, which is what lets the lookup stay a
+/// search over one name rather than a name paired with the section it came from — and the same rule is what keeps two
+/// endpoints from sharing one resilience circuit and one log identity.
+/// </para>
+/// <para>
+/// The chat declaration is read from the published snapshot and the embedding chain from the composed options, because
+/// that is what each of them is: the chat endpoint is reloadable down to its alias, so a lookup reading the startup
+/// value would fail to find an endpoint an operator renamed, while the embedding chain is read once while the host
+/// composes itself and takes a restart to change.
 /// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this credential source.")]
 internal sealed class ConfiguredProviderEndpointCredentialSource(
     IOptions<EmbeddingOptions> embeddingSettings,
-    IOptions<ChatModelOptions> chatSettings,
+    ISettingsSnapshot<ChatModelOptions> chatSettings,
     ISecretReferenceResolver secretReferenceResolver) : IProviderEndpointCredentialSource
 {
     /// <inheritdoc />
@@ -40,7 +46,7 @@ internal sealed class ConfiguredProviderEndpointCredentialSource(
 
         var declaration = this.FindDeclaration(endpointAlias)
             ?? throw new InvalidOperationException(
-                $"AI endpoint '{endpointAlias}' is not present in the configuration this deployment started with.");
+                $"AI endpoint '{endpointAlias}' is not present in the configuration currently in force.");
 
         return declaration.Entra is { } entra
             ? this.ResolveEntraCredentialAsync(endpointAlias, entra, cancellationToken)
@@ -62,7 +68,7 @@ internal sealed class ConfiguredProviderEndpointCredentialSource(
             return new ProviderCredentialDeclaration(embeddingEndpoint.ApiKey, embeddingEndpoint.EntraCredential);
         }
 
-        var chat = chatSettings.Value;
+        var chat = chatSettings.Current;
 
         return chat.IsConfigured && NamesEndpoint(chat.Alias, endpointAlias)
             ? new ProviderCredentialDeclaration(chat.ApiKey, chat.EntraCredential)

--- a/src/Host/Configuration/ValidatedSettingsSnapshot.cs
+++ b/src/Host/Configuration/ValidatedSettingsSnapshot.cs
@@ -26,9 +26,12 @@ namespace MailFathom.Host.Configuration;
 /// only the newest one, so a burst of reloads costs one validation rather than a queue of stale ones.
 /// </para>
 /// <para>
-/// The initial snapshot is published without being validated here, because the startup validator has already proven
-/// the whole deployment's secret configuration and failed the host if it could not. Validating it again would double
-/// every startup retrieval for no additional guarantee.
+/// The initial snapshot is published without being validated here. It is the configuration the process was composed
+/// from rather than a candidate, and for the groups the startup validator covers it has already been proven — so
+/// validating it again would double every startup retrieval for no additional guarantee. The chat declaration is the
+/// one group outside that gate, deliberately: a chat provider is an optional capability whose absence degrades an
+/// instance rather than breaking it, so an unresolvable key there is reported by the first question instead of taking
+/// a deployment that serves search perfectly well offline at startup.
 /// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this hosted service.")]

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.AI;
+using MailFathom.AI.Chat;
 using MailFathom.AI.Providers;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.AiProviders;
@@ -150,12 +151,16 @@ try
     // choices with separate consequences: an instance may generate and not embed, or embed and not generate, and each
     // is a working deployment with a different set of capabilities. An absent section is one of those states rather
     // than a startup failure.
+    // Bound without ValidateDataAnnotations, unlike every section around it, because this one reloads and the framework
+    // validator is the wrong place for a reloadable group's rules: it runs while the options monitor materializes a
+    // reloaded value, on the thread the configuration provider reported the change from, where a failure has nowhere to
+    // be reported and the candidate is dropped in silence. ChatDeclarationRules runs the same validator from the two
+    // places that can report it — composition below, which fails startup with every problem at once, and the reload
+    // validator, which logs the refusal and leaves the previous declaration serving.
     builder.Services.AddOptions<ChatModelOptions>()
         .Bind(
-            builder.Configuration.GetSection("Chat"),
-            binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
-        .ValidateDataAnnotations()
-        .ValidateOnStart();
+            builder.Configuration.GetSection(ChatModelOptions.SectionName),
+            binderOptions => binderOptions.ErrorOnUnknownConfiguration = true);
     // A configuration root of its own beside Chat rather than a block inside it, because the two answer different
     // questions: Chat says which endpoint generates text and what one call to it may carry, while this says what
     // answering a question is allowed to cost and how much of a mailbox may leave the process to do it. Unlike the
@@ -391,9 +396,10 @@ try
 
     // Read the same way and for the same reason as the embedding declaration: whether this deployment generates text
     // decides which services exist, and that decision is taken before the container that would resolve an options
-    // snapshot. Only the presence of a declaration is read this way — every rule about what it says is validated on
-    // start, where a failure reports every problem at once instead of the first one to be built.
-    var declaredChat = builder.Configuration.GetSection("Chat").Get<ChatModelOptions>();
+    // snapshot. Unlike the embedding chain, everything else this says is reloadable, so what is frozen here is the
+    // presence of the declaration and nothing more — the model, the address, the parameters, and the bounds are read
+    // again from the published snapshot on every question.
+    var declaredChat = builder.Configuration.GetSection(ChatModelOptions.SectionName).Get<ChatModelOptions>();
 
     // Read the same way, and needed before the container for the same reason: the retrieval ceiling it carries is what
     // caps the relevance filter's candidate count and what supplies that count's default, and both are decided while
@@ -419,32 +425,40 @@ try
 
     var answeringBudget = MailAnsweringBudgetMapper.Map(declaredAnswering);
 
-    // The one rule spanning two sections. A filter declared to judge more candidates than a lookup hands over states a
-    // ceiling no question could reach, and neither options type can see both numbers, so it is refused here rather than
-    // producing an instance whose filter silently judges fewer passages than its operator wrote down.
-    if (PassageRelevanceCandidateAgreement.FindUnreachableCandidateCount(declaredChat, declaredAnswering) is { } unreachableCandidateCount)
+    // Every rule the chat declaration answers to, in one reading: the section's own bounds, the alias that names one AI
+    // endpoint across the whole deployment because a credential, a resilience circuit, and a log line are all keyed by
+    // it, and the filter's candidate count against what a lookup actually hands over. Judged here rather than through
+    // ValidateOnStart so the same rules judge a reloaded candidate, and reported together so an operator who wrote two
+    // mistakes reads both.
+    var chatConfigurationErrors = ChatDeclarationRules.FindDeclarationErrors(
+        declaredChat,
+        declaredEmbeddings,
+        declaredAnswering);
+
+    if (chatConfigurationErrors.Count > 0)
     {
         throw new OptionsValidationException(
-            "Chat",
+            ChatModelOptions.SectionName,
             typeof(ChatModelOptions),
-            [
-                PassageRelevanceCandidateAgreement.DescribeUnreachableCandidateCount(
-                    unreachableCandidateCount,
-                    declaredAnswering.MaxPassagesPerRetrieval),
-            ]);
+            chatConfigurationErrors);
     }
 
-    // An alias names one AI endpoint across the whole deployment, because it is what a credential is resolved by, what
-    // a resilience circuit is keyed by, and what every log line naming an endpoint carries. Two endpoints answering to
-    // one name would share all three, so a chat endpoint reusing an embedding alias is refused here rather than
-    // producing an instance whose chat outage opens the circuit its embeddings are served through.
-    if (ProviderEndpointAliases.FindReusedAlias(declaredEmbeddings, declaredChat) is { } reusedAlias)
-    {
-        throw new OptionsValidationException(
-            "Chat",
-            typeof(ChatModelOptions),
-            [ProviderEndpointAliases.DescribeReusedAlias(reusedAlias)]);
-    }
+    // Registered whether or not a chat endpoint was declared, because the credential source below reads it on behalf of
+    // an embedding-only deployment too, and because an instance that declared nothing is the one whose operator has to
+    // be told that adding the section takes a restart rather than being ignored.
+    builder.Services.AddSingleton(provider => new ChatSettingsReloadValidator(
+        provider.GetRequiredService<SecretConfigurationValidator>(),
+        declaredChat ?? new ChatModelOptions(),
+        declaredEmbeddings,
+        declaredAnswering));
+    builder.Services.AddSingleton(provider => new ValidatedSettingsSnapshot<ChatModelOptions>(
+        provider.GetRequiredService<IOptionsMonitor<ChatModelOptions>>(),
+        (candidate, cancellationToken) => provider.GetRequiredService<ChatSettingsReloadValidator>()
+            .FindConfigurationErrorsAsync(candidate, cancellationToken),
+        ChatModelOptions.SectionName,
+        provider.GetRequiredService<ILogger<ValidatedSettingsSnapshot<ChatModelOptions>>>()));
+    builder.Services.AddSingleton<ISettingsSnapshot<ChatModelOptions>>(provider => provider.GetRequiredService<ValidatedSettingsSnapshot<ChatModelOptions>>());
+    builder.Services.AddHostedService(provider => provider.GetRequiredService<ValidatedSettingsSnapshot<ChatModelOptions>>());
 
     // Registered once for both declarations, because it resolves by alias and the aliases are unique across them. It is
     // needed by whichever adapter exists, so it is registered when either does rather than by each of them.
@@ -470,22 +484,25 @@ try
 
     if (declaredChat?.IsConfigured is true)
     {
-        builder.Services.AddSingleton(provider => ChatGenerationPlanMapper.Map(
-            provider.GetRequiredService<IOptions<ChatModelOptions>>().Value)
-            ?? throw new InvalidOperationException(
-                "The chat endpoint was declared at registration and is absent from the validated configuration."));
+        // The source is a singleton because one published declaration maps to one plan; the plan itself is scoped
+        // because one scope is one question, and reading it once per question is what keeps a run that has begun on the
+        // plan it began with while the next one picks up an edited model.
+        builder.Services.AddSingleton<IChatGenerationPlanSource, ChatGenerationPlanSource>();
+        builder.Services.AddScoped(provider => provider.GetRequiredService<IChatGenerationPlanSource>().Current);
         builder.Services.AddChatProviderAdapter();
         builder.Services.AddMailAnsweringAgent();
 
         // The plan is registered here beside the endpoint it judges with; the filter itself is registered after
-        // AddInfrastructure below, because it decorates the retrieval that call registers.
+        // AddInfrastructure below, because it decorates the retrieval that call registers. Scoped for the reason the
+        // generation plan is: the two numbers it carries are a lookup's, and whether the pass runs at all is the part
+        // that was decided here and cannot follow a reload.
         if (declaredChat.RelevanceFilter.Enabled)
         {
-            builder.Services.AddSingleton(provider => PassageRelevanceFilterPlanMapper.Map(
-                provider.GetRequiredService<IOptions<ChatModelOptions>>().Value,
+            builder.Services.AddScoped(provider => PassageRelevanceFilterPlanMapper.Map(
+                provider.GetRequiredService<ISettingsSnapshot<ChatModelOptions>>().Current,
                 answeringBudget.Retrieval)
                 ?? throw new InvalidOperationException(
-                    "The relevance filter was enabled at registration and is absent from the validated configuration."));
+                    "The relevance filter was enabled at registration and is absent from the configuration in force."));
         }
 
         // Readiness alone, and never worse than degraded. Neither provider serves a request path, so a failing one must

--- a/tests/AI.UnitTests/AiServiceCollectionExtensionsTests.cs
+++ b/tests/AI.UnitTests/AiServiceCollectionExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.AI.Chat;
 using MailFathom.AI.Embeddings;
 using MailFathom.AI.ProviderAdapters;
 using MailFathom.AI.Providers;
@@ -140,7 +141,8 @@ public sealed class AiServiceCollectionExtensionsTests
         var services = new ServiceCollection();
         services.AddHttpClient();
         services.AddLogging();
-        services.AddSingleton(ChatDeclarations.Plan());
+        services.AddSingleton(ChatDeclarations.PlanSource());
+        services.AddScoped(provider => provider.GetRequiredService<IChatGenerationPlanSource>().Current);
         services.AddSingleton(Substitute.For<IProviderEndpointCredentialSource>());
         services.AddSingleton(Substitute.For<IOutboundOperationRunner>());
         services.AddSingleton(Substitute.For<IAiProviderHealthRecorder>());
@@ -150,7 +152,8 @@ public sealed class AiServiceCollectionExtensionsTests
 
         // Assert
         using var provider = services.BuildServiceProvider();
-        var client = provider.GetRequiredService<IChatModelClient>();
+        using var scope = provider.CreateScope();
+        var client = scope.ServiceProvider.GetRequiredService<IChatModelClient>();
         using var transport = provider
             .GetRequiredService<IHttpClientFactory>()
             .CreateClient(ProviderChatModelClient.TransportName);
@@ -158,7 +161,39 @@ public sealed class AiServiceCollectionExtensionsTests
         Assert.NotNull(client);
 
         // The bounds live in the registration rather than at a call site, so a client asked for by name carries them.
+        // They are read from the plan source, because the factory builds a client on the root provider while the plan
+        // itself belongs to an operation's scope.
         Assert.Equal(ChatDeclarations.RequestTimeout + TimeSpan.FromSeconds(30), transport.Timeout);
+    }
+
+    /// <summary>
+    /// The declaration behind the plan reloads, so a client built once for the process would go on calling the model
+    /// the process started with. One scope is one operation, and the client belongs to it.
+    /// </summary>
+    [Fact]
+    public void AddChatProviderAdapter_ResolvesTheChatClientOncePerScope()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddHttpClient();
+        services.AddLogging();
+        services.AddSingleton(ChatDeclarations.PlanSource());
+        services.AddScoped(provider => provider.GetRequiredService<IChatGenerationPlanSource>().Current);
+        services.AddSingleton(Substitute.For<IProviderEndpointCredentialSource>());
+        services.AddSingleton(Substitute.For<IOutboundOperationRunner>());
+        services.AddSingleton(Substitute.For<IAiProviderHealthRecorder>());
+
+        // Act
+        services.AddChatProviderAdapter();
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        using var otherScope = provider.CreateScope();
+
+        Assert.NotSame(
+            scope.ServiceProvider.GetRequiredService<IChatModelClient>(),
+            otherScope.ServiceProvider.GetRequiredService<IChatModelClient>());
     }
 
     /// <summary>
@@ -173,7 +208,8 @@ public sealed class AiServiceCollectionExtensionsTests
         services.AddHttpClient();
         services.AddLogging();
         services.AddSingleton(EmbeddingDeclarations.Plan());
-        services.AddSingleton(ChatDeclarations.Plan());
+        services.AddSingleton(ChatDeclarations.PlanSource());
+        services.AddScoped(provider => provider.GetRequiredService<IChatGenerationPlanSource>().Current);
         services.AddSingleton(Substitute.For<IProviderEndpointCredentialSource>());
         services.AddSingleton(Substitute.For<IOutboundOperationRunner>());
         services.AddSingleton(Substitute.For<IAiProviderHealthRecorder>());
@@ -184,9 +220,10 @@ public sealed class AiServiceCollectionExtensionsTests
 
         // Assert
         using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
 
         Assert.NotNull(provider.GetRequiredService<ITextEmbeddingGenerator>());
-        Assert.NotNull(provider.GetRequiredService<IChatModelClient>());
+        Assert.NotNull(scope.ServiceProvider.GetRequiredService<IChatModelClient>());
         Assert.Single(services, service => service.ServiceType == typeof(OpenAiCompatibleClientFactory));
     }
 
@@ -208,7 +245,8 @@ public sealed class AiServiceCollectionExtensionsTests
         var services = new ServiceCollection();
         services.AddHttpClient();
         services.AddLogging();
-        services.AddSingleton(ChatDeclarations.Plan());
+        services.AddSingleton(ChatDeclarations.PlanSource());
+        services.AddScoped(provider => provider.GetRequiredService<IChatGenerationPlanSource>().Current);
         services.AddSingleton(MailAnsweringRunBounds.Default);
         services.AddSingleton(Substitute.For<IProviderEndpointCredentialSource>());
         services.AddSingleton(Substitute.For<IOutboundOperationRunner>());

--- a/tests/AI.UnitTests/TestDoubles/ChatDeclarations.cs
+++ b/tests/AI.UnitTests/TestDoubles/ChatDeclarations.cs
@@ -39,4 +39,13 @@ internal static class ChatDeclarations
             maximumMessagesPerRequest,
             maximumRequestCharacters,
             requestTimeout ?? RequestTimeout);
+
+    /// <summary>Publishes one fixed plan, standing in for the composition root's reading of the declaration in force.</summary>
+    public static IChatGenerationPlanSource PlanSource(ChatGenerationPlan? plan = null) =>
+        new FixedPlanSource(plan ?? Plan());
+
+    private sealed class FixedPlanSource(ChatGenerationPlan plan) : IChatGenerationPlanSource
+    {
+        public ChatGenerationPlan Current => plan;
+    }
 }

--- a/tests/Host.UnitTests/Configuration/Chat/ChatDeclarationRulesTests.cs
+++ b/tests/Host.UnitTests/Configuration/Chat/ChatDeclarationRulesTests.cs
@@ -1,0 +1,191 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Answering;
+using MailFathom.Host.Configuration.Chat;
+using MailFathom.Host.Configuration.Embeddings;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Chat;
+
+/// <summary>Covers the one reading of the chat section that composition and a reload both judge a declaration by.</summary>
+/// <remarks>
+/// The section is reloadable, so a rule that held at startup and lapsed on reload would publish a declaration nothing
+/// proved. These tests establish that the same reading reports the section's own bounds, both rules that span sections,
+/// and the two settings composition acted on and a reload therefore cannot move.
+/// </remarks>
+public sealed class ChatDeclarationRulesTests
+{
+    [Fact]
+    public void FindDeclarationErrors_AUsableDeclaration_ReportsNothing()
+    {
+        // Act
+        var errors = ChatDeclarationRules.FindDeclarationErrors(Declared(), null, new MailAnsweringOptions());
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>An absent section is a deployment that answers no questions, which is supported rather than refused.</summary>
+    [Fact]
+    public void FindDeclarationErrors_AnAbsentSection_ReportsNothing()
+    {
+        // Act
+        var errors = ChatDeclarationRules.FindDeclarationErrors(null, null, new MailAnsweringOptions());
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>The attribute bounds are the half no reload would otherwise report, because the options framework drops the candidate before anything can log it.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ABoundOutsideItsRange_NamesTheKeyAnOperatorEdits()
+    {
+        // Arrange
+        var candidate = Declared();
+        candidate.MaxOutputTokens = 0;
+
+        // Act
+        var errors = ChatDeclarationRules.FindDeclarationErrors(candidate, null, new MailAnsweringOptions());
+
+        // Assert
+        Assert.Contains(
+            errors,
+            error => error.StartsWith("Chat:MaxOutputTokens — ", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindDeclarationErrors_ADeclarationWithNoModel_ReportsTheSectionsOwnRule()
+    {
+        // Arrange
+        var candidate = Declared();
+        candidate.Model = string.Empty;
+
+        // Act
+        var errors = ChatDeclarationRules.FindDeclarationErrors(candidate, null, new MailAnsweringOptions());
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("declares no Model", StringComparison.Ordinal));
+    }
+
+    /// <summary>An alias names one AI endpoint across the deployment, and neither options type can see the other section.</summary>
+    [Fact]
+    public void FindDeclarationErrors_AnAliasAnEmbeddingEndpointAlreadyDeclares_ReportsTheCollision()
+    {
+        // Arrange
+        var embeddings = new EmbeddingOptions();
+        embeddings.Endpoints.Add(new EmbeddingEndpointOptions
+        {
+            Alias = "answering",
+            Model = "an-embedding-model",
+            Dimension = 4,
+        });
+
+        // Act
+        var errors = ChatDeclarationRules.FindDeclarationErrors(Declared(), embeddings, new MailAnsweringOptions());
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("both declare the alias 'answering'", StringComparison.Ordinal));
+    }
+
+    /// <summary>The second rule spanning two sections, and the reason a reloaded filter count is judged rather than adopted.</summary>
+    [Fact]
+    public void FindDeclarationErrors_AFilterJudgingMoreThanOneLookupHandsOver_ReportsTheDisagreement()
+    {
+        // Arrange
+        var candidate = Declared();
+        candidate.RelevanceFilter.Enabled = true;
+        candidate.RelevanceFilter.MaxCandidates = 9;
+
+        // Act
+        var errors = ChatDeclarationRules.FindDeclarationErrors(
+            candidate,
+            null,
+            new MailAnsweringOptions { MaxPassagesPerRetrieval = 8 });
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("Chat:RelevanceFilter:MaxCandidates", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FindDeclarationErrors_WithoutTheAnsweringDeclaration_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(
+            () => ChatDeclarationRules.FindDeclarationErrors(Declared(), null, null!));
+    }
+
+    [Fact]
+    public void FindChangesNeedingRestart_ADeclarationThatMovesNothingCompositionRead_ReportsNothing()
+    {
+        // Arrange
+        var candidate = Declared();
+        candidate.Model = "a-corrected-model";
+        candidate.Temperature = 0.4f;
+
+        // Act
+        var errors = ChatDeclarationRules.FindChangesNeedingRestart(candidate, Declared());
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>Whether the endpoint exists decides which services were registered, and the container is built once.</summary>
+    [Fact]
+    public void FindChangesNeedingRestart_ARemovedEndpoint_RefusesRatherThanTakingTheCapabilityOffline()
+    {
+        // Act
+        var errors = ChatDeclarationRules.FindChangesNeedingRestart(new ChatModelOptions(), Declared());
+
+        // Assert
+        Assert.Contains(errors, error => error.StartsWith("Chat:Alias — ", StringComparison.Ordinal));
+    }
+
+    /// <summary>Adopting this silently would report the setting as taken while the tool went on answering nothing.</summary>
+    [Fact]
+    public void FindChangesNeedingRestart_ADeclaredEndpointWhereNoneWasComposed_RefusesRatherThanBeingIgnored()
+    {
+        // Act
+        var errors = ChatDeclarationRules.FindChangesNeedingRestart(Declared(), new ChatModelOptions());
+
+        // Assert
+        Assert.Contains(errors, error => error.StartsWith("Chat:Alias — ", StringComparison.Ordinal));
+    }
+
+    /// <summary>The filter's registration decorates the retrieval, so turning the pass on is a composition decision; its two numbers are not.</summary>
+    [Fact]
+    public void FindChangesNeedingRestart_ARelevanceFilterTurnedOn_RefusesTheSwitchAndNotTheNumbersBesideIt()
+    {
+        // Arrange
+        var candidate = Declared();
+        candidate.RelevanceFilter.Enabled = true;
+        candidate.RelevanceFilter.MinimumRelevance = 70;
+
+        var composed = Declared();
+        composed.RelevanceFilter.MinimumRelevance = 50;
+
+        // Act
+        var errors = ChatDeclarationRules.FindChangesNeedingRestart(candidate, composed);
+
+        // Assert
+        Assert.Contains(errors, error => error.StartsWith("Chat:RelevanceFilter:Enabled — ", StringComparison.Ordinal));
+        Assert.Single(errors);
+    }
+
+    [Fact]
+    public void FindChangesNeedingRestart_WithoutADeclarationToCompare_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => ChatDeclarationRules.FindChangesNeedingRestart(null!, Declared()));
+        Assert.Throws<ArgumentNullException>(() => ChatDeclarationRules.FindChangesNeedingRestart(Declared(), null!));
+    }
+
+    private static ChatModelOptions Declared() => new()
+    {
+        Alias = "answering",
+        Model = "a-chat-model",
+        ApiKey = new ConfiguredSecret { SecretReference = "env:CHAT_KEY" },
+    };
+}

--- a/tests/Host.UnitTests/Configuration/Chat/ChatGenerationPlanSourceTests.cs
+++ b/tests/Host.UnitTests/Configuration/Chat/ChatGenerationPlanSourceTests.cs
@@ -1,0 +1,102 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Chat;
+using MailFathom.Host.UnitTests.TestDoubles;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Chat;
+
+/// <summary>Covers the value that turns a reloadable declaration into the plan a question is answered through.</summary>
+/// <remarks>
+/// What these establish is the reload contract of the chat section: a corrected model reaches the next question without
+/// a restart, and a question already holding a plan is unaffected by the correction.
+/// </remarks>
+public sealed class ChatGenerationPlanSourceTests
+{
+    [Fact]
+    public void Current_ADeclaredEndpoint_BuildsThePlanThatDeclarationDescribes()
+    {
+        // Arrange
+        var source = new ChatGenerationPlanSource(
+            new StubSettingsSnapshot<ChatModelOptions>(Declaring("a-chat-model")));
+
+        // Act
+        var plan = source.Current;
+
+        // Assert
+        Assert.Equal("a-chat-model", plan.Endpoint.RoutedModelName);
+    }
+
+    /// <summary>The whole point of the source: an operator correcting a model the provider refused pays an edit rather than a restart.</summary>
+    [Fact]
+    public void Current_AfterTheDeclarationIsRepublished_BuildsThePlanTheNewOneDescribes()
+    {
+        // Arrange
+        var published = new StubSettingsSnapshot<ChatModelOptions>(Declaring("a-refused-model"));
+        var source = new ChatGenerationPlanSource(published);
+
+        _ = source.Current;
+
+        // Act
+        published.Current = Declaring("a-corrected-model");
+
+        // Assert
+        Assert.Equal("a-corrected-model", source.Current.Endpoint.RoutedModelName);
+    }
+
+    /// <summary>A run holds the plan it began with, so a reload that lands mid-question changes the next question and not that one.</summary>
+    [Fact]
+    public void Current_APlanTakenBeforeTheDeclarationMoved_GoesOnDescribingTheModelItWasTakenWith()
+    {
+        // Arrange
+        var published = new StubSettingsSnapshot<ChatModelOptions>(Declaring("the-model-the-run-began-with"));
+        var source = new ChatGenerationPlanSource(published);
+        var planTheRunHolds = source.Current;
+
+        // Act
+        published.Current = Declaring("a-model-declared-mid-run");
+
+        // Assert
+        Assert.Equal("the-model-the-run-began-with", planTheRunHolds.Endpoint.RoutedModelName);
+        Assert.Equal("a-model-declared-mid-run", source.Current.Endpoint.RoutedModelName);
+    }
+
+    /// <summary>One published declaration is one plan, so reading it on every request and every client the factory builds costs nothing.</summary>
+    [Fact]
+    public void Current_ReadTwiceOverOneDeclaration_AnswersWithTheSamePlan()
+    {
+        // Arrange
+        var source = new ChatGenerationPlanSource(
+            new StubSettingsSnapshot<ChatModelOptions>(Declaring("a-chat-model")));
+
+        // Act
+        var first = source.Current;
+        var second = source.Current;
+
+        // Assert
+        Assert.Same(first, second);
+    }
+
+    /// <summary>Registered only where an endpoint was declared and protected by a reload rule that refuses its removal, so the absence is a contradiction rather than a state.</summary>
+    [Fact]
+    public void Current_ADeclarationCarryingNoEndpoint_RefusesRatherThanAnswering()
+    {
+        // Arrange
+        var source = new ChatGenerationPlanSource(
+            new StubSettingsSnapshot<ChatModelOptions>(new ChatModelOptions()));
+
+        // Act
+        var refusal = Assert.Throws<InvalidOperationException>(() => source.Current);
+
+        // Assert
+        Assert.Contains("declared at registration", refusal.Message, StringComparison.Ordinal);
+    }
+
+    private static ChatModelOptions Declaring(string model) => new()
+    {
+        Alias = "answering",
+        Model = model,
+    };
+}

--- a/tests/Host.UnitTests/Configuration/Chat/ChatSettingsReloadValidatorTests.cs
+++ b/tests/Host.UnitTests/Configuration/Chat/ChatSettingsReloadValidatorTests.cs
@@ -1,0 +1,151 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration;
+using MailFathom.Host.Configuration.Answering;
+using MailFathom.Host.Configuration.Chat;
+using MailFathom.Host.Configuration.Embeddings;
+using MailFathom.Host.Configuration.Persistence;
+using MailFathom.Host.UnitTests.TestDoubles;
+using MailFathom.Infrastructure;
+using MailFathom.Infrastructure.Certificates;
+using MailFathom.Infrastructure.Persistence.Connections;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Chat;
+
+/// <summary>Covers what a reloaded chat declaration has to prove before it becomes the one new questions run through.</summary>
+/// <remarks>
+/// Everything reported here leaves the previous declaration serving, which is the behavior that makes the section
+/// reloadable at all: an operator correcting a model has to be able to correct a mistake in the correction.
+/// </remarks>
+public sealed class ChatSettingsReloadValidatorTests
+{
+    [Fact]
+    public async Task FindConfigurationErrorsAsync_ACorrectedModel_IsAdoptable()
+    {
+        // Arrange
+        var candidate = Declared();
+        candidate.Model = "a-corrected-model";
+
+        // Act
+        var errors = await ValidatorOver(Declared())
+            .FindConfigurationErrorsAsync(candidate, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>The credential is proven here and resolved again per request, so a reference repointed to nothing is refused rather than published.</summary>
+    [Fact]
+    public async Task FindConfigurationErrorsAsync_AKeyReferenceThatResolvesToNothing_IsRefused()
+    {
+        // Arrange
+        var candidate = Declared();
+        candidate.ApiKey = new ConfiguredSecret { Name = "chat-key", SecretReference = "env:NOTHING_PROVISIONS_THIS" };
+
+        // Act
+        var errors = await ValidatorOver(Declared())
+            .FindConfigurationErrorsAsync(candidate, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("Chat:ApiKey", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task FindConfigurationErrorsAsync_ABoundOutsideItsRange_IsRefused()
+    {
+        // Arrange
+        var candidate = Declared();
+        candidate.MaxMessagesPerRequest = 0;
+
+        // Act
+        var errors = await ValidatorOver(Declared())
+            .FindConfigurationErrorsAsync(candidate, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Contains(errors, error => error.StartsWith("Chat:MaxMessagesPerRequest — ", StringComparison.Ordinal));
+    }
+
+    /// <summary>Which services exist was decided while the host composed itself, so removing the endpoint is a restart rather than a reload.</summary>
+    [Fact]
+    public async Task FindConfigurationErrorsAsync_ARemovedEndpoint_IsRefusedAsNeedingARestart()
+    {
+        // Act
+        var errors = await ValidatorOver(Declared())
+            .FindConfigurationErrorsAsync(new ChatModelOptions(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("needs a restart", StringComparison.Ordinal));
+    }
+
+    /// <summary>The alias uniqueness rule spans two sections and is enforced on every reload, not only at startup.</summary>
+    [Fact]
+    public async Task FindConfigurationErrorsAsync_AnAliasRenamedOntoAnEmbeddingEndpoint_IsRefused()
+    {
+        // Arrange
+        var embeddings = new EmbeddingOptions();
+        embeddings.Endpoints.Add(new EmbeddingEndpointOptions
+        {
+            Alias = "indexing",
+            Model = "an-embedding-model",
+            Dimension = 4,
+        });
+
+        var candidate = Declared();
+        candidate.Alias = "indexing";
+
+        // Act
+        var errors = await ValidatorOver(Declared(), embeddings)
+            .FindConfigurationErrorsAsync(candidate, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("both declare the alias 'indexing'", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task FindConfigurationErrorsAsync_WithoutACandidate_IsRefused()
+    {
+        // Arrange
+        var validator = ValidatorOver(Declared());
+
+        // Act, Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => validator.FindConfigurationErrorsAsync(null!, TestContext.Current.CancellationToken));
+    }
+
+    private static ChatSettingsReloadValidator ValidatorOver(
+        ChatModelOptions composed,
+        EmbeddingOptions? embeddings = null) =>
+        new(
+            SecretValidator(),
+            composed,
+            embeddings,
+            new MailAnsweringOptions());
+
+    private static SecretConfigurationValidator SecretValidator()
+    {
+        var resolver = new PlaintextOnlySecretReferenceResolver();
+
+        return new SecretConfigurationValidator(
+            resolver,
+            new TrustAnchorLoader(resolver),
+            new DatabaseConnectionSettingsMapper(new ConfigurationBuilder().Build()),
+            new StubDatabaseConnectionSettingsValidator(),
+            PostgresTextSearchConfiguration.Default,
+            new DatabaseCommandTimeout(TimeSpan.FromSeconds(HostApplicationBuilderExtensions.DefaultDatabaseCommandTimeoutSeconds)),
+            new FakeTimeProvider(new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero)),
+            new RecordingLogger<SecretConfigurationValidator>());
+    }
+
+    private static ChatModelOptions Declared() => new()
+    {
+        Alias = "answering",
+        Model = "a-chat-model",
+        ApiKey = new ConfiguredSecret { Name = "chat-key", SecretReference = "plaintext:the-chat-key" },
+    };
+}

--- a/tests/Host.UnitTests/Configuration/Providers/ConfiguredProviderEndpointCredentialSourceTests.cs
+++ b/tests/Host.UnitTests/Configuration/Providers/ConfiguredProviderEndpointCredentialSourceTests.cs
@@ -6,6 +6,7 @@ using MailFathom.AI.Providers;
 using MailFathom.Host.Configuration.Chat;
 using MailFathom.Host.Configuration.Embeddings;
 using MailFathom.Host.Configuration.Providers;
+using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using MailFathom.Infrastructure.Secrets.References;
 using MailFathom.Infrastructure.Secrets.Resolution;
@@ -153,7 +154,7 @@ public sealed class ConfiguredProviderEndpointCredentialSourceTests
 
         return new ConfiguredProviderEndpointCredentialSource(
             Options.Create(embeddings),
-            Options.Create(chat),
+            new StubSettingsSnapshot<ChatModelOptions>(chat),
             resolver);
     }
 


### PR DESCRIPTION
Every key under `Chat` was frozen while the host composed itself. The generation plan was mapped into a singleton at registration, so correcting a model the provider refused meant restarting a process that is synchronizing mailboxes and holding an IMAP IDLE connection — and picking a model is exactly the setting an operator iterates on, because a wrong one is only discovered from a refusal on a real question.

## What changed

The chat declaration now runs through the same validated-snapshot path the mail, persistence, and data-encryption sections already use.

- `ValidatedSettingsSnapshot<ChatModelOptions>` publishes the declaration in force, and `ChatGenerationPlanSource` maps it to one plan per published declaration.
- The plan is **scoped** rather than a singleton, so one scope — one question — resolves it once and holds it. A reload landing mid-question changes the next question and not that one, which is what keeps a run from answering half a question in one model's voice and half in another's. `IChatModelClient` is scoped for the same reason; the transport's own bounds are read from the plan source, because the factory builds a client on the root provider.
- The credential source reads the snapshot rather than `IOptions`, which is what lets a declared alias be renamed without stranding the lookup its credential and its resilience circuit are keyed by.
- `PassageRelevanceFilterPlan` follows the same way: its two numbers are a lookup's.

## What a reloaded candidate has to prove

`ChatDeclarationRules` is one reading, used by composition and by the reload validator, so a rule cannot hold at startup and lapse on reload: the section's own bounds, the deployment-wide alias uniqueness against every embedding endpoint, the relevance filter's agreement with what a retrieval hands over, plus the secret references the declaration carries. A candidate that breaks one is logged with the key to fix, the previous declaration goes on answering, and the process stays up.

The section is bound **without** `ValidateDataAnnotations` for that last guarantee. The options framework materializes a reloaded value on the thread the configuration provider reported the change from, where a validation failure has nowhere to be reported and the candidate is dropped without a word; running the same validator from the two places that *can* report it is what turns a mistyped bound into a logged refusal rather than silence. Startup reports the same failures, aggregated, and earlier than `ValidateOnStart` did.

## What still takes a restart

The two settings that decided which services this deployment registered, refused with that message rather than adopted and quietly ignored:

- whether `Chat:Alias` names an endpoint at all — going from no chat section to one, or the reverse. *Renaming* a declared alias reloads.
- whether `Chat:RelevanceFilter:Enabled` turns the second retrieval pass on.

## Contract surfaces

No break. Every key keeps its name, its type, and its meaning; what changed is when it is read. `docs/operations/configuration-reference.md` moves the affected rows from `restart` to `reload` and states the two that stay, and `docs/features/chat-generation.md` gains a section on what a reload changes and what it does not. [ADR 0002](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0002-configuration-reading-mapping-and-reload-boundary.md) already classifies a group like this as reloadable for new operations, so no ADR change was needed.

One deliberate scope note: `Chat` stays outside the startup secret gate, so an unresolvable key there is still reported by the first question rather than failing the host. A chat provider is an optional capability whose absence degrades an instance rather than breaking it, and taking a deployment that serves search perfectly well offline at startup would be the worse trade. The remark in `ValidatedSettingsSnapshot` that claimed otherwise is corrected in this change.

## Verification

`scripts/verify-full.sh` green: 4423 tests, 0 failed, aggregate line coverage 95.14% against the 85% gate. New unit tests cover the plan source (including the in-flight guarantee and the reload), the declaration rules, and the reload validator.

Closes #623
