### PR TITLE
Grep the release smoke test for the abbreviated revision the host reports

### DIFF
--- a/.github/workflows/publish-container-image.yml
+++ b/.github/workflows/publish-container-image.yml
@@ -301,7 +301,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          expected_startup_line="at version ${EXPECTED_VERSION} built from revision ${EXPECTED_REVISION}."
+          # The host abbreviates the revision it reports, so the line to grep for is not the reference this workflow
+          # was handed. StampedAssemblyVersion.Abbreviate shortens the build metadata of InformationalVersion to seven
+          # characters when the whole of it is hexadecimal, and leaves anything else — a workspace revision carrying a
+          # suffix, or the literal `unknown` — as it stands. The rule is mirrored here rather than relaxed into a
+          # prefix match, because what this step exists to prove is that the process reports the commit the registries
+          # will index it under: a match on the version alone would pass an image built from the wrong tree.
+          expected_revision="$EXPECTED_REVISION"
+          if [[ "${#expected_revision}" -gt 7 && "$expected_revision" =~ ^[0-9a-fA-F]+$ ]]; then
+            expected_revision="${expected_revision:0:7}"
+          fi
+
+          expected_startup_line="at version ${EXPECTED_VERSION} built from revision ${expected_revision}."
 
           docker run --detach --name mailfathom-smoke mailfathom:gate > /dev/null
           trap 'docker rm --force mailfathom-smoke > /dev/null 2>&1 || true' EXIT
@@ -345,7 +356,7 @@ jobs:
             exit 1
           fi
 
-          echo "The image starts, reports ${EXPECTED_VERSION} from ${EXPECTED_REVISION}, and publishes the documented runtime contract."
+          echo "The image starts, reports ${EXPECTED_VERSION} from ${expected_revision}, and publishes the documented runtime contract."
 
       # A release publishes nothing when this finds something fixable; a nightly reports and publishes anyway, because a
       # nightly exists to be tried and a blocked one tells nobody what broke. The caller decides which, so the rule lives


### PR DESCRIPTION
The `0.5.0` release run failed in **Publish**, at the image smoke test, before anything reached a registry: [run 31375391065](https://github.com/Krzysztof318/MailFathom/actions/runs/31375391065). The `v0.5.0` tag has been deleted, and re-tagging waits on this merging.

## What broke

The smoke test greps the container's log for the line the host writes at startup and builds the expected text from the full commit reference:

```bash
expected_startup_line="at version ${EXPECTED_VERSION} built from revision ${EXPECTED_REVISION}."
```

The host does not write that. `StampedAssemblyVersion.Abbreviate` shortens the build metadata of `InformationalVersion` to seven characters when the whole of it is hexadecimal, so the process reported

```
at version 0.5.0 built from revision 2304bd6.
```

against an expectation of `... revision 2304bd6984f09cc3d3663386b33abb6bdb4bec60.` — a string that can never appear. The grep never matched, the loop spent its thirty attempts, and the step printed the last forty lines of the container log, which is the host stopping at the database it has no configuration for. **That tail is the correct behaviour and not the failure**; the failure is the line above it.

## Why it surfaced now and not earlier

The abbreviation arrived with #655, which merged after the newest nightly — GHCR's most recent one is `0.5.0-nightly.10-175c950`, built from `175c950`, one commit before it. So `v0.5.0` was the first publication to run this gate against an abbreviating host, and tonight's nightly would have hit it too: `nightly.yml` calls the same reusable workflow and the same step.

## The fix

Mirror the host's rule in the workflow rather than relax the assertion — shorten to seven characters when the reference is entirely hexadecimal, and leave anything else alone, which is what `unknown` and a suffixed workspace revision need. Checked against `StampedAssemblyVersion.Abbreviate` case by case:

| Reference | Expected line carries |
| --- | --- |
| `2304bd6984f09cc3d3663386b33abb6bdb4bec60` | `2304bd6` |
| `2304bd6` | `2304bd6` |
| `unknown` | `unknown` |
| `2304bd69…bec60-dev` | unchanged — not all hexadecimal |

A prefix match on the version alone would have been the shorter change and the wrong one: what this step exists to prove is that the process reports the commit the registries index it under, so an image built from the wrong tree has to fail it.

The success line at the end of the step reported `EXPECTED_REVISION` as well, and now reports what was actually asserted.

## What is deliberately not in this diff

The two `org.opencontainers.image.revision` assertions, at the immutability check and at the published-manifest check, compare a **label** rather than a log line. The label carries the full reference and is correct as it stands.

## Verification

- `scripts/test-agent-workflow.sh` — 145 passed, 0 failed.
- `actionlint` over the changed file reports the same 7 pre-existing `SC2016` infos as `origin/main` does, in an unrelated step; the change adds none.
- The abbreviation branch was executed against the four references in the table above and produced that column.

`scripts/verify-full.sh` was not run, at the owner's instruction and because the diff is one workflow file: no C#, no project file, no lock file.
