### PR TITLE
[#653] Log EF Core executed commands at Debug rather than Information

### DIFF
--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -779,6 +779,15 @@ among the framework-shaped entries exempt from the strict binding above — a ke
 framework's to accept or to ignore, so a misspelling here leaves a default in force instead of failing startup with
 the path.
 
+**Executed SQL is a `Debug` record.** EF Core reports every command it runs through
+`Microsoft.EntityFrameworkCore.Database.Command`, at `Information` in the library's own configuration. MailFathom logs
+that one event at `Debug` instead, because a synchronization run, a backfill sweep, and every MCP read reach the
+database repeatedly, and one record per round trip would leave the stream mostly SQL. What is lowered is the level of
+the event rather than a filter over the category, so the records come back by asking for them — set
+`Logging:LogLevel:Microsoft.EntityFrameworkCore.Database.Command` to `Debug` for the commands alone, or `Default`
+where a whole run is being read. A command that *fails* is untouched and stays in the default stream: only the
+executed-command event is lowered, and every other EF Core event keeps the level the library gives it.
+
 Select `json` where something parses the stream rather than reads it, and `systemd` where `journalctl` should read
 the level rather than print it as text. Both are worth setting deliberately: `simple` is the default because it is
 what a person reading `docker compose logs` wants, and it is the wrong shape for everything downstream of that.

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -60,6 +60,7 @@ using MailFathom.Infrastructure.Secrets.Sources;
 using MailFathom.Infrastructure.Security.OAuth;
 using MailKit.Net.Imap;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Npgsql;
@@ -195,8 +196,16 @@ public static class ServiceCollectionExtensions
         // every write at session start rather than merely leave it un-retried. Adopting it instead means handing each
         // unit of work to Database.CreateExecutionStrategy().ExecuteAsync so the strategy can replay it whole, and
         // dropping OutboundDependency.DatabaseCommandExecution from those paths so the two never stack.
-        services.AddDbContext<MailFathomDbContext>((provider, options) =>
-            options.UseNpgsql(provider.GetRequiredService<NpgsqlDataSource>(), npgsql => npgsql.UseVector()));
+        // EF Core reports every executed command at Information, which is one record per round trip and therefore most
+        // of what a deployment writes: a synchronization run, a backfill sweep, and every MCP read reach the database
+        // repeatedly, so the records an operator is reading for are buried among the SQL that served them. Lowering the
+        // event to Debug is not the same as filtering the category out, which would remove the records at every level:
+        // they stay reachable through Logging:LogLevel:Microsoft.EntityFrameworkCore.Database.Command, which is what a
+        // slow or unexpected query is diagnosed with. Only this event moves, so a failed command still surfaces at its
+        // own level.
+        services.AddDbContext<MailFathomDbContext>((provider, options) => options
+            .UseNpgsql(provider.GetRequiredService<NpgsqlDataSource>(), npgsql => npgsql.UseVector())
+            .ConfigureWarnings(warnings => warnings.Log((RelationalEventId.CommandExecuted, LogLevel.Debug))));
         services.AddScoped<IPersistenceSessionFactory, PersistenceSessionFactory>();
         services.AddScoped<ISynchronizationCheckpointStore, SynchronizationCheckpointStore>();
         // Registered here rather than beside the chunker it calls, because what it is is a table: it decides which

--- a/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -8,10 +8,15 @@ using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Emails.SearchEmails;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
+using MailFathom.Infrastructure.Persistence;
 using MailFathom.Infrastructure.Persistence.Connections;
 using MailFathom.Infrastructure.Secrets.Resolution;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Npgsql;
 using Xunit;
 
@@ -69,6 +74,33 @@ public sealed class ServiceCollectionExtensionsTests
         Assert.Same(provider.GetRequiredService<NpgsqlDataSource>(), provider.GetRequiredService<NpgsqlDataSource>());
         Assert.IsNotAssignableFrom<IDisposable>(connectionStringProvider);
         Assert.IsNotAssignableFrom<IAsyncDisposable>(connectionStringProvider);
+    }
+
+    /// <summary>
+    /// One record per database round trip is most of what a deployment writes, so the executed-command event is
+    /// emitted at <see cref="LogLevel.Debug" /> rather than at the <see cref="LogLevel.Information" /> EF Core
+    /// defaults to. The distinction the assertion holds is against filtering the category out: the level is configured
+    /// on the event, so lowering the category's minimum brings the records back, and every other event — a failed
+    /// command above all — keeps the level EF Core chose for it.
+    /// </summary>
+    [Fact]
+    public async Task AddInfrastructure_AfterStartup_LogsAnExecutedCommandAtDebugAndLeavesAFailedOneAtItsOwnLevel()
+    {
+        // Arrange
+        await using var provider = BuildConfiguredProvider();
+        var connectionStringProvider = provider.GetServices<IHostedService>()
+            .OfType<IHostedLifecycleService>()
+            .Single();
+        await connectionStringProvider.StartingAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var coreOptions = provider.GetRequiredService<DbContextOptions<MailFathomDbContext>>()
+            .FindExtension<CoreOptionsExtension>();
+
+        // Assert
+        Assert.NotNull(coreOptions);
+        Assert.Equal(LogLevel.Debug, coreOptions.WarningsConfiguration.GetLevel(RelationalEventId.CommandExecuted));
+        Assert.Null(coreOptions.WarningsConfiguration.GetLevel(RelationalEventId.CommandError));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #653

## What changes

`AddInfrastructure` now registers the context with
`ConfigureWarnings(warnings => warnings.Log((RelationalEventId.CommandExecuted, LogLevel.Debug)))`, so
`Executed DbCommand` is a `Debug` record rather than the `Information` one EF Core emits by default. One
record per database round trip is most of what a deployment writes — a synchronization run, a backfill
sweep, and every MCP read reach the database repeatedly — so the records an operator is reading for sit
among the SQL that served them.

Two things this deliberately is not, both decided here rather than derived:

- **Not a log filter.** `Logging:LogLevel:Microsoft.EntityFrameworkCore.Database.Command = Warning` would
  remove the records at every level, so an operator diagnosing a slow query could not get them back. The
  level is configured on the event instead, which leaves
  `Logging:LogLevel:Microsoft.EntityFrameworkCore.Database.Command` (or `Default`) set to `Debug` as the
  way to read them again. `appsettings.json` is untouched.
- **Not the design-time context.** `MailFathomDbContextDesignTimeFactory` keeps EF Core's default, because
  `dotnet ef` applying a migration is the case in which seeing the SQL at `Information` is wanted.

Only that one event moves. `RelationalEventId.CommandError` and every other EF Core event keep the level
the library gives them, so a failed command still surfaces in the default stream — which is what the test
asserts alongside the lowered level.

The enrichment in `AddDatabaseHealthAndTelemetry` composes with this rather than replacing it: it patches
the Npgsql relational extension for the command timeout, and the warnings configuration lives on the core
options extension.

## How it was verified

- `bash scripts/verify-full.sh` — pass. 4564 tests, 0 failed; aggregate line coverage 95.17% (13168/13837),
  required 85%.
- One test added, `AddInfrastructure_AfterStartup_LogsAnExecutedCommandAtDebugAndLeavesAFailedOneAtItsOwnLevel`,
  which resolves `DbContextOptions<MailFathomDbContext>` from the registered container and reads the
  configured level off `CoreOptionsExtension.WarningsConfiguration` — `Debug` for `CommandExecuted`, and
  unset for `CommandError`.
- `bash scripts/review-obligations.sh` — the test row is covered by the file above; its documentation row
  named `docs/architecture/outbound-resilience.md`, whose telemetry section is about Polly's own logging
  and says nothing that this changes.
- The `WarningsConfigurationBuilder.Log((EventId, LogLevel))` overload and
  `WarningsConfiguration.GetLevel(EventId)` were checked against the current EF Core 10 API reference.
- Not verified by an automated check: that the emitted stream is quieter on a running deployment. Nothing
  in the unit suite reaches a database, and the integration suite runs only on request.

## Checklist

- [x] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [x] Behavior changes are covered by unit tests, and the coverage gate passes.
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail.
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.
