### PR TITLE
[#638] Say on Docker Hub what get_email_content actually returns

### DIFF
--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -24,7 +24,7 @@ An agent gets five tools, and they are the whole surface:
 | `list_accounts` | Which mailboxes this deployment serves, each with the readable name you gave it and how current its local copy is — the tool an agent calls first, so it knows what to narrow the others to |
 | `list_emails` | A page of the timeline, newest first, filtered by account, folder, sender, recipient, subject, date range, seen state, or attachment presence |
 | `search_emails` | Ranked matches for a text query across subjects, participants, and body text, each with short extracts around what matched — ranked lexically, and by embedding similarity beside it once an embedding model is configured |
-| `get_email_content` | Up to ten messages in full: normalized headers, plain-text body, optionally sanitized HTML, and attachment names, types, and sizes — never attachment bytes |
+| `get_email_content` | Up to ten messages in full: normalized headers, plain-text body, optionally sanitized HTML, and every attachment by name, type, and size — plus the files themselves as base64 when a call asks for them, which is off by default and bounded per attachment and per call |
 | `ask_mail` | A question answered from the mail a chat model looks up while answering, citing the identifiers of every message it drew on |
 
 The first four are always there. `ask_mail` needs a chat model and an embedding model you configure and point at, so a deployment with neither does not advertise it at all.


### PR DESCRIPTION
`deploy/docker/README.md` is the Docker Hub repository overview, and its tool table still said `get_email_content` returns "attachment names, types, and sizes — never attachment bytes". That stopped being true when #629 landed. The root `README.md` was corrected in the same change; this file was not, so the two documents rendered outside the repository contradicted each other about the one question a reader sizes before enabling the endpoint — whether whole files leave the process.

## What changed

The `get_email_content` row now states that every attachment is described by name, type, and size, and that the files themselves come back as base64 when a call asks for them — off by default, and bounded per attachment and per call. Verified against `src/Mcp/Tools/GetEmailContentTool.cs:87,97` and `src/Host/Configuration/Persistence/EmailContentOptions.cs:75,85`.

## The rest of the file, read in the same pass

The acceptance asked for the whole overview to be checked for the same drift, since it was written against a surface that has moved more than once. Nothing else was found untrue:

- the other four tool rows match `README.md:50-54` verbatim in substance, including the `list_accounts` row that #635 moved;
- the tag table matches `docs/operations/container-image.md:211-257`;
- the image properties match `deploy/docker/Dockerfile` — base `10.0.10-noble-chiseled-extra`, uid `1654`, `EXPOSE 8080 8081`, `DOTNET_EnableDiagnostics=0`, `dotnet /app/MailFathom.Host.dll`, no `HEALTHCHECK`;
- the Compose block matches `docs/operations/deployment-compose.md:31-44` and the assets under `deploy/compose/`;
- the verification paragraph matches `.github/workflows/publish-container-image.yml:353-361`.

Two things are deliberately left alone rather than overlooked. The administrative endpoint gets no row in the ports table, because it is off in this image and takes no port of its own — the Dockerfile states that where the `EXPOSE` line is. And `specs/2026-07-22-mail-fathom-architecture-draft.md` still names four tools; it is a dated draft rather than documentation of what ships.

## Breaking changes

None. No public surface moves — this is a documentation correction.

Closes #638
