### PR TITLE
[#549] Bump main version to 0.6.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
        same assembly identity. InformationalVersion is left to the SDK, which is what composes VersionPrefix,
        VersionSuffix, and SourceRevisionId into the single string the runtime reports. -->
   <PropertyGroup>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
   </PropertyGroup>

--- a/src/AI/packages.lock.json
+++ b/src/AI/packages.lock.json
@@ -428,7 +428,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/src/Cli/packages.lock.json
+++ b/src/Cli/packages.lock.json
@@ -53,7 +53,7 @@
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/src/Host/packages.lock.json
+++ b/src/Host/packages.lock.json
@@ -598,8 +598,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
-          "MailFathom.Application": "[0.5.0, )",
-          "MailFathom.Domain": "[0.5.0, )",
+          "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Domain": "[0.6.0, )",
           "Microsoft.Agents.AI": "[1.15.0, )",
           "Microsoft.Extensions.AI": "[10.8.1, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.8.1, )",
@@ -611,13 +611,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -628,9 +628,9 @@
         "dependencies": {
           "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL": "[13.4.6, )",
           "HtmlSanitizer": "[9.1.974, )",
-          "MailFathom.Application": "[0.5.0, )",
-          "MailFathom.Common": "[0.5.0, )",
-          "MailFathom.Domain": "[0.5.0, )",
+          "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Common": "[0.6.0, )",
+          "MailFathom.Domain": "[0.6.0, )",
           "MailKit": "[4.17.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",
@@ -646,8 +646,8 @@
       "MailFathom.Mcp": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Application": "[0.5.0, )",
-          "MailFathom.Domain": "[0.5.0, )",
+          "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Domain": "[0.6.0, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }
       },

--- a/src/Infrastructure/packages.lock.json
+++ b/src/Infrastructure/packages.lock.json
@@ -710,13 +710,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/src/Mcp/packages.lock.json
+++ b/src/Mcp/packages.lock.json
@@ -130,7 +130,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/AI.UnitTests/packages.lock.json
+++ b/tests/AI.UnitTests/packages.lock.json
@@ -520,8 +520,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
-          "MailFathom.Application": "[0.5.0, )",
-          "MailFathom.Domain": "[0.5.0, )",
+          "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Domain": "[0.6.0, )",
           "Microsoft.Agents.AI": "[1.15.0, )",
           "Microsoft.Extensions.AI": "[10.8.1, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.8.1, )",
@@ -534,7 +534,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/Application.UnitTests/packages.lock.json
+++ b/tests/Application.UnitTests/packages.lock.json
@@ -267,7 +267,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/Cli.UnitTests/packages.lock.json
+++ b/tests/Cli.UnitTests/packages.lock.json
@@ -245,7 +245,7 @@
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -254,7 +254,7 @@
       "mfctl": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Common": "[0.5.0, )",
+          "MailFathom.Common": "[0.6.0, )",
           "System.CommandLine": "[2.0.10, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.10, )"
         }

--- a/tests/Common.UnitTests/packages.lock.json
+++ b/tests/Common.UnitTests/packages.lock.json
@@ -245,7 +245,7 @@
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/Host.UnitTests/packages.lock.json
+++ b/tests/Host.UnitTests/packages.lock.json
@@ -770,8 +770,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
-          "MailFathom.Application": "[0.5.0, )",
-          "MailFathom.Domain": "[0.5.0, )",
+          "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Domain": "[0.6.0, )",
           "Microsoft.Agents.AI": "[1.15.0, )",
           "Microsoft.Extensions.AI": "[10.8.1, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.8.1, )",
@@ -784,13 +784,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -799,12 +799,12 @@
       "MailFathom.Host": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.AI": "[0.5.0, )",
-          "MailFathom.Application": "[0.5.0, )",
-          "MailFathom.Common": "[0.5.0, )",
-          "MailFathom.Domain": "[0.5.0, )",
-          "MailFathom.Infrastructure": "[0.5.0, )",
-          "MailFathom.Mcp": "[0.5.0, )",
+          "MailFathom.AI": "[0.6.0, )",
+          "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Common": "[0.6.0, )",
+          "MailFathom.Domain": "[0.6.0, )",
+          "MailFathom.Infrastructure": "[0.6.0, )",
+          "MailFathom.Mcp": "[0.6.0, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.10, )",
           "Microsoft.Extensions.Http.Resilience": "[10.6.0, )",
           "Microsoft.Extensions.ServiceDiscovery": "[10.6.0, )",
@@ -820,9 +820,9 @@
         "dependencies": {
           "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL": "[13.4.6, )",
           "HtmlSanitizer": "[9.1.974, )",
-          "MailFathom.Application": "[0.5.0, )",
-          "MailFathom.Common": "[0.5.0, )",
-          "MailFathom.Domain": "[0.5.0, )",
+          "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Common": "[0.6.0, )",
+          "MailFathom.Domain": "[0.6.0, )",
           "MailKit": "[4.17.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",
@@ -841,8 +841,8 @@
       "MailFathom.Mcp": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Application": "[0.5.0, )",
-          "MailFathom.Domain": "[0.5.0, )",
+          "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Domain": "[0.6.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }

--- a/tests/Infrastructure.UnitTests/packages.lock.json
+++ b/tests/Infrastructure.UnitTests/packages.lock.json
@@ -580,13 +580,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -597,9 +597,9 @@
         "dependencies": {
           "Aspire.Npgsql.EntityFrameworkCore.PostgreSQL": "[13.4.6, )",
           "HtmlSanitizer": "[9.1.974, )",
-          "MailFathom.Application": "[0.5.0, )",
-          "MailFathom.Common": "[0.5.0, )",
-          "MailFathom.Domain": "[0.5.0, )",
+          "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Common": "[0.6.0, )",
+          "MailFathom.Domain": "[0.6.0, )",
           "MailKit": "[4.17.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",

--- a/tests/Mcp.UnitTests/packages.lock.json
+++ b/tests/Mcp.UnitTests/packages.lock.json
@@ -312,7 +312,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -321,8 +321,8 @@
       "MailFathom.Mcp": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Application": "[0.5.0, )",
-          "MailFathom.Domain": "[0.5.0, )",
+          "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Domain": "[0.6.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }

--- a/tests/SharedSources.UnitTests/packages.lock.json
+++ b/tests/SharedSources.UnitTests/packages.lock.json
@@ -248,7 +248,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.5.0, )"
+          "MailFathom.Domain": "[0.6.0, )"
         }
       },
       "MailFathom.Domain": {


### PR DESCRIPTION
Closes #549.

Part two of cutting `0.5.0`. **It merges after the tag, never before**, so `main` returns to naming the *next* release rather than the one just published — and it is what closes the tracking issue, because a release is finished when `main` names `0.6.0` rather than when the changelog merged.

## Merge order

1. #672 — `[#549] Prepare release 0.5.0`. Its merge commit is what gets tagged and published.
2. The annotated `v0.5.0` tag on that merge commit, pushed by the owner.
3. **This pull request.**

## What is in the diff

- `Directory.Build.props` — `<VersionPrefix>` from `0.5.0` to `0.6.0`. It is the only place a version is *written*: the image's tags and labels arrive as build arguments, and the chart's `version` and `appVersion` are both supplied at package time from the same declaration.
- Thirteen `packages.lock.json` files — every `MailFathom.*` project reference they record, from `[0.5.0, )` to `[0.6.0, )`. Regenerated with `dotnet restore MailFathom.slnx --force-evaluate`, which is where the number they hold stops being true.

`deploy/helm/mailfathom/Chart.yaml` is deliberately untouched: its `version` is a `0.0.0` placeholder and it declares no `appVersion`, both of which the release run supplies. The prose files naming the current release belong to #672 for the reason the ordering rests on — this pull request merges after the tag, so a `README.md` corrected here would have been wrong in the tagged tree.

## Verification

The transitive closure did not move. `git diff -U0 -- '**/packages.lock.json'` filtered of `MailFathom.` lines prints nothing, so this is a project-version bump and no dependency change is hiding inside it:

```
$ git diff -U0 -- '**/packages.lock.json' | grep -E '^[+-][^+-]' | grep -v 'MailFathom\.'
(no output)
```

All 45 project references name `0.6.0`, checked against the new version rather than the old one:

```
$ git grep -hoE '"MailFathom\.[A-Za-z]+": "\[[0-9]+\.[0-9]+\.[0-9]+' -- '**/packages.lock.json' | grep -v '0.6.0'
(no output)
```

`scripts/read-declared-version.sh` reports `0.6.0`, and `scripts/verify-full.sh` passed.

**Nothing in that gates the lock-file half**, and it is worth saying so rather than letting a green run imply it. Locked-mode restore does not compare a project reference's version, so lock files left naming `[0.5.0, )` would have restored green in both verification scripts and in every workflow — `NU1004` is what a moved *package* pin produces, not a stale project version. The two greps above are what actually verified this half, by inspection, which is why `docs/operations/release-procedure.md` step 3 keeps it a step rather than a check. What a skipped regeneration costs is paid later: the next `--force-evaluate` writes the truth, so the next pull request moving a central pin would arrive carrying this bump beside it, and its reviewer would have to tell the two apart.

`AppHost` and `IntegrationTests` carry no lock file and were not given one: the Aspire SDK picks part of their graph from the host platform's runtime identifier.

