### PR TITLE
[#667] Name security@mailfathom.org as the private reporting channel

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ Behavior outside those spaces is in scope only where it makes participation here
 
 ## Reporting
 
-Email <security-mail-fathom@impe.pl>. It reaches the maintainer directly and privately, and it is the same address the [security policy](SECURITY.md) uses, because both need a channel nobody else reads.
+Email <security@mailfathom.org>. It reaches the maintainer directly and privately, and it is the same address the [security policy](SECURITY.md) uses, because both need a channel nobody else reads.
 
 A useful report says what happened, where, and when — links help. Reporting something that turns out not to be a violation carries no cost; the only thing that reliably goes wrong here is an incident nobody mentioned.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ MailFathom holds mailbox credentials, OAuth tokens, certificate material, and a 
 
 Report it privately, through either channel:
 
-- **Email <security-mail-fathom@impe.pl>.** This channel always works and needs no GitHub account. Encrypt if you prefer; ask in a first message carrying no details and a key will be supplied.
+- **Email <security@mailfathom.org>.** This channel always works and needs no GitHub account. Encrypt if you prefer; ask in a first message carrying no details and a key will be supplied.
 - **GitHub private vulnerability reporting** — the *Report a vulnerability* button on the repository's **Security** tab, or [this form](https://github.com/Krzysztof318/MailFathom/security/advisories/new) directly. It needs a GitHub account and opens a draft security advisory, which is where the fix, the credit, and any CVE request are then handled.
 
 A useful report contains the affected version or commit, the configuration the issue needs, reproduction steps or a proof of concept, and what an attacker gains. Say so explicitly if you intend to publish, and when.


### PR DESCRIPTION
Closes #667

`SECURITY.md` and `CODE_OF_CONDUCT.md` both directed a private report to an address on a domain
unrelated to the project. Both now name `security@mailfathom.org`, which is the project's own
address and the one channel the two documents promise nobody else reads.

Nothing else in either file changes, and the sentences that depend on the address stay true:
`SECURITY.md` still tells a researcher to send a reminder "to the same address", and
`CODE_OF_CONDUCT.md` still says the conduct channel is the address the security policy uses.

No other file in the repository carried the address — the issue templates and `README.md` link to
`SECURITY.md` rather than repeating it — so no occurrence of the old domain remains.

## Contract surfaces

None. This touches no MCP tool contract, configuration key, database schema, or deployment
contract, so nothing here is a break to record.

## Verification

- `scripts/verify-full.sh` — pass, aggregate line coverage 95.15%.
- `scripts/test-agent-workflow.sh` — 145 passed, 0 failed.
- `scripts/review-obligations.sh` — no production file changed, no `describes:` marker covers either
  path, no register triggered.
