### PR TITLE
[#599] Reach a model server on a private address without a credential

### DIFF
--- a/docs/features/chat-generation.md
+++ b/docs/features/chat-generation.md
@@ -1,6 +1,6 @@
 # Chat generation
 
-<!-- describes: src/AI/Chat/**, src/AI/Providers/**, src/AI/ProviderAdapters/Chat*.cs, src/AI/ProviderAdapters/ProviderChatModelClient.cs, src/AI/ProviderAdapters/ProviderCallFailure*.cs, src/Application/Chat/**, src/Application/AiProviders/**, src/Host/Configuration/Chat/**, src/Host/Configuration/Providers/**, src/Host/Hosting/AiProviderHealthCheck.cs, src/Infrastructure/Observability/AiProviderHealthTracker.cs -->
+<!-- describes: src/AI/Chat/**, src/AI/Providers/**, src/AI/ProviderAdapters/Chat*.cs, src/AI/ProviderAdapters/ProviderChatModelClient.cs, src/AI/ProviderAdapters/ProviderCallFailure*.cs, src/Application/Chat/**, src/Application/AiProviders/**, src/Host/Configuration/Chat/**, src/Host/Configuration/Providers/**, src/Host/Hosting/AiProviderHealthCheck.cs, src/Host/Hosting/Warnings/AiProviderTransportEncryptionWarning.cs, src/Infrastructure/Observability/AiProviderHealthTracker.cs -->
 
 Text in, generated text out. This page describes the second kind of outbound AI call MailFathom makes: what a
 deployment declares to enable it, what one call is allowed to spend, what a failing call is classified as, and how an
@@ -75,11 +75,20 @@ There is no vendor and no model identity in the declaration beside the routed na
 embedding endpoint rather than an omission. A vector is stored and later compared against other vectors, so which model
 produced it has to be recorded and proved; an answer is produced, presented, and gone.
 
-**The address rule is the same one, for the same reason.** An address is absolute and HTTPS or startup refuses it,
-because the request carries a credential; an empty address means the provider library's own default, which is the
-first-party OpenAI API, so any other service writes its own address out. [What an address has to
-be](embedding-generation.md#what-an-address-has-to-be) carries the rule and what it costs an operator with a
-plain-HTTP model server.
+**The address and credential rules are the same ones, for the same reasons, and one implementation judges both roles.**
+An address is absolute HTTP or HTTPS; a plain `http` one is refused wherever the endpoint holds a credential, because
+the request would publish it to everything on the path; and exactly one of a provider key, a Microsoft Entra credential,
+and `Unauthenticated` says what a request presents. An empty address means the provider library's own default, which is
+the first-party OpenAI API, so any other service writes its own address out. [What an address has to
+be](embedding-generation.md#what-an-address-has-to-be) and [authentication has three
+shapes](embedding-generation.md#authentication-has-three-shapes) carry both rules with their reasoning.
+
+**A chat model you run yourself is declared here the same way an embedding model is** — the plain address plus
+`"Unauthenticated": true` — and what such a deployment gains and gives up is set out under [a model server you run
+yourself](embedding-generation.md#a-model-server-you-run-yourself). One thing is worth repeating on this page, because
+this role is where it bites hardest: the hop carries the question asked, the mail passages the model is given to answer
+it, and the answer it returns, all readable by anything on the network path. The startup report names the endpoint so
+that fact is visible rather than inferred.
 
 ### A worked example: an endpoint that is neither
 
@@ -161,13 +170,15 @@ tool loop, and without it each turn after the first would begin without what the
 mail it read, which the model then pays to work out again. A model that does not reason returns none, and the request is
 otherwise unchanged.
 
-## Authentication has two shapes
+## Authentication has three shapes
 
-The same two, under the same rules, as an embedding endpoint's: **either** a provider key **or** one of four
-non-interactive Microsoft Entra credentials, never both and never neither. [Embedding generation § Authentication has
-two shapes](embedding-generation.md#authentication-has-two-shapes) states them in full, including why
-`DefaultAzureCredential` is deliberately not used and what rotating each shape costs. One credential source resolves
-both sections, keyed by the alias, which is what the deployment-wide uniqueness rule above exists to make safe.
+The same three, under the same rules and through the same implementation of them as an embedding endpoint's: **exactly
+one** of a provider key, one of four non-interactive Microsoft Entra credentials, and `Unauthenticated`. [Embedding
+generation § Authentication has three
+shapes](embedding-generation.md#authentication-has-three-shapes) states them in full, including why
+`DefaultAzureCredential` is deliberately not used, what rotating each shape costs, and why needing no credential is
+written rather than left out. One credential source resolves both sections, keyed by the alias, which is what the
+deployment-wide uniqueness rule above exists to make safe.
 
 ## The model and its parameters come from configuration
 

--- a/docs/features/embedding-generation.md
+++ b/docs/features/embedding-generation.md
@@ -1,6 +1,6 @@
 # Embedding generation
 
-<!-- describes: src/AI/Embeddings/**, src/AI/Providers/**, src/AI/ProviderAdapters/**, src/Application/Emails/Embeddings/**, src/Host/Configuration/Embeddings/**, src/Host/Configuration/Providers/** -->
+<!-- describes: src/AI/Embeddings/**, src/AI/Providers/**, src/AI/ProviderAdapters/**, src/Application/Emails/Embeddings/**, src/Host/Configuration/Embeddings/**, src/Host/Configuration/Providers/**, src/Host/Hosting/Warnings/AiProviderTransportEncryptionWarning.cs -->
 
 A chunk is a passage of text. A vector is where that passage lands in a space a model defines, and two vectors of one
 space can be compared, which is what makes semantic search possible at all. This page describes how MailFathom turns
@@ -106,7 +106,7 @@ parameter would be a list of model names in code, and it would be wrong the week
 
 **`Address` and the credential are where the endpoint is and what it presents.** Neither is part of a profile — moving
 either changes where a vector is bought, never what it means. Both carry a rule, stated in full in [what an address has
-to be](#what-an-address-has-to-be) and [authentication has two shapes](#authentication-has-two-shapes) below.
+to be](#what-an-address-has-to-be) and [authentication has three shapes](#authentication-has-three-shapes) below.
 
 ## Vector width is a database decision
 
@@ -204,32 +204,80 @@ nothing here can ask a service what it serves without paying for a request.
 
 ## What an address has to be
 
-**Absolute, and HTTPS.** Startup refuses anything else, naming the endpoint alias and the rule. The scheme is not a
-preference: the request carries a credential, so a plain `http` address would publish that credential to everyone on
-the path between this deployment and the service, and an endpoint declared once wrongly would go on doing it on every
-call.
+**Absolute, and HTTP or HTTPS.** Startup refuses anything else, naming the endpoint alias and the rule.
+
+**A credential never travels in the clear.** A plain `http` address is refused wherever the endpoint declares a provider
+key or a Microsoft Entra credential, because the request would publish that credential to everything on the path between
+this deployment and the service, and an endpoint declared once wrongly would go on doing it on every call. That is the
+rule the whole scheme check was ever about: what makes a plain address dangerous is the secret travelling on it, so an
+endpoint holding no secret is a different situation rather than an exception to the same one, and it is the one shape a
+plain address is accepted for.
 
 **Empty means the provider library's own default**, which is the first-party OpenAI API. That is a convenience for the
 one case it fits and a trap for every other, so any endpoint that is not first-party OpenAI writes the address out —
 including a cloud deployment, whose resource has an address of its own ending in `/openai/v1/`.
 
-One consequence is worth stating plainly, because it is the shape an operator most often arrives with: a model server
-on a private address, serving plain HTTP with no credential at all, cannot be declared. Neither rule reads the network —
-a loopback or private address is accepted where it is HTTPS and carries a credential, and refused where it is not,
-exactly as a public one would be.
+## A model server you run yourself
 
-## Authentication has two shapes
+Every local inference server presents one shape: the OpenAI wire protocol, on a private or loopback address, over plain
+HTTP, with no credential in front of it. Declaring one is an ordinary endpoint entry that writes the plain address and
+`"Unauthenticated": true`, and it reaches the same client construction, the same resilience pipeline, and the same
+ceilings as a vendor endpoint.
 
-An endpoint carries **either** a provider key **or** a Microsoft Entra credential, never both and never neither, and
-startup refuses any other combination, naming the alias. Neither is the shape a forgotten reference takes — an operator
+```json
+{
+  "Embeddings": {
+    "Endpoints": [
+      {
+        "Alias": "house-embeddings",
+        "Provider": "example-ai",
+        "Model": "example-embed-2",
+        "Dimension": 1024,
+        "SupportsRequestedDimension": false,
+        "Address": "http://model-server:8000/v1",
+        "Unauthenticated": true
+      }
+    ]
+  }
+}
+```
+
+**What it gains** is that no mail content leaves the machines the operator runs. The passages that are embedded, and on
+the chat side the questions and the answers, reach a service the operator started rather than an account with a vendor;
+there is no third-party processor, no per-token invoice, and no key to provision or rotate.
+
+**What it gives up** is the confidentiality of that hop, and MailFathom cannot judge how much that costs. A container
+network name and a public host name are the same string in a configuration file, so no startup rule can tell a server
+beside this process from one across the internet — which is why nothing here reads the address to decide whether the
+plain scheme is allowed. What runs instead is a report: an instance holding an endpoint on a plain address writes one
+warning per endpoint at startup, naming the alias and what crosses the hop readable, and leaving the judgement about the
+network with the person who built it. The address itself is never written to a log, for the reason no address or
+credential is.
+
+**MailFathom reaches such a server; it does not run one.** No model, no weights, and no inference runtime are loaded
+into this process or shipped in its image — that would make MailFathom responsible for model distribution, licensing,
+hardware sizing, and a second failure domain inside its own process, for a capability an operator gets by starting one
+container beside it. Which servers the project has actually exercised is stated under [compatible is not
+verified](#compatible-is-not-verified), and that set is unchanged by this: the mechanism reaches a service, and reaching
+it is not a claim that it was tested.
+
+## Authentication has three shapes
+
+An endpoint declares **exactly one** of a provider key, a Microsoft Entra credential, and `Unauthenticated`, and startup
+refuses any other combination, naming the alias. Declaring none is the shape a forgotten reference takes — an operator
 who wrote the address and the model and expects the endpoint to work learns it here rather than from a rejected call
-they paid for — and both is a declaration that does not say which one a request should present, which is a question no
-default here should answer on an operator's behalf. The rules below govern a declared chat endpoint identically, and
+they paid for — which is why an endpoint that genuinely needs no credential says so rather than leaving the blocks out;
+and declaring two does not say which one a request should present, which is a question no default here should answer on
+an operator's behalf. The rules below govern a declared chat endpoint identically, and
 one credential source resolves both — which is why an alias names one endpoint across the whole deployment rather than
 within one section.
 
 A key is a secret reference like every other credential this deployment holds, resolved per request — so rotating it
 behind an unchanged reference takes effect on the next call, with no cache to invalidate and no restart.
+
+`Unauthenticated` resolves nothing and presents nothing: the request carries no authorization header at all, rather than
+a placeholder one. It is the shape [a model server you run yourself](#a-model-server-you-run-yourself) needs, and it is
+what makes a plain address permitted.
 
 A Microsoft Entra credential exists for the deployment where there is no secret to provision at all. Four shapes are
 supported and they are the whole of the set: managed identity, workload identity, client secret, and client

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -303,14 +303,18 @@ disagree, naming both aliases and the property.
 
 An entry declares any service reachable over the OpenAI wire protocol, not one of a fixed set: `Provider`, `Model`, and
 `ModelVersion` are what the profile records, while `RoutedModelName` — or `Model` where that is empty — is the string a
-request is routed on. Two rules bind the address and the credential: an address is absolute HTTPS or startup refuses it,
-because the request carries a credential, and exactly one of `ApiKey` and `EntraCredential` is declared, because
-neither is what a forgotten reference looks like and both leaves unsaid which one a request presents. [Embedding
+request is routed on. Two rules bind the address and the credential, and one implementation applies them to this section
+and to `Chat` alike: an address is absolute HTTP or HTTPS, with a plain `http` one refused wherever the endpoint holds a
+credential, because the request would publish it to everything on the path; and exactly one of `ApiKey`,
+`EntraCredential`, and `Unauthenticated` is declared, because none of them is what a forgotten reference looks like and
+two leaves unsaid which one a request presents. [Embedding
 generation § An endpoint is any
 service that speaks the OpenAI wire
 protocol](../features/embedding-generation.md#an-endpoint-is-any-service-that-speaks-the-openai-wire-protocol) holds
 both rules with their reasons, what each setting decides, and a worked example of an endpoint that is neither OpenAI
-nor Azure.
+nor Azure. [Embedding generation § A model server you run
+yourself](../features/embedding-generation.md#a-model-server-you-run-yourself) covers the plain-address case, what it
+gains, what it gives up, and the startup warning an instance holding such an endpoint writes.
 
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
@@ -324,9 +328,10 @@ nor Azure.
 | `…:InputCharacterLimit` | int | `8000` | positive; what a passage is cut to before it is sent, which is what the model saw and therefore part of what a vector means | restart |
 | `…:PassageInstruction` | string | *(empty)* | at most 512 characters; empty for a model that requires none. Whitespace is refused, because it would register a second profile for a space identical to one already registered | restart |
 | `…:NormalizeVectors` | bool | `true` | whether the space's vectors are of unit length | restart |
-| `…:Address` | string | *(empty)* | absolute HTTPS; empty uses the provider library's default. A cloud resource's OpenAI-compatible address ends in `/openai/v1/` | restart |
+| `…:Address` | string | *(empty)* | absolute HTTP or HTTPS; a plain `http` one only for an endpoint declaring `Unauthenticated`. Empty uses the provider library's default. A cloud resource's OpenAI-compatible address ends in `/openai/v1/` | restart |
 | `…:SupportsRequestedDimension` | bool | `true` | whether the endpoint honours a requested width, so the narrower space is asked for rather than cut out of a wider answer | restart |
-| `…:ApiKey` | secret block | *(absent)* | the provider key. Exactly one of this and `EntraCredential` is declared | restart, value read per request |
+| `…:ApiKey` | secret block | *(absent)* | the provider key. Exactly one of this, `EntraCredential`, and `Unauthenticated` is declared | restart, value read per request |
+| `…:Unauthenticated` | bool | `false` | that this endpoint asks for no credential, so a request presents none — the shape of a model server you run yourself. Written rather than inferred from the other two being absent, because that is what a forgotten key reference looks like | restart |
 
 ### Microsoft Entra credential — `Embeddings:Endpoints:<n>:EntraCredential`
 
@@ -336,7 +341,7 @@ reaches an interactive browser credential and the developer-tool credentials of 
 
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
-| `…:Kind` | enum | `ManagedIdentity` | `ManagedIdentity`, `WorkloadIdentity`, `ClientSecret`, `ClientCertificate`. `ApiKey` is refused here; a key is declared as one | restart |
+| `…:Kind` | enum | `ManagedIdentity` | `ManagedIdentity`, `WorkloadIdentity`, `ClientSecret`, `ClientCertificate`. `ApiKey` and `Unauthenticated` are refused here; a key is declared as one, and an endpoint needing no credential says so on the endpoint | restart |
 | `…:TokenScope` | string | `https://ai.azure.com/.default` | required; the audience an access token is minted for. Declared rather than derived from the address, so a renamed service does not silently mint tokens for the wrong audience | restart |
 | `…:TenantId` | string | *(empty)* | required for `ClientSecret` and `ClientCertificate` | restart |
 | `…:ClientId` | string | *(empty)* | required for `ClientSecret` and `ClientCertificate`; optional for `ManagedIdentity`, where it selects a user-assigned identity | restart |
@@ -358,8 +363,9 @@ model's voice with nothing above able to tell. An operator who wants failover pu
 endpoint.
 
 The endpoint is any service reachable over the OpenAI wire protocol, under the same two rules the embedding chain
-follows: an absolute HTTPS address, and exactly one credential. [Chat generation § An endpoint is any service that
-speaks the OpenAI wire
+follows and through the same implementation of them: an absolute HTTP or HTTPS address with a plain `http` one refused
+wherever a credential is held, and exactly one of `ApiKey`, `EntraCredential`, and `Unauthenticated`. [Chat generation §
+An endpoint is any service that speaks the OpenAI wire
 protocol](../features/chat-generation.md#an-endpoint-is-any-service-that-speaks-the-openai-wire-protocol) carries a
 worked example of one that is neither OpenAI nor Azure, and `Chat:Api` is the key most often decided by which of the
 two paths such a service serves.
@@ -368,7 +374,7 @@ two paths such a service serves.
 | --- | --- | --- | --- | --- |
 | `Chat:Alias` | string | *(empty)* | writing one is what configures a chat provider at all; unique across every AI endpoint the deployment declares, embedding endpoints included. A section carrying other settings without it is refused rather than ignored | reload to rename, restart to declare or remove |
 | `Chat:Model` | string | — | required once an alias is written; what a request is routed to, which for a cloud deployment is the deployment's own name rather than the vendor's model identifier | reload |
-| `Chat:Address` | string | *(empty)* | absolute HTTPS; empty uses the provider library's default. A cloud resource's OpenAI-compatible address ends in `/openai/v1/` | reload |
+| `Chat:Address` | string | *(empty)* | absolute HTTP or HTTPS; a plain `http` one only for an endpoint declaring `Chat:Unauthenticated`. Empty uses the provider library's default. A cloud resource's OpenAI-compatible address ends in `/openai/v1/` | reload |
 | `Chat:Api` | enum | `ChatCompletions` | `ChatCompletions` or `Responses`; which of the provider's two request APIs a call goes to under the declared address. Declared rather than derived, because the routed model name is the operator's own deployment name and nothing about it says which paths the server serves. State `Responses` for a reasoning model that refuses function tools beside a stated effort; a server that does not serve that path answers *request refused* | reload |
 | `Chat:MaxOutputTokens` | int | `1024` | 1 – 200000; what one answer may occupy. Reaching it is not a failure — the answer arrives marked as cut short | reload |
 | `Chat:Temperature` | float | *(unset)* | 0 – 2; left unset sends nothing, which is required by the models that reject the parameter outright | reload |
@@ -377,7 +383,8 @@ two paths such a service serves.
 | `Chat:MaxMessagesPerRequest` | int | `64` | 1 – 512; the turns one request carries, refused rather than truncated | reload |
 | `Chat:MaxRequestCharacters` | int | `120000` | 1 – 4000000; what those turns may add up to. Stated in characters rather than tokens because counting tokens would mean carrying the model's own tokenizer; set it below what the model's context window allows | reload |
 | `Chat:RequestTimeout` | TimeSpan | `00:02:00` | positive; one request. Longer than an embedding request's by default, because generating an answer takes as long as the answer is | reload |
-| `Chat:ApiKey` | secret block | *(absent)* | the provider key. Exactly one of this and `EntraCredential` is declared | reload, value read per request |
+| `Chat:ApiKey` | secret block | *(absent)* | the provider key. Exactly one of this, `EntraCredential`, and `Unauthenticated` is declared | reload, value read per request |
+| `Chat:Unauthenticated` | bool | `false` | that this endpoint asks for no credential, so a request presents none — the shape of a model server you run yourself. Written rather than inferred from the other two being absent, because that is what a forgotten key reference looks like | reload |
 
 **What a reload changes here, and what it does not.** Everything the declared endpoint says is read again per
 question, so correcting a model the provider refused — the ordinary case, because a wrong model is only discovered from

--- a/src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs
+++ b/src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs
@@ -202,16 +202,27 @@ internal sealed class OpenAiCompatibleClientFactory
         options.RetryPolicy = new ClientRetryPolicy(maxRetries: 0);
     }
 
-    /// <summary>Resolves the bearer-token policy for an endpoint authenticated with Microsoft Entra.</summary>
+    /// <summary>Resolves the policy every request to one endpoint is sent under, for each shape that is not a key.</summary>
     /// <remarks>
-    /// The credential is built once per endpoint and kept, because fetching an access token is what it exists to do
+    /// <para>
+    /// An endpoint declaring no credential is reached through the policy that adds nothing, because the client library
+    /// offers no construction taking neither a key nor a policy. Everything else here is a Microsoft Entra credential.
+    /// </para>
+    /// <para>
+    /// That credential is built once per endpoint and kept, because fetching an access token is what it exists to do
     /// and it caches the token it fetched. Building one per request would discard that cache and turn every provider
     /// call into a token request as well. The consequence is that rotating the client secret of a registered
     /// application takes effect at the next restart, while rotating a provider key — the shape with no token to cache —
     /// takes effect on the next call.
+    /// </para>
     /// </remarks>
-    private BearerTokenPolicy AuthenticationPolicyFor(string endpointAlias, ProviderEndpointCredential credential)
+    private AuthenticationPolicy AuthenticationPolicyFor(string endpointAlias, ProviderEndpointCredential credential)
     {
+        if (credential.Kind is ProviderEndpointCredentialKind.Unauthenticated)
+        {
+            return UnauthenticatedRequestPolicy.Instance;
+        }
+
         var declaration = credential.Entra!;
         var tokenCredential = this.entraCredentials.GetOrAdd(
             endpointAlias,

--- a/src/AI/ProviderAdapters/UnauthenticatedRequestPolicy.cs
+++ b/src/AI/ProviderAdapters/UnauthenticatedRequestPolicy.cs
@@ -1,0 +1,39 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.ClientModel.Primitives;
+
+namespace MailFathom.AI.ProviderAdapters;
+
+/// <summary>Carries a request to an endpoint that asks for no credential, adding nothing to it.</summary>
+/// <remarks>
+/// <para>
+/// The client library takes either a key or an authentication policy and has no third construction for an endpoint that
+/// wants neither, so the shape with no credential is expressed as the policy that authenticates nothing. What that buys
+/// over the alternative is exactness: passing a placeholder key would put an <c>Authorization</c> header on every
+/// request carrying a value the operator never wrote, and a server that reads the header would then be told something
+/// untrue rather than nothing at all.
+/// </para>
+/// <para>
+/// One instance serves every such endpoint, because the policy holds no state and its whole behaviour is to pass
+/// control on.
+/// </para>
+/// </remarks>
+internal sealed class UnauthenticatedRequestPolicy : AuthenticationPolicy
+{
+    private UnauthenticatedRequestPolicy()
+    {
+    }
+
+    /// <summary>Gets the policy every endpoint declaring no credential is reached through.</summary>
+    public static UnauthenticatedRequestPolicy Instance { get; } = new();
+
+    /// <inheritdoc />
+    public override void Process(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex) =>
+        ProcessNext(message, pipeline, currentIndex);
+
+    /// <inheritdoc />
+    public override ValueTask ProcessAsync(PipelineMessage message, IReadOnlyList<PipelinePolicy> pipeline, int currentIndex) =>
+        ProcessNextAsync(message, pipeline, currentIndex);
+}

--- a/src/AI/Providers/ProviderEndpointCredential.cs
+++ b/src/AI/Providers/ProviderEndpointCredential.cs
@@ -72,6 +72,19 @@ public sealed class ProviderEndpointCredential : IDisposable
         return new ProviderEndpointCredential(declaration.Kind, apiKey: null, declaration, resolvedMaterial);
     }
 
+    /// <summary>Builds the credential of an endpoint that asks for none, which presents nothing.</summary>
+    /// <returns>The credential.</returns>
+    /// <remarks>
+    /// A value rather than a null credential, so every caller goes on receiving one and the request that carries no
+    /// authentication is a declared shape instead of a missing object nobody has to handle. It holds no material, so
+    /// disposing it releases nothing.
+    /// </remarks>
+    public static ProviderEndpointCredential Unauthenticated() => new(
+        ProviderEndpointCredentialKind.Unauthenticated,
+        apiKey: null,
+        entra: null,
+        resolvedMaterial: null);
+
     /// <inheritdoc />
     public void Dispose() => this.resolvedMaterial?.Dispose();
 }

--- a/src/AI/Providers/ProviderEndpointCredentialKind.cs
+++ b/src/AI/Providers/ProviderEndpointCredentialKind.cs
@@ -37,4 +37,13 @@ public enum ProviderEndpointCredentialKind
 
     /// <summary>A registered application authenticating with its certificate.</summary>
     ClientCertificate = 4,
+
+    /// <summary>Nothing at all: the endpoint asks for no credential, and the request carries none.</summary>
+    /// <remarks>
+    /// The ordinary shape of a model server the operator runs themselves, which admits a caller by being reachable only
+    /// from the network it was put on. It is a member of this set rather than an absence outside it, because an
+    /// endpoint that needs no credential has to be able to say so: an omission is what a forgotten key reference looks
+    /// like, and startup goes on refusing that.
+    /// </remarks>
+    Unauthenticated = 5,
 }

--- a/src/Host/Configuration/Chat/ChatModelOptions.cs
+++ b/src/Host/Configuration/Chat/ChatModelOptions.cs
@@ -38,7 +38,7 @@ namespace MailFathom.Host.Configuration.Chat;
 /// </para>
 /// </remarks>
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
-internal sealed class ChatModelOptions : IValidatableObject
+internal sealed class ChatModelOptions : IValidatableObject, IProviderEndpointReachDeclaration
 {
     /// <summary>The configuration section this declaration is bound from.</summary>
     public const string SectionName = "Chat";
@@ -68,9 +68,10 @@ internal sealed class ChatModelOptions : IValidatableObject
     /// <summary>Gets or sets the base address requests are sent to.</summary>
     /// <remarks>
     /// Empty uses the provider library's own default, which is what a first-party OpenAI endpoint needs. A cloud
-    /// deployment sets the resource's OpenAI-compatible address, which ends in <c>/openai/v1/</c>. The scheme is not a
-    /// preference: the request carries a credential, so an <c>http</c> address would publish it to anyone on the path
-    /// and startup refuses one.
+    /// deployment sets the resource's OpenAI-compatible address, which ends in <c>/openai/v1/</c>. A plain <c>http</c>
+    /// address is refused wherever this endpoint holds a credential, because the request would publish it to anything
+    /// on the path; it is accepted for an endpoint declaring <see cref="Unauthenticated" />, which is the shape of a
+    /// model server the operator runs themselves.
     /// </remarks>
     public string Address { get; set; } = string.Empty;
 
@@ -127,12 +128,20 @@ internal sealed class ChatModelOptions : IValidatableObject
     public TimeSpan RequestTimeout { get; set; } = TimeSpan.FromSeconds(120);
 
     /// <summary>Gets or sets the reference to the provider key this endpoint is authenticated with.</summary>
-    /// <remarks>Absent for an endpoint authenticated with Microsoft Entra, and absent by default rather than an empty block, so secret discovery does not find an unresolvable reference nobody wrote.</remarks>
+    /// <remarks>Absent for an endpoint reached with Microsoft Entra or with no credential at all, and absent by default rather than an empty block, so secret discovery does not find an unresolvable reference nobody wrote.</remarks>
     public ConfiguredSecret? ApiKey { get; set; }
 
     /// <summary>Gets or sets the non-interactive Microsoft Entra credential this endpoint is authenticated with.</summary>
-    /// <remarks>Absent for an endpoint authenticated with a key. Exactly one of the two is declared, and startup refuses both or neither.</remarks>
+    /// <remarks>Absent for an endpoint reached with a key or with no credential at all. Exactly one of the three shapes is declared, and startup refuses none of them or more than one.</remarks>
     public ProviderEntraCredentialOptions? EntraCredential { get; set; }
+
+    /// <summary>Gets or sets whether this endpoint asks for no credential, so a request presents none.</summary>
+    /// <remarks>
+    /// The shape of a model server the operator runs themselves, which admits a caller by being reachable only from the
+    /// network it was put on. Written rather than inferred from the absence of the other two, because an omission is
+    /// exactly what a forgotten key reference looks like and startup has to go on refusing that.
+    /// </remarks>
+    public bool Unauthenticated { get; set; }
 
     /// <summary>Gets or sets whether retrieval puts its candidates to this endpoint before handing them over, and what that pass may spend.</summary>
     /// <remarks>Present rather than nullable, because every member of it has a usable default and the block's own <c>Enabled</c> is what says whether the pass runs. Off is the default and is a supported deployment.</remarks>
@@ -159,6 +168,7 @@ internal sealed class ChatModelOptions : IValidatableObject
                 || this.ReasoningEffort is not null
                 || this.ApiKey is not null
                 || this.EntraCredential is not null
+                || this.Unauthenticated
                 || this.RelevanceFilter.Enabled)
             {
                 yield return new ValidationResult(
@@ -203,18 +213,9 @@ internal sealed class ChatModelOptions : IValidatableObject
                 [nameof(this.ReasoningEffort)]);
         }
 
-        if (this.Address.Length > 0 && !IsUsableAddress(this.Address))
+        foreach (var error in ProviderEndpointReachRules.FindConfigurationErrors($"Chat endpoint '{alias}'", this))
         {
-            yield return new ValidationResult(
-                $"Chat endpoint '{alias}' declares an Address that is not an absolute HTTPS address.",
-                [nameof(this.Address)]);
-        }
-
-        if (this.ApiKey is null == this.EntraCredential is null)
-        {
-            yield return new ValidationResult(
-                $"Chat endpoint '{alias}' declares neither a provider key nor a Microsoft Entra credential, or declares both. Exactly one authenticates an endpoint.",
-                [nameof(this.ApiKey)]);
+            yield return error;
         }
 
         foreach (var error in this.EntraCredential?.FindConfigurationErrors(alias) ?? [])
@@ -237,8 +238,4 @@ internal sealed class ChatModelOptions : IValidatableObject
         this.Address is { Length: > 0 } address ? new Uri(address, UriKind.Absolute) : null,
         this.Model.Trim(),
         this.Api);
-
-    private static bool IsUsableAddress(string address) =>
-        Uri.TryCreate(address, UriKind.Absolute, out var parsed)
-        && parsed.Scheme == Uri.UriSchemeHttps;
 }

--- a/src/Host/Configuration/Embeddings/EmbeddingEndpointOptions.cs
+++ b/src/Host/Configuration/Embeddings/EmbeddingEndpointOptions.cs
@@ -25,7 +25,7 @@ namespace MailFathom.Host.Configuration.Embeddings;
 /// and so a model released after this version can be declared without one.
 /// </para>
 /// </remarks>
-internal sealed class EmbeddingEndpointOptions
+internal sealed class EmbeddingEndpointOptions : IProviderEndpointReachDeclaration
 {
     /// <summary>Gets or sets the deployment's own name for this endpoint.</summary>
     /// <remarks>
@@ -80,9 +80,10 @@ internal sealed class EmbeddingEndpointOptions
     /// <summary>Gets or sets the base address requests are sent to.</summary>
     /// <remarks>
     /// Empty uses the provider library's own default, which is what a first-party OpenAI endpoint needs. A cloud
-    /// deployment sets the resource's OpenAI-compatible address, which ends in <c>/openai/v1/</c>. The scheme is not a
-    /// preference: the request carries a credential, so an <c>http</c> address would publish it to anyone on the path
-    /// and startup refuses one.
+    /// deployment sets the resource's OpenAI-compatible address, which ends in <c>/openai/v1/</c>. A plain <c>http</c>
+    /// address is refused wherever this endpoint holds a credential, because the request would publish it to anything
+    /// on the path; it is accepted for an endpoint declaring <see cref="Unauthenticated" />, which is the shape of a
+    /// model server the operator runs themselves.
     /// </remarks>
     public string Address { get; set; } = string.Empty;
 
@@ -96,12 +97,20 @@ internal sealed class EmbeddingEndpointOptions
     public bool SupportsRequestedDimension { get; set; } = true;
 
     /// <summary>Gets or sets the reference to the provider key this endpoint is authenticated with.</summary>
-    /// <remarks>Absent for an endpoint authenticated with Microsoft Entra, and absent by default rather than an empty block, so secret discovery does not find an unresolvable reference nobody wrote.</remarks>
+    /// <remarks>Absent for an endpoint reached with Microsoft Entra or with no credential at all, and absent by default rather than an empty block, so secret discovery does not find an unresolvable reference nobody wrote.</remarks>
     public ConfiguredSecret? ApiKey { get; set; }
 
     /// <summary>Gets or sets the non-interactive Microsoft Entra credential this endpoint is authenticated with.</summary>
-    /// <remarks>Absent for an endpoint authenticated with a key. Exactly one of the two is declared, and startup refuses both or neither.</remarks>
+    /// <remarks>Absent for an endpoint reached with a key or with no credential at all. Exactly one of the three shapes is declared, and startup refuses none of them or more than one.</remarks>
     public ProviderEntraCredentialOptions? EntraCredential { get; set; }
+
+    /// <summary>Gets or sets whether this endpoint asks for no credential, so a request presents none.</summary>
+    /// <remarks>
+    /// The shape of a model server the operator runs themselves, which admits a caller by being reachable only from the
+    /// network it was put on. Written rather than inferred from the absence of the other two, because an omission is
+    /// exactly what a forgotten key reference looks like and startup has to go on refusing that.
+    /// </remarks>
+    public bool Unauthenticated { get; set; }
 
     /// <summary>Reports every reason this endpoint could not be used, by reading the declaration alone.</summary>
     /// <returns>One result per rule this declaration breaks.</returns>
@@ -129,16 +138,9 @@ internal sealed class EmbeddingEndpointOptions
                 $"declares a Dimension of {this.Dimension}, above the {IndexableVectorWidth.GreatestStorable} a vector column stores.");
         }
 
-        if (this.ApiKey is null == this.EntraCredential is null)
+        foreach (var error in ProviderEndpointReachRules.FindConfigurationErrors(DescribeEndpoint(alias), this))
         {
-            yield return Error(
-                alias,
-                "declares neither a provider key nor a Microsoft Entra credential, or declares both. Exactly one authenticates an endpoint.");
-        }
-
-        if (this.Address.Length > 0 && !IsUsableAddress(this.Address))
-        {
-            yield return Error(alias, "declares an Address that is not an absolute HTTPS address.");
+            yield return error;
         }
 
         if (this.PassageInstruction.Length > 0 && this.PassageInstruction.Trim().Length == 0)
@@ -180,10 +182,8 @@ internal sealed class EmbeddingEndpointOptions
             this.SupportsRequestedDimension);
     }
 
-    private static bool IsUsableAddress(string address) =>
-        Uri.TryCreate(address, UriKind.Absolute, out var parsed)
-        && parsed.Scheme == Uri.UriSchemeHttps;
+    private static string DescribeEndpoint(string endpointAlias) => $"Embedding endpoint '{endpointAlias}'";
 
     private static ValidationResult Error(string endpointAlias, string detail) =>
-        new($"Embedding endpoint '{endpointAlias}' {detail}");
+        new($"{DescribeEndpoint(endpointAlias)} {detail}");
 }

--- a/src/Host/Configuration/Providers/ConfiguredProviderEndpointCredentialSource.cs
+++ b/src/Host/Configuration/Providers/ConfiguredProviderEndpointCredentialSource.cs
@@ -48,6 +48,14 @@ internal sealed class ConfiguredProviderEndpointCredentialSource(
             ?? throw new InvalidOperationException(
                 $"AI endpoint '{endpointAlias}' is not present in the configuration currently in force.");
 
+        if (declaration.Unauthenticated)
+        {
+            // Nothing to resolve and nothing to release: the endpoint asked for no credential, so the request presents
+            // none. Startup already refused this beside a key or a Microsoft Entra credential, so reading it first
+            // decides the shape rather than competing with them.
+            return Task.FromResult(ProviderEndpointCredential.Unauthenticated());
+        }
+
         return declaration.Entra is { } entra
             ? this.ResolveEntraCredentialAsync(endpointAlias, entra, cancellationToken)
             : this.ResolveApiKeyAsync(endpointAlias, declaration.ApiKey, cancellationToken);
@@ -65,13 +73,16 @@ internal sealed class ConfiguredProviderEndpointCredentialSource(
 
         if (embeddingEndpoint is not null)
         {
-            return new ProviderCredentialDeclaration(embeddingEndpoint.ApiKey, embeddingEndpoint.EntraCredential);
+            return new ProviderCredentialDeclaration(
+                embeddingEndpoint.ApiKey,
+                embeddingEndpoint.EntraCredential,
+                embeddingEndpoint.Unauthenticated);
         }
 
         var chat = chatSettings.Current;
 
         return chat.IsConfigured && NamesEndpoint(chat.Alias, endpointAlias)
-            ? new ProviderCredentialDeclaration(chat.ApiKey, chat.EntraCredential)
+            ? new ProviderCredentialDeclaration(chat.ApiKey, chat.EntraCredential, chat.Unauthenticated)
             : null;
     }
 
@@ -153,8 +164,9 @@ internal sealed class ConfiguredProviderEndpointCredentialSource(
 
     private static string? NullWhenEmpty(string value) => value.Trim() is { Length: > 0 } trimmed ? trimmed : null;
 
-    /// <summary>The two credential blocks an endpoint of either section declares, once the section it came from stops mattering.</summary>
+    /// <summary>The three credential shapes an endpoint of either section chooses between, once the section it came from stops mattering.</summary>
     private sealed record ProviderCredentialDeclaration(
         ConfiguredSecret? ApiKey,
-        ProviderEntraCredentialOptions? Entra);
+        ProviderEntraCredentialOptions? Entra,
+        bool Unauthenticated);
 }

--- a/src/Host/Configuration/Providers/IProviderEndpointReachDeclaration.cs
+++ b/src/Host/Configuration/Providers/IProviderEndpointReachDeclaration.cs
@@ -1,0 +1,35 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Secrets.Discovery;
+
+namespace MailFathom.Host.Configuration.Providers;
+
+/// <summary>The part of an AI endpoint declaration that says where the endpoint is and what a request to it presents.</summary>
+/// <remarks>
+/// <para>
+/// Both roles declare these four settings and both are judged by the same rules, because the question they answer is
+/// one question: whether a credential this deployment holds would cross a network in the clear. Writing the rules twice
+/// is how the two would come to differ, and the direction that matters is the lax one — an embedding endpoint accepting
+/// what a chat endpoint refuses is a confidentiality decision nobody took.
+/// </para>
+/// <para>
+/// An interface rather than a shared record the two copy themselves into, so the member names the rules report are the
+/// keys an operator actually edits and a rename moves both sides at once.
+/// </para>
+/// </remarks>
+internal interface IProviderEndpointReachDeclaration
+{
+    /// <summary>Gets the base address requests are sent to, empty for the provider library's own default.</summary>
+    string Address { get; }
+
+    /// <summary>Gets the reference to the provider key this endpoint is authenticated with, absent for the other two shapes.</summary>
+    ConfiguredSecret? ApiKey { get; }
+
+    /// <summary>Gets the non-interactive Microsoft Entra credential this endpoint is authenticated with, absent for the other two shapes.</summary>
+    ProviderEntraCredentialOptions? EntraCredential { get; }
+
+    /// <summary>Gets whether this endpoint is declared to need no credential at all.</summary>
+    bool Unauthenticated { get; }
+}

--- a/src/Host/Configuration/Providers/ProviderEndpointReachRules.cs
+++ b/src/Host/Configuration/Providers/ProviderEndpointReachRules.cs
@@ -1,0 +1,99 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.ComponentModel.DataAnnotations;
+
+namespace MailFathom.Host.Configuration.Providers;
+
+/// <summary>Judges where one AI endpoint is and what a request to it presents, identically for both roles.</summary>
+/// <remarks>
+/// <para>
+/// The rule these enforce is that a credential never crosses a network in the clear. It is stated that way rather than
+/// as <em>the address is HTTPS</em>, because the scheme was only ever a proxy for it: what makes a plain address
+/// dangerous is the secret travelling on it, and an endpoint with no secret to publish is a different situation rather
+/// than an exception to the same one. That is what makes a model server the operator runs themselves reachable — the
+/// ordinary shape of every local inference server is a plain address on a private network with no credential in front
+/// of it — while leaving the protection around a vendor key exactly where it was.
+/// </para>
+/// <para>
+/// What confidentiality a plain hop costs beyond the credential is not settled here, because nothing startup can read
+/// decides it: a container network name and a public host name are the same string, so a rule reading the address would
+/// refuse the deployment this exists to allow or accept everything, and neither is worth the false confidence.
+/// <see cref="Hosting.Warnings.AiProviderTransportEncryptionWarning" /> reports the hop instead, which
+/// is how a clear-text MCP endpoint is handled for the same reason.
+/// </para>
+/// <para>
+/// The absent credential stays refused. An endpoint that needs none says so, so an operator who forgot to reference
+/// their key is still told at startup rather than discovering it from a rejected request.
+/// </para>
+/// </remarks>
+internal static class ProviderEndpointReachRules
+{
+    /// <summary>Reports every reason an endpoint could not be reached as declared, by reading the declaration alone.</summary>
+    /// <param name="endpointDescription">How a message names this endpoint, already carrying its role and its alias.</param>
+    /// <param name="declaration">The address and the three credential shapes, exactly one of which is declared.</param>
+    /// <returns>One result per rule the declaration breaks, empty when it is usable.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="declaration" /> is <see langword="null" />.</exception>
+    public static IEnumerable<ValidationResult> FindConfigurationErrors(
+        string endpointDescription,
+        IProviderEndpointReachDeclaration declaration)
+    {
+        ArgumentNullException.ThrowIfNull(declaration);
+
+        var declaredShapes = (declaration.ApiKey is null ? 0 : 1)
+            + (declaration.EntraCredential is null ? 0 : 1)
+            + (declaration.Unauthenticated ? 1 : 0);
+
+        if (declaredShapes == 0)
+        {
+            yield return new ValidationResult(
+                $"{endpointDescription} declares neither a provider key, nor a Microsoft Entra credential, nor Unauthenticated. Exactly one of the three says what a request presents, and an endpoint that needs no credential declares Unauthenticated so that a forgotten reference stays distinguishable from a deliberate absence.",
+                [nameof(IProviderEndpointReachDeclaration.ApiKey)]);
+        }
+        else if (declaredShapes > 1)
+        {
+            yield return new ValidationResult(
+                $"{endpointDescription} declares more than one of a provider key, a Microsoft Entra credential, and Unauthenticated. Exactly one of the three says what a request presents.",
+                [nameof(IProviderEndpointReachDeclaration.ApiKey)]);
+        }
+
+        if (declaration.Address.Length == 0)
+        {
+            yield break;
+        }
+
+        if (!Uri.TryCreate(declaration.Address, UriKind.Absolute, out var address)
+            || (address.Scheme != Uri.UriSchemeHttps && address.Scheme != Uri.UriSchemeHttp))
+        {
+            // Reported once and no further, because everything below reads the scheme of an address that parsed.
+            yield return new ValidationResult(
+                $"{endpointDescription} declares an Address that is not an absolute HTTP or HTTPS address.",
+                [nameof(IProviderEndpointReachDeclaration.Address)]);
+
+            yield break;
+        }
+
+        // Read from the credential blocks rather than from the negation of Unauthenticated, so an endpoint that declared
+        // nothing at all is told once that it declared nothing, instead of being told it holds a credential it does not.
+        var carriesACredential = declaration.ApiKey is not null || declaration.EntraCredential is not null;
+
+        if (address.Scheme == Uri.UriSchemeHttp && carriesACredential)
+        {
+            yield return new ValidationResult(
+                $"{endpointDescription} declares a credential and a plain http Address, which would publish that credential to anything on the network path. Give the endpoint an https address, or — where it is a server you run yourself that asks for no credential — declare Unauthenticated and remove the credential.",
+                [nameof(IProviderEndpointReachDeclaration.Address)]);
+        }
+    }
+
+    /// <summary>Reports whether a declared address names a hop nothing encrypts.</summary>
+    /// <param name="address">The declared address, which may be empty.</param>
+    /// <returns><see langword="true" /> when the address is an absolute plain HTTP one.</returns>
+    /// <remarks>
+    /// An empty address is the provider library's own default, which is HTTPS, so it is not one of these. The startup
+    /// report reads this rather than the scheme directly, so what counts as a clear-text hop is decided once beside the
+    /// rule that permits it.
+    /// </remarks>
+    public static bool IsReachedInClearText(string address) =>
+        Uri.TryCreate(address, UriKind.Absolute, out var parsed) && parsed.Scheme == Uri.UriSchemeHttp;
+}

--- a/src/Host/Configuration/Providers/ProviderEntraCredentialOptions.cs
+++ b/src/Host/Configuration/Providers/ProviderEntraCredentialOptions.cs
@@ -25,7 +25,7 @@ namespace MailFathom.Host.Configuration.Providers;
 internal sealed class ProviderEntraCredentialOptions
 {
     /// <summary>Gets or sets which non-interactive shape the deployment holds.</summary>
-    /// <remarks><see cref="ProviderEndpointCredentialKind.ApiKey" /> is rejected here: a key is declared as one, in the endpoint's own key block.</remarks>
+    /// <remarks>The two members naming something other than a Microsoft Entra credential are rejected here: a key is declared as one in the endpoint's own key block, and an endpoint needing no credential declares that on the endpoint rather than inside a credential.</remarks>
     public ProviderEndpointCredentialKind Kind { get; set; } = ProviderEndpointCredentialKind.ManagedIdentity;
 
     /// <summary>Gets or sets the scope an access token is requested for.</summary>
@@ -62,6 +62,13 @@ internal sealed class ProviderEntraCredentialOptions
         if (this.Kind is ProviderEndpointCredentialKind.ApiKey)
         {
             yield return Error(endpointAlias, "declares a Microsoft Entra credential of kind ApiKey. A provider key is declared in the endpoint's ApiKey block instead.");
+
+            yield break;
+        }
+
+        if (this.Kind is ProviderEndpointCredentialKind.Unauthenticated)
+        {
+            yield return Error(endpointAlias, "declares a Microsoft Entra credential of kind Unauthenticated. An endpoint that asks for no credential declares Unauthenticated on the endpoint and no credential block at all.");
 
             yield break;
         }

--- a/src/Host/Hosting/Warnings/AiProviderTransportEncryptionWarning.cs
+++ b/src/Host/Hosting/Warnings/AiProviderTransportEncryptionWarning.cs
@@ -1,0 +1,103 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Host.Configuration;
+using MailFathom.Host.Configuration.Chat;
+using MailFathom.Host.Configuration.Embeddings;
+using MailFathom.Host.Configuration.Providers;
+using Microsoft.Extensions.Options;
+
+namespace MailFathom.Host.Hosting.Warnings;
+
+/// <summary>States at startup which declared AI endpoints this deployment reaches over a hop nothing encrypts.</summary>
+/// <remarks>
+/// <para>
+/// Reaching a model server over a plain address is a supported posture rather than a mistake, which is why this reports
+/// and does not refuse: it is the ordinary shape of a server the operator runs themselves, and refusing it would mean
+/// refusing the only arrangement in which no mail content leaves the operator's own machines at all. What startup does
+/// refuse is the combination that is unambiguously wrong — a credential travelling on such a hop —
+/// <see cref="ProviderEndpointReachRules" /> holds that rule.
+/// </para>
+/// <para>
+/// The part no rule can decide is what the hop itself costs, so it is reported instead. Nothing readable from the
+/// configuration says whether a host name belongs to a container beside this process or to a service across the
+/// internet, and the mail that crosses the hop is confidential either way: the passages sent to be embedded, the
+/// question asked of a chat model, the passages it is given to answer it, and the answer it returns. Only the operator
+/// knows which network that is, so the report tells them what is on the wire and leaves the judgement with them —
+/// which is how <see cref="McpTransportEncryptionWarning" /> treats the same question at the other end of the process.
+/// </para>
+/// <para>
+/// A startup report, like every warning beside it. The chat declaration reloads, so an address edited into it later is
+/// adopted without passing through here; the embedding chain takes a restart and cannot move at all.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this hosted service.")]
+internal sealed partial class AiProviderTransportEncryptionWarning : IHostedService
+{
+    private readonly EmbeddingOptions embeddingSettings;
+    private readonly ISettingsSnapshot<ChatModelOptions> chatSettings;
+    private readonly ILogger<AiProviderTransportEncryptionWarning> logger;
+
+    /// <summary>Initializes a new startup warning.</summary>
+    /// <param name="embeddingSettings">The embedding chain startup was composed from.</param>
+    /// <param name="chatSettings">The published chat declaration, which is the one in force when this runs.</param>
+    /// <param name="logger">The startup logger.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="embeddingSettings" /> or <paramref name="chatSettings" /> is <see langword="null" />.</exception>
+    public AiProviderTransportEncryptionWarning(
+        IOptions<EmbeddingOptions> embeddingSettings,
+        ISettingsSnapshot<ChatModelOptions> chatSettings,
+        ILogger<AiProviderTransportEncryptionWarning> logger)
+    {
+        ArgumentNullException.ThrowIfNull(embeddingSettings);
+        ArgumentNullException.ThrowIfNull(chatSettings);
+
+        this.embeddingSettings = embeddingSettings.Value;
+        this.chatSettings = chatSettings;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var clearTextEmbeddingAliases = this.embeddingSettings.Endpoints
+            .Where(endpoint => ProviderEndpointReachRules.IsReachedInClearText(endpoint.Address))
+            .Select(endpoint => endpoint.Alias.Trim());
+
+        foreach (var endpointAlias in clearTextEmbeddingAliases)
+        {
+            this.LogEmbeddingEndpointReachedInClearText(endpointAlias);
+        }
+
+        var chat = this.chatSettings.Current;
+
+        if (chat.IsConfigured && ProviderEndpointReachRules.IsReachedInClearText(chat.Address))
+        {
+            this.LogChatEndpointReachedInClearText(chat.Alias.Trim());
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Embedding endpoint {EndpointAlias} is declared with a plain http address, so every passage of your "
+            + "mail that is embedded crosses that hop readable by anything on the network path. No credential is on it, "
+            + "because startup refuses one over a plain address, but the mail content is not protected either. This is "
+            + "the expected posture for a model server you run yourself on a network you control; anywhere else, give "
+            + "the endpoint an https address.")]
+    private partial void LogEmbeddingEndpointReachedInClearText(string endpointAlias);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Chat endpoint {EndpointAlias} is declared with a plain http address, so the question asked, the "
+            + "passages of your mail the model is given to answer it, and the answer it returns all cross that hop "
+            + "readable by anything on the network path. No credential is on it, because startup refuses one over a "
+            + "plain address, but nothing else on the hop is protected either. This is the expected posture for a model "
+            + "server you run yourself on a network you control; anywhere else, give the endpoint an https address.")]
+    private partial void LogChatEndpointReachedInClearText(string endpointAlias);
+}

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -467,6 +467,9 @@ try
     if (declaredEmbeddings?.IsConfigured is true || declaredChat?.IsConfigured is true)
     {
         builder.Services.AddSingleton<IProviderEndpointCredentialSource, ConfiguredProviderEndpointCredentialSource>();
+        // Registered under the same condition and for the same reason: an instance that declared no endpoint at all
+        // reaches none, so it has nothing to report about how it reaches them.
+        builder.Services.AddHostedService<AiProviderTransportEncryptionWarning>();
     }
 
     if (declaredEmbeddings?.IsConfigured is true)

--- a/tests/AI.UnitTests/ProviderAdapters/OpenAiCompatibleClientFactoryTests.cs
+++ b/tests/AI.UnitTests/ProviderAdapters/OpenAiCompatibleClientFactoryTests.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Text;
 using MailFathom.AI.Chat;
 using MailFathom.AI.ProviderAdapters;
 using MailFathom.AI.Providers;
@@ -66,6 +69,78 @@ public sealed class OpenAiCompatibleClientFactoryTests
 
         // Assert
         Assert.NotNull(generator);
+    }
+
+    /// <summary>The shape of a model server the operator runs themselves, which asks for no credential at all.</summary>
+    [Fact]
+    public void OpenEmbeddingGenerator_AnEndpointNeedingNoCredential_OpensAGenerator()
+    {
+        // Arrange
+        using var handler = new FakeHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)));
+        using var transport = new HttpClient(handler, disposeHandler: false);
+        using var credential = ProviderEndpointCredential.Unauthenticated();
+
+        var endpoint = EmbeddingDeclarations.Endpoint("local-server", address: "http://model-server:8000/v1");
+
+        // Act
+        using var generator = this.factory.OpenEmbeddingGenerator(endpoint, credential, transport);
+
+        // Assert
+        Assert.NotNull(generator);
+    }
+
+    /// <summary>
+    /// What "no credential" has to mean on the wire. The client library takes either a key or an authentication policy,
+    /// so the shape with neither is a policy that adds nothing — and a placeholder key put there instead would send an
+    /// authorization header the operator never wrote, which is the failure this proves does not happen.
+    /// </summary>
+    [Fact]
+    public async Task OpenEmbeddingGenerator_AnEndpointNeedingNoCredential_SendsNoAuthorizationHeader()
+    {
+        // Arrange
+        HttpRequestHeaders? sentHeaders = null;
+        using var handler = new FakeHttpMessageHandler((request, _) =>
+        {
+            sentHeaders = request.Headers;
+
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(OneVectorOfWidth(4), Encoding.UTF8, "application/json"),
+            });
+        });
+        using var transport = new HttpClient(handler, disposeHandler: false);
+        using var credential = ProviderEndpointCredential.Unauthenticated();
+
+        var endpoint = EmbeddingDeclarations.Endpoint("local-server", address: "http://model-server:8000/v1");
+        using var generator = this.factory.OpenEmbeddingGenerator(endpoint, credential, transport);
+
+        // Act
+        await generator.GenerateAsync(["a passage"], cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(sentHeaders);
+        Assert.Null(sentHeaders.Authorization);
+        Assert.DoesNotContain(sentHeaders, header => header.Key.Contains("api-key", StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>The other role reaches the same server through the same construction, so neither is left unreachable.</summary>
+    [Fact]
+    public void OpenChatClient_AnEndpointNeedingNoCredential_OpensAClient()
+    {
+        // Arrange
+        using var handler = new FakeHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)));
+        using var transport = new HttpClient(handler, disposeHandler: false);
+        using var credential = ProviderEndpointCredential.Unauthenticated();
+
+        var endpoint = ChatDeclarations.Endpoint("local-server", address: "http://model-server:8000/v1");
+
+        // Act
+        using var client = this.factory.OpenChatClient(endpoint, credential, transport);
+
+        // Assert
+        Assert.NotNull(client);
     }
 
     /// <summary>An endpoint with no address of its own is the provider's first-party API at the library's default.</summary>
@@ -214,5 +289,17 @@ public sealed class OpenAiCompatibleClientFactoryTests
             ChatDeclarations.Endpoint(api: (ChatProviderApi)7),
             credential,
             transport));
+    }
+
+    /// <summary>The narrowest embeddings answer a client will read, so a request can be sent and its headers inspected.</summary>
+    private static string OneVectorOfWidth(int width)
+    {
+        var components = Enumerable
+            .Range(0, width)
+            .Select(_ => (1d / Math.Sqrt(width)).ToString("R", CultureInfo.InvariantCulture));
+
+        return "{\"object\":\"list\",\"model\":\"an-embedding-model\",\"data\":[{\"object\":\"embedding\","
+            + $"\"index\":0,\"embedding\":[{string.Join(',', components)}]}}],"
+            + "\"usage\":{\"prompt_tokens\":1,\"total_tokens\":1}}";
     }
 }

--- a/tests/AI.UnitTests/Providers/ProviderEndpointCredentialTests.cs
+++ b/tests/AI.UnitTests/Providers/ProviderEndpointCredentialTests.cs
@@ -53,6 +53,22 @@ public sealed class ProviderEndpointCredentialTests
     }
 
     /// <summary>
+    /// An endpoint that asks for no credential still hands one to the client construction, so nothing above has a null
+    /// to handle. What it carries is nothing at all, in both shapes and in material.
+    /// </summary>
+    [Fact]
+    public void Unauthenticated_CarriesNeitherAKeyNorAnEntraDeclaration()
+    {
+        // Act
+        using var credential = ProviderEndpointCredential.Unauthenticated();
+
+        // Assert
+        Assert.Equal(ProviderEndpointCredentialKind.Unauthenticated, credential.Kind);
+        Assert.Null(credential.ApiKey);
+        Assert.Null(credential.Entra);
+    }
+
+    /// <summary>
     /// The window in which a process dump could hold the material is bounded by one request rather than by uptime, so
     /// releasing the credential has to release what it was read from.
     /// </summary>

--- a/tests/Host.UnitTests/Configuration/Chat/ChatModelOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Chat/ChatModelOptionsTests.cs
@@ -45,6 +45,7 @@ public sealed class ChatModelOptionsTests
     [InlineData("address")]
     [InlineData("api-key")]
     [InlineData("entra-credential")]
+    [InlineData("unauthenticated")]
     [InlineData("reasoning-effort")]
     [InlineData("api")]
     public void Validate_SettingsWithNoAlias_AreRefusedRatherThanIgnored(string writtenSetting)
@@ -107,12 +108,12 @@ public sealed class ChatModelOptionsTests
         Assert.Contains(errors, error => error.Contains("Model", StringComparison.Ordinal));
     }
 
-    /// <summary>The request carries a credential, so an unencrypted address would publish it to anyone on the path.</summary>
+    /// <summary>Only the two schemes a request could be sent over are addresses at all.</summary>
     [Theory]
-    [InlineData("http://provider.invalid/v1/")]
     [InlineData("/openai/v1/")]
     [InlineData("not an address")]
-    public void Validate_AnAddressThatIsNotAbsoluteHttps_IsRefused(string address)
+    [InlineData("ftp://provider.invalid/v1/")]
+    public void Validate_AnAddressThatIsNotAbsoluteHttpOrHttps_IsRefused(string address)
     {
         // Arrange
         var settings = Declared();
@@ -123,6 +124,56 @@ public sealed class ChatModelOptionsTests
 
         // Assert
         Assert.Contains(errors, error => error.Contains("Address", StringComparison.Ordinal));
+    }
+
+    /// <summary>The declared endpoint carries a credential, so an unencrypted address would publish it to anything on the path.</summary>
+    [Fact]
+    public void Validate_ACredentialOverAPlainAddress_IsRefused()
+    {
+        // Arrange
+        var settings = Declared();
+        settings.Address = "http://127.0.0.1:11434/v1";
+
+        // Act
+        var errors = Validate(settings);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("plain http Address", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The shape of a model server the operator runs themselves, and the reason this role reaches the shared rule rather
+    /// than keeping a copy: a scheme rule of its own would refuse what the other role accepts.
+    /// </summary>
+    [Fact]
+    public void Validate_AnEndpointNeedingNoCredentialOnAPlainAddress_IsAccepted()
+    {
+        // Arrange
+        var settings = Declared();
+        settings.Address = "http://model-server:8000/v1";
+        settings.ApiKey = null;
+        settings.Unauthenticated = true;
+
+        // Act
+        var errors = Validate(settings);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>Needing no credential is one of the three shapes rather than a fourth thing beside them.</summary>
+    [Fact]
+    public void Validate_AnEndpointDeclaringBothAKeyAndNoCredential_IsRefused()
+    {
+        // Arrange
+        var settings = Declared();
+        settings.Unauthenticated = true;
+
+        // Act
+        var errors = Validate(settings);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("more than one", StringComparison.Ordinal));
     }
 
     /// <summary>Exactly one credential authenticates an endpoint, so both and neither are equally wrong.</summary>
@@ -174,6 +225,25 @@ public sealed class ChatModelOptionsTests
 
         // Assert
         Assert.Contains(errors, error => error.Contains("ApiKey", StringComparison.Ordinal));
+    }
+
+    /// <summary>Needing no credential is declared on the endpoint, so naming it as a Microsoft Entra shape is a declaration to correct.</summary>
+    [Fact]
+    public void Validate_AnEntraCredentialOfKindUnauthenticated_IsRefused()
+    {
+        // Arrange
+        var settings = Declared();
+        settings.ApiKey = null;
+        settings.EntraCredential = new ProviderEntraCredentialOptions
+        {
+            Kind = ProviderEndpointCredentialKind.Unauthenticated,
+        };
+
+        // Act
+        var errors = Validate(settings);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("kind Unauthenticated", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -274,6 +344,7 @@ public sealed class ChatModelOptionsTests
         "model" => new ChatModelOptions { Model = "a-chat-model" },
         "address" => new ChatModelOptions { Address = "https://resource.cloud.invalid/openai/v1/" },
         "api-key" => new ChatModelOptions { ApiKey = new ConfiguredSecret { SecretReference = "env:CHAT_KEY" } },
+        "unauthenticated" => new ChatModelOptions { Unauthenticated = true },
         "reasoning-effort" => new ChatModelOptions { ReasoningEffort = "low" },
         "api" => new ChatModelOptions { Api = ChatProviderApi.Responses },
         _ => new ChatModelOptions

--- a/tests/Host.UnitTests/Configuration/Embeddings/EmbeddingOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Embeddings/EmbeddingOptionsTests.cs
@@ -158,11 +158,11 @@ public sealed class EmbeddingOptionsTests
         Assert.Contains(errors, error => error.ErrorMessage!.Contains("Exactly one", StringComparison.Ordinal));
     }
 
-    /// <summary>The request carries a credential, so an unencrypted address would publish it to anyone on the path.</summary>
+    /// <summary>Only the two schemes a request could be sent over are addresses at all.</summary>
     [Theory]
-    [InlineData("http://provider.invalid/v1/")]
     [InlineData("provider.invalid/v1/")]
-    public void Validate_AnAddressThatIsNotAbsoluteHttps_IsRefused(string address)
+    [InlineData("ftp://provider.invalid/v1/")]
+    public void Validate_AnAddressThatIsNotAbsoluteHttpOrHttps_IsRefused(string address)
     {
         // Arrange
         var settings = new EmbeddingOptions();
@@ -172,7 +172,60 @@ public sealed class EmbeddingOptionsTests
         var errors = Validate(settings);
 
         // Assert
-        Assert.Contains(errors, error => error.ErrorMessage!.Contains("HTTPS", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.ErrorMessage!.Contains("absolute HTTP or HTTPS", StringComparison.Ordinal));
+    }
+
+    /// <summary>The declared endpoint carries a credential, so an unencrypted address would publish it to anything on the path.</summary>
+    [Fact]
+    public void Validate_ACredentialOverAPlainAddress_IsRefused()
+    {
+        // Arrange
+        var settings = new EmbeddingOptions();
+        settings.Endpoints.Add(Endpoint("primary", address: "http://127.0.0.1:11434/v1"));
+
+        // Act
+        var errors = Validate(settings);
+
+        // Assert
+        Assert.Contains(errors, error => error.ErrorMessage!.Contains("plain http Address", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The shape of a model server the operator runs themselves, and the reason this role reaches the shared rule rather
+    /// than keeping a copy: a scheme rule of its own would refuse what the other role accepts.
+    /// </summary>
+    [Fact]
+    public void Validate_AnEndpointNeedingNoCredentialOnAPlainAddress_IsAccepted()
+    {
+        // Arrange
+        var settings = new EmbeddingOptions();
+        var endpoint = Endpoint("local-server", address: "http://model-server:8000/v1");
+        endpoint.ApiKey = null;
+        endpoint.Unauthenticated = true;
+        settings.Endpoints.Add(endpoint);
+
+        // Act
+        var errors = Validate(settings);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>Needing no credential is one of the three shapes rather than a fourth thing beside them.</summary>
+    [Fact]
+    public void Validate_AnEndpointDeclaringBothAKeyAndNoCredential_IsRefused()
+    {
+        // Arrange
+        var settings = new EmbeddingOptions();
+        var endpoint = Endpoint("primary");
+        endpoint.Unauthenticated = true;
+        settings.Endpoints.Add(endpoint);
+
+        // Act
+        var errors = Validate(settings);
+
+        // Assert
+        Assert.Contains(errors, error => error.ErrorMessage!.Contains("more than one", StringComparison.Ordinal));
     }
 
     /// <summary>An alias keys a credential, a resilience circuit, and every log line, so two endpoints cannot share one.</summary>
@@ -335,6 +388,27 @@ public sealed class EmbeddingOptionsTests
 
         // Assert
         Assert.Contains(errors, error => error.ErrorMessage!.Contains("kind ApiKey", StringComparison.Ordinal));
+    }
+
+    /// <summary>Needing no credential is declared on the endpoint, so naming it here would give a deployment two places to say it.</summary>
+    [Fact]
+    public void Validate_AnEntraCredentialOfKindUnauthenticated_IsRefused()
+    {
+        // Arrange
+        var settings = new EmbeddingOptions();
+        var endpoint = Endpoint("primary");
+        endpoint.ApiKey = null;
+        endpoint.EntraCredential = new ProviderEntraCredentialOptions
+        {
+            Kind = ProviderEndpointCredentialKind.Unauthenticated,
+        };
+        settings.Endpoints.Add(endpoint);
+
+        // Act
+        var errors = Validate(settings);
+
+        // Assert
+        Assert.Contains(errors, error => error.ErrorMessage!.Contains("kind Unauthenticated", StringComparison.Ordinal));
     }
 
     /// <summary>

--- a/tests/Host.UnitTests/Configuration/Providers/ConfiguredProviderEndpointCredentialSourceTests.cs
+++ b/tests/Host.UnitTests/Configuration/Providers/ConfiguredProviderEndpointCredentialSourceTests.cs
@@ -120,6 +120,60 @@ public sealed class ConfiguredProviderEndpointCredentialSourceTests
         Assert.DoesNotContain("MISSING_KEY", failure.Message, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// A model server the operator runs themselves asks for no credential, so the request presents one that carries
+    /// nothing and no reference is resolved on its behalf — an endpoint with no key must not reach the resolver at all,
+    /// because a resolver asked for nothing reports a failure and would take the endpoint out of service.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_AnEndpointNeedingNoCredential_ResolvesNothingAndPresentsNothing()
+    {
+        // Arrange
+        var embeddings = new EmbeddingOptions();
+        embeddings.Endpoints.Add(new EmbeddingEndpointOptions
+        {
+            Alias = "local-server",
+            Provider = "self-hosted",
+            Model = "an-embedding-model",
+            Dimension = 4,
+            Address = "http://model-server:8000/v1",
+            Unauthenticated = true,
+        });
+
+        var source = SourceOver(embeddings, new ChatModelOptions());
+
+        // Act
+        using var credential = await source.ResolveAsync("local-server", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(ProviderEndpointCredentialKind.Unauthenticated, credential.Kind);
+        Assert.Null(credential.ApiKey);
+        Assert.Null(credential.Entra);
+    }
+
+    /// <summary>The chat role reaches the same shape through the same lookup, so one role cannot resolve what the other does not.</summary>
+    [Fact]
+    public async Task ResolveAsync_AChatEndpointNeedingNoCredential_PresentsNothing()
+    {
+        // Arrange
+        var chat = new ChatModelOptions
+        {
+            Alias = "answering",
+            Model = "a-chat-model",
+            Address = "http://model-server:8000/v1",
+            Unauthenticated = true,
+        };
+
+        var source = SourceOver(new EmbeddingOptions(), chat);
+
+        // Act
+        using var credential = await source.ResolveAsync("answering", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(ProviderEndpointCredentialKind.Unauthenticated, credential.Kind);
+        Assert.Null(credential.ApiKey);
+    }
+
     private static EmbeddingOptions EmbeddingsDeclaring(string alias, string secretReference)
     {
         var settings = new EmbeddingOptions();

--- a/tests/Host.UnitTests/Configuration/Providers/ProviderEndpointReachRulesTests.cs
+++ b/tests/Host.UnitTests/Configuration/Providers/ProviderEndpointReachRulesTests.cs
@@ -1,0 +1,196 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.AI.Providers;
+using MailFathom.Host.Configuration.Providers;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Providers;
+
+/// <summary>Covers the one rule both AI roles are judged by: where an endpoint is, and what a request to it presents.</summary>
+/// <remarks>
+/// The whole matrix is exercised here rather than twice over in the two options types, because the rule is one decision
+/// and this is the one implementation of it. Each role's own tests then prove that it reaches this, which is what would
+/// catch one of them quietly keeping a copy.
+/// </remarks>
+public sealed class ProviderEndpointReachRulesTests
+{
+    /// <summary>The declared credential shapes, named rather than passed, because the declaration type is internal to the host.</summary>
+    private const string ApiKey = "api-key";
+    private const string EntraCredential = "entra-credential";
+    private const string NoCredential = "unauthenticated";
+
+    /// <summary>
+    /// Every combination in which no secret would cross a network somebody else can see. The plain address is accepted
+    /// only in the last of them, which is the shape of a model server the operator runs themselves.
+    /// </summary>
+    [Theory]
+    [InlineData("", ApiKey)]
+    [InlineData("", EntraCredential)]
+    [InlineData("", NoCredential)]
+    [InlineData("https://provider.invalid/v1/", ApiKey)]
+    [InlineData("https://resource.cloud.invalid/openai/v1/", EntraCredential)]
+    [InlineData("https://models.invalid/v1/", NoCredential)]
+    [InlineData("http://127.0.0.1:11434/v1", NoCredential)]
+    [InlineData("http://model-server:8000/v1", NoCredential)]
+    public void FindConfigurationErrors_AnEndpointPublishingNoCredential_ReportsNothing(string address, string credential)
+    {
+        // Arrange
+        var declaration = Reached(address, credential);
+
+        // Act
+        var errors = FindErrors(declaration);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>
+    /// The rule the scheme was always a proxy for. A credential on a plain hop is readable by anything on the path, and
+    /// that is refused whichever shape the credential takes and whatever the address's host suggests about the network.
+    /// </summary>
+    [Theory]
+    [InlineData("http://127.0.0.1:11434/v1", ApiKey)]
+    [InlineData("http://model-server:8000/v1", ApiKey)]
+    [InlineData("http://provider.invalid/v1/", ApiKey)]
+    [InlineData("http://provider.invalid/v1/", EntraCredential)]
+    public void FindConfigurationErrors_ACredentialOverAPlainAddress_IsRefused(string address, string credential)
+    {
+        // Arrange
+        var declaration = Reached(address, credential);
+
+        // Act
+        var errors = FindErrors(declaration);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("plain http Address", StringComparison.Ordinal));
+    }
+
+    /// <summary>Only the two schemes a request could be sent over are addresses at all; the rest name nothing this could reach.</summary>
+    [Theory]
+    [InlineData("provider.invalid/v1/")]
+    [InlineData("/openai/v1/")]
+    [InlineData("not an address")]
+    [InlineData("ftp://provider.invalid/v1/")]
+    public void FindConfigurationErrors_AnAddressThatIsNotAbsoluteHttpOrHttps_IsRefused(string address)
+    {
+        // Arrange
+        var declaration = Reached(address, NoCredential);
+
+        // Act
+        var errors = FindErrors(declaration);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("absolute HTTP or HTTPS", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The protection that survives the change: an endpoint saying nothing about its credential is what a forgotten key
+    /// reference looks like, so needing none has to be written rather than left out.
+    /// </summary>
+    [Fact]
+    public void FindConfigurationErrors_AnEndpointDeclaringNoCredentialShapeAtAll_IsRefused()
+    {
+        // Arrange
+        var declaration = new Declaration { Address = "https://provider.invalid/v1/" };
+
+        // Act
+        var errors = FindErrors(declaration);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("Exactly one of the three", StringComparison.Ordinal));
+    }
+
+    /// <summary>Two shapes leave unsaid which one a request presents, and that is as undecided as declaring none.</summary>
+    [Theory]
+    [InlineData(true, true, false)]
+    [InlineData(true, false, true)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public void FindConfigurationErrors_AnEndpointDeclaringMoreThanOneCredentialShape_IsRefused(
+        bool declaresApiKey,
+        bool declaresEntraCredential,
+        bool declaresNoCredential)
+    {
+        // Arrange
+        var declaration = new Declaration
+        {
+            Address = "https://provider.invalid/v1/",
+            ApiKey = declaresApiKey ? new ConfiguredSecret { SecretReference = "env:PROVIDER_KEY" } : null,
+            EntraCredential = declaresEntraCredential
+                ? new ProviderEntraCredentialOptions { Kind = ProviderEndpointCredentialKind.ManagedIdentity }
+                : null,
+            Unauthenticated = declaresNoCredential,
+        };
+
+        // Act
+        var errors = FindErrors(declaration);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("more than one", StringComparison.Ordinal));
+    }
+
+    /// <summary>An operator told an endpoint is wrong has to be told which one, because a chain declares several.</summary>
+    [Fact]
+    public void FindConfigurationErrors_ARefusedDeclaration_NamesTheEndpointAndTheKeyToEdit()
+    {
+        // Arrange
+        var declaration = Reached("http://provider.invalid/v1/", ApiKey);
+
+        // Act
+        var errors = ProviderEndpointReachRules
+            .FindConfigurationErrors("Embedding endpoint 'primary'", declaration)
+            .ToArray();
+
+        // Assert
+        Assert.Contains(errors, error => error.ErrorMessage!.StartsWith("Embedding endpoint 'primary'", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.MemberNames.Contains("Address", StringComparer.Ordinal));
+    }
+
+    /// <summary>What the startup report reads, so a hop nobody encrypts is the same fact for the rule and for the warning.</summary>
+    [Theory]
+    [InlineData("http://127.0.0.1:11434/v1", true)]
+    [InlineData("http://model-server:8000/v1", true)]
+    [InlineData("https://provider.invalid/v1/", false)]
+    [InlineData("", false)]
+    [InlineData("not an address", false)]
+    public void IsReachedInClearText_ADeclaredAddress_ReportsWhetherAnythingEncryptsTheHop(string address, bool expected)
+    {
+        // Arrange, Act
+        var reachedInClearText = ProviderEndpointReachRules.IsReachedInClearText(address);
+
+        // Assert
+        Assert.Equal(expected, reachedInClearText);
+    }
+
+    private static Declaration Reached(string address, string credential) => new()
+    {
+        Address = address,
+        ApiKey = credential == ApiKey ? new ConfiguredSecret { SecretReference = "env:PROVIDER_KEY" } : null,
+        EntraCredential = credential == EntraCredential
+            ? new ProviderEntraCredentialOptions { Kind = ProviderEndpointCredentialKind.ManagedIdentity }
+            : null,
+        Unauthenticated = credential == NoCredential,
+    };
+
+    private static IReadOnlyList<string> FindErrors(Declaration declaration) =>
+    [
+        .. ProviderEndpointReachRules
+            .FindConfigurationErrors("Embedding endpoint 'primary'", declaration)
+            .Select(result => result.ErrorMessage ?? string.Empty),
+    ];
+
+    /// <summary>Stands in for either options type, so the rule is exercised without either role's other settings taking part.</summary>
+    private sealed class Declaration : IProviderEndpointReachDeclaration
+    {
+        public string Address { get; init; } = string.Empty;
+
+        public ConfiguredSecret? ApiKey { get; init; }
+
+        public ProviderEntraCredentialOptions? EntraCredential { get; init; }
+
+        public bool Unauthenticated { get; init; }
+    }
+}

--- a/tests/Host.UnitTests/Hosting/Warnings/AiProviderTransportEncryptionWarningTests.cs
+++ b/tests/Host.UnitTests/Hosting/Warnings/AiProviderTransportEncryptionWarningTests.cs
@@ -1,0 +1,194 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Chat;
+using MailFathom.Host.Configuration.Embeddings;
+using MailFathom.Host.Hosting.Warnings;
+using MailFathom.Host.UnitTests.TestDoubles;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Hosting.Warnings;
+
+/// <summary>Covers what an operator is told about an AI endpoint this deployment reaches over an unencrypted hop.</summary>
+/// <remarks>
+/// Reaching a model server the operator runs themselves over a plain address is a supported posture, so this reports
+/// rather than refuses — and its silence matters as much as its text, because a line that also fired for every ordinary
+/// vendor endpoint is one an operator learns to scroll past.
+/// </remarks>
+public sealed class AiProviderTransportEncryptionWarningTests
+{
+    [Fact]
+    public async Task StartAsync_AnEmbeddingEndpointOnAPlainAddress_NamesItAndWhatCrossesTheHop()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningOver(EmbeddingsReachedAt(("local-server", "http://model-server:8000/v1")), new ChatModelOptions(), logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("plain http address", record.Message, StringComparison.Ordinal);
+        Assert.Contains("passage", record.Message, StringComparison.Ordinal);
+        Assert.Equal("local-server", Assert.Contains("EndpointAlias", record.Properties));
+    }
+
+    /// <summary>The chat hop carries the question and the answer beside the mail, so it says so rather than reusing the other line.</summary>
+    [Fact]
+    public async Task StartAsync_AChatEndpointOnAPlainAddress_NamesTheQuestionAndTheAnswerToo()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningOver(new EmbeddingOptions(), ChatReachedAt("answering", "http://127.0.0.1:11434/v1"), logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("the question asked", record.Message, StringComparison.Ordinal);
+        Assert.Contains("the answer it returns", record.Message, StringComparison.Ordinal);
+        Assert.Equal("answering", Assert.Contains("EndpointAlias", record.Properties));
+    }
+
+    /// <summary>A chain is reported endpoint by endpoint, because a fallback reached in the clear is a hop of its own.</summary>
+    [Fact]
+    public async Task StartAsync_SeveralEndpointsOnPlainAddresses_ReportsEachOne()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var embeddings = EmbeddingsReachedAt(
+            ("primary", "https://provider.invalid/v1/"),
+            ("fallback", "http://model-server:8000/v1"));
+        var warning = WarningOver(embeddings, ChatReachedAt("answering", "http://model-server:8000/v1"), logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            ["fallback", "answering"],
+            logs.Records.Select(record => Assert.Contains("EndpointAlias", record.Properties)));
+    }
+
+    /// <summary>
+    /// An address is a host name and a port and says nothing about whose network it is on, so no log line may carry one:
+    /// the alias is MailFathom's own name for the endpoint and is the whole of what identifies it here.
+    /// </summary>
+    [Fact]
+    public async Task StartAsync_AnEndpointOnAPlainAddress_NeverWritesTheAddressDown()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningOver(
+            EmbeddingsReachedAt(("local-server", "http://model-server.internal:8000/v1")),
+            new ChatModelOptions(),
+            logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.DoesNotContain("model-server.internal", record.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(record.Properties, property => property.Value is string value && value.Contains("8000", StringComparison.Ordinal));
+    }
+
+    /// <summary>An https endpoint and one left at the provider library's own default are both encrypted, and neither is worth a line.</summary>
+    [Theory]
+    [InlineData("https://provider.invalid/v1/")]
+    [InlineData("")]
+    public async Task StartAsync_EndpointsReachedOverAnEncryptedHop_SayNothing(string address)
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningOver(EmbeddingsReachedAt(("primary", address)), ChatReachedAt("answering", address), logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    /// <summary>A chat section carrying an address but no alias declares no endpoint, so there is no hop to describe.</summary>
+    [Fact]
+    public async Task StartAsync_AChatSectionDeclaringNoEndpoint_SaysNothing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var chat = new ChatModelOptions { Address = "http://model-server:8000/v1" };
+        var warning = WarningOver(new EmbeddingOptions(), chat, logs);
+
+        // Act
+        await warning.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    [Fact]
+    public async Task StopAsync_AnyPosture_CompletesWithoutSayingAnythingFurther()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var warning = WarningOver(
+            EmbeddingsReachedAt(("local-server", "http://model-server:8000/v1")),
+            new ChatModelOptions(),
+            logs);
+
+        // Act
+        await warning.StopAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    private static EmbeddingOptions EmbeddingsReachedAt(params (string Alias, string Address)[] endpoints)
+    {
+        var settings = new EmbeddingOptions();
+
+        foreach (var endpoint in endpoints)
+        {
+            settings.Endpoints.Add(new EmbeddingEndpointOptions
+            {
+                Alias = endpoint.Alias,
+                Provider = "self-hosted",
+                Model = "an-embedding-model",
+                Dimension = 4,
+                Address = endpoint.Address,
+                Unauthenticated = true,
+            });
+        }
+
+        return settings;
+    }
+
+    private static ChatModelOptions ChatReachedAt(string alias, string address) => new()
+    {
+        Alias = alias,
+        Model = "a-chat-model",
+        Address = address,
+        Unauthenticated = true,
+    };
+
+    private static AiProviderTransportEncryptionWarning WarningOver(
+        EmbeddingOptions embeddings,
+        ChatModelOptions chat,
+        RecordingLoggerProvider logs)
+    {
+        using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(logs));
+
+        return new AiProviderTransportEncryptionWarning(
+            Options.Create(embeddings),
+            new StubSettingsSnapshot<ChatModelOptions>(chat),
+            loggerFactory.CreateLogger<AiProviderTransportEncryptionWarning>());
+    }
+}


### PR DESCRIPTION
Closes #599

## What this changes

Every local inference server — Ollama, llama.cpp's server, vLLM, LM Studio, text-embeddings-inference, LocalAI — presents the same shape: the OpenAI wire protocol, on a loopback or private address, over plain HTTP, with no credential. MailFathom refused that shape twice over, and refused it twice in code, because both rules were written once in `EmbeddingEndpointOptions` and again in `ChatModelOptions`.

The rules now read the condition they were always about instead of a proxy for it.

**The address rule.** An address is absolute HTTP or HTTPS. A plain `http` one is refused wherever the endpoint holds a provider key or a Microsoft Entra credential — naming the endpoint alias and the rule, never the address — and accepted for an endpoint that declares it holds none. What makes a plain address dangerous is the secret travelling on it, so an endpoint with no secret is a different situation rather than an exception to the same one.

**The credential rule.** Exactly one of `ApiKey`, `EntraCredential`, and `Unauthenticated` says what a request presents. Needing no credential is *written* rather than inferred from the other two being absent, because an omission is exactly what a forgotten key reference looks like — which is the protection the old "neither is refused" rule bought, and it is unchanged.

**One implementation for both roles.** `ProviderEndpointReachRules` holds both rules; `EmbeddingEndpointOptions` and `ChatModelOptions` reach it through `IProviderEndpointReachDeclaration`, so the member names a refusal reports are the keys an operator edits, a rename moves both sides, and neither role can quietly keep a copy that drifts lax.

**The posture is reported.** `AiProviderTransportEncryptionWarning` writes one startup warning per endpoint reached in the clear, naming the alias and what crosses readable — the passages embedded, and for a chat endpoint the question asked, the mail passages the model is given, and the answer it returns. The address is never written to a log, exactly as no address or credential is.

**On the wire, no credential means no header.** `UnauthenticatedRequestPolicy` passes the request through untouched rather than sending a placeholder key, because the client library takes either a key or an authentication policy and offers no third construction.

## Why no address-kind rule

The issue left the permitting condition open between a private-address check, an explicit acknowledgement, or both. This settles it as **no credential is declared**, and deliberately reads nothing about the network.

A container network name and a public host name are the same string in a configuration file. `http://ollama:11434/v1` and `http://models.example.com:8000/v1` are indistinguishable to any check startup could run, so a private-range rule would refuse the Compose and Kubernetes deployments this issue exists to enable, and one widened to accept a bare host name would accept everything. The acknowledgement flag that would rescue it is a checkbox copied out of an example. What the address-kind check was reaching for — the confidentiality of mail crossing that hop — is something only the operator can judge, so it is reported rather than refused, which is how `McpTransportEncryptionWarning` already treats the same question at the other end of the process.

## Public surfaces

**Nothing breaks.** Every previously valid declaration stays valid: a plain address was refused outright before, so no configuration that started yesterday fails today. `Unauthenticated` is a new key defaulting to `false` on both roles, and `ProviderEndpointCredentialKind` gains an appended member. No operator action is required on upgrade.

One judgement worth flagging for review: **ADR 0006 is deliberately untouched.** Its line 114 enumerates two credential shapes, but its decision is that *authentication is configuration and never part of the profile identity* — which a third configuration shape reinforces rather than amends — so no ADR is created or edited, and an accepted one stays closed.

## Tests

- `ProviderEndpointReachRulesTests` covers the matrix once against the one implementation: eight accepted combinations of scheme and credential shape, four refused credential-over-plain-http ones, four addresses that are not absolute HTTP or HTTPS, the declaration naming no shape, four naming more than one, and what the startup report reads.
- Both `EmbeddingOptionsTests` and `ChatModelOptionsTests` gained accept and refuse cases proving each role reaches that rule rather than keeping a copy, plus the `EntraCredential` of kind `Unauthenticated` refusal.
- `OpenAiCompatibleClientFactoryTests` opens both clients over a plain address and sends a real request through `FakeHttpMessageHandler`, asserting no `Authorization` and no `api-key` header arrives — which also establishes that the OpenAI SDK accepts a plain endpoint.
- `AiProviderTransportEncryptionWarningTests` covers both roles' text, a chain reported endpoint by endpoint, silence for HTTPS and for the library default, silence for a chat section declaring no endpoint, and that neither the message nor a log property ever carries the host or the port.
- `ConfiguredProviderEndpointCredentialSourceTests` proves an unauthenticated endpoint resolves nothing, which matters because a resolver asked for nothing reports a failure and would take the endpoint out of service.

## Known limitation

The warning is a startup report, like every other one in `src/Host/Hosting/Warnings/`. `Chat:Address` reloads, so an address edited from `https` to `http` at runtime is adopted without a second warning. `ISettingsSnapshot` publishes no change callback by design, so closing this would widen a surface ADR 0002 governs; the class remarks and the documentation both say the report describes startup.

## Verification

- `scripts/verify-full.sh` — exit 0; 4640 tests passed, 0 failed; aggregate line coverage 95.21% (13247/13913), gate 85%; `dotnet format` reported 0 of 1559 files changed.
- `scripts/test-agent-workflow.sh` — 145 passed, 0 failed.
- `$check-docs-licenses` — Docs `pass`, Changelog `n/a`, Licenses `n/a`. No package was added, upgraded, or replaced: `Directory.Packages.props` and every `packages.lock.json` are unchanged, and `AuthenticationPolicy` comes from `System.ClientModel` 1.14.0, already registered as a transitive of the OpenAI row and already used in the same file.
