### PR TITLE
[#600] Record which provider endpoints were checked, and what each check rests on

### DIFF
--- a/docs/features/chat-generation.md
+++ b/docs/features/chat-generation.md
@@ -69,7 +69,9 @@ OpenAI-compatible, so a cloud deployment is that same client pointed at the reso
 the deployment's name as the routed model. A third-party service speaking the same protocol is declared by the same
 values and reaches the same code — and "compatible" is that service's claim about itself rather than something checked
 here, which [embedding generation § Compatible is not
-verified](embedding-generation.md#compatible-is-not-verified) states in full for both roles.
+verified](embedding-generation.md#compatible-is-not-verified) states in full for both roles. [Provider
+endpoints](../operations/provider-endpoints.md) is where a service somebody checked is recorded, including which of the
+two request APIs below it was found to serve.
 
 There is no vendor and no model identity in the declaration beside the routed name, and that is the difference from an
 embedding endpoint rather than an omission. A vector is stored and later compared against other vectors, so which model

--- a/docs/features/embedding-generation.md
+++ b/docs/features/embedding-generation.md
@@ -202,6 +202,13 @@ name matches one elsewhere may answer at a different width or with vectors that 
 surfaces as a *request refused* or an *unexpected vector shape* on the first call rather than at startup, because
 nothing here can ask a service what it serves without paying for a request.
 
+What an operator has instead of a check at startup is a record of checks somebody made. [Provider
+endpoints](../operations/provider-endpoints.md) is that record: which roles each checked service serves, the address
+and credential its entry writes, whether it honours a requested width, and — on every row — whether the entry rests on
+a call through this adapter or on the service's own documentation read on a stated date. Presence on it is a check at a
+point in time and absence from it is not a refusal, which is the same statement this section makes and the reason the
+two are one page apart rather than one list.
+
 ## What an address has to be
 
 **Absolute, and HTTP or HTTPS.** Startup refuses anything else, naming the endpoint alias and the rule.
@@ -259,7 +266,9 @@ into this process or shipped in its image — that would make MailFathom respons
 hardware sizing, and a second failure domain inside its own process, for a capability an operator gets by starting one
 container beside it. Which servers the project has actually exercised is stated under [compatible is not
 verified](#compatible-is-not-verified), and that set is unchanged by this: the mechanism reaches a service, and reaching
-it is not a claim that it was tested.
+it is not a claim that it was tested. [Provider endpoints § a model server you run
+yourself](../operations/provider-endpoints.md#a-model-server-you-run-yourself) is the register of the servers somebody
+checked, with the address shape and the requested-width answer each was found to have.
 
 ## Authentication has three shapes
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -372,7 +372,10 @@ protocol](../features/embedding-generation.md#an-endpoint-is-any-service-that-sp
 both rules with their reasons, what each setting decides, and a worked example of an endpoint that is neither OpenAI
 nor Azure. [Embedding generation § A model server you run
 yourself](../features/embedding-generation.md#a-model-server-you-run-yourself) covers the plain-address case, what it
-gains, what it gives up, and the startup warning an instance holding such an endpoint writes.
+gains, what it gives up, and the startup warning an instance holding such an endpoint writes. [Provider
+endpoints](provider-endpoints.md) is the register of services somebody checked — what each one's `Address` and
+credential are, whether it serves an embeddings route at all, and whether `SupportsRequestedDimension` may stay at its
+default.
 
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
@@ -426,7 +429,8 @@ wherever a credential is held, and exactly one of `ApiKey`, `EntraCredential`, a
 An endpoint is any service that speaks the OpenAI wire
 protocol](../features/chat-generation.md#an-endpoint-is-any-service-that-speaks-the-openai-wire-protocol) carries a
 worked example of one that is neither OpenAI nor Azure, and `Chat:Api` is the key most often decided by which of the
-two paths such a service serves.
+two paths such a service serves. [Provider endpoints](provider-endpoints.md) records which paths each checked service
+was found to serve.
 
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |

--- a/docs/operations/provider-endpoints.md
+++ b/docs/operations/provider-endpoints.md
@@ -1,0 +1,224 @@
+# Provider endpoints, and what each entry rests on
+
+<!-- describes: src/AI/ProviderAdapters/**, src/AI/Embeddings/**, src/AI/Chat/**, tests/IntegrationTests/ProviderAdapters/** -->
+
+MailFathom reaches a model through one client construction that speaks the OpenAI wire protocol, so pointing a
+deployment at a service is a configuration entry rather than a feature request. [Embedding generation § an endpoint is
+any service that speaks the OpenAI wire
+protocol](../features/embedding-generation.md#an-endpoint-is-any-service-that-speaks-the-openai-wire-protocol) holds
+the mechanism. What the mechanism cannot supply is the thing an operator actually needs before they write the entry:
+whether *this* service, today, serves the route the role needs, at which address, against which credential, and whether
+it honours the vector width the declaration asks for.
+
+"It speaks the OpenAI wire protocol" does not answer any of those. A service can serve chat completions and no
+embeddings route at all; can serve both and reject the `dimensions` parameter an embedding declaration may send; can
+name that parameter something else; can serve the responses API on one model family and not another. This page is the
+register of what was checked, entry by entry, with what each check rests on.
+
+## Two claims this page does not make
+
+**Presence is a check at a point in time, not a supported-provider list.** Every entry below is what a third party's own
+current documentation said on the date the entry carries, or what a call through this project's own adapter
+established. None of these services is under this project's control, and any of them may change the answer next week
+without anybody here touching anything. An entry that stops being true is a defect in this page rather than in the
+deployment that trusted it.
+
+**Absence is not a refusal.** A service missing from this page is not blocked, unsupported, or known to fail — it is
+unchecked. The mechanism reaches any service that speaks the protocol, and an operator who points a deployment at one
+is doing an ordinary thing. What they do not get is this page's word for it.
+
+Neither claim is a review of the service's terms, and this page is not the place one is recorded. MailFathom itself
+calls two of these — the two its own deployment may be pointed at without an operator choosing anything further — and
+[`THIRD_PARTY_LICENSES.md`](https://github.com/Krzysztof318/MailFathom/blob/main/THIRD_PARTY_LICENSES.md) reviews those
+two under *Hosted services*, with what each one retains and what the operator has to hold to send mail text to it. Every
+other entry below is named rather than adopted, which is exactly why it has no row there.
+
+**Declaring any of them sends mail content out of the deployment.** An embedding endpoint receives the prepared passage
+text of the mail this instance holds; a chat endpoint receives the question a caller asked together with the passages
+retrieved to answer it. That is personal data of the operator's own correspondents, and choosing where it goes is the
+decision this page exists to inform rather than one it makes. [What leaves your instance when you
+ask](../users/usage.md#what-leaves-your-instance-when-you-ask) states it from the reader's side, and a server the
+operator runs themselves is the entry that answers it differently.
+
+## What "checked" means here
+
+Each entry says which of two kinds of evidence it rests on, because they are not the same claim:
+
+- **Called** — a request went through MailFathom's own adapter to the real service and the answer was what the port
+  publishes. The provider-contract tests are the instrument, and [how to exercise an entry
+  yourself](#how-to-exercise-an-entry-yourself) below is how one is run against any address. It carries no date,
+  because the tests are run on request rather than on a schedule and the last run is what a pipeline record says rather
+  than what this page could.
+- **Documented** — the service's own current documentation was read on the date the entry carries, and nothing was
+  called. It establishes that the route exists and what it accepts; it does not establish that MailFathom's request is
+  the shape that route accepts.
+
+Nothing here is inferred from a model's name, from another service serving the same open-weights model, or from a
+compatibility claim on a landing page.
+
+## What an entry has to establish
+
+Five things, because those are what a declaration writes and what a first call fails on:
+
+| What | Why it decides the entry |
+| --- | --- |
+| Which roles it serves | Embeddings and chat are separate declarations reaching separate routes, and a compatibility layer commonly serves one and not the other |
+| The address | `Address` carries the whole base path the service documents, version segment included; empty means the provider library's own default, which is first-party OpenAI |
+| The credential shape | Exactly one of `ApiKey`, `EntraCredential`, and `Unauthenticated` is declared, and a credential over a plain `http` address is refused at startup |
+| Whether a requested width is honoured | `SupportsRequestedDimension` defaults to `true`, so an endpoint that ignores or rejects `dimensions` needs it written `false` |
+| Which chat API it serves | `Chat:Api` names `ChatCompletions` or `Responses`, and a service serving only one refuses the other as *request refused* |
+
+[Configuration reference § `Embeddings`](configuration-reference.md#embeddings) and [§ `Chat`](configuration-reference.md#chat)
+are the inventory of every key named here.
+
+## Vendor APIs with a compatibility layer
+
+| Service | Roles | `Address` | Credential | `SupportsRequestedDimension` | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| [OpenAI](https://platform.openai.com/docs/api-reference/introduction) | embeddings, chat | *(empty — the library's default)* | `ApiKey` | `true` | Called, through the provider-contract tests |
+| [Azure OpenAI](https://learn.microsoft.com/en-us/azure/foundry/openai/api-version-lifecycle) | embeddings, chat | the resource's own address ending `/openai/v1/` | `ApiKey` or `EntraCredential` | `true` | Called, through the provider-contract tests |
+| [Google Gemini](https://ai.google.dev/gemini-api/docs/openai) | embeddings, chat | `https://generativelanguage.googleapis.com/v1beta/openai/` | `ApiKey` | **`false`** | Documented, 2026-08-12 |
+| [Mistral](https://docs.mistral.ai/api/) | embeddings, chat | `https://api.mistral.ai/v1` | `ApiKey` | **`false`** | Documented, 2026-08-12 |
+| [Cohere](https://docs.cohere.com/docs/compatibility-api) | embeddings, chat | `https://api.cohere.ai/compatibility/v1` | `ApiKey` | **`false`** | Documented, 2026-08-12 |
+| [xAI](https://docs.x.ai/docs/api-reference) | chat only | `https://api.x.ai/v1` | `ApiKey` | n/a | Documented, 2026-08-12 |
+
+Azure is not a special case in the code and is not one here: its v1 data plane is OpenAI-compatible, so a deployment is
+the same client pointed at the resource with the deployment's own name as `RoutedModelName`. It is the one entry on the
+page that takes a Microsoft Entra credential, and [embedding generation § authentication has three
+shapes](../features/embedding-generation.md#authentication-has-three-shapes) holds the four non-interactive shapes that
+covers.
+
+Cohere is the only vendor entry that refuses the width parameter in writing: its compatibility API lists `dimensions`
+among the parameters it does not support. Gemini's compatibility page documents an embeddings request of `model` and
+`input` and nothing else. Mistral does accept a requested width, under the name `output_dimension` — which is not the
+member MailFathom sends, so the effect is the same and the reason is worth knowing, because a reader comparing the
+vendor's page against this one will otherwise think this entry is wrong.
+
+## Aggregators and hosted open models
+
+| Service | Roles | `Address` | Credential | `SupportsRequestedDimension` | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| [Groq](https://console.groq.com/docs/openai) | chat only | `https://api.groq.com/openai/v1` | `ApiKey` | n/a | Documented, 2026-08-12 |
+| [Together AI](https://docs.together.ai/docs/openai-api-compatibility) | embeddings, chat | `https://api.together.ai/v1` | `ApiKey` | **`false`** | Documented, 2026-08-12 |
+| [Fireworks AI](https://docs.fireworks.ai/tools-sdks/openai-compatibility) | embeddings, chat | `https://api.fireworks.ai/inference/v1` | `ApiKey` | per model | Documented, 2026-08-12 |
+| [DeepInfra](https://docs.deepinfra.com/chat/overview) | embeddings, chat | `https://api.deepinfra.com/v1/openai` | `ApiKey` | unestablished | Documented, 2026-08-12 |
+| [Nebius Token Factory](https://docs.tokenfactory.nebius.com/) | embeddings, chat | `https://api.tokenfactory.nebius.com/v1/` | `ApiKey` | unestablished | Documented, 2026-08-12 |
+| [OpenRouter](https://openrouter.ai/docs/api_reference/embeddings) | embeddings, chat | `https://openrouter.ai/api/v1` | `ApiKey` | unestablished | Documented, 2026-08-12 |
+| [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers/index) | chat only | `https://router.huggingface.co/v1` | `ApiKey` | n/a | Documented, 2026-08-12 |
+
+The Hugging Face router is the entry most likely to be assumed wrong, so it is worth stating outright: the router serves
+embedding models, and its **OpenAI-compatible** surface does not. Its own documentation says the compatible endpoint is
+"currently available for chat completion tasks only" and directs every other task, embeddings included, at the Hugging
+Face inference clients — which are a different protocol and out of this mechanism's reach.
+
+Fireworks documents `dimensions` as accepted but honoured only by particular models, so the value is a property of the
+model an entry names rather than of the service. It also documents `normalize` as defaulting to false, which is a
+declaration to check against `NormalizeVectors` rather than to assume.
+
+"Unestablished" is not "no". It means the service's request schema, as published, does not name the parameter and no
+call was made to find out. `false` is the safe declaration until a call says otherwise, because an endpoint sent a
+parameter it does not accept refuses the request rather than ignoring it.
+
+## A model server you run yourself
+
+These are the entries an operator can exercise without an account or a per-token invoice, and they share one shape: the
+OpenAI wire protocol on a private or loopback address over plain HTTP with nothing in front of it. That shape is
+declared with the plain address and `"Unauthenticated": true`, and [embedding generation § a model server you run
+yourself](../features/embedding-generation.md#a-model-server-you-run-yourself) holds what it gains, what it gives up,
+and the startup warning an instance writes about the hop.
+
+| Server | Roles | `Address` shape | Credential | `SupportsRequestedDimension` | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| [Ollama](https://docs.ollama.com/openai) | embeddings, chat | `http://<host>:11434/v1` | `Unauthenticated` | `true` | Documented, 2026-08-12 |
+| [llama.cpp](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md) (`llama-server`) | embeddings, chat | `http://<host>:8080/v1` | `Unauthenticated` | unestablished | Documented, 2026-08-12 |
+| [vLLM](https://docs.vllm.ai/en/stable/serving/online_serving/) | embeddings, chat | `http://<host>:8000/v1` | `Unauthenticated` | per model | Documented, 2026-08-12 |
+| [LM Studio](https://lmstudio.ai/docs/app/api/endpoints/openai) | embeddings, chat | `http://<host>:1234/v1` | `Unauthenticated` | unestablished | Documented, 2026-08-12 |
+| [LocalAI](https://localai.io/docs/features/embeddings/) | embeddings, chat | `http://<host>:8080/v1` | `Unauthenticated` | `true` | Documented, 2026-08-12 |
+| [Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference) | embeddings only | `http://<host>:8080/v1` | `Unauthenticated` | **`false`** | Documented, 2026-08-12 |
+
+Each port above is what the server's own documentation shows and is the part most likely to be wrong in a given
+deployment, because every one of these is routinely published on another one. Text Embeddings Inference is the entry
+where that gap is already visible: its container listens on `80` and the `docker run` its quick tour shows maps that to
+`8080`, so the number in the table is a mapping rather than the server's own default. The address is whatever the
+operator's network says it is; the port is recorded so a reader recognises the shape rather than copies it.
+
+Several of these accept an optional key — llama.cpp, vLLM, LM Studio, and Text Embeddings Inference each document a
+flag that turns authentication on — and an entry that uses one declares `ApiKey` and an `https` address instead,
+because a credential over a plain address is refused at startup. Declaring `Unauthenticated` against a server that does
+require a key is a *credential rejected*, which is not repeated. Ollama is the case in between: its compatibility layer
+documents a key as required by the client and ignored by the server, so `Unauthenticated` is the correct declaration
+and the request carrying no authorization header at all is what the server expects.
+
+vLLM is the one entry where the width parameter fails loudly rather than quietly: it accepts `dimensions` and returns
+an error naming the model for one that was not trained for Matryoshka representation, so `SupportsRequestedDimension`
+must follow the model an entry names, not the server. Text Embeddings Inference serves the OpenAI-compatible embeddings
+route and publishes no width parameter on it at all.
+
+llama.cpp serves the embeddings route only for a model loaded with a pooling type, and a deployment that wants both
+roles from it runs two servers with two declarations rather than one — which the chain and the separate `Chat` section
+already express.
+
+## What has no embeddings route at all
+
+Groq, xAI, and the Hugging Face router each serve chat and no OpenAI-compatible embeddings route. That is a fact about
+the service rather than a failure, and it costs nothing structurally: the chat endpoint and the embedding chain are
+separate declarations with separate aliases and separate credentials, so a deployment may take chat from one of these
+and embeddings from an entry above. What it must not do is declare one of them under `Embeddings:Endpoints` and wait
+for the first call to say so.
+
+## Which chat API an entry serves
+
+`Chat:Api` defaults to `ChatCompletions`, which every chat-serving entry on this page documents. A `Responses` path is
+documented by OpenAI, Azure OpenAI, xAI, Groq (in beta), Ollama, llama.cpp, LM Studio, and vLLM. The Gemini, Mistral,
+and Cohere compatibility layers document none, and a deployment stating `Responses` against one of those is answered
+*request refused*. Every other entry above was checked for the embeddings route rather than for this path, so its
+answer here is unestablished in the same sense the width column uses.
+
+Serving the path is not the whole of it. MailFathom conducts every responses call statelessly and asks for the
+reasoning content it will hand back on the next turn, for the reasons [chat generation § the responses API is used
+statelessly](../features/chat-generation.md#the-responses-api-is-used-statelessly-and-that-is-not-an-option) gives, and
+a server implementing part of that surface may accept the path and refuse the request. Ollama, for one, documents its
+responses route as serving no stateful request at all — which is what MailFathom asks for anyway, and is why the
+distinction is worth reading before an entry is trusted.
+
+The other half is capability rather than protocol. The `ask_mail` run offers the model function tools and the model
+calls them when it decides it needs mail, so a model that cannot be given tools cannot answer here whichever API it is
+reached over. That surfaces as *request refused* on the first question.
+
+## How to exercise an entry yourself
+
+The provider-contract tests in `tests/IntegrationTests/ProviderAdapters/` are what turn a **Documented** entry into a
+**Called** one. They run MailFathom's own adapter against whatever address they are given and assert the four things
+only a real service can establish: that the adapter speaks the protocol, authenticates, classifies a real refusal, and
+returns an answer or a vector in the shape the port publishes.
+
+They are skipped unless asked for, and asking for one without what it needs fails the run rather than skipping it.
+`MAILFATHOM_AI_CONTRACT_TESTS` turns them on; the embedding half then reads `MAILFATHOM_EMBEDDING_ADDRESS`,
+`MAILFATHOM_EMBEDDING_MODEL`, `MAILFATHOM_EMBEDDING_DIMENSION`, and `MAILFATHOM_EMBEDDING_API_KEY`, with
+`MAILFATHOM_EMBEDDING_ROUTED_MODEL` where the routed name differs, and the chat half reads the corresponding
+`MAILFATHOM_CHAT_*` variables. The address is the same string an `Address` key would carry, so an entry is checked
+exactly as it would be deployed. [Local development](local-development.md) holds how the suite is run at all.
+
+**One limit of the instrument is worth knowing before an entry is trusted.** A contract run reads the key variable as
+required and presents what it reads, so it exercises the `ApiKey` shape and never the `Unauthenticated` one. Against a
+server that ignores an authorization header it did not ask for — which is what a self-hosted server started without its
+own key flag does — the run still establishes the protocol, the route, and the vector shape, which is what the entry
+claims. What it does not establish for that entry is the credential column, and that is why every row in [a model
+server you run yourself](#a-model-server-you-run-yourself) reads **Documented**.
+
+A run against a hosted service costs whatever that service charges for the handful of calls the tests make. It is the
+only evidence this page treats as stronger than reading, which is why the distinction is on every row rather than in a
+footnote.
+
+## What this page deliberately does not carry
+
+**Continuous verification.** Nothing here runs on a schedule or in a pull-request check. A suite that re-checked every
+entry would need an account and a budget with each of these services, which is a different decision from writing the
+register, and the dates on the rows exist precisely because nothing renews them automatically.
+
+**Anything that does not speak this protocol.** A service reachable only through its own SDK or its own wire format is
+out of the mechanism's reach entirely, and pointing a deployment at one is not a configuration entry. Adding a second
+protocol is an architectural decision rather than an addition to this table.
+
+**A verdict on quality.** Which model retrieves or answers better is not what any of this establishes. Every entry says
+only that the protocol, the route, the credential, and the width behaved as recorded.

--- a/docs/operations/toc.yml
+++ b/docs/operations/toc.yml
@@ -11,6 +11,8 @@
       href: configuration-reference.md
     - name: Configuration sources
       href: configuration-sources.md
+    - name: Provider endpoints
+      href: provider-endpoints.md
     - name: Secret provisioning
       href: secret-provisioning.md
     - name: Secret rotation


### PR DESCRIPTION
## What this changes

"It speaks the OpenAI wire protocol" is a claim about somebody else's service, and it goes stale without anybody here
touching anything. It also answers none of the questions that decide whether an operator's configuration works: whether
the service serves an embeddings route at all, at which address, against which credential, and whether it honours the
vector width the declaration asks for. The two feature pages said only that compatibility is unverified — true, and it
leaves the operator with nothing to act on.

`docs/operations/provider-endpoints.md` is the register that answers it, one row per service, with the evidence on the
row rather than in a footnote. Nineteen entries in three groups — vendor compatibility layers, aggregators and hosted
open models, and the servers an operator runs themselves — each carrying the roles it serves, the base path `Address`
writes, the credential shape, whether `SupportsRequestedDimension` may stay at its default, and whether the row rests
on a call through this project's own adapter or on the service's own documentation read on a stated date.

## What the check actually found

The embedding role was verified separately from the chat role for every candidate, because that is the half a
compatibility layer most often leaves out, and it turned out to be the half that most often fails:

- **No OpenAI-compatible embeddings route at all** — Groq, xAI, and the Hugging Face Inference Providers router. The
  last is the one most likely to be assumed wrong: the router serves embedding models, and its OpenAI-compatible
  surface does not, which its own documentation states outright.
- **The requested-width parameter is not honoured** — Cohere lists `dimensions` among the parameters its compatibility
  API does not support; Mistral accepts a requested width under the name `output_dimension`, which is not the member
  that is sent; Gemini and Together document an embeddings request of `model` and `input` and nothing else; Text
  Embeddings Inference publishes no width parameter on the route at all. `SupportsRequestedDimension` defaults to
  `true`, so every one of those needs it written `false`.
- **It fails loudly rather than quietly on vLLM**, which accepts `dimensions` and refuses the request for a model that
  was not trained for Matryoshka representation — so the value follows the model an entry names, not the server.
- **Fireworks honours it per model** and documents `normalize` as defaulting to false, which is a declaration to check
  against `NormalizeVectors` rather than to assume.

## What the page refuses to imply

Presence is a check at a point in time by a project that controls none of these services, and absence is not a refusal
— both stated on the page rather than assumed. Naming a service is not adopting one, which is why none of the
seventeen unadopted entries takes a row in `THIRD_PARTY_LICENSES.md`; the register's own rule excludes a component that
is "merely named somewhere". And declaring any of them sends mail text out of the deployment, which the page states as
the decision it exists to inform rather than one it makes.

The limit of the instrument is on the page rather than behind it: a contract run reads its key variable as required and
presents what it reads, so it exercises the `ApiKey` shape and never `Unauthenticated` — which is why every
self-hosted row reads as documented rather than called.

## Breaking changes

None. No configuration key, tool contract, database column, or deployment contract moves; nothing outside `docs/`
changes at all.

## Verification

- `scripts/verify-full.sh` — green, 4853 tests, aggregate line coverage 95.31%, workflow contracts run because the
  change reaches beyond C#.
- `scripts/build-docs-site.sh` — builds with the one pre-existing `CHANGELOG.md` warning and no new link failure.
- `scripts/review-obligations.sh` — the new page carries a `describes:` marker resolving through git, joins
  `docs/operations/toc.yml`, and is reached from `embedding-generation.md`, `chat-generation.md`, and
  `configuration-reference.md`. No source changed, so no test or register row is owed.

Closes #600
