### PR TITLE
[#665] Assert the stop each chat API reports in the provider contract test

### DIFF
--- a/tests/IntegrationTests/ProviderAdapters/ChatProviderContractTests.cs
+++ b/tests/IntegrationTests/ProviderAdapters/ChatProviderContractTests.cs
@@ -89,9 +89,16 @@ public sealed class ChatProviderContractTests
         // that expected a particular word would fail on a correct answer phrased differently.
         Assert.False(string.IsNullOrWhiteSpace(answer.Text));
 
-        // Both stops are a real answer. A model that spends its budget reasoning reaches the ceiling on a question this
-        // short, and the text before the cut is still what the adapter had to return.
-        ChatGenerationStop[] answered = [ChatGenerationStop.Completed, ChatGenerationStop.OutputLimitReached];
+        // Which stop a finished answer carries belongs to the surface rather than to the model: chat completions names
+        // the reason generation stopped, while the responses API names one only where it stopped early, so an answer
+        // that simply finished reaches the port unreported. Both stops below are a real answer either way — a model
+        // that spends its budget reasoning reaches the ceiling on a question this short, and the text before the cut is
+        // still what the adapter had to return.
+        var finished = api is ChatProviderApi.Responses
+            ? ChatGenerationStop.Unreported
+            : ChatGenerationStop.Completed;
+
+        ChatGenerationStop[] answered = [finished, ChatGenerationStop.OutputLimitReached];
         Assert.Contains(answer.Stop, answered);
 
         // Usage is what a spend ceiling is measured in, so a provider that reports none is worth knowing about here


### PR DESCRIPTION
The chat provider contract test asserted `[Completed, OutputLimitReached]` over both request APIs, and the responses API can report neither for an answer that simply finished. That surface names an outcome rather than a finish reason, so `Microsoft.Extensions.AI.OpenAI` derives one from `IncompleteStatusDetails.Reason` alone on the non-streaming path — a content filter and a max-output-token cut, nothing else — and a completed answer arrives with none. `ProviderChatModelClient` reads that as `Unreported` deliberately: claiming a completion the provider never stated is the one thing the mapping refuses to do everywhere else, and both the unit tests and `docs/features/chat-generation.md` carry that reading already.

So the `api: Responses` case could only ever have passed on a run whose model exhausted its output budget. It went unseen because a provider-contract test is skipped unless a dispatch asks for one, and the first run that asked reported the failure:

```
Assert.Contains() Failure: Item not found in collection
Collection: [Completed, OutputLimitReached]
Not found:  Unreported
```

The expected stop now follows the surface under test — `Completed` over chat completions, `Unreported` over the responses API — with `OutputLimitReached` accepted on both, since a model that spends its budget reasoning reaches the ceiling on a question this short either way.

No production behaviour changes: the adapter's mapping, the port's stop values, and the documented reading are untouched, and no page said anything about the assertion that stopped being true.

Verification of the assertion itself needs a dispatch of `Integration tests` with `run_ai_provider_contract_tests` turned on, which is the owner's call because it spends provider credit.

Breaking change: none.

Closes #665
