### PR TITLE
[#455] Evaluate rules in the account synchronization run, on arrival and on demand

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -26,6 +26,8 @@ The five columns are an observation and never an instruction. Reading mail canno
 
 **The local copy kept without a remote occurrence.** `is_retained_after_authored_delete` is what separates a row the server no longer holds from a row a reader may no longer see, and only a change MailFathom itself performed under `RetainLocalCopy` sets it — a delete, or a relocation into a folder nothing mirrors, which is the same loss of the occurrence and is answered by the same setting. Such a row carries the tombstone timestamp as well, because the server genuinely no longer holds the message and the reconciliation queue has to stop selecting it; the flag is what keeps it inside the mailbox queries the timestamp would otherwise take it out of. So a row is excluded from every mailbox query when `remote_expunge_observed_at` is set **and** this flag is false, while `ix_stored_emails_reconciliation_queue` filters on the timestamp alone. Nothing else sets it: a relocation between mirrored folders carries the row into the destination instead, a disappearance somebody else caused is answered by `RemotelyDeletedEmailDisposition`, which has no value that keeps the mail readable, and carrying the row onto a new occurrence clears the flag along with the timestamp. [What becomes of a message MailFathom deleted](../features/imap-synchronization.md#what-becomes-of-a-message-mailfathom-deleted-itself) states which disposition produces which of the three outcomes.
 
+**What the rules have seen.** `rules_evaluated_at` records when a rule pass last evaluated this message, and is null while none has. It is not only a record: its absence is the queue a pass reads, so writing it is what takes a message out of the mail rules apply to on arrival, and `ix_stored_emails_awaiting_rule_evaluation` is what makes reading that queue proportionate to it rather than to the mailbox. The migration that adds the column stamps every row already stored, which is the same statement made about mail that existed before rules ran at all — an upgrade must not hand a deployment's first rule set an entire mailbox's history as though it had just arrived. Re-evaluating mail that already carries a value is the whole-mailbox run below, and never something an edit sets off; [mail rules](../features/mail-rules.md#when-rules-run) states both halves as behaviour.
+
 **Concurrency.** `ConcurrencyVersion` maps onto the PostgreSQL `xmin` system column rather than a column of its own, so PostgreSQL maintains the token and no writer has to.
 
 ### Sender and recipients
@@ -315,6 +317,24 @@ and no query. A record that stored the retrieved passages would be a second copy
 access, export, and erasure obligations — for the sake of a debugging convenience. What the identifier buys instead is
 that the message can be fetched and read whole through the reads that already serve it.
 
+## The whole-mailbox rule run an account has outstanding
+
+`mail_rule_evaluation_runs` holds the one re-evaluation of an account's whole mailbox that somebody has asked for, and how far the account's synchronization runs have carried it. It is keyed by the account, which is what makes "one outstanding run per account" a property of the schema rather than a check somebody has to remember: two requests arriving together collide on the key, and the loser is recognized as the second caller learning the first got there instead of as a failure.
+
+| Column | What it records |
+|---|---|
+| `mailbox_account_id` | The account whose mail the run walks, and the primary key |
+| `requested_at` | When the run was asked for |
+| `revision` | The rule set the run is bound to, null until the first pass picks it up. Bound when the run starts rather than when it is requested, because the set may reload between the two and what matters is the one in force when the first message is actually evaluated |
+| `position` | The identity of the last message a batch committed, null while the run has committed none. Committed with the evaluations it accounts for, which is what makes the run resumable rather than merely restartable |
+| `evaluated_email_count`, `matched_email_count`, `skipped_email_count` | What the run has done so far, across every account run that has carried it |
+| `ended_at`, `ending` | When and how the run stopped being outstanding. `Completed` is the end of the account's mail; `Superseded` is the rule set having changed while the run was outstanding, which ends it rather than letting one walk apply two rule sets to one mailbox. The ending is text for the reason every other outcome here is: it stays readable in an ad-hoc query and survives a reordering of the enum |
+| `ConcurrencyVersion` | The `xmin` token again, because a pass committing a position and a request arriving can both reach this row |
+
+The row survives the run it describes, holding the last ending until a new request replaces it, and there is no history behind it: one account has one row. Nothing cascades into it and it carries no foreign key onto `mailbox_accounts`, for the reason `mailbox_refresh_tokens` carries none — a run may be asked for before any folder of the account has been bound.
+
+Nothing in it is personal data. An account alias, a derived rule set identity, a message identifier, three counts, and three instants are MailFathom's own names for things, which is what lets a run be explained without any of the mail it walked being copied.
+
 ## Indexes
 
 | Index | Columns | Purpose |
@@ -323,6 +343,8 @@ that the message can be fetched and read whole through the reads that already se
 | `ix_stored_emails_account_timeline` | `(mailbox_account_id, received_at DESC NULLS LAST, id DESC)` | The account-wide timeline |
 | `ix_stored_emails_folder_timeline` | `(mail_folder_id, received_at DESC NULLS LAST, id DESC)` | The per-folder timeline |
 | `ix_stored_emails_awaiting_content` | `(mail_folder_id, uid_validity, uid)` over the rows whose `content_availability` is `AwaitingStorageHeadroom` | The queue of occurrences stored without their payload, which every folder run reads once. The filter is what keeps the index proportionate to that queue rather than to the mailbox: on a deployment that has never reached its storage ceiling the index is empty, and the read costs nothing instead of walking a folder's whole occurrence index to discover that no row qualifies |
+| `ix_stored_emails_account_identity` | `(mailbox_account_id, id)` | The order a whole-mailbox rule run walks an account's mail in. The identity rather than the timeline, because a walk that has to resume needs a total order no later write disturbs and a position that is one column rather than a nullable timestamp paired with a tie-breaker |
+| `ix_stored_emails_awaiting_rule_evaluation` | `(mailbox_account_id, id)` over the rows whose `rules_evaluated_at` is null | The queue of mail no rule pass has evaluated, read once per account run. The filter is the point: in steady state almost every row of an account has been evaluated, so without it the read would walk the account's whole index to find the handful that qualify, on every run of every account |
 | `ix_stored_emails_sender` | `(sender_normalized_address)` | Filtering by who sent a message |
 | `ix_stored_emails_to_addresses` | `(to_addresses)`, GIN | Containment tests over the `To` recipients |
 | `ix_stored_emails_cc_addresses` | `(cc_addresses)`, GIN | Containment tests over the `Cc` recipients |

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -253,9 +253,11 @@ rather than replaying a batch or stepping over one.
 
 **A message whose body text has not been extracted yet is skipped and stays eligible.** It applies only where the
 account's rules actually name `bodyText`: such a message is left in the queue and evaluated once its text has been
-derived, rather than evaluated against a fact that would answer absent and then never reconsidered. A message whose
-content will never yield text — one stored without its payload, for instance — is evaluated now with the fact absent,
-because waiting for text that is not coming would stall the queue behind it.
+derived, rather than evaluated against a fact that would answer absent and then never reconsidered. Mail whose payload
+local storage has not had headroom for is waited on the same way, because a later run fetches it as soon as the ceiling
+permits. A message whose content will never yield text — one above the size limit, which every later run refuses for
+the same reason — is evaluated now with the fact absent, because waiting for text that is not coming would stall the
+queue behind it.
 
 **A rule that cannot answer for one message costs that message's rule and nothing else.** It is recorded as a failed
 rule with a reason, the rules below it still run, the remaining messages of the batch are still evaluated, and the

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -1,6 +1,6 @@
 # Mail rules
 
-<!-- describes: src/Application/Rules/**, src/Infrastructure/Rules/**, src/Host/Configuration/Rules/** -->
+<!-- describes: src/Application/Rules/**, src/Infrastructure/Rules/**, src/Infrastructure/Persistence/Rules/**, src/Host/Configuration/Rules/** -->
 
 A mail rule selects mail. It is a name, a condition, the accounts it applies to, and whether a match ends the pass, and
 an owner writes it in the configuration their deployment already carries. This page documents the whole of what a
@@ -95,7 +95,7 @@ comparison, operator, and function checks below are made against.
 | `isFlagged` | boolean | Whether the server reports the email as flagged |
 | `isDraft` | boolean | Whether the server reports the email as a draft |
 | `hasExtractedContent` | boolean | Whether text has been extracted from the email's body |
-| `bodyText` | text | The text extracted from the email's body; absent while no extraction has run for it |
+| `bodyText` | text | The text extracted from the email's body, after quoted history and signatures were removed; absent while no extraction has run for it |
 
 Names are case-sensitive. `senderDomain` is a fact and `SenderDomain` is not, so the surface documented here and the
 surface accepted are the same one.
@@ -223,6 +223,71 @@ outcome on every run and on every instance.
 
 `StopWhenMatched` on a rule that matches ends the pass, and the rules below it are not reached. It defaults to `false`.
 A rule that does not match never stops a pass whatever it declares.
+
+## When rules run
+
+**Rules are evaluated as a step of the account's synchronization run, and there is no schedule of their own.** That run
+already has everything a rule pass needs — one account at a time, a slot count that stops one account starving another,
+a jittered backoff when something is wrong, and a shutdown that lets work in flight finish — so evaluation joins it
+instead of adding a second thing to configure and watch.
+
+The step is the last of the run's local work: it comes after every folder has synchronized and committed, after mail
+belonging to folders the account no longer mirrors has been erased, and outside the synchronization transaction
+entirely. Two consequences follow that are worth stating rather than inferring. A rule can only ever see mail the run
+before it has already stored, so a provider redelivering a message or a synchronization retry cannot produce a different
+processing boundary than a clean run. And nothing an MCP tool does waits on a rule: reads are served from what is
+already stored, and a pass neither blocks one nor is blocked by one.
+
+**A rule applies to mail that arrives after the rule exists.** Each message is evaluated once, and the record of that
+evaluation is what takes it out of the queue the next pass reads — so editing a rule changes what happens to the mail
+that arrives from then on and does nothing to the mail already in the mailbox. Mail an instance stored before it had
+rule evaluation at all is recorded as evaluated when the schema is applied, for the same reason: an upgrade must not
+hand a first rule set an entire mailbox's history as though all of it had just arrived. Re-running the rules over mail
+already stored is the whole-mailbox run below, and it is always something somebody asks for.
+
+**A pass is bounded, and what it leaves behind is the next run's.** It reads, evaluates, and commits `EvaluationBatchSize`
+messages at a time and takes at most `MaxEvaluationBatchesPerPass` batches, so an account whose mail has never been
+evaluated drains over as many runs as its size needs instead of holding up the run that fetches its mail. Each batch
+commits its evaluations together with the position they account for, so a restart resumes at the message nobody read
+rather than replaying a batch or stepping over one.
+
+**A message whose body text has not been extracted yet is skipped and stays eligible.** It applies only where the
+account's rules actually name `bodyText`: such a message is left in the queue and evaluated once its text has been
+derived, rather than evaluated against a fact that would answer absent and then never reconsidered. A message whose
+content will never yield text — one stored without its payload, for instance — is evaluated now with the fact absent,
+because waiting for text that is not coming would stall the queue behind it.
+
+**A rule that cannot answer for one message costs that message's rule and nothing else.** It is recorded as a failed
+rule with a reason, the rules below it still run, the remaining messages of the batch are still evaluated, and the
+message is recorded as evaluated. The account is not put into backoff for it either: a rule pass reaches no mail server,
+so fetching the account's mail less often would answer a local problem by slowing remote work that had nothing to do
+with it. The next section lists the two reasons.
+
+**Nothing scans on a timer.** The account run recurs already, so anything a scan would find on arrival is found by the
+first trigger; a rule whose condition only becomes true with the passage of time — mail older than some age — fires when
+the owner asks for a whole-mailbox run.
+
+## Running the rules over mail you already have
+
+Editing a rule is only useful if the rules can be applied to mail that arrived before the edit, and that is what a
+**whole-mailbox run** is: a walk over everything stored for one account, evaluating each message again under the rules
+now in force.
+
+- **One per account, and asking twice is asking once.** A request that finds a run already outstanding is answered with
+  that run rather than starting a second walk of the same mailbox.
+- **It runs where every other pass runs.** The request records that the run is wanted and nothing more; the work happens
+  as a step of the account's synchronization run, bounded by the same two settings. Whoever asked is not what keeps it
+  alive, so closing a terminal does not cancel a walk of a mailbox.
+- **It is bound to one rule set.** The revision in force when the run starts is recorded with it, so a reload cannot
+  change what the run is doing halfway through. If the rules do change while a run is outstanding, the run ends as
+  **superseded** and says so, because MailFathom keeps only the rule set its configuration currently declares and
+  finishing under a different one would apply two rule sets to one mailbox. Asking again re-runs under the rules now in
+  force.
+- **It is resumable and cancellable.** Its position is committed with each batch, so a restart or a shutdown costs at
+  most the batch that was in flight, and the run finishes over as many account runs as it needs.
+
+**Nothing submits such a request yet.** The run and every guarantee above are in place and an account carries at most
+one, but no command, tool, or endpoint asks for one, so an owner cannot start one from outside the process today.
 
 ## When a condition cannot answer
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -603,6 +603,8 @@ use — every fact, every function, every operator — and this section document
 | `MailRules:MaxConditionLength` | int | `1000` | 1 – 10000 characters; a condition over it is refused naming the rule | reload |
 | `MailRules:MaxConditionNestingDepth` | int | `16` | 1 – 64 levels of the parsed condition. A length limit alone would admit a short expression nested past reading | reload |
 | `MailRules:ConditionEvaluationTimeout` | TimeSpan | `00:00:01` | Greater than zero and at most `00:00:30`; bounds one condition against one email, including resolving the facts it names | reload |
+| `MailRules:EvaluationBatchSize` | int | `200` | 1 – 10000 messages read, evaluated, and committed together; the unit of progress an interrupted pass gives back | reload |
+| `MailRules:MaxEvaluationBatchesPerPass` | int | `5` | 1 – 1000 batches per walk per account run; what a pass leaves behind is the next run's, so a long queue drains over several runs instead of holding one up | reload |
 | `MailRules:Rules` | list | empty | At most 200 rules, evaluated in the order they are written | reload |
 | `MailRules:Rules:0:Name` | string | required | 1 – 64 characters of letters, digits, spaces, and `.`, `_`, `-`; unique across the section, ignoring case | reload |
 | `MailRules:Rules:0:Accounts` | list | empty | The accounts the rule applies to, each naming a declared `MailSynchronization:Accounts:<n>:AccountId` exactly; empty applies the rule to every account | reload |

--- a/src/Application/Rules/Evaluation/IMailRuleEvaluationRunStore.cs
+++ b/src/Application/Rules/Evaluation/IMailRuleEvaluationRunStore.cs
@@ -1,0 +1,30 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>Keeps the one whole-mailbox run an account may have outstanding, and the progress an account run makes on it.</summary>
+public interface IMailRuleEvaluationRunStore
+{
+    /// <summary>Reads the run this account is still waiting to have carried further.</summary>
+    /// <param name="accountId">The account to read.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The outstanding run, or <see langword="null" /> when the account has none — including when the last one ended.</returns>
+    Task<MailRuleEvaluationRun?> FindOutstandingAsync(MailAccountId accountId, CancellationToken cancellationToken);
+
+    /// <summary>Stages a run — a request, a batch's progress, or an ending — in the session it commits through.</summary>
+    /// <param name="session">The session the batch's evaluations are staged in, so progress and evaluations commit together.</param>
+    /// <param name="run">The run as it stands.</param>
+    /// <param name="cancellationToken">Cancels the staging.</param>
+    /// <returns>A task that completes once the write is staged in the session.</returns>
+    /// <remarks>
+    /// One run per account, so this replaces whatever the account last had rather than appending. Committing the
+    /// position with the evaluations it accounts for is what makes the run resumable rather than merely restartable: a
+    /// crash between the two would otherwise either replay a batch or step over one.
+    /// </remarks>
+    Task SaveAsync(IPersistenceSession session, MailRuleEvaluationRun run, CancellationToken cancellationToken);
+}

--- a/src/Application/Rules/Evaluation/IMailRuleEvaluationStore.cs
+++ b/src/Application/Rules/Evaluation/IMailRuleEvaluationStore.cs
@@ -1,0 +1,86 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>The local state a rule pass reads its candidates from and records what it has evaluated into.</summary>
+/// <remarks>
+/// <para>
+/// Every member here reads or writes what an earlier synchronization run already committed. Nothing on this port reaches
+/// a mail server, which is what makes evaluation safe to run as a step beside synchronization rather than inside it: a
+/// pass cannot open a mailbox session, and therefore cannot touch a remote <c>\Seen</c> flag however long it runs.
+/// </para>
+/// <para>
+/// Both walks are keyset reads over one account, ordered by the stored email's identity, because that is the only
+/// ordering that is total, stable, and unaffected by anything a later write does to a row. The pass hands back the
+/// position it reached rather than the implementation remembering one, so a batch that stopped short of its own end
+/// resumes at the email nobody read.
+/// </para>
+/// </remarks>
+public interface IMailRuleEvaluationStore
+{
+    /// <summary>Reads the account's emails that no pass has evaluated, oldest identity first.</summary>
+    /// <param name="accountId">The account whose arrival queue is read.</param>
+    /// <param name="resumeAfter">The identity the previous batch of this walk reached, or <see langword="null" /> to start at the beginning.</param>
+    /// <param name="batchSize">How many emails to read at most.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The candidates, which is empty once the queue is drained.</returns>
+    /// <remarks>
+    /// The queue shrinks as the pass records evaluations, so a completed email never appears in a later batch. The
+    /// resume position exists for the emails a pass skipped rather than evaluated: without it a batch whose head is
+    /// waiting for extraction would be read again on the next batch and the walk would never move past it.
+    /// </remarks>
+    Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>> GetEmailsAwaitingFirstEvaluationAsync(
+        MailAccountId accountId,
+        StoredEmailId? resumeAfter,
+        int batchSize,
+        CancellationToken cancellationToken);
+
+    /// <summary>Reads the account's stored emails in identity order, whether or not a pass has evaluated them.</summary>
+    /// <param name="accountId">The account whose mailbox is walked.</param>
+    /// <param name="resumeAfter">The identity the requested run last committed, or <see langword="null" /> to start at the beginning.</param>
+    /// <param name="batchSize">How many emails to read at most.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The candidates, which is empty once the walk has reached the end of the mailbox.</returns>
+    /// <remarks>
+    /// This walk does not shrink as it progresses, which is exactly why the requested run commits its position: the
+    /// position is the whole of what a restart resumes from.
+    /// </remarks>
+    Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>> GetStoredEmailsAsync(
+        MailAccountId accountId,
+        StoredEmailId? resumeAfter,
+        int batchSize,
+        CancellationToken cancellationToken);
+
+    /// <summary>Reads the text extracted from one email's body.</summary>
+    /// <param name="storedEmailId">The email a condition named the body text of.</param>
+    /// <param name="cancellationToken">Cancels the read, which the evaluation timeout also reaches through.</param>
+    /// <returns>The extracted text, or <see langword="null" /> when no extraction has produced any for this email.</returns>
+    /// <remarks>
+    /// Reached only when a condition names the body-text fact, and at most once per email per pass, which
+    /// <see cref="Facts.MailRuleFacts" /> is what guarantees.
+    /// </remarks>
+    Task<string?> ReadExtractedBodyTextAsync(StoredEmailId storedEmailId, CancellationToken cancellationToken);
+
+    /// <summary>Records that a rule set has been evaluated for each of these emails.</summary>
+    /// <param name="session">The session the batch's evaluations and the run's position commit together in.</param>
+    /// <param name="storedEmailIds">The emails the batch evaluated, which excludes every email it skipped.</param>
+    /// <param name="evaluatedAt">When the pass evaluated them.</param>
+    /// <param name="cancellationToken">Cancels the staging.</param>
+    /// <returns>A task that completes once the writes are staged in the session.</returns>
+    /// <remarks>
+    /// This is what takes an email out of the arrival queue, and therefore what makes a rule apply to mail arriving from
+    /// now on rather than to a mailbox's whole history. An email the pass skipped is deliberately left out, so it
+    /// returns to the queue's head and is evaluated once whatever it was waiting for has arrived.
+    /// </remarks>
+    Task RecordEvaluatedAsync(
+        IPersistenceSession session,
+        IReadOnlyList<StoredEmailId> storedEmailIds,
+        DateTimeOffset evaluatedAt,
+        CancellationToken cancellationToken);
+}

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationOptions.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationOptions.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>Bounds how much of an account's mail one evaluation pass takes in hand.</summary>
+/// <remarks>
+/// <para>
+/// Neither setting is a schedule. Evaluation is a step of the account's synchronization run, so how often a pass happens
+/// is that run's interval and its backoff; what is configured here is how wide one pass is allowed to be, which is what
+/// stops a mailbox that has never been evaluated from turning one run into a walk of its whole history while the folders
+/// the run exists to fetch wait behind it.
+/// </para>
+/// <para>
+/// The two bounds apply to each of the pass's two walks separately, because they answer the same question about
+/// different work: an account that has just been given its first rule set has a long arrival queue and no requested run,
+/// and an account whose owner asked for a re-run has the opposite. Sharing one budget between them would let either one
+/// starve the other for as many runs as it took to drain.
+/// </para>
+/// </remarks>
+public sealed class MailRuleEvaluationOptions
+{
+    /// <summary>Gets or sets how many stored emails one batch reads, evaluates, and commits together.</summary>
+    /// <remarks>
+    /// A batch is the unit of progress an interrupted pass loses, and the unit of work one transaction covers. Raising
+    /// it drains a backlog in fewer transactions; lowering it shortens the window a cancelled pass has to give back.
+    /// </remarks>
+    public int BatchSize { get; set; } = 200;
+
+    /// <summary>Gets or sets how many batches one walk of one pass may commit before it leaves the rest to the next run.</summary>
+    public int MaxBatchesPerPass { get; set; } = 5;
+}

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs
@@ -1,0 +1,425 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules.Conditions;
+using MailFathom.Application.Rules.Facts;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>Runs one account's rules over the mail that has arrived, and over its whole mailbox where somebody asked.</summary>
+/// <remarks>
+/// <para>
+/// A step of the account's synchronization run rather than a schedule of its own. That run already has per-account
+/// isolation, a jittered backoff, a slot count that stops one account starving another, and a failure path that defers
+/// the account instead of the process; a rule pass needs every one of those and none of them differently, so it takes
+/// the ones that exist. It follows that only one pass per account is ever in flight, structurally rather than by a lock.
+/// </para>
+/// <para>
+/// It runs after the mail and its content are committed and never inside the synchronization transaction, so a provider
+/// redelivery or a synchronization retry cannot produce a different processing boundary than a clean run — and nothing
+/// an MCP read does waits on a rule.
+/// </para>
+/// <para>
+/// The two walks are the two triggers. The arrival walk reaches mail no pass has evaluated, and recording an evaluation
+/// is what takes an email out of it, which is what makes a rule apply to mail arriving from now on. The requested walk
+/// is the only way mail already evaluated is evaluated again: reprocessing under a newer rule set is something an owner
+/// asks for, never something an edit sets off.
+/// </para>
+/// <para>
+/// Both walks are bounded per batch and commit each batch with the position it reached, so an interrupted pass resumes
+/// at the email nobody read rather than replaying one or stepping over one. What a batch budget leaves behind is the
+/// next account run's, which is the same answer synchronization itself gives to a folder it could not finish.
+/// </para>
+/// </remarks>
+public sealed class MailRuleEvaluationPass
+{
+    private readonly IMailRuleSetSource ruleSetSource;
+    private readonly MailRuleSetEvaluator evaluator;
+    private readonly IMailRuleEvaluationStore store;
+    private readonly IMailRuleEvaluationRunStore runStore;
+    private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly MailRuleEvaluationOptions options;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes the pass from the rule set it applies and the local state it walks.</summary>
+    /// <param name="ruleSetSource">Hands out the rule set the pass runs under, read once when the pass begins.</param>
+    /// <param name="evaluator">Runs a rule set over one email and classifies every way a condition can fail to answer.</param>
+    /// <param name="store">Reads the candidates and records which emails have been evaluated.</param>
+    /// <param name="runStore">Reads the requested whole-mailbox run and records how far it has been carried.</param>
+    /// <param name="commitPolicy">Commits a batch's evaluations together with the position they account for.</param>
+    /// <param name="options">Bounds one walk.</param>
+    /// <param name="timeProvider">Supplies the instant each email is evaluated at and each record is stamped with.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when a configured bound is below one.</exception>
+    public MailRuleEvaluationPass(
+        IMailRuleSetSource ruleSetSource,
+        MailRuleSetEvaluator evaluator,
+        IMailRuleEvaluationStore store,
+        IMailRuleEvaluationRunStore runStore,
+        OptimisticConcurrencyRetryPolicy commitPolicy,
+        MailRuleEvaluationOptions options,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(ruleSetSource);
+        ArgumentNullException.ThrowIfNull(evaluator);
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(runStore);
+        ArgumentNullException.ThrowIfNull(commitPolicy);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.BatchSize, 1, nameof(options));
+        ArgumentOutOfRangeException.ThrowIfLessThan(options.MaxBatchesPerPass, 1, nameof(options));
+
+        this.ruleSetSource = ruleSetSource;
+        this.evaluator = evaluator;
+        this.store = store;
+        this.runStore = runStore;
+        this.commitPolicy = commitPolicy;
+        this.options = options;
+        this.timeProvider = timeProvider;
+    }
+
+    /// <summary>Takes one bounded pass over the account's arrivals, and over its requested run where it has one.</summary>
+    /// <param name="accountId">The account whose mail is evaluated.</param>
+    /// <param name="cancellationToken">Cancels the pass between emails and between batches; committed batches stay durable.</param>
+    /// <returns>What each walk did, under the revision the pass read when it began.</returns>
+    /// <exception cref="PersistenceConcurrencyConflictException">
+    /// Thrown when a competing writer wins a race the bounded retries could not resolve. Batches already committed stay
+    /// durable and the next account run resumes from them.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels. Committed batches stay durable.</exception>
+    /// <remarks>
+    /// The rule set is read once here and held for both walks, which is the whole of the reload contract for a pass: an
+    /// edit reaches the next pass rather than this one, so what a rule means cannot change halfway through a mailbox.
+    /// </remarks>
+    public async Task<MailRuleEvaluationReport> RunAsync(MailAccountId accountId, CancellationToken cancellationToken)
+    {
+        var ruleSet = this.ruleSetSource.Current;
+        var requiresExtractedBodyText = RequiresExtractedBodyText(ruleSet, accountId);
+
+        var arrivals = await this.WalkArrivalsAsync(accountId, ruleSet, requiresExtractedBodyText, cancellationToken);
+        var requestedRun = await this.WalkRequestedRunAsync(
+            accountId,
+            ruleSet,
+            requiresExtractedBodyText,
+            cancellationToken);
+
+        return new MailRuleEvaluationReport(ruleSet.Revision, arrivals, requestedRun.Walk, requestedRun.Ending);
+    }
+
+    /// <summary>Reports whether any rule this account's mail reaches names the one fact that costs a stored-content read.</summary>
+    /// <remarks>
+    /// Answered for the whole pass rather than per email, because it is a property of the rule set and the account
+    /// filter. It is what decides whether an email still awaiting extraction is a message to wait for or one to evaluate
+    /// now with the fact absent: a rule set that never names the body text has nothing to wait for.
+    /// </remarks>
+    private static bool RequiresExtractedBodyText(MailRuleSet ruleSet, MailAccountId accountId) => ruleSet.Rules
+        .Where(rule => rule.AppliesTo(accountId.Value))
+        .Any(rule => rule.Condition.ReferencedFacts.Contains(MailRuleFact.BodyText));
+
+    /// <summary>Walks the mail no pass has evaluated, in identity order, until the queue or the batch budget runs out.</summary>
+    /// <remarks>
+    /// The resume position is held for the length of the walk and never committed, because the record of an evaluation
+    /// is what the queue is made of: an email this walk evaluated is gone from the next batch, and an email it skipped
+    /// has to be stepped over within the walk so a message waiting for extraction cannot hold up the mail behind it.
+    /// </remarks>
+    private async Task<MailRuleEvaluationWalk> WalkArrivalsAsync(
+        MailAccountId accountId,
+        MailRuleSet ruleSet,
+        bool requiresExtractedBodyText,
+        CancellationToken cancellationToken)
+    {
+        var tally = new EvaluationTally();
+        StoredEmailId? position = null;
+        var emailsRemain = false;
+
+        for (var batchNumber = 1; batchNumber <= this.options.MaxBatchesPerPass; batchNumber++)
+        {
+            var batch = await this.store.GetEmailsAwaitingFirstEvaluationAsync(
+                accountId,
+                position,
+                this.options.BatchSize,
+                cancellationToken);
+
+            if (batch.Count == 0)
+            {
+                emailsRemain = false;
+
+                break;
+            }
+
+            var outcome = await this.EvaluateBatchAsync(
+                ruleSet,
+                requiresExtractedBodyText,
+                batch,
+                cancellationToken);
+
+            if (outcome.EvaluatedEmailIds.Count > 0)
+            {
+                var evaluatedAt = this.timeProvider.GetUtcNow();
+
+                await this.commitPolicy.CommitAsync(
+                    (session, attemptCancellationToken) => this.store.RecordEvaluatedAsync(
+                        session,
+                        outcome.EvaluatedEmailIds,
+                        evaluatedAt,
+                        attemptCancellationToken),
+                    cancellationToken);
+            }
+
+            tally.Add(outcome);
+            position = batch[^1].StoredEmailId;
+            emailsRemain = batch.Count == this.options.BatchSize;
+
+            if (!emailsRemain)
+            {
+                break;
+            }
+        }
+
+        return tally.ToWalk(emailsRemain);
+    }
+
+    /// <summary>Carries a requested whole-mailbox run as far as one pass's batch budget reaches.</summary>
+    /// <remarks>
+    /// The revision check is the first thing the run meets. A run that has already started under one rule set cannot be
+    /// finished under another — MailFathom holds only the set its configuration currently declares — so a set that has
+    /// moved ends the run as superseded rather than letting one walk apply two rule sets to one mailbox.
+    /// </remarks>
+    private async Task<RequestedRunOutcome> WalkRequestedRunAsync(
+        MailAccountId accountId,
+        MailRuleSet ruleSet,
+        bool requiresExtractedBodyText,
+        CancellationToken cancellationToken)
+    {
+        var run = await this.runStore.FindOutstandingAsync(accountId, cancellationToken);
+
+        if (run is null)
+        {
+            return new RequestedRunOutcome(Walk: null, Ending: null);
+        }
+
+        if (run.Revision.IsSpecified && run.Revision != ruleSet.Revision)
+        {
+            await this.CommitRunAsync(
+                run with
+                {
+                    EndedAt = this.timeProvider.GetUtcNow(),
+                    Ending = MailRuleEvaluationRunEnding.Superseded,
+                },
+                cancellationToken);
+
+            return new RequestedRunOutcome(MailRuleEvaluationWalk.Empty, MailRuleEvaluationRunEnding.Superseded);
+        }
+
+        if (!run.Revision.IsSpecified)
+        {
+            run = run with { Revision = ruleSet.Revision };
+        }
+
+        var tally = new EvaluationTally();
+
+        for (var batchNumber = 1; batchNumber <= this.options.MaxBatchesPerPass && run.IsOutstanding; batchNumber++)
+        {
+            run = await this.CarryRunBatchAsync(run, ruleSet, requiresExtractedBodyText, tally, cancellationToken);
+        }
+
+        return new RequestedRunOutcome(tally.ToWalk(run.IsOutstanding), run.Ending);
+    }
+
+    /// <summary>Evaluates one batch of the requested run and commits it together with the position it reached.</summary>
+    private async Task<MailRuleEvaluationRun> CarryRunBatchAsync(
+        MailRuleEvaluationRun run,
+        MailRuleSet ruleSet,
+        bool requiresExtractedBodyText,
+        EvaluationTally tally,
+        CancellationToken cancellationToken)
+    {
+        var batch = await this.store.GetStoredEmailsAsync(
+            run.AccountId,
+            run.Position,
+            this.options.BatchSize,
+            cancellationToken);
+
+        if (batch.Count == 0)
+        {
+            var finished = run with
+            {
+                EndedAt = this.timeProvider.GetUtcNow(),
+                Ending = MailRuleEvaluationRunEnding.Completed,
+            };
+
+            await this.CommitRunAsync(finished, cancellationToken);
+
+            return finished;
+        }
+
+        var outcome = await this.EvaluateBatchAsync(ruleSet, requiresExtractedBodyText, batch, cancellationToken);
+        var reachedTheEnd = batch.Count < this.options.BatchSize;
+        var recordedAt = this.timeProvider.GetUtcNow();
+
+        var carried = run with
+        {
+            Position = batch[^1].StoredEmailId,
+            EvaluatedEmailCount = run.EvaluatedEmailCount + outcome.EvaluatedEmailIds.Count,
+            MatchedEmailCount = run.MatchedEmailCount + outcome.MatchedEmailCount,
+            SkippedEmailCount = run.SkippedEmailCount + outcome.SkippedEmailCount,
+            EndedAt = reachedTheEnd ? recordedAt : null,
+            Ending = reachedTheEnd ? MailRuleEvaluationRunEnding.Completed : null,
+        };
+
+        await this.commitPolicy.CommitAsync(
+            async (session, attemptCancellationToken) =>
+            {
+                await this.store.RecordEvaluatedAsync(
+                    session,
+                    outcome.EvaluatedEmailIds,
+                    recordedAt,
+                    attemptCancellationToken);
+
+                await this.runStore.SaveAsync(session, carried, attemptCancellationToken);
+            },
+            cancellationToken);
+
+        tally.Add(outcome);
+
+        return carried;
+    }
+
+    private Task CommitRunAsync(MailRuleEvaluationRun run, CancellationToken cancellationToken) =>
+        this.commitPolicy.CommitAsync(
+            (session, attemptCancellationToken) => this.runStore.SaveAsync(session, run, attemptCancellationToken),
+            cancellationToken);
+
+    /// <summary>Evaluates the rule set for each email of one batch, outside any transaction.</summary>
+    /// <remarks>
+    /// The evaluation instant is taken per email rather than per batch, because it is what the age fact is measured
+    /// against and an email is one reading of one message at one moment. Nothing here catches a failure: the evaluator
+    /// is where totality is applied, so a condition that cannot answer for one email is already a failed rule by the
+    /// time it reaches this tally and the emails behind it are unaffected.
+    /// </remarks>
+    private async Task<MailRuleEvaluationBatch> EvaluateBatchAsync(
+        MailRuleSet ruleSet,
+        bool requiresExtractedBodyText,
+        IReadOnlyList<StoredEmailAwaitingRuleEvaluation> batch,
+        CancellationToken cancellationToken)
+    {
+        var outcome = new MailRuleEvaluationBatch(batch.Count);
+
+        foreach (var candidate in batch)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // An email whose text is still expected is left in the queue rather than evaluated against a fact that
+            // would answer absent and then never be reconsidered. One whose content will never yield text is evaluated
+            // now, because waiting for it would stall this account's queue behind a message that can never become
+            // eligible.
+            if (requiresExtractedBodyText && candidate.AwaitsExtraction)
+            {
+                outcome.Skipped();
+
+                continue;
+            }
+
+            var facts = new MailRuleFacts(
+                candidate.Facts,
+                new StoredEmailBodyTextReader(this.store, candidate.StoredEmailId),
+                this.timeProvider.GetUtcNow());
+
+            var evaluation = await this.evaluator.EvaluateAsync(ruleSet, facts, cancellationToken);
+
+            outcome.Evaluated(candidate.StoredEmailId, evaluation);
+        }
+
+        return outcome;
+    }
+
+    /// <summary>What one batch's evaluations produced, before any of them were committed.</summary>
+    private sealed class MailRuleEvaluationBatch
+    {
+        internal MailRuleEvaluationBatch(int capacity) => this.EvaluatedEmailIds = new List<StoredEmailId>(capacity);
+
+        internal List<StoredEmailId> EvaluatedEmailIds { get; }
+
+        internal int MatchedEmailCount { get; private set; }
+
+        internal int SkippedEmailCount { get; private set; }
+
+        internal int FailedRuleCount { get; private set; }
+
+        internal int TimedOutRuleCount { get; private set; }
+
+        internal SortedSet<string> MatchedRuleNames { get; } = new(StringComparer.Ordinal);
+
+        internal SortedSet<string> FailedRuleNames { get; } = new(StringComparer.Ordinal);
+
+        internal void Skipped() => this.SkippedEmailCount++;
+
+        internal void Evaluated(StoredEmailId storedEmailId, MailRuleSetEvaluation evaluation)
+        {
+            this.EvaluatedEmailIds.Add(storedEmailId);
+
+            if (evaluation.MatchedRuleNames.Count > 0)
+            {
+                this.MatchedEmailCount++;
+                this.MatchedRuleNames.UnionWith(evaluation.MatchedRuleNames);
+            }
+
+            foreach (var failed in evaluation.Evaluations.Where(rule => rule.Outcome == MailRuleOutcome.Failed))
+            {
+                this.FailedRuleCount++;
+                this.FailedRuleNames.Add(failed.RuleName);
+
+                if (failed.Failure == MailRuleConditionFailure.EvaluationTimedOut)
+                {
+                    this.TimedOutRuleCount++;
+                }
+            }
+        }
+    }
+
+    /// <summary>Adds up the batches of one walk into the counts an operator reads.</summary>
+    private sealed class EvaluationTally
+    {
+        private readonly SortedSet<string> matchedRuleNames = new(StringComparer.Ordinal);
+        private readonly SortedSet<string> failedRuleNames = new(StringComparer.Ordinal);
+
+        private int evaluatedEmailCount;
+        private int matchedEmailCount;
+        private int skippedEmailCount;
+        private int failedRuleCount;
+        private int timedOutRuleCount;
+
+        internal void Add(MailRuleEvaluationBatch batch)
+        {
+            this.evaluatedEmailCount += batch.EvaluatedEmailIds.Count;
+            this.matchedEmailCount += batch.MatchedEmailCount;
+            this.skippedEmailCount += batch.SkippedEmailCount;
+            this.failedRuleCount += batch.FailedRuleCount;
+            this.timedOutRuleCount += batch.TimedOutRuleCount;
+            this.matchedRuleNames.UnionWith(batch.MatchedRuleNames);
+            this.failedRuleNames.UnionWith(batch.FailedRuleNames);
+        }
+
+        internal MailRuleEvaluationWalk ToWalk(bool emailsRemain) => new()
+        {
+            EvaluatedEmailCount = this.evaluatedEmailCount,
+            MatchedEmailCount = this.matchedEmailCount,
+            SkippedEmailCount = this.skippedEmailCount,
+            FailedRuleCount = this.failedRuleCount,
+            TimedOutRuleCount = this.timedOutRuleCount,
+            MatchedRuleNames = [.. this.matchedRuleNames],
+            FailedRuleNames = [.. this.failedRuleNames],
+            EmailsRemain = emailsRemain,
+        };
+    }
+
+    /// <summary>What the requested-run walk produced, keeping "no run outstanding" apart from "a run that did nothing".</summary>
+    private readonly record struct RequestedRunOutcome(
+        MailRuleEvaluationWalk? Walk,
+        MailRuleEvaluationRunEnding? Ending);
+}

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationReport.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationReport.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>What one account run's evaluation step did, under the rule set it read when it began.</summary>
+/// <param name="Revision">The rule set every email of the arrival walk was evaluated against.</param>
+/// <param name="Arrivals">What the walk over mail no pass had evaluated did.</param>
+/// <param name="RequestedRun">
+/// What the walk over a requested whole-mailbox run did, or <see langword="null" /> when the account had no run
+/// outstanding. A run the pass ended without evaluating anything — because the rule set moved under it — reports an
+/// empty walk beside its ending rather than no walk at all.
+/// </param>
+/// <param name="RequestedRunEnding">
+/// How the requested run stopped being outstanding, or <see langword="null" /> when it is still outstanding or when
+/// there was none.
+/// </param>
+public sealed record MailRuleEvaluationReport(
+    MailRuleSetRevision Revision,
+    MailRuleEvaluationWalk Arrivals,
+    MailRuleEvaluationWalk? RequestedRun,
+    MailRuleEvaluationRunEnding? RequestedRunEnding)
+{
+    /// <summary>A pass that had no rule set to run and no mail to run it over.</summary>
+    /// <param name="revision">The revision the pass read.</param>
+    /// <returns>The report.</returns>
+    public static MailRuleEvaluationReport Nothing(MailRuleSetRevision revision) =>
+        new(revision, MailRuleEvaluationWalk.Empty, RequestedRun: null, RequestedRunEnding: null);
+
+    /// <summary>Gets whether the pass did anything an operator would want reported.</summary>
+    public bool IsEmpty => this.Arrivals.IsEmpty && this.RequestedRun is null;
+}

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationRun.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationRun.cs
@@ -1,0 +1,62 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>A whole-mailbox rule run somebody asked for, and how far the account's synchronization runs have carried it.</summary>
+/// <remarks>
+/// <para>
+/// Durable because it has to survive the process. The run spans as many account runs as its batch budget needs, so a
+/// restart in the middle of one must resume at the email nobody has reached rather than at the beginning of a mailbox —
+/// and a request that arrived seconds before a shutdown must still be a request afterwards.
+/// </para>
+/// <para>
+/// One outstanding run per account, which is what makes a second request an answer rather than a second walk. There is
+/// no queue behind it: asking twice for the same thing is asking once, and the reply says the run is already under way.
+/// </para>
+/// <para>
+/// Every field is either MailFathom's own identity for something or a count. Nothing derived from a message belongs in
+/// a record an operator reads to find out what their instance is doing.
+/// </para>
+/// </remarks>
+public sealed record MailRuleEvaluationRun
+{
+    /// <summary>Gets the account whose mail the run walks.</summary>
+    public required MailAccountId AccountId { get; init; }
+
+    /// <summary>Gets when the run was asked for.</summary>
+    public required DateTimeOffset RequestedAt { get; init; }
+
+    /// <summary>Gets the rule set the run is bound to, which is unspecified until the first pass picks the run up.</summary>
+    /// <remarks>
+    /// Bound when the run starts rather than when it is requested, because a request is answered on a thread that has no
+    /// business deciding what the run will apply: the rule set may reload between the two, and the revision that matters
+    /// is the one in force when the first email is actually evaluated.
+    /// </remarks>
+    public MailRuleSetRevision Revision { get; init; }
+
+    /// <summary>Gets the identity of the last email the run committed, or <see langword="null" /> while it has committed none.</summary>
+    public StoredEmailId? Position { get; init; }
+
+    /// <summary>Gets how many of the account's emails the run has evaluated.</summary>
+    public int EvaluatedEmailCount { get; init; }
+
+    /// <summary>Gets how many of those emails at least one rule matched.</summary>
+    public int MatchedEmailCount { get; init; }
+
+    /// <summary>Gets how many emails the run stepped over because their body text had not been extracted yet.</summary>
+    public int SkippedEmailCount { get; init; }
+
+    /// <summary>Gets when the run stopped being outstanding, or <see langword="null" /> while it still is.</summary>
+    public DateTimeOffset? EndedAt { get; init; }
+
+    /// <summary>Gets how the run ended, which is absent for exactly as long as <see cref="EndedAt" /> is.</summary>
+    public MailRuleEvaluationRunEnding? Ending { get; init; }
+
+    /// <summary>Gets whether the run is still waiting to be carried further by an account run.</summary>
+    public bool IsOutstanding => this.EndedAt is null;
+}

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationRunEnding.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationRunEnding.cs
@@ -1,0 +1,24 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>How a requested whole-mailbox run stopped being outstanding.</summary>
+/// <remarks>
+/// A run that is still outstanding has no ending, which is what the absence of a value means rather than an unremarkable
+/// one. Both members are terminal: nothing resumes a run that has an ending, and asking for another one is a new request.
+/// </remarks>
+public enum MailRuleEvaluationRunEnding
+{
+    /// <summary>The run reached the end of the account's mail under the rule set it started with.</summary>
+    Completed = 0,
+
+    /// <summary>The rule set changed while the run was outstanding, so it stopped rather than finishing under rules it did not start with.</summary>
+    /// <remarks>
+    /// A run is bound to one revision, and MailFathom keeps only the rule set its configuration currently declares — so
+    /// a reload leaves no way to finish the run as itself. Ending it here says that plainly instead of quietly applying
+    /// two rule sets to one mailbox, and the remedy is to ask for the run again under the rules now in force.
+    /// </remarks>
+    Superseded = 1,
+}

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationRunRequest.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationRunRequest.cs
@@ -1,0 +1,14 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>The answer to somebody asking for a whole-mailbox rule run.</summary>
+/// <param name="Run">The run the account has outstanding, which is this request's own when <paramref name="Accepted" /> is true.</param>
+/// <param name="Accepted">
+/// Whether this request is what put the run in front of the account. A request that finds one already outstanding is
+/// answered with that run rather than refused: the caller asked for the account's mail to be re-evaluated and it is
+/// going to be, which is the answer they wanted even though nothing new was written.
+/// </param>
+public sealed record MailRuleEvaluationRunRequest(MailRuleEvaluationRun Run, bool Accepted);

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationRunRequests.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationRunRequests.cs
@@ -1,0 +1,83 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>Takes a request to run an account's rules over its whole mailbox, and answers one that is already under way.</summary>
+/// <remarks>
+/// <para>
+/// The request is recorded and nothing is evaluated here. Running the rules is a step of the account's synchronization
+/// run, so what this writes is the statement that the run is wanted; the request thread neither performs the work nor
+/// keeps it alive, which is what stops an operator's terminal closing from cancelling a walk of their mailbox.
+/// </para>
+/// <para>
+/// A second request while one is outstanding is answered with the run already in front of the account rather than
+/// refused or queued. Asking twice for the same thing is asking once: what the caller wanted is for the mail to be
+/// re-evaluated, and it is going to be.
+/// </para>
+/// </remarks>
+public sealed class MailRuleEvaluationRunRequests
+{
+    private readonly IMailRuleEvaluationRunStore runStore;
+    private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes the request intake.</summary>
+    /// <param name="runStore">Reads whether a run is outstanding and records the one this request asks for.</param>
+    /// <param name="commitPolicy">Makes the read and the write one decision, and resolves a race with a competing request.</param>
+    /// <param name="timeProvider">Stamps the request.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
+    public MailRuleEvaluationRunRequests(
+        IMailRuleEvaluationRunStore runStore,
+        OptimisticConcurrencyRetryPolicy commitPolicy,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(runStore);
+        ArgumentNullException.ThrowIfNull(commitPolicy);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.runStore = runStore;
+        this.commitPolicy = commitPolicy;
+        this.timeProvider = timeProvider;
+    }
+
+    /// <summary>Asks for the account's rules to be run over every message stored for it.</summary>
+    /// <param name="accountId">The account to run the rules over.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>The run the account now has outstanding, and whether this request is what put it there.</returns>
+    /// <exception cref="PersistenceConcurrencyConflictException">Thrown when two requests raced past the bounded retries.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    /// <remarks>
+    /// The read and the write are one committed decision rather than a check followed by an insert, because two requests
+    /// arriving together must resolve to one run. The loser of that race meets the account's own key, is retried from a
+    /// fresh read, and is answered with the run the winner asked for.
+    /// </remarks>
+    public Task<MailRuleEvaluationRunRequest> SubmitAsync(
+        MailAccountId accountId,
+        CancellationToken cancellationToken) =>
+        this.commitPolicy.CommitAsync(
+            async (session, attemptCancellationToken) =>
+            {
+                var outstanding = await this.runStore.FindOutstandingAsync(accountId, attemptCancellationToken);
+
+                if (outstanding is not null)
+                {
+                    return new MailRuleEvaluationRunRequest(outstanding, Accepted: false);
+                }
+
+                var requested = new MailRuleEvaluationRun
+                {
+                    AccountId = accountId,
+                    RequestedAt = this.timeProvider.GetUtcNow(),
+                };
+
+                await this.runStore.SaveAsync(session, requested, attemptCancellationToken);
+
+                return new MailRuleEvaluationRunRequest(requested, Accepted: true);
+            },
+            cancellationToken);
+}

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationWalk.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationWalk.cs
@@ -1,0 +1,58 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>What one walk of an evaluation pass did to one account's mail.</summary>
+/// <remarks>
+/// Counts and MailFathom's own configured rule names, and nothing else. A rule name is restricted to letters, digits,
+/// spaces, and three punctuation marks precisely so that it can be reported here and in a log line while everything
+/// else about the mail it selected stays where it is.
+/// </remarks>
+public sealed record MailRuleEvaluationWalk
+{
+    /// <summary>A walk that found nothing to do.</summary>
+    public static readonly MailRuleEvaluationWalk Empty = new();
+
+    /// <summary>Gets how many emails the walk evaluated the rule set for.</summary>
+    public int EvaluatedEmailCount { get; init; }
+
+    /// <summary>Gets how many of those emails at least one rule matched.</summary>
+    public int MatchedEmailCount { get; init; }
+
+    /// <summary>Gets how many emails the walk stepped over because their body text had not been extracted yet.</summary>
+    /// <remarks>
+    /// A skipped email is not evaluated and not recorded as evaluated, so it stays in the arrival queue and is reached
+    /// again once extraction has run for it. It is a wait rather than a failure, which is why it is counted apart from
+    /// one.
+    /// </remarks>
+    public int SkippedEmailCount { get; init; }
+
+    /// <summary>Gets how many rule evaluations produced no answer, counted per rule and per email rather than per email.</summary>
+    public int FailedRuleCount { get; init; }
+
+    /// <summary>Gets how many of those failures were a condition outlasting the evaluation timeout.</summary>
+    /// <remarks>
+    /// Separated from the rest because the two have different remedies: a timeout is answered by simplifying the
+    /// condition or raising the bound, and everything else is answered by looking at the rule.
+    /// </remarks>
+    public int TimedOutRuleCount { get; init; }
+
+    /// <summary>Gets the names of the rules that matched something during the walk, sorted and without repetition.</summary>
+    /// <remarks>
+    /// Sorted rather than kept in the order the walk met them, so two runs over the same mail report the same line: the
+    /// order rules are first reached in depends on which email came first, which says nothing about the rule set.
+    /// </remarks>
+    public IReadOnlyList<string> MatchedRuleNames { get; init; } = [];
+
+    /// <summary>Gets the names of the rules that failed to answer during the walk, sorted and without repetition.</summary>
+    public IReadOnlyList<string> FailedRuleNames { get; init; } = [];
+
+    /// <summary>Gets whether the walk left work behind because its batch budget ran out.</summary>
+    public bool EmailsRemain { get; init; }
+
+    /// <summary>Gets whether the walk did anything worth reporting.</summary>
+    public bool IsEmpty =>
+        this.EvaluatedEmailCount == 0 && this.SkippedEmailCount == 0 && !this.EmailsRemain;
+}

--- a/src/Application/Rules/Evaluation/StoredEmailAwaitingRuleEvaluation.cs
+++ b/src/Application/Rules/Evaluation/StoredEmailAwaitingRuleEvaluation.cs
@@ -11,9 +11,10 @@ namespace MailFathom.Application.Rules.Evaluation;
 /// <param name="StoredEmailId">The local identity the pass records its progress and its evaluation against.</param>
 /// <param name="Facts">The metadata every fact but the body text is resolved from.</param>
 /// <param name="AwaitsExtraction">
-/// Whether text is still expected to be derived from this email's stored content. It separates a message whose body text
-/// has not been extracted <em>yet</em> from one that will never have any, which is the difference between skipping the
-/// email until the text arrives and evaluating it now with the fact absent.
+/// Whether text is still expected to be derived from this email's content — the content already stored, or the content a
+/// later run will fetch once local storage has headroom for it. It separates a message whose body text has not been
+/// extracted <em>yet</em> from one that will never have any, which is the difference between skipping the email until
+/// the text arrives and evaluating it now with the fact absent.
 /// </param>
 public sealed record StoredEmailAwaitingRuleEvaluation(
     StoredEmailId StoredEmailId,

--- a/src/Application/Rules/Evaluation/StoredEmailAwaitingRuleEvaluation.cs
+++ b/src/Application/Rules/Evaluation/StoredEmailAwaitingRuleEvaluation.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Rules.Facts;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>One stored email a pass is about to evaluate, with everything a condition can read without a second query.</summary>
+/// <param name="StoredEmailId">The local identity the pass records its progress and its evaluation against.</param>
+/// <param name="Facts">The metadata every fact but the body text is resolved from.</param>
+/// <param name="AwaitsExtraction">
+/// Whether text is still expected to be derived from this email's stored content. It separates a message whose body text
+/// has not been extracted <em>yet</em> from one that will never have any, which is the difference between skipping the
+/// email until the text arrives and evaluating it now with the fact absent.
+/// </param>
+public sealed record StoredEmailAwaitingRuleEvaluation(
+    StoredEmailId StoredEmailId,
+    MailRuleEmailFacts Facts,
+    bool AwaitsExtraction);

--- a/src/Application/Rules/Evaluation/StoredEmailBodyTextReader.cs
+++ b/src/Application/Rules/Evaluation/StoredEmailBodyTextReader.cs
@@ -1,0 +1,30 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Rules.Facts;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>Binds the store's body-text read to the one email a rule set is being evaluated for.</summary>
+/// <remarks>
+/// The port it implements is deliberately email-less, so a condition cannot name a message other than the one in front
+/// of it. This is where that binding is made: one instance per email, constructed by the pass, holding no cache of its
+/// own because the fact surface already resolves a fact once per email.
+/// </remarks>
+internal sealed class StoredEmailBodyTextReader : IMailRuleBodyTextReader
+{
+    private readonly IMailRuleEvaluationStore store;
+    private readonly StoredEmailId storedEmailId;
+
+    internal StoredEmailBodyTextReader(IMailRuleEvaluationStore store, StoredEmailId storedEmailId)
+    {
+        this.store = store;
+        this.storedEmailId = storedEmailId;
+    }
+
+    /// <inheritdoc />
+    public Task<string?> ReadBodyTextAsync(CancellationToken cancellationToken) =>
+        this.store.ReadExtractedBodyTextAsync(this.storedEmailId, cancellationToken);
+}

--- a/src/Application/Rules/MailRuleSetRevision.cs
+++ b/src/Application/Rules/MailRuleSetRevision.cs
@@ -112,6 +112,31 @@ public readonly record struct MailRuleSetRevision
         return new MailRuleSetRevision(Convert.ToHexStringLower(digest)[..LengthInCharacters]);
     }
 
+    /// <summary>Reads back an identity this system derived earlier and recorded.</summary>
+    /// <param name="value">The recorded identity.</param>
+    /// <returns>The revision, which compares equal to a freshly derived one of the same rule set.</returns>
+    /// <exception cref="ArgumentException">Thrown when the value is not an identity this type could have produced.</exception>
+    /// <remarks>
+    /// A durable record of a run has to say which rule set the run was bound to, and it survives the process that
+    /// derived it — so the identity has to come back from storage rather than only out of <see cref="Create" />. The
+    /// shape is checked rather than trusted, because a value that is not one this type produces would compare unequal
+    /// to every rule set and silently make every run look superseded.
+    /// </remarks>
+    public static MailRuleSetRevision Restore(string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        if (value.Length != LengthInCharacters
+            || !value.All(static character => char.IsAsciiDigit(character) || char.IsAsciiLetterLower(character) && character <= 'f'))
+        {
+            throw new ArgumentException(
+                $"A rule set revision is exactly {LengthInCharacters} lowercase hexadecimal characters.",
+                nameof(value));
+        }
+
+        return new MailRuleSetRevision(value);
+    }
+
     /// <inheritdoc />
     public override string ToString() => this.value ?? "(unspecified)";
 }

--- a/src/Host/Configuration/Rules/MailRulesOptions.cs
+++ b/src/Host/Configuration/Rules/MailRulesOptions.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Application.Rules.Conditions;
+using MailFathom.Application.Rules.Evaluation;
 
 namespace MailFathom.Host.Configuration.Rules;
 
@@ -56,6 +57,23 @@ internal sealed class MailRulesOptions : IValidatableObject
     /// <summary>Gets or sets how long one condition may take to evaluate, including resolving the facts it names.</summary>
     public TimeSpan ConditionEvaluationTimeout { get; set; } = TimeSpan.FromSeconds(1);
 
+    /// <summary>Gets or sets how many stored emails one evaluation batch reads, evaluates, and commits together.</summary>
+    /// <remarks>
+    /// A batch is the unit of progress an interrupted pass gives back, and the unit of work one transaction covers.
+    /// Nothing about it is a schedule: when a pass happens is the account's synchronization interval.
+    /// </remarks>
+    [Range(1, 10_000)]
+    public int EvaluationBatchSize { get; set; } = 200;
+
+    /// <summary>Gets or sets how many batches one walk of one pass may commit before leaving the rest to the next run.</summary>
+    /// <remarks>
+    /// What bounds a run rather than what bounds the work: an account whose mail has never been evaluated drains over
+    /// as many runs as its size needs, instead of turning one run into a walk of its whole history while the folders
+    /// that run exists to fetch wait behind it.
+    /// </remarks>
+    [Range(1, 1_000)]
+    public int MaxEvaluationBatchesPerPass { get; set; } = 5;
+
     /// <summary>Turns the declared limits into the bounds a condition is read and run under.</summary>
     /// <returns>The bounds.</returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when a limit is not positive, which validation refuses first.</exception>
@@ -63,6 +81,14 @@ internal sealed class MailRulesOptions : IValidatableObject
         this.MaxConditionLength,
         this.MaxConditionNestingDepth,
         this.ConditionEvaluationTimeout);
+
+    /// <summary>Turns the declared limits into the bounds one evaluation pass runs under.</summary>
+    /// <returns>The bounds.</returns>
+    public MailRuleEvaluationOptions ToEvaluationOptions() => new()
+    {
+        BatchSize = this.EvaluationBatchSize,
+        MaxBatchesPerPass = this.MaxEvaluationBatchesPerPass,
+    };
 
     /// <inheritdoc />
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Retrieval.AskMail.Audit;
+using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Reconciliation;
 using MailFathom.Application.Synchronization.Sessions;
@@ -244,6 +245,7 @@ internal sealed partial class AccountSynchronizationSupervisor
             {
                 await this.EraseUnmirroredFolderContentAsync(runSettings, unmirroredFolders, workUnitToken);
                 await this.EraseExpiredAuditEntriesAsync(runSettings, workUnitToken);
+                await this.EvaluateMailRulesAsync(runSettings, workUnitToken);
             }
         }
         finally
@@ -424,6 +426,125 @@ internal sealed partial class AccountSynchronizationSupervisor
             this.LogAuditRetentionFailed(exception, this.accountId.Value);
         }
     }
+
+    /// <summary>Runs this account's rules over the mail that has arrived, and over its whole mailbox where one was asked for.</summary>
+    /// <remarks>
+    /// <para>
+    /// Last of the run's local steps, and after the folders rather than beside them, which is what makes "evaluation
+    /// never runs inside the synchronization transaction" true rather than merely intended: every message it can reach
+    /// was committed by a folder that has already finished, in a scope and a transaction of its own. It is also after
+    /// the unmirrored erasure, so a folder the operator has stopped mirroring has already given up its rows instead of
+    /// offering them to a rule on the way out.
+    /// </para>
+    /// <para>
+    /// A failure never fails the run. Evaluation reaches no mail server — everything it reads was already stored — so
+    /// backing the account off, which is to say fetching its mail less often, would answer a local problem by slowing
+    /// the remote work that had nothing to do with it. What a pass did not finish, the next run resumes from the
+    /// batches this one committed.
+    /// </para>
+    /// </remarks>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Rule evaluation is a local pass rather than a mail operation; one that failed is logged and resumed by the next run rather than putting the account into backoff.")]
+    private async Task EvaluateMailRulesAsync(
+        MailSynchronizationOptions runSettings,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = this.scopeFactory.CreateScope();
+
+            scope.ServiceProvider.GetRequiredService<ScopedMailSynchronizationSettings>().UseRunSnapshot(runSettings);
+
+            var report = await scope.ServiceProvider
+                .GetRequiredService<MailRuleEvaluationPass>()
+                .RunAsync(this.accountId, cancellationToken);
+
+            this.ReportRuleEvaluation(report);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            this.LogMailRuleEvaluationFailed(exception, this.accountId.Value);
+        }
+    }
+
+    /// <summary>Emits what the rules did, in counts and rule names; nothing derived from a message may appear here.</summary>
+    /// <remarks>
+    /// A pass that found nothing says nothing, so an account whose mail is all evaluated does not repeat a line per
+    /// interval forever. A rule's name is the one part of a rule that can be promised to carry no address somebody
+    /// typed, which is what makes naming the rules that matched safe as well as useful.
+    /// </remarks>
+    private void ReportRuleEvaluation(MailRuleEvaluationReport report)
+    {
+        if (!report.Arrivals.IsEmpty)
+        {
+            var matchedRuleNames = NameList(report.Arrivals.MatchedRuleNames);
+
+            this.LogArrivedMailEvaluated(
+                this.accountId.Value,
+                report.Revision.Value,
+                report.Arrivals.EvaluatedEmailCount,
+                report.Arrivals.MatchedEmailCount,
+                report.Arrivals.SkippedEmailCount,
+                matchedRuleNames,
+                report.Arrivals.EmailsRemain);
+        }
+
+        this.ReportFailedRules(report.Arrivals);
+
+        if (report.RequestedRun is { } requestedRun)
+        {
+            if (!requestedRun.IsEmpty)
+            {
+                var matchedRuleNames = NameList(requestedRun.MatchedRuleNames);
+
+                this.LogRequestedRunProgressed(
+                    this.accountId.Value,
+                    requestedRun.EvaluatedEmailCount,
+                    requestedRun.MatchedEmailCount,
+                    requestedRun.SkippedEmailCount,
+                    matchedRuleNames,
+                    requestedRun.EmailsRemain);
+            }
+
+            this.ReportFailedRules(requestedRun);
+        }
+
+        switch (report.RequestedRunEnding)
+        {
+            case MailRuleEvaluationRunEnding.Completed:
+                this.LogRequestedRunCompleted(this.accountId.Value, report.Revision.Value);
+
+                break;
+            case MailRuleEvaluationRunEnding.Superseded:
+                this.LogRequestedRunSuperseded(this.accountId.Value);
+
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void ReportFailedRules(MailRuleEvaluationWalk walk)
+    {
+        if (walk.FailedRuleCount == 0)
+        {
+            return;
+        }
+
+        var failedRuleNames = NameList(walk.FailedRuleNames);
+
+        this.LogRuleEvaluationsFailed(
+            this.accountId.Value,
+            walk.FailedRuleCount,
+            walk.TimedOutRuleCount,
+            failedRuleNames);
+    }
+
+    /// <summary>Renders a set of rule names for one log line, which is safe because a rule name carries nothing personal.</summary>
+    private static string NameList(IReadOnlyList<string> ruleNames) => string.Join(", ", ruleNames);
 
     /// <summary>Synchronizes one folder in a scope of its own and reports whether it completed and what it resolved to.</summary>
     /// <remarks>
@@ -771,6 +892,57 @@ internal sealed partial class AccountSynchronizationSupervisor
         Level = LogLevel.Warning,
         Message = "Erasing the stored mail of the folders account {AccountId} no longer mirrors ended unexpectedly; the account is not backed off for it and its next run erases what this one did not.")]
     private partial void LogUnmirroredFolderErasureFailed(Exception exception, string accountId);
+
+    /// <summary>States what the rules did to mail that has just arrived, naming the revision so an edit is visible in the record.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Evaluated rule set {RuleSetRevision} over {EvaluatedEmailCount} newly stored messages of account {AccountId}; {MatchedEmailCount} matched, {SkippedEmailCount} are waiting for their text to be extracted, rules that matched: [{MatchedRuleNames}], and more remain: {EmailsRemain}.")]
+    private partial void LogArrivedMailEvaluated(
+        string accountId,
+        string ruleSetRevision,
+        int evaluatedEmailCount,
+        int matchedEmailCount,
+        int skippedEmailCount,
+        string matchedRuleNames,
+        bool emailsRemain);
+
+    /// <summary>Reports one account run's share of a whole-mailbox run, which spans as many runs as its batch budget needs.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Carried the whole-mailbox rule run of account {AccountId} over {EvaluatedEmailCount} messages; {MatchedEmailCount} matched, {SkippedEmailCount} are waiting for their text to be extracted, rules that matched: [{MatchedRuleNames}], and more remain: {EmailsRemain}.")]
+    private partial void LogRequestedRunProgressed(
+        string accountId,
+        int evaluatedEmailCount,
+        int matchedEmailCount,
+        int skippedEmailCount,
+        string matchedRuleNames,
+        bool emailsRemain);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The whole-mailbox rule run of account {AccountId} reached the end of its mail under rule set {RuleSetRevision}.")]
+    private partial void LogRequestedRunCompleted(string accountId, string ruleSetRevision);
+
+    /// <summary>Names the remedy, because a superseded run is answered by asking for another rather than by waiting.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The rule set changed while the whole-mailbox rule run of account {AccountId} was outstanding, so the run ended without reaching the end of its mail; ask for it again to re-evaluate under the rules now in force.")]
+    private partial void LogRequestedRunSuperseded(string accountId);
+
+    /// <summary>Separates a rule that could not answer for one message from a pass that did not run, which are different faults.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "{FailedRuleCount} rule evaluations produced no answer for account {AccountId}, {TimedOutRuleCount} of them by outlasting the condition timeout; rules: [{FailedRuleNames}]. The messages are recorded as evaluated and the pass continued.")]
+    private partial void LogRuleEvaluationsFailed(
+        string accountId,
+        int failedRuleCount,
+        int timedOutRuleCount,
+        string failedRuleNames);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Evaluating the rules of account {AccountId} ended unexpectedly; the account is not backed off for it and its next run resumes from the batches this one committed.")]
+    private partial void LogMailRuleEvaluationFailed(Exception exception, string accountId);
 
     [LoggerMessage(
         Level = LogLevel.Warning,

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -24,6 +24,7 @@ using MailFathom.Application.Persistence;
 using MailFathom.Application.Retrieval.AskMail.Audit;
 using MailFathom.Application.Rules;
 using MailFathom.Application.Rules.Conditions;
+using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Redaction;
 using MailFathom.Application.Synchronization;
@@ -300,6 +301,13 @@ try
         provider.GetRequiredService<ILogger<ValidatedSettingsSnapshot<MailRulesOptions>>>()));
     builder.Services.AddSingleton<ISettingsSnapshot<MailRulesOptions>>(
         provider => provider.GetRequiredService<ValidatedSettingsSnapshot<MailRulesOptions>>());
+    // Evaluation is a step of the account's synchronization run, so its collaborators are scoped exactly as that run's
+    // other steps are: one scope per work unit, and the pass bounds read from the published snapshot when the scope is
+    // built rather than captured once at startup.
+    builder.Services.AddScoped(provider =>
+        provider.GetRequiredService<ISettingsSnapshot<MailRulesOptions>>().Current.ToEvaluationOptions());
+    builder.Services.AddScoped<MailRuleEvaluationPass>();
+    builder.Services.AddScoped<MailRuleEvaluationRunRequests>();
     builder.Services.AddHostedService(
         provider => provider.GetRequiredService<ValidatedSettingsSnapshot<MailRulesOptions>>());
     // The published snapshot, not the bound one, is what every consumer reads: a reload whose secret references do not

--- a/src/Infrastructure/Persistence/Entities/MailRuleEvaluationRunEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/MailRuleEvaluationRunEntity.cs
@@ -1,0 +1,62 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Rules.Evaluation;
+using MailFathom.CodeCoverage;
+
+namespace MailFathom.Infrastructure.Persistence.Entities;
+
+/// <summary>The whole-mailbox rule run an account has been asked for, and how far its synchronization runs have carried it.</summary>
+/// <remarks>
+/// <para>
+/// Keyed by the account rather than by a run identifier, which is what makes one outstanding run per account a property
+/// of the schema instead of a check somebody has to remember: a second request reaches the same row, so two callers
+/// asking together resolve to one run rather than to two walks over one mailbox.
+/// </para>
+/// <para>
+/// The row survives the run it describes, holding the ending of the last one until a new request replaces it. That is
+/// what lets a request be answered with "the previous run finished" rather than with silence, and it costs one row per
+/// account.
+/// </para>
+/// <para>
+/// No foreign key onto the mailbox account, for the reason the refresh-token row has none: the account row is written by
+/// whichever synchronization run first binds a folder, and a run may be asked for before that has happened.
+/// </para>
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class MailRuleEvaluationRunEntity
+{
+    /// <summary>The greatest length a rule set revision has, which is the derived identity's own fixed width.</summary>
+    internal const int RevisionLength = 12;
+
+    public required string MailboxAccountId { get; set; }
+
+    public DateTimeOffset RequestedAt { get; set; }
+
+    /// <summary>Gets or sets the rule set the run is bound to, absent until the first pass picks the run up.</summary>
+    public string? Revision { get; set; }
+
+    /// <summary>Gets or sets the identity of the last email a batch committed, absent while the run has committed none.</summary>
+    public Guid? Position { get; set; }
+
+    public int EvaluatedEmailCount { get; set; }
+
+    public int MatchedEmailCount { get; set; }
+
+    public int SkippedEmailCount { get; set; }
+
+    /// <summary>Gets or sets when the run stopped being outstanding, absent while it still is.</summary>
+    public DateTimeOffset? EndedAt { get; set; }
+
+    /// <summary>Gets or sets how the run ended, absent for exactly as long as <see cref="EndedAt" /> is.</summary>
+    public MailRuleEvaluationRunEnding? Ending { get; set; }
+
+    /// <summary>Gets or sets the optimistic concurrency token, which is PostgreSQL's own <c>xmin</c> rather than a column.</summary>
+    /// <remarks>
+    /// A pass and an arriving request can both reach this row: the pass commits a position while somebody asks for a run
+    /// the pass is about to finish. The token is what turns that into a conflict the retry policy resolves from a fresh
+    /// read instead of one writer overwriting the other's decision.
+    /// </remarks>
+    public uint ConcurrencyVersion { get; set; }
+}

--- a/src/Infrastructure/Persistence/Entities/StoredEmailEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/StoredEmailEntity.cs
@@ -159,6 +159,22 @@ internal sealed class StoredEmailEntity
 
     public bool IsRemotelyDeleted { get; set; }
 
+    /// <summary>
+    /// Gets or sets when a rule pass last evaluated this email, or <see langword="null" /> while none has.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The column is the arrival queue. A pass reads the account's rows carrying no value, in identity order, and
+    /// writing one is what takes a row out of the queue — so a rule applies to mail arriving from now on rather than to
+    /// a mailbox's whole history, and running the rules over mail already stored is something an owner asks for.
+    /// </para>
+    /// <para>
+    /// The migration that adds it stamps every row already stored, which is the same statement made about the mail that
+    /// existed before rules ran at all: an upgrade must not turn a first rule set loose on years of correspondence.
+    /// </para>
+    /// </remarks>
+    public DateTimeOffset? RulesEvaluatedAt { get; set; }
+
     public uint ConcurrencyVersion { get; set; }
 
     public EmailMessageContentEntity? Content { get; set; }

--- a/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -41,6 +41,12 @@ internal sealed class MailFathomDbContext : DbContext
 
     internal const string StoredEmailAwaitingContentIndexName = "ix_stored_emails_awaiting_content";
 
+    /// <summary>The order a requested whole-mailbox rule run walks an account's mail in.</summary>
+    internal const string StoredEmailAccountIdentityIndexName = "ix_stored_emails_account_identity";
+
+    /// <summary>The queue of mail no rule pass has evaluated, which is read once per account run and is usually empty.</summary>
+    internal const string StoredEmailAwaitingRuleEvaluationIndexName = "ix_stored_emails_awaiting_rule_evaluation";
+
     internal const string StoredEmailSenderIndexName = "ix_stored_emails_sender";
 
     internal const string StoredEmailToAddressesIndexName = "ix_stored_emails_to_addresses";
@@ -89,6 +95,14 @@ internal sealed class MailFathomDbContext : DbContext
     internal const string EmailEmbeddingProfileIndexName = "ix_email_embeddings_profile";
 
     internal const string MailboxRefreshTokenKeyIndexName = "ix_mailbox_refresh_tokens_data_encryption_key";
+
+    /// <summary>The key that keeps one whole-mailbox rule run per account, and which a second request is recognized by.</summary>
+    /// <remarks>
+    /// Named because losing this race is the mechanism rather than a fault: two requests for one account's first run
+    /// reach the database together, one of them violates this key, and the retry reads back the run the winner asked
+    /// for — which is exactly how asking twice produces one walk of one mailbox.
+    /// </remarks>
+    internal const string MailRuleEvaluationRunPrimaryKeyConstraintName = "pk_mail_rule_evaluation_runs";
 
     /// <summary>The constraint a mutation's idempotency identity is enforced by, and which a losing writer is recognized from.</summary>
     /// <remarks>
@@ -161,6 +175,8 @@ internal sealed class MailFathomDbContext : DbContext
     internal DbSet<EmailContentRepairRequestEntity> EmailContentRepairRequests => this.Set<EmailContentRepairRequestEntity>();
 
     internal DbSet<BackfillPositionEntity> BackfillPositions => this.Set<BackfillPositionEntity>();
+
+    internal DbSet<MailRuleEvaluationRunEntity> MailRuleEvaluationRuns => this.Set<MailRuleEvaluationRunEntity>();
 
     internal DbSet<SynchronizationCheckpointEntity> SynchronizationCheckpoints => this.Set<SynchronizationCheckpointEntity>();
 
@@ -336,6 +352,23 @@ internal sealed class MailFathomDbContext : DbContext
                 .WithOne(email => email.ContentRepairRequest)
                 .HasForeignKey<EmailContentRepairRequestEntity>(repairRequest => repairRequest.StoredEmailId)
                 .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        // One row per account, which is what makes "one outstanding whole-mailbox rule run" a property of the key rather
+        // than of a check. The ending is stored as text for the reason every other outcome here is: it stays readable
+        // in an ad-hoc query and survives a later reordering of the enum.
+        modelBuilder.Entity<MailRuleEvaluationRunEntity>(entity =>
+        {
+            entity.ToTable("mail_rule_evaluation_runs");
+            entity.HasKey(run => run.MailboxAccountId).HasName(MailRuleEvaluationRunPrimaryKeyConstraintName);
+            entity.Property(run => run.MailboxAccountId).HasMaxLength(128).ValueGeneratedNever();
+            entity.Property(run => run.Revision)
+                .HasMaxLength(MailRuleEvaluationRunEntity.RevisionLength)
+                .IsFixedLength();
+            entity.Property(run => run.Ending).HasConversion<string>().HasMaxLength(64);
+
+            // See the stored-email mapping: this is the PostgreSQL `xmin` system column, not a user-defined column.
+            entity.Property(run => run.ConcurrencyVersion).IsRowVersion();
         });
 
         modelBuilder.Entity<BackfillPositionEntity>(entity =>
@@ -854,6 +887,21 @@ internal sealed class MailFathomDbContext : DbContext
             .HasDatabaseName(StoredEmailAwaitingContentIndexName)
             .HasFilter(
                 $"\"{nameof(StoredEmailEntity.ContentAvailability)}\" = '{nameof(StoredEmailContentAvailability.AwaitingStorageHeadroom)}'");
+
+        // The order a requested whole-mailbox rule run walks in. It is the identity rather than the timeline because a
+        // walk that has to resume needs a total order no later write disturbs, and because the position it commits is
+        // one column rather than a nullable timestamp paired with a tie-breaker.
+        entity.HasIndex(email => new { email.MailboxAccountId, email.Id })
+            .HasDatabaseName(StoredEmailAccountIdentityIndexName);
+
+        // The arrival queue, and the filter is the whole point of it. In steady state almost every row of an account
+        // has been evaluated, so without the filter this read would walk the account's entire index once per run to
+        // find the handful of rows that qualify — and it runs for every account on every synchronization run.
+        entity.HasIndex(
+                email => new { email.MailboxAccountId, email.Id },
+                StoredEmailAwaitingRuleEvaluationIndexName)
+            .HasDatabaseName(StoredEmailAwaitingRuleEvaluationIndexName)
+            .HasFilter($"\"{nameof(StoredEmailEntity.RulesEvaluatedAt)}\" IS NULL");
 
         entity.HasIndex(email => email.SenderNormalizedAddress)
             .HasDatabaseName(StoredEmailSenderIndexName);

--- a/src/Infrastructure/Persistence/Migrations/20260812073051_AddMailRuleEvaluationState.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260812073051_AddMailRuleEvaluationState.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260812073051_AddMailRuleEvaluationState")]
+    partial class AddMailRuleEvaluationState
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260812073051_AddMailRuleEvaluationState.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260812073051_AddMailRuleEvaluationState.cs
@@ -1,0 +1,83 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMailRuleEvaluationState : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "RulesEvaluatedAt",
+                table: "stored_emails",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            // Every message already stored is stamped as evaluated, and the stamp is the point of the column rather
+            // than a tidying of it. The arrival queue is "rows carrying no value", so without this an upgrade would
+            // hand the deployment's first rule set an entire mailbox's history as though it had all just arrived —
+            // which, once a match leads to a change to the mail, is a mass filing nobody asked for. Running the rules
+            // over mail already stored stays available as the whole-mailbox run an owner requests deliberately.
+            // One statement over the table at upgrade time, before the partial index below is built over the result.
+            migrationBuilder.Sql("UPDATE stored_emails SET \"RulesEvaluatedAt\" = now() WHERE \"RulesEvaluatedAt\" IS NULL;");
+
+            migrationBuilder.CreateTable(
+                name: "mail_rule_evaluation_runs",
+                columns: table => new
+                {
+                    MailboxAccountId = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    RequestedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Revision = table.Column<string>(type: "character(12)", fixedLength: true, maxLength: 12, nullable: true),
+                    Position = table.Column<Guid>(type: "uuid", nullable: true),
+                    EvaluatedEmailCount = table.Column<int>(type: "integer", nullable: false),
+                    MatchedEmailCount = table.Column<int>(type: "integer", nullable: false),
+                    SkippedEmailCount = table.Column<int>(type: "integer", nullable: false),
+                    EndedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    Ending = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    xmin = table.Column<uint>(type: "xid", rowVersion: true, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_mail_rule_evaluation_runs", x => x.MailboxAccountId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_stored_emails_account_identity",
+                table: "stored_emails",
+                columns: new[] { "MailboxAccountId", "Id" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_stored_emails_awaiting_rule_evaluation",
+                table: "stored_emails",
+                columns: new[] { "MailboxAccountId", "Id" },
+                filter: "\"RulesEvaluatedAt\" IS NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "mail_rule_evaluation_runs");
+
+            migrationBuilder.DropIndex(
+                name: "ix_stored_emails_account_identity",
+                table: "stored_emails");
+
+            migrationBuilder.DropIndex(
+                name: "ix_stored_emails_awaiting_rule_evaluation",
+                table: "stored_emails");
+
+            migrationBuilder.DropColumn(
+                name: "RulesEvaluatedAt",
+                table: "stored_emails");
+        }
+    }
+}

--- a/src/Infrastructure/Persistence/Rules/MailRuleEvaluationRunStore.cs
+++ b/src/Infrastructure/Persistence/Rules/MailRuleEvaluationRunStore.cs
@@ -1,0 +1,89 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Evaluation;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Sessions;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailFathom.Infrastructure.Persistence.Rules;
+
+/// <summary>EF Core state for the one whole-mailbox rule run an account may have outstanding.</summary>
+[RequiresIntegrationCoverage]
+internal sealed class MailRuleEvaluationRunStore(MailFathomDbContext dbContext) : IMailRuleEvaluationRunStore
+{
+    /// <inheritdoc />
+    public async Task<MailRuleEvaluationRun?> FindOutstandingAsync(
+        MailAccountId accountId,
+        CancellationToken cancellationToken)
+    {
+        var mailboxAccountId = accountId.Value;
+        var outstanding = await dbContext.MailRuleEvaluationRuns
+            .AsNoTracking()
+            .SingleOrDefaultAsync(
+                run => run.MailboxAccountId == mailboxAccountId && run.EndedAt == null,
+                cancellationToken);
+
+        return outstanding is null ? null : Read(outstanding, accountId);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// One row per account, so a request that follows a completed run overwrites it rather than appending. The lookup
+    /// resolves a row this session already staged from the change tracker, which is what lets a pass commit several
+    /// batches through one session without inserting a second row under the same key.
+    /// </remarks>
+    public async Task SaveAsync(
+        IPersistenceSession session,
+        MailRuleEvaluationRun run,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(run);
+
+        var sessionContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
+        var stored = await sessionContext.MailRuleEvaluationRuns.FindAsync(
+            [run.AccountId.Value],
+            cancellationToken);
+
+        if (stored is null)
+        {
+            stored = new MailRuleEvaluationRunEntity { MailboxAccountId = run.AccountId.Value };
+            sessionContext.MailRuleEvaluationRuns.Add(stored);
+        }
+
+        Write(stored, run);
+    }
+
+    private static MailRuleEvaluationRun Read(MailRuleEvaluationRunEntity entity, MailAccountId accountId) => new()
+    {
+        AccountId = accountId,
+        RequestedAt = entity.RequestedAt,
+        Revision = entity.Revision is { } revision
+            ? MailRuleSetRevision.Restore(revision)
+            : default,
+        Position = entity.Position is { } position ? StoredEmailId.Create(position) : null,
+        EvaluatedEmailCount = entity.EvaluatedEmailCount,
+        MatchedEmailCount = entity.MatchedEmailCount,
+        SkippedEmailCount = entity.SkippedEmailCount,
+        EndedAt = entity.EndedAt,
+        Ending = entity.Ending,
+    };
+
+    private static void Write(MailRuleEvaluationRunEntity entity, MailRuleEvaluationRun run)
+    {
+        entity.RequestedAt = run.RequestedAt;
+        entity.Revision = run.Revision.IsSpecified ? run.Revision.Value : null;
+        entity.Position = run.Position?.Value;
+        entity.EvaluatedEmailCount = run.EvaluatedEmailCount;
+        entity.MatchedEmailCount = run.MatchedEmailCount;
+        entity.SkippedEmailCount = run.SkippedEmailCount;
+        entity.EndedAt = run.EndedAt;
+        entity.Ending = run.Ending;
+    }
+}

--- a/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
+++ b/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
@@ -98,9 +98,19 @@ internal sealed class MailRuleEvaluationStore(MailFathomDbContext dbContext) : I
 
     /// <summary>Reads one keyset batch of an account's mail as the fact surface a condition is evaluated against.</summary>
     /// <remarks>
+    /// <para>
     /// Ordering is by the primary key, which is total, stable, and already indexed for this account. Both the ordering
     /// and the keyset comparison are evaluated by PostgreSQL, so a walk runs entirely under that server's <c>uuid</c>
     /// ordering and never has to agree with how the CLR compares two identifiers.
+    /// </para>
+    /// <para>
+    /// Text is still expected wherever content is stored or is going to be, which is why
+    /// <see cref="StoredEmailContentAvailability.AwaitingStorageHeadroom" /> counts alongside
+    /// <see cref="StoredEmailContentAvailability.Available" />: a later run fetches that payload as soon as the ceiling
+    /// permits, and evaluating the email now would stamp it as evaluated and leave a rule naming the body text never
+    /// seeing it. <see cref="StoredEmailContentAvailability.ExceededSizeLimit" /> is the opposite future — every later
+    /// run refuses it for the same reason — so such an email is evaluated now with the fact absent rather than waited on.
+    /// </para>
     /// </remarks>
     private async Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>> ReadCandidatesAsync(
         IQueryable<StoredEmailEntity> emails,
@@ -141,7 +151,8 @@ internal sealed class MailRuleEvaluationStore(MailFathomDbContext dbContext) : I
                 email.IsRemotelyFlagged,
                 email.IsRemotelyDraft,
                 HasExtractedContent = email.SearchDocument != null,
-                AwaitsExtraction = email.ContentAvailability == StoredEmailContentAvailability.Available
+                AwaitsExtraction = (email.ContentAvailability == StoredEmailContentAvailability.Available
+                        || email.ContentAvailability == StoredEmailContentAvailability.AwaitingStorageHeadroom)
                     && email.SearchDocument == null,
             })
             .ToArrayAsync(cancellationToken);

--- a/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
+++ b/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
@@ -1,0 +1,176 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules.Evaluation;
+using MailFathom.Application.Rules.Facts;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Infrastructure.Persistence.Emails;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Sessions;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailFathom.Infrastructure.Persistence.Rules;
+
+/// <summary>EF Core state for the rule passes that run inside an account's synchronization run.</summary>
+/// <remarks>
+/// Both walks project straight into the fact surface rather than loading rows, because a condition reads twenty of its
+/// twenty-one facts from metadata and none of them is the raw MIME sitting beside it in the same aggregate. The
+/// twenty-first is read one email at a time and only when a condition names it, which is what keeps a rule set that
+/// mentions no body text free of a content read.
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class MailRuleEvaluationStore(MailFathomDbContext dbContext) : IMailRuleEvaluationStore
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// The absent evaluation timestamp is the predicate and the partial index behind it, so the queue costs a read
+    /// proportional to what is in it rather than to the account's mail. A tombstoned email is left out for the reason
+    /// both backfills leave one out: applying a rule to mail nothing may read is work with no reader.
+    /// </remarks>
+    public Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>> GetEmailsAwaitingFirstEvaluationAsync(
+        MailAccountId accountId,
+        StoredEmailId? resumeAfter,
+        int batchSize,
+        CancellationToken cancellationToken) =>
+        this.ReadCandidatesAsync(
+            dbContext.StoredEmails.Where(email => email.RulesEvaluatedAt == null),
+            accountId,
+            resumeAfter,
+            batchSize,
+            cancellationToken);
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>> GetStoredEmailsAsync(
+        MailAccountId accountId,
+        StoredEmailId? resumeAfter,
+        int batchSize,
+        CancellationToken cancellationToken) =>
+        this.ReadCandidatesAsync(dbContext.StoredEmails, accountId, resumeAfter, batchSize, cancellationToken);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The trimmed reading is what a condition sees, which is the same text lexical search matches on. A rule asking
+    /// whether a message says something is asking about what its author wrote, not about the quoted history and the
+    /// signature underneath it.
+    /// </remarks>
+    public async Task<string?> ReadExtractedBodyTextAsync(
+        StoredEmailId storedEmailId,
+        CancellationToken cancellationToken) =>
+        await dbContext.EmailSearchDocuments
+            .AsNoTracking()
+            .Where(document => document.StoredEmailId == storedEmailId.Value)
+            .Select(document => document.BodyText)
+            .SingleOrDefaultAsync(cancellationToken);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Written as one statement over the batch rather than through tracked entities, and the reason is a race rather
+    /// than a saving. Synchronization and reconciliation write these same rows under an optimistic token, so loading
+    /// two hundred of them to set one column would turn every overlap into a conflict the pass has to retry — over a
+    /// column no other writer touches.
+    /// </remarks>
+    public async Task RecordEvaluatedAsync(
+        IPersistenceSession session,
+        IReadOnlyList<StoredEmailId> storedEmailIds,
+        DateTimeOffset evaluatedAt,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(storedEmailIds);
+
+        if (storedEmailIds.Count == 0)
+        {
+            return;
+        }
+
+        var identities = storedEmailIds.Select(storedEmailId => storedEmailId.Value).ToArray();
+        var sessionContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
+
+        await sessionContext.StoredEmails
+            .Where(email => identities.Contains(email.Id))
+            .ExecuteUpdateAsync(
+                update => update.SetProperty(email => email.RulesEvaluatedAt, evaluatedAt),
+                cancellationToken);
+    }
+
+    /// <summary>Reads one keyset batch of an account's mail as the fact surface a condition is evaluated against.</summary>
+    /// <remarks>
+    /// Ordering is by the primary key, which is total, stable, and already indexed for this account. Both the ordering
+    /// and the keyset comparison are evaluated by PostgreSQL, so a walk runs entirely under that server's <c>uuid</c>
+    /// ordering and never has to agree with how the CLR compares two identifiers.
+    /// </remarks>
+    private async Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>> ReadCandidatesAsync(
+        IQueryable<StoredEmailEntity> emails,
+        MailAccountId accountId,
+        StoredEmailId? resumeAfter,
+        int batchSize,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(batchSize);
+
+        var mailboxAccountId = accountId.Value;
+        var resumeAfterId = resumeAfter?.Value;
+
+        var candidates = await emails
+            .AsNoTracking()
+            .Where(StoredEmailTombstone.IsNotTombstoned)
+            .Where(email => email.MailboxAccountId == mailboxAccountId
+                && (resumeAfterId == null || email.Id > resumeAfterId))
+            .OrderBy(email => email.Id)
+            .Take(batchSize)
+            .Select(email => new
+            {
+                email.Id,
+                email.MailFolder.Alias,
+                email.Subject,
+                email.SenderNormalizedAddress,
+                email.ToAddresses,
+                email.CcAddresses,
+                email.ReceivedAt,
+                email.SentAt,
+                email.SizeOctets,
+                email.AttachmentCount,
+                email.AttachmentTotalSizeOctets,
+                email.IsEncrypted,
+                email.CarriesUnverifiedSignature,
+                email.IsRemotelySeen,
+                email.IsRemotelyAnswered,
+                email.IsRemotelyFlagged,
+                email.IsRemotelyDraft,
+                HasExtractedContent = email.SearchDocument != null,
+                AwaitsExtraction = email.ContentAvailability == StoredEmailContentAvailability.Available
+                    && email.SearchDocument == null,
+            })
+            .ToArrayAsync(cancellationToken);
+
+        return
+        [
+            .. candidates.Select(candidate => new StoredEmailAwaitingRuleEvaluation(
+                StoredEmailId.Create(candidate.Id),
+                new MailRuleEmailFacts
+                {
+                    Account = mailboxAccountId,
+                    Folder = candidate.Alias,
+                    Subject = candidate.Subject,
+                    SenderAddress = candidate.SenderNormalizedAddress,
+                    RecipientAddresses = [.. candidate.ToAddresses, .. candidate.CcAddresses],
+                    ReceivedAt = candidate.ReceivedAt,
+                    SentAt = candidate.SentAt,
+                    SizeInBytes = candidate.SizeOctets,
+                    AttachmentCount = candidate.AttachmentCount,
+                    AttachmentTotalBytes = candidate.AttachmentTotalSizeOctets,
+                    IsEncrypted = candidate.IsEncrypted,
+                    CarriesUnverifiedSignature = candidate.CarriesUnverifiedSignature,
+                    IsSeen = candidate.IsRemotelySeen,
+                    IsAnswered = candidate.IsRemotelyAnswered,
+                    IsFlagged = candidate.IsRemotelyFlagged,
+                    IsDraft = candidate.IsRemotelyDraft,
+                    HasExtractedContent = candidate.HasExtractedContent,
+                },
+                candidate.AwaitsExtraction)),
+        ];
+    }
+}

--- a/src/Infrastructure/Persistence/Sessions/PersistenceSessionFactory.cs
+++ b/src/Infrastructure/Persistence/Sessions/PersistenceSessionFactory.cs
@@ -79,6 +79,11 @@ internal sealed class PersistenceSessionFactory(MailFathomDbContext dbContext) :
         /// crossing the application boundary, and the activation turns that into the answer the operator needs, which
         /// is that a different reindex is already running.
         /// </para>
+        /// <para>
+        /// The last is the mutation identity's case once more, for the account's whole-mailbox rule run: two requests
+        /// for an account that has never had one reach the database together, and the retry reads back the run the
+        /// winner asked for instead of the second caller starting a second walk of one mailbox.
+        /// </para>
         /// </remarks>
         public bool IsConcurrencyConflict(DbUpdateException exception) =>
             exception.InnerException is PostgresException
@@ -90,7 +95,8 @@ internal sealed class PersistenceSessionFactory(MailFathomDbContext dbContext) :
                     or MailFathomDbContext.MailboxMutationIdentityUniqueIndexName
                     or MailFathomDbContext.MailboxMutationAuditEntryMutationUniqueIndexName
                     or MailFathomDbContext.EmbeddingProfileFingerprintUniqueIndexName
-                    or MailFathomDbContext.EmbeddingProfileLifecycleUniqueIndexName,
+                    or MailFathomDbContext.EmbeddingProfileLifecycleUniqueIndexName
+                    or MailFathomDbContext.MailRuleEvaluationRunPrimaryKeyConstraintName,
             };
 
         public void ClearTrackedState() => dbContext.ChangeTracker.Clear();

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ using MailFathom.Application.Resilience;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
 using MailFathom.Application.Retrieval.AskMail.Audit;
+using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
@@ -56,6 +57,7 @@ using MailFathom.Infrastructure.Persistence.Connections;
 using MailFathom.Infrastructure.Persistence.Emails;
 using MailFathom.Infrastructure.Persistence.Embeddings;
 using MailFathom.Infrastructure.Persistence.Mutations;
+using MailFathom.Infrastructure.Persistence.Rules;
 using MailFathom.Infrastructure.Persistence.Sessions;
 using MailFathom.Infrastructure.Persistence.Synchronization;
 using MailFathom.Infrastructure.Resilience;
@@ -274,6 +276,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IStoredEmailContentInventory, StoredEmailContentInventory>();
         services.AddScoped<IStoredEmailExtractionBackfillStore, StoredEmailExtractionBackfillStore>();
         services.AddScoped<IStoredEmailReconciliationStore, StoredEmailReconciliationStore>();
+        services.AddScoped<IMailRuleEvaluationStore, MailRuleEvaluationStore>();
+        services.AddScoped<IMailRuleEvaluationRunStore, MailRuleEvaluationRunStore>();
         // The read side takes no persistence session and joins no transaction, so its ports are registered beside the
         // write repositories rather than through one of them.
         services.AddScoped<IStoredEmailTimelineReader, StoredEmailTimelineReader>();

--- a/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationPassTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationPassTests.cs
@@ -1,0 +1,377 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Conditions;
+using MailFathom.Application.Rules.Evaluation;
+using MailFathom.Application.Rules.Facts;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Rules.Evaluation;
+
+/// <summary>Covers the two triggers, what each of them records, and everything a pass is allowed to leave behind.</summary>
+public sealed class MailRuleEvaluationPassTests
+{
+    private static readonly DateTimeOffset EvaluatedAt = new(2026, 4, 2, 11, 0, 0, TimeSpan.Zero);
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+    private static readonly MailAccountId OtherAccount = MailAccountId.Create("personal");
+
+    private readonly InMemoryMailRuleEvaluationStore store = new();
+    private readonly InMemoryMailRuleEvaluationRunStore runStore = new();
+    private readonly FakeTimeProvider timeProvider = new(EvaluatedAt);
+
+    [Fact]
+    public async Task RunAsync_MailNoPassHasEvaluated_EvaluatesItAndRecordsIt()
+    {
+        // Arrange
+        var matching = ScriptedMailRuleCondition.Answering(matches: true);
+        var arrived = this.store.Add(FactsFor(Account));
+        var pass = this.CreatePass(RuleSetOf(MailRule.Create("file-it", matching, stopWhenMatched: false)));
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, matching.EvaluationCount);
+        Assert.Equal([arrived], this.store.Evaluated);
+        Assert.Equal(1, report.Arrivals.EvaluatedEmailCount);
+        Assert.Equal(1, report.Arrivals.MatchedEmailCount);
+        Assert.Equal(["file-it"], report.Arrivals.MatchedRuleNames);
+        Assert.False(report.Arrivals.EmailsRemain);
+    }
+
+    /// <summary>The arrival queue must never become a back door to reprocessing, whatever the rule set now says.</summary>
+    [Fact]
+    public async Task RunAsync_MailAPassAlreadyEvaluated_IsNotEvaluatedAgain()
+    {
+        // Arrange
+        var condition = ScriptedMailRuleCondition.Answering(matches: true);
+        this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1));
+        var pass = this.CreatePass(RuleSetOf(MailRule.Create("new-rule", condition, stopWhenMatched: false)));
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, condition.EvaluationCount);
+        Assert.True(report.Arrivals.IsEmpty);
+    }
+
+    /// <summary>An account with no rule of its own still leaves the queue behind it, so a later rule starts from now.</summary>
+    [Fact]
+    public async Task RunAsync_NoRuleReachesThisAccount_StillRecordsItsArrivalsAsEvaluated()
+    {
+        // Arrange
+        var condition = ScriptedMailRuleCondition.Answering(matches: true);
+        var arrived = this.store.Add(FactsFor(Account));
+        var pass = this.CreatePass(
+            RuleSetOf(MailRule.Create("other-account", condition, stopWhenMatched: false, [OtherAccount.Value])));
+
+        // Act
+        await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, condition.EvaluationCount);
+        Assert.True(this.store.IsEvaluated(arrived));
+    }
+
+    [Fact]
+    public async Task RunAsync_MailOfAnotherAccount_IsNotReached()
+    {
+        // Arrange
+        var elsewhere = this.store.Add(FactsFor(OtherAccount));
+        var pass = this.CreatePass(RuleSetOf(
+            MailRule.Create("everywhere", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false)));
+
+        // Act
+        await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(this.store.IsEvaluated(elsewhere));
+    }
+
+    [Fact]
+    public async Task RunAsync_MoreArrivalsThanTheBatchBudgetReaches_EvaluatesWhatItCanAndReportsTheRest()
+    {
+        // Arrange
+        var arrived = Enumerable
+            .Range(0, 5)
+            .Select(_ => this.store.Add(FactsFor(Account)))
+            .ToArray();
+        var pass = this.CreatePass(
+            RuleSetOf(MailRule.Create("all", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: false)),
+            batchSize: 1,
+            maxBatchesPerPass: 2);
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(arrived.Take(2), this.store.Evaluated);
+        Assert.Equal(2, report.Arrivals.EvaluatedEmailCount);
+        Assert.True(report.Arrivals.EmailsRemain);
+    }
+
+    [Fact]
+    public async Task RunAsync_RequestedRun_EvaluatesMailAlreadyEvaluatedAndCompletes()
+    {
+        // Arrange
+        var already = this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1));
+        this.runStore.Arrange(RequestedRun());
+        var pass = this.CreatePass(RuleSetOf(
+            MailRule.Create("re-run", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false)));
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal([already], this.store.Evaluated);
+        Assert.Equal(1, report.RequestedRun?.EvaluatedEmailCount);
+        Assert.Equal(MailRuleEvaluationRunEnding.Completed, report.RequestedRunEnding);
+        Assert.Equal(MailRuleEvaluationRunEnding.Completed, this.runStore.Find(Account)?.Ending);
+        Assert.Null(await this.runStore.FindOutstandingAsync(Account, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task RunAsync_RequestedRunPickedUp_BindsTheRevisionItStartedUnder()
+    {
+        // Arrange
+        var ruleSet = RuleSetOf(
+            MailRule.Create("re-run", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: false));
+        this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1));
+        this.runStore.Arrange(RequestedRun());
+
+        // Act
+        await this.CreatePass(ruleSet).RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(ruleSet.Revision, this.runStore.Find(Account)?.Revision);
+    }
+
+    [Fact]
+    public async Task RunAsync_RequestedRunLeftPartWayThrough_ResumesFromTheCommittedPosition()
+    {
+        // Arrange
+        var ruleSet = RuleSetOf(
+            MailRule.Create("re-run", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: false));
+        var mail = Enumerable
+            .Range(0, 3)
+            .Select(_ => this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1)))
+            .ToArray();
+        this.runStore.Arrange(RequestedRun() with
+        {
+            Revision = ruleSet.Revision,
+            Position = mail[0],
+            EvaluatedEmailCount = 1,
+        });
+
+        // Act
+        var report = await this.CreatePass(ruleSet).RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(mail.Skip(1), this.store.Evaluated);
+        Assert.Equal(2, report.RequestedRun?.EvaluatedEmailCount);
+        Assert.Equal(3, this.runStore.Find(Account)?.EvaluatedEmailCount);
+    }
+
+    /// <summary>A run cannot finish under rules it did not start with, and nothing keeps the set it did start with.</summary>
+    [Fact]
+    public async Task RunAsync_RuleSetChangedWhileARunWasOutstanding_EndsItAsSupersededWithoutEvaluating()
+    {
+        // Arrange
+        var condition = ScriptedMailRuleCondition.Answering(matches: true);
+        this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1));
+        this.runStore.Arrange(RequestedRun() with
+        {
+            Revision = RuleSetOf(MailRule.Create(
+                "the-old-one",
+                ScriptedMailRuleCondition.Answering(matches: false),
+                stopWhenMatched: false)).Revision,
+        });
+        var pass = this.CreatePass(RuleSetOf(MailRule.Create("the-new-one", condition, stopWhenMatched: false)));
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, condition.EvaluationCount);
+        Assert.Empty(this.store.Evaluated);
+        Assert.Equal(MailRuleEvaluationRunEnding.Superseded, report.RequestedRunEnding);
+        Assert.Equal(MailRuleEvaluationRunEnding.Superseded, this.runStore.Find(Account)?.Ending);
+    }
+
+    [Fact]
+    public async Task RunAsync_RuleNamingTheBodyTextAndAnEmailStillAwaitingExtraction_SkipsItAndLeavesItInTheQueue()
+    {
+        // Arrange
+        var awaiting = this.store.Add(FactsFor(Account), awaitsExtraction: true);
+        var pass = this.CreatePass(RuleSetOf(MailRule.Create(
+            "reads-the-body",
+            ScriptedMailRuleCondition.Answering(matches: true, MailRuleFact.BodyText),
+            stopWhenMatched: false)));
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(this.store.IsEvaluated(awaiting));
+        Assert.Equal(0, report.Arrivals.EvaluatedEmailCount);
+        Assert.Equal(1, report.Arrivals.SkippedEmailCount);
+        Assert.Empty(this.store.BodyTextReads);
+    }
+
+    [Fact]
+    public async Task RunAsync_ExtractionArrivedForASkippedEmail_EvaluatesItOnTheNextPass()
+    {
+        // Arrange
+        var awaiting = this.store.Add(FactsFor(Account), awaitsExtraction: true);
+        var pass = this.CreatePass(RuleSetOf(MailRule.Create(
+            "reads-the-body",
+            ScriptedMailRuleCondition.Answering(matches: true, MailRuleFact.BodyText),
+            stopWhenMatched: false)));
+
+        await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Act
+        this.store.CompleteExtraction(awaiting, "the invoice is attached");
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(this.store.IsEvaluated(awaiting));
+        Assert.Equal(1, report.Arrivals.EvaluatedEmailCount);
+        Assert.Equal([awaiting], this.store.BodyTextReads);
+    }
+
+    /// <summary>Waiting for text nothing will ever extract would stall the queue behind a message that cannot become eligible.</summary>
+    [Fact]
+    public async Task RunAsync_EmailWhoseContentWillNeverYieldText_IsEvaluatedWithTheFactAbsent()
+    {
+        // Arrange
+        var withoutText = this.store.Add(FactsFor(Account), awaitsExtraction: false);
+        var pass = this.CreatePass(RuleSetOf(MailRule.Create(
+            "reads-the-body",
+            ScriptedMailRuleCondition.Answering(matches: false, MailRuleFact.BodyText),
+            stopWhenMatched: false)));
+
+        // Act
+        await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(this.store.IsEvaluated(withoutText));
+        Assert.Equal([withoutText], this.store.BodyTextReads);
+    }
+
+    [Fact]
+    public async Task RunAsync_ConditionThatCannotAnswer_RecordsTheFailureAndEvaluatesTheRestOfTheBatch()
+    {
+        // Arrange
+        var unlucky = this.store.Add(FactsFor(Account));
+        var next = this.store.Add(FactsFor(Account));
+        var pass = this.CreatePass(RuleSetOf(
+            MailRule.Create(
+                "raises",
+                ScriptedMailRuleCondition.Raising(new InvalidOperationException("no answer")),
+                stopWhenMatched: false),
+            MailRule.Create("answers", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false)));
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal([unlucky, next], this.store.Evaluated);
+        Assert.Equal(2, report.Arrivals.FailedRuleCount);
+        Assert.Equal(0, report.Arrivals.TimedOutRuleCount);
+        Assert.Equal(["raises"], report.Arrivals.FailedRuleNames);
+        Assert.Equal(["answers"], report.Arrivals.MatchedRuleNames);
+    }
+
+    [Fact]
+    public async Task RunAsync_CancelledPartWayThrough_KeepsTheCommittedBatchAndLeavesTheRestInTheQueue()
+    {
+        // Arrange
+        using var cancellation = new CancellationTokenSource();
+        var first = this.store.Add(FactsFor(Account));
+        var second = this.store.Add(FactsFor(Account));
+        var pass = this.CreatePass(
+            RuleSetOf(MailRule.Create("withdraws", new CancellingCondition(cancellation), stopWhenMatched: false)),
+            batchSize: 1);
+
+        // Act
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => pass.RunAsync(Account, cancellation.Token));
+
+        // Assert
+        Assert.True(this.store.IsEvaluated(first));
+        Assert.False(this.store.IsEvaluated(second));
+    }
+
+    private static MailRuleEmailFacts FactsFor(MailAccountId accountId) =>
+        new() { Account = accountId.Value, Folder = "inbox" };
+
+    private static MailRuleEvaluationRun RequestedRun() => new()
+    {
+        AccountId = Account,
+        RequestedAt = EvaluatedAt.AddMinutes(-1),
+    };
+
+    private static MailRuleSet RuleSetOf(params MailRule[] rules) => MailRuleSet.Create(
+        rules,
+        MailRuleSetRevision.Create(
+            [.. rules.Select(rule => new MailRuleDeclaration(rule.Name, "isSeen", rule.StopWhenMatched, [.. rule.Accounts]))]),
+        MailRuleConditionBounds.Default);
+
+    private MailRuleEvaluationPass CreatePass(
+        MailRuleSet ruleSet,
+        int batchSize = 100,
+        int maxBatchesPerPass = 5)
+    {
+        var ruleSetSource = Substitute.For<IMailRuleSetSource>();
+        ruleSetSource.Current.Returns(ruleSet);
+
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
+
+        return new MailRuleEvaluationPass(
+            ruleSetSource,
+            new MailRuleSetEvaluator(this.timeProvider),
+            this.store,
+            this.runStore,
+            new OptimisticConcurrencyRetryPolicy(
+                sessionFactory,
+                new PersistenceConcurrencyOptions(),
+                this.timeProvider),
+            new MailRuleEvaluationOptions { BatchSize = batchSize, MaxBatchesPerPass = maxBatchesPerPass },
+            this.timeProvider);
+    }
+
+    /// <summary>Answers for the first email, then withdraws the pass, which is how a shutdown reaches a walk mid-batch.</summary>
+    private sealed class CancellingCondition(CancellationTokenSource cancellation) : IMailRuleCondition
+    {
+        private int answeredCount;
+
+        public IReadOnlyList<MailRuleFact> ReferencedFacts { get; } = [];
+
+        public Task<bool> EvaluateAsync(MailRuleFacts facts, CancellationToken cancellationToken)
+        {
+            if (this.answeredCount++ > 0)
+            {
+                cancellation.Cancel();
+            }
+
+            return Task.FromResult(false);
+        }
+    }
+
+    private sealed class CommittingSession : IPersistenceSession
+    {
+        public Task<PersistenceCommitResult> CommitAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(PersistenceCommitResult.Committed);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationRunRequestsTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationRunRequestsTests.cs
@@ -1,0 +1,98 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules.Evaluation;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Rules.Evaluation;
+
+/// <summary>Covers the one thing the request path decides: whether this request is what puts a run in front of an account.</summary>
+public sealed class MailRuleEvaluationRunRequestsTests
+{
+    private static readonly DateTimeOffset RequestedAt = new(2026, 4, 2, 11, 0, 0, TimeSpan.Zero);
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+
+    private readonly InMemoryMailRuleEvaluationRunStore runStore = new();
+    private readonly FakeTimeProvider timeProvider = new(RequestedAt);
+
+    [Fact]
+    public async Task SubmitAsync_AccountWithNoRunOutstanding_RecordsOneAndAcceptsTheRequest()
+    {
+        // Act
+        var request = await this.CreateRequests().SubmitAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(request.Accepted);
+        Assert.Equal(RequestedAt, request.Run.RequestedAt);
+        Assert.True(request.Run.IsOutstanding);
+        Assert.Equal(Account, this.runStore.Find(Account)?.AccountId);
+    }
+
+    /// <summary>Asking twice is asking once: the caller wanted the mail re-evaluated, and it is going to be.</summary>
+    [Fact]
+    public async Task SubmitAsync_RunAlreadyOutstanding_AnswersWithItAndRecordsNothing()
+    {
+        // Arrange
+        var requests = this.CreateRequests();
+        var first = await requests.SubmitAsync(Account, TestContext.Current.CancellationToken);
+
+        this.timeProvider.Advance(TimeSpan.FromMinutes(5));
+
+        // Act
+        var second = await requests.SubmitAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(second.Accepted);
+        Assert.Equal(first.Run.RequestedAt, second.Run.RequestedAt);
+        Assert.Single(this.runStore.Saves);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_PreviousRunAlreadyEnded_AcceptsANewOne()
+    {
+        // Arrange
+        this.runStore.Arrange(new MailRuleEvaluationRun
+        {
+            AccountId = Account,
+            RequestedAt = RequestedAt.AddDays(-1),
+            EndedAt = RequestedAt.AddDays(-1).AddMinutes(3),
+            Ending = MailRuleEvaluationRunEnding.Completed,
+        });
+
+        // Act
+        var request = await this.CreateRequests().SubmitAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(request.Accepted);
+        Assert.Equal(RequestedAt, this.runStore.Find(Account)?.RequestedAt);
+        Assert.Null(this.runStore.Find(Account)?.Ending);
+    }
+
+    private MailRuleEvaluationRunRequests CreateRequests()
+    {
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
+
+        return new MailRuleEvaluationRunRequests(
+            this.runStore,
+            new OptimisticConcurrencyRetryPolicy(
+                sessionFactory,
+                new PersistenceConcurrencyOptions(),
+                this.timeProvider),
+            this.timeProvider);
+    }
+
+    private sealed class CommittingSession : IPersistenceSession
+    {
+        public Task<PersistenceCommitResult> CommitAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(PersistenceCommitResult.Committed);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Application.UnitTests/Rules/MailRuleSetRevisionTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleSetRevisionTests.cs
@@ -115,6 +115,35 @@ public sealed class MailRuleSetRevisionTests
         Assert.Equal(revision.Value, revision.ToString());
     }
 
+    /// <summary>A durable record of a run names the rule set it was bound to, so the identity has to come back from storage.</summary>
+    [Fact]
+    public void Restore_AnIdentityThisTypeDerived_ComparesEqualToTheDerivedOne()
+    {
+        // Arrange
+        var derived = MailRuleSetRevision.Create([FileInvoices]);
+
+        // Act
+        var restored = MailRuleSetRevision.Restore(derived.Value);
+
+        // Assert
+        Assert.Equal(derived, restored);
+        Assert.True(restored.IsSpecified);
+    }
+
+    /// <summary>A value this type could not have produced would compare unequal to every rule set and say nothing about why.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("abcdef0123456")]
+    [InlineData("ABCDEF012345")]
+    [InlineData("abcdefg12345")]
+    public void Restore_AValueThatIsNotADerivedIdentity_IsRefused(string value)
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() => MailRuleSetRevision.Restore(value));
+    }
+
     [Fact]
     public void Value_UnspecifiedDefault_IsRefusedRatherThanAnswered()
     {

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailRuleEvaluationRunStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailRuleEvaluationRunStore.cs
@@ -1,0 +1,46 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules.Evaluation;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.UnitTests.TestDoubles;
+
+/// <summary>The one whole-mailbox rule run an account may have, keyed by the account exactly as the table is.</summary>
+internal sealed class InMemoryMailRuleEvaluationRunStore : IMailRuleEvaluationRunStore
+{
+    private readonly Dictionary<string, MailRuleEvaluationRun> runs = new(StringComparer.Ordinal);
+    private readonly List<MailRuleEvaluationRun> saves = [];
+
+    /// <summary>Gets every state a run was saved in, which is what proves a batch committed its position.</summary>
+    internal IReadOnlyList<MailRuleEvaluationRun> Saves => this.saves;
+
+    /// <summary>Gets the run recorded for an account, whether or not it is still outstanding.</summary>
+    /// <param name="accountId">The account to read.</param>
+    /// <returns>The run, or <see langword="null" /> when the account has never had one.</returns>
+    internal MailRuleEvaluationRun? Find(MailAccountId accountId) =>
+        this.runs.GetValueOrDefault(accountId.Value);
+
+    /// <summary>Puts a run in front of an account without going through the request path.</summary>
+    /// <param name="run">The run to record.</param>
+    internal void Arrange(MailRuleEvaluationRun run) => this.runs[run.AccountId.Value] = run;
+
+    /// <inheritdoc />
+    public Task<MailRuleEvaluationRun?> FindOutstandingAsync(
+        MailAccountId accountId,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(this.runs.GetValueOrDefault(accountId.Value) is { IsOutstanding: true } outstanding
+            ? outstanding
+            : null);
+
+    /// <inheritdoc />
+    public Task SaveAsync(IPersistenceSession session, MailRuleEvaluationRun run, CancellationToken cancellationToken)
+    {
+        this.runs[run.AccountId.Value] = run;
+        this.saves.Add(run);
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailRuleEvaluationStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailRuleEvaluationStore.cs
@@ -1,0 +1,147 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules.Evaluation;
+using MailFathom.Application.Rules.Facts;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.UnitTests.TestDoubles;
+
+/// <summary>An account's stored mail as a rule pass sees it, in insertion order.</summary>
+/// <remarks>
+/// Insertion order stands in for the identity ordering PostgreSQL walks, which is what both keyset reads rely on. The
+/// evaluation record is a field of the row rather than a separate table, exactly as it is in the schema, so a test can
+/// arrange mail that has already been evaluated and read back what a pass wrote.
+/// </remarks>
+internal sealed class InMemoryMailRuleEvaluationStore : IMailRuleEvaluationStore
+{
+    private readonly List<StoredRow> rows = [];
+    private readonly List<StoredEmailId> bodyTextReads = [];
+    private readonly List<StoredEmailId> evaluated = [];
+
+    /// <summary>Gets the identities whose body text a condition actually asked for.</summary>
+    internal IReadOnlyList<StoredEmailId> BodyTextReads => this.bodyTextReads;
+
+    /// <summary>Gets the identities a pass has recorded an evaluation for, in the order it recorded them.</summary>
+    internal IReadOnlyList<StoredEmailId> Evaluated => this.evaluated;
+
+    /// <summary>Adds one stored email and answers with the identity a pass will see it under.</summary>
+    /// <param name="facts">The metadata a condition reads.</param>
+    /// <param name="awaitsExtraction">Whether text is still expected to be derived from the email's content.</param>
+    /// <param name="bodyText">The extracted text a condition naming the body text resolves.</param>
+    /// <param name="evaluatedAt">When a pass last evaluated it, which takes it out of the arrival queue.</param>
+    /// <returns>The identity of the added email.</returns>
+    internal StoredEmailId Add(
+        MailRuleEmailFacts facts,
+        bool awaitsExtraction = false,
+        string? bodyText = null,
+        DateTimeOffset? evaluatedAt = null)
+    {
+        var row = new StoredRow
+        {
+            Id = StoredEmailId.Create(Guid.CreateVersion7()),
+            Facts = facts,
+            AwaitsExtraction = awaitsExtraction,
+            BodyText = bodyText,
+            EvaluatedAt = evaluatedAt,
+        };
+
+        this.rows.Add(row);
+
+        return row.Id;
+    }
+
+    /// <summary>Reports whether a pass has recorded an evaluation for one email.</summary>
+    /// <param name="storedEmailId">The email to ask about.</param>
+    /// <returns><see langword="true" /> when the email carries an evaluation record.</returns>
+    internal bool IsEvaluated(StoredEmailId storedEmailId) =>
+        this.rows.Single(row => row.Id == storedEmailId).EvaluatedAt is not null;
+
+    /// <summary>Lets an email that was waiting for its text become eligible, as extraction committing would.</summary>
+    /// <param name="storedEmailId">The email whose text has arrived.</param>
+    /// <param name="bodyText">The text extraction produced.</param>
+    internal void CompleteExtraction(StoredEmailId storedEmailId, string bodyText)
+    {
+        var row = this.rows.Single(candidate => candidate.Id == storedEmailId);
+
+        row.AwaitsExtraction = false;
+        row.BodyText = bodyText;
+        row.Facts = row.Facts with { HasExtractedContent = true };
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>> GetEmailsAwaitingFirstEvaluationAsync(
+        MailAccountId accountId,
+        StoredEmailId? resumeAfter,
+        int batchSize,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(this.Read(accountId, resumeAfter, batchSize, row => row.EvaluatedAt is null));
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>> GetStoredEmailsAsync(
+        MailAccountId accountId,
+        StoredEmailId? resumeAfter,
+        int batchSize,
+        CancellationToken cancellationToken) =>
+        Task.FromResult(this.Read(accountId, resumeAfter, batchSize, static _ => true));
+
+    /// <inheritdoc />
+    public Task<string?> ReadExtractedBodyTextAsync(StoredEmailId storedEmailId, CancellationToken cancellationToken)
+    {
+        this.bodyTextReads.Add(storedEmailId);
+
+        return Task.FromResult(this.rows.Single(row => row.Id == storedEmailId).BodyText);
+    }
+
+    /// <inheritdoc />
+    public Task RecordEvaluatedAsync(
+        IPersistenceSession session,
+        IReadOnlyList<StoredEmailId> storedEmailIds,
+        DateTimeOffset evaluatedAt,
+        CancellationToken cancellationToken)
+    {
+        foreach (var storedEmailId in storedEmailIds)
+        {
+            this.rows.Single(candidate => candidate.Id == storedEmailId).EvaluatedAt = evaluatedAt;
+            this.evaluated.Add(storedEmailId);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private IReadOnlyList<StoredEmailAwaitingRuleEvaluation> Read(
+        MailAccountId accountId,
+        StoredEmailId? resumeAfter,
+        int batchSize,
+        Func<StoredRow, bool> admits)
+    {
+        var startIndex = resumeAfter is { } position
+            ? this.rows.FindIndex(row => row.Id == position) + 1
+            : 0;
+
+        return
+        [
+            .. this.rows
+                .Skip(startIndex)
+                .Where(row => row.Facts.Account == accountId.Value && admits(row))
+                .Take(batchSize)
+                .Select(row => new StoredEmailAwaitingRuleEvaluation(row.Id, row.Facts, row.AwaitsExtraction)),
+        ];
+    }
+
+    private sealed class StoredRow
+    {
+        internal required StoredEmailId Id { get; init; }
+
+        internal required MailRuleEmailFacts Facts { get; set; }
+
+        internal bool AwaitsExtraction { get; set; }
+
+        internal string? BodyText { get; set; }
+
+        internal DateTimeOffset? EvaluatedAt { get; set; }
+    }
+}

--- a/tests/Application.UnitTests/TestDoubles/ScriptedMailRuleCondition.cs
+++ b/tests/Application.UnitTests/TestDoubles/ScriptedMailRuleCondition.cs
@@ -34,10 +34,16 @@ internal sealed class ScriptedMailRuleCondition : IMailRuleCondition
     public Task Started => this.started.Task;
 
     /// <inheritdoc />
-    public IReadOnlyList<MailRuleFact> ReferencedFacts { get; } = [];
+    public IReadOnlyList<MailRuleFact> ReferencedFacts { get; private init; } = [];
 
-    /// <summary>Creates a condition that answers the same way about every email.</summary>
-    public static ScriptedMailRuleCondition Answering(bool matches) => new(matches, failure: null, neverAnswers: false);
+    /// <summary>Creates a condition that answers the same way about every email, naming the facts it reads.</summary>
+    /// <remarks>
+    /// The named facts are resolved before the answer, because naming a fact and reading it are the same thing for a
+    /// real condition: a test about what a rule set costs would prove nothing against a double that declared a fact and
+    /// never asked for it.
+    /// </remarks>
+    public static ScriptedMailRuleCondition Answering(bool matches, params MailRuleFact[] referencedFacts) =>
+        new(matches, failure: null, neverAnswers: false) { ReferencedFacts = referencedFacts };
 
     /// <summary>Creates a condition that raises instead of answering.</summary>
     public static ScriptedMailRuleCondition Raising(Exception failure) => new(matches: false, failure, neverAnswers: false);
@@ -50,6 +56,11 @@ internal sealed class ScriptedMailRuleCondition : IMailRuleCondition
     {
         this.EvaluationCount++;
         this.started.TrySetResult();
+
+        foreach (var fact in this.ReferencedFacts)
+        {
+            await facts.ResolveAsync(fact, cancellationToken);
+        }
 
         if (this.failure is { } raised)
         {

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleSetMappingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleSetMappingTests.cs
@@ -99,6 +99,25 @@ public sealed class MailRuleSetMappingTests
         Assert.Equal(TimeSpan.FromMilliseconds(250), ruleSet.Bounds.EvaluationTimeout);
     }
 
+    /// <summary>The pass bounds are a separate contract from the condition bounds, and neither may pick up the other's value.</summary>
+    [Fact]
+    public void ToEvaluationOptions_DeclaredPassBounds_ReachTheEvaluationContract()
+    {
+        // Arrange
+        var settings = new MailRulesOptions
+        {
+            EvaluationBatchSize = 25,
+            MaxEvaluationBatchesPerPass = 3,
+        };
+
+        // Act
+        var evaluation = settings.ToEvaluationOptions();
+
+        // Assert
+        Assert.Equal(25, evaluation.BatchSize);
+        Assert.Equal(3, evaluation.MaxBatchesPerPass);
+    }
+
     [Fact]
     public void Map_NoRules_IsAnEmptySetUnderAnIdentityOfItsOwn()
     {

--- a/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Domain.Accounts;
@@ -607,6 +608,89 @@ public sealed class AccountSynchronizationSupervisorTests
         return options;
     }
 
+    /// <summary>A rule may only see mail its own run has already committed, which is what running last is for.</summary>
+    [Fact]
+    public async Task RunAsync_RulesEvaluated_ReachesTheAccountOnlyAfterItsFoldersHaveRun()
+    {
+        // Arrange
+        var evaluatedAfterTheFolder = new TaskCompletionSource<bool>();
+        var folderWasOpened = 0;
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        sessionFactory
+            .OpenReadOnlyAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailFolderResolution>(),
+                Arg.Any<MailTransportSecurityPolicy>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Volatile.Write(ref folderWasOpened, 1);
+
+                return Task.FromException<IMailboxSession>(new InvalidOperationException("connect failed"));
+            });
+        var ruleStore = Substitute.For<IMailRuleEvaluationStore>();
+        ruleStore
+            .GetEmailsAwaitingFirstEvaluationAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<StoredEmailId?>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                evaluatedAfterTheFolder.TrySetResult(Volatile.Read(ref folderWasOpened) == 1);
+
+                return Task.FromResult<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>>([]);
+            });
+        using var harness = CreateHarness(
+            SynchronizationTestHost.CreateSingleAccountOptions(enabled: true, "INBOX"),
+            sessionFactory,
+            ruleEvaluationStore: ruleStore);
+
+        // Act
+        await harness.SuperviseUntilAsync(evaluatedAfterTheFolder.Task);
+
+        // Assert
+        Assert.True(await evaluatedAfterTheFolder.Task);
+    }
+
+    /// <summary>Evaluation reaches no mail server, so failing one must not make the account fetch its mail less often.</summary>
+    [Fact]
+    public async Task RunAsync_RuleEvaluationFails_DoesNotDeferTheAccountsNextRun()
+    {
+        // Arrange
+        var passFailed = new TaskCompletionSource();
+        var ruleStore = Substitute.For<IMailRuleEvaluationStore>();
+        ruleStore
+            .GetEmailsAwaitingFirstEvaluationAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<StoredEmailId?>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>>>(_ =>
+            {
+                passFailed.TrySetResult();
+
+                throw new InvalidOperationException("The rule candidates could not be read.");
+            });
+        using var harness = CreateHarness(
+            SynchronizationTestHost.CreateSingleAccountOptions(enabled: true),
+            Substitute.For<IMailboxSessionFactory>(),
+            ruleEvaluationStore: ruleStore);
+
+        // Act
+        await harness.SuperviseUntilAsync(passFailed.Task);
+
+        // Assert
+        Assert.Contains(
+            harness.Logger.Messages,
+            message => message.Contains(
+                "Evaluating the rules of account primary ended unexpectedly",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            harness.Logger.Messages,
+            message => message.Contains("runs in a row", StringComparison.Ordinal));
+    }
+
     private static IMailboxSessionFactory CreateFailingSessionFactory(
         List<string> attemptedFolders,
         TaskCompletionSource runReached,
@@ -669,6 +753,7 @@ public sealed class AccountSynchronizationSupervisorTests
         IRemoteFolderCatalog? remoteFolderCatalog = null,
         IMailboxMutationRecordStore? mutationRecordStore = null,
         IStoredMailFolderMirrorStore? folderMirrorStore = null,
+        IMailRuleEvaluationStore? ruleEvaluationStore = null,
         params string[] unadvertisedAliases)
     {
         var clock = new FakeTimeProvider();
@@ -682,6 +767,7 @@ public sealed class AccountSynchronizationSupervisorTests
             remoteFolderCatalog,
             mutationRecordStore,
             folderMirrorStore,
+            ruleEvaluationStore,
             unadvertisedAliases);
 
         return new SupervisorHarness(

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -12,6 +12,9 @@ using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Conditions;
+using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.Synchronization.Reconciliation;
@@ -77,6 +80,7 @@ internal static class SynchronizationTestHost
     /// <param name="remoteFolderCatalog">Replaces the catalog that advertises exactly the configured folders.</param>
     /// <param name="mutationRecordStore">Replaces the record store that reports nothing outstanding to converge.</param>
     /// <param name="folderMirrorStore">Replaces the store a run erases an unmirrored folder's local copy through.</param>
+    /// <param name="ruleEvaluationStore">Replaces the store a rule pass reads its candidates from; one with nothing to evaluate is the default.</param>
     /// <param name="unadvertisedAliases">Aliases the modelled server does not advertise.</param>
     /// <returns>A provider whose scopes resolve a synchronizer over substituted infrastructure.</returns>
     internal static ServiceProvider BuildServiceProvider(
@@ -88,6 +92,7 @@ internal static class SynchronizationTestHost
         IRemoteFolderCatalog? remoteFolderCatalog = null,
         IMailboxMutationRecordStore? mutationRecordStore = null,
         IStoredMailFolderMirrorStore? folderMirrorStore = null,
+        IMailRuleEvaluationStore? ruleEvaluationStore = null,
         params string[] unadvertisedAliases)
     {
         var services = new ServiceCollection();
@@ -146,6 +151,15 @@ internal static class SynchronizationTestHost
         // from its own scope. The store below records which folders it was asked about and erases nothing.
         services.AddSingleton(folderMirrorStore ?? new RecordingMailFolderMirrorStore());
         services.AddScoped<UnmirroredMailFolderEraser>();
+
+        // The run's last local step. The default rule set declares nothing and the default store holds nothing, so a
+        // test that is not about rules pays for one query that finds no mail and no outstanding run.
+        services.AddSingleton(ruleEvaluationStore ?? CreateRuleStoreWithNothingToEvaluate());
+        services.AddSingleton(CreateRunStoreWithNothingOutstanding());
+        services.AddSingleton(CreateSourceOfAnEmptyRuleSet());
+        services.AddSingleton(new MailRuleSetEvaluator(timeProvider));
+        services.AddScoped(_ => new MailRuleEvaluationOptions());
+        services.AddScoped<MailRuleEvaluationPass>();
         services.AddLogging();
 
         // Each run hands its own snapshot to the scopes it opens, and every per-account reader answers from that
@@ -159,6 +173,48 @@ internal static class SynchronizationTestHost
         services.AddScoped<IRemotelyDeletedEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
 
         return services.BuildServiceProvider();
+    }
+
+    /// <summary>Answers every rule query with nothing, which is what an account whose mail is all evaluated looks like.</summary>
+    private static IMailRuleEvaluationStore CreateRuleStoreWithNothingToEvaluate()
+    {
+        var store = Substitute.For<IMailRuleEvaluationStore>();
+
+        store.GetEmailsAwaitingFirstEvaluationAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<StoredEmailId?>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>>([]));
+        store.GetStoredEmailsAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<StoredEmailId?>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>>([]));
+
+        return store;
+    }
+
+    /// <summary>Answers with a rule set that declares nothing, which is what a deployment configuring no rule has.</summary>
+    private static IMailRuleSetSource CreateSourceOfAnEmptyRuleSet()
+    {
+        var ruleSetSource = Substitute.For<IMailRuleSetSource>();
+
+        ruleSetSource.Current.Returns(
+            MailRuleSet.Create([], MailRuleSetRevision.Create([]), MailRuleConditionBounds.Default));
+
+        return ruleSetSource;
+    }
+
+    private static IMailRuleEvaluationRunStore CreateRunStoreWithNothingOutstanding()
+    {
+        var runStore = Substitute.For<IMailRuleEvaluationRunStore>();
+
+        runStore.FindOutstandingAsync(Arg.Any<MailAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<MailRuleEvaluationRun?>(null));
+
+        return runStore;
     }
 
     /// <summary>Advances a fake clock until the awaited signal arrives, or until the test's own guard gives up.</summary>

--- a/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
@@ -94,6 +94,50 @@ public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationF
     }
 
     /// <summary>
+    /// The two ways an email can be sitting in the queue without extracted text, which the projection has to tell apart:
+    /// content the ceiling has not had headroom for is still coming, and content above the size limit never is.
+    /// </summary>
+    /// <remarks>
+    /// The distinction decides whether a message is waited for or evaluated with the body-text fact absent, and getting
+    /// it wrong is silent — the email is stamped as evaluated, leaves the queue for good, and a rule naming its text
+    /// never sees it. It is a <c>CASE</c> PostgreSQL evaluates over a string-converted enum column beside a correlated
+    /// existence check, so only a real database settles what it produces.
+    /// </remarks>
+    [Fact]
+    public async Task TheArrivalQueue_MailWhoseTextWasNeverExtracted_WaitsOnlyForContentThatIsStillComing()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await DrainArrivalQueueAsync(services, cancellationToken);
+        var headroomPending = await StoreOneUnextractedMessageAsync(
+            services,
+            uid: 9431,
+            StoredEmailContentAvailability.AwaitingStorageHeadroom,
+            cancellationToken);
+        var oversized = await StoreOneUnextractedMessageAsync(
+            services,
+            uid: 9432,
+            StoredEmailContentAvailability.ExceededSizeLimit,
+            cancellationToken);
+
+        // Act
+        var queued = await ReadArrivalQueueAsync(services, resumeAfter: null, DrainBatchSize, cancellationToken);
+
+        // Assert
+        var waited = Assert.Single(queued, candidate => candidate.StoredEmailId == headroomPending);
+        var evaluatedWithoutText = Assert.Single(queued, candidate => candidate.StoredEmailId == oversized);
+
+        Assert.False(waited.Facts.HasExtractedContent);
+        Assert.False(evaluatedWithoutText.Facts.HasExtractedContent);
+
+        // The control the assertion below needs: both rows look identical to a reader of the search document, so an
+        // observation that reported nothing would pass the first assertion and fail the second.
+        Assert.True(waited.AwaitsExtraction);
+        Assert.False(evaluatedWithoutText.AwaitsExtraction);
+    }
+
+    /// <summary>
     /// The whole-mailbox walk against a real schema: it selects mail a pass has already evaluated, it never hands the
     /// same email to two batches, and the position one batch commits is exactly what the next resumes past.
     /// </summary>
@@ -220,6 +264,33 @@ public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationF
                         SyntheticEmail.BodyTextContaining(subject, wordCount: 40),
                         RecipientAddress),
                     StoredEmailContentAvailability.Available,
+                    token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+
+        return storedEmailId;
+    }
+
+    /// <summary>Stores one synthetic message whose MIME nothing read, under the content state a test names.</summary>
+    private static async Task<StoredEmailId> StoreOneUnextractedMessageAsync(
+        OrchestratedMailFathomServices services,
+        uint uid,
+        StoredEmailContentAvailability contentAvailability,
+        CancellationToken cancellationToken)
+    {
+        var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
+        var occurrenceId = SyntheticEmail.OccurrenceIn(binding, uid);
+        var storedEmailId = default(StoredEmailId);
+
+        var commitResult = await services.CommitAsync(
+            async (scope, session, token) => storedEmailId = await scope
+                .GetRequiredService<IEmailMetadataRepository>()
+                .UpsertMetadataAsync(
+                    session,
+                    SyntheticEmail.RemoteMetadataOf(occurrenceId, SubjectOf(uid)),
+                    extractedMetadata: null,
+                    contentAvailability,
                     token),
             cancellationToken);
 

--- a/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
@@ -1,0 +1,359 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Evaluation;
+using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Emails;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Persistence;
+
+/// <summary>
+/// Proves the two state stores a rule pass runs on against a real schema: the arrival queue that shrinks as evaluations
+/// are recorded, the keyset walk over a whole mailbox that resumes past a committed position, and the one run row an
+/// account may have outstanding.
+/// </summary>
+/// <remarks>
+/// None of it is reachable without a real server. The queue is a partial index over a nullable timestamp, the two walks
+/// order and compare <c>uuid</c> values under PostgreSQL's collation rather than the CLR's, the evaluations are written
+/// as one <c>UPDATE</c> over a batch instead of through tracked entities, and the run's revision lives in a fixed-length
+/// character column that would pad a shorter value. A substitute for the database would report whatever the test told it
+/// to, whatever the translation actually produced.
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationFixture orchestration)
+{
+    private const string FolderAlias = "rule-evaluation";
+
+    private const string RecipientAddress = "recipient@mailfathom.test";
+
+    /// <summary>How much of a walk one read takes, small enough that paging is what the test observes.</summary>
+    private const int BatchSize = 2;
+
+    /// <summary>How much of the queue one drain reads, large enough that arrangement costs a query or two.</summary>
+    private const int DrainBatchSize = 200;
+
+    /// <summary>Bounds every paging loop. A walk that has not ended by then is a defect rather than a slow database.</summary>
+    private const int MaximumBatches = 200;
+
+    private static readonly DateTimeOffset EvaluatedAt = new(2026, 6, 1, 9, 0, 0, TimeSpan.Zero);
+
+    private static readonly DateTimeOffset RequestedAt = new(2026, 6, 1, 10, 0, 0, TimeSpan.Zero);
+
+    private static readonly DateTimeOffset EndedAt = new(2026, 6, 1, 11, 0, 0, TimeSpan.Zero);
+
+    /// <summary>An identity of the shape the compiler derives, restored rather than computed so the column is what is under test.</summary>
+    private static readonly MailRuleSetRevision Revision = MailRuleSetRevision.Restore("0a1b2c3d4e5f");
+
+    /// <summary>
+    /// The whole arrival path over a real schema: mail nobody has evaluated is what the queue holds, the fact surface
+    /// comes back projected from the row rather than loaded from it, and recording an evaluation is what takes an email
+    /// out — which is what makes a rule apply to mail arriving from now on rather than to a mailbox's history.
+    /// </summary>
+    [Fact]
+    public async Task TheArrivalQueue_MailNoPassHasEvaluated_HoldsItUntilTheEvaluationsAreRecorded()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await DrainArrivalQueueAsync(services, cancellationToken);
+        var evaluated = await StoreOneMessageAsync(services, uid: 9401, cancellationToken);
+        var awaiting = await StoreOneMessageAsync(services, uid: 9402, cancellationToken);
+
+        // Act
+        var queued = await ReadArrivalQueueAsync(services, resumeAfter: null, DrainBatchSize, cancellationToken);
+        var bodyText = await ReadExtractedBodyTextAsync(services, evaluated, cancellationToken);
+        var recorded = await RecordEvaluatedAsync(services, [evaluated], cancellationToken);
+        var afterRecording = await ReadArrivalQueueAsync(services, resumeAfter: null, DrainBatchSize, cancellationToken);
+
+        // Assert
+        Assert.Equal(
+            new HashSet<StoredEmailId>([evaluated, awaiting]),
+            queued.Select(candidate => candidate.StoredEmailId).ToHashSet());
+
+        var arrival = Assert.Single(queued, candidate => candidate.StoredEmailId == evaluated);
+        Assert.Equal(SyntheticMailAccount.AccountId.Value, arrival.Facts.Account);
+        Assert.Equal(FolderAlias, arrival.Facts.Folder);
+        Assert.Equal(SyntheticEmail.DefaultSenderAddress, arrival.Facts.SenderAddress);
+        Assert.Contains(RecipientAddress, arrival.Facts.RecipientAddresses);
+        Assert.Equal(SyntheticEmail.ReceivedAt, arrival.Facts.ReceivedAt);
+        Assert.True(arrival.Facts.HasExtractedContent);
+
+        // Text was extracted, so nothing about this message is still expected and a body-text condition reads it now.
+        Assert.False(arrival.AwaitsExtraction);
+        Assert.NotNull(bodyText);
+        Assert.Contains(SubjectOf(9401), bodyText, StringComparison.Ordinal);
+
+        Assert.Equal(PersistenceCommitResult.Committed, recorded);
+        Assert.Equal(awaiting, Assert.Single(afterRecording).StoredEmailId);
+    }
+
+    /// <summary>
+    /// The whole-mailbox walk against a real schema: it selects mail a pass has already evaluated, it never hands the
+    /// same email to two batches, and the position one batch commits is exactly what the next resumes past.
+    /// </summary>
+    /// <remarks>
+    /// The order is PostgreSQL's over <c>uuid</c>, which is not the order the CLR compares two <see cref="Guid" /> values
+    /// in, so the assertions compare the walk against itself rather than against an order stated here.
+    /// </remarks>
+    [Fact]
+    public async Task TheWholeMailboxWalk_APositionABatchCommitted_ResumesPastItOverMailAlreadyEvaluated()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var seeded = new List<StoredEmailId>();
+        foreach (var uid in (uint[])[9411, 9412, 9413])
+        {
+            seeded.Add(await StoreOneMessageAsync(services, uid, cancellationToken));
+        }
+
+        // Nothing is left in the arrival queue, so what the walk finds cannot be the queue under another name.
+        await DrainArrivalQueueAsync(services, cancellationToken);
+        var emptyQueue = await ReadArrivalQueueAsync(services, resumeAfter: null, DrainBatchSize, cancellationToken);
+
+        // Act
+        var walked = await WalkWholeMailboxAsync(services, cancellationToken);
+        var resumed = await ReadWholeMailboxAsync(services, walked[0], walked.Count, cancellationToken);
+
+        // Assert
+        Assert.Empty(emptyQueue);
+        Assert.Equal(walked.Count, walked.Distinct().Count());
+        Assert.All(seeded, storedEmailId => Assert.Contains(storedEmailId, walked));
+        Assert.Equal(walked.Skip(1), resumed.Select(candidate => candidate.StoredEmailId));
+    }
+
+    /// <summary>
+    /// The one run row an account may have outstanding, through the store that owns it: a request is found afterwards,
+    /// the progress a batch commits replaces it rather than appending a second row, and an ended run is outstanding no
+    /// longer.
+    /// </summary>
+    /// <remarks>
+    /// The revision is the part only a real column settles. It is stored in a fixed-length character type, which pads a
+    /// shorter value with spaces on the way out, so a round trip that compares equal is the evidence that a run reads
+    /// back bound to the rule set it was bound to rather than to a value nothing matches.
+    /// </remarks>
+    [Fact]
+    public async Task TheOutstandingRun_ARequestCarriedAndThenEnded_ReadsBackAsOneRowPerAccount()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var position = await StoreOneMessageAsync(services, uid: 9421, cancellationToken);
+        await EndAnyOutstandingRunAsync(services, cancellationToken);
+        var request = new MailRuleEvaluationRun
+        {
+            AccountId = SyntheticMailAccount.AccountId,
+            RequestedAt = RequestedAt,
+        };
+
+        // Act
+        var requested = await SaveRunAsync(services, request, cancellationToken);
+        var afterRequest = await FindOutstandingRunAsync(services, cancellationToken);
+        var carried = await SaveRunAsync(
+            services,
+            afterRequest! with
+            {
+                Revision = Revision,
+                Position = position,
+                EvaluatedEmailCount = 2,
+                MatchedEmailCount = 1,
+                SkippedEmailCount = 1,
+            },
+            cancellationToken);
+        var afterProgress = await FindOutstandingRunAsync(services, cancellationToken);
+        var ended = await SaveRunAsync(
+            services,
+            afterProgress! with { EndedAt = EndedAt, Ending = MailRuleEvaluationRunEnding.Completed },
+            cancellationToken);
+        var afterEnding = await FindOutstandingRunAsync(services, cancellationToken);
+
+        // Assert
+        Assert.Equal(PersistenceCommitResult.Committed, requested);
+        Assert.Equal(PersistenceCommitResult.Committed, carried);
+        Assert.Equal(PersistenceCommitResult.Committed, ended);
+
+        Assert.NotNull(afterRequest);
+        Assert.Equal(RequestedAt, afterRequest.RequestedAt);
+        Assert.False(afterRequest.Revision.IsSpecified);
+        Assert.Null(afterRequest.Position);
+        Assert.True(afterRequest.IsOutstanding);
+
+        Assert.NotNull(afterProgress);
+        Assert.Equal(Revision, afterProgress.Revision);
+        Assert.Equal(position, afterProgress.Position);
+        Assert.Equal(2, afterProgress.EvaluatedEmailCount);
+        Assert.Equal(1, afterProgress.MatchedEmailCount);
+        Assert.Equal(1, afterProgress.SkippedEmailCount);
+        Assert.True(afterProgress.IsOutstanding);
+
+        Assert.Null(afterEnding);
+    }
+
+    private static string SubjectOf(uint uid) => $"{FolderAlias}-{uid}";
+
+    /// <summary>Stores one synthetic message, whose extraction the same session derives its search document from.</summary>
+    private static async Task<StoredEmailId> StoreOneMessageAsync(
+        OrchestratedMailFathomServices services,
+        uint uid,
+        CancellationToken cancellationToken)
+    {
+        var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
+        var occurrenceId = SyntheticEmail.OccurrenceIn(binding, uid);
+        var subject = SubjectOf(uid);
+        var storedEmailId = default(StoredEmailId);
+
+        var commitResult = await services.CommitAsync(
+            async (scope, session, token) => storedEmailId = await scope
+                .GetRequiredService<IEmailMetadataRepository>()
+                .UpsertMetadataAsync(
+                    session,
+                    SyntheticEmail.RemoteMetadataOf(occurrenceId, subject),
+                    SyntheticEmail.ExtractionOf(
+                        occurrenceId,
+                        subject,
+                        SyntheticEmail.BodyTextContaining(subject, wordCount: 40),
+                        RecipientAddress),
+                    StoredEmailContentAvailability.Available,
+                    token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+
+        return storedEmailId;
+    }
+
+    /// <summary>
+    /// Records an evaluation for everything the arrival queue holds, so a test observes its own mail rather than
+    /// whatever an earlier class in this collection left behind.
+    /// </summary>
+    private static async Task DrainArrivalQueueAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<StoredEmailAwaitingRuleEvaluation> queued;
+        var batch = 0;
+
+        do
+        {
+            queued = await ReadArrivalQueueAsync(services, resumeAfter: null, DrainBatchSize, cancellationToken);
+
+            if (queued.Count > 0)
+            {
+                var commitResult = await RecordEvaluatedAsync(
+                    services,
+                    [.. queued.Select(candidate => candidate.StoredEmailId)],
+                    cancellationToken);
+
+                Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+            }
+
+            batch++;
+        }
+        while (queued.Count > 0 && batch < MaximumBatches);
+
+        Assert.Empty(queued);
+    }
+
+    /// <summary>Pages the whole-mailbox walk to its end, the way a requested run does across account runs.</summary>
+    private static async Task<IReadOnlyList<StoredEmailId>> WalkWholeMailboxAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken)
+    {
+        var walked = new List<StoredEmailId>();
+        StoredEmailId? position = null;
+        IReadOnlyList<StoredEmailAwaitingRuleEvaluation> candidates;
+        var batch = 0;
+
+        do
+        {
+            candidates = await ReadWholeMailboxAsync(services, position, BatchSize, cancellationToken);
+            walked.AddRange(candidates.Select(candidate => candidate.StoredEmailId));
+            position = candidates.Count == 0 ? position : candidates[^1].StoredEmailId;
+            batch++;
+        }
+        while (candidates.Count > 0 && batch < MaximumBatches);
+
+        Assert.Empty(candidates);
+
+        return walked;
+    }
+
+    private static Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>> ReadArrivalQueueAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailId? resumeAfter,
+        int batchSize,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IMailRuleEvaluationStore>()
+                .GetEmailsAwaitingFirstEvaluationAsync(
+                    SyntheticMailAccount.AccountId,
+                    resumeAfter,
+                    batchSize,
+                    token),
+            cancellationToken);
+
+    private static Task<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>> ReadWholeMailboxAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailId? resumeAfter,
+        int batchSize,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IMailRuleEvaluationStore>()
+                .GetStoredEmailsAsync(SyntheticMailAccount.AccountId, resumeAfter, batchSize, token),
+            cancellationToken);
+
+    private static Task<string?> ReadExtractedBodyTextAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailId storedEmailId,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IMailRuleEvaluationStore>()
+                .ReadExtractedBodyTextAsync(storedEmailId, token),
+            cancellationToken);
+
+    private static Task<PersistenceCommitResult> RecordEvaluatedAsync(
+        OrchestratedMailFathomServices services,
+        IReadOnlyList<StoredEmailId> storedEmailIds,
+        CancellationToken cancellationToken) => services.CommitAsync(
+            (scope, session, token) => scope.GetRequiredService<IMailRuleEvaluationStore>()
+                .RecordEvaluatedAsync(session, storedEmailIds, EvaluatedAt, token),
+            cancellationToken);
+
+    private static Task<MailRuleEvaluationRun?> FindOutstandingRunAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IMailRuleEvaluationRunStore>()
+                .FindOutstandingAsync(SyntheticMailAccount.AccountId, token),
+            cancellationToken);
+
+    private static Task<PersistenceCommitResult> SaveRunAsync(
+        OrchestratedMailFathomServices services,
+        MailRuleEvaluationRun run,
+        CancellationToken cancellationToken) => services.CommitAsync(
+            (scope, session, token) => scope.GetRequiredService<IMailRuleEvaluationRunStore>()
+                .SaveAsync(session, run, token),
+            cancellationToken);
+
+    /// <summary>Ends whatever run the account carries, so a test arranges the request it is about to make.</summary>
+    private static async Task EndAnyOutstandingRunAsync(
+        OrchestratedMailFathomServices services,
+        CancellationToken cancellationToken)
+    {
+        var outstanding = await FindOutstandingRunAsync(services, cancellationToken);
+
+        if (outstanding is null)
+        {
+            return;
+        }
+
+        var commitResult = await SaveRunAsync(
+            services,
+            outstanding with { EndedAt = EndedAt, Ending = MailRuleEvaluationRunEnding.Completed },
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+    }
+}


### PR DESCRIPTION
Rules are now evaluated as a step of the account's synchronization run: over the mail that has arrived, and — where one was asked for — over the whole mailbox. There is no scheduler, worker, or queue of its own, because the account run already owns one-account-at-a-time scheduling, a slot count, jittered backoff, and a shutdown that lets work in flight finish.

## Where the step sits

It is the last of the run's local work, after every folder has synchronized and committed and after the mail of folders the account no longer mirrors has been erased. Two guarantees follow from that placement rather than from intent: nothing is evaluated inside the synchronization transaction, and a pass reaches no mail server at all — every fact it reads was already stored, so no MCP read waits on one and no `\Seen` flag can be touched however long a pass runs.

## What a pass does

- **Arrivals.** An email is evaluated once, and recording that evaluation is what takes it out of the queue the next pass reads. The queue is "rows whose `RulesEvaluatedAt` is null", behind a partial index, so it costs a read proportional to the queue rather than to the mailbox.
- **The whole-mailbox run.** One outstanding per account; a second request is answered with the run already under way rather than starting a second walk. It binds the revision in force when it starts, so a reload cannot change what it is doing; if the rule set moves under it, it ends as **superseded** and says so, because MailFathom keeps only the rule set its configuration currently declares.
- **Bounds.** `MailRules:EvaluationBatchSize` (default 200) and `MailRules:MaxEvaluationBatchesPerPass` (default 5) bound each of the two walks separately. Each batch commits its evaluations together with the position they account for, so a restart resumes at the email nobody read rather than replaying a batch or stepping over one.
- **Missing content.** An email whose body text has not been extracted yet is skipped and stays eligible, but only where the account's rules actually name `bodyText`. One whose content will never yield text is evaluated now with the fact absent, so a stalled extraction cannot block the queue behind it.
- **Failure.** A rule that cannot answer for one email fails that rule with a reason; the rules below it still run, the batch continues, and the email is recorded as evaluated. A pass that fails outright is logged and does not put the account into backoff — a local problem must not slow the remote work it had nothing to do with. Counts and rule names reach the log; nothing derived from a message does.

## Upgrade note

The migration is additive, and it carries one data statement: `UPDATE stored_emails SET "RulesEvaluatedAt" = now()` over every existing row. The arrival queue is defined by that column being null, so without it an upgrade would hand the deployment's first rule set an entire mailbox's history as though all of it had just arrived — which, once #456 gives rules their actions, is a mass change to somebody's mail. Re-running the rules over stored mail stays available as the whole-mailbox run, which is always something somebody asks for. On a large mailbox that statement, and the two indexes created after it, take time proportional to the table; `docs/operations/database-schema.md` already describes planning for DDL on a live database.

## Deliberately not here

Nothing submits a whole-mailbox request yet: the use case and the run row exist and every guarantee above holds, but no command, tool, or endpoint asks for one — that is #458. The actions a match leads to are #456. The documentation says so in as many words rather than describing a button that is not there.

## Verification

- `scripts/verify-full.sh`: green. 5283 tests, 0 failed; aggregate line coverage 95.69% (15147/15830), required 85%; `dotnet format` reformatted 0 of 1732 files.
- The migration was applied to the orchestrated PostgreSQL over existing data and the resulting schema read back with `scripts/dump-local-schema.sh`: the column, the `mail_rule_evaluation_runs` table with `pk_mail_rule_evaluation_runs`, and both indexes including `WHERE ("RulesEvaluatedAt" IS NULL)`. `mailfathom-host` then reached Running and Healthy against it.
- `tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs` covers the two `[RequiresIntegrationCoverage]` stores — the arrival queue shrinking as evaluations are recorded, the keyset walk resuming past a committed position under PostgreSQL's own `uuid` ordering, and the run row round-tripping through its fixed-length revision column. **It was written but not run**, because the integration suite starts a container and runs only when the owner asks for it; it compiles and is ready for the next dispatched `Integration tests` run.

Closes #455
