### PR TITLE
[#456] Ship the rule action set over the mutation record: move, copy, delete, and mark as read

### DIFF
--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -1148,12 +1148,12 @@ happens to mail a person moved or deleted in their own client.
 #### A change MailFathom made is not a change to react to
 
 The join above is one reader of the record. The other is provenance: a change MailFathom performed must not come back
-as something to act on. Once rules can write to a mailbox, that stops being tidiness. A rule matching on folder would
-file a message, meet it in its new folder, match again, and go round for as long as the folder is watched — an IMAP
-command a lap — and two rules with overlapping conditions would do the same to each other. `\Seen` is the case that
-makes it unavoidable: a flag change reaches synchronization as a changed modification sequence, which is precisely the
-signal a person marking mail read in their own client produces, so a rule conditioned on unread mail that marks mail
-read would re-evaluate everything it had just acted on.
+as something to act on. Rules write to a mailbox, which is what makes that a correctness rule rather than tidiness. A
+rule matching on folder would file a message, meet it in its new folder, match again, and go round for as long as the
+folder is watched — an IMAP command a lap — and two rules with overlapping conditions would do the same to each other.
+`\Seen` is the case that makes it unavoidable: a flag change reaches synchronization as a changed modification
+sequence, which is precisely the signal a person marking mail read in their own client produces, so a rule conditioned
+on unread mail that marks mail read would re-evaluate everything it had just acted on.
 
 A run therefore **withholds** every change a mutation record accounts for, and raises everything else. There is no
 cycle counter, no depth limit, and no rate limit involved, and that is deliberate: a cycle limit stops a loop only

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -2,13 +2,10 @@
 
 <!-- describes: src/Application/Rules/**, src/Infrastructure/Rules/**, src/Infrastructure/Persistence/Rules/**, src/Host/Configuration/Rules/** -->
 
-A mail rule selects mail. It is a name, a condition, the accounts it applies to, and whether a match ends the pass, and
-an owner writes it in the configuration their deployment already carries. This page documents the whole of what a
-condition may say: every fact it can read, every function and operator available to it, the limits it is read and run
-under, and the order a set of rules is evaluated in.
-
-What a match leads to is not a property of the rule set and is not on this page. A rule states which mail it selects,
-and nothing more.
+A mail rule selects mail and changes it. It is a name, a condition, the accounts it applies to, what a match leads to,
+and whether a match ends the pass, and an owner writes it in the configuration their deployment already carries. This
+page documents both halves: every fact a condition can read, every function and operator available to it, the limits it
+is read and run under, the order a set of rules is evaluated in, and the four changes a matching rule can ask for.
 
 Rules live in configuration rather than in a table, and a condition is one expression rather than a nested structure of
 predicates. [ADR 0010](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0010-rule-authoring-in-configuration-and-ncalc-conditions.md)
@@ -25,6 +22,7 @@ MCP, not the administrative endpoint. An owner who wants to change what their in
         "Name": "supplier-invoices",
         "Accounts": [ "work" ],
         "Condition": "senderDomain == 'supplier.test' and attachmentCount > 0",
+        "Actions": { "MoveTo": "invoices", "MarkAsRead": true },
         "StopWhenMatched": true
       },
       {
@@ -67,6 +65,141 @@ that applies to several.
 
 [Configuration reference](../operations/configuration-reference.md#mailrules) lists every key of the section with its
 type, default, and constraint.
+
+## What a matching rule does
+
+A rule declares what a match leads to in an `Actions` block, one named key per change:
+
+| Key | Value | What a match asks for |
+| --- | --- | --- |
+| `MoveTo` | a folder alias | The message leaves the folder it matched in and is filed into the named one |
+| `CopyTo` | a folder alias | A second copy of the message is placed in the named folder, and the one that matched stays where it is |
+| `Delete` | `true` | The message is removed from the folder it matched in |
+| `MarkAsRead` | `true` or `false` | The message's remote `\Seen` flag is set, or cleared |
+
+**An absent key is a change the rule does not ask for**, which is why `MarkAsRead` carries a value rather than being a
+switch: `MarkAsRead: false` is a rule asking for mail to be marked *unread*, and leaving the key out is a rule that does
+not touch the flag at all. `Delete: false` says the same thing as leaving `Delete` out. One key per action rather than a
+list of action objects, because a rule declaring the same action twice is then unrepresentable rather than merely
+refused, and because a binder drops a list element whose value it cannot read — which would leave a rule quietly doing
+less than its file says.
+
+**A rule that declares no action is not a defect.** It selects mail and changes nothing, which is what a rule ending the
+pass with `StopWhenMatched` does to keep the mail it names away from the rules below it.
+
+A destination is a **folder alias** — one an account declares under `MailSynchronization:Accounts:<n>:Folders` — and
+never a path on the server. What that alias is bound to is resolved when the change is written down, so a rule goes on
+working across a server that renames the folder underneath it, and a rule may only name a folder the account actually
+mirrors. [Folder aliases and discovery](imap-synchronization.md#folder-aliases-and-discovery) states what a binding is
+and when it moves.
+
+### Which combinations a rule may declare
+
+At most one action decides where the matched occurrence ends up — a relocation, a copy, or a deletion — and a deletion
+admits nothing beside it.
+
+| Combination | Verdict | Why |
+| --- | --- | --- |
+| `MoveTo` alone | permitted | |
+| `CopyTo` alone | permitted | |
+| `Delete` alone | permitted | |
+| `MarkAsRead` alone | permitted | |
+| `MoveTo` and `MarkAsRead` | permitted | The flag is written first, on the occurrence the condition matched |
+| `CopyTo` and `MarkAsRead` | permitted | The same: the flag is written before the copy is placed |
+| `MoveTo` and `CopyTo` | refused | Two fates for one occurrence; whichever ran second would act on a message no longer where the rule matched it |
+| `MoveTo` and `Delete` | refused | The same, and the deletion would undo the filing |
+| `CopyTo` and `Delete` | refused | The same |
+| `Delete` and `MarkAsRead` | refused | A flag written on a message being removed is a flag nobody will ever read |
+
+**A refused combination is refused where it is written.** Startup fails naming the rule, the key, and which action could
+not be honored beside which, rather than a run resolving it against a mailbox — no resolution invented at run time would
+be the one the operator meant, and a rule that resolved differently depending on what a server answered would not be a
+rule.
+
+### The order they are applied in
+
+The actions of one rule are applied in **MailFathom's order rather than the order they were written in**, so that every
+permitted combination acts on the occurrence the condition matched, and so that the answer is the same on every run and
+on every instance:
+
+1. `MarkAsRead`
+2. `CopyTo`
+3. `MoveTo`
+4. `Delete`
+
+The same order governs the actions of two rules that both match one email, which no single rule's block could order on
+its own.
+
+### How a change reaches the mail server
+
+**A rule pass opens no connection.** Each action a match asks for is written down as a
+[durable mutation record](imap-synchronization.md#every-change-is-written-down-before-it-is-issued) inside the same
+transaction that records the evaluation, and the account's own convergence pass — the first thing every account run does
+— is what issues the IMAP commands. Three things follow, and each is the point of the arrangement:
+
+- **A pass that fails costs no mail server work.** Evaluation reaches nothing remote, so a local failure never defers the
+  account's fetching.
+- **A change survives a restart.** A record written and not yet carried is picked up by the next run, and
+  [a change nobody finished finishes by itself](imap-synchronization.md#a-change-nobody-finished-finishes-by-itself)
+  states every way one can be left and what becomes of it.
+- **Asking twice asks once.** The record's identity is the email occurrence, the mutation, and who asked — and for a
+  rule, *who asked* is the rule's name together with the revision of the rule set that matched. So a whole-mailbox run
+  over mail a rule has already acted on issues nothing, while an edit to the rule set is a new revision and therefore a
+  fresh request. An owner who moved the message back by hand is not overruled by the rule that filed it.
+
+**A change MailFathom made does not come back as something to act on.** A rule filing a message would otherwise meet it
+in its new folder, match again, and file it again for as long as the folder is watched;
+[a change MailFathom made is not a change to react to](imap-synchronization.md#a-change-mailfathom-made-is-not-a-change-to-react-to)
+states how the record answers that exactly, without a cycle counter or a rate limit.
+
+**What a deletion does to the local copy is the account's decision**, taken from `AuthoredDeleteEmailDisposition` at the
+moment the request is written, exactly as a deletion somebody authored through a tool is.
+[What becomes of a message MailFathom deleted itself](imap-synchronization.md#what-becomes-of-a-message-mailfathom-deleted-itself)
+states the three answers.
+
+### What an account permits a rule to do
+
+Each account states, under `MailSynchronization:Accounts:<n>:RuleActions`, which of the four changes a rule may make to
+its mailbox:
+
+| Key | Default | What it permits |
+| --- | --- | --- |
+| `Move` | `true` | A rule may file this account's mail into another of its folders |
+| `Copy` | `true` | A rule may place a copy of this account's mail in another of its folders |
+| `Delete` | `false` | A rule may remove this account's mail |
+| `MarkAsRead` | `true` | A rule may set or clear this account's `\Seen` flag |
+
+**Deletion is opt-in and the other three are opt-out**, because deletion is the one action whose result cannot be
+undone by editing a rule afterwards.
+
+**A rule declaring an action an account it reaches does not permit is refused when the configuration is read**, naming
+the rule, the action, and the account. It is refused rather than skipped for the reason a mistyped account identifier
+is: a rule that silently did less on one account than on another would be indistinguishable from a rule that never
+matched there. An unscoped rule reaches every declared account, so the remedy is either to permit the action on that
+account or to narrow the rule's `Accounts` filter to the accounts that permit it.
+
+**Withdrawing a permission takes effect at the next pass, not at the next edit of the rules.** The two sections reload
+independently, so narrowing what an account permits leaves a rule set nobody edited in force; the permission is
+therefore read again when each change is written down, and an action it now refuses is
+[a failed action](#when-a-change-cannot-be-made) rather than one more deletion. The rule itself stays as written and is
+refused the next time the rule section is read, which is the message that says what to edit.
+
+### When a change cannot be made
+
+Validation settles what a rule may declare, so what is left is what only the mailbox in front of the pass can cause.
+Each is recorded against the rule that asked, and the actions beside it are still carried:
+
+| Reason | What happened |
+| --- | --- |
+| `DestinationFolderUnresolved` | The destination alias is bound to no folder on the server — nothing has discovered it yet, or the folder it named has gone |
+| `AccountNoLongerConfigured` | The account was withdrawn from the configuration between the rule set being read and the change being written |
+| `ActionNoLongerPermitted` | The account has stopped permitting this action since the rule set that declares it was read |
+
+Nothing is written down in any of the three cases: filing into whichever folder looked closest to the name is precisely
+what a stale destination must not do. The account run reports how many changes it asked for, how many it withheld because
+another matching rule had already settled the same message, and how many named something that no longer resolves,
+together with the rules involved. Counts and rule names only — nothing derived from a message reaches a log line, a
+metric, or a span.
 
 ## The facts a condition can read
 
@@ -200,6 +333,13 @@ each is refused with a message naming the rule, what was wrong, and where:
 The rule's `Accounts` filter is checked beside those four: every identifier names a declared account, none is blank, and
 none is repeated.
 
+So is its `Actions` block, against the rule itself and against every account the rule reaches:
+
+- **The destinations.** Each names something readable as a folder alias, and each names a folder the account actually
+  mirrors — a rule filing into a folder nothing mirrors could never resolve a destination.
+- **The combination.** The actions are ones MailFathom applies together, per [the table above](#which-combinations-a-rule-may-declare).
+- **The permissions.** Every action is one the account permits a rule to take.
+
 Every defect in every rule is reported together, so a rule set with three mistakes is fixed once rather than three
 restarts running.
 
@@ -223,6 +363,18 @@ outcome on every run and on every instance.
 
 `StopWhenMatched` on a rule that matches ends the pass, and the rules below it are not reached. It defaults to `false`.
 A rule that does not match never stops a pass whatever it declares.
+
+**Declared order also settles what two matching rules do to one email.** Their actions are gathered in that order, and
+an action the ones already gathered leave no room for is **withheld** — judged by exactly the table one rule's own
+actions are judged by, so two rules naming incompatible fates settle the way one rule declaring both would have been
+refused. Two rules filing one email into different folders therefore file it into the folder the rule written first
+names; the same two rules the other way round file it the other way; and a rule deleting an email leaves nothing for a
+later rule to file. Whatever survives is then applied in the fixed order above, so a flag a later rule asked for is
+still written before an earlier rule moves the message.
+
+A withheld action is reported with the name of the rule that asked for it, because a rule that appears not to have fired
+is otherwise indistinguishable from one that never matched. `StopWhenMatched` is the way to say which rule owns a
+message rather than leaving it to be settled this way.
 
 ## When rules run
 
@@ -313,7 +465,7 @@ and two instances reading the same file name the same revision.
 
 What moves it and what does not:
 
-- Changing a rule's name, its condition, its `StopWhenMatched`, or the accounts it applies to moves it.
+- Changing a rule's name, its condition, its actions, its `StopWhenMatched`, or the accounts it applies to moves it.
 - Adding, removing, or switching off a rule moves it.
 - Reordering the rules moves it, because declared order is part of what a rule set means.
 - Reformatting the file, reordering the keys within one rule, and changing an unrelated configuration section all leave
@@ -322,6 +474,10 @@ What moves it and what does not:
 The identity carries none of the authored text and no ordering. A record naming a revision therefore holds nothing
 personal that a condition contributed, and a record that has to say which of two revisions came first carries its own
 timestamp rather than inferring one.
+
+The revision is also half of what makes a change idempotent, so moving it has a consequence worth stating: a rule whose
+actions were edited asks afresh for mail it has already acted on, while an unchanged rule re-evaluated under the same
+revision asks for nothing it has already asked for.
 
 ## Worked conditions
 
@@ -379,4 +535,61 @@ Size measured in a unit an owner thinks in:
 
 ```text
 sizeInBytes / 1048576 > 25
+```
+
+## Worked rules
+
+Filing supplier invoices and marking them read, on one account, so that the rules below never see them:
+
+```json
+{
+  "Name": "supplier-invoices",
+  "Accounts": [ "work" ],
+  "Condition": "senderDomain == 'supplier.test' and attachmentCount > 0",
+  "Actions": { "MoveTo": "invoices", "MarkAsRead": true },
+  "StopWhenMatched": true
+}
+```
+
+Keeping a copy of everything a regulator sends, without disturbing where the message itself sits or whether it has been
+read:
+
+```json
+{
+  "Name": "regulator-copies",
+  "Condition": "senderDomain == 'regulator.example'",
+  "Actions": { "CopyTo": "compliance" }
+}
+```
+
+Putting automated notices back in front of somebody by clearing the flag, and nothing else:
+
+```json
+{
+  "Name": "unread-alerts",
+  "Condition": "contains(subject, 'alert') and isSeen",
+  "Actions": { "MarkAsRead": false }
+}
+```
+
+Deleting mail nobody needs — which the account has to permit under
+`MailSynchronization:Accounts:<n>:RuleActions:Delete`, and which is refused at startup if it does not:
+
+```json
+{
+  "Name": "drop-build-notifications",
+  "Accounts": [ "work" ],
+  "Condition": "senderAddress == 'builds@ci.example' and ageInDays > 7",
+  "Actions": { "Delete": true }
+}
+```
+
+Selecting mail and changing nothing, which is what a rule owning a message ahead of the rules below it looks like:
+
+```json
+{
+  "Name": "leave-family-mail-alone",
+  "Condition": "senderDomain == 'family.example'",
+  "StopWhenMatched": true
+}
 ```

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -113,11 +113,25 @@ shape the coordinator loop itself, which are read once at start and marked *rest
 | `…:EarliestEmailReceivedDate` | date | unset (everything) | Not in the future (compared in UTC) | reload |
 | `…:RemotelyDeletedEmailDisposition` | enum | `RetainTombstone` | `RetainTombstone`, `EraseLocalCopy` | reload; governs disappearances observed from then on |
 | `…:AuthoredDeleteEmailDisposition` | enum | `RetainLocalCopy` | `RetainLocalCopy`, `RetainTombstone`, `EraseLocalCopy`; what becomes of the local copy of mail MailFathom itself deleted, and it takes precedence over the key above for those | reload; governs deletes authored from then on |
+| `…:RuleActions:Move` | bool | `true` | Whether a rule may file this account's mail into another of its folders | reload; the next rule pass writes down no change this refuses |
+| `…:RuleActions:Copy` | bool | `true` | Whether a rule may place a copy of this account's mail in another of its folders | reload; the same |
+| `…:RuleActions:Delete` | bool | `false` | Whether a rule may remove this account's mail; the one action that is opt-in | reload; the same |
+| `…:RuleActions:MarkAsRead` | bool | `true` | Whether a rule may set or clear this account's remote `\Seen` flag | reload; the same |
 | `…:AuditTrail:Enabled` | bool | `false` | Whether a finished change to this account's mailbox leaves a durable audit entry | reload; governs changes authored from then on |
 | `…:AuditTrail:Retention` | TimeSpan | `90.00:00:00` | 1 day – 3650 days; how long this account's audit entries are kept | reload; the next account run erases against the new window |
 | `…:AnsweringAuditTrail:Enabled` | bool | `false` | Whether a finished `ask_mail` run leaves a durable entry naming the mail it read from this account | reload; governs runs from then on |
 | `…:AnsweringAuditTrail:Retention` | TimeSpan | `30.00:00:00` | 1 day – 3650 days; how long this account's answering entries are kept | reload; the next account run erases against the new window |
 | `…:Folders` | list | inbox by role | Aliases unique; each entry below | reload |
+
+`RuleActions` is what a rule is judged against rather than what it is filtered by: a rule declaring an action this
+account does not permit **fails startup** naming the rule, the action, and the account, rather than running with that
+action quietly dropped. An unscoped rule reaches every declared account, so permitting an action on one account and not
+on another means either permitting it on both or narrowing the rule's own `Accounts` filter. Narrowing this block while
+a rule set that declares the action is in force is the one case the two do not resolve together, since the sections
+reload apart: the permission is read again as each change is written down, so the withdrawal takes effect at the next
+pass and the rule is refused the next time the rule section is read.
+[What an account permits a rule to do](../features/mail-rules.md#what-an-account-permits-a-rule-to-do) states why
+deletion is the one opt-in of the four.
 
 `AuditTrail` is off by default because the record it keeps is derived personal data: it says where a person's mail has
 been, when, and at whose instruction. Turning it on commits the deployment to holding that history, describing it, and
@@ -611,6 +625,17 @@ use — every fact, every function, every operator — and this section document
 | `MailRules:Rules:0:Condition` | string | required | One expression producing a boolean, within the two limits above | reload |
 | `MailRules:Rules:0:StopWhenMatched` | bool | `false` | A match ends the pass and the rules below it are not reached | reload |
 | `MailRules:Rules:0:Enabled` | bool | `true` | A rule switched off is left out of the set entirely | reload |
+| `MailRules:Rules:0:Actions:MoveTo` | string | unset | The alias of the folder a match is filed into; the account must mirror it | reload |
+| `MailRules:Rules:0:Actions:CopyTo` | string | unset | The alias of the folder a copy of a match is placed in; the account must mirror it | reload |
+| `MailRules:Rules:0:Actions:Delete` | bool | unset | `true` removes a match from the folder it matched in; the account must permit deletion | reload |
+| `MailRules:Rules:0:Actions:MarkAsRead` | bool | unset | `true` sets the remote `\Seen` flag and `false` clears it; leaving the key out leaves the flag alone | reload |
+
+An absent action key is a change the rule does not ask for, which is why `MarkAsRead` carries a value rather than being
+a switch. At most one of `MoveTo`, `CopyTo`, and `Delete` may be declared by one rule, `Delete` admits nothing beside
+it, and every permitted combination is applied in MailFathom's own order — the flag first and the relocation or the
+deletion last. A rule declaring nothing here selects mail and changes nothing.
+[What a matching rule does](../features/mail-rules.md#what-a-matching-rule-does) states the whole table, the order, and
+how a change reaches the mail server.
 
 Every condition is read while the host composes itself, and a defect in one — an unparseable expression, a name that is
 not a fact, a call that is not an available function, a comparison between shapes that could never match, a result that

--- a/src/Application/Rules/Actions/IMailRuleActionPermissionReader.cs
+++ b/src/Application/Rules/Actions/IMailRuleActionPermissionReader.cs
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.Rules.Actions;
+
+/// <summary>Answers which changes one account currently permits a rule to make to its mailbox.</summary>
+/// <remarks>
+/// <para>
+/// A rule declaring an action an account refuses is refused when the rule set is read, so this port is the second half
+/// of that answer rather than the first: the two sections reload independently, and an operator narrowing what an
+/// account permits does not touch the rule section that would be re-read against it. Without this the revocation would
+/// take effect only when something else edited the rules, which for a deletion is the wrong way round.
+/// </para>
+/// <para>
+/// It answers for the account as it is configured at the moment the change is written down, which is the same instant
+/// <see cref="Mail.Mutations.IAuthoredDeleteEmailDispositionReader" /> is read at and for the same reason: what the
+/// operator permits now is what the request may carry, and a run that performs it later carries the answer on the
+/// record rather than asking again.
+/// </para>
+/// </remarks>
+public interface IMailRuleActionPermissionReader
+{
+    /// <summary>Gets the actions one account permits a rule to take.</summary>
+    /// <param name="accountId">The account whose mail a rule matched.</param>
+    /// <returns>What a rule may ask for against that account.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the configuration no longer declares the account.</exception>
+    MailRuleActionPermissions GetRuleActionPermissions(MailAccountId accountId);
+}

--- a/src/Application/Rules/Actions/MailRuleAction.cs
+++ b/src/Application/Rules/Actions/MailRuleAction.cs
@@ -1,0 +1,83 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Rules.Actions;
+
+/// <summary>One change a matching rule asks for, named as the mutation it will be requested through.</summary>
+/// <remarks>
+/// <para>
+/// The set an action may name is exactly <see cref="MailboxMutation.All" />, because a rule asks for a change through
+/// the same record every other requester uses and nothing here issues a command of its own. What this adds over the
+/// mutation is the parameter the rule declared: a relocation and a copy name a destination alias, a <c>\Seen</c> change
+/// names a direction, and a delete names neither.
+/// </para>
+/// <para>
+/// The destination is an alias rather than a remote path, because an alias is MailFathom's own name for a folder and
+/// survives the server renaming what it is bound to. The path is resolved when the request is written, which is what
+/// makes a destination that has stopped being resolvable fail visibly instead of being filed somewhere else.
+/// </para>
+/// <para>
+/// The factories are the only way to build one, so an action carrying a parameter its mutation does not take cannot be
+/// constructed — the same invariant <see cref="MailboxMutationRequest" /> holds one layer down.
+/// </para>
+/// </remarks>
+public sealed record MailRuleAction
+{
+    private MailRuleAction(MailboxMutation mutation, MailFolderAlias? destinationAlias, bool? desiredSeenState)
+    {
+        this.Mutation = mutation;
+        this.DestinationAlias = destinationAlias;
+        this.DesiredSeenState = desiredSeenState;
+    }
+
+    /// <summary>Gets the change this action asks for.</summary>
+    public MailboxMutation Mutation { get; }
+
+    /// <summary>Gets the folder a relocation or a copy names, and <see langword="null" /> for every other action.</summary>
+    public MailFolderAlias? DestinationAlias { get; }
+
+    /// <summary>Gets which way a <c>\Seen</c> change was asked for, and <see langword="null" /> for every other action.</summary>
+    public bool? DesiredSeenState { get; }
+
+    /// <summary>Gets the form this action is rendered in for a rule set's derived revision identity.</summary>
+    /// <remarks>
+    /// It names the mutation and its parameter, so editing either moves the revision and the edited rule asks afresh
+    /// rather than being read as the request already performed.
+    /// </remarks>
+    public string CanonicalForm => this switch
+    {
+        { DestinationAlias: { } alias } => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{this.Mutation.Name}={alias.Value}"),
+        { DesiredSeenState: { } isSeen } => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{this.Mutation.Name}={(isSeen ? "true" : "false")}"),
+        _ => this.Mutation.Name,
+    };
+
+    /// <summary>Asks for the matching email to be moved into another folder.</summary>
+    /// <param name="destinationAlias">The folder to move it into.</param>
+    /// <returns>The action.</returns>
+    public static MailRuleAction Relocate(MailFolderAlias destinationAlias) =>
+        new(MailboxMutation.Relocate, destinationAlias, desiredSeenState: null);
+
+    /// <summary>Asks for a second live occurrence of the matching email to be put into another folder.</summary>
+    /// <param name="destinationAlias">The folder to copy it into.</param>
+    /// <returns>The action.</returns>
+    public static MailRuleAction Copy(MailFolderAlias destinationAlias) =>
+        new(MailboxMutation.Copy, destinationAlias, desiredSeenState: null);
+
+    /// <summary>Asks for the matching email to be removed from the folder it is in.</summary>
+    /// <returns>The action.</returns>
+    public static MailRuleAction Delete() => new(MailboxMutation.Delete, destinationAlias: null, desiredSeenState: null);
+
+    /// <summary>Asks for the remote <c>\Seen</c> flag of the matching email to be set or cleared.</summary>
+    /// <param name="isSeen"><see langword="true" /> to mark the email read; <see langword="false" /> to mark it unread.</param>
+    /// <returns>The action.</returns>
+    public static MailRuleAction SetSeen(bool isSeen) => new(MailboxMutation.SetSeen, destinationAlias: null, isSeen);
+}

--- a/src/Application/Rules/Actions/MailRuleActionFailure.cs
+++ b/src/Application/Rules/Actions/MailRuleActionFailure.cs
@@ -1,0 +1,23 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Rules.Actions;
+
+/// <summary>One action a rule asked for and nothing was recorded against, with the reason nothing was.</summary>
+/// <param name="RuleName">The rule that asked, which is MailFathom's own configured name for it.</param>
+/// <param name="Mutation">The change it asked for, which is the same word a log line and a counter use.</param>
+/// <param name="Reason">Why the request could not be written.</param>
+/// <param name="DestinationAlias">The folder the action named, and <see langword="null" /> for an action naming none.</param>
+/// <remarks>
+/// It names identities and a mutation name only. A rule name and a folder alias are both MailFathom's own configured
+/// names, which is what lets a failure be reported without saying which message it was about.
+/// </remarks>
+public sealed record MailRuleActionFailure(
+    string RuleName,
+    MailboxMutation Mutation,
+    MailRuleActionFailureReason Reason,
+    MailFolderAlias? DestinationAlias = null);

--- a/src/Application/Rules/Actions/MailRuleActionFailureReason.cs
+++ b/src/Application/Rules/Actions/MailRuleActionFailureReason.cs
@@ -1,0 +1,38 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Rules.Actions;
+
+/// <summary>Why one planned action produced no request against the mailbox.</summary>
+/// <remarks>
+/// Every member describes something that was true when the rule set was read and has stopped being true since. The
+/// action fails visibly rather than choosing an alternative, because every alternative would be MailFathom deciding
+/// where somebody's mail goes.
+/// </remarks>
+public enum MailRuleActionFailureReason
+{
+    /// <summary>The destination alias names no folder this account currently has bound.</summary>
+    /// <remarks>
+    /// The alias was declared as a mapped folder when the rule set was read, and discovery has not bound it since — the
+    /// server no longer advertises the folder, or has never been asked for it. Filing into the nearest folder whose name
+    /// looks right is precisely what this refuses.
+    /// </remarks>
+    DestinationFolderUnresolved = 0,
+
+    /// <summary>The account the email belongs to is no longer one the configuration declares.</summary>
+    /// <remarks>
+    /// A reload can withdraw an account while a pass over its mail is running. What the account decided about its own
+    /// deletions is then unknown, and a change asked for on behalf of a mailbox the deployment has stopped declaring is
+    /// one nobody is currently asking for.
+    /// </remarks>
+    AccountNoLongerConfigured = 1,
+
+    /// <summary>The account no longer permits a rule to make this change to its mailbox.</summary>
+    /// <remarks>
+    /// The rule set was refused if it declared an action the account did not permit, but the two sections reload
+    /// independently: narrowing what an account permits leaves a rule set nobody edited in force, and an operator who
+    /// has just withdrawn permission to delete is not asking for one more deletion first.
+    /// </remarks>
+    ActionNoLongerPermitted = 2,
+}

--- a/src/Application/Rules/Actions/MailRuleActionPermissions.cs
+++ b/src/Application/Rules/Actions/MailRuleActionPermissions.cs
@@ -1,0 +1,68 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Rules.Actions;
+
+/// <summary>States which of the four mutations a rule may ask for on one account.</summary>
+/// <param name="PermitsRelocate">Whether a rule may move mail into another folder.</param>
+/// <param name="PermitsCopy">Whether a rule may put a second occurrence into another folder.</param>
+/// <param name="PermitsDelete">Whether a rule may remove mail from the folder it is in.</param>
+/// <param name="PermitsSetSeen">Whether a rule may set or clear the remote <c>\Seen</c> flag.</param>
+/// <remarks>
+/// <para>
+/// What automation may do to a mailbox is the owner's decision rather than a rule's, so it is declared per account and
+/// per mutation instead of as one switch: an installation can run every rule it has with deletion refused, which is the
+/// case this exists for. A rule declaring an action its account does not permit is refused when the configuration is
+/// read rather than skipped later, because a rule that silently does nothing is indistinguishable from one that never
+/// matched.
+/// </para>
+/// <para>
+/// Deletion is the one action that is opt-in. The other three are reversible from an ordinary mail client — a message
+/// filed can be moved back, a copy removed, a flag cleared — and a deletion is the one that is not, so an account
+/// saying nothing about it means no.
+/// </para>
+/// </remarks>
+public sealed record MailRuleActionPermissions(
+    bool PermitsRelocate,
+    bool PermitsCopy,
+    bool PermitsDelete,
+    bool PermitsSetSeen)
+{
+    /// <summary>Gets the permissions of an account that says nothing: every reversible change, and no deletion.</summary>
+    public static MailRuleActionPermissions Default { get; } = new(
+        PermitsRelocate: true,
+        PermitsCopy: true,
+        PermitsDelete: false,
+        PermitsSetSeen: true);
+
+    /// <summary>Reports whether a rule on this account may ask for one mutation.</summary>
+    /// <param name="mutation">The mutation the rule declares.</param>
+    /// <returns><see langword="true" /> when the account permits it.</returns>
+    /// <remarks>
+    /// A closed enumeration's members are not compile-time constants, so the answer is reached by comparison rather
+    /// than by a switch over cases. An unspecified mutation is permitted by nothing, which is what the final answer
+    /// gives it.
+    /// </remarks>
+    public bool Permits(MailboxMutation mutation)
+    {
+        if (mutation == MailboxMutation.Relocate)
+        {
+            return this.PermitsRelocate;
+        }
+
+        if (mutation == MailboxMutation.Copy)
+        {
+            return this.PermitsCopy;
+        }
+
+        if (mutation == MailboxMutation.Delete)
+        {
+            return this.PermitsDelete;
+        }
+
+        return mutation == MailboxMutation.SetSeen && this.PermitsSetSeen;
+    }
+}

--- a/src/Application/Rules/Actions/MailRuleActionPlan.cs
+++ b/src/Application/Rules/Actions/MailRuleActionPlan.cs
@@ -1,0 +1,80 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Rules.Actions;
+
+/// <summary>What one email's matching rules together ask the mailbox for, in the order the changes are applied.</summary>
+/// <remarks>
+/// <para>
+/// One rule's actions are already proven compatible when the configuration is read; two rules matching one email are
+/// not, and cannot be — which rules match is a property of the message rather than of the set. Two rules filing one
+/// email into different folders is the case this resolves, and it resolves it the only way a rule set's own contract
+/// allows: the rules are folded in declared order, and an action the ones before it leave no room for is withheld
+/// rather than applied. Nothing here consults timing, so one email produces the same plan on every run and on every
+/// instance.
+/// </para>
+/// <para>
+/// A withheld action is named by its rule so a run can say which rule did not get its way. Without that, a rule whose
+/// action was withheld reads exactly like a rule that never matched, which is the silence every part of this contract
+/// exists to avoid.
+/// </para>
+/// </remarks>
+public sealed record MailRuleActionPlan
+{
+    private MailRuleActionPlan(IReadOnlyList<PlannedMailRuleAction> actions, IReadOnlyList<string> withheldRuleNames)
+    {
+        this.Actions = actions;
+        this.WithheldRuleNames = withheldRuleNames;
+    }
+
+    /// <summary>Gets the plan of an email whose rules ask for nothing.</summary>
+    public static MailRuleActionPlan Nothing { get; } = new([], []);
+
+    /// <summary>Gets the actions to apply, in the order MailFathom applies them.</summary>
+    public IReadOnlyList<PlannedMailRuleAction> Actions { get; }
+
+    /// <summary>Gets the names of the rules at least one of whose actions another rule had already settled.</summary>
+    public IReadOnlyList<string> WithheldRuleNames { get; }
+
+    /// <summary>Gets whether the plan asks for no change at all.</summary>
+    public bool IsEmpty => this.Actions.Count == 0;
+
+    /// <summary>Folds the actions of the rules that matched one email into the changes the mailbox will be asked for.</summary>
+    /// <param name="matchedRules">The rules that matched, in the order the set declares them.</param>
+    /// <returns>The plan.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="matchedRules" /> is <see langword="null" />.</exception>
+    public static MailRuleActionPlan Compose(IReadOnlyList<MailRule> matchedRules)
+    {
+        ArgumentNullException.ThrowIfNull(matchedRules);
+
+        var honored = new List<PlannedMailRuleAction>();
+        var withheld = new SortedSet<string>(StringComparer.Ordinal);
+
+        foreach (var rule in matchedRules)
+        {
+            foreach (var action in rule.Actions.Actions)
+            {
+                if (MailRuleActionSet.FindRefusal([.. honored.Select(planned => planned.Action)], action) is not null)
+                {
+                    withheld.Add(rule.Name);
+
+                    continue;
+                }
+
+                honored.Add(new PlannedMailRuleAction(rule.Name, action));
+            }
+        }
+
+        if (honored.Count == 0 && withheld.Count == 0)
+        {
+            return Nothing;
+        }
+
+        // Ordered across rules rather than within one, so a flag declared by a later rule is still written before an
+        // earlier rule moves the occurrence it would have been written on.
+        return new MailRuleActionPlan(
+            [.. honored.OrderBy(planned => MailRuleActionSet.ApplicationOrderOf(planned.Action))],
+            [.. withheld]);
+    }
+}

--- a/src/Application/Rules/Actions/MailRuleActionRecorder.cs
+++ b/src/Application/Rules/Actions/MailRuleActionRecorder.cs
@@ -1,0 +1,272 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Rules.Actions;
+
+/// <summary>Writes down the changes one email's matching rules ask for, as the mutation records every requester uses.</summary>
+/// <remarks>
+/// <para>
+/// This is the join between a rule and a mailbox, and it is deliberately the whole of it. Nothing here issues an IMAP
+/// command: it opens a durable record per action, and the account's own convergence pass carries each record to a
+/// completed or a dead-lettered ending exactly as it carries a change somebody authored by hand. What this adds is the
+/// identity, the order, and the refusal of an action whose account or destination has stopped permitting it.
+/// </para>
+/// <para>
+/// What an account permits is read here as well as when the rule set is read, and the second reading is not redundant:
+/// the two configuration sections reload independently, so narrowing what an account permits leaves a rule set nobody
+/// edited in force. Without this, a revoked permission would take effect at the next edit of the rules rather than at
+/// the next pass, which for a deletion is the wrong way round.
+/// </para>
+/// <para>
+/// The records join the caller's session, so a batch's evaluations and the requests they produced commit together. A
+/// crash between them is therefore impossible in the direction that matters: an email is never recorded as evaluated
+/// while the change its rules asked for was lost, and a rolled-back batch is evaluated again and asks again under the
+/// same identity.
+/// </para>
+/// <para>
+/// A destination alias is resolved to a remote folder once per pass and remembered, because a batch of two hundred
+/// emails matching one filing rule would otherwise re-read one binding two hundred times. The binding a pass began with
+/// is the one it finishes with, which is the same contract the rule set itself is read under.
+/// </para>
+/// </remarks>
+public sealed class MailRuleActionRecorder
+{
+    private readonly IMailboxMutationRecordStore records;
+    private readonly IMailFolderResolutionStore folderResolutions;
+    private readonly IAuthoredDeleteEmailDispositionReader deleteDispositions;
+    private readonly IMailRuleActionPermissionReader permissions;
+    private readonly Dictionary<(MailAccountId Account, MailFolderAlias Alias), RemoteFolderPath?> destinations = [];
+
+    /// <summary>Initializes the recorder from the record it writes and the decisions it has to read.</summary>
+    /// <param name="records">Opens the durable record one action is carried by.</param>
+    /// <param name="folderResolutions">Resolves a destination alias to the remote folder it currently names.</param>
+    /// <param name="deleteDispositions">Answers what the account keeps locally of an email a rule deletes.</param>
+    /// <param name="permissions">Answers which changes the account currently permits a rule to make.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
+    public MailRuleActionRecorder(
+        IMailboxMutationRecordStore records,
+        IMailFolderResolutionStore folderResolutions,
+        IAuthoredDeleteEmailDispositionReader deleteDispositions,
+        IMailRuleActionPermissionReader permissions)
+    {
+        ArgumentNullException.ThrowIfNull(records);
+        ArgumentNullException.ThrowIfNull(folderResolutions);
+        ArgumentNullException.ThrowIfNull(deleteDispositions);
+        ArgumentNullException.ThrowIfNull(permissions);
+
+        this.records = records;
+        this.folderResolutions = folderResolutions;
+        this.deleteDispositions = deleteDispositions;
+        this.permissions = permissions;
+    }
+
+    /// <summary>Opens one mutation record per action the plan honors, in the order the changes are applied.</summary>
+    /// <param name="session">The session the records are staged in, which is the one the batch commits.</param>
+    /// <param name="storedEmailId">The local email the rules matched.</param>
+    /// <param name="occurrence">Where that email is, which is what an IMAP command will be issued against.</param>
+    /// <param name="plan">What the matching rules together ask for.</param>
+    /// <param name="revision">The rule set revision the pass ran under, which is part of every request's identity.</param>
+    /// <param name="cancellationToken">Cancels the staging.</param>
+    /// <returns>How many records were opened, and every action nothing was opened for.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="revision" /> names no rule set.</exception>
+    public async Task<MailRuleActionRecording> RecordAsync(
+        IPersistenceSession session,
+        StoredEmailId storedEmailId,
+        EmailOccurrenceId occurrence,
+        MailRuleActionPlan plan,
+        MailRuleSetRevision revision,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(occurrence);
+        ArgumentNullException.ThrowIfNull(plan);
+
+        if (!revision.IsSpecified)
+        {
+            throw new ArgumentException("A recorded rule action must name the revision it was planned under.", nameof(revision));
+        }
+
+        if (plan.IsEmpty)
+        {
+            return MailRuleActionRecording.Nothing;
+        }
+
+        if (this.TryReadPermissions(occurrence.AccountId) is not { } permitted)
+        {
+            return new MailRuleActionRecording(0, WithdrawnAccountFailures(plan));
+        }
+
+        var failures = new List<MailRuleActionFailure>();
+        var recordedCount = 0;
+
+        foreach (var planned in plan.Actions)
+        {
+            // Read again here rather than trusted from validation, because the synchronization section and the rule
+            // section reload independently: narrowing what an account permits leaves a rule set nobody edited in force,
+            // and the revocation has to reach the next pass rather than the next edit of the rules.
+            if (!permitted.Permits(planned.Action.Mutation))
+            {
+                failures.Add(new MailRuleActionFailure(
+                    planned.RuleName,
+                    planned.Action.Mutation,
+                    MailRuleActionFailureReason.ActionNoLongerPermitted,
+                    planned.Action.DestinationAlias));
+
+                continue;
+            }
+
+            var request = await this.BuildRequestAsync(
+                storedEmailId,
+                occurrence,
+                planned,
+                revision,
+                failures,
+                cancellationToken);
+
+            if (request is null)
+            {
+                continue;
+            }
+
+            await this.records.OpenAsync(session, request, cancellationToken);
+            recordedCount++;
+        }
+
+        return new MailRuleActionRecording(recordedCount, failures);
+    }
+
+    /// <summary>Reads what the account permits, or nothing when the configuration no longer declares it.</summary>
+    private MailRuleActionPermissions? TryReadPermissions(MailAccountId accountId)
+    {
+        try
+        {
+            return this.permissions.GetRuleActionPermissions(accountId);
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Reports every action of a plan as failed, for an account the configuration has stopped declaring.</summary>
+    private static IReadOnlyList<MailRuleActionFailure> WithdrawnAccountFailures(MailRuleActionPlan plan) =>
+    [
+        .. plan.Actions.Select(planned => new MailRuleActionFailure(
+            planned.RuleName,
+            planned.Action.Mutation,
+            MailRuleActionFailureReason.AccountNoLongerConfigured,
+            planned.Action.DestinationAlias)),
+    ];
+
+    /// <summary>Turns one planned action into the request that carries it, or records why it has none.</summary>
+    private async Task<MailboxMutationRequest?> BuildRequestAsync(
+        StoredEmailId storedEmailId,
+        EmailOccurrenceId occurrence,
+        PlannedMailRuleAction planned,
+        MailRuleSetRevision revision,
+        List<MailRuleActionFailure> failures,
+        CancellationToken cancellationToken)
+    {
+        var action = planned.Action;
+        var requester = MailboxMutationRequester.Rule(planned.RuleName, revision.Value);
+
+        if (action.DesiredSeenState is { } isSeen)
+        {
+            return MailboxMutationRequest.SetSeen(storedEmailId, occurrence, requester, isSeen);
+        }
+
+        if (action.DestinationAlias is { } destinationAlias)
+        {
+            var destinationPath = await this.ResolveDestinationAsync(
+                occurrence.AccountId,
+                destinationAlias,
+                cancellationToken);
+
+            if (destinationPath is not { } path)
+            {
+                failures.Add(new MailRuleActionFailure(
+                    planned.RuleName,
+                    action.Mutation,
+                    MailRuleActionFailureReason.DestinationFolderUnresolved,
+                    destinationAlias));
+
+                return null;
+            }
+
+            // No local disposition travels with a relocation here. One is supplied exactly when the destination is a
+            // folder MailFathom does not mirror, and a rule may not name such a folder at all: the rule set is refused
+            // when it is read if it does, so a destination that reaches this point is one whose mail stays mirrored.
+            return action.Mutation == MailboxMutation.Relocate
+                ? MailboxMutationRequest.Relocate(storedEmailId, occurrence, requester, path)
+                : MailboxMutationRequest.Copy(storedEmailId, occurrence, requester, path);
+        }
+
+        return this.BuildDeleteRequest(storedEmailId, occurrence, planned, requester, failures);
+    }
+
+    /// <summary>Builds a delete, whose local disposition is the account's answer at the moment the request is written.</summary>
+    /// <remarks>
+    /// The reader refuses an account the configuration no longer declares, which a reload can produce while a pass over
+    /// that account's mail is still running. That is reported as a failed action rather than allowed to end the pass:
+    /// what the withdrawn account decided about its own deletions is unknown, and no value invented here would be it.
+    /// </remarks>
+    private MailboxMutationRequest? BuildDeleteRequest(
+        StoredEmailId storedEmailId,
+        EmailOccurrenceId occurrence,
+        PlannedMailRuleAction planned,
+        MailboxMutationRequester requester,
+        List<MailRuleActionFailure> failures)
+    {
+        AuthoredDeleteEmailDisposition disposition;
+
+        try
+        {
+            disposition = this.deleteDispositions.GetAuthoredDeleteDisposition(occurrence.AccountId);
+        }
+        catch (InvalidOperationException)
+        {
+            failures.Add(new MailRuleActionFailure(
+                planned.RuleName,
+                planned.Action.Mutation,
+                MailRuleActionFailureReason.AccountNoLongerConfigured));
+
+            return null;
+        }
+
+        return MailboxMutationRequest.Delete(storedEmailId, occurrence, requester, disposition);
+    }
+
+    private async Task<RemoteFolderPath?> ResolveDestinationAsync(
+        MailAccountId accountId,
+        MailFolderAlias destinationAlias,
+        CancellationToken cancellationToken)
+    {
+        // Keyed by the account as well as the alias, because one alias names a different folder on each account and
+        // nothing in this type's contract says a scope holds one account's pass.
+        if (this.destinations.TryGetValue((accountId, destinationAlias), out var remembered))
+        {
+            return remembered;
+        }
+
+        var resolution = await this.folderResolutions.GetCurrentResolutionAsync(
+            accountId,
+            destinationAlias,
+            cancellationToken);
+
+        var destinationPath = resolution?.RemotePath;
+
+        this.destinations[(accountId, destinationAlias)] = destinationPath;
+
+        return destinationPath;
+    }
+}

--- a/src/Application/Rules/Actions/MailRuleActionRecording.cs
+++ b/src/Application/Rules/Actions/MailRuleActionRecording.cs
@@ -1,0 +1,19 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Rules.Actions;
+
+/// <summary>What recording one email's planned actions produced.</summary>
+/// <param name="RecordedCount">How many mutation records the plan opened, counting one already open as recorded.</param>
+/// <param name="Failures">The actions nothing was recorded for, each with the reason.</param>
+/// <remarks>
+/// A record already open is counted as recorded rather than as a second request, because that is what it is: the
+/// identity of a rule's request is the occurrence, the rule with its revision, and the mutation, so the same rule asking
+/// for the same email again finds the record it wrote the first time.
+/// </remarks>
+public sealed record MailRuleActionRecording(int RecordedCount, IReadOnlyList<MailRuleActionFailure> Failures)
+{
+    /// <summary>Gets the recording of an email whose rules asked for nothing.</summary>
+    public static MailRuleActionRecording Nothing { get; } = new(0, []);
+}

--- a/src/Application/Rules/Actions/MailRuleActionSet.cs
+++ b/src/Application/Rules/Actions/MailRuleActionSet.cs
@@ -1,0 +1,203 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Rules.Actions;
+
+/// <summary>What one rule does to a matching email, as the actions it declared in the order MailFathom applies them.</summary>
+/// <remarks>
+/// <para>
+/// A set rather than one value, because the ordinary cases are combinations: file it and mark it read, copy it to an
+/// archive folder and mark it read. What the set refuses is a combination naming two fates for one occurrence, and it
+/// refuses it where the configuration is read rather than resolving it at run time — whichever of two such actions ran
+/// second would act on a message that is no longer where the rule matched it, and no resolution invented here would be
+/// the one the operator meant.
+/// </para>
+/// <para>
+/// One rule therefore names at most one fate — relocate, copy, or delete — and a delete admits nothing beside it, since
+/// a flag written on a message being removed is a flag nobody will ever read. Everything the table below permits is a
+/// flag change beside a relocation or a copy, or a single action on its own.
+/// </para>
+/// <para>
+/// The order is MailFathom's rather than the order the actions were written in: the flag is written first and the
+/// relocation or the delete last, so every permitted combination acts on the occurrence the condition matched. It is
+/// fixed here so that it is the same on every run and on every instance.
+/// </para>
+/// <para>
+/// An empty set is permitted and is not a defect. A rule that declares no action selects mail and nothing more, which is
+/// what a rule ending the pass with <c>StopWhenMatched</c> does to keep the mail it names away from the rules below it.
+/// </para>
+/// </remarks>
+public sealed class MailRuleActionSet
+{
+    private MailRuleActionSet(IReadOnlyList<MailRuleAction> actions) => this.Actions = actions;
+
+    /// <summary>Gets the set a rule that does nothing to the mail it selects declares.</summary>
+    public static MailRuleActionSet Empty { get; } = new([]);
+
+    /// <summary>Gets the actions in the order MailFathom applies them.</summary>
+    public IReadOnlyList<MailRuleAction> Actions { get; }
+
+    /// <summary>Gets whether the rule asks for no change at all.</summary>
+    public bool IsEmpty => this.Actions.Count == 0;
+
+    /// <summary>Reports every reason the declared actions could not be honored together.</summary>
+    /// <param name="ruleName">The rule the actions belong to, which every message names.</param>
+    /// <param name="actions">The actions as they were declared.</param>
+    /// <returns>One message per refused action, empty when the combination is one MailFathom applies.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="actions" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Reported rather than thrown, because this is what an operator reads while their configuration is being validated
+    /// and every defect in a rule set is reported together. <see cref="Create" /> refuses the same combinations, which
+    /// is what keeps a set built without this check from reaching a mailbox.
+    /// </remarks>
+    public static IReadOnlyList<string> FindErrors(string ruleName, IReadOnlyList<MailRuleAction> actions)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(ruleName);
+        ArgumentNullException.ThrowIfNull(actions);
+
+        return
+        [
+            .. FindRefusedActions(actions)
+                .Select(refused => $"Rule '{ruleName}' declares {Describe(refused.Action)}, which {refused.Refusal}"),
+        ];
+    }
+
+    /// <summary>Builds the set of actions a rule applies, in the order they are applied.</summary>
+    /// <param name="actions">The actions as they were declared, in any order.</param>
+    /// <returns>The set.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="actions" /> is <see langword="null" />, or one of them is.</exception>
+    /// <exception cref="ArgumentException">Thrown when the actions name a combination MailFathom refuses, which validation reports first.</exception>
+    public static MailRuleActionSet Create(IReadOnlyList<MailRuleAction> actions)
+    {
+        ArgumentNullException.ThrowIfNull(actions);
+
+        if (actions.Any(action => action is null))
+        {
+            throw new ArgumentException("A rule cannot declare an action that is null.", nameof(actions));
+        }
+
+        if (actions.Count == 0)
+        {
+            return Empty;
+        }
+
+        // Reaching this means a rule set was mapped without having been proven usable, which is a defect in the
+        // composition rather than in what an operator wrote, so the reasons are joined in rather than dropped.
+        var refusals = FindRefusedActions(actions);
+
+        if (refusals.Count > 0)
+        {
+            throw new ArgumentException(
+                $"A rule declares actions that cannot be honored together. {string.Join(" ", refusals.Select(refused => $"{Describe(refused.Action)} {refused.Refusal}"))}",
+                nameof(actions));
+        }
+
+        return new MailRuleActionSet([.. actions.OrderBy(ApplicationOrderOf)]);
+    }
+
+    /// <summary>Reports why one further action cannot join the actions already being applied to one email.</summary>
+    /// <param name="honored">The actions that will be applied, which may come from more than one rule.</param>
+    /// <param name="candidate">The action being considered.</param>
+    /// <returns>The reason it is refused, or <see langword="null" /> when it can be applied beside them.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Written over an accumulated list rather than over one rule's declaration, because two rules matching one email
+    /// can name incompatible fates exactly as one rule can. Reading both cases through this method is what makes the
+    /// answer the same in either: whichever fate is reached first in declared order is the one applied.
+    /// </remarks>
+    public static string? FindRefusal(IReadOnlyCollection<MailRuleAction> honored, MailRuleAction candidate)
+    {
+        ArgumentNullException.ThrowIfNull(honored);
+        ArgumentNullException.ThrowIfNull(candidate);
+
+        if (honored.Any(action => action.Mutation == candidate.Mutation))
+        {
+            return "is already asked for; one email is changed at most once each way, and a second destination is a second rule.";
+        }
+
+        if (honored.Any(action => action.Mutation == MailboxMutation.Delete))
+        {
+            return "cannot be honored beside the deletion of the same message, which leaves nothing for it to act on.";
+        }
+
+        if (candidate.Mutation == MailboxMutation.Delete && honored.Count > 0)
+        {
+            return "cannot be honored beside another change to the same message, which the deletion would undo.";
+        }
+
+        if (NamesAFate(candidate) && honored.Any(NamesAFate))
+        {
+            return "names a second fate for one occurrence; whichever ran second would act on a message that is no longer where the rule matched it.";
+        }
+
+        return null;
+    }
+
+    /// <summary>Walks the declared actions in order and reports each one the ones before it leave no room for.</summary>
+    private static List<RefusedMailRuleAction> FindRefusedActions(IReadOnlyList<MailRuleAction> actions)
+    {
+        var honored = new List<MailRuleAction>(actions.Count);
+        var refused = new List<RefusedMailRuleAction>();
+
+        foreach (var action in actions)
+        {
+            if (FindRefusal(honored, action) is { } refusal)
+            {
+                refused.Add(new RefusedMailRuleAction(action, refusal));
+
+                continue;
+            }
+
+            honored.Add(action);
+        }
+
+        return refused;
+    }
+
+    /// <summary>Reports whether an action decides where the matched occurrence ends up, which at most one action may.</summary>
+    private static bool NamesAFate(MailRuleAction action) =>
+        action.Mutation == MailboxMutation.Relocate
+        || action.Mutation == MailboxMutation.Copy
+        || action.Mutation == MailboxMutation.Delete;
+
+    /// <summary>Ranks one action within the fixed order every permitted combination is applied in.</summary>
+    /// <param name="action">The action to rank.</param>
+    /// <returns>Its position in the order, lowest first.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="action" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The flag first and the relocation or the delete last, so every permitted combination acts on the occurrence the
+    /// condition matched. It is published because the same order governs the actions of two rules matching one email,
+    /// which no single rule's set can order on its own. A closed enumeration's members are not compile-time constants,
+    /// so the rank is decided by comparison rather than by a switch over cases.
+    /// </remarks>
+    public static int ApplicationOrderOf(MailRuleAction action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+
+        if (action.Mutation == MailboxMutation.SetSeen)
+        {
+            return 0;
+        }
+
+        if (action.Mutation == MailboxMutation.Copy)
+        {
+            return 1;
+        }
+
+        return action.Mutation == MailboxMutation.Relocate ? 2 : 3;
+    }
+
+    /// <summary>Names one action the way an operator wrote it, so a refusal points at the key they edit.</summary>
+    private static string Describe(MailRuleAction action) => action switch
+    {
+        { DestinationAlias: { } alias } => $"'{action.Mutation.Name}' into '{alias.Value}'",
+        { DesiredSeenState: { } isSeen } => $"'{action.Mutation.Name}' to {(isSeen ? "read" : "unread")}",
+        _ => $"'{action.Mutation.Name}'",
+    };
+
+    /// <summary>One declared action and the reason the actions before it leave no room for it.</summary>
+    private readonly record struct RefusedMailRuleAction(MailRuleAction Action, string Refusal);
+}

--- a/src/Application/Rules/Actions/PlannedMailRuleAction.cs
+++ b/src/Application/Rules/Actions/PlannedMailRuleAction.cs
@@ -1,0 +1,15 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Rules.Actions;
+
+/// <summary>One action a pass will ask the mailbox for, and the rule that asked.</summary>
+/// <param name="RuleName">The name of the rule the action was declared on, which is what the request is identified by.</param>
+/// <param name="Action">The change asked for.</param>
+/// <remarks>
+/// The rule name travels with the action because it is half of the request's idempotency identity: the same rule asking
+/// again for the same email is the same request, and a different rule asking for the same change is a different one.
+/// It carries no mail content, being MailFathom's own configured name for the rule.
+/// </remarks>
+public sealed record PlannedMailRuleAction(string RuleName, MailRuleAction Action);

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Rules.Conditions;
 using MailFathom.Application.Rules.Facts;
 using MailFathom.Domain.Accounts;
@@ -34,6 +35,13 @@ namespace MailFathom.Application.Rules.Evaluation;
 /// at the email nobody read rather than replaying one or stepping over one. What a batch budget leaves behind is the
 /// next account run's, which is the same answer synchronization itself gives to a folder it could not finish.
 /// </para>
+/// <para>
+/// What a match asks the mailbox for is written down in the batch's own transaction, as the durable mutation record
+/// every requester uses, and never issued from here: a pass reaches no mail server, and the account's convergence pass
+/// is what carries each record to a completed or a dead-lettered ending. Committing the requests with the evaluations
+/// is what makes the pair atomic — an email is never recorded as evaluated while the change its rules asked for was
+/// lost, and a rolled-back batch asks again under the same identity.
+/// </para>
 /// </remarks>
 public sealed class MailRuleEvaluationPass
 {
@@ -41,6 +49,7 @@ public sealed class MailRuleEvaluationPass
     private readonly MailRuleSetEvaluator evaluator;
     private readonly IMailRuleEvaluationStore store;
     private readonly IMailRuleEvaluationRunStore runStore;
+    private readonly MailRuleActionRecorder actionRecorder;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
     private readonly MailRuleEvaluationOptions options;
     private readonly TimeProvider timeProvider;
@@ -50,6 +59,7 @@ public sealed class MailRuleEvaluationPass
     /// <param name="evaluator">Runs a rule set over one email and classifies every way a condition can fail to answer.</param>
     /// <param name="store">Reads the candidates and records which emails have been evaluated.</param>
     /// <param name="runStore">Reads the requested whole-mailbox run and records how far it has been carried.</param>
+    /// <param name="actionRecorder">Writes down the changes a matching rule asks the mailbox for.</param>
     /// <param name="commitPolicy">Commits a batch's evaluations together with the position they account for.</param>
     /// <param name="options">Bounds one walk.</param>
     /// <param name="timeProvider">Supplies the instant each email is evaluated at and each record is stamped with.</param>
@@ -60,6 +70,7 @@ public sealed class MailRuleEvaluationPass
         MailRuleSetEvaluator evaluator,
         IMailRuleEvaluationStore store,
         IMailRuleEvaluationRunStore runStore,
+        MailRuleActionRecorder actionRecorder,
         OptimisticConcurrencyRetryPolicy commitPolicy,
         MailRuleEvaluationOptions options,
         TimeProvider timeProvider)
@@ -68,6 +79,7 @@ public sealed class MailRuleEvaluationPass
         ArgumentNullException.ThrowIfNull(evaluator);
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(runStore);
+        ArgumentNullException.ThrowIfNull(actionRecorder);
         ArgumentNullException.ThrowIfNull(commitPolicy);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(timeProvider);
@@ -78,6 +90,7 @@ public sealed class MailRuleEvaluationPass
         this.evaluator = evaluator;
         this.store = store;
         this.runStore = runStore;
+        this.actionRecorder = actionRecorder;
         this.commitPolicy = commitPolicy;
         this.options = options;
         this.timeProvider = timeProvider;
@@ -163,11 +176,20 @@ public sealed class MailRuleEvaluationPass
                 var evaluatedAt = this.timeProvider.GetUtcNow();
 
                 await this.commitPolicy.CommitAsync(
-                    (session, attemptCancellationToken) => this.store.RecordEvaluatedAsync(
-                        session,
-                        outcome.EvaluatedEmailIds,
-                        evaluatedAt,
-                        attemptCancellationToken),
+                    async (session, attemptCancellationToken) =>
+                    {
+                        await this.store.RecordEvaluatedAsync(
+                            session,
+                            outcome.EvaluatedEmailIds,
+                            evaluatedAt,
+                            attemptCancellationToken);
+
+                        await this.RecordActionsAsync(
+                            session,
+                            ruleSet.Revision,
+                            outcome,
+                            attemptCancellationToken);
+                    },
                     cancellationToken);
             }
 
@@ -281,6 +303,8 @@ public sealed class MailRuleEvaluationPass
                     recordedAt,
                     attemptCancellationToken);
 
+                await this.RecordActionsAsync(session, ruleSet.Revision, outcome, attemptCancellationToken);
+
                 await this.runStore.SaveAsync(session, carried, attemptCancellationToken);
             },
             cancellationToken);
@@ -288,6 +312,34 @@ public sealed class MailRuleEvaluationPass
         tally.Add(outcome);
 
         return carried;
+    }
+
+    /// <summary>Writes down every change the batch's matching rules asked for, inside the batch's own transaction.</summary>
+    /// <remarks>
+    /// The counts are reset at the start rather than added to, because the commit policy re-runs this whole delegate
+    /// when it loses an optimistic race. Adding to them would count the losing attempt's records as well as the winning
+    /// one's, and the losing attempt wrote nothing.
+    /// </remarks>
+    private async Task RecordActionsAsync(
+        IPersistenceSession session,
+        MailRuleSetRevision revision,
+        MailRuleEvaluationBatch outcome,
+        CancellationToken cancellationToken)
+    {
+        outcome.ForgetRecordedActions();
+
+        foreach (var pending in outcome.PendingActions)
+        {
+            var recording = await this.actionRecorder.RecordAsync(
+                session,
+                pending.StoredEmailId,
+                pending.Occurrence,
+                pending.Plan,
+                revision,
+                cancellationToken);
+
+            outcome.ActionsRecorded(recording);
+        }
     }
 
     private Task CommitRunAsync(MailRuleEvaluationRun run, CancellationToken cancellationToken) =>
@@ -332,7 +384,7 @@ public sealed class MailRuleEvaluationPass
 
             var evaluation = await this.evaluator.EvaluateAsync(ruleSet, facts, cancellationToken);
 
-            outcome.Evaluated(candidate.StoredEmailId, evaluation);
+            outcome.Evaluated(candidate, evaluation);
         }
 
         return outcome;
@@ -353,15 +405,25 @@ public sealed class MailRuleEvaluationPass
 
         internal int TimedOutRuleCount { get; private set; }
 
+        internal int RequestedActionCount { get; private set; }
+
+        internal int WithheldActionCount { get; private set; }
+
+        internal int FailedActionCount { get; private set; }
+
         internal SortedSet<string> MatchedRuleNames { get; } = new(StringComparer.Ordinal);
 
         internal SortedSet<string> FailedRuleNames { get; } = new(StringComparer.Ordinal);
 
+        internal SortedSet<string> UnappliedActionRuleNames { get; } = new(StringComparer.Ordinal);
+
+        internal List<PendingMailRuleActions> PendingActions { get; } = [];
+
         internal void Skipped() => this.SkippedEmailCount++;
 
-        internal void Evaluated(StoredEmailId storedEmailId, MailRuleSetEvaluation evaluation)
+        internal void Evaluated(StoredEmailAwaitingRuleEvaluation candidate, MailRuleSetEvaluation evaluation)
         {
-            this.EvaluatedEmailIds.Add(storedEmailId);
+            this.EvaluatedEmailIds.Add(candidate.StoredEmailId);
 
             if (evaluation.MatchedRuleNames.Count > 0)
             {
@@ -379,20 +441,57 @@ public sealed class MailRuleEvaluationPass
                     this.TimedOutRuleCount++;
                 }
             }
+
+            // The withheld actions are counted where the plan is composed rather than where it is recorded, because
+            // nothing about them reaches the database and a retried commit would otherwise count them twice.
+            this.WithheldActionCount += evaluation.ActionPlan.WithheldRuleNames.Count;
+            this.UnappliedActionRuleNames.UnionWith(evaluation.ActionPlan.WithheldRuleNames);
+
+            if (!evaluation.ActionPlan.IsEmpty)
+            {
+                this.PendingActions.Add(new PendingMailRuleActions(
+                    candidate.StoredEmailId,
+                    candidate.Occurrence,
+                    evaluation.ActionPlan));
+            }
+        }
+
+        /// <summary>Drops what a commit attempt recorded, so a retry of it counts its own writes and not the lost ones.</summary>
+        internal void ForgetRecordedActions()
+        {
+            this.RequestedActionCount = 0;
+            this.FailedActionCount = 0;
+        }
+
+        internal void ActionsRecorded(MailRuleActionRecording recording)
+        {
+            this.RequestedActionCount += recording.RecordedCount;
+            this.FailedActionCount += recording.Failures.Count;
+            this.UnappliedActionRuleNames.UnionWith(recording.Failures.Select(failure => failure.RuleName));
         }
     }
+
+    /// <summary>One evaluated email whose matching rules asked for a change, held until the batch commits.</summary>
+    private sealed record PendingMailRuleActions(
+        StoredEmailId StoredEmailId,
+        EmailOccurrenceId Occurrence,
+        MailRuleActionPlan Plan);
 
     /// <summary>Adds up the batches of one walk into the counts an operator reads.</summary>
     private sealed class EvaluationTally
     {
         private readonly SortedSet<string> matchedRuleNames = new(StringComparer.Ordinal);
         private readonly SortedSet<string> failedRuleNames = new(StringComparer.Ordinal);
+        private readonly SortedSet<string> unappliedActionRuleNames = new(StringComparer.Ordinal);
 
         private int evaluatedEmailCount;
         private int matchedEmailCount;
         private int skippedEmailCount;
         private int failedRuleCount;
         private int timedOutRuleCount;
+        private int requestedActionCount;
+        private int withheldActionCount;
+        private int failedActionCount;
 
         internal void Add(MailRuleEvaluationBatch batch)
         {
@@ -401,8 +500,12 @@ public sealed class MailRuleEvaluationPass
             this.skippedEmailCount += batch.SkippedEmailCount;
             this.failedRuleCount += batch.FailedRuleCount;
             this.timedOutRuleCount += batch.TimedOutRuleCount;
+            this.requestedActionCount += batch.RequestedActionCount;
+            this.withheldActionCount += batch.WithheldActionCount;
+            this.failedActionCount += batch.FailedActionCount;
             this.matchedRuleNames.UnionWith(batch.MatchedRuleNames);
             this.failedRuleNames.UnionWith(batch.FailedRuleNames);
+            this.unappliedActionRuleNames.UnionWith(batch.UnappliedActionRuleNames);
         }
 
         internal MailRuleEvaluationWalk ToWalk(bool emailsRemain) => new()
@@ -412,8 +515,12 @@ public sealed class MailRuleEvaluationPass
             SkippedEmailCount = this.skippedEmailCount,
             FailedRuleCount = this.failedRuleCount,
             TimedOutRuleCount = this.timedOutRuleCount,
+            RequestedActionCount = this.requestedActionCount,
+            WithheldActionCount = this.withheldActionCount,
+            FailedActionCount = this.failedActionCount,
             MatchedRuleNames = [.. this.matchedRuleNames],
             FailedRuleNames = [.. this.failedRuleNames],
+            UnappliedActionRuleNames = [.. this.unappliedActionRuleNames],
             EmailsRemain = emailsRemain,
         };
     }

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationWalk.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationWalk.cs
@@ -49,6 +49,27 @@ public sealed record MailRuleEvaluationWalk
     /// <summary>Gets the names of the rules that failed to answer during the walk, sorted and without repetition.</summary>
     public IReadOnlyList<string> FailedRuleNames { get; init; } = [];
 
+    /// <summary>Gets how many changes to the mailbox the walk asked for, counted per action rather than per email.</summary>
+    /// <remarks>
+    /// A change is asked for by writing a durable record down; the account's convergence pass is what carries it to the
+    /// mail server. A record a previous pass already opened for the same rule, revision, and email is counted here as
+    /// well, because asking again is the same request rather than a second one.
+    /// </remarks>
+    public int RequestedActionCount { get; init; }
+
+    /// <summary>Gets how many actions another matching rule had already settled the same occurrence's fate for.</summary>
+    public int WithheldActionCount { get; init; }
+
+    /// <summary>Gets how many actions nothing was asked for because what they named had stopped being resolvable.</summary>
+    public int FailedActionCount { get; init; }
+
+    /// <summary>Gets the names of the rules at least one of whose actions the walk did not carry out, sorted and without repetition.</summary>
+    /// <remarks>
+    /// Sorted for the reason <see cref="MatchedRuleNames" /> is. Both a withheld action and a failed one put a rule
+    /// here, because to the operator reading a rule that appears not to have fired they are the same question.
+    /// </remarks>
+    public IReadOnlyList<string> UnappliedActionRuleNames { get; init; } = [];
+
     /// <summary>Gets whether the walk left work behind because its batch budget ran out.</summary>
     public bool EmailsRemain { get; init; }
 

--- a/src/Application/Rules/Evaluation/StoredEmailAwaitingRuleEvaluation.cs
+++ b/src/Application/Rules/Evaluation/StoredEmailAwaitingRuleEvaluation.cs
@@ -9,6 +9,11 @@ namespace MailFathom.Application.Rules.Evaluation;
 
 /// <summary>One stored email a pass is about to evaluate, with everything a condition can read without a second query.</summary>
 /// <param name="StoredEmailId">The local identity the pass records its progress and its evaluation against.</param>
+/// <param name="Occurrence">
+/// Where the email is on the mail server, which is what a change a matching rule asks for is issued against. It is read
+/// with the facts rather than looked up afterwards, because an occurrence a later query returned would be the one the
+/// mailbox holds now rather than the one the rule matched.
+/// </param>
 /// <param name="Facts">The metadata every fact but the body text is resolved from.</param>
 /// <param name="AwaitsExtraction">
 /// Whether text is still expected to be derived from this email's content — the content already stored, or the content a
@@ -18,5 +23,6 @@ namespace MailFathom.Application.Rules.Evaluation;
 /// </param>
 public sealed record StoredEmailAwaitingRuleEvaluation(
     StoredEmailId StoredEmailId,
+    EmailOccurrenceId Occurrence,
     MailRuleEmailFacts Facts,
     bool AwaitsExtraction);

--- a/src/Application/Rules/MailRule.cs
+++ b/src/Application/Rules/MailRule.cs
@@ -3,11 +3,12 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Collections.Frozen;
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Rules.Conditions;
 
 namespace MailFathom.Application.Rules;
 
-/// <summary>One rule of a bound rule set: a name, the accounts it applies to, a condition, and what a match does to the pass.</summary>
+/// <summary>One rule of a bound rule set: a name, the accounts it applies to, a condition, and what a match does.</summary>
 /// <remarks>
 /// Carries a compiled condition rather than the text it was written from, so nothing downstream of binding can read what
 /// an operator typed. What a rule can be reported by is its name, which is MailFathom's own configured name for it and
@@ -18,11 +19,13 @@ public sealed class MailRule
     private MailRule(
         string name,
         IMailRuleCondition condition,
+        MailRuleActionSet actions,
         bool stopWhenMatched,
         FrozenSet<string> accounts)
     {
         this.Name = name;
         this.Condition = condition;
+        this.Actions = actions;
         this.StopWhenMatched = stopWhenMatched;
         this.Accounts = accounts;
     }
@@ -32,6 +35,13 @@ public sealed class MailRule
 
     /// <summary>Gets the condition an email is matched against.</summary>
     public IMailRuleCondition Condition { get; }
+
+    /// <summary>Gets what a match does to the matching email, in the order the changes are applied.</summary>
+    /// <remarks>
+    /// Empty for a rule that selects mail and changes nothing, which is what a rule ending the pass declares to keep the
+    /// mail it names away from the rules below it.
+    /// </remarks>
+    public MailRuleActionSet Actions { get; }
 
     /// <summary>Gets whether a match ends the pass rather than continuing to the rules declared below this one.</summary>
     public bool StopWhenMatched { get; }
@@ -47,6 +57,7 @@ public sealed class MailRule
     /// <summary>Creates a rule from a condition that has already been proven usable.</summary>
     /// <param name="name">The name the rule is declared and reported under.</param>
     /// <param name="condition">The compiled condition.</param>
+    /// <param name="actions">What a match does to the matching email, or nothing for a rule that changes nothing.</param>
     /// <param name="stopWhenMatched">Whether a match ends the pass.</param>
     /// <param name="accounts">The accounts the rule applies to, or nothing for a rule that applies to every account.</param>
     /// <returns>The rule.</returns>
@@ -55,7 +66,8 @@ public sealed class MailRule
     public static MailRule Create(
         string name,
         IMailRuleCondition condition,
-        bool stopWhenMatched,
+        MailRuleActionSet? actions = null,
+        bool stopWhenMatched = false,
         IReadOnlyList<string>? accounts = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
@@ -69,6 +81,7 @@ public sealed class MailRule
         return new MailRule(
             name,
             condition,
+            actions ?? MailRuleActionSet.Empty,
             stopWhenMatched,
             accounts is null ? FrozenSet<string>.Empty : accounts.Select(account => account.Trim()).ToFrozenSet(StringComparer.Ordinal));
     }

--- a/src/Application/Rules/MailRuleDeclaration.cs
+++ b/src/Application/Rules/MailRuleDeclaration.cs
@@ -2,21 +2,32 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Rules.Actions;
+
 namespace MailFathom.Application.Rules;
 
 /// <summary>One rule exactly as it was declared, which is what a rule set's revision identity is derived from.</summary>
 /// <param name="Name">The name the rule is declared and reported under.</param>
 /// <param name="ConditionText">The condition as the operator wrote it.</param>
+/// <param name="Actions">What a match does to the matching email, in the order the changes are applied.</param>
 /// <param name="StopWhenMatched">Whether a match ends the pass rather than continuing to the rules below.</param>
 /// <param name="Accounts">The accounts the rule was scoped to, in declared order, empty for a rule that applies to every account.</param>
 /// <remarks>
+/// <para>
 /// Deliberately separate from <see cref="MailRule" />, which carries a compiled condition and no authored text. A
 /// declaration exists for the moment between binding and compiling: long enough to be hashed into a revision, and never
 /// held afterwards. A condition can legitimately contain an address its author typed, so keeping the text out of the
 /// rule that is passed around is what stops a run record that names a rule from carrying somebody's address with it.
+/// </para>
+/// <para>
+/// The actions are part of the declaration for the same reason the condition is: what a rule does to the mail it selects
+/// is part of what the rule set means, so editing an action moves the revision and the edited rule asks the mailbox
+/// afresh instead of being read as the request it already performed.
+/// </para>
 /// </remarks>
 public sealed record MailRuleDeclaration(
     string Name,
     string ConditionText,
+    IReadOnlyList<MailRuleAction> Actions,
     bool StopWhenMatched,
     IReadOnlyList<string> Accounts);

--- a/src/Application/Rules/MailRuleSetEvaluation.cs
+++ b/src/Application/Rules/MailRuleSetEvaluation.cs
@@ -2,24 +2,35 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Rules.Actions;
+
 namespace MailFathom.Application.Rules;
 
 /// <summary>What a whole rule set concluded about one email, under the revision it concluded it.</summary>
 /// <remarks>
+/// <para>
 /// The evaluations are in declared order and stop where the pass stopped, so the record says both what every rule
 /// concluded and which rules were never reached. That distinction is what a later explanation of a run needs: a rule
 /// that did not match and a rule nobody asked are different facts about the same pass.
+/// </para>
+/// <para>
+/// The action plan travels with them rather than being derived by a caller, because composing it needs the rules in
+/// declared order and the caller holds only their names. Deriving it here is also what keeps the resolution of two
+/// conflicting rules a property of the set rather than of whoever asks.
+/// </para>
 /// </remarks>
 public sealed record MailRuleSetEvaluation
 {
     private MailRuleSetEvaluation(
         MailRuleSetRevision revision,
         IReadOnlyList<MailRuleEvaluation> evaluations,
-        bool stoppedEarly)
+        bool stoppedEarly,
+        MailRuleActionPlan actionPlan)
     {
         this.Revision = revision;
         this.Evaluations = evaluations;
         this.StoppedEarly = stoppedEarly;
+        this.ActionPlan = actionPlan;
     }
 
     /// <summary>Gets the identity of the rule set the pass ran against.</summary>
@@ -30,6 +41,9 @@ public sealed record MailRuleSetEvaluation
 
     /// <summary>Gets whether a matching rule ended the pass before the rules below it were reached.</summary>
     public bool StoppedEarly { get; }
+
+    /// <summary>Gets what the matching rules together ask the mailbox for, in the order the changes are applied.</summary>
+    public MailRuleActionPlan ActionPlan { get; }
 
     /// <summary>Gets the names of the rules that matched, in declared order.</summary>
     public IReadOnlyList<string> MatchedRuleNames =>
@@ -46,13 +60,15 @@ public sealed record MailRuleSetEvaluation
     /// <param name="revision">The rule set the pass ran against.</param>
     /// <param name="evaluations">What each rule the pass reached concluded, in declared order.</param>
     /// <param name="stoppedEarly">Whether a matching rule ended the pass.</param>
+    /// <param name="actionPlan">What the matching rules ask the mailbox for, or nothing when they ask for no change.</param>
     /// <returns>The pass.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="evaluations" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException">Thrown when the revision is unspecified.</exception>
     public static MailRuleSetEvaluation Create(
         MailRuleSetRevision revision,
         IReadOnlyList<MailRuleEvaluation> evaluations,
-        bool stoppedEarly)
+        bool stoppedEarly,
+        MailRuleActionPlan? actionPlan = null)
     {
         ArgumentNullException.ThrowIfNull(evaluations);
 
@@ -61,6 +77,10 @@ public sealed record MailRuleSetEvaluation
             throw new ArgumentException("A pass must name the revision it ran against.", nameof(revision));
         }
 
-        return new MailRuleSetEvaluation(revision, [.. evaluations], stoppedEarly);
+        return new MailRuleSetEvaluation(
+            revision,
+            [.. evaluations],
+            stoppedEarly,
+            actionPlan ?? MailRuleActionPlan.Nothing);
     }
 }

--- a/src/Application/Rules/MailRuleSetEvaluator.cs
+++ b/src/Application/Rules/MailRuleSetEvaluator.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Rules.Conditions;
 using MailFathom.Application.Rules.Facts;
 
@@ -10,6 +11,11 @@ namespace MailFathom.Application.Rules;
 
 /// <summary>Runs a rule set over one email in declared order, bounding each condition and classifying every failure.</summary>
 /// <remarks>
+/// <para>
+/// What the matching rules ask the mailbox for is composed here as well, because composing it needs the matched rules
+/// in declared order and this is the only place that order and those rules are held together. A rule that failed asked
+/// for nothing, since it did not match.
+/// </para>
 /// <para>
 /// A rule scoped to accounts this email does not belong to is passed over rather than evaluated, and leaves no
 /// evaluation behind: it did not decline to match, it was not one of this account's rules. That also means it cannot end
@@ -62,6 +68,7 @@ public sealed class MailRuleSetEvaluator
         ArgumentNullException.ThrowIfNull(facts);
 
         var evaluations = new List<MailRuleEvaluation>(ruleSet.Rules.Count);
+        var matchedRules = new List<MailRule>();
         var stoppedEarly = false;
 
         foreach (var rule in ruleSet.Rules)
@@ -75,7 +82,14 @@ public sealed class MailRuleSetEvaluator
 
             evaluations.Add(evaluation);
 
-            if (evaluation.Outcome == MailRuleOutcome.Matched && rule.StopWhenMatched)
+            if (evaluation.Outcome != MailRuleOutcome.Matched)
+            {
+                continue;
+            }
+
+            matchedRules.Add(rule);
+
+            if (rule.StopWhenMatched)
             {
                 stoppedEarly = true;
 
@@ -83,7 +97,11 @@ public sealed class MailRuleSetEvaluator
             }
         }
 
-        return MailRuleSetEvaluation.Create(ruleSet.Revision, evaluations, stoppedEarly);
+        return MailRuleSetEvaluation.Create(
+            ruleSet.Revision,
+            evaluations,
+            stoppedEarly,
+            MailRuleActionPlan.Compose(matchedRules));
     }
 
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "A condition that fails for any reason must be recorded as a failed rule rather than end the pass, which is the totality this type exists to apply.")]

--- a/src/Application/Rules/MailRuleSetRevision.cs
+++ b/src/Application/Rules/MailRuleSetRevision.cs
@@ -21,7 +21,9 @@ namespace MailFathom.Application.Rules;
 /// configuration key leaves it alone, and so does reformatting the file or reordering the keys within one rule.
 /// Reordering the rules themselves does move it, because declared order is part of what a rule set means. So is the
 /// scope: narrowing a rule to one account changes which mail it reaches, which is a different rule set rather than the
-/// same one applied differently.
+/// same one applied differently. So are the actions, for the reason the revision is part of a request's identity at all
+/// — a rule now filing into a different folder must ask afresh rather than be answered by the record of the filing it
+/// asked for before the edit.
 /// </para>
 /// <para>
 /// It carries none of the authored text and no ordering. A record naming a revision therefore holds nothing personal
@@ -47,12 +49,13 @@ public readonly record struct MailRuleSetRevision
     private const char FieldSeparator = '\u001F';
     private const char RuleSeparator = '\u001E';
 
-    /// <summary>Separates the accounts inside one rule's scope, which is the one field holding several values.</summary>
+    /// <summary>Separates the values inside a field holding several of them: the scope, and the declared actions.</summary>
     /// <remarks>
     /// A third separator rather than a reused one, so that a scope of two accounts cannot render as the same text as a
-    /// rule whose next field begins where the second account would have.
+    /// rule whose next field begins where the second account would have. Both multi-valued fields use this one, which
+    /// stays unambiguous because a field separator ends each of them.
     /// </remarks>
-    private const char AccountSeparator = '\u001D';
+    private const char ListSeparator = '\u001D';
 
     private readonly string? value;
 
@@ -77,7 +80,7 @@ public readonly record struct MailRuleSetRevision
     /// impossible.
     /// </remarks>
     public static bool ContainsSeparator(string? value) =>
-        value?.AsSpan().IndexOfAny(FieldSeparator, RuleSeparator, AccountSeparator) >= 0;
+        value?.AsSpan().IndexOfAny(FieldSeparator, RuleSeparator, ListSeparator) >= 0;
 
     /// <summary>Derives the identity of a rule set from the rules it declares, in the order it declares them.</summary>
     /// <param name="declarations">Every rule of the bound set, in declared order.</param>
@@ -101,9 +104,11 @@ public readonly record struct MailRuleSetRevision
                 .Append(FieldSeparator)
                 .Append(declaration.ConditionText)
                 .Append(FieldSeparator)
+                .AppendJoin(ListSeparator, declaration.Actions.Select(action => action.CanonicalForm))
+                .Append(FieldSeparator)
                 .Append(declaration.StopWhenMatched ? "stop" : "continue")
                 .Append(FieldSeparator)
-                .AppendJoin(AccountSeparator, declaration.Accounts)
+                .AppendJoin(ListSeparator, declaration.Accounts)
                 .Append(RuleSeparator);
         }
 

--- a/src/Domain/Mutations/MailboxMutationRequester.cs
+++ b/src/Domain/Mutations/MailboxMutationRequester.cs
@@ -40,21 +40,21 @@ public sealed record MailboxMutationRequester
 
     /// <summary>Names a rule together with the revision of it that asked.</summary>
     /// <param name="ruleName">The operator's own name for the rule.</param>
-    /// <param name="revision">The revision of the rule the request was produced from.</param>
+    /// <param name="revision">The identity of the rule set revision the request was produced from.</param>
     /// <returns>A requester naming that revision of that rule.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="ruleName" /> is blank, carries a control character, or is long enough that the composed identity exceeds <see cref="MaximumIdentityLength" />.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="revision" /> is negative.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="ruleName" /> or <paramref name="revision" /> is blank, carries a control character, or is long enough that the composed identity exceeds <see cref="MaximumIdentityLength" />.</exception>
     /// <remarks>
     /// The revision is part of the identity rather than a column beside it, because the comparison that matters is
     /// equality of the whole thing: an edited rule is a different requester and asks again, while an unchanged one
-    /// re-evaluated on every pass asks once.
+    /// re-evaluated on every pass asks once. It is text rather than a counter because the revision a rule set is known
+    /// by is a digest over its own declarations, which is what makes two instances reading one file agree on it.
     /// </remarks>
-    public static MailboxMutationRequester Rule(string ruleName, int revision)
+    public static MailboxMutationRequester Rule(string ruleName, string revision)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(ruleName);
-        ArgumentOutOfRangeException.ThrowIfNegative(revision);
+        ArgumentException.ThrowIfNullOrWhiteSpace(revision);
 
-        var identity = string.Create(CultureInfo.InvariantCulture, $"{ruleName.Trim()}@{revision}");
+        var identity = string.Create(CultureInfo.InvariantCulture, $"{ruleName.Trim()}@{revision.Trim()}");
 
         // Reported against the rule name rather than against the composed identity, because that is the part the caller
         // supplied and the only part they can shorten.

--- a/src/Host/Configuration/Mail/MailRuleActionPermissionOptions.cs
+++ b/src/Host/Configuration/Mail/MailRuleActionPermissionOptions.cs
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Rules.Actions;
+
+namespace MailFathom.Host.Configuration.Mail;
+
+/// <summary>States which changes a rule may make to one account's mailbox.</summary>
+/// <remarks>
+/// <para>
+/// Four switches rather than one, because what an owner is willing to let automation do is not one decision: filing
+/// mail and marking it read are undone from any mail client, and a deletion is not. An account that says nothing gets
+/// the three reversible actions and no deletion, so deletion is opt-in on every account of every deployment.
+/// </para>
+/// <para>
+/// It is enforced where the rule set is read. A rule declaring an action one of its accounts refuses fails startup
+/// naming both, rather than being carried and quietly skipped when that account's mail reaches it — a rule that does
+/// nothing is indistinguishable from a rule that never matched, and this is exactly the setting an owner would check
+/// last.
+/// </para>
+/// <para>
+/// It is read a second time as each change is written down, through
+/// <see cref="IMailRuleActionPermissionReader" />, because this section reloads independently of the rule section: an
+/// operator narrowing what an account permits leaves a rule set nobody edited in force, and the withdrawal has to
+/// reach the next pass rather than the next edit of the rules.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed class MailRuleActionPermissionOptions
+{
+    /// <summary>Gets or sets whether a rule may move this account's mail into another folder.</summary>
+    public bool Move { get; set; } = true;
+
+    /// <summary>Gets or sets whether a rule may put a second occurrence of this account's mail into another folder.</summary>
+    public bool Copy { get; set; } = true;
+
+    /// <summary>Gets or sets whether a rule may remove this account's mail from the folder it is in.</summary>
+    public bool Delete { get; set; }
+
+    /// <summary>Gets or sets whether a rule may set or clear the remote <c>\Seen</c> flag of this account's mail.</summary>
+    public bool MarkAsRead { get; set; } = true;
+
+    /// <summary>Reads the block as the permissions a rule set is judged against.</summary>
+    /// <returns>The permissions.</returns>
+    internal MailRuleActionPermissions ToPermissions() =>
+        new(this.Move, this.Copy, this.Delete, this.MarkAsRead);
+}

--- a/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
+++ b/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
@@ -11,6 +11,7 @@ using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Retrieval.AskMail.Audit;
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.Synchronization.Reconciliation;
@@ -34,6 +35,7 @@ internal sealed class MailSynchronizationOptions
         IMailSynchronizationWindowReader,
         IRemotelyDeletedEmailDispositionReader,
         IAuthoredDeleteEmailDispositionReader,
+        IMailRuleActionPermissionReader,
         IMailboxMutationAuditSettingsReader,
         IMailAnsweringAuditSettingsReader,
         IMailAccountCatalog,
@@ -416,6 +418,14 @@ internal sealed class MailSynchronizationOptions
     }
 
     /// <inheritdoc />
+    public MailRuleActionPermissions GetRuleActionPermissions(MailAccountId accountId)
+    {
+        var account = this.FindAccount(accountId.Value);
+
+        return (account.RuleActions ?? new MailRuleActionPermissionOptions()).ToPermissions();
+    }
+
+    /// <inheritdoc />
     /// <remarks>
     /// An account this snapshot no longer names reports <see cref="MailboxMutationAuditSettings.Disabled" /> rather
     /// than failing, unlike every other per-account reader here. The two callers are why: a mutation is only recorded
@@ -736,6 +746,14 @@ internal sealed class MailSynchronizationAccountOptions : IValidatableObject
     public AuthoredDeleteEmailDisposition AuthoredDeleteEmailDisposition { get; set; } =
         AuthoredDeleteEmailDisposition.RetainLocalCopy;
 
+    /// <summary>Gets or sets which changes a mail rule may make to this account's mailbox.</summary>
+    /// <remarks>
+    /// Omitting the block permits the three reversible actions and refuses deletion, which is what every account gets
+    /// until it says otherwise. What a rule declares is judged against this when the rule set is read, so an account
+    /// that refuses an action never has a rule silently skipped over it.
+    /// </remarks>
+    public MailRuleActionPermissionOptions RuleActions { get; set; } = new();
+
     /// <summary>Gets or sets whether and for how long this account keeps a record of the changes MailFathom made to it.</summary>
     /// <remarks>
     /// Omitting the block leaves the trail off, which is the default for the reason the privacy rules require: the trail
@@ -859,6 +877,16 @@ internal sealed class MailSynchronizationAccountOptions : IValidatableObject
             yield return new ValidationResult(
                 $"Account '{this.AccountId}': the answering audit trail retention must be between {MailAnsweringAuditTrailOptions.MinimumRetention} and {MailAnsweringAuditTrailOptions.MaximumRetention}.",
                 [nameof(this.AnsweringAuditTrail)]);
+        }
+
+        // Checked here for the reason the blocks above are. A missing block would read as an account that permits
+        // nothing, so every rule declaring an action over it would be refused with a message naming the rule rather
+        // than the configuration that actually went missing.
+        if (this.RuleActions is null)
+        {
+            yield return new ValidationResult(
+                $"Account '{this.AccountId}': the rule action permissions must be a block.",
+                [nameof(this.RuleActions)]);
         }
 
         if (this.Folders is null)

--- a/src/Host/Configuration/Rules/DeclaredMailAccount.cs
+++ b/src/Host/Configuration/Rules/DeclaredMailAccount.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Rules.Actions;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Host.Configuration.Rules;
+
+/// <summary>One account as a rule set is judged against it: its identifier, its mirrored folders, and what it permits.</summary>
+/// <param name="AccountId">The identifier a rule's scope names, compared exactly as the synchronization section writes it.</param>
+/// <param name="MirroredFolderAliases">
+/// The aliases of the folders this account mirrors, which are the folders a rule may name as a destination. A mapped
+/// folder the account does not mirror is deliberately absent: nothing binds such an alias to a remote folder, so a rule
+/// filing into one could never resolve a path to file into.
+/// </param>
+/// <param name="PermittedRuleActions">Which of the four changes a rule may ask for on this account.</param>
+internal sealed record DeclaredMailAccount(
+    string AccountId,
+    IReadOnlyCollection<MailFolderAlias> MirroredFolderAliases,
+    MailRuleActionPermissions PermittedRuleActions);

--- a/src/Host/Configuration/Rules/DeclaredMailAccounts.cs
+++ b/src/Host/Configuration/Rules/DeclaredMailAccounts.cs
@@ -2,23 +2,29 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Rules.Actions;
+using MailFathom.Domain.Folders;
 using MailFathom.Host.Configuration.Mail;
 
 namespace MailFathom.Host.Configuration.Rules;
 
-/// <summary>Reads the account identifiers a rule's scope may name, from wherever the accounts are available.</summary>
+/// <summary>Reads the accounts a rule is judged against, from wherever the accounts are available.</summary>
 /// <remarks>
 /// <para>
-/// A rule's scope is a claim about another section, so judging it needs that section's account identifiers — and the two
-/// moments it is judged in reach them differently. Composition has configuration and no container, so it reads the keys;
-/// a reload has a container and the published synchronization snapshot, so it reads that. One type holds both, because
-/// what counts as a declared account has to be the same answer in both or a rule set startup accepted would be refused
-/// on the first reload that changed nothing.
+/// A rule's scope, its destination folders, and the actions it declares are all claims about another section, so judging
+/// them needs that section — and the two moments they are judged in reach it differently. Composition has configuration
+/// and no container, so it reads the keys; a reload has a container and the published synchronization snapshot, so it
+/// reads that. One type holds both, because what counts as a declared account has to be the same answer in both or a
+/// rule set startup accepted would be refused on the first reload that changed nothing.
 /// </para>
 /// <para>
 /// Identifiers are trimmed and blanks are dropped, which is what <see cref="Domain.Accounts.MailAccountId" />
 /// does to the same text. A blank identifier is the synchronization section's own defect to report, and reporting it
 /// again here would name the wrong section.
+/// </para>
+/// <para>
+/// A folder alias that is not a value this system issues is dropped for the same reason, and so is an unmirrored
+/// folder — the second deliberately, because a rule may only file into a folder whose mail this account mirrors.
 /// </para>
 /// </remarks>
 internal static class DeclaredMailAccounts
@@ -26,11 +32,11 @@ internal static class DeclaredMailAccounts
     /// <summary>The configuration section the accounts are declared in.</summary>
     private const string SynchronizationSectionName = "MailSynchronization";
 
-    /// <summary>Reads the declared account identifiers straight from configuration, before any binding has happened.</summary>
+    /// <summary>Reads the declared accounts straight from configuration, before any binding has happened.</summary>
     /// <param name="configuration">The configuration the host is composing itself from.</param>
-    /// <returns>The identifiers, in the order they are declared.</returns>
+    /// <returns>The accounts, in the order they are declared.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
-    public static IReadOnlyCollection<string> ReadFrom(IConfiguration configuration)
+    public static IReadOnlyCollection<DeclaredMailAccount> ReadFrom(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
@@ -39,26 +45,91 @@ internal static class DeclaredMailAccounts
             .. configuration
                 .GetSection($"{SynchronizationSectionName}:{nameof(MailSynchronizationOptions.Accounts)}")
                 .GetChildren()
-                .Select(account => account[nameof(MailSynchronizationAccountOptions.AccountId)]?.Trim())
-                .Where(accountId => !string.IsNullOrEmpty(accountId))
-                .OfType<string>(),
+                .Select(ReadAccount)
+                .OfType<DeclaredMailAccount>(),
         ];
     }
 
-    /// <summary>Reads the declared account identifiers from a bound synchronization configuration.</summary>
+    /// <summary>Reads the declared accounts from a bound synchronization configuration.</summary>
     /// <param name="settings">The synchronization configuration a reload published, or the one currently in force.</param>
-    /// <returns>The identifiers, in the order they are declared.</returns>
+    /// <returns>The accounts, in the order they are declared.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="settings" /> is <see langword="null" />.</exception>
-    public static IReadOnlyCollection<string> ReadFrom(MailSynchronizationOptions settings)
+    public static IReadOnlyCollection<DeclaredMailAccount> ReadFrom(MailSynchronizationOptions settings)
     {
         ArgumentNullException.ThrowIfNull(settings);
 
         return
         [
             .. settings.Accounts
-                .Select(account => account.AccountId?.Trim())
-                .Where(accountId => !string.IsNullOrEmpty(accountId))
-                .OfType<string>(),
+                .Where(account => !string.IsNullOrWhiteSpace(account.AccountId))
+                .Select(account => new DeclaredMailAccount(
+                    account.AccountId.Trim(),
+                    ReadMirroredAliases(account),
+                    (account.RuleActions ?? new MailRuleActionPermissionOptions()).ToPermissions())),
         ];
     }
+
+    /// <summary>Reads one account's mirrored folder aliases from the bound folders it is actually run with.</summary>
+    private static IReadOnlyCollection<MailFolderAlias> ReadMirroredAliases(MailSynchronizationAccountOptions account) =>
+    [
+        .. account.EffectiveFolders
+            .Where(folder => folder.Participation.IsSynchronized)
+            .Select(folder => TryReadAlias(folder.Alias))
+            .OfType<MailFolderAlias>(),
+    ];
+
+    /// <summary>Reads one account's keys, which is the shape available before anything has been bound.</summary>
+    /// <remarks>
+    /// The folder participation is read as <c>Synchronize</c> alone rather than through
+    /// <see cref="MailFolderParticipation" />, because that type derives the other two answers from this one and the
+    /// other two decide nothing about a destination. An account declaring no folder is read as mirroring the inbox,
+    /// which is the mapping it is actually run with.
+    /// </remarks>
+    private static DeclaredMailAccount? ReadAccount(IConfigurationSection account)
+    {
+        var accountId = account[nameof(MailSynchronizationAccountOptions.AccountId)]?.Trim();
+
+        if (string.IsNullOrEmpty(accountId))
+        {
+            return null;
+        }
+
+        var folders = account
+            .GetSection(nameof(MailSynchronizationAccountOptions.Folders))
+            .GetChildren()
+            .ToArray();
+
+        var mirroredAliases = folders.Length == 0
+            ? [TryReadAlias(nameof(MailFolderSpecialUse.Inbox))]
+            : folders
+                .Where(folder => !IsDeclaredFalse(folder[nameof(MailFolderMappingOptions.Synchronize)]))
+                .Select(folder => TryReadAlias(folder[nameof(MailFolderMappingOptions.Alias)]))
+                .ToArray();
+
+        return new DeclaredMailAccount(
+            accountId,
+            [.. mirroredAliases.OfType<MailFolderAlias>()],
+            ReadPermissions(account.GetSection(nameof(MailSynchronizationAccountOptions.RuleActions))));
+    }
+
+    /// <summary>Reads one account's rule-action permissions, with every key it did not write taking its default.</summary>
+    private static MailRuleActionPermissions ReadPermissions(IConfigurationSection ruleActions) =>
+        new(
+            !IsDeclaredFalse(ruleActions[nameof(MailRuleActionPermissionOptions.Move)]),
+            !IsDeclaredFalse(ruleActions[nameof(MailRuleActionPermissionOptions.Copy)]),
+            IsDeclaredTrue(ruleActions[nameof(MailRuleActionPermissionOptions.Delete)]),
+            !IsDeclaredFalse(ruleActions[nameof(MailRuleActionPermissionOptions.MarkAsRead)]));
+
+    /// <summary>Reads a switch an operator wrote, treating an unreadable value as unwritten.</summary>
+    /// <remarks>
+    /// The binder refuses a value that is neither, so a typo fails startup through the section's own validation rather
+    /// than through this reading. Both directions are answered from the written text so that the default of a key is
+    /// stated once, on the options type, and inherited here.
+    /// </remarks>
+    private static bool IsDeclaredFalse(string? value) => bool.TryParse(value, out var declared) && !declared;
+
+    private static bool IsDeclaredTrue(string? value) => bool.TryParse(value, out var declared) && declared;
+
+    private static MailFolderAlias? TryReadAlias(string? alias) =>
+        MailRuleActionOptions.TryReadAlias(alias, out var readAlias) ? readAlias : null;
 }

--- a/src/Host/Configuration/Rules/MailRuleActionOptions.cs
+++ b/src/Host/Configuration/Rules/MailRuleActionOptions.cs
@@ -1,0 +1,85 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Rules.Actions;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Host.Configuration.Rules;
+
+/// <summary>What one rule does to the mail it selects, as an operator declares it.</summary>
+/// <remarks>
+/// <para>
+/// One named key per action rather than a list of action objects, for two reasons. A binder drops an element of a list
+/// whose value it cannot convert, so a typo inside one entry would silently leave a rule doing less than it says; and a
+/// rule declaring one action twice is unrepresentable in this shape rather than merely refused, which is the stronger
+/// form of the same rule.
+/// </para>
+/// <para>
+/// An absent key is an action the rule does not ask for, which is why every one of them is nullable. Writing
+/// <c>MarkAsRead: false</c> is a rule asking for mail to be marked <em>unread</em>, and leaving the key out is a rule
+/// that does not touch the flag at all; the two would be indistinguishable on a plain boolean.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed class MailRuleActionOptions
+{
+    /// <summary>Gets or sets the alias of the folder a matching email is moved into.</summary>
+    public string? MoveTo { get; set; }
+
+    /// <summary>Gets or sets the alias of the folder a second occurrence of a matching email is put into.</summary>
+    public string? CopyTo { get; set; }
+
+    /// <summary>Gets or sets whether a matching email is removed from the folder it is in.</summary>
+    /// <remarks>Deletion is the one action an account must permit explicitly, whatever a rule declares.</remarks>
+    public bool? Delete { get; set; }
+
+    /// <summary>Gets or sets whether a matching email's remote <c>\Seen</c> flag is set or cleared.</summary>
+    public bool? MarkAsRead { get; set; }
+
+    /// <summary>Gets whether the block asks for anything at all.</summary>
+    internal bool IsEmpty => this.ToActions().Count == 0;
+
+    /// <summary>Reads the declared keys as the actions they name, in the order they are written above.</summary>
+    /// <returns>The actions, empty for a rule that selects mail and changes nothing.</returns>
+    /// <remarks>
+    /// An alias that is not one this system issues is left out rather than thrown over, because a blank or unusable
+    /// alias is reported by validation against the key an operator edits and reading it here would raise instead.
+    /// </remarks>
+    internal IReadOnlyList<MailRuleAction> ToActions() =>
+    [
+        .. new[]
+        {
+            TryReadDestination(this.MoveTo, MailRuleAction.Relocate),
+            TryReadDestination(this.CopyTo, MailRuleAction.Copy),
+            this.Delete == true ? MailRuleAction.Delete() : null,
+            this.MarkAsRead is { } isRead ? MailRuleAction.SetSeen(isRead) : null,
+        }.OfType<MailRuleAction>(),
+    ];
+
+    /// <summary>Reports the aliases the block names, whether or not they are values this system could issue.</summary>
+    /// <returns>The destination aliases as they were written, in declared order.</returns>
+    internal IReadOnlyList<string> DeclaredDestinations() =>
+        [.. new[] { this.MoveTo, this.CopyTo }.Where(alias => alias is not null).OfType<string>()];
+
+    private static MailRuleAction? TryReadDestination(
+        string? alias,
+        Func<MailFolderAlias, MailRuleAction> toAction) =>
+        TryReadAlias(alias, out var readAlias) ? toAction(readAlias) : null;
+
+    /// <summary>Reads an alias without raising, so an unusable one is reported by validation rather than here.</summary>
+    internal static bool TryReadAlias(string? value, out MailFolderAlias alias)
+    {
+        alias = default;
+
+        if (string.IsNullOrWhiteSpace(value) || value.Any(char.IsControl))
+        {
+            return false;
+        }
+
+        alias = MailFolderAlias.Create(value);
+
+        return true;
+    }
+}

--- a/src/Host/Configuration/Rules/MailRuleDeclarationRules.cs
+++ b/src/Host/Configuration/Rules/MailRuleDeclarationRules.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Rules.Conditions;
 
 namespace MailFathom.Host.Configuration.Rules;
@@ -34,7 +35,7 @@ internal static class MailRuleDeclarationRules
     /// <summary>Reports everything an operator must fix before a declared rule set can be used.</summary>
     /// <param name="candidate">The bound declaration, or <see langword="null" /> when the deployment wrote no section.</param>
     /// <param name="compiler">Reads each condition against the fact surface.</param>
-    /// <param name="declaredAccounts">The identifiers of the accounts the deployment declares, which a rule's scope may name.</param>
+    /// <param name="declaredAccounts">The accounts the deployment declares, which a rule's scope, destinations, and actions are judged against.</param>
     /// <returns>One message per rule the declaration breaks, empty when it is usable.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="compiler" /> or <paramref name="declaredAccounts" /> is <see langword="null" />.</exception>
     /// <remarks>
@@ -44,7 +45,7 @@ internal static class MailRuleDeclarationRules
     public static IReadOnlyList<string> FindDeclarationErrors(
         MailRulesOptions? candidate,
         IMailRuleConditionCompiler compiler,
-        IReadOnlyCollection<string> declaredAccounts)
+        IReadOnlyCollection<DeclaredMailAccount> declaredAccounts)
     {
         ArgumentNullException.ThrowIfNull(compiler);
         ArgumentNullException.ThrowIfNull(declaredAccounts);
@@ -79,10 +80,11 @@ internal static class MailRuleDeclarationRules
     private static IReadOnlyList<string> FindDeclaredRuleErrors(
         MailRuleOptions rule,
         int position,
-        IReadOnlyCollection<string> declaredAccounts) =>
+        IReadOnlyCollection<DeclaredMailAccount> declaredAccounts) =>
     [
         .. FindRuleErrors(rule, position),
         .. FindScopeErrors(rule, position, declaredAccounts),
+        .. FindActionErrors(rule, position, declaredAccounts),
         .. FindIdentityErrors(rule, position),
     ];
 
@@ -113,7 +115,10 @@ internal static class MailRuleDeclarationRules
             .Where(_ => MailRuleSetRevision.ContainsSeparator(rule.Condition))
             .Concat(rule.Accounts
                 .Where(MailRuleSetRevision.ContainsSeparator)
-                .Select(_ => nameof(MailRuleOptions.Accounts)));
+                .Select(_ => nameof(MailRuleOptions.Accounts)))
+            .Concat(DeclaredActions(rule).DeclaredDestinations()
+                .Where(MailRuleSetRevision.ContainsSeparator)
+                .Select(_ => nameof(MailRuleOptions.Actions)));
 
         return offending
             .Distinct(StringComparer.Ordinal)
@@ -131,8 +136,10 @@ internal static class MailRuleDeclarationRules
     private static IEnumerable<string> FindScopeErrors(
         MailRuleOptions rule,
         int position,
-        IReadOnlyCollection<string> declaredAccounts)
+        IReadOnlyCollection<DeclaredMailAccount> declaredAccounts)
     {
+        var declaredIdentifiers = declaredAccounts.Select(account => account.AccountId).ToArray();
+
         var opening =
             $"{MailRulesOptions.SectionName}:{nameof(MailRulesOptions.Rules)}:{position}:{nameof(MailRuleOptions.Accounts)}";
         var scope = rule.Accounts.Select(account => account?.Trim() ?? string.Empty).ToArray();
@@ -153,12 +160,106 @@ internal static class MailRuleDeclarationRules
             yield return $"{opening} — the account '{repeated.Key}' is named more than once.";
         }
 
-        foreach (var unknown in scope.Where(account => !declaredAccounts.Contains(account, StringComparer.Ordinal)))
+        foreach (var unknown in scope.Where(account => !declaredIdentifiers.Contains(account, StringComparer.Ordinal)))
         {
             yield return
                 $"{opening} — no account named '{unknown}' is declared under MailSynchronization:Accounts, so this rule would reach no mail.";
         }
     }
+
+    /// <summary>Judges what a rule does to the mail it selects, against the rule itself and against every account it reaches.</summary>
+    /// <remarks>
+    /// <para>
+    /// Three separate claims are checked here. Whether the declared actions can be honored together is a property of
+    /// the rule alone. Whether a destination names a folder the account mirrors, and whether the account permits the
+    /// action at all, are claims about the synchronization section — and both are refused rather than deferred, because
+    /// a rule that would be skipped when the mail reached it is indistinguishable from a rule nothing matched.
+    /// </para>
+    /// <para>
+    /// A rule that is switched off is judged like any other, exactly as its scope already is. Only the condition is
+    /// exempt from being read, because reading one is what costs a compilation.
+    /// </para>
+    /// </remarks>
+    private static IEnumerable<string> FindActionErrors(
+        MailRuleOptions rule,
+        int position,
+        IReadOnlyCollection<DeclaredMailAccount> declaredAccounts)
+    {
+        var opening =
+            $"{MailRulesOptions.SectionName}:{nameof(MailRulesOptions.Rules)}:{position}:{nameof(MailRuleOptions.Actions)}";
+        var declared = DeclaredActions(rule);
+        var unusable = declared.DeclaredDestinations()
+            .Where(alias => !MailRuleActionOptions.TryReadAlias(alias, out _))
+            .ToArray();
+
+        if (unusable.Length > 0)
+        {
+            yield return $"{opening} — a destination folder is named by nothing this system could read as an alias.";
+
+            yield break;
+        }
+
+        var actions = declared.ToActions();
+        var ruleName = DescribeRule(rule, position);
+
+        foreach (var refusal in MailRuleActionSet.FindErrors(ruleName, actions))
+        {
+            yield return $"{opening} — {refusal}";
+        }
+
+        foreach (var account in AccountsTheRuleReaches(rule, declaredAccounts))
+        {
+            foreach (var refusal in FindAccountActionErrors(ruleName, actions, account))
+            {
+                yield return $"{opening} — {refusal}";
+            }
+        }
+    }
+
+    /// <summary>Judges one rule's actions against one account's mirrored folders and its own permissions.</summary>
+    private static IEnumerable<string> FindAccountActionErrors(
+        string ruleName,
+        IReadOnlyList<MailRuleAction> actions,
+        DeclaredMailAccount account)
+    {
+        foreach (var action in actions.Where(action => !account.PermittedRuleActions.Permits(action.Mutation)))
+        {
+            yield return
+                $"Rule '{ruleName}' declares '{action.Mutation.Name}', which account '{account.AccountId}' does not permit a rule to do. Permit it under MailSynchronization:Accounts:<n>:RuleActions or narrow the rule's scope.";
+        }
+
+        foreach (var action in actions.Where(action =>
+            action.DestinationAlias is { } alias && !account.MirroredFolderAliases.Contains(alias)))
+        {
+            yield return
+                $"Rule '{ruleName}' files into '{action.DestinationAlias!.Value.Value}', which account '{account.AccountId}' does not declare as a mirrored folder, so nothing would bind it to a folder on the server.";
+        }
+    }
+
+    /// <summary>Reads the accounts one rule's mail can come from, which is every declared account for an unscoped rule.</summary>
+    private static IEnumerable<DeclaredMailAccount> AccountsTheRuleReaches(
+        MailRuleOptions rule,
+        IReadOnlyCollection<DeclaredMailAccount> declaredAccounts)
+    {
+        var scope = rule.Accounts?.Select(account => account?.Trim() ?? string.Empty).ToArray() ?? [];
+
+        // An account the scope names and nothing declares is already reported against the scope, so it is left out here
+        // rather than reported a second time under a different key.
+        return scope.Length == 0
+            ? declaredAccounts
+            : declaredAccounts.Where(account => scope.Contains(account.AccountId, StringComparer.Ordinal));
+    }
+
+    /// <summary>Names a rule the way a message about it should, falling back to its position when it has no name.</summary>
+    /// <remarks>
+    /// A nameless rule is refused by its own attribute bound, and this keeps a second message about the same rule
+    /// readable rather than quoting an empty name.
+    /// </remarks>
+    private static string DescribeRule(MailRuleOptions rule, int position) =>
+        string.IsNullOrWhiteSpace(rule.Name) ? $"#{position}" : rule.Name.Trim();
+
+    /// <summary>Reads a rule's action block, treating one an operator wrote as empty as a rule that changes nothing.</summary>
+    private static MailRuleActionOptions DeclaredActions(MailRuleOptions rule) => rule.Actions ?? new MailRuleActionOptions();
 
     /// <summary>Runs the section's own attribute bounds and everything <see cref="MailRulesOptions.Validate" /> reports.</summary>
     private static IEnumerable<string> FindSectionErrors(MailRulesOptions candidate) =>

--- a/src/Host/Configuration/Rules/MailRuleOptions.cs
+++ b/src/Host/Configuration/Rules/MailRuleOptions.cs
@@ -41,6 +41,15 @@ internal sealed class MailRuleOptions
     [Required]
     public string Condition { get; set; } = string.Empty;
 
+    /// <summary>Gets or sets what a match does to the matching email.</summary>
+    /// <remarks>
+    /// Optional, because a rule that changes nothing is a rule that selects mail: paired with
+    /// <see cref="StopWhenMatched" /> it is how mail is kept away from the rules below it. A combination naming two
+    /// fates for one occurrence is refused when the configuration is read rather than resolved while mail is being
+    /// processed.
+    /// </remarks>
+    public MailRuleActionOptions Actions { get; set; } = new();
+
     /// <summary>Gets or sets whether a match ends the pass rather than continuing to the rules below this one.</summary>
     public bool StopWhenMatched { get; set; }
 

--- a/src/Host/Configuration/Rules/MailRuleSetMapper.cs
+++ b/src/Host/Configuration/Rules/MailRuleSetMapper.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Rules.Conditions;
 
 namespace MailFathom.Host.Configuration.Rules;
@@ -38,6 +39,7 @@ internal static class MailRuleSetMapper
             .Select(rule => new MailRuleDeclaration(
                 rule.Name,
                 rule.Condition,
+                (rule.Actions ?? new MailRuleActionOptions()).ToActions(),
                 rule.StopWhenMatched,
                 [.. rule.Accounts.Select(account => account.Trim())]))
             .ToArray();
@@ -46,6 +48,7 @@ internal static class MailRuleSetMapper
             .Select(declaration => MailRule.Create(
                 declaration.Name,
                 Compile(compiler, declaration, bounds),
+                MailRuleActionSet.Create(declaration.Actions),
                 declaration.StopWhenMatched,
                 declaration.Accounts))
             .ToArray();

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -493,6 +493,7 @@ internal sealed partial class AccountSynchronizationSupervisor
         }
 
         this.ReportFailedRules(report.Arrivals);
+        this.ReportRuleActions(report.Arrivals);
 
         if (report.RequestedRun is { } requestedRun)
         {
@@ -510,6 +511,7 @@ internal sealed partial class AccountSynchronizationSupervisor
             }
 
             this.ReportFailedRules(requestedRun);
+            this.ReportRuleActions(requestedRun);
         }
 
         switch (report.RequestedRunEnding)
@@ -541,6 +543,31 @@ internal sealed partial class AccountSynchronizationSupervisor
             walk.FailedRuleCount,
             walk.TimedOutRuleCount,
             failedRuleNames);
+    }
+
+    /// <summary>States what the walk asked the mailbox to change, and separately what it declined to ask for.</summary>
+    /// <remarks>
+    /// A change is a request written down rather than an IMAP operation, so this line says what the account's next
+    /// convergence pass has to carry. What was not asked for is a second line at warning level, because an action a
+    /// rule declared and the mailbox never received is the case an operator has to act on.
+    /// </remarks>
+    private void ReportRuleActions(MailRuleEvaluationWalk walk)
+    {
+        if (walk.RequestedActionCount > 0)
+        {
+            this.LogRuleActionsRequested(this.accountId.Value, walk.RequestedActionCount);
+        }
+
+        if (walk.WithheldActionCount == 0 && walk.FailedActionCount == 0)
+        {
+            return;
+        }
+
+        this.LogRuleActionsUnapplied(
+            this.accountId.Value,
+            walk.WithheldActionCount,
+            walk.FailedActionCount,
+            NameList(walk.UnappliedActionRuleNames));
     }
 
     /// <summary>Renders a set of rule names for one log line, which is safe because a rule name carries nothing personal.</summary>
@@ -938,6 +965,22 @@ internal sealed partial class AccountSynchronizationSupervisor
         int failedRuleCount,
         int timedOutRuleCount,
         string failedRuleNames);
+
+    /// <summary>States what the rules asked the mailbox for, which the account's convergence pass carries rather than this one.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The rules of account {AccountId} asked for {RequestedActionCount} changes to its mailbox; the account's next convergence pass carries them to the mail server.")]
+    private partial void LogRuleActionsRequested(string accountId, int requestedActionCount);
+
+    /// <summary>Separates an action another rule had already settled from one the account or its folders no longer admit.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "{WithheldActionCount} actions declared for account {AccountId} were withheld because an earlier rule had already settled the same message, and {FailedActionCount} named something the account no longer resolves or no longer permits; rules: [{UnappliedActionRuleNames}].")]
+    private partial void LogRuleActionsUnapplied(
+        string accountId,
+        int withheldActionCount,
+        int failedActionCount,
+        string unappliedActionRuleNames);
 
     [LoggerMessage(
         Level = LogLevel.Warning,

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -23,6 +23,7 @@ using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Retrieval.AskMail.Audit;
 using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Rules.Conditions;
 using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.SensitiveContent.Detection;
@@ -306,6 +307,9 @@ try
     // built rather than captured once at startup.
     builder.Services.AddScoped(provider =>
         provider.GetRequiredService<ISettingsSnapshot<MailRulesOptions>>().Current.ToEvaluationOptions());
+    // Scoped beside the pass rather than transient, because it remembers the folder a destination alias resolved to for
+    // the length of the pass; a batch of mail matching one filing rule would otherwise re-read one binding per message.
+    builder.Services.AddScoped<MailRuleActionRecorder>();
     builder.Services.AddScoped<MailRuleEvaluationPass>();
     builder.Services.AddScoped<MailRuleEvaluationRunRequests>();
     builder.Services.AddHostedService(
@@ -348,6 +352,7 @@ try
     builder.Services.AddScoped<IMailSynchronizationWindowReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IRemotelyDeletedEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IAuthoredDeleteEmailDispositionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
+    builder.Services.AddScoped<IMailRuleActionPermissionReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IMailboxMutationAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IMailAnsweringAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IMailAccountCatalog>(provider => provider.GetRequiredService<MailSynchronizationOptions>());

--- a/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
+++ b/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Rules.Facts;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
 using MailFathom.Infrastructure.Persistence.Emails;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
@@ -135,6 +136,9 @@ internal sealed class MailRuleEvaluationStore(MailFathomDbContext dbContext) : I
             {
                 email.Id,
                 email.MailFolder.Alias,
+                email.MailFolder.ResolutionGeneration,
+                email.UidValidity,
+                email.Uid,
                 email.Subject,
                 email.SenderNormalizedAddress,
                 email.ToAddresses,
@@ -161,6 +165,13 @@ internal sealed class MailRuleEvaluationStore(MailFathomDbContext dbContext) : I
         [
             .. candidates.Select(candidate => new StoredEmailAwaitingRuleEvaluation(
                 StoredEmailId.Create(candidate.Id),
+                EmailOccurrenceId.Create(
+                    accountId,
+                    new MailFolderResolutionId(
+                        MailFolderAlias.Create(candidate.Alias),
+                        MailFolderResolutionGeneration.Create(candidate.ResolutionGeneration)),
+                    ImapUidValidity.Create(candidate.UidValidity),
+                    ImapUid.Create(candidate.Uid)),
                 new MailRuleEmailFacts
                 {
                     Account = mailboxAccountId,

--- a/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditCursorTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditCursorTests.cs
@@ -97,7 +97,7 @@ public sealed class MailboxMutationAuditCursorTests
         DestinationFolderPath = RemoteFolderPath.Create("Archive", '/'),
         Placement = RemoteEmailPlacement.NotReported(),
         DesiredSeenState = null,
-        Requester = MailboxMutationRequester.Rule("file-newsletters", 3),
+        Requester = MailboxMutationRequester.Rule("file-newsletters", "3"),
         RequestedAt = CompletedAt.AddMinutes(-1),
         CompletedAt = CompletedAt,
         Outcome = MailboxMutationAuditOutcome.Performed,

--- a/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditQueryTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditQueryTests.cs
@@ -147,7 +147,7 @@ public sealed class MailboxMutationAuditQueryTests
         DestinationFolderPath = RemoteFolderPath.Create("Archive", '/'),
         Placement = RemoteEmailPlacement.NotReported(),
         DesiredSeenState = null,
-        Requester = MailboxMutationRequester.Rule("file-newsletters", 3),
+        Requester = MailboxMutationRequester.Rule("file-newsletters", "3"),
         RequestedAt = CompletedAt.AddMinutes(-1),
         CompletedAt = CompletedAt,
         Outcome = MailboxMutationAuditOutcome.Performed,

--- a/tests/Application.UnitTests/Mail/Mutations/Convergence/MailboxMutationConvergerTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Convergence/MailboxMutationConvergerTests.cs
@@ -377,19 +377,19 @@ public sealed class MailboxMutationConvergerTests
     private static MailboxMutationRequest RelocationRequest() => MailboxMutationRequest.Relocate(
         StoredEmailId.Create(Guid.CreateVersion7()),
         Occurrence(42U),
-        MailboxMutationRequester.Rule("file-newsletters", 3),
+        MailboxMutationRequester.Rule("file-newsletters", "3"),
         ArchivePath);
 
     private static MailboxMutationRequest CopyRequest() => MailboxMutationRequest.Copy(
         StoredEmailId.Create(Guid.CreateVersion7()),
         Occurrence(42U),
-        MailboxMutationRequester.Rule("keep-a-copy", 4),
+        MailboxMutationRequester.Rule("keep-a-copy", "4"),
         ArchivePath);
 
     private static MailboxMutationRequest DeleteRequest(uint uid) => MailboxMutationRequest.Delete(
         StoredEmailId.Create(Guid.CreateVersion7()),
         Occurrence(uid),
-        MailboxMutationRequester.Rule("drop-notifications", 5),
+        MailboxMutationRequester.Rule("drop-notifications", "5"),
         AuthoredDeleteEmailDisposition.RetainLocalCopy);
 
     /// <summary>Assembles the converger over the same in-memory record store the performer's own tests use.</summary>

--- a/tests/Application.UnitTests/Mail/Mutations/MailboxMutationPerformerTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/MailboxMutationPerformerTests.cs
@@ -332,7 +332,7 @@ public sealed class MailboxMutationPerformerTests
         var context = new PerformerContext();
         var occurrence = Occurrence(42U);
         var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
-        var requester = MailboxMutationRequester.Rule("file-newsletters", 3);
+        var requester = MailboxMutationRequester.Rule("file-newsletters", "3");
 
         // Act
         await context.Performer.PerformAsync(
@@ -394,7 +394,7 @@ public sealed class MailboxMutationPerformerTests
         var request = MailboxMutationRequest.SetSeen(
             StoredEmailId.Create(Guid.CreateVersion7()),
             occurrence,
-            MailboxMutationRequester.Rule("surface-invoices", 2),
+            MailboxMutationRequester.Rule("surface-invoices", "2"),
             isSeen);
 
         // Act
@@ -553,7 +553,7 @@ public sealed class MailboxMutationPerformerTests
     {
         var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
         var occurrence = Occurrence(42U);
-        var requester = MailboxMutationRequester.Rule("file-newsletters", 3);
+        var requester = MailboxMutationRequester.Rule("file-newsletters", "3");
 
         return mutationName switch
         {
@@ -577,7 +577,7 @@ public sealed class MailboxMutationPerformerTests
     private static MailboxMutationRequest RelocationRequest() => MailboxMutationRequest.Relocate(
         StoredEmailId.Create(Guid.CreateVersion7()),
         Occurrence(42U),
-        MailboxMutationRequester.Rule("file-newsletters", 3),
+        MailboxMutationRequester.Rule("file-newsletters", "3"),
         ArchivePath);
 
     /// <summary>Assembles the performer over an in-memory record store and a substituted write session.</summary>

--- a/tests/Application.UnitTests/Rules/Actions/MailRuleActionPlanTests.cs
+++ b/tests/Application.UnitTests/Rules/Actions/MailRuleActionPlanTests.cs
@@ -1,0 +1,123 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Actions;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Rules.Actions;
+
+/// <summary>Covers how the actions of several rules matching one email are resolved into the changes it actually gets.</summary>
+public sealed class MailRuleActionPlanTests
+{
+    private static readonly MailFolderAlias Archive = MailFolderAlias.Create("archive");
+    private static readonly MailFolderAlias Backup = MailFolderAlias.Create("backup");
+
+    /// <summary>Declared order decides, so two rules filing one email into different folders answer the same way every run.</summary>
+    [Fact]
+    public void Compose_TwoRulesFilingIntoDifferentFolders_HonorsTheOneDeclaredFirst()
+    {
+        // Arrange
+        var first = RuleNamed("file-invoices", MailRuleAction.Relocate(Archive));
+        var second = RuleNamed("file-everything", MailRuleAction.Relocate(Backup));
+
+        // Act
+        var plan = MailRuleActionPlan.Compose([first, second]);
+
+        // Assert
+        var honored = Assert.Single(plan.Actions);
+        Assert.Equal("file-invoices", honored.RuleName);
+        Assert.Equal(Archive, honored.Action.DestinationAlias);
+        Assert.Equal(["file-everything"], plan.WithheldRuleNames);
+    }
+
+    /// <summary>The same two rules the other way round settle the other way, which is what "by declared order" means.</summary>
+    [Fact]
+    public void Compose_TheSameTwoRulesReordered_HonorsTheOtherOne()
+    {
+        // Arrange
+        var filing = RuleNamed("file-invoices", MailRuleAction.Relocate(Archive));
+        var everything = RuleNamed("file-everything", MailRuleAction.Relocate(Backup));
+
+        // Act
+        var plan = MailRuleActionPlan.Compose([everything, filing]);
+
+        // Assert
+        var honored = Assert.Single(plan.Actions);
+        Assert.Equal("file-everything", honored.RuleName);
+        Assert.Equal(["file-invoices"], plan.WithheldRuleNames);
+    }
+
+    /// <summary>A rule naming a deletion leaves no room for anything a later rule asks for on the same message.</summary>
+    [Fact]
+    public void Compose_ADeletionFollowedByAFiling_WithholdsTheFiling()
+    {
+        // Arrange
+        var deleting = RuleNamed("drop-notifications", MailRuleAction.Delete());
+        var filing = RuleNamed("file-invoices", MailRuleAction.Relocate(Archive));
+
+        // Act
+        var plan = MailRuleActionPlan.Compose([deleting, filing]);
+
+        // Assert
+        Assert.Equal([MailboxMutation.Delete], plan.Actions.Select(planned => planned.Action.Mutation));
+        Assert.Equal(["file-invoices"], plan.WithheldRuleNames);
+    }
+
+    /// <summary>A flag declared by a later rule is still written before an earlier rule moves the occurrence.</summary>
+    [Fact]
+    public void Compose_AFilingRuleAndAFlaggingRuleBelowIt_AppliesTheFlagFirst()
+    {
+        // Arrange
+        var filing = RuleNamed("file-invoices", MailRuleAction.Relocate(Archive));
+        var flagging = RuleNamed("mark-them-read", MailRuleAction.SetSeen(isSeen: true));
+
+        // Act
+        var plan = MailRuleActionPlan.Compose([filing, flagging]);
+
+        // Assert
+        Assert.Equal(
+            [MailboxMutation.SetSeen, MailboxMutation.Relocate],
+            plan.Actions.Select(planned => planned.Action.Mutation));
+        Assert.Empty(plan.WithheldRuleNames);
+    }
+
+    /// <summary>Each action carries the rule that asked, because that is half of the request's idempotency identity.</summary>
+    [Fact]
+    public void Compose_ActionsFromTwoRules_EachNamesTheRuleThatAskedForIt()
+    {
+        // Arrange
+        var filing = RuleNamed("file-invoices", MailRuleAction.Relocate(Archive));
+        var flagging = RuleNamed("mark-them-read", MailRuleAction.SetSeen(isSeen: true));
+
+        // Act
+        var plan = MailRuleActionPlan.Compose([filing, flagging]);
+
+        // Assert
+        Assert.Equal(["mark-them-read", "file-invoices"], plan.Actions.Select(planned => planned.RuleName));
+    }
+
+    [Fact]
+    public void Compose_RulesThatChangeNothing_IsAnEmptyPlan()
+    {
+        // Act
+        var plan = MailRuleActionPlan.Compose([RuleNamed("select-only")]);
+
+        // Assert
+        Assert.True(plan.IsEmpty);
+        Assert.Empty(plan.WithheldRuleNames);
+    }
+
+    [Fact]
+    public void Compose_NoMatchingRules_IsTheEmptyPlan() =>
+        Assert.Same(MailRuleActionPlan.Nothing, MailRuleActionPlan.Compose([]));
+
+    private static MailRule RuleNamed(string name, params MailRuleAction[] actions) => MailRule.Create(
+        name,
+        ScriptedMailRuleCondition.Answering(matches: true),
+        MailRuleActionSet.Create(actions));
+}

--- a/tests/Application.UnitTests/Rules/Actions/MailRuleActionRecorderTests.cs
+++ b/tests/Application.UnitTests/Rules/Actions/MailRuleActionRecorderTests.cs
@@ -1,0 +1,315 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Actions;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Rules.Actions;
+
+/// <summary>Covers what a matched rule writes down, what identity it writes it under, and what it refuses to write.</summary>
+public sealed class MailRuleActionRecorderTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+    private static readonly MailFolderAlias Inbox = MailFolderAlias.Create("inbox");
+    private static readonly MailFolderAlias Archive = MailFolderAlias.Create("archive");
+    private static readonly StoredEmailId LocalEmail = StoredEmailId.Create(Guid.CreateVersion7());
+    private static readonly MailRuleSetRevision Revision = MailRuleSetRevision.Restore("a1b2c3d4e5f6");
+
+    private readonly InMemoryMailboxMutationRecordStore records = new();
+    private readonly InMemoryMailFolderResolutionStore folders = new();
+    private readonly IAuthoredDeleteEmailDispositionReader dispositions =
+        Substitute.For<IAuthoredDeleteEmailDispositionReader>();
+
+    private readonly IMailRuleActionPermissionReader permissions =
+        Substitute.For<IMailRuleActionPermissionReader>();
+
+    public MailRuleActionRecorderTests()
+    {
+        this.dispositions
+            .GetAuthoredDeleteDisposition(Arg.Any<MailAccountId>())
+            .Returns(AuthoredDeleteEmailDisposition.RetainTombstone);
+
+        this.permissions
+            .GetRuleActionPermissions(Arg.Any<MailAccountId>())
+            .Returns(MailRuleActionPermissions.Default with { PermitsDelete = true });
+    }
+
+    [Fact]
+    public async Task RecordAsync_ARuleFilingMail_WritesARelocationNamingTheBoundFolder()
+    {
+        // Arrange
+        var binding = this.folders.Bind(Account, Archive, "INBOX/Archive");
+
+        // Act
+        var recording = await this.RecordAsync(Planned("file-invoices", MailRuleAction.Relocate(Archive)));
+
+        // Assert
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal(MailboxMutation.Relocate, request.Mutation);
+        Assert.Equal(binding.RemotePath, request.DestinationPath);
+        Assert.Empty(recording.Failures);
+        Assert.Equal(1, recording.RecordedCount);
+    }
+
+    /// <summary>A relocation between mirrored folders disposes of nothing locally; the row follows the message.</summary>
+    [Fact]
+    public async Task RecordAsync_ARuleFilingMail_LeavesTheLocalCopyWhereTheDestinationWillCarryIt()
+    {
+        // Arrange
+        this.folders.Bind(Account, Archive);
+
+        // Act
+        await this.RecordAsync(Planned("file-invoices", MailRuleAction.Relocate(Archive)));
+
+        // Assert
+        Assert.Null(Assert.Single(this.records.OpenedRequests).LocalDisposition);
+    }
+
+    [Fact]
+    public async Task RecordAsync_ARuleMarkingMailRead_WritesTheFlagDirectionItDeclared()
+    {
+        // Act
+        await this.RecordAsync(Planned("mark-them-read", MailRuleAction.SetSeen(isSeen: true)));
+
+        // Assert
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal(MailboxMutation.SetSeen, request.Mutation);
+        Assert.True(request.DesiredSeenState);
+    }
+
+    /// <summary>The disposition is the account's answer at the moment the request is written, exactly as an authored delete's is.</summary>
+    [Fact]
+    public async Task RecordAsync_ARuleDeletingMail_CarriesTheAccountsLocalDisposition()
+    {
+        // Act
+        await this.RecordAsync(Planned("drop-notifications", MailRuleAction.Delete()));
+
+        // Assert
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal(MailboxMutation.Delete, request.Mutation);
+        Assert.Equal(AuthoredDeleteEmailDisposition.RetainTombstone, request.LocalDisposition);
+    }
+
+    /// <summary>The identity is the occurrence, the rule with its revision, and the mutation, so asking again asks once.</summary>
+    [Fact]
+    public async Task RecordAsync_TheSameRuleAndRevisionTwice_OpensOneRecord()
+    {
+        // Arrange
+        var planned = Planned("mark-them-read", MailRuleAction.SetSeen(isSeen: true));
+
+        // Act
+        await this.RecordAsync(planned);
+        var second = await this.RecordAsync(planned);
+
+        // Assert
+        Assert.Equal(1, this.records.OpenedRecordCount);
+        Assert.Equal(1, second.RecordedCount);
+    }
+
+    /// <summary>An edited rule set is a different revision, so the same rule over the same email asks afresh.</summary>
+    [Fact]
+    public async Task RecordAsync_TheSameRuleUnderANewRevision_OpensASecondRecord()
+    {
+        // Arrange
+        var planned = Planned("mark-them-read", MailRuleAction.SetSeen(isSeen: true));
+
+        // Act
+        await this.RecordAsync(planned);
+        await this.RecordAsync(planned, MailRuleSetRevision.Restore("ffffffffffff"));
+
+        // Assert
+        Assert.Equal(2, this.records.OpenedRecordCount);
+    }
+
+    /// <summary>Filing into the nearest folder whose name looks right is precisely what a stale destination must not do.</summary>
+    [Fact]
+    public async Task RecordAsync_ADestinationNothingHasBound_WritesNothingAndSaysWhy()
+    {
+        // Act
+        var recording = await this.RecordAsync(Planned("file-invoices", MailRuleAction.Relocate(Archive)));
+
+        // Assert
+        Assert.Equal(0, this.records.OpenedRecordCount);
+        var failure = Assert.Single(recording.Failures);
+        Assert.Equal("file-invoices", failure.RuleName);
+        Assert.Equal(MailRuleActionFailureReason.DestinationFolderUnresolved, failure.Reason);
+        Assert.Equal(Archive, failure.DestinationAlias);
+    }
+
+    /// <summary>What a withdrawn account decided about its own deletions is unknown, and no value invented here would be it.</summary>
+    [Fact]
+    public async Task RecordAsync_AnAccountTheConfigurationNoLongerDeclares_RefusesTheDeletionVisibly()
+    {
+        // Arrange
+        this.dispositions
+            .GetAuthoredDeleteDisposition(Arg.Any<MailAccountId>())
+            .Returns(_ => throw new InvalidOperationException("Account 'work' is not configured."));
+
+        // Act
+        var recording = await this.RecordAsync(Planned("drop-notifications", MailRuleAction.Delete()));
+
+        // Assert
+        Assert.Equal(0, this.records.OpenedRecordCount);
+        var failure = Assert.Single(recording.Failures);
+        Assert.Equal(MailRuleActionFailureReason.AccountNoLongerConfigured, failure.Reason);
+    }
+
+    /// <summary>The two sections reload apart, so a revoked permission has to reach the next pass rather than the next edit of the rules.</summary>
+    [Fact]
+    public async Task RecordAsync_AnActionTheAccountHasStoppedPermitting_WritesNothingAndSaysWhy()
+    {
+        // Arrange
+        this.permissions
+            .GetRuleActionPermissions(Arg.Any<MailAccountId>())
+            .Returns(MailRuleActionPermissions.Default with { PermitsDelete = false });
+
+        // Act
+        var recording = await this.RecordAsync(Planned("drop-notifications", MailRuleAction.Delete()));
+
+        // Assert
+        Assert.Equal(0, this.records.OpenedRecordCount);
+        var failure = Assert.Single(recording.Failures);
+        Assert.Equal("drop-notifications", failure.RuleName);
+        Assert.Equal(MailRuleActionFailureReason.ActionNoLongerPermitted, failure.Reason);
+    }
+
+    /// <summary>Revoking one action leaves the others alone, which is what makes the four switches four decisions.</summary>
+    [Fact]
+    public async Task RecordAsync_AFlagBesideARevokedRelocation_StillWritesTheFlag()
+    {
+        // Arrange
+        this.folders.Bind(Account, Archive);
+        this.permissions
+            .GetRuleActionPermissions(Arg.Any<MailAccountId>())
+            .Returns(MailRuleActionPermissions.Default with { PermitsRelocate = false });
+        var plan = MailRuleActionPlan.Compose(
+        [
+            RuleNamed("file-invoices", MailRuleAction.Relocate(Archive)),
+            RuleNamed("mark-them-read", MailRuleAction.SetSeen(isSeen: true)),
+        ]);
+
+        // Act
+        var recording = await this.RecordAsync(plan);
+
+        // Assert
+        Assert.Equal(MailboxMutation.SetSeen, Assert.Single(this.records.OpenedRequests).Mutation);
+        Assert.Equal(1, recording.RecordedCount);
+        Assert.Equal(
+            MailRuleActionFailureReason.ActionNoLongerPermitted,
+            Assert.Single(recording.Failures).Reason);
+    }
+
+    /// <summary>An account the configuration has stopped declaring permits nothing that could be asked on its behalf.</summary>
+    [Fact]
+    public async Task RecordAsync_AnAccountWhosePermissionsCannotBeRead_RefusesEveryActionVisibly()
+    {
+        // Arrange
+        this.folders.Bind(Account, Archive);
+        this.permissions
+            .GetRuleActionPermissions(Arg.Any<MailAccountId>())
+            .Returns(_ => throw new InvalidOperationException("Account 'work' is not configured."));
+
+        // Act
+        var recording = await this.RecordAsync(Planned("file-invoices", MailRuleAction.Relocate(Archive)));
+
+        // Assert
+        Assert.Equal(0, this.records.OpenedRecordCount);
+        Assert.Equal(0, recording.RecordedCount);
+        var failure = Assert.Single(recording.Failures);
+        Assert.Equal(MailRuleActionFailureReason.AccountNoLongerConfigured, failure.Reason);
+        Assert.Equal(Archive, failure.DestinationAlias);
+    }
+
+    /// <summary>One failing action must not cost the ones beside it, which is why each is recorded on its own.</summary>
+    [Fact]
+    public async Task RecordAsync_AFlagBesideAnUnresolvableDestination_StillWritesTheFlag()
+    {
+        // Arrange
+        var plan = MailRuleActionPlan.Compose(
+        [
+            RuleNamed("file-invoices", MailRuleAction.Relocate(Archive)),
+            RuleNamed("mark-them-read", MailRuleAction.SetSeen(isSeen: true)),
+        ]);
+
+        // Act
+        var recording = await this.RecordAsync(plan);
+
+        // Assert
+        Assert.Equal(MailboxMutation.SetSeen, Assert.Single(this.records.OpenedRequests).Mutation);
+        Assert.Single(recording.Failures);
+        Assert.Equal(1, recording.RecordedCount);
+    }
+
+    /// <summary>A batch of mail matching one filing rule must not re-read one binding per message.</summary>
+    [Fact]
+    public async Task RecordAsync_TheSameDestinationOverSeveralEmails_ResolvesTheBindingOnce()
+    {
+        // Arrange
+        this.folders.Bind(Account, Archive);
+        var recorder = this.CreateRecorder();
+        var plan = MailRuleActionPlan.Compose([RuleNamed("file-invoices", MailRuleAction.Relocate(Archive))]);
+
+        // Act
+        foreach (var uid in Enumerable.Range(1, 3))
+        {
+            await recorder.RecordAsync(
+                Substitute.For<IPersistenceSession>(),
+                StoredEmailId.Create(Guid.CreateVersion7()),
+                OccurrenceAt((uint)uid),
+                plan,
+                Revision,
+                TestContext.Current.CancellationToken);
+        }
+
+        // Assert
+        Assert.Equal(1, this.folders.ResolutionReadCount);
+        Assert.Equal(3, this.records.OpenedRecordCount);
+    }
+
+    [Fact]
+    public async Task RecordAsync_APlanThatAsksForNothing_WritesNothing()
+    {
+        // Act
+        var recording = await this.RecordAsync(MailRuleActionPlan.Nothing);
+
+        // Assert
+        Assert.Same(MailRuleActionRecording.Nothing, recording);
+        Assert.Equal(0, this.records.OpenedRecordCount);
+    }
+
+    private static MailRuleActionPlan Planned(string ruleName, MailRuleAction action) =>
+        MailRuleActionPlan.Compose([RuleNamed(ruleName, action)]);
+
+    private static MailRule RuleNamed(string name, MailRuleAction action) => MailRule.Create(
+        name,
+        ScriptedMailRuleCondition.Answering(matches: true),
+        MailRuleActionSet.Create([action]));
+
+    private static EmailOccurrenceId OccurrenceAt(uint uid) => EmailOccurrenceId.Create(
+        Account,
+        new MailFolderResolutionId(Inbox, MailFolderResolutionGeneration.First),
+        ImapUidValidity.Create(42),
+        ImapUid.Create(uid));
+
+    private Task<MailRuleActionRecording> RecordAsync(MailRuleActionPlan plan, MailRuleSetRevision? revision = null) =>
+        this.CreateRecorder().RecordAsync(
+            Substitute.For<IPersistenceSession>(),
+            LocalEmail,
+            OccurrenceAt(7),
+            plan,
+            revision ?? Revision,
+            TestContext.Current.CancellationToken);
+
+    private MailRuleActionRecorder CreateRecorder() =>
+        new(this.records, this.folders, this.dispositions, this.permissions);
+}

--- a/tests/Application.UnitTests/Rules/Actions/MailRuleActionSetTests.cs
+++ b/tests/Application.UnitTests/Rules/Actions/MailRuleActionSetTests.cs
@@ -1,0 +1,129 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Rules.Actions;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Rules.Actions;
+
+/// <summary>Covers which combinations of actions one rule may declare, and the order the permitted ones are applied in.</summary>
+public sealed class MailRuleActionSetTests
+{
+    private static readonly MailFolderAlias Archive = MailFolderAlias.Create("archive");
+    private static readonly MailFolderAlias Backup = MailFolderAlias.Create("backup");
+
+    public static TheoryData<string, MailRuleAction[]> PermittedCombinations => new()
+    {
+        { "relocate alone", [MailRuleAction.Relocate(Archive)] },
+        { "copy alone", [MailRuleAction.Copy(Archive)] },
+        { "delete alone", [MailRuleAction.Delete()] },
+        { "flag alone", [MailRuleAction.SetSeen(isSeen: true)] },
+        { "relocate and flag", [MailRuleAction.Relocate(Archive), MailRuleAction.SetSeen(isSeen: true)] },
+        { "copy and flag", [MailRuleAction.Copy(Archive), MailRuleAction.SetSeen(isSeen: false)] },
+    };
+
+    public static TheoryData<string, MailRuleAction[]> RefusedCombinations => new()
+    {
+        { "relocate and copy", [MailRuleAction.Relocate(Archive), MailRuleAction.Copy(Backup)] },
+        { "relocate and delete", [MailRuleAction.Relocate(Archive), MailRuleAction.Delete()] },
+        { "copy and delete", [MailRuleAction.Copy(Archive), MailRuleAction.Delete()] },
+        { "delete and flag", [MailRuleAction.Delete(), MailRuleAction.SetSeen(isSeen: true)] },
+        { "flag and delete", [MailRuleAction.SetSeen(isSeen: true), MailRuleAction.Delete()] },
+        { "two relocations", [MailRuleAction.Relocate(Archive), MailRuleAction.Relocate(Backup)] },
+        { "two flags", [MailRuleAction.SetSeen(isSeen: true), MailRuleAction.SetSeen(isSeen: false)] },
+    };
+
+    [Theory]
+    [MemberData(nameof(PermittedCombinations))]
+    public void FindErrors_ACombinationMailFathomApplies_ReportsNothing(string scenario, MailRuleAction[] actions)
+    {
+        // Act
+        var errors = MailRuleActionSet.FindErrors("file-invoices", actions);
+
+        // Assert
+        Assert.True(errors.Count == 0, $"'{scenario}' should be permitted but reported: {string.Join(" ", errors)}");
+    }
+
+    /// <summary>A combination naming two fates for one occurrence is refused where it is written, naming the rule.</summary>
+    [Theory]
+    [MemberData(nameof(RefusedCombinations))]
+    public void FindErrors_ACombinationThatCannotBeHonored_NamesTheRuleAndTheReason(
+        string scenario,
+        MailRuleAction[] actions)
+    {
+        // Act
+        var error = Assert.Single(MailRuleActionSet.FindErrors("file-invoices", actions));
+
+        // Assert
+        Assert.Contains("file-invoices", error, StringComparison.Ordinal);
+        Assert.False(string.IsNullOrWhiteSpace(scenario));
+    }
+
+    [Theory]
+    [MemberData(nameof(RefusedCombinations))]
+    public void Create_ACombinationThatCannotBeHonored_IsRefused(string scenario, MailRuleAction[] actions)
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentException>(() => MailRuleActionSet.Create(actions));
+
+        // Assert
+        Assert.Equal("actions", refusal.ParamName);
+        Assert.False(string.IsNullOrWhiteSpace(scenario));
+    }
+
+    /// <summary>The flag is written first and the relocation last, so every permitted combination acts on the matched occurrence.</summary>
+    [Fact]
+    public void Create_AFlagDeclaredAfterARelocation_AppliesTheFlagFirst()
+    {
+        // Act
+        var actions = MailRuleActionSet
+            .Create([MailRuleAction.Relocate(Archive), MailRuleAction.SetSeen(isSeen: true)])
+            .Actions;
+
+        // Assert
+        Assert.Equal(
+            [MailboxMutation.SetSeen, MailboxMutation.Relocate],
+            actions.Select(action => action.Mutation));
+    }
+
+    /// <summary>The order is MailFathom's, so writing the two the other way round produces the same order.</summary>
+    [Fact]
+    public void Create_TheSameTwoActionsWrittenEitherWay_ProducesOneOrder()
+    {
+        // Act
+        var flagFirst = MailRuleActionSet.Create([MailRuleAction.SetSeen(isSeen: true), MailRuleAction.Copy(Archive)]);
+        var copyFirst = MailRuleActionSet.Create([MailRuleAction.Copy(Archive), MailRuleAction.SetSeen(isSeen: true)]);
+
+        // Assert
+        Assert.Equal(
+            flagFirst.Actions.Select(action => action.Mutation),
+            copyFirst.Actions.Select(action => action.Mutation));
+    }
+
+    /// <summary>A rule that changes nothing selects mail, which is what a stopping rule with no action is for.</summary>
+    [Fact]
+    public void Create_NoActions_IsTheEmptySetRatherThanARefusal()
+    {
+        // Act
+        var actions = MailRuleActionSet.Create([]);
+
+        // Assert
+        Assert.True(actions.IsEmpty);
+        Assert.Empty(actions.Actions);
+    }
+
+    /// <summary>The identity is a digest over what a rule declares, so an action has to render as itself and its parameter.</summary>
+    [Theory]
+    [InlineData("relocate=ARCHIVE")]
+    public void CanonicalForm_ADestinationAction_NamesTheMutationAndTheFolder(string expected) =>
+        Assert.Equal(expected, MailRuleAction.Relocate(Archive).CanonicalForm);
+
+    [Fact]
+    public void CanonicalForm_TheTwoFlagDirections_RenderDifferently() =>
+        Assert.NotEqual(
+            MailRuleAction.SetSeen(isSeen: true).CanonicalForm,
+            MailRuleAction.SetSeen(isSeen: false).CanonicalForm);
+}

--- a/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationPassTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationPassTests.cs
@@ -2,13 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Rules.Conditions;
 using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Rules.Facts;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -21,10 +25,25 @@ public sealed class MailRuleEvaluationPassTests
     private static readonly DateTimeOffset EvaluatedAt = new(2026, 4, 2, 11, 0, 0, TimeSpan.Zero);
     private static readonly MailAccountId Account = MailAccountId.Create("work");
     private static readonly MailAccountId OtherAccount = MailAccountId.Create("personal");
+    private static readonly MailFolderAlias Archive = MailFolderAlias.Create("archive");
+    private static readonly MailFolderAlias Backup = MailFolderAlias.Create("backup");
 
     private readonly InMemoryMailRuleEvaluationStore store = new();
     private readonly InMemoryMailRuleEvaluationRunStore runStore = new();
+    private readonly InMemoryMailboxMutationRecordStore mutations = new();
+    private readonly InMemoryMailFolderResolutionStore folders = new();
+    private readonly IAuthoredDeleteEmailDispositionReader deleteDispositions =
+        Substitute.For<IAuthoredDeleteEmailDispositionReader>();
+
+    private readonly IMailRuleActionPermissionReader permissions =
+        Substitute.For<IMailRuleActionPermissionReader>();
+
     private readonly FakeTimeProvider timeProvider = new(EvaluatedAt);
+
+    public MailRuleEvaluationPassTests() =>
+        this.permissions
+            .GetRuleActionPermissions(Arg.Any<MailAccountId>())
+            .Returns(MailRuleActionPermissions.Default with { PermitsDelete = true });
 
     [Fact]
     public async Task RunAsync_MailNoPassHasEvaluated_EvaluatesItAndRecordsIt()
@@ -44,6 +63,99 @@ public sealed class MailRuleEvaluationPassTests
         Assert.Equal(1, report.Arrivals.MatchedEmailCount);
         Assert.Equal(["file-it"], report.Arrivals.MatchedRuleNames);
         Assert.False(report.Arrivals.EmailsRemain);
+    }
+
+    /// <summary>What a match leads to is a durable request, written in the batch's own transaction and issued by nothing here.</summary>
+    [Fact]
+    public async Task RunAsync_ARuleWithAnAction_WritesTheChangeDownAgainstTheMatchedOccurrence()
+    {
+        // Arrange
+        this.folders.Bind(Account, Archive);
+        var arrived = this.store.Add(FactsFor(Account));
+        var pass = this.CreatePass(RuleSetOf(FilingRule("file-it")));
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = Assert.Single(this.mutations.OpenedRequests);
+        Assert.Equal(MailboxMutation.Relocate, request.Mutation);
+        Assert.Equal(arrived, request.StoredEmailId);
+        Assert.Equal(MailboxMutationOrigin.Rule, request.Requester.Origin);
+        Assert.Equal(1, report.Arrivals.RequestedActionCount);
+    }
+
+    /// <summary>Two rules asking for one email's fate resolve by declared order, and the withheld one is reported by name.</summary>
+    [Fact]
+    public async Task RunAsync_TwoRulesFilingOneEmailDifferently_AsksOnceAndNamesTheRuleItWithheld()
+    {
+        // Arrange
+        this.folders.Bind(Account, Archive);
+        this.folders.Bind(Account, Backup);
+        this.store.Add(FactsFor(Account));
+        var pass = this.CreatePass(RuleSetOf(FilingRule("file-invoices"), FilingRule("file-everything", Backup)));
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, this.mutations.OpenedRecordCount);
+        Assert.Equal(1, report.Arrivals.RequestedActionCount);
+        Assert.Equal(1, report.Arrivals.WithheldActionCount);
+        Assert.Equal(["file-everything"], report.Arrivals.UnappliedActionRuleNames);
+    }
+
+    /// <summary>A whole-mailbox run re-asks under the same identity, so re-running the rules performs each change once.</summary>
+    [Fact]
+    public async Task RunAsync_AWholeMailboxRunOverMailAlreadyFiled_OpensNoSecondRecord()
+    {
+        // Arrange
+        this.folders.Bind(Account, Archive);
+        this.store.Add(FactsFor(Account));
+        var ruleSet = RuleSetOf(FilingRule("file-it"));
+        await this.CreatePass(ruleSet).RunAsync(Account, TestContext.Current.CancellationToken);
+        this.runStore.Arrange(RequestedRun());
+
+        // Act
+        var report = await this.CreatePass(ruleSet).RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, this.mutations.OpenedRecordCount);
+        Assert.Equal(1, report.RequestedRun?.RequestedActionCount);
+    }
+
+    /// <summary>A destination that has stopped resolving fails visibly rather than filing the mail somewhere unintended.</summary>
+    [Fact]
+    public async Task RunAsync_ADestinationNothingHasBound_RecordsNothingAndNamesTheRule()
+    {
+        // Arrange
+        this.store.Add(FactsFor(Account));
+        var pass = this.CreatePass(RuleSetOf(FilingRule("file-it")));
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, this.mutations.OpenedRecordCount);
+        Assert.Equal(1, report.Arrivals.FailedActionCount);
+        Assert.Equal(["file-it"], report.Arrivals.UnappliedActionRuleNames);
+    }
+
+    /// <summary>A rule that selects mail and changes nothing is an ordinary rule, so the mailbox is asked for nothing.</summary>
+    [Fact]
+    public async Task RunAsync_AMatchingRuleThatDeclaresNoAction_AsksTheMailboxForNothing()
+    {
+        // Arrange
+        this.store.Add(FactsFor(Account));
+        var pass = this.CreatePass(
+            RuleSetOf(MailRule.Create("select-only", ScriptedMailRuleCondition.Answering(matches: true))));
+
+        // Act
+        var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, this.mutations.OpenedRecordCount);
+        Assert.Equal(0, report.Arrivals.RequestedActionCount);
     }
 
     /// <summary>The arrival queue must never become a back door to reprocessing, whatever the rule set now says.</summary>
@@ -71,7 +183,7 @@ public sealed class MailRuleEvaluationPassTests
         var condition = ScriptedMailRuleCondition.Answering(matches: true);
         var arrived = this.store.Add(FactsFor(Account));
         var pass = this.CreatePass(
-            RuleSetOf(MailRule.Create("other-account", condition, stopWhenMatched: false, [OtherAccount.Value])));
+            RuleSetOf(MailRule.Create("other-account", condition, stopWhenMatched: false, accounts: [OtherAccount.Value])));
 
         // Act
         await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -313,6 +425,12 @@ public sealed class MailRuleEvaluationPassTests
     private static MailRuleEmailFacts FactsFor(MailAccountId accountId) =>
         new() { Account = accountId.Value, Folder = "inbox" };
 
+    /// <summary>A rule that matches everything and files it, which is the shape every action assertion here needs.</summary>
+    private static MailRule FilingRule(string name, MailFolderAlias? destination = null) => MailRule.Create(
+        name,
+        ScriptedMailRuleCondition.Answering(matches: true),
+        MailRuleActionSet.Create([MailRuleAction.Relocate(destination ?? Archive)]));
+
     private static MailRuleEvaluationRun RequestedRun() => new()
     {
         AccountId = Account,
@@ -322,7 +440,7 @@ public sealed class MailRuleEvaluationPassTests
     private static MailRuleSet RuleSetOf(params MailRule[] rules) => MailRuleSet.Create(
         rules,
         MailRuleSetRevision.Create(
-            [.. rules.Select(rule => new MailRuleDeclaration(rule.Name, "isSeen", rule.StopWhenMatched, [.. rule.Accounts]))]),
+            [.. rules.Select(rule => new MailRuleDeclaration(rule.Name, "isSeen", [.. rule.Actions.Actions], rule.StopWhenMatched, [.. rule.Accounts]))]),
         MailRuleConditionBounds.Default);
 
     private MailRuleEvaluationPass CreatePass(
@@ -341,6 +459,7 @@ public sealed class MailRuleEvaluationPassTests
             new MailRuleSetEvaluator(this.timeProvider),
             this.store,
             this.runStore,
+            new MailRuleActionRecorder(this.mutations, this.folders, this.deleteDispositions, this.permissions),
             new OptimisticConcurrencyRetryPolicy(
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),

--- a/tests/Application.UnitTests/Rules/MailRuleSetEvaluatorTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleSetEvaluatorTests.cs
@@ -3,9 +3,12 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Rules.Conditions;
 using MailFathom.Application.Rules.Facts;
 using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
@@ -166,8 +169,8 @@ public sealed class MailRuleSetEvaluatorTests
         var elsewhere = ScriptedMailRuleCondition.Answering(matches: true);
         var ruleSet = CreateRuleSet(
         [
-            MailRule.Create("other-account", elsewhere, stopWhenMatched: false, ["primary"]),
-            MailRule.Create("this-account", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false, ["work"]),
+            MailRule.Create("other-account", elsewhere, stopWhenMatched: false, accounts: ["primary"]),
+            MailRule.Create("this-account", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false, accounts: ["work"]),
             MailRule.Create("every-account", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false),
         ]);
 
@@ -191,7 +194,7 @@ public sealed class MailRuleSetEvaluatorTests
         // Arrange
         var ruleSet = CreateRuleSet(
         [
-            MailRule.Create("stopping-elsewhere", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: true, ["primary"]),
+            MailRule.Create("stopping-elsewhere", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: true, accounts: ["primary"]),
             MailRule.Create("below", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false),
         ]);
 
@@ -212,7 +215,7 @@ public sealed class MailRuleSetEvaluatorTests
     {
         // Arrange
         var ruleSet = CreateRuleSet(
-            [MailRule.Create("mistyped", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false, ["Work"])]);
+            [MailRule.Create("mistyped", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false, accounts: ["Work"])]);
 
         // Act
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
@@ -222,6 +225,34 @@ public sealed class MailRuleSetEvaluatorTests
 
         // Assert
         Assert.Empty(evaluation.Evaluations);
+    }
+
+    /// <summary>A rule that could not answer did not match, so what it declared is not something the mailbox is asked for.</summary>
+    [Fact]
+    public async Task EvaluateAsync_RuleThatFailedBesideOneThatMatched_PlansOnlyTheMatchingRulesActions()
+    {
+        // Arrange
+        var filing = MailRuleActionSet.Create([MailRuleAction.Relocate(MailFolderAlias.Create("archive"))]);
+        var ruleSet = CreateRuleSet(
+        [
+            MailRule.Create(
+                "raising",
+                ScriptedMailRuleCondition.Raising(new InvalidOperationException("unusable operand")),
+                MailRuleActionSet.Create([MailRuleAction.Delete()])),
+            MailRule.Create("below", ScriptedMailRuleCondition.Answering(matches: true), filing),
+        ]);
+
+        // Act
+        var evaluation = await this.CreateEvaluator().EvaluateAsync(
+            ruleSet,
+            CreateFacts(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var planned = Assert.Single(evaluation.ActionPlan.Actions);
+        Assert.Equal("below", planned.RuleName);
+        Assert.Equal(MailboxMutation.Relocate, planned.Action.Mutation);
+        Assert.Empty(evaluation.ActionPlan.WithheldRuleNames);
     }
 
     [Fact]
@@ -250,7 +281,7 @@ public sealed class MailRuleSetEvaluatorTests
         return MailRuleSet.Create(
             materialized,
             MailRuleSetRevision.Create(
-                [.. materialized.Select(rule => new MailRuleDeclaration(rule.Name, "isSeen", rule.StopWhenMatched, [.. rule.Accounts]))]),
+                [.. materialized.Select(rule => new MailRuleDeclaration(rule.Name, "isSeen", [.. rule.Actions.Actions], rule.StopWhenMatched, [.. rule.Accounts]))]),
             MailRuleConditionBounds.Default);
     }
 

--- a/tests/Application.UnitTests/Rules/MailRuleSetRevisionTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleSetRevisionTests.cs
@@ -3,6 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Actions;
+using MailFathom.Domain.Folders;
 using Xunit;
 
 namespace MailFathom.Application.UnitTests.Rules;
@@ -10,11 +12,22 @@ namespace MailFathom.Application.UnitTests.Rules;
 /// <summary>Covers what moves a rule set's identity and, just as importantly, what leaves it alone.</summary>
 public sealed class MailRuleSetRevisionTests
 {
+    private static readonly MailRuleAction FileIntoArchive =
+        MailRuleAction.Relocate(MailFolderAlias.Create("archive"));
+
+    public static TheoryData<string, MailRuleAction[]> ActionEdits => new()
+    {
+        { "a different destination", [MailRuleAction.Relocate(MailFolderAlias.Create("backup"))] },
+        { "a different mutation", [MailRuleAction.Copy(MailFolderAlias.Create("archive"))] },
+        { "one more action", [FileIntoArchive, MailRuleAction.SetSeen(isSeen: true)] },
+        { "no action at all", [] },
+    };
+
     private static readonly MailRuleDeclaration FileInvoices =
-        new("file-invoices", "senderDomain == 'supplier.test'", StopWhenMatched: true, Accounts: []);
+        new("file-invoices", "senderDomain == 'supplier.test'", Actions: [], StopWhenMatched: true, Accounts: []);
 
     private static readonly MailRuleDeclaration ArchiveOld =
-        new("archive-old", "ageInDays > 365", StopWhenMatched: false, Accounts: []);
+        new("archive-old", "ageInDays > 365", Actions: [], StopWhenMatched: false, Accounts: []);
 
     [Fact]
     public void Create_SameRulesInSameOrder_ProducesTheSameIdentity()
@@ -52,10 +65,38 @@ public sealed class MailRuleSetRevisionTests
         string[] accounts)
     {
         // Act
-        var changed = MailRuleSetRevision.Create([new MailRuleDeclaration(name, conditionText, stopWhenMatched, accounts)]);
+        var changed = MailRuleSetRevision.Create(
+            [new MailRuleDeclaration(name, conditionText, FileInvoices.Actions, stopWhenMatched, accounts)]);
 
         // Assert
         Assert.NotEqual(MailRuleSetRevision.Create([FileInvoices]), changed);
+    }
+
+    /// <summary>A request's identity carries the revision, so an edited action has to ask afresh rather than be answered by the old record.</summary>
+    [Theory]
+    [MemberData(nameof(ActionEdits))]
+    public void Create_AnEditToWhatARuleDoes_ProducesADifferentIdentity(string scenario, MailRuleAction[] actions)
+    {
+        // Act
+        var edited = MailRuleSetRevision.Create([FileInvoices with { Actions = actions }]);
+
+        // Assert
+        Assert.NotEqual(MailRuleSetRevision.Create([FileInvoices with { Actions = [FileIntoArchive] }]), edited);
+        Assert.False(string.IsNullOrWhiteSpace(scenario));
+    }
+
+    /// <summary>The actions inside one rule are separated too, so two action sets cannot render as the same text.</summary>
+    [Fact]
+    public void Create_ActionsWhoseNamesRunTogether_StayDistinct()
+    {
+        // Act
+        var twoActions = MailRuleSetRevision.Create(
+            [FileInvoices with { Actions = [MailRuleAction.SetSeen(isSeen: true), FileIntoArchive] }]);
+        var oneAction = MailRuleSetRevision.Create(
+            [FileInvoices with { Actions = [MailRuleAction.Relocate(MailFolderAlias.Create("set-seen=truerelocate=archive"))] }]);
+
+        // Assert
+        Assert.NotEqual(twoActions, oneAction);
     }
 
     /// <summary>No separator a rule could contain, so two different sets cannot render as one.</summary>
@@ -65,13 +106,13 @@ public sealed class MailRuleSetRevisionTests
         // Act
         var first = MailRuleSetRevision.Create(
         [
-            new MailRuleDeclaration("a", "isSeen", StopWhenMatched: false, Accounts: []),
-            new MailRuleDeclaration("b", "isDraft", StopWhenMatched: false, Accounts: []),
+            new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: []),
+            new MailRuleDeclaration("b", "isDraft", Actions: [], StopWhenMatched: false, Accounts: []),
         ]);
         var second = MailRuleSetRevision.Create(
         [
-            new MailRuleDeclaration("a", "isSeen", StopWhenMatched: false, Accounts: []),
-            new MailRuleDeclaration("bisDraft", "continue", StopWhenMatched: false, Accounts: []),
+            new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: []),
+            new MailRuleDeclaration("bisDraft", "continue", Actions: [], StopWhenMatched: false, Accounts: []),
         ]);
 
         // Assert
@@ -84,9 +125,9 @@ public sealed class MailRuleSetRevisionTests
     {
         // Act
         var twoAccounts = MailRuleSetRevision.Create(
-            [new MailRuleDeclaration("a", "isSeen", StopWhenMatched: false, Accounts: ["primary", "work"])]);
+            [new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: ["primary", "work"])]);
         var oneAccount = MailRuleSetRevision.Create(
-            [new MailRuleDeclaration("a", "isSeen", StopWhenMatched: false, Accounts: ["primarywork"])]);
+            [new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: ["primarywork"])]);
 
         // Assert
         Assert.NotEqual(twoAccounts, oneAccount);

--- a/tests/Application.UnitTests/Rules/MailRuleSetTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleSetTests.cs
@@ -13,7 +13,7 @@ namespace MailFathom.Application.UnitTests.Rules;
 public sealed class MailRuleSetTests
 {
     private static readonly MailRuleSetRevision Revision =
-        MailRuleSetRevision.Create([new MailRuleDeclaration("rule", "isSeen", StopWhenMatched: false, Accounts: [])]);
+        MailRuleSetRevision.Create([new MailRuleDeclaration("rule", "isSeen", Actions: [], StopWhenMatched: false, Accounts: [])]);
 
     [Fact]
     public void Create_Rules_KeepsThemInTheOrderTheyWereDeclared()

--- a/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -2023,7 +2023,7 @@ public sealed class MailboxSynchronizerTests
             Request = MailboxMutationRequest.Relocate(
                 relocatedEmailId,
                 EmailOccurrenceId.Create(accountId, sourceBinding, ImapUidValidity.Create(3), ImapUid.Create(41)),
-                MailboxMutationRequester.Rule("file-newsletters", 1),
+                MailboxMutationRequester.Rule("file-newsletters", "1"),
                 InboxFolder.RemotePath),
             Stage = MailboxMutationStage.Completed,
             IsAudited = false,

--- a/tests/Application.UnitTests/Synchronization/Reconciliation/MailboxReconcilerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/Reconciliation/MailboxReconcilerTests.cs
@@ -1145,7 +1145,7 @@ public sealed class MailboxReconcilerTests
         AuthoredDeleteEmailDisposition? relocationDisposition = null)
     {
         var occurrence = EmailOccurrenceId.Create(Account, InboxFolder.Id, SelectedUidValidity, ImapUid.Create(uid));
-        var requester = MailboxMutationRequester.Rule("file-newsletters", 1);
+        var requester = MailboxMutationRequester.Rule("file-newsletters", "1");
         var opened = recordedAt ?? RunInstant;
 
         return new MailboxMutationRecord
@@ -1193,7 +1193,7 @@ public sealed class MailboxReconcilerTests
             Request = MailboxMutationRequest.SetSeen(
                 storedEmailId,
                 occurrence,
-                MailboxMutationRequester.Rule("mark-newsletters-read", 1),
+                MailboxMutationRequester.Rule("mark-newsletters-read", "1"),
                 isSeen),
             Stage = stage,
             IsAudited = false,

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailFolderResolutionStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailFolderResolutionStore.cs
@@ -1,0 +1,66 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Application.UnitTests.TestDoubles;
+
+/// <summary>Holds the alias bindings an account has, so a test can arrange a destination that resolves and one that does not.</summary>
+/// <remarks>
+/// Only the newest binding of an alias is kept, which is what <see cref="IMailFolderResolutionStore" /> answers with.
+/// The read is counted, because a caller that remembers a binding for the length of a pass is making a claim about how
+/// often it asks.
+/// </remarks>
+internal sealed class InMemoryMailFolderResolutionStore : IMailFolderResolutionStore
+{
+    private readonly Dictionary<(string AccountId, MailFolderAlias Alias), MailFolderResolution> bindings = [];
+
+    /// <summary>Gets how many times a binding was looked up, whether or not one was found.</summary>
+    internal int ResolutionReadCount { get; private set; }
+
+    /// <summary>Binds one alias to the remote folder it names, as discovery would have.</summary>
+    /// <param name="accountId">The account the binding belongs to.</param>
+    /// <param name="alias">The alias being bound.</param>
+    /// <param name="remotePath">The remote folder it names, which defaults to the alias itself.</param>
+    /// <returns>The binding, so a test can name the path it arranged.</returns>
+    internal MailFolderResolution Bind(MailAccountId accountId, MailFolderAlias alias, string? remotePath = null)
+    {
+        var resolution = MailFolderResolution.FirstBindingOf(
+            alias,
+            RemoteFolderPath.Create(remotePath ?? alias.Value));
+
+        this.bindings[(accountId.Value, alias)] = resolution;
+
+        return resolution;
+    }
+
+    /// <inheritdoc />
+    public Task<MailFolderResolution?> GetCurrentResolutionAsync(
+        MailAccountId accountId,
+        MailFolderAlias folderAlias,
+        CancellationToken cancellationToken)
+    {
+        this.ResolutionReadCount++;
+
+        return Task.FromResult(
+            this.bindings.TryGetValue((accountId.Value, folderAlias), out var resolution) ? resolution : null);
+    }
+
+    /// <inheritdoc />
+    public Task SaveResolutionAsync(
+        IPersistenceSession session,
+        MailAccountId accountId,
+        MailFolderResolution resolution,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(resolution);
+
+        this.bindings[(accountId.Value, resolution.Alias)] = resolution;
+
+        return Task.CompletedTask;
+    }
+}

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailRuleEvaluationStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailRuleEvaluationStore.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Rules.Facts;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
 
 namespace MailFathom.Application.UnitTests.TestDoubles;
 
@@ -43,6 +44,13 @@ internal sealed class InMemoryMailRuleEvaluationStore : IMailRuleEvaluationStore
         var row = new StoredRow
         {
             Id = StoredEmailId.Create(Guid.CreateVersion7()),
+            Occurrence = EmailOccurrenceId.Create(
+                MailAccountId.Create(facts.Account),
+                new MailFolderResolutionId(
+                    MailFolderAlias.Create(facts.Folder),
+                    MailFolderResolutionGeneration.First),
+                ImapUidValidity.Create(1),
+                ImapUid.Create((uint)this.rows.Count + 1)),
             Facts = facts,
             AwaitsExtraction = awaitsExtraction,
             BodyText = bodyText,
@@ -128,13 +136,19 @@ internal sealed class InMemoryMailRuleEvaluationStore : IMailRuleEvaluationStore
                 .Skip(startIndex)
                 .Where(row => row.Facts.Account == accountId.Value && admits(row))
                 .Take(batchSize)
-                .Select(row => new StoredEmailAwaitingRuleEvaluation(row.Id, row.Facts, row.AwaitsExtraction)),
+                .Select(row => new StoredEmailAwaitingRuleEvaluation(
+                    row.Id,
+                    row.Occurrence,
+                    row.Facts,
+                    row.AwaitsExtraction)),
         ];
     }
 
     private sealed class StoredRow
     {
         internal required StoredEmailId Id { get; init; }
+
+        internal required EmailOccurrenceId Occurrence { get; init; }
 
         internal required MailRuleEmailFacts Facts { get; set; }
 

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationRecordStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationRecordStore.cs
@@ -28,6 +28,14 @@ internal sealed class InMemoryMailboxMutationRecordStore : IMailboxMutationRecor
     /// <summary>Gets how many requests were written down, which is one per idempotency identity however often it was asked.</summary>
     internal int OpenedRecordCount => this.recordsById.Count;
 
+    /// <summary>Gets the requests written down, in the order they were opened.</summary>
+    /// <remarks>
+    /// The order matters to a caller that asks for several changes to one email, because the order they are asked for
+    /// in is the order MailFathom applies them.
+    /// </remarks>
+    internal IReadOnlyList<MailboxMutationRequest> OpenedRequests =>
+        [.. this.recordsById.Values.OrderBy(record => record.RecordedAt).Select(record => record.Request)];
+
     /// <summary>Gets or sets what the account's audit trail setting resolves to when a record is opened.</summary>
     /// <remarks>
     /// It is a property of the store because that is where the real one resolves it: the answer is written onto the row

--- a/tests/Domain.UnitTests/Mutations/Audit/MailboxMutationAuditEntryTests.cs
+++ b/tests/Domain.UnitTests/Mutations/Audit/MailboxMutationAuditEntryTests.cs
@@ -25,7 +25,7 @@ public sealed class MailboxMutationAuditEntryTests
 
     private static readonly StoredEmailId LocalEmail = StoredEmailId.Create(Guid.CreateVersion7(RecordedAt));
 
-    private static readonly MailboxMutationRequester Requester = MailboxMutationRequester.Rule("file-newsletters", 3);
+    private static readonly MailboxMutationRequester Requester = MailboxMutationRequester.Rule("file-newsletters", "3");
 
     private static readonly MailFolderResolution SourceFolder = MailFolderResolution.FirstBindingOf(
         MailFolderAlias.Create("inbox"),

--- a/tests/Domain.UnitTests/Mutations/MailboxMutationRecordTests.cs
+++ b/tests/Domain.UnitTests/Mutations/MailboxMutationRecordTests.cs
@@ -21,7 +21,7 @@ public sealed class MailboxMutationRecordTests
 
     private static readonly StoredEmailId LocalEmail = StoredEmailId.Create(Guid.CreateVersion7(RecordedAt));
 
-    private static readonly MailboxMutationRequester Requester = MailboxMutationRequester.Rule("file-newsletters", 3);
+    private static readonly MailboxMutationRequester Requester = MailboxMutationRequester.Rule("file-newsletters", "3");
 
     private static readonly ImapUidValidity DestinationUidValidity = ImapUidValidity.Create(9001);
 

--- a/tests/Domain.UnitTests/Mutations/MailboxMutationRequestTests.cs
+++ b/tests/Domain.UnitTests/Mutations/MailboxMutationRequestTests.cs
@@ -17,7 +17,7 @@ public sealed class MailboxMutationRequestTests
     private static readonly StoredEmailId LocalEmail = StoredEmailId.Create(Guid.CreateVersion7());
 
     private static readonly MailboxMutationRequester Requester =
-        MailboxMutationRequester.Rule("file-newsletters", 3);
+        MailboxMutationRequester.Rule("file-newsletters", "3");
 
     /// <summary>The parameter names a wrongly shaped request can be refused against, whichever is checked first.</summary>
     private static readonly string[] RejectedParameterNames =

--- a/tests/Domain.UnitTests/Mutations/MailboxMutationRequesterTests.cs
+++ b/tests/Domain.UnitTests/Mutations/MailboxMutationRequesterTests.cs
@@ -14,14 +14,14 @@ public sealed class MailboxMutationRequesterTests
     public void Rule_TwoRevisionsOfOneRule_AreDifferentRequesters()
     {
         // Arrange
-        var third = MailboxMutationRequester.Rule("file-newsletters", 3);
+        var third = MailboxMutationRequester.Rule("file-newsletters", "3");
 
         // Act
-        var fourth = MailboxMutationRequester.Rule("file-newsletters", 4);
+        var fourth = MailboxMutationRequester.Rule("file-newsletters", "4");
 
         // Assert
         Assert.NotEqual(third, fourth);
-        Assert.Equal(MailboxMutationRequester.Rule("file-newsletters", 3), third);
+        Assert.Equal(MailboxMutationRequester.Rule("file-newsletters", "3"), third);
     }
 
     /// <summary>Two requesters that differ only in kind are different, so an invocation named like a rule is never the same request.</summary>
@@ -63,16 +63,26 @@ public sealed class MailboxMutationRequesterTests
         Assert.Equal("invocationIdentity", refusal.ParamName);
     }
 
-    [Fact]
-    public void Rule_NegativeRevision_IsRefused() =>
-        Assert.Throws<ArgumentOutOfRangeException>(() => MailboxMutationRequester.Rule("file-newsletters", -1));
+    /// <summary>A revision is what makes an edited rule ask again, so a request naming none could never be told from a repeat.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Rule_RevisionNamingNothing_IsRefused(string revision)
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentException>(
+            () => MailboxMutationRequester.Rule("file-newsletters", revision));
+
+        // Assert
+        Assert.Equal("revision", refusal.ParamName);
+    }
 
     /// <summary>A record hands back what it stored, so restoring has to produce the requester that was written.</summary>
     [Fact]
     public void Create_FromTheStoredOriginAndIdentity_RestoresTheRequesterThatWasWritten()
     {
         // Arrange
-        var original = MailboxMutationRequester.Rule("file-newsletters", 3);
+        var original = MailboxMutationRequester.Rule("file-newsletters", "3");
 
         // Act
         var restored = MailboxMutationRequester.Create(original.Origin, original.Identity);

--- a/tests/Host.UnitTests/Configuration/Mail/MailSynchronizationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailSynchronizationOptionsTests.cs
@@ -433,6 +433,23 @@ public sealed class MailSynchronizationOptionsTests
             && message.Contains("answering audit trail configuration must be a block", StringComparison.Ordinal));
     }
 
+    /// <summary>A missing block would read as an account permitting nothing, which refuses rules while naming the wrong cause.</summary>
+    [Fact]
+    public void ValidateForSynchronization_AccountWithNoRuleActionBlock_ReportsIt()
+    {
+        // Arrange
+        var account = CreateAccount("primary");
+        account.RuleActions = null!;
+        var options = new MailSynchronizationOptions { Enabled = true, Accounts = [account] };
+
+        // Act
+        var messages = options.ValidateForSynchronization().Select(result => result.ErrorMessage).ToArray();
+
+        // Assert
+        Assert.Contains(messages, message => message!.Contains("Account 'primary'", StringComparison.Ordinal)
+            && message.Contains("rule action permissions must be a block", StringComparison.Ordinal));
+    }
+
     /// <summary>Off by default and separate from the mutation trail, which is what the two blocks together have to mean.</summary>
     [Fact]
     public void GetAnsweringAuditSettings_AnAccountThatTurnedOnlyTheMutationTrailOn_KeepsTheAnsweringRecordOff()

--- a/tests/Host.UnitTests/Configuration/Rules/DeclaredMailAccountsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/DeclaredMailAccountsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Host.Configuration.Mail;
 using MailFathom.Host.Configuration.Rules;
 using Microsoft.Extensions.Configuration;
@@ -9,7 +10,7 @@ using Xunit;
 
 namespace MailFathom.Host.UnitTests.Configuration.Rules;
 
-/// <summary>Covers the two readings of one question: which accounts a rule's scope is allowed to name.</summary>
+/// <summary>Covers the two readings of one question: what a rule set is allowed to name and to ask for.</summary>
 /// <remarks>
 /// Composition reads keys and a reload reads a bound snapshot, so the two have to agree. A rule set startup accepted and
 /// the first reload refused would be the failure, and it would arrive on an edit that changed nothing about the rules.
@@ -20,19 +21,17 @@ public sealed class DeclaredMailAccountsTests
     public void ReadFrom_Configuration_NamesEveryDeclaredAccountInDeclaredOrder()
     {
         // Arrange
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["MailSynchronization:Accounts:0:AccountId"] = "primary",
-                ["MailSynchronization:Accounts:1:AccountId"] = "work",
-            })
-            .Build();
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["MailSynchronization:Accounts:0:AccountId"] = "primary",
+            ["MailSynchronization:Accounts:1:AccountId"] = "work",
+        });
 
         // Act
         var accounts = DeclaredMailAccounts.ReadFrom(configuration);
 
         // Assert
-        Assert.Equal(["primary", "work"], accounts);
+        Assert.Equal(["primary", "work"], Identifiers(accounts));
     }
 
     /// <summary>A blank identifier is the synchronization section's own defect, so it is dropped rather than reported here.</summary>
@@ -40,19 +39,17 @@ public sealed class DeclaredMailAccountsTests
     public void ReadFrom_ConfigurationWithABlankIdentifier_LeavesItOut()
     {
         // Arrange
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["MailSynchronization:Accounts:0:AccountId"] = "  primary  ",
-                ["MailSynchronization:Accounts:1:AccountId"] = "   ",
-            })
-            .Build();
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["MailSynchronization:Accounts:0:AccountId"] = "  primary  ",
+            ["MailSynchronization:Accounts:1:AccountId"] = "   ",
+        });
 
         // Act
         var accounts = DeclaredMailAccounts.ReadFrom(configuration);
 
         // Assert
-        Assert.Equal(["primary"], accounts);
+        Assert.Equal(["primary"], Identifiers(accounts));
     }
 
     [Fact]
@@ -68,23 +65,111 @@ public sealed class DeclaredMailAccountsTests
         Assert.Empty(accounts);
     }
 
+    /// <summary>An account that configures no folder is run with the inbox mapping, so that is the folder a rule may file into.</summary>
+    [Fact]
+    public void ReadFrom_AccountDeclaringNoFolder_MirrorsTheInbox()
+    {
+        // Arrange
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["MailSynchronization:Accounts:0:AccountId"] = "primary",
+        });
+
+        // Act
+        var account = Assert.Single(DeclaredMailAccounts.ReadFrom(configuration));
+
+        // Assert
+        Assert.Equal(["INBOX"], account.MirroredFolderAliases.Select(alias => alias.Value));
+    }
+
+    /// <summary>Nothing binds an unmirrored folder to a remote path, so it is not a folder a rule can file into.</summary>
+    [Fact]
+    public void ReadFrom_FolderTheAccountDoesNotMirror_IsNotADestination()
+    {
+        // Arrange
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["MailSynchronization:Accounts:0:AccountId"] = "primary",
+            ["MailSynchronization:Accounts:0:Folders:0:Alias"] = "inbox",
+            ["MailSynchronization:Accounts:0:Folders:0:SpecialUse"] = "Inbox",
+            ["MailSynchronization:Accounts:0:Folders:1:Alias"] = "spam",
+            ["MailSynchronization:Accounts:0:Folders:1:SpecialUse"] = "Junk",
+            ["MailSynchronization:Accounts:0:Folders:1:Synchronize"] = "false",
+        });
+
+        // Act
+        var account = Assert.Single(DeclaredMailAccounts.ReadFrom(configuration));
+
+        // Assert
+        Assert.Equal(["INBOX"], account.MirroredFolderAliases.Select(alias => alias.Value));
+    }
+
+    /// <summary>Deletion is opt-in on every account, and the three reversible actions are permitted until refused.</summary>
+    [Fact]
+    public void ReadFrom_AccountDeclaringNoRuleActions_PermitsEverythingButDeletion()
+    {
+        // Arrange
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["MailSynchronization:Accounts:0:AccountId"] = "primary",
+        });
+
+        // Act
+        var account = Assert.Single(DeclaredMailAccounts.ReadFrom(configuration));
+
+        // Assert
+        Assert.Equal(MailRuleActionPermissions.Default, account.PermittedRuleActions);
+    }
+
+    [Fact]
+    public void ReadFrom_AccountNarrowingWhatRulesMayDo_ReadsEverySwitch()
+    {
+        // Arrange
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["MailSynchronization:Accounts:0:AccountId"] = "primary",
+            ["MailSynchronization:Accounts:0:RuleActions:Move"] = "false",
+            ["MailSynchronization:Accounts:0:RuleActions:Copy"] = "false",
+            ["MailSynchronization:Accounts:0:RuleActions:Delete"] = "true",
+            ["MailSynchronization:Accounts:0:RuleActions:MarkAsRead"] = "false",
+        });
+
+        // Act
+        var account = Assert.Single(DeclaredMailAccounts.ReadFrom(configuration));
+
+        // Assert
+        Assert.Equal(
+            new MailRuleActionPermissions(
+                PermitsRelocate: false,
+                PermitsCopy: false,
+                PermitsDelete: true,
+                PermitsSetSeen: false),
+            account.PermittedRuleActions);
+    }
+
     /// <summary>The bound reading is the one a reload uses, and it has to answer exactly as the key reading does.</summary>
     [Fact]
     public void ReadFrom_BoundSettings_AnswersAsTheConfigurationReadingDoes()
     {
         // Arrange
-        var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["MailSynchronization:Accounts:0:AccountId"] = "  primary  ",
-                ["MailSynchronization:Accounts:1:AccountId"] = "work",
-            })
-            .Build();
+        var configuration = Configuration(new Dictionary<string, string?>
+        {
+            ["MailSynchronization:Accounts:0:AccountId"] = "  primary  ",
+            ["MailSynchronization:Accounts:0:Folders:0:Alias"] = "archive",
+            ["MailSynchronization:Accounts:0:Folders:0:RemotePath"] = "Archive",
+            ["MailSynchronization:Accounts:0:RuleActions:Delete"] = "true",
+            ["MailSynchronization:Accounts:1:AccountId"] = "work",
+        });
         var settings = new MailSynchronizationOptions
         {
             Accounts =
             [
-                new MailSynchronizationAccountOptions { AccountId = "  primary  " },
+                new MailSynchronizationAccountOptions
+                {
+                    AccountId = "  primary  ",
+                    Folders = [new MailFolderMappingOptions { Alias = "archive", RemotePath = "Archive" }],
+                    RuleActions = new MailRuleActionPermissionOptions { Delete = true },
+                },
                 new MailSynchronizationAccountOptions { AccountId = "work" },
             ],
         };
@@ -94,7 +179,20 @@ public sealed class DeclaredMailAccountsTests
         var fromSettings = DeclaredMailAccounts.ReadFrom(settings);
 
         // Assert
-        Assert.Equal(fromConfiguration, fromSettings);
-        Assert.Equal(["primary", "work"], fromSettings);
+        Assert.Equal(Describe(fromConfiguration), Describe(fromSettings));
+        Assert.Equal(["primary", "work"], Identifiers(fromSettings));
     }
+
+    private static IConfiguration Configuration(Dictionary<string, string?> keys) =>
+        new ConfigurationBuilder().AddInMemoryCollection(keys).Build();
+
+    private static IReadOnlyList<string> Identifiers(IEnumerable<DeclaredMailAccount> accounts) =>
+        [.. accounts.Select(account => account.AccountId)];
+
+    /// <summary>Renders each account as text, because the read model holds collections that compare by reference.</summary>
+    private static IReadOnlyList<string> Describe(IEnumerable<DeclaredMailAccount> accounts) =>
+    [
+        .. accounts.Select(account =>
+            $"{account.AccountId}|{string.Join(',', account.MirroredFolderAliases.Select(alias => alias.Value))}|{account.PermittedRuleActions}"),
+    ];
 }

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleDeclarationRulesTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleDeclarationRulesTests.cs
@@ -3,6 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Globalization;
+using MailFathom.Application.Rules.Actions;
+using MailFathom.Domain.Folders;
 using MailFathom.Host.Configuration.Rules;
 using MailFathom.Infrastructure.Rules;
 using Xunit;
@@ -16,8 +18,13 @@ public sealed class MailRuleDeclarationRulesTests
     private const char FieldSeparator = '\u001F';
     private const char AccountSeparator = '\u001D';
 
-    /// <summary>The accounts the deployment declares, which is what a rule's scope is judged against.</summary>
-    private static readonly string[] DeclaredAccounts = ["primary", "work"];
+    /// <summary>The accounts the deployment declares, which is what a rule's scope, destinations, and actions are judged against.</summary>
+    /// <remarks>Both mirror an archive folder and neither permits deletion, which is what an account says by saying nothing.</remarks>
+    private static readonly DeclaredMailAccount[] DeclaredAccounts =
+    [
+        DeclaredAccount("primary"),
+        DeclaredAccount("work"),
+    ];
 
     private readonly NCalcMailRuleConditionCompiler compiler = new();
 
@@ -391,16 +398,222 @@ public sealed class MailRuleDeclarationRulesTests
         Assert.Empty(generalErrors);
     }
 
+    /// <summary>The ordinary combinations are what an owner writes most, so accepting them is worth asserting outright.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ARuleFilingMailAndMarkingItRead_ReportsNothing()
+    {
+        // Arrange
+        var candidate = new MailRulesOptions
+        {
+            Rules =
+            [
+                CreateRule(
+                    "file-invoices",
+                    "isSeen",
+                    actions: new MailRuleActionOptions { MoveTo = "archive", MarkAsRead = true }),
+            ],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>A combination naming two fates for one occurrence is refused where it is written, not resolved at run time.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ARuleFilingAndDeletingOneEmail_IsRefusedNamingTheRule()
+    {
+        // Arrange
+        var permitting = DeclaredAccount("primary", MailRuleActionPermissions.Default with { PermitsDelete = true });
+        var candidate = new MailRulesOptions
+        {
+            Rules =
+            [
+                CreateRule(
+                    "file-invoices",
+                    "isSeen",
+                    accounts: ["primary"],
+                    actions: new MailRuleActionOptions { MoveTo = "archive", Delete = true }),
+            ],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, [permitting]);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.Contains("MailRules:Rules:0:Actions", error, StringComparison.Ordinal);
+        Assert.Contains("file-invoices", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>Deletion is opt-in, so a rule declaring it over an account that permits none is refused rather than skipped.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ARuleDeletingMailOnAnAccountThatRefusesDeletion_IsRefused()
+    {
+        // Arrange
+        var candidate = new MailRulesOptions
+        {
+            Rules = [CreateRule("drop-notifications", "isSeen", actions: new MailRuleActionOptions { Delete = true })],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        Assert.Equal(2, errors.Count);
+        Assert.All(errors, error => Assert.Contains("does not permit", error, StringComparison.Ordinal));
+    }
+
+    /// <summary>An account that permits the action accepts the same rule, which is what makes the refusal a decision rather than a ban.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ARuleDeletingMailOnAnAccountThatPermitsIt_ReportsNothing()
+    {
+        // Arrange
+        var permitting = DeclaredAccount(
+            "primary",
+            MailRuleActionPermissions.Default with { PermitsDelete = true });
+        var candidate = new MailRulesOptions
+        {
+            Rules =
+            [
+                CreateRule(
+                    "drop-notifications",
+                    "isSeen",
+                    accounts: ["primary"],
+                    actions: new MailRuleActionOptions { Delete = true }),
+            ],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, [permitting]);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>Nothing binds an unmirrored folder to a remote path, so a rule filing into one could never resolve a destination.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ARuleFilingIntoAFolderTheAccountDoesNotMirror_IsRefused()
+    {
+        // Arrange
+        var candidate = new MailRulesOptions
+        {
+            Rules =
+            [
+                CreateRule(
+                    "file-invoices",
+                    "isSeen",
+                    accounts: ["primary"],
+                    actions: new MailRuleActionOptions { MoveTo = "nowhere" }),
+            ],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.Contains("NOWHERE", error, StringComparison.Ordinal);
+        Assert.Contains("primary", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>An unscoped rule reaches every account, so a destination one of them does not mirror is refused for that one.</summary>
+    [Fact]
+    public void FindDeclarationErrors_AnUnscopedRuleFilingIntoAFolderOneAccountLacks_IsRefusedForThatAccount()
+    {
+        // Arrange
+        var accounts = new[] { DeclaredAccount("primary"), NoFolderAccount("work") };
+        var candidate = new MailRulesOptions
+        {
+            Rules = [CreateRule("file-invoices", "isSeen", actions: new MailRuleActionOptions { MoveTo = "archive" })],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, accounts);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.Contains("work", error, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FindDeclarationErrors_ADestinationNamedByNothing_IsRefused(string destination)
+    {
+        // Arrange
+        var candidate = new MailRulesOptions
+        {
+            Rules =
+            [
+                CreateRule("file-invoices", "isSeen", actions: new MailRuleActionOptions { MoveTo = destination }),
+            ],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        Assert.Contains(
+            errors,
+            error => error.Contains("MailRules:Rules:0:Actions", StringComparison.Ordinal));
+    }
+
+    /// <summary>The identity is a digest over the declarations, so a destination carrying a separator could blur two rule sets into one.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ADestinationCarryingADigestSeparator_IsRefused()
+    {
+        // Arrange
+        var candidate = new MailRulesOptions
+        {
+            Rules =
+            [
+                CreateRule(
+                    "file-invoices",
+                    "isSeen",
+                    actions: new MailRuleActionOptions
+                    {
+                        MoveTo = string.Create(CultureInfo.InvariantCulture, $"arch{FieldSeparator}ive"),
+                    }),
+            ],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        Assert.Contains(
+            errors,
+            error => error.Contains("MailRules:Rules:0:Actions", StringComparison.Ordinal));
+    }
+
     private static MailRuleOptions CreateRule(
         string name,
         string conditionText,
         bool enabled = true,
-        string[]? accounts = null) =>
+        string[]? accounts = null,
+        MailRuleActionOptions? actions = null) =>
         new()
         {
             Name = name,
             Condition = conditionText,
             Enabled = enabled,
             Accounts = accounts ?? [],
+            Actions = actions ?? new MailRuleActionOptions(),
         };
+
+    /// <summary>One declared account, mirroring an archive folder and permitting whatever the caller says it does.</summary>
+    private static DeclaredMailAccount DeclaredAccount(
+        string accountId,
+        MailRuleActionPermissions? permissions = null) =>
+        new(
+            accountId,
+            [MailFolderAlias.Create("archive")],
+            permissions ?? MailRuleActionPermissions.Default);
+
+    /// <summary>One declared account mirroring nothing a rule could file into.</summary>
+    private static DeclaredMailAccount NoFolderAccount(string accountId) =>
+        new(accountId, [], MailRuleActionPermissions.Default);
 }

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleSetMappingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleSetMappingTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.Host.Configuration.Rules;
 using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.Infrastructure.Rules;
@@ -219,12 +221,76 @@ public sealed class MailRuleSetMappingTests
         Assert.NotEqual(beforeScoping.Revision, afterScoping.Revision);
     }
 
+    /// <summary>The declared keys become the actions the pass asks for, in the order MailFathom applies them.</summary>
+    [Fact]
+    public void Map_DeclaredActions_ReachTheRuleInTheOrderTheyAreApplied()
+    {
+        // Arrange
+        var settings = new MailRulesOptions
+        {
+            Rules =
+            [
+                CreateRule(
+                    "file-invoices",
+                    "isSeen",
+                    actions: new MailRuleActionOptions { MoveTo = "archive", MarkAsRead = true }),
+            ],
+        };
+
+        // Act
+        var ruleSet = MailRuleSetMapper.Map(settings, this.compiler);
+
+        // Assert
+        var actions = ruleSet.Rules[0].Actions.Actions;
+        Assert.Equal(
+            [MailboxMutation.SetSeen, MailboxMutation.Relocate],
+            actions.Select(action => action.Mutation));
+        Assert.Equal(MailFolderAlias.Create("archive"), actions[1].DestinationAlias);
+        Assert.True(actions[0].DesiredSeenState);
+    }
+
+    [Fact]
+    public void Map_ARuleDeclaringNoAction_SelectsMailAndChangesNothing()
+    {
+        // Arrange
+        var settings = new MailRulesOptions { Rules = [CreateRule("select-only", "isSeen")] };
+
+        // Act
+        var ruleSet = MailRuleSetMapper.Map(settings, this.compiler);
+
+        // Assert
+        Assert.True(ruleSet.Rules[0].Actions.IsEmpty);
+    }
+
+    /// <summary>A request's identity carries the revision, so an edited action asks afresh rather than reusing the old record.</summary>
+    [Fact]
+    public void Map_EditingWhatARuleDoes_MovesTheRevision()
+    {
+        // Arrange
+        var filing = new MailRulesOptions
+        {
+            Rules = [CreateRule("running", "isDraft", actions: new MailRuleActionOptions { MoveTo = "archive" })],
+        };
+        var copying = new MailRulesOptions
+        {
+            Rules = [CreateRule("running", "isDraft", actions: new MailRuleActionOptions { CopyTo = "archive" })],
+        };
+
+        // Act
+        var beforeEdit = MailRuleSetMapper.Map(filing, this.compiler);
+        var afterEdit = MailRuleSetMapper.Map(copying, this.compiler);
+
+        // Assert
+        Assert.NotEqual(beforeEdit.Revision, afterEdit.Revision);
+    }
+
     private static MailRuleOptions CreateRule(
         string name,
         string conditionText,
         bool stopWhenMatched = false,
         bool enabled = true,
-        string[]? accounts = null) =>
+        string[]? accounts = null,
+        MailRuleActionOptions? actions = null) =>
         new()
         {
             Name = name,
@@ -232,5 +298,6 @@ public sealed class MailRuleSetMappingTests
             StopWhenMatched = stopWhenMatched,
             Enabled = enabled,
             Accounts = accounts ?? [],
+            Actions = actions ?? new MailRuleActionOptions(),
         };
 }

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -13,6 +13,7 @@ using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Rules.Conditions;
 using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Synchronization;
@@ -159,6 +160,11 @@ internal static class SynchronizationTestHost
         services.AddSingleton(CreateSourceOfAnEmptyRuleSet());
         services.AddSingleton(new MailRuleSetEvaluator(timeProvider));
         services.AddScoped(_ => new MailRuleEvaluationOptions());
+        services.AddScoped<IAuthoredDeleteEmailDispositionReader>(
+            provider => provider.GetRequiredService<MailSynchronizationOptions>());
+        services.AddScoped<IMailRuleActionPermissionReader>(
+            provider => provider.GetRequiredService<MailSynchronizationOptions>());
+        services.AddScoped<MailRuleActionRecorder>();
         services.AddScoped<MailRuleEvaluationPass>();
         services.AddLogging();
 

--- a/tests/Infrastructure.UnitTests/Persistence/Mutations/MailboxMutationAuditTrailTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Mutations/MailboxMutationAuditTrailTests.cs
@@ -176,7 +176,7 @@ public sealed class MailboxMutationAuditTrailTests : IDisposable
             Request = MailboxMutationRequest.Relocate(
                 StoredEmailId.Create(Guid.CreateVersion7(RecordedAt)),
                 occurrence,
-                MailboxMutationRequester.Rule("file-newsletters", 3),
+                MailboxMutationRequester.Rule("file-newsletters", "3"),
                 ArchivePath),
             Stage = MailboxMutationStage.Completed,
             IsAudited = true,

--- a/tests/IntegrationTests/Synchronization/OrchestratedAuthoredDeleteTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedAuthoredDeleteTests.cs
@@ -49,7 +49,7 @@ public sealed class OrchestratedAuthoredDeleteTests(MailFathomOrchestrationFixtu
         RemoteFolderPath.Create(FolderName, hierarchyDelimiter: '.'));
 
     private static readonly MailboxMutationRequester Requester =
-        MailboxMutationRequester.Rule("free-the-server", 1);
+        MailboxMutationRequester.Rule("free-the-server", "1");
 
     /// <summary>Each disposition decides one local copy, and the account's remote-deletion setting decides none of them.</summary>
     [Fact]

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxConvergenceTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxConvergenceTests.cs
@@ -69,7 +69,7 @@ public sealed class OrchestratedMailboxConvergenceTests(MailFathomOrchestrationF
         RemoteFolderPath.Create(CopyFolderName, hierarchyDelimiter: '.');
 
     private static readonly MailboxMutationRequester Requester =
-        MailboxMutationRequester.Rule("converge-to-archive", 1);
+        MailboxMutationRequester.Rule("converge-to-archive", "1");
 
     /// <summary>
     /// The restart case the whole design exists for. A process stopped between the copy and the expunge left the

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationAuditTrailTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationAuditTrailTests.cs
@@ -50,7 +50,7 @@ public sealed class OrchestratedMailboxMutationAuditTrailTests(MailFathomOrchest
         RemoteFolderPath.Create(ArchiveFolderName, hierarchyDelimiter: '.');
 
     private static readonly MailboxMutationRequester Requester =
-        MailboxMutationRequester.Rule("keep-an-audit-trail", 1);
+        MailboxMutationRequester.Rule("keep-an-audit-trail", "1");
 
     /// <summary>
     /// Every change MailFathom is permitted to make leaves exactly one entry on an account that asked for a trail, and

--- a/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationRecordTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMailboxMutationRecordTests.cs
@@ -55,7 +55,7 @@ public sealed class OrchestratedMailboxMutationRecordTests(MailFathomOrchestrati
         RemoteFolderPath.Create(ArchiveFolderName, hierarchyDelimiter: '.');
 
     private static readonly MailboxMutationRequester Requester =
-        MailboxMutationRequester.Rule("file-to-archive", 1);
+        MailboxMutationRequester.Rule("file-to-archive", "1");
 
     /// <summary>
     /// A relocation whose process stopped after the copy landed and before the source was removed. The message is in

--- a/tests/IntegrationTests/Synchronization/OrchestratedMutationReconciliationReadTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedMutationReconciliationReadTests.cs
@@ -55,7 +55,7 @@ public sealed class OrchestratedMutationReconciliationReadTests(MailFathomOrches
     private static readonly DateTimeOffset ObservedAt = new(2026, 5, 4, 9, 0, 0, TimeSpan.Zero);
 
     private static readonly MailboxMutationRequester Requester =
-        MailboxMutationRequester.Rule("reconciliation-read", 1);
+        MailboxMutationRequester.Rule("reconciliation-read", "1");
 
     /// <summary>
     /// The whole convergence loop for a relocation MailFathom performed: the run meeting the new occurrence finds the

--- a/tests/IntegrationTests/Synchronization/OrchestratedRelocationReconciliationTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedRelocationReconciliationTests.cs
@@ -73,7 +73,7 @@ public sealed class OrchestratedRelocationReconciliationTests(MailFathomOrchestr
         RemoteFolderPath.Create(TargetFolderName, hierarchyDelimiter: '.');
 
     private static readonly MailboxMutationRequester Requester =
-        MailboxMutationRequester.Rule("file-to-relocation-target", 1);
+        MailboxMutationRequester.Rule("file-to-relocation-target", "1");
 
     /// <summary>The message arrives in its new folder as an ordinary discovery, and is the email that was already stored.</summary>
     [Fact]

--- a/tests/IntegrationTests/Synchronization/OrchestratedSeenStateProvenanceTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedSeenStateProvenanceTests.cs
@@ -48,7 +48,7 @@ public sealed class OrchestratedSeenStateProvenanceTests(MailFathomOrchestration
         RemoteFolderPath.Create(FolderName, hierarchyDelimiter: '.'));
 
     private static readonly MailboxMutationRequester MarkingRule =
-        MailboxMutationRequester.Rule("mark-newsletters-read", 1);
+        MailboxMutationRequester.Rule("mark-newsletters-read", "1");
 
     /// <summary>
     /// A second rule, because the idempotency identity is the occurrence, the mutation, and who asked, and a
@@ -58,7 +58,7 @@ public sealed class OrchestratedSeenStateProvenanceTests(MailFathomOrchestration
     /// answer rather than the clearing this class is about.
     /// </summary>
     private static readonly MailboxMutationRequester SurfacingRule =
-        MailboxMutationRequester.Rule("surface-unpaid-invoices", 1);
+        MailboxMutationRequester.Rule("surface-unpaid-invoices", "1");
 
     /// <summary>Each flag MailFathom moved is withheld from rule evaluation, the owner's is not, and the stored value follows only an observation.</summary>
     [Fact]


### PR DESCRIPTION
A rule declares what a match does in an `Actions` block of named keys — `MoveTo`, `CopyTo`, `Delete`, and `MarkAsRead` — one per mutation `MailboxMutation.All` already holds. One key per action rather than a list of action objects, so a rule declaring the same action twice is unrepresentable rather than merely refused, and no binder can drop a malformed element in silence.

## What a match now leads to

Nothing here issues IMAP. Each action a match asks for is written down as the durable mutation record every requester uses, inside the same transaction that records the evaluation, and the account's convergence pass carries it. So a rule pass still reaches no mail server, a change survives a restart, and the pair is atomic: an email is never recorded as evaluated while the change its rules asked for was lost.

The requester is the rule's name together with the rule set revision, which is what makes asking twice ask once — a whole-mailbox run over mail a rule already acted on issues nothing, while an edited rule set is a new revision and asks afresh. The revision therefore had to become text on `MailboxMutationRequester.Rule`, since a rule set is known by a twelve-character digest rather than by a counter, and the actions joined the digest's input.

## What is refused, and where

A combination naming two fates for one occurrence is refused where it is written, naming the rule and the key: at most one of `MoveTo`, `CopyTo`, and `Delete`, and a deletion admits nothing beside it. What survives is applied in MailFathom's own order rather than the declared one — the flag first, the relocation or the deletion last — so every permitted combination acts on the occurrence the condition matched.

Two rules matching one email are resolved by declared order through that same table, so whichever fate is reached first is applied and the rule behind it is reported as withheld. A destination must be a folder the account mirrors, which is what lets a relocation carry no local disposition.

## What an account permits

Each account states which of the four a rule may ask for under `MailSynchronization:Accounts:<n>:RuleActions`, with deletion opt-in and the three reversible actions opt-out. A rule declaring a refused action fails startup naming the rule, the action, and the account. Because that section reloads independently of the rule section, the permission is read again as each change is written down, so withdrawing one reaches the next pass rather than the next edit of the rules.

## When a change cannot be made

A destination that no longer resolves, an account the configuration has withdrawn, and an action it no longer permits each fail visibly, cost the actions beside them nothing, and write nothing down — filing into whichever folder looked closest to the name is precisely what a stale destination must not do. The account run reports what it asked for, what it withheld, and what failed, in counts and MailFathom's own rule names alone; nothing derived from a message reaches a log line, a metric, or a span.

## Public surfaces

No break. The configuration schema only gains optional keys, and the MCP tool contract, the database schema, and the deployment contract are untouched.

## Verification

- `scripts/verify-full.sh` — passed; 5358 unit tests, 0 failed; aggregate line coverage 95.81% (15461/16137), required 85%.
- `scripts/review-obligations.sh` — every row confirmed in the file it points at.
- `$check-docs-licenses` — docs pass, changelog n/a, licenses n/a (no dependency added, upgraded, or newly called).
- Integration suite not run; it is owner-invoked only.

Closes #456
