### PR TITLE
[#669] Correct the PostgreSQL 17 to 18 upgrade procedure, which described a failure that does not happen

### DIFF
--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -240,23 +240,47 @@ enough.
 ### Upgrading a deployment that ran PostgreSQL 17
 
 The database image is now `pgvector/pgvector:0.8.6-pg18`, and PostgreSQL does not read a data directory written by an
-earlier major version. **An existing volume is not upgraded in place by bringing the new image up** — it is a different
-data directory entirely, because PostgreSQL 18 moved this image's `PGDATA` into a version-specific subdirectory and the
-Compose file now mounts the volume at the parent that holds it. A server started against the old volume initializes an
-empty database beside the one that is there and comes up with no mail in it.
+earlier major version. **An existing volume is not upgraded in place by bringing the new image up**, and what that
+costs is worth knowing before it happens rather than after: PostgreSQL 18 moved this image's `PGDATA` into a
+version-specific subdirectory and the Compose file now mounts the volume at the parent that holds it, so the image
+finds a PostgreSQL 17 data directory where it expects that parent and **refuses to start**. The container exits `1`
+carrying the image's own message — *there appears to be PostgreSQL data in: `/var/lib/postgresql`* — the server never
+listens, the health check never passes, and nothing that depends on it comes up. The attempt writes nothing, so the
+old data directory is intact and still dumpable afterwards.
 
-Move the data across a dump, which is the migration path between majors:
+Move the data across a dump, which is the migration path between majors. The dump has to come from a running
+PostgreSQL 17 server, and the upgraded Compose file no longer starts one, so the first step is getting that server
+back — against the same volume, mounted where 17 expects it:
 
 ```bash
-docker compose exec -T postgres pg_dump --username mailfathom --format custom mailfathom > mailfathom-pg17.dump
-
 docker compose down
+
+docker run --detach --name mailfathom-pg17 \
+  --volume mailfathom-postgres-data:/var/lib/postgresql/data \
+  pgvector/pgvector:0.8.2-pg17                      # whichever image the deployment ran before the upgrade
+
+docker exec mailfathom-pg17 \
+  pg_dump --username mailfathom --format custom --exclude-extension=vector mailfathom > mailfathom-pg17.dump
+docker rm --force mailfathom-pg17
+
 docker volume rm mailfathom-postgres-data           # or MAILFATHOM_POSTGRES_VOLUME, if you named it
 docker compose up -d postgres                       # initializes 18 and re-creates the role, database, and extension
 
-docker compose exec -T postgres pg_restore --username mailfathom --dbname mailfathom --clean --if-exists < mailfathom-pg17.dump
+docker compose exec -T postgres pg_restore --username mailfathom --dbname mailfathom < mailfathom-pg17.dump
 docker compose up -d
 ```
+
+Two details of those commands are what keep the restore clean, and both follow from the database being owned by an
+unprivileged role. The dump **excludes the `vector` extension**, because the extension belongs to initialization rather
+than to the data: a superuser installs it, `mailfathom` does not own it, and a dump carrying it makes `pg_restore`
+fail on `COMMENT ON EXTENSION` with `must be owner of extension vector`. The restore takes **no `--clean`**, because
+the database it restores into was created moments earlier and holds nothing to drop — and `--clean` would reach for
+that same extension. Either one left in place ends the restore at exit `1` with the rows already in, which reads like a
+failed migration and is not one.
+
+Neither `pg_dump` nor `pg_restore` passes a password, because both reach the server over its Unix socket from inside
+the container, where the image's own `initdb` left local connections trusted. Nothing on the `backend` network can
+take that path: `pg_hba.conf` answers a connection arriving from there with `scram-sha-256`.
 
 Resynchronizing from IMAP instead of restoring is also a complete answer, and a slower one: delete the volume, bring the
 deployment up, apply the schema artifact, and let synchronization refill it. What it costs beyond time is everything

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -217,6 +217,19 @@ The AppHost PostgreSQL resource uses the `pgvector/pgvector:0.8.6-pg18` image so
 
 That volume is mounted at `/var/lib/postgresql` rather than through Aspire's `WithDataVolume`, which would choose the wrong path here. PostgreSQL 18 moved the image's data directory into a version-specific subdirectory and moved the declared volume up to the parent, and Aspire picks between the two by parsing a major version out of the image tag — taking everything before the first `-`, which on a pgvector tag shaped `0.8.6-pg18` is `0.8.6`, and reading the major component of that, which is `0`. The version test therefore never sees 18: it would mount the pre-18 path, the server would write to neither, and the database would live in the container's writable layer until the container was removed. The volume keeps the name `WithDataVolume` would have generated, so it is still one database per checkout.
 
+That name is also the one a checkout used before PostgreSQL 18, which is what a first start after this change runs
+into: the volume holding a PostgreSQL 17 data directory is mounted at the parent path, and the image refuses to start
+against it rather than initializing a second cluster beside it. The container exits `1` saying *there appears to be
+PostgreSQL data in: `/var/lib/postgresql`*, so the server never listens and the resource never becomes healthy. A
+local database is resynchronized rather than preserved, so remove the volume and let the next start build it — the
+deployment path, where the mail is worth a dump and a restore, is
+[Upgrading a deployment that ran PostgreSQL 17](deployment-compose.md#upgrading-a-deployment-that-ran-postgresql-17):
+
+```bash
+docker volume ls --filter name=postgres-data      # one per checkout, named after its AppHost
+docker volume rm <the volume this checkout owns>
+```
+
 The resource is also given a persistent container lifetime, which the ephemeral integration-test topology deliberately
 is not. A session lifetime removes the server on every shutdown and builds it again on the next start — an image check,
 an initialization pass, and a health wait, several times a day, against data that was never in question. A persistent


### PR DESCRIPTION
Closes #669

`docs/operations/deployment-compose.md` § *Upgrading a deployment that ran PostgreSQL 17* described a failure that does not occur, and then gave a recovery procedure that cannot be run from the state it describes and whose commands fail as written. All three are corrected here, each against a reproduction rather than a reading.

## The failure mode was wrong

The page said:

> A server started against the old volume initializes an empty database beside the one that is there and comes up with no mail in it.

It does not. PostgreSQL 18 moved this image's `PGDATA` into a version-specific subdirectory and the Compose file now mounts the volume at the parent, so the image finds a PostgreSQL 17 data directory where it expects that parent and refuses to start — `exit 1`, carrying the upstream message that points at [docker-library/postgres#1259](https://github.com/docker-library/postgres/pull/1259). The server never listens and the health check never passes.

The difference matters to whoever hits it: the old text sends an operator looking for missing mail in a running deployment, when what they have is a database that never started.

## The recovery procedure could not be run

It opened with `docker compose exec -T postgres pg_dump …`, which needs a running server — and by that point the Compose file no longer starts one. The dump now comes from a PostgreSQL 17 server brought up explicitly over the same volume, mounted where 17 expects it.

## Two of its commands failed as written

`pg_restore --clean --if-exists` ends at `exit 1` with `must be owner of extension vector`. The unprivileged role does not own an extension that `10-create-mailfathom-database.sh` installs as a superuser, and `--clean` reaches for it. The rows land regardless, so the operator sees a non-zero exit and error output on what was actually a successful restore — indistinguishable, at a glance, from a failed migration.

The dump now passes `--exclude-extension=vector`, and the restore drops `--clean`: the target database is created moments earlier by the initialization script and holds nothing to drop.

## Local development had the same gap

`docs/operations/local-development.md` said nothing about a volume a checkout wrote under PostgreSQL 17. `VolumeNameGenerator.Generate(postgres, "data")` keeps the name the pre-18 orchestration generated, so every existing checkout meets the same refusal on its first start. Local mail is resynchronized rather than preserved, so the page says to remove the volume and points at the deployment path for the case where the data is worth a dump.

## Verification

Every claim now on the pages was reproduced against the two images the upgrade moves between:

| Claim | Result |
|---|---|
| A pg17 volume mounted at `/var/lib/postgresql` under pg18 | container `exited`, `exit=1`, upstream message |
| The failed attempt leaves the data intact | 3/3 rows readable afterwards, `pg_dump` `exit=0` |
| `--clean --if-exists` fails on the extension | `exit=1`, `must be owner of extension vector`, rows present |
| `--exclude-extension=vector` plus restore without `--clean` | `exit=0`, rows restored, tables still owned by `mailfathom` |
| `pg_dump`/`pg_restore` need no password over the socket | `exit=0`; `pg_hba.conf` answers network connections with `scram-sha-256` |

Gates: `scripts/test-agent-workflow.sh` 145 passed / 0 failed; `scripts/build-docs-site.sh` `exit 0`, 0 errors; `typos` v1.48.0 with `.config/typos.toml` `exit 0`; `scripts/review-obligations.sh` reported no obligations.

`scripts/verify-full.sh` was **waived by the owner** for this change: no C#, no test, and no build input is touched, so the Release build and the test suite would reprove what is already green on `main`.
