### PR TITLE
[#714] Create a mapped folder on the mail server when it does not exist yet

### DIFF
--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -669,6 +669,53 @@ An alias that resolves to no single folder ends that one folder's run and no oth
 folders continue — a mistyped alias is a configuration mistake, not a mail-server failure, and the three are logged as
 different things because each asks the operator for something different.
 
+### A folder the mapping asked for is created
+
+A mapping naming a `RemotePath` may also ask for that folder to be **created** when the server advertises none at it.
+`CreateIfMissing` is the switch, it defaults to `false`, and it is the only thing that ever makes MailFathom change the
+shape of a mailbox. Everything else about folder management stays refused: nothing here renames a folder, deletes one,
+or unsubscribes from one, and no folder MailFathom did not create is ever subscribed to.
+
+The default is the opposite way round from the three participation switches, and deliberately so. Those withdraw a
+folder that already exists from something MailFathom does locally; this one authorizes an act against your mail server.
+So a mapping that says nothing behaves exactly as it did before creation existed, and a mistyped `RemotePath` stays the
+unresolved alias above rather than becoming a folder on your server named after the mistake.
+
+Creation happens **where the alias is resolved** — before the run of a mirrored folder, and on demand for a folder that
+is only a destination — which is one rule covering both rather than two triggers to keep in step. Nothing is created by
+reading configuration, and nothing is created for a mapping nothing ever resolves. After the first creation the server
+advertises the folder, so resolution finds it and no further `CREATE` is issued.
+
+What the creation does with the awkward parts of IMAP is fixed rather than left to the server that was tested against:
+
+- **A folder already at the path is success**, not a failure. A `CREATE` the server refuses is followed by one lookup of
+  the path; a folder now advertised there means another client — or another MailFathom process — created it between the
+  listing and the attempt.
+- **The path is split with the delimiter the server reports** through `NAMESPACE`, never an assumed `/`. The configured
+  text is the server's own path and is never rewritten; the delimiter only says where its levels are.
+- **The ancestors the configured path names are created first**, in order, each skipped where it is already there. Every
+  one of them is a name you wrote, so none of them is a folder nobody named.
+- **A name the server already holds as a hierarchy container, or as a node holding no mail, is refused.** Discovery
+  leaves both out of the catalog, so the alias resolves to nothing while the name is taken, and what that needs is a
+  different path rather than an act MailFathom can take for you.
+- **The created folder is subscribed to**, so it appears in a mail client that lists subscriptions and you can find mail
+  a rule filed there. A server that refuses the subscription does not fail the creation — the folder exists, which is
+  what was asked for — and the refusal is logged as a warning naming the alias.
+
+A creation the server refuses fails as itself, under error code `26001` and with a message naming the alias alone. It is
+deliberately distinguishable from the alias that resolves to nothing: a quota, a namespace that forbids the name, or a
+name the server will not accept each ask you for something different from a path you mistyped.
+
+`CreateIfMissing: true` beside a `SpecialUse` mapping **fails startup**, naming the alias. A folder that does not exist
+advertises no role, so creating one from a role would mean either an extension whose support is uneven or MailFathom
+inventing a name in your own mailbox — and writing the path you wanted is one line of configuration.
+
+The creation is issued over the account's **single write connection**, the same one the mutations run over, so it costs
+no second login. It reaches that connection through a port of its own, `IRemoteFolderCreator`, rather than through the
+write session: a component that can file a message into a folder cannot create one, and a component that can create one
+cannot relocate, delete, flag, or copy a message. A created folder then binds, resolves, and appears in the
+mapping-change audit exactly as a discovered one does.
+
 ### Why a binding carries a generation
 
 The repository treats `(account, folder, UIDVALIDITY, UID)` as the stable remote occurrence identity, and that tuple
@@ -1375,7 +1422,7 @@ The extraction backfill has a section of its own rather than a block inside the 
 
 Every configured account carries a `DisplayName`, whether or not synchronization is enabled, because the stored copy stays readable after the switch is turned off and the name is what a caller reads the account back as. There is no fallback to `AccountId`: a name MailFathom invented would be published to callers as though an operator had chosen it. The two share one naming space — a request may name an account by either — so startup refuses a display name another account's identifier or display name already carries, compared without regard to case; one equal to the account's own identifier is accepted, since both spellings then reach the same mailbox.
 
-When enabled, at least one account with a non-blank `AccountId`, host, and user name must be configured. The account password is not a configuration value at all: `Secrets.Password` carries a reference, and startup fails when it cannot be resolved. Each entry of `Folders` names an alias and exactly one of `RemotePath` and `SpecialUse`; naming both, naming neither, or naming a role that does not exist fails startup with a message identifying the alias. Supported roles are `Inbox`, `Archive`, `Drafts`, `Sent`, `Junk`, `Trash`, `All`, `Flagged`, and `Important`. If an account omits `Folders`, its supervisor applies the post-binding default of one alias `inbox` mapped to the inbox role; explicit folder lists replace that default.
+When enabled, at least one account with a non-blank `AccountId`, host, and user name must be configured. The account password is not a configuration value at all: `Secrets.Password` carries a reference, and startup fails when it cannot be resolved. Each entry of `Folders` names an alias and exactly one of `RemotePath` and `SpecialUse`; naming both, naming neither, or naming a role that does not exist fails startup with a message identifying the alias. Supported roles are `Inbox`, `Archive`, `Drafts`, `Sent`, `Junk`, `Trash`, `All`, `Flagged`, and `Important`. An entry naming a `RemotePath` may additionally set `CreateIfMissing`, which defaults to `false` and is what [creates the folder](#a-folder-the-mapping-asked-for-is-created) when the server advertises none at that path; setting it beside a `SpecialUse` fails startup naming the alias. If an account omits `Folders`, its supervisor applies the post-binding default of one alias `inbox` mapped to the inbox role; explicit folder lists replace that default.
 
 ### Bounding how far back a run reaches
 

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -681,10 +681,14 @@ folder that already exists from something MailFathom does locally; this one auth
 So a mapping that says nothing behaves exactly as it did before creation existed, and a mistyped `RemotePath` stays the
 unresolved alias above rather than becoming a folder on your server named after the mistake.
 
-Creation happens **where the alias is resolved** — before the run of a mirrored folder, and on demand for a folder that
-is only a destination — which is one rule covering both rather than two triggers to keep in step. Nothing is created by
-reading configuration, and nothing is created for a mapping nothing ever resolves. After the first creation the server
-advertises the folder, so resolution finds it and no further `CREATE` is issued.
+Creation happens **where the alias is resolved**, which is before the run of a folder MailFathom mirrors. Nothing is
+created by reading configuration, and nothing is created for a mapping nothing ever resolves. After the first creation
+the server advertises the folder, so resolution finds it and no further `CREATE` is issued.
+
+A run resolves the folders it mirrors and no others, so `CreateIfMissing` on a `Synchronize: false` mapping creates
+nothing: such a folder is a destination for what is already bound to it rather than something a run reaches. A folder to
+be created is therefore one the account mirrors, and a mapping that only files mail into a folder needs that folder to
+be there.
 
 What the creation does with the awkward parts of IMAP is fixed rather than left to the server that was tested against:
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -161,19 +161,31 @@ A folder entry names `Alias` (required — your stable name for the folder) and 
 server's own path) or `SpecialUse` (a role discovery resolves: `Inbox`, `Archive`, `Drafts`, `Sent`, `Junk`, `Trash`,
 `All`, `Flagged`, `Important`). Configuring no folder synchronizes the inbox by role.
 
-The same entry decides what MailFathom does with the folder, through three switches that each default to `true`:
+The same entry decides what MailFathom does with the folder, through three switches that each default to `true`, and
+whether the folder may be created at all, through a fourth that defaults to `false`:
 
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
 | `…:Folders:<n>:Synchronize` | bool | `true` | With `false`, no run schedules the folder: no connection is opened for it and nothing of it is stored | reload; the next run stops scheduling it and begins erasing what is stored for it |
 | `…:Folders:<n>:GenerateEmbeddings` | bool | `true` | With `false`, stored mail of the folder is never cut into passages and never reaches an embedding provider; refused alongside `Synchronize: false` | reload; governs what is stored from then on, and passages already produced stay |
 | `…:Folders:<n>:VisibleToTools` | bool | `true` | With `false`, no MCP tool lists, searches, reads, or answers from the folder; refused alongside `Synchronize: false` | reload; the next request reads the new value |
+| `…:Folders:<n>:CreateIfMissing` | bool | `false` | With `true`, the folder is created on the mail server when the server advertises none at `RemotePath`; refused alongside `SpecialUse` | reload; the next resolution of the alias creates it |
 
 Startup refuses a folder that asks for embedding or tool visibility while `Synchronize` is `false`, naming the alias,
 because a folder that stores nothing has nothing to embed and nothing a tool could read. Leaving a switch out is not
 asking for it, so `Synchronize: false` on its own binds. Mirrored, embedded, and withheld from tools binds as well and
 costs what it says: the vectors are produced and paid for while no reader reaches them, since the tools are the only
 readers there are.
+
+`CreateIfMissing` is the one switch here that authorizes an act against your mail server rather than withdrawing an
+existing folder from something MailFathom does locally, which is why it defaults to `false` while the other three
+default to `true`: a mapping that says nothing keeps a mistyped `RemotePath` reporting itself as an alias that resolves
+to nothing, instead of turning the mistake into a folder named after it. Startup refuses it beside a `SpecialUse`
+mapping, naming the alias, because a folder that does not exist advertises no role. Renaming, deleting, and
+unsubscribing from a folder stay refused outright, and no folder MailFathom did not create is ever subscribed to.
+[A folder the mapping asked for is created](../features/imap-synchronization.md#a-folder-the-mapping-asked-for-is-created)
+states when the creation happens, what it does with a folder that already exists and with a hierarchical path, and what
+a server's refusal reports.
 
 Switching `Synchronize` off for a folder that was mirrored **erases what is stored for it**, in bounded passes on the
 account's own runs and through the deletion path an erasing disposition already uses. The mapping stays, so the alias

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -181,8 +181,10 @@ readers there are.
 existing folder from something MailFathom does locally, which is why it defaults to `false` while the other three
 default to `true`: a mapping that says nothing keeps a mistyped `RemotePath` reporting itself as an alias that resolves
 to nothing, instead of turning the mistake into a folder named after it. Startup refuses it beside a `SpecialUse`
-mapping, naming the alias, because a folder that does not exist advertises no role. Renaming, deleting, and
-unsubscribing from a folder stay refused outright, and no folder MailFathom did not create is ever subscribed to.
+mapping, naming the alias, because a folder that does not exist advertises no role. It is issued where the alias is
+resolved, and a run resolves the folders it mirrors and no others, so the switch creates nothing on a mapping that also
+carries `Synchronize: false`. Renaming, deleting, and unsubscribing from a folder stay refused outright, and no folder
+MailFathom did not create is ever subscribed to.
 [A folder the mapping asked for is created](../features/imap-synchronization.md#a-folder-the-mapping-asked-for-is-created)
 states when the creation happens, what it does with a folder that already exists and with a hierarchical path, and what
 a server's refusal reports.

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -94,10 +94,11 @@ Points worth knowing before you adapt it:
   [What a mapping decides beyond where the folder is](../features/imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
   states what each one costs, including what happens to mail already stored when you turn mirroring off.
 - **A folder you name is created only if you ask for it.** Add `CreateIfMissing: true` beside a `RemotePath` and
-  MailFathom creates that folder when your server has none at it — which is what a rule filing mail into an archive
-  folder you decided on needs, without a detour through a mail client. It defaults to `false`, so leaving it out keeps a
-  mistyped path reporting itself as an alias that resolves to nothing rather than becoming a folder named after the
-  typo. Nothing else about your folders is ever changed: MailFathom never renames, deletes, or unsubscribes from one.
+  MailFathom creates that folder on its first run, when your server has none at it — which is what a rule filing mail
+  into an archive folder you decided on needs, without a detour through a mail client. A run reaches the folders it
+  mirrors, so a mapping that also carries `Synchronize: false` has nothing created for it. The switch defaults to
+  `false`, so leaving it out keeps a mistyped path reporting itself as an alias that resolves to nothing rather than
+  becoming a folder named after the typo. Nothing else about your folders is ever changed: MailFathom never renames, deletes, or unsubscribes from one.
   [A folder the mapping asked for is created](../features/imap-synchronization.md#a-folder-the-mapping-asked-for-is-created)
   states when it happens and what a server's refusal reports.
 - **The transport is TLS by default.** Port 993 with TLS-on-connect is the default posture, and every weakening —

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -93,6 +93,13 @@ Points worth knowing before you adapt it:
   an assistant can read.
   [What a mapping decides beyond where the folder is](../features/imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
   states what each one costs, including what happens to mail already stored when you turn mirroring off.
+- **A folder you name is created only if you ask for it.** Add `CreateIfMissing: true` beside a `RemotePath` and
+  MailFathom creates that folder when your server has none at it — which is what a rule filing mail into an archive
+  folder you decided on needs, without a detour through a mail client. It defaults to `false`, so leaving it out keeps a
+  mistyped path reporting itself as an alias that resolves to nothing rather than becoming a folder named after the
+  typo. Nothing else about your folders is ever changed: MailFathom never renames, deletes, or unsubscribes from one.
+  [A folder the mapping asked for is created](../features/imap-synchronization.md#a-folder-the-mapping-asked-for-is-created)
+  states when it happens and what a server's refusal reports.
 - **The transport is TLS by default.** Port 993 with TLS-on-connect is the default posture, and every weakening —
   an unencrypted connection, clear-text authentication over one — must be stated explicitly and fails startup
   otherwise. A server with a private certificate authority is supported by trusting that authority, never by turning

--- a/src/Application/Folders/IRemoteFolderCreator.cs
+++ b/src/Application/Folders/IRemoteFolderCreator.cs
@@ -1,0 +1,64 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Synchronization.Sessions;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Transport;
+
+namespace MailFathom.Application.Folders;
+
+/// <summary>Creates the one folder a mapping asked to have created, and can do nothing else to a mailbox.</summary>
+/// <remarks>
+/// <para>
+/// The name states the port's whole surface. There is no method that renames a folder, deletes one, or unsubscribes
+/// from one, and permitting any of those is a decision to reopen
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md">ADR 0007</see>
+/// rather than a method to append here.
+/// </para>
+/// <para>
+/// It is a port of its own rather than a fifth method on <see cref="Mail.Mutations.IMailboxWriteSession" />, which is
+/// what buys the same separation the write session itself buys: a component that can file a message into a folder
+/// cannot create one, and a component that can create one cannot relocate, delete, flag, or copy a message. No second
+/// connection is opened for it — a creation is issued over the account's single write connection, so an account still
+/// holds at most one connection able to change its mailbox.
+/// </para>
+/// <para>
+/// Nothing reaches this port from configuration binding, from mail content, from a tool argument, or from model output.
+/// A path arrives here from the <c>RemotePath</c> of a mapping the operator wrote and from nowhere else, which is the
+/// input class the decision's authorization review turns on.
+/// </para>
+/// </remarks>
+public interface IRemoteFolderCreator
+{
+    /// <summary>Creates the folder a configured path names, together with the ancestors that path names above it.</summary>
+    /// <param name="accountId">The account whose mailbox gains the folder.</param>
+    /// <param name="folderAlias">The folder alias the path was configured under, which is the name every failure reports.</param>
+    /// <param name="configuredPath">The path the operator wrote, which is used exactly as written and never rewritten.</param>
+    /// <param name="transportSecurityPolicy">The connection and authentication policy the implementation must obey.</param>
+    /// <param name="cancellationToken">Cancels waiting for the account's write connection, connecting, authenticating, and creating.</param>
+    /// <returns>The created folder as the server advertises it, with the hierarchy delimiter the server reported.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="transportSecurityPolicy" /> is <see langword="null" />.</exception>
+    /// <exception cref="RemoteFolderCreationRefusedException">Thrown when the mail server answered and refused to hold a folder at that path.</exception>
+    /// <exception cref="MailboxUnavailableException">Thrown when the mail server did not serve the creation within its configured resilience budget.</exception>
+    /// <remarks>
+    /// <para>
+    /// A folder already at that path is the successful answer rather than a failure, because another mail client — or
+    /// another MailFathom process — may have created it between the listing that found nothing and this attempt. The
+    /// path comes back as the server advertises it either way, so a caller binds a created folder exactly as it binds a
+    /// discovered one.
+    /// </para>
+    /// <para>
+    /// The folder is subscribed to as part of creating it, so it appears in a mail client that lists subscriptions and
+    /// the operator can find the mail a rule files there. A server that refuses the subscription does not fail the
+    /// creation: the folder exists, which is what was asked for.
+    /// </para>
+    /// </remarks>
+    Task<RemoteFolderPath> CreateFolderAsync(
+        MailAccountId accountId,
+        MailFolderAlias folderAlias,
+        RemoteFolderPath configuredPath,
+        MailTransportSecurityPolicy transportSecurityPolicy,
+        CancellationToken cancellationToken);
+}

--- a/src/Application/Folders/MailFolderResolver.cs
+++ b/src/Application/Folders/MailFolderResolver.cs
@@ -17,10 +17,12 @@ namespace MailFathom.Application.Folders;
 /// run that starts its new generation, so no work is ever committed under a binding that has not been recorded.
 /// </para>
 /// <para>
-/// It is also where a folder a mapping asked to have created comes into existence, which is one rule covering both the
-/// folder that is mirrored and the folder that is only a destination rather than two triggers to keep in step. Nothing
-/// is created by reading configuration and nothing is created for a mapping nothing ever resolves; after the first
-/// creation the server advertises the folder, so a later run matches it and issues no second creation.
+/// It is also where a folder a mapping asked to have created comes into existence. Placing the creation at resolution
+/// rather than at a call site means every path that resolves an alias creates the folder that alias names, without a
+/// second trigger to keep in step with this one; the synchronization run is that path, so a mapping no run resolves has
+/// nothing created for it. Nothing is created by reading configuration and nothing is created for a mapping nothing ever
+/// resolves; after the first creation the server advertises the folder, so a later run matches it and issues no second
+/// creation.
 /// </para>
 /// </remarks>
 public sealed class MailFolderResolver

--- a/src/Application/Folders/MailFolderResolver.cs
+++ b/src/Application/Folders/MailFolderResolver.cs
@@ -11,9 +11,17 @@ namespace MailFathom.Application.Folders;
 
 /// <summary>Turns a configured alias into the durable binding synchronization reads under.</summary>
 /// <remarks>
+/// <para>
 /// Resolution runs before every synchronization run rather than once, because the folder an alias names is the
 /// server's answer and the server is free to change it. The run that observes a different remote folder is also the
 /// run that starts its new generation, so no work is ever committed under a binding that has not been recorded.
+/// </para>
+/// <para>
+/// It is also where a folder a mapping asked to have created comes into existence, which is one rule covering both the
+/// folder that is mirrored and the folder that is only a destination rather than two triggers to keep in step. Nothing
+/// is created by reading configuration and nothing is created for a mapping nothing ever resolves; after the first
+/// creation the server advertises the folder, so a later run matches it and issues no second creation.
+/// </para>
 /// </remarks>
 public sealed class MailFolderResolver
 {
@@ -21,6 +29,7 @@ public sealed class MailFolderResolver
     private const string MandatoryInboxPath = "INBOX";
 
     private readonly IRemoteFolderCatalog remoteFolderCatalog;
+    private readonly IRemoteFolderCreator remoteFolderCreator;
     private readonly IMailFolderResolutionStore resolutionStore;
     private readonly IMailFolderMappingChangeAuditor mappingChangeAuditor;
     private readonly IPersistenceSessionFactory persistenceSessionFactory;
@@ -29,12 +38,14 @@ public sealed class MailFolderResolver
     /// <summary>Initializes a new folder resolver.</summary>
     public MailFolderResolver(
         IRemoteFolderCatalog remoteFolderCatalog,
+        IRemoteFolderCreator remoteFolderCreator,
         IMailFolderResolutionStore resolutionStore,
         IMailFolderMappingChangeAuditor mappingChangeAuditor,
         IPersistenceSessionFactory persistenceSessionFactory,
         TimeProvider timeProvider)
     {
         this.remoteFolderCatalog = remoteFolderCatalog;
+        this.remoteFolderCreator = remoteFolderCreator;
         this.resolutionStore = resolutionStore;
         this.mappingChangeAuditor = mappingChangeAuditor;
         this.persistenceSessionFactory = persistenceSessionFactory;
@@ -49,6 +60,7 @@ public sealed class MailFolderResolver
     /// <returns>The durable binding, or the reason the alias resolved to no single advertised folder.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="mapping" /> is <see langword="null" />.</exception>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when a competing writer recorded a binding for the same alias first.</exception>
+    /// <exception cref="RemoteFolderCreationRefusedException">Thrown when a mapping asked for its folder to be created and the mail server refused to hold one at that path.</exception>
     /// <remarks>
     /// A binding that already matches the advertised folder is returned without a write and without an audit record.
     /// A binding that names a different remote folder is replaced by the next generation, which starts with no
@@ -68,17 +80,20 @@ public sealed class MailFolderResolver
             cancellationToken);
 
         var matchedFolders = FindAdvertisedMatches(mapping, advertisedFolders);
-        if (matchedFolders.Count == 0)
-        {
-            return MailFolderResolutionResult.NoAdvertisedFolderMatched();
-        }
 
         if (matchedFolders.Count > 1)
         {
             return MailFolderResolutionResult.AdvertisedFoldersAreAmbiguous();
         }
 
-        var advertisedPath = matchedFolders[0].Path;
+        RemoteFolderPath? matchedPath = matchedFolders.Count == 1
+            ? matchedFolders[0].Path
+            : await this.CreateConfiguredFolderAsync(accountId, mapping, transportSecurityPolicy, cancellationToken);
+
+        if (matchedPath is not { } advertisedPath)
+        {
+            return MailFolderResolutionResult.NoAdvertisedFolderMatched();
+        }
 
         var currentResolution =
             await this.resolutionStore.GetCurrentResolutionAsync(accountId, mapping.Alias, cancellationToken);
@@ -95,6 +110,39 @@ public sealed class MailFolderResolver
         await this.RecordNewBindingAsync(accountId, currentResolution, newResolution, cancellationToken);
 
         return MailFolderResolutionResult.Resolved(newResolution);
+    }
+
+    /// <summary>Creates the folder a mapping asked to have created, and reports nothing for a mapping that asked for none.</summary>
+    /// <returns>The created folder as the server advertises it, or <see langword="null" /> when the alias simply resolved to nothing.</returns>
+    /// <remarks>
+    /// <para>
+    /// Only a mapping naming an explicit path reaches a creation, and only one whose <c>CreateIfMissing</c> switch is
+    /// on. Everything else keeps the unresolved alias, which is the only report a mistyped path ever produces: creating
+    /// the folder would make the mistake succeed and leave a folder named after it on somebody's mail server.
+    /// </para>
+    /// <para>
+    /// The path comes back as the server advertises it rather than as it was configured, because the two differ in the
+    /// hierarchy delimiter the binding is compared against on every later run. Binding the configured text instead would
+    /// repoint the alias and start a generation on the run after the one that created the folder.
+    /// </para>
+    /// </remarks>
+    private async Task<RemoteFolderPath?> CreateConfiguredFolderAsync(
+        MailAccountId accountId,
+        MailFolderMapping mapping,
+        MailTransportSecurityPolicy transportSecurityPolicy,
+        CancellationToken cancellationToken)
+    {
+        if (mapping is not { MayCreateMissingFolder: true, RemotePath: { } configuredPath })
+        {
+            return null;
+        }
+
+        return await this.remoteFolderCreator.CreateFolderAsync(
+            accountId,
+            mapping.Alias,
+            configuredPath,
+            transportSecurityPolicy,
+            cancellationToken);
     }
 
     /// <summary>Finds every advertised folder a mapping names, so an alias that names more than one is answerable.</summary>

--- a/src/Application/Folders/RemoteFolderCreationRefusedException.cs
+++ b/src/Application/Folders/RemoteFolderCreationRefusedException.cs
@@ -1,0 +1,68 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Application.Folders;
+
+/// <summary>Indicates that a mail server was asked to create the folder a mapping named and answered by refusing it.</summary>
+/// <remarks>
+/// <para>
+/// It is raised rather than returned, and it carries a code of its own, because the operator's remedy depends on being
+/// able to tell it apart from the alias that resolves to nothing. A quota reached, a namespace that forbids creating
+/// there, and a name the server will not accept are each something to act on; a folder nobody has is a path to correct.
+/// Reporting the first as the second would leave an operator reading the message a typo produces about a path they
+/// wrote correctly.
+/// </para>
+/// <para>
+/// The message names the alias alone. The remote path is the mailbox owner's own naming of their mail, which no message
+/// an operator reads may carry — it belongs to the mapping-change audit record and to the debug detail.
+/// </para>
+/// </remarks>
+public sealed class RemoteFolderCreationRefusedException : MailFathomException
+{
+    /// <summary>Initializes a new refusal naming the alias whose folder the mail server would not create.</summary>
+    /// <param name="accountId">The account whose mailbox the folder was to be created in.</param>
+    /// <param name="folderAlias">The alias the configured path was written under.</param>
+    /// <param name="innerException">The mail-library failure the server's refusal arrived as.</param>
+    public RemoteFolderCreationRefusedException(
+        MailAccountId accountId,
+        MailFolderAlias folderAlias,
+        Exception innerException)
+        : base(DescribeRefusedCreation(accountId, folderAlias), innerException)
+    {
+        this.AccountId = accountId;
+        this.FolderAlias = folderAlias;
+    }
+
+    /// <summary>Initializes a new refusal for a path the server holds under a name it will not let a folder take.</summary>
+    /// <param name="accountId">The account whose mailbox the folder was to be created in.</param>
+    /// <param name="folderAlias">The alias the configured path was written under.</param>
+    /// <remarks>
+    /// This is the answer to a name the server already lists as a hierarchy container or as a node holding no mail. The
+    /// server refused nothing, because nothing was asked of it: the name is taken, so what the operator needs is a
+    /// different path rather than an act MailFathom can take for them.
+    /// </remarks>
+    public RemoteFolderCreationRefusedException(MailAccountId accountId, MailFolderAlias folderAlias)
+        : base(DescribeRefusedCreation(accountId, folderAlias))
+    {
+        this.AccountId = accountId;
+        this.FolderAlias = folderAlias;
+    }
+
+    /// <inheritdoc />
+    public override MailFathomErrorCode ErrorCode => MailFathomErrorCode.RemoteFolderCreationRefused;
+
+    /// <summary>Gets the account whose mailbox the folder was to be created in.</summary>
+    public MailAccountId AccountId { get; }
+
+    /// <summary>Gets the alias the configured path was written under.</summary>
+    public MailFolderAlias FolderAlias { get; }
+
+    private static string DescribeRefusedCreation(MailAccountId accountId, MailFolderAlias folderAlias) =>
+        $"The mail server for {accountId.Value}/{folderAlias.Value} will not hold a folder at the path that alias "
+        + "is configured with, so the folder was not created.";
+}

--- a/src/Application/Synchronization/MailboxSynchronizer.cs
+++ b/src/Application/Synchronization/MailboxSynchronizer.cs
@@ -105,11 +105,18 @@ public sealed class MailboxSynchronizer
     /// Thrown when a recovered connection reselected the folder with a different UIDVALIDITY, so the identities this
     /// run was working with no longer name the same emails. The next run starts the folder over.
     /// </exception>
+    /// <exception cref="RemoteFolderCreationRefusedException">
+    /// Thrown when the mapping asked for its folder to be created and the mail server refused to hold one at that path.
+    /// It fails this folder's run and no other, and it is deliberately not the unresolved alias below: a quota, a
+    /// namespace that forbids the name, or a name the server will not accept asks the operator for something different
+    /// from a path they mistyped.
+    /// </exception>
     /// <remarks>
     /// <para>
     /// The alias is resolved against the server's advertised folders before anything is read, so a run always works
     /// under the binding that is durable at the moment it starts. An alias the server advertises no folder for ends
-    /// this run and no other.
+    /// this run and no other, unless its mapping asked for the folder to be created, in which case the run creates it
+    /// and binds it exactly as it binds a folder it discovered.
     /// </para>
     /// <para>
     /// The account's synchronization window is read at the same moment as its transport security policy and bounds

--- a/src/Domain/Failures/MailFathomErrorCode.cs
+++ b/src/Domain/Failures/MailFathomErrorCode.cs
@@ -114,6 +114,17 @@ public readonly record struct MailFathomErrorCode
     /// </remarks>
     public static MailFathomErrorCode MailboxMutationDestinationMissing { get; } = new(25005);
 
+    /// <summary>Gets subcategory 6, folder creation: a mail server refused to create the folder a mapping asked for.</summary>
+    /// <remarks>
+    /// It is a subcategory of its own rather than one more mutation failure, because creating a folder is not one of the
+    /// four mutations at all: it changes the shape of a mailbox rather than a message in one, and it is reached through a
+    /// port no path that moves mail can obtain. Keeping it apart is also what makes it readable beside
+    /// <see cref="MailboxMutationDestinationMissing" />, which is the code an alias that resolves to nothing produces —
+    /// a quota, a namespace that forbids the name, or a name the server will not accept says something different from a
+    /// folder nobody has.
+    /// </remarks>
+    public static MailFathomErrorCode RemoteFolderCreationRefused { get; } = new(26001);
+
     #endregion
 
     #region Category 3 — Persistence
@@ -323,6 +334,7 @@ public readonly record struct MailFathomErrorCode
         MailboxMutationAttemptsExhausted,
         MailboxMutationFailedUnexpectedly,
         MailboxMutationDestinationMissing,
+        RemoteFolderCreationRefused,
         PersistenceConcurrencyConflict,
         DatabaseSchemaOutOfDate,
         DatabaseSchemaStateUnreadable,

--- a/src/Domain/Folders/MailFolderMapping.cs
+++ b/src/Domain/Folders/MailFolderMapping.cs
@@ -16,13 +16,15 @@ public sealed record MailFolderMapping
         MailFolderMappingTarget target,
         RemoteFolderPath? remotePath,
         MailFolderSpecialUse? specialUse,
-        MailFolderParticipation participation)
+        MailFolderParticipation participation,
+        bool mayCreateMissingFolder)
     {
         this.Alias = alias;
         this.Target = target;
         this.RemotePath = remotePath;
         this.SpecialUse = specialUse;
         this.Participation = participation;
+        this.MayCreateMissingFolder = mayCreateMissingFolder;
     }
 
     /// <summary>Gets the operator-facing folder name.</summary>
@@ -45,20 +47,40 @@ public sealed record MailFolderMapping
     /// </remarks>
     public MailFolderParticipation Participation { get; }
 
+    /// <summary>Gets whether MailFathom may create the folder on the mail server when the account's server advertises none at the configured path.</summary>
+    /// <remarks>
+    /// <para>
+    /// It defaults to <see langword="false" /> and is the one switch on a mapping that authorizes an act against
+    /// somebody else's mail server rather than withdrawing a folder from something MailFathom does locally, which is
+    /// why it does not follow the participation switches in defaulting to <see langword="true" />. A mapping that says
+    /// nothing therefore behaves as it did before creation existed, and a mistyped path stays an alias that resolves to
+    /// nothing rather than becoming a folder named after the mistake.
+    /// </para>
+    /// <para>
+    /// It is expressible only alongside a configured path, because a folder that does not exist advertises no role and
+    /// nothing here may invent a name for one. That is a property of the factories rather than a rule stated elsewhere:
+    /// <see cref="ToSpecialUse" /> takes no such argument, so a role mapping can never carry it.
+    /// </para>
+    /// </remarks>
+    public bool MayCreateMissingFolder { get; }
+
     /// <summary>Maps an alias onto the server-advertised path an operator wrote.</summary>
     /// <param name="alias">The operator-facing folder name.</param>
     /// <param name="remotePath">The remote path the alias names.</param>
     /// <param name="participation">How far the folder is admitted, or <see langword="null" /> for a folder that takes part in everything.</param>
+    /// <param name="mayCreateMissingFolder">Whether the folder may be created when the server advertises none at that path.</param>
     /// <returns>A mapping resolved by matching the advertised path.</returns>
     public static MailFolderMapping ToRemotePath(
         MailFolderAlias alias,
         RemoteFolderPath remotePath,
-        MailFolderParticipation? participation = null) => new(
+        MailFolderParticipation? participation = null,
+        bool mayCreateMissingFolder = false) => new(
             alias,
             MailFolderMappingTarget.RemotePath,
             remotePath,
             specialUse: null,
-            participation ?? MailFolderParticipation.Full);
+            participation ?? MailFolderParticipation.Full,
+            mayCreateMissingFolder);
 
     /// <summary>Maps an alias onto a special-use role, so the server's own naming stays out of configuration.</summary>
     /// <param name="alias">The operator-facing folder name.</param>
@@ -84,6 +106,7 @@ public sealed record MailFolderMapping
             MailFolderMappingTarget.SpecialUse,
             remotePath: null,
             specialUse,
-            participation ?? MailFolderParticipation.Full);
+            participation ?? MailFolderParticipation.Full,
+            mayCreateMissingFolder: false);
     }
 }

--- a/src/Host/Configuration/Mail/MailFolderMappingOptions.cs
+++ b/src/Host/Configuration/Mail/MailFolderMappingOptions.cs
@@ -41,6 +41,14 @@ internal sealed class MailFolderMappingOptions : IValidatableObject
     /// <summary>Gets or sets whether MCP tools may list, search, read, or answer from the folder.</summary>
     public bool? VisibleToTools { get; set; }
 
+    /// <summary>Gets or sets whether MailFathom may create the folder when the server advertises none at <see cref="RemotePath" />.</summary>
+    /// <remarks>
+    /// It defaults to <see langword="false" />, unlike the three switches above, because it authorizes an act against
+    /// the operator's mail server rather than withdrawing an existing folder from something MailFathom does locally.
+    /// Leaving it out therefore keeps a mistyped path reporting itself as an alias that resolves to nothing.
+    /// </remarks>
+    public bool? CreateIfMissing { get; set; }
+
     /// <summary>Gets what this configured folder takes part in, with every unset switch reading as its default.</summary>
     internal MailFolderParticipation Participation => MailFolderParticipation.Create(
         this.Synchronize ?? true,
@@ -56,7 +64,11 @@ internal sealed class MailFolderMappingOptions : IValidatableObject
 
         if (!string.IsNullOrWhiteSpace(this.RemotePath))
         {
-            return MailFolderMapping.ToRemotePath(alias, RemoteFolderPath.Create(this.RemotePath), this.Participation);
+            return MailFolderMapping.ToRemotePath(
+                alias,
+                RemoteFolderPath.Create(this.RemotePath),
+                this.Participation,
+                this.CreateIfMissing ?? false);
         }
 
         if (TryParseSpecialUse(this.SpecialUse, out var specialUse))
@@ -92,6 +104,13 @@ internal sealed class MailFolderMappingOptions : IValidatableObject
             yield return new ValidationResult(
                 $"Folder alias '{this.Alias}' names special-use role '{this.SpecialUse}', which is not supported. Supported roles are {string.Join(", ", Enum.GetNames<MailFolderSpecialUse>())}.",
                 [nameof(this.SpecialUse)]);
+        }
+
+        if (namesSpecialUse && this.CreateIfMissing is true)
+        {
+            yield return new ValidationResult(
+                $"Folder alias '{this.Alias}' asks for its folder to be created while naming a special-use role, and a folder that does not exist advertises no role. Name the path the folder is to be created at in 'RemotePath'.",
+                [nameof(this.CreateIfMissing)]);
         }
 
         foreach (var result in this.ValidateConfiguredValues(namesRemotePath))

--- a/src/Infrastructure/Mail/MailKit/MailKitImapConnection.cs
+++ b/src/Infrastructure/Mail/MailKit/MailKitImapConnection.cs
@@ -33,8 +33,12 @@ namespace MailFathom.Infrastructure.Mail.MailKit;
 /// <see cref="ForWriting" /> is the one path that selects otherwise, and only the write session reaches it.
 /// </para>
 /// <para>
-/// A connection may also be opened for no folder at all, which is what folder discovery uses: an IMAP <c>LIST</c>
-/// selects nothing, so there is no folder to pin and no message whose flags could change.
+/// A connection may also be opened for no folder at all, which two paths use. Folder discovery issues an IMAP
+/// <c>LIST</c>, which selects nothing, so there is no folder to pin and no message whose flags could change; folder
+/// creation issues a <c>CREATE</c>, which names its mailbox in the command and could not pin one, since the folder
+/// being created does not exist yet. <see cref="ForFolderManagement" /> is the second of those and the only connection
+/// <see cref="ExecuteFolderManagementAsync" /> runs on, so the permission to change a mailbox's shape and the
+/// permission to change the emails in a folder never sit on the same connection.
 /// </para>
 /// <para>
 /// Establishment and retrieval run under different dependency classes, because a rejected credential must never be
@@ -161,6 +165,40 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
             transientFailureClassifier,
             accountId,
             folder,
+            FolderAccess.ReadWrite,
+            transportSecurityPolicy);
+
+    /// <summary>Creates a connection that selects no folder and may still change the mailbox, which folder creation needs.</summary>
+    /// <param name="clientFactory">Creates one IMAP client per establishment attempt.</param>
+    /// <param name="settingsProvider">Resolves the endpoint and the credential material of the account, per attempt.</param>
+    /// <param name="accessTokenSource">Supplies the access token when the account's policy authenticates with one.</param>
+    /// <param name="operationExecutor">Runs establishment and the creation under their configured pipelines.</param>
+    /// <param name="transientFailureClassifier">Decides whether a failure left the connection worth keeping.</param>
+    /// <param name="accountId">The account this connection belongs to, which also isolates its pipeline state.</param>
+    /// <param name="transportSecurityPolicy">The connection and authentication policy each attempt must obey.</param>
+    /// <returns>A connection that has not been established yet.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
+    /// <remarks>
+    /// An IMAP <c>CREATE</c> names its mailbox in the command and selects nothing, so there is no folder to pin — and
+    /// pinning one would be wrong rather than merely unnecessary, since the folder being created cannot be selected
+    /// until it exists. What this shares with <see cref="ForWriting" /> is only the permission: both are created able to
+    /// change the mailbox, and only <see cref="ExecuteFolderManagementAsync" /> runs on this one.
+    /// </remarks>
+    internal static MailKitImapConnection ForFolderManagement(
+        Func<IImapClient> clientFactory,
+        IImapAccountSettingsProvider settingsProvider,
+        IMailAccessTokenSource accessTokenSource,
+        OutboundOperationExecutor operationExecutor,
+        ITransientFailureClassifier transientFailureClassifier,
+        MailAccountId accountId,
+        MailTransportSecurityPolicy transportSecurityPolicy) => new(
+            clientFactory,
+            settingsProvider,
+            accessTokenSource,
+            operationExecutor,
+            transientFailureClassifier,
+            accountId,
+            folder: null,
             FolderAccess.ReadWrite,
             transportSecurityPolicy);
 
@@ -307,7 +345,6 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
     /// connection is discarded, so the next call starts from a session it established itself.
     /// </para>
     /// </remarks>
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Every failure is inspected for whether it left the connection usable and is then rethrown, translated only where a mail-library type would otherwise cross an application port.")]
     internal async Task<TResult> ExecuteUnrepeatedFolderOperationAsync<TResult>(
         Func<IImapClient, IMailFolder, CancellationToken, Task<TResult>> operation,
         CancellationToken cancellationToken)
@@ -317,9 +354,56 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
         var authenticatedClient = await this.EnsureAuthenticatedClientAsync(cancellationToken);
         var openFolder = await this.EnsureOpenFolderAsync(cancellationToken);
 
+        return await this.AttemptUnrepeatedOperationAsync(
+            () => operation(authenticatedClient, openFolder, cancellationToken));
+    }
+
+    /// <summary>Runs one operation that changes the shape of the mailbox rather than a message in it, exactly once.</summary>
+    /// <typeparam name="TResult">The result the operation produces.</typeparam>
+    /// <param name="folderManagement">The change, which is issued exactly once.</param>
+    /// <param name="cancellationToken">Cancels establishing the session and the operation itself.</param>
+    /// <returns>The result of the single attempt.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="folderManagement" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the connection was not created by <see cref="ForFolderManagement" />.</exception>
+    /// <exception cref="MailboxUnavailableException">Thrown when establishment stopped at a configured limit, or when the operation failed on something transient.</exception>
+    /// <remarks>
+    /// <para>
+    /// The guard is the point of the method, exactly as it is on <see cref="ExecuteMutationAsync" />, and it is the
+    /// stricter of the two: a connection pinned to a folder is the one that moves messages, and asking it to change the
+    /// mailbox's shape fails here rather than reaching a server. The two permissions are therefore not one — no
+    /// connection in this process can both file a message into a folder and create one.
+    /// </para>
+    /// <para>
+    /// Nothing is repeated. An IMAP <c>CREATE</c> against a folder that already exists is answered as an error rather
+    /// than as success, so a repeat would report the previous attempt's own work as a refusal; whether the folder is
+    /// there afterwards is the caller's question to put to the server rather than this method's to guess at.
+    /// </para>
+    /// </remarks>
+    internal async Task<TResult> ExecuteFolderManagementAsync<TResult>(
+        Func<IImapClient, CancellationToken, Task<TResult>> folderManagement,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(folderManagement);
+
+        if (this.folderAccess is not FolderAccess.ReadWrite || this.folder is not null)
+        {
+            throw new InvalidOperationException(
+                "This connection was not created to manage folders and cannot change the shape of the mailbox.");
+        }
+
+        var authenticatedClient = await this.EnsureAuthenticatedClientAsync(cancellationToken);
+
+        return await this.AttemptUnrepeatedOperationAsync(
+            () => folderManagement(authenticatedClient, cancellationToken));
+    }
+
+    /// <summary>Runs one attempt that is never repeated, keeping the connection only where the failure proves it survived.</summary>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Every failure is inspected for whether it left the connection usable and is then rethrown, translated only where a mail-library type would otherwise cross an application port.")]
+    private async Task<TResult> AttemptUnrepeatedOperationAsync<TResult>(Func<Task<TResult>> operation)
+    {
         try
         {
-            return await operation(authenticatedClient, openFolder, cancellationToken);
+            return await operation();
         }
         catch (Exception failure) when (this.IsRepeatableFailure(OutboundDependency.MailboxDataRetrieval, failure))
         {
@@ -369,6 +453,12 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
         {
             throw new InvalidOperationException(
                 "This connection selects its folder read-only and cannot change the mailbox.");
+        }
+
+        if (this.folder is null)
+        {
+            throw new InvalidOperationException(
+                "This connection selects no folder and cannot change the emails in one.");
         }
 
         return this.ExecuteUnrepeatedFolderOperationAsync(mutation, cancellationToken);

--- a/src/Infrastructure/Mail/MailKit/Writes/MailKitRemoteFolderCreator.cs
+++ b/src/Infrastructure/Mail/MailKit/Writes/MailKitRemoteFolderCreator.cs
@@ -1,0 +1,263 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Transport;
+using MailKit;
+using MailKit.Net.Imap;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.Infrastructure.Mail.MailKit.Writes;
+
+/// <summary>Creates one configured folder over the account's single write connection, and can do nothing else.</summary>
+/// <remarks>
+/// <para>
+/// It leases the same connection the mutations run over rather than opening one of its own, so an account still holds
+/// at most one connection able to change its mailbox. The lease selects no folder, which is both necessary — the folder
+/// being created cannot be selected until it exists — and the property that keeps this adapter unable to touch a
+/// message: the connection it holds refuses every mutation.
+/// </para>
+/// <para>
+/// What IMAP makes awkward is settled here rather than left to whichever server was tested against. A refused
+/// <c>CREATE</c> is followed by one lookup of the path, because another client may have created the folder between the
+/// listing that found nothing and this attempt; the hierarchy is split with the delimiter the server reported through
+/// <c>NAMESPACE</c> rather than an assumed one; the ancestors the configured path names are created first, in order,
+/// each skipped where it is already there; and a name the server already holds as a container or as a node holding no
+/// mail is a refusal rather than a creation, because the name is taken and a different path is what the operator needs.
+/// </para>
+/// </remarks>
+internal sealed partial class MailKitRemoteFolderCreator(
+    MailboxWriteConnectionPool connectionPool,
+    ILogger<MailKitRemoteFolderCreator> logger) : IRemoteFolderCreator
+{
+    /// <inheritdoc />
+    public async Task<RemoteFolderPath> CreateFolderAsync(
+        MailAccountId accountId,
+        MailFolderAlias folderAlias,
+        RemoteFolderPath configuredPath,
+        MailTransportSecurityPolicy transportSecurityPolicy,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(transportSecurityPolicy);
+
+        await using var lease = await connectionPool.LeaseForFolderManagementAsync(
+            accountId,
+            transportSecurityPolicy,
+            cancellationToken);
+
+        return await lease.Connection.ExecuteFolderManagementAsync(
+            (client, attemptToken) =>
+                this.CreateConfiguredHierarchyAsync(client, accountId, folderAlias, configuredPath, attemptToken),
+            cancellationToken);
+    }
+
+    /// <summary>Walks the configured path level by level, creating each level the server does not already advertise.</summary>
+    /// <remarks>
+    /// Every level is a name the operator wrote, so nothing here creates a folder nobody named. Walking the path is one
+    /// behaviour rather than a branch on how much implicit parent creation a given server chooses to do, which RFC 3501
+    /// leaves to its discretion. The walk starts at the account's personal namespace, which is where a path an operator
+    /// wrote is rooted; a server that reports none has said nothing about where its folders live, and guessing is not
+    /// something to do inside somebody's mailbox.
+    /// </remarks>
+    private async Task<RemoteFolderPath> CreateConfiguredHierarchyAsync(
+        IImapClient client,
+        MailAccountId accountId,
+        MailFolderAlias alias,
+        RemoteFolderPath configuredPath,
+        CancellationToken cancellationToken)
+    {
+        if (client.PersonalNamespaces.Count == 0)
+        {
+            throw new RemoteFolderCreationRefusedException(accountId, alias);
+        }
+
+        var personalNamespace = client.PersonalNamespaces[0];
+        var levels = SplitIntoLevels(
+            configuredPath,
+            NormalizeHierarchyDelimiter(personalNamespace.DirectorySeparator),
+            accountId,
+            alias);
+
+        var folder = client.GetFolder(personalNamespace);
+
+        foreach (var level in levels)
+        {
+            folder = await FindAdvertisedFolderAsync(client, level.Path, cancellationToken)
+                ?? await this.CreateLevelAsync(client, folder, level, accountId, alias, cancellationToken);
+        }
+
+        return DescribeConfiguredFolder(folder, configuredPath, accountId, alias);
+    }
+
+    /// <summary>Splits the configured path into the levels the server's own delimiter says it has.</summary>
+    /// <remarks>
+    /// A server reporting no delimiter has a flat hierarchy, so the whole configured text is one folder name. An empty
+    /// level is a path that names no folder — two delimiters in a row — and is refused before anything is created,
+    /// rather than reaching the server as a nameless mailbox.
+    /// </remarks>
+    private static IReadOnlyList<ConfiguredFolderLevel> SplitIntoLevels(
+        RemoteFolderPath configuredPath,
+        char? hierarchyDelimiter,
+        MailAccountId accountId,
+        MailFolderAlias alias)
+    {
+        var levelNames = hierarchyDelimiter is { } delimiter
+            ? configuredPath.Value.Split(delimiter)
+            : [configuredPath.Value];
+
+        if (levelNames.Any(string.IsNullOrEmpty))
+        {
+            throw new RemoteFolderCreationRefusedException(accountId, alias);
+        }
+
+        var separator = hierarchyDelimiter?.ToString() ?? string.Empty;
+
+        return
+        [
+            .. levelNames.Select((name, index) => new ConfiguredFolderLevel(
+                name,
+                string.Join(separator, levelNames.Take(index + 1)))),
+        ];
+    }
+
+    /// <summary>Creates one level of the path, treating a refusal the server answers as the settled failure it is.</summary>
+    /// <remarks>
+    /// The one lookup that follows a refusal is what separates the race from the failure. A folder now advertised at the
+    /// path means another client — or another MailFathom process — created it between the listing and this attempt, and
+    /// the creation reads as success; anything else is the server saying it will not hold a folder there. That lookup
+    /// asks exactly the question that was put, which is why it is a lookup rather than the destination search the write
+    /// session deliberately refuses for a relocation.
+    /// </remarks>
+    private async Task<IMailFolder> CreateLevelAsync(
+        IImapClient client,
+        IMailFolder parent,
+        ConfiguredFolderLevel level,
+        MailAccountId accountId,
+        MailFolderAlias alias,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            // The library's contract permits no answer here, and a folder nothing describes is one nothing can be bound
+            // to, so it is the same refusal a server that would not create it produces.
+            var created = await parent.CreateAsync(level.Name, isMessageFolder: true, cancellationToken)
+                ?? throw new RemoteFolderCreationRefusedException(accountId, alias);
+
+            this.LogFolderCreated(alias.Value, accountId.Value);
+            await this.SubscribeToCreatedFolderAsync(created, accountId, alias, cancellationToken);
+
+            return created;
+        }
+        catch (Exception refusal) when (refusal is CommandException or InvalidOperationException)
+        {
+            return await FindAdvertisedFolderAsync(client, level.Path, cancellationToken)
+                ?? throw new RemoteFolderCreationRefusedException(accountId, alias, refusal);
+        }
+    }
+
+    /// <summary>Subscribes to a folder this adapter created, so it appears in the operator's own mail client.</summary>
+    /// <remarks>
+    /// A refused subscription does not fail the creation, because the folder exists and that is what was asked for. It
+    /// is worth a warning rather than silence: mail a rule files there is mail the operator will not find by browsing,
+    /// and the remedy — subscribing in their own client — is theirs. Nothing here ever unsubscribes, and no folder this
+    /// adapter did not create is ever subscribed to.
+    /// </remarks>
+    private async Task SubscribeToCreatedFolderAsync(
+        IMailFolder created,
+        MailAccountId accountId,
+        MailFolderAlias alias,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await created.SubscribeAsync(cancellationToken);
+        }
+        catch (Exception refusal) when (refusal is CommandException or InvalidOperationException or FolderNotFoundException)
+        {
+            this.LogSubscriptionRefused(refusal, alias.Value, accountId.Value);
+        }
+    }
+
+    /// <summary>Looks the path up on the server, reporting absence rather than raising it.</summary>
+    /// <remarks>
+    /// A name the server lists as holding no mail at all is reported as absent, so the level is created rather than
+    /// walked through. Whether the configured folder itself may be a container the server refuses to open is settled
+    /// where the walk ends, in <see cref="DescribeConfiguredFolder" />.
+    /// </remarks>
+    private static async Task<IMailFolder?> FindAdvertisedFolderAsync(
+        IImapClient client,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var advertised = await client.GetFolderAsync(path, cancellationToken);
+
+            return advertised.Attributes.HasFlag(FolderAttributes.NonExistent) ? null : advertised;
+        }
+        catch (FolderNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Reads the folder back as the server advertises it, which is the value a binding is compared against later.</summary>
+    /// <remarks>
+    /// <para>
+    /// The delimiter comes from the server rather than from the configured text, because every later run matches this
+    /// alias against a listing that carries it. Binding the configured spelling instead would repoint the alias and
+    /// start a generation on the run after the one that created the folder, with nothing on the server having changed.
+    /// </para>
+    /// <para>
+    /// A folder the server placed at a path other than the configured one is refused for that same reason, and it is a
+    /// real case rather than a defensive one: a server whose personal namespace has a prefix resolves a name written
+    /// without it underneath that prefix, so the folder the operator asked for would exist under a path their mapping
+    /// never matches and every later run would ask for it again. A name the server holds as a hierarchy container or as
+    /// a node holding no mail is refused as well, because the name is taken and no act here can free it.
+    /// </para>
+    /// </remarks>
+    private static RemoteFolderPath DescribeConfiguredFolder(
+        IMailFolder folder,
+        RemoteFolderPath configuredPath,
+        MailAccountId accountId,
+        MailFolderAlias alias)
+    {
+        if (folder.Attributes.HasFlag(FolderAttributes.NoSelect) || folder.Attributes.HasFlag(FolderAttributes.NonExistent))
+        {
+            throw new RemoteFolderCreationRefusedException(accountId, alias);
+        }
+
+        if (!RemoteFolderPath.TryCreate(
+            folder.FullName,
+            NormalizeHierarchyDelimiter(folder.DirectorySeparator),
+            out var advertisedPath)
+            || !string.Equals(advertisedPath.Value, configuredPath.Value, StringComparison.Ordinal))
+        {
+            throw new RemoteFolderCreationRefusedException(accountId, alias);
+        }
+
+        return advertisedPath;
+    }
+
+    /// <summary>Reads the delimiter a server that reports a flat hierarchy leaves unset.</summary>
+    private static char? NormalizeHierarchyDelimiter(char directorySeparator) =>
+        directorySeparator == '\0' ? null : directorySeparator;
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Created a folder on the path configured for alias {FolderAlias} of account {AccountId}.")]
+    private partial void LogFolderCreated(string folderAlias, string accountId);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The mail server refused to subscribe to a folder created for alias {FolderAlias} of account {AccountId}, so the folder exists but may not appear in a mail client that lists subscriptions.")]
+    private partial void LogSubscriptionRefused(Exception refusal, string folderAlias, string accountId);
+
+    /// <summary>One level of a configured path: the name that creates it, and the whole path it sits at.</summary>
+    /// <param name="Name">The level's own name, which is what an IMAP <c>CREATE</c> against its parent takes.</param>
+    /// <param name="Path">The path from the root down to this level, which is what a lookup takes.</param>
+    private readonly record struct ConfiguredFolderLevel(string Name, string Path);
+}

--- a/src/Infrastructure/Mail/MailKit/Writes/MailboxWriteConnectionPool.cs
+++ b/src/Infrastructure/Mail/MailKit/Writes/MailboxWriteConnectionPool.cs
@@ -35,7 +35,9 @@ namespace MailFathom.Infrastructure.Mail.MailKit.Writes;
 /// <para>
 /// A connection is pinned to the folder it selected, because that is what an IMAP selection is. A session for a
 /// different folder of the same account therefore replaces the connection rather than joining it, which keeps the
-/// one-per-account bound exact instead of turning it into one per folder.
+/// one-per-account bound exact instead of turning it into one per folder. A folder creation is the same rule with no
+/// folder on one side of it: it selects nothing — the folder being created cannot be selected until it exists — so it
+/// replaces a connection pinned to a folder and is replaced by the next session that needs one.
 /// </para>
 /// <para>
 /// Each live connection owns a dependency-injection scope of its own, disposed with it. The collaborators it needs to
@@ -100,9 +102,34 @@ internal sealed partial class MailboxWriteConnectionPool : IAsyncDisposable
     /// <param name="cancellationToken">Cancels waiting for the connection, connecting, authenticating, and selecting.</param>
     /// <returns>The lease, which the caller must dispose to give the connection back.</returns>
     /// <exception cref="ObjectDisposedException">Thrown when the pool has been disposed with the host.</exception>
-    internal async Task<MailboxWriteConnectionLease> LeaseAsync(
+    internal Task<MailboxWriteConnectionLease> LeaseAsync(
         MailAccountId accountId,
         MailFolderResolution folder,
+        MailTransportSecurityPolicy transportSecurityPolicy,
+        CancellationToken cancellationToken) =>
+        this.LeaseConnectionAsync(accountId, folder, transportSecurityPolicy, cancellationToken);
+
+    /// <summary>Takes the account's write connection for a change to the mailbox's own shape, which selects no folder.</summary>
+    /// <param name="accountId">The account whose mailbox is to gain a folder.</param>
+    /// <param name="transportSecurityPolicy">The connection and authentication policy every attempt must obey.</param>
+    /// <param name="cancellationToken">Cancels waiting for the connection, connecting, and authenticating.</param>
+    /// <returns>The lease, which the caller must dispose to give the connection back.</returns>
+    /// <exception cref="ObjectDisposedException">Thrown when the pool has been disposed with the host.</exception>
+    /// <remarks>
+    /// It is the same one-per-account connection the mutations run over, which is what keeps a creation from being a
+    /// second login. A connection currently pinned to a folder is replaced rather than joined, for the same reason a
+    /// session for a different folder replaces it: an IMAP selection is a property of the connection, and the folder
+    /// being created cannot be selected at all.
+    /// </remarks>
+    internal Task<MailboxWriteConnectionLease> LeaseForFolderManagementAsync(
+        MailAccountId accountId,
+        MailTransportSecurityPolicy transportSecurityPolicy,
+        CancellationToken cancellationToken) =>
+        this.LeaseConnectionAsync(accountId, folder: null, transportSecurityPolicy, cancellationToken);
+
+    private async Task<MailboxWriteConnectionLease> LeaseConnectionAsync(
+        MailAccountId accountId,
+        MailFolderResolution? folder,
         MailTransportSecurityPolicy transportSecurityPolicy,
         CancellationToken cancellationToken)
     {
@@ -161,6 +188,11 @@ internal sealed partial class MailboxWriteConnectionPool : IAsyncDisposable
 
     [LoggerMessage(
         Level = LogLevel.Debug,
+        Message = "Opened the write connection for account {AccountId}, selecting no folder so the mailbox's own folders can be managed.")]
+    private partial void LogFolderManagementConnectionOpened(string accountId);
+
+    [LoggerMessage(
+        Level = LogLevel.Debug,
         Message = "Closed the write connection for account {AccountId}.")]
     private partial void LogWriteConnectionClosed(string accountId);
 
@@ -189,7 +221,7 @@ internal sealed partial class MailboxWriteConnectionPool : IAsyncDisposable
         private volatile Task pendingEviction = Task.CompletedTask;
 
         internal async Task<MailboxWriteConnectionLease> LeaseAsync(
-            MailFolderResolution folder,
+            MailFolderResolution? folder,
             MailTransportSecurityPolicy transportSecurityPolicy,
             CancellationToken cancellationToken)
         {
@@ -207,14 +239,26 @@ internal sealed partial class MailboxWriteConnectionPool : IAsyncDisposable
                 // Nothing may expire the connection while a caller holds it; the clock starts again on release.
                 this.idleTimer?.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
-                if (this.selectedFolderId is { } heldFolderId && heldFolderId != folder.Id)
+                // A held connection whose selection is not the one this caller needs is replaced rather than reselected,
+                // because what a connection selects is fixed when it is created. That covers a second folder and it
+                // covers a folder creation, which selects nothing at all and so can share a connection with neither.
+                if (this.connection is not null && this.selectedFolderId != folder?.Id)
                 {
                     await this.CloseHeldConnectionAsync();
                 }
 
                 this.connection ??= this.OpenConnection(folder, transportSecurityPolicy);
-                await this.connection.EnsureOpenFolderAsync(cancellationToken);
-                this.selectedFolderId = folder.Id;
+
+                if (folder is null)
+                {
+                    await this.connection.EnsureAuthenticatedClientAsync(cancellationToken);
+                }
+                else
+                {
+                    await this.connection.EnsureOpenFolderAsync(cancellationToken);
+                }
+
+                this.selectedFolderId = folder?.Id;
 
                 return new MailboxWriteConnectionLease(accountId, this.connection, this.ReleaseAsync);
             }
@@ -263,25 +307,45 @@ internal sealed partial class MailboxWriteConnectionPool : IAsyncDisposable
         }
 
         private MailKitImapConnection OpenConnection(
-            MailFolderResolution folder,
+            MailFolderResolution? folder,
             MailTransportSecurityPolicy transportSecurityPolicy)
         {
             var scope = pool.scopeFactory.CreateScope();
 
             try
             {
-                var establishedConnection = MailKitImapConnection.ForWriting(
-                    pool.clientFactory,
-                    scope.ServiceProvider.GetRequiredService<IImapAccountSettingsProvider>(),
-                    scope.ServiceProvider.GetRequiredService<IMailAccessTokenSource>(),
-                    pool.operationExecutor,
-                    pool.transientFailureClassifier,
-                    accountId,
-                    folder,
-                    transportSecurityPolicy);
+                var settingsProvider = scope.ServiceProvider.GetRequiredService<IImapAccountSettingsProvider>();
+                var accessTokenSource = scope.ServiceProvider.GetRequiredService<IMailAccessTokenSource>();
+
+                var establishedConnection = folder is { } selectedFolder
+                    ? MailKitImapConnection.ForWriting(
+                        pool.clientFactory,
+                        settingsProvider,
+                        accessTokenSource,
+                        pool.operationExecutor,
+                        pool.transientFailureClassifier,
+                        accountId,
+                        selectedFolder,
+                        transportSecurityPolicy)
+                    : MailKitImapConnection.ForFolderManagement(
+                        pool.clientFactory,
+                        settingsProvider,
+                        accessTokenSource,
+                        pool.operationExecutor,
+                        pool.transientFailureClassifier,
+                        accountId,
+                        transportSecurityPolicy);
 
                 this.connectionScope = scope;
-                pool.LogWriteConnectionOpened(accountId.Value, folder.Alias.Value);
+
+                if (folder is { } openedFolder)
+                {
+                    pool.LogWriteConnectionOpened(accountId.Value, openedFolder.Alias.Value);
+                }
+                else
+                {
+                    pool.LogFolderManagementConnectionOpened(accountId.Value);
+                }
 
                 return establishedConnection;
             }

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -427,6 +427,12 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IMailboxWriteSessionFactory>(provider => new MailKitImapWriteSessionFactory(
             provider.GetRequiredService<MailboxWriteConnectionPool>(),
             provider.GetRequiredService<MailboxMutationTelemetry>()));
+        // Registered beside the write session and against the same pool, because a creation is issued over the account's
+        // one write connection. It is a separate port rather than a method on the session above, so a component holding
+        // one of the two can never reach the other.
+        services.AddScoped<IRemoteFolderCreator>(provider => new MailKitRemoteFolderCreator(
+            provider.GetRequiredService<MailboxWriteConnectionPool>(),
+            provider.GetRequiredService<ILogger<MailKitRemoteFolderCreator>>()));
         // The record is written before the session that acts on it is opened, so the store is registered beside the
         // other repositories that take a persistence session rather than with the mail adapters above.
         services.AddScoped<IMailboxMutationRecordStore, MailboxMutationRecordStore>();

--- a/tests/Application.UnitTests/Folders/MailFolderResolverTests.cs
+++ b/tests/Application.UnitTests/Folders/MailFolderResolverTests.cs
@@ -270,10 +270,132 @@ public sealed class MailFolderResolverTests
         await context.MappingChangeAuditor.DidNotReceive().RecordMappingChangeAsync(Arg.Any<MailFolderMappingChange>(), Arg.Any<CancellationToken>());
     }
 
+    /// <summary>
+    /// The two halves of the reopened decision, asserted side by side so the refusal cannot quietly become a creation.
+    /// A mapping that says nothing about creation keeps reporting the unresolved alias a mistyped path produces, and
+    /// only the mapping that asked for it reaches the mail server at all.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_NothingAdvertisedAtTheConfiguredPath_CreatesTheFolderOnlyForTheMappingThatAskedFor()
+    {
+        // Arrange
+        var context = new ResolverContext(new RemoteFolder(RemoteFolderPath.Create("INBOX", '/'), [MailFolderSpecialUse.Inbox]));
+        var silentMapping = MailFolderMapping.ToRemotePath(
+            MailFolderAlias.Create("archief"),
+            RemoteFolderPath.Create("Archief"));
+        var creatingMapping = MailFolderMapping.ToRemotePath(
+            MailFolderAlias.Create("archive"),
+            RemoteFolderPath.Create("Archive/2026"),
+            participation: null,
+            mayCreateMissingFolder: true);
+
+        // Act
+        var silentResult = await context.Resolver.ResolveAsync(PrimaryAccount, silentMapping, RequiredTlsPolicy, CancellationToken.None);
+        var creatingResult = await context.Resolver.ResolveAsync(PrimaryAccount, creatingMapping, RequiredTlsPolicy, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(MailFolderResolutionOutcome.NoAdvertisedFolderMatched, silentResult.Outcome);
+        Assert.Equal(MailFolderResolutionOutcome.Resolved, creatingResult.Outcome);
+        Assert.Equal(["Archive/2026"], context.CreatedPaths.Select(path => path.Value));
+    }
+
+    /// <summary>A created folder is bound exactly as a discovered one, which is what keeps everything downstream of resolution indifferent to how the folder came to exist.</summary>
+    [Fact]
+    public async Task ResolveAsync_FolderWasCreated_BindsItAndAuditsTheChangeAsAnOrdinaryFirstBinding()
+    {
+        // Arrange
+        var context = new ResolverContext(new RemoteFolder(RemoteFolderPath.Create("INBOX", '/'), [MailFolderSpecialUse.Inbox]));
+        var mapping = MailFolderMapping.ToRemotePath(
+            MailFolderAlias.Create("archive"),
+            RemoteFolderPath.Create("Archive/2026"),
+            participation: null,
+            mayCreateMissingFolder: true);
+
+        // Act
+        var result = await context.Resolver.ResolveAsync(PrimaryAccount, mapping, RequiredTlsPolicy, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(RemoteFolderPath.Create("Archive/2026", '/'), result.Resolution!.RemotePath);
+        Assert.Equal(1, result.Resolution.Generation.Value);
+
+        var change = Assert.Single(context.RecordedChanges);
+        Assert.Null(change.PreviousRemotePath);
+        Assert.Equal("Archive/2026", change.NewRemotePath.Value);
+        Assert.Equal(ResolverContext.ResolvedAt, change.OccurredAt);
+    }
+
+    /// <summary>
+    /// The created folder binds under the delimiter the server reports rather than the configured spelling, which is
+    /// what stops the run after the creating one from reading its own binding as a repointed alias and starting a
+    /// second generation over a folder nothing changed.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_RunAfterTheOneThatCreatedTheFolder_ReturnsTheSameBindingWithoutWritingAgain()
+    {
+        // Arrange
+        var createdPath = RemoteFolderPath.Create("Archive/2026", '/');
+        var context = new ResolverContext(new RemoteFolder(createdPath, []));
+        var mapping = MailFolderMapping.ToRemotePath(
+            MailFolderAlias.Create("archive"),
+            RemoteFolderPath.Create("Archive/2026"),
+            participation: null,
+            mayCreateMissingFolder: true);
+        context.BindAliasTo(MailFolderResolution.FirstBindingOf(mapping.Alias, createdPath));
+
+        // Act
+        var result = await context.Resolver.ResolveAsync(PrimaryAccount, mapping, RequiredTlsPolicy, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.Resolution!.Generation.Value);
+        Assert.Empty(context.CreatedPaths);
+        await context.MappingChangeAuditor.DidNotReceive().RecordMappingChangeAsync(Arg.Any<MailFolderMappingChange>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>A folder that does not exist advertises no role, so a role mapping can never be the thing that creates one.</summary>
+    [Fact]
+    public async Task ResolveAsync_RoleMappingMatchesNothingAdvertised_ReachesNoCreationAtAll()
+    {
+        // Arrange
+        var context = new ResolverContext(new RemoteFolder(RemoteFolderPath.Create("INBOX", '/'), [MailFolderSpecialUse.Inbox]));
+        var mapping = MailFolderMapping.ToSpecialUse(MailFolderAlias.Create("archive"), MailFolderSpecialUse.Archive);
+
+        // Act
+        var result = await context.Resolver.ResolveAsync(PrimaryAccount, mapping, RequiredTlsPolicy, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(MailFolderResolutionOutcome.NoAdvertisedFolderMatched, result.Outcome);
+        Assert.Empty(context.CreatedPaths);
+    }
+
+    /// <summary>A refused creation stays what it is rather than becoming the message a mistyped path gets, and nothing is bound behind it.</summary>
+    [Fact]
+    public async Task ResolveAsync_MailServerRefusedTheCreation_ReportsTheRefusalAndRecordsNoBinding()
+    {
+        // Arrange
+        var context = new ResolverContext(new RemoteFolder(RemoteFolderPath.Create("INBOX", '/'), [MailFolderSpecialUse.Inbox]));
+        var mapping = MailFolderMapping.ToRemotePath(
+            MailFolderAlias.Create("archive"),
+            RemoteFolderPath.Create("Archive/2026"),
+            participation: null,
+            mayCreateMissingFolder: true);
+        context.RefuseCreationOf(mapping.Alias);
+
+        // Act, Assert
+        var refusal = await Assert.ThrowsAsync<RemoteFolderCreationRefusedException>(
+            () => context.Resolver.ResolveAsync(PrimaryAccount, mapping, RequiredTlsPolicy, CancellationToken.None));
+
+        Assert.Equal("ARCHIVE", refusal.FolderAlias.Value);
+        Assert.DoesNotContain("Archive/2026", refusal.Message, StringComparison.Ordinal);
+        await context.PersistenceSessionFactory.DidNotReceive().BeginSessionAsync(Arg.Any<CancellationToken>());
+    }
+
     /// <summary>Builds a resolver over a server that advertises exactly the folders a test names.</summary>
     private sealed class ResolverContext
     {
         internal static readonly DateTimeOffset ResolvedAt = new(2026, 7, 28, 9, 0, 0, TimeSpan.Zero);
+
+        /// <summary>The delimiter the modelled server reports for every folder it advertises or creates.</summary>
+        internal const char AdvertisedDelimiter = '/';
 
         private readonly Dictionary<string, MailFolderResolution> bindingsByAlias = new(StringComparer.Ordinal);
 
@@ -305,8 +427,27 @@ public sealed class MailFolderResolverTests
                     return Task.CompletedTask;
                 });
 
+            this.FolderCreator = Substitute.For<IRemoteFolderCreator>();
+            this.FolderCreator
+                .CreateFolderAsync(
+                    Arg.Any<MailAccountId>(),
+                    Arg.Any<MailFolderAlias>(),
+                    Arg.Any<RemoteFolderPath>(),
+                    Arg.Any<MailTransportSecurityPolicy>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(call =>
+                {
+                    var configuredPath = call.Arg<RemoteFolderPath>();
+                    this.CreatedPaths.Add(configuredPath);
+
+                    // A server answers with the folder as it advertises it, delimiter included, which is exactly what a
+                    // later listing would report for the same folder.
+                    return Task.FromResult(RemoteFolderPath.Create(configuredPath.Value, AdvertisedDelimiter));
+                });
+
             this.Resolver = new MailFolderResolver(
                 remoteFolderCatalog,
+                this.FolderCreator,
                 this.ResolutionStore,
                 this.MappingChangeAuditor,
                 this.PersistenceSessionFactory,
@@ -314,6 +455,10 @@ public sealed class MailFolderResolverTests
         }
 
         internal MailFolderResolver Resolver { get; }
+
+        internal IRemoteFolderCreator FolderCreator { get; }
+
+        internal List<RemoteFolderPath> CreatedPaths { get; } = [];
 
         internal IMailFolderResolutionStore ResolutionStore { get; }
 
@@ -327,5 +472,17 @@ public sealed class MailFolderResolverTests
 
         internal void BindAliasTo(MailFolderResolution resolution) =>
             this.bindingsByAlias[resolution.Alias.Value] = resolution;
+
+        /// <summary>Models a mail server that answers the creation of one alias's folder by refusing it.</summary>
+        internal void RefuseCreationOf(MailFolderAlias alias) =>
+            this.FolderCreator
+                .CreateFolderAsync(
+                    Arg.Any<MailAccountId>(),
+                    alias,
+                    Arg.Any<RemoteFolderPath>(),
+                    Arg.Any<MailTransportSecurityPolicy>(),
+                    Arg.Any<CancellationToken>())
+                .Returns<Task<RemoteFolderPath>>(_ =>
+                    throw new RemoteFolderCreationRefusedException(PrimaryAccount, alias));
     }
 }

--- a/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -1738,6 +1738,7 @@ public sealed class MailboxSynchronizerTests
 
         return new MailFolderResolver(
             remoteFolderCatalog,
+            Substitute.For<IRemoteFolderCreator>(),
             Substitute.For<IMailFolderResolutionStore>(),
             Substitute.For<IMailFolderMappingChangeAuditor>(),
             persistenceSessionFactory,
@@ -1767,6 +1768,7 @@ public sealed class MailboxSynchronizerTests
 
         return new MailFolderResolver(
             remoteFolderCatalog,
+            Substitute.For<IRemoteFolderCreator>(),
             resolutionStore,
             Substitute.For<IMailFolderMappingChangeAuditor>(),
             persistenceSessionFactory,

--- a/tests/Domain.UnitTests/Folders/MailFolderTests.cs
+++ b/tests/Domain.UnitTests/Folders/MailFolderTests.cs
@@ -175,6 +175,56 @@ public sealed class MailFolderTests
         Assert.Null(mapping.RemotePath);
     }
 
+    /// <summary>
+    /// A mapping that says nothing about creation authorizes none. The asymmetry with the participation switches is the
+    /// decision rather than an oversight: those withdraw a folder that already exists from something MailFathom does
+    /// locally, while this one would have it act against somebody's mail server.
+    /// </summary>
+    [Fact]
+    public void ToRemotePath_NoCreationNamed_MayNotCreateTheFolder()
+    {
+        // Arrange
+        var alias = MailFolderAlias.Create("archive");
+
+        // Act
+        var mapping = MailFolderMapping.ToRemotePath(alias, RemoteFolderPath.Create("Archief"));
+
+        // Assert
+        Assert.False(mapping.MayCreateMissingFolder);
+    }
+
+    /// <summary>A folder that does not exist advertises no role, so a role mapping is structurally unable to carry the authorization.</summary>
+    [Fact]
+    public void ToSpecialUse_AnyRole_MayNotCreateTheFolder()
+    {
+        // Arrange
+        var alias = MailFolderAlias.Create("junk");
+
+        // Act
+        var mapping = MailFolderMapping.ToSpecialUse(alias, MailFolderSpecialUse.Junk);
+
+        // Assert
+        Assert.False(mapping.MayCreateMissingFolder);
+    }
+
+    [Fact]
+    public void ToRemotePath_CreationAsked_CarriesTheAuthorizationBesideTheConfiguredPath()
+    {
+        // Arrange
+        var alias = MailFolderAlias.Create("archive");
+
+        // Act
+        var mapping = MailFolderMapping.ToRemotePath(
+            alias,
+            RemoteFolderPath.Create("Archief"),
+            participation: null,
+            mayCreateMissingFolder: true);
+
+        // Assert
+        Assert.True(mapping.MayCreateMissingFolder);
+        Assert.Equal("Archief", mapping.RemotePath!.Value.Value);
+    }
+
     /// <summary>A mapping written before the switches existed still means the same thing, which is what keeps an existing configuration unchanged.</summary>
     [Fact]
     public void ToRemotePath_NoParticipationNamed_TakesPartInEverything()

--- a/tests/Host.UnitTests/Configuration/Mail/MailFolderParticipationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailFolderParticipationOptionsTests.cs
@@ -240,6 +240,70 @@ public sealed class MailFolderParticipationOptionsTests
         Assert.Empty(results);
     }
 
+    /// <summary>
+    /// A folder that does not exist advertises no role, so creating one from a role would mean either an extension
+    /// whose support is uneven or MailFathom inventing a name in somebody's own mailbox. Writing the path the folder is
+    /// to be created at is one line of configuration, so the contradiction is refused where it binds.
+    /// </summary>
+    [Fact]
+    public void ValidateForSynchronization_ARoleMappingAskingToBeCreated_IsRefusedNamingTheFolder()
+    {
+        // Arrange
+        var options = OptionsFor(CreateAccount(new MailFolderMappingOptions
+        {
+            Alias = "junk",
+            SpecialUse = "Junk",
+            CreateIfMissing = true,
+        }));
+
+        // Act
+        var messages = options.ValidateForSynchronization().Select(result => result.ErrorMessage!).ToArray();
+
+        // Assert
+        Assert.Contains(
+            messages,
+            message => message.Contains("'junk'", StringComparison.Ordinal)
+                && message.Contains("RemotePath", StringComparison.Ordinal));
+    }
+
+    /// <summary>The switch belongs to a configured path, which is the only mapping that names where a folder would be created.</summary>
+    [Fact]
+    public void ValidateForSynchronization_APathMappingAskingToBeCreated_ReportsNoError()
+    {
+        // Arrange
+        var options = OptionsFor(CreateAccount(new MailFolderMappingOptions
+        {
+            Alias = "archive",
+            RemotePath = "Archief/2026",
+            CreateIfMissing = true,
+        }));
+
+        // Act
+        var results = options.ValidateForSynchronization().ToArray();
+
+        // Assert
+        Assert.Empty(results);
+    }
+
+    /// <summary>Explicitly declining a creation beside a role says nothing a role mapping cannot do, so it is not the contradiction above.</summary>
+    [Fact]
+    public void ValidateForSynchronization_ARoleMappingDecliningCreation_ReportsNoError()
+    {
+        // Arrange
+        var options = OptionsFor(CreateAccount(new MailFolderMappingOptions
+        {
+            Alias = "junk",
+            SpecialUse = "Junk",
+            CreateIfMissing = false,
+        }));
+
+        // Act
+        var results = options.ValidateForSynchronization().ToArray();
+
+        // Assert
+        Assert.Empty(results);
+    }
+
     private static MailSynchronizationOptions OptionsFor(MailSynchronizationAccountOptions account) =>
         new() { Accounts = [account] };
 

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -123,6 +123,10 @@ internal static class SynchronizationTestHost
         services.AddSingleton(remoteFolderCatalog ?? catalog);
         services.AddSingleton(resolutionStore);
         services.AddSingleton(Substitute.For<IMailFolderMappingChangeAuditor>());
+        // Registered so a resolver can be composed at all, and never configured to answer: no mapping these tests build
+        // asks for its folder to be created, so a call reaching it would mean resolution had started creating folders
+        // for a mapping that never asked.
+        services.AddSingleton(Substitute.For<IRemoteFolderCreator>());
         services.AddScoped<MailFolderResolver>();
         services.AddScoped<OptimisticConcurrencyRetryPolicy>();
         services.AddScoped<MailboxSynchronizer>();

--- a/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitImapConnectionAccessTests.cs
+++ b/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitImapConnectionAccessTests.cs
@@ -80,4 +80,90 @@ public sealed class MailKitImapConnectionAccessTests
         Assert.Equal(7U, read);
         Assert.Equal(1, client.ConnectCount);
     }
+
+    /// <summary>
+    /// The two write permissions are separate connections rather than one. A connection that selects a folder is the
+    /// one that moves messages in it, and asking it to change the mailbox's own shape fails here rather than reaching
+    /// a server — which is what keeps a component able to file a message unable to create a folder.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteFolderManagementAsync_OnAConnectionThatSelectedAFolder_IsRefusedWithoutReachingTheServer()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient { Folder = CreateSelectedFolder() };
+        client.AuthenticationMechanisms.Add("PLAIN");
+        await using var connection = MailKitImapConnection.ForWriting(
+            () => client.Client,
+            CreateSettingsProvider(),
+            new UnusedMailAccessTokenSource(),
+            resilience.Executor,
+            resilience.TransientFailureClassifier,
+            PrimaryAccount,
+            InboxFolder,
+            TlsOnConnectWithPlainPolicy);
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => connection.ExecuteFolderManagementAsync((_, _) => Task.FromResult(true), CancellationToken.None));
+
+        // Assert
+        Assert.Contains("manage folders", refusal.Message, StringComparison.Ordinal);
+        Assert.Equal(0, client.ConnectCount);
+    }
+
+    /// <summary>And the reverse, which is the half that keeps a component able to create a folder unable to touch a message in one.</summary>
+    [Fact]
+    public async Task ExecuteMutationAsync_OnAConnectionOpenedToManageFolders_IsRefusedWithoutReachingTheServer()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient { Folder = CreateSelectedFolder() };
+        client.AuthenticationMechanisms.Add("PLAIN");
+        await using var connection = MailKitImapConnection.ForFolderManagement(
+            () => client.Client,
+            CreateSettingsProvider(),
+            new UnusedMailAccessTokenSource(),
+            resilience.Executor,
+            resilience.TransientFailureClassifier,
+            PrimaryAccount,
+            TlsOnConnectWithPlainPolicy);
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => connection.ExecuteMutationAsync((_, _, _) => Task.FromResult(true), CancellationToken.None));
+
+        // Assert
+        Assert.Contains("selects no folder", refusal.Message, StringComparison.Ordinal);
+        Assert.Equal(0, client.ConnectCount);
+    }
+
+    /// <summary>A connection opened to manage folders authenticates and selects nothing, which is what a <c>CREATE</c> needs and all it needs.</summary>
+    [Fact]
+    public async Task ExecuteFolderManagementAsync_OnAConnectionOpenedToManageFolders_RunsWithoutSelectingAFolder()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var openFolder = CreateSelectedFolder();
+        var client = new FakeImapClient { Folder = openFolder };
+        client.AuthenticationMechanisms.Add("PLAIN");
+        await using var connection = MailKitImapConnection.ForFolderManagement(
+            () => client.Client,
+            CreateSettingsProvider(),
+            new UnusedMailAccessTokenSource(),
+            resilience.Executor,
+            resilience.TransientFailureClassifier,
+            PrimaryAccount,
+            TlsOnConnectWithPlainPolicy);
+
+        // Act
+        var managed = await connection.ExecuteFolderManagementAsync(
+            (managedClient, _) => Task.FromResult(managedClient.IsConnected),
+            CancellationToken.None);
+
+        // Assert
+        Assert.True(managed);
+        Assert.Equal(1, client.ConnectCount);
+        await openFolder.DidNotReceive().OpenAsync(Arg.Any<FolderAccess>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Infrastructure.UnitTests/Mail/MailKit/Writes/MailKitRemoteFolderCreatorTests.cs
+++ b/tests/Infrastructure.UnitTests/Mail/MailKit/Writes/MailKitRemoteFolderCreatorTests.cs
@@ -1,0 +1,290 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Domain.Failures;
+using MailFathom.Domain.Folders;
+using MailFathom.Infrastructure.UnitTests.TestDoubles;
+using MailKit;
+using MailKit.Net.Imap;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using static MailFathom.Infrastructure.UnitTests.TestDoubles.MailKitImapSessionTestContext;
+using static MailFathom.Infrastructure.UnitTests.TestDoubles.MailKitImapWriteSessionTestContext;
+
+namespace MailFathom.Infrastructure.UnitTests.Mail.MailKit.Writes;
+
+public sealed class MailKitRemoteFolderCreatorTests
+{
+    private static readonly MailFolderAlias ArchiveAlias = MailFolderAlias.Create("archive");
+
+    /// <summary>The whole point of the reopened decision: a folder an operator configured comes into existence.</summary>
+    [Fact]
+    public async Task CreateFolderAsync_ServerAdvertisesNothingAtThePath_CreatesTheFolderAndSubscribesToIt()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var root = AdvertisedFolder(string.Empty);
+        var created = AdvertisedFolder("Archief");
+        AnswerCreationOf(root, "Archief", created);
+        PrepareMissingFolders(client, root, "Archief");
+        await using var harness = CreateHarness(resilience, client, CreateWritableFolder());
+
+        // Act
+        var advertisedPath = await harness.CreateFolderAsync(ArchiveAlias, "Archief");
+
+        // Assert
+        Assert.Equal("Archief", advertisedPath.Value);
+        Assert.Equal('/', advertisedPath.HierarchyDelimiter);
+        await created.Received(1).SubscribeAsync(Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A folder already at the path is the answer rather than a failure, and nothing is created beside it. Resolution
+    /// only asks for a creation when its listing found nothing, so reaching this means something else put the folder
+    /// there — which is exactly the state the operator wanted.
+    /// </summary>
+    [Fact]
+    public async Task CreateFolderAsync_FolderIsAlreadyThere_ReturnsItWithoutCreatingASecond()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var root = AdvertisedFolder(string.Empty);
+        PrepareMissingFolders(client, root);
+        client.FoldersByPath["Archief"] = AdvertisedFolder("Archief");
+        await using var harness = CreateHarness(resilience, client, CreateWritableFolder());
+
+        // Act
+        var advertisedPath = await harness.CreateFolderAsync(ArchiveAlias, "Archief");
+
+        // Assert
+        Assert.Equal("Archief", advertisedPath.Value);
+        await root.DidNotReceive().CreateAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// An IMAP <c>CREATE</c> against an existing folder is answered as an error, so the refusal alone says nothing
+    /// about whether the folder is there. The one lookup that follows is what separates another client winning the race
+    /// from a server that will not hold a folder at that path.
+    /// </summary>
+    [Fact]
+    public async Task CreateFolderAsync_AnotherClientCreatedTheFolderFirst_ReadsTheRefusalAsSuccess()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var root = AdvertisedFolder(string.Empty);
+        var racedFolder = AdvertisedFolder("Archief");
+        PrepareMissingFolders(client, root, "Archief");
+        root
+            .CreateAsync("Archief", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IMailFolder?>>(_ =>
+            {
+                client.AbsentFolderPaths.Remove("Archief");
+                client.FoldersByPath["Archief"] = racedFolder;
+
+                throw new ImapCommandException(ImapCommandResponse.No, "Mailbox already exists.");
+            });
+        await using var harness = CreateHarness(resilience, client, CreateWritableFolder());
+
+        // Act
+        var advertisedPath = await harness.CreateFolderAsync(ArchiveAlias, "Archief");
+
+        // Assert
+        Assert.Equal("Archief", advertisedPath.Value);
+        await racedFolder.DidNotReceive().SubscribeAsync(Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// The configured text is the server's own path and is never rewritten. What the delimiter decides is only where
+    /// its levels are, so a server separating them with a dot builds the same hierarchy the same way.
+    /// </summary>
+    [Fact]
+    public async Task CreateFolderAsync_ServerSeparatesLevelsWithSomethingOtherThanASlash_BuildsTheSameHierarchy()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient { PersonalNamespaces = [new FolderNamespace('.', string.Empty)] };
+        var root = AdvertisedFolder(string.Empty, '.');
+        var parent = AdvertisedFolder("Archief", '.');
+        var leaf = AdvertisedFolder("Archief.2026", '.');
+        AnswerCreationOf(root, "Archief", parent);
+        AnswerCreationOf(parent, "2026", leaf);
+        PrepareMissingFolders(client, root, "Archief", "Archief.2026");
+        await using var harness = CreateHarness(resilience, client, CreateWritableFolder());
+
+        // Act
+        var advertisedPath = await harness.CreateFolderAsync(ArchiveAlias, "Archief.2026");
+
+        // Assert
+        Assert.Equal("Archief.2026", advertisedPath.Value);
+        Assert.Equal('.', advertisedPath.HierarchyDelimiter);
+        Received.InOrder(() =>
+        {
+            _ = root.CreateAsync("Archief", Arg.Any<bool>(), Arg.Any<CancellationToken>());
+            _ = parent.CreateAsync("2026", Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        });
+    }
+
+    /// <summary>Every level of the path is a name the operator wrote, and a level already there is stepped over rather than recreated.</summary>
+    [Fact]
+    public async Task CreateFolderAsync_OnlyTheLastLevelIsMissing_CreatesThatLevelAlone()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var root = AdvertisedFolder(string.Empty);
+        var parent = AdvertisedFolder("Archief");
+        var leaf = AdvertisedFolder("Archief/2026");
+        AnswerCreationOf(parent, "2026", leaf);
+        PrepareMissingFolders(client, root, "Archief/2026");
+        client.FoldersByPath["Archief"] = parent;
+        await using var harness = CreateHarness(resilience, client, CreateWritableFolder());
+
+        // Act
+        var advertisedPath = await harness.CreateFolderAsync(ArchiveAlias, "Archief/2026");
+
+        // Assert
+        Assert.Equal("Archief/2026", advertisedPath.Value);
+        await root.DidNotReceive().CreateAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        await parent.Received(1).CreateAsync("2026", Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A refused creation has to be readable as itself. Telling it from an alias that resolves to nothing is what makes
+    /// the operator's remedy findable, and the message may name the alias and nothing about the mailbox behind it.
+    /// </summary>
+    [Fact]
+    public async Task CreateFolderAsync_ServerRefusesTheCreation_ReportsARefusalNamingTheAliasAndNotThePath()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var root = AdvertisedFolder(string.Empty);
+        root
+            .CreateAsync("Archief", Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IMailFolder?>>(_ =>
+                throw new ImapCommandException(ImapCommandResponse.No, "Over quota."));
+        PrepareMissingFolders(client, root, "Archief");
+        await using var harness = CreateHarness(resilience, client, CreateWritableFolder());
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<RemoteFolderCreationRefusedException>(
+            () => harness.CreateFolderAsync(ArchiveAlias, "Archief"));
+
+        // Assert
+        Assert.Equal(MailFathomErrorCode.RemoteFolderCreationRefused, refusal.ErrorCode);
+        Assert.Contains("ARCHIVE", refusal.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Archief", refusal.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>A folder that exists is what was asked for, so the subscription that follows it may fail without undoing it.</summary>
+    [Fact]
+    public async Task CreateFolderAsync_ServerRefusesTheSubscription_LeavesTheCreationSuccessfulAndWarns()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var root = AdvertisedFolder(string.Empty);
+        var created = AdvertisedFolder("Archief");
+        created
+            .SubscribeAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => throw new ImapCommandException(ImapCommandResponse.No, "Subscriptions unavailable."));
+        AnswerCreationOf(root, "Archief", created);
+        PrepareMissingFolders(client, root, "Archief");
+        await using var harness = CreateHarness(resilience, client, CreateWritableFolder());
+
+        // Act
+        var advertisedPath = await harness.CreateFolderAsync(ArchiveAlias, "Archief");
+
+        // Assert
+        Assert.Equal("Archief", advertisedPath.Value);
+        Assert.Contains(
+            harness.RecordedLogs.Records,
+            record => record.Level == LogLevel.Warning && record.Properties.ContainsKey("FolderAlias"));
+    }
+
+    /// <summary>
+    /// Discovery leaves a container the server refuses to open out of its catalog, so the alias resolves to nothing
+    /// while the name is already taken. What the operator needs then is a different path rather than an act this
+    /// adapter can take for them.
+    /// </summary>
+    [Fact]
+    public async Task CreateFolderAsync_NameIsAlreadyAContainerTheServerWillNotOpen_RefusesRatherThanCreating()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient();
+        var root = AdvertisedFolder(string.Empty);
+        PrepareMissingFolders(client, root);
+        client.FoldersByPath["Archief"] = AdvertisedFolder("Archief", '/', FolderAttributes.NoSelect);
+        await using var harness = CreateHarness(resilience, client, CreateWritableFolder());
+
+        // Act, Assert
+        await Assert.ThrowsAsync<RemoteFolderCreationRefusedException>(
+            () => harness.CreateFolderAsync(ArchiveAlias, "Archief"));
+
+        await root.DidNotReceive().CreateAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A server whose personal namespace has a prefix resolves a name written without it underneath that prefix, so the
+    /// folder would exist at a path the mapping never matches and every later run would ask for it again. Refusing says
+    /// what the operator has to change; binding the path the server chose would hide it.
+    /// </summary>
+    [Fact]
+    public async Task CreateFolderAsync_ServerPlacedTheFolderSomewhereElse_RefusesInsteadOfBindingThePathItChose()
+    {
+        // Arrange
+        using var resilience = CreateSingleAttemptResilience();
+        var client = new FakeImapClient { PersonalNamespaces = [new FolderNamespace('.', "INBOX.")] };
+        var root = AdvertisedFolder("INBOX", '.');
+        AnswerCreationOf(root, "Archief", AdvertisedFolder("INBOX.Archief", '.'));
+        PrepareMissingFolders(client, root, "Archief");
+        await using var harness = CreateHarness(resilience, client, CreateWritableFolder());
+
+        // Act, Assert
+        await Assert.ThrowsAsync<RemoteFolderCreationRefusedException>(
+            () => harness.CreateFolderAsync(ArchiveAlias, "Archief"));
+    }
+
+    /// <summary>Builds a folder the modelled server advertises, with the attributes and delimiter it reports for it.</summary>
+    private static IMailFolder AdvertisedFolder(
+        string fullName,
+        char directorySeparator = '/',
+        FolderAttributes attributes = FolderAttributes.None)
+    {
+        var folder = Substitute.For<IMailFolder>();
+        folder.FullName.Returns(fullName);
+        folder.DirectorySeparator.Returns(directorySeparator);
+        folder.Attributes.Returns(attributes);
+
+        return folder;
+    }
+
+    /// <summary>Scripts one level of the hierarchy being created under its parent.</summary>
+    private static void AnswerCreationOf(IMailFolder parent, string levelName, IMailFolder created) =>
+        parent
+            .CreateAsync(levelName, Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IMailFolder?>(created));
+
+    /// <summary>Points the server at its namespace root and states which paths it advertises no folder for.</summary>
+    /// <remarks>
+    /// Naming the absent paths is required rather than optional: the scripted server answers a lookup it was told
+    /// nothing about with the selected folder, so a path left unnamed here would read as an existing folder and the
+    /// creation under test would never be attempted.
+    /// </remarks>
+    private static void PrepareMissingFolders(FakeImapClient client, IMailFolder root, params string[] missingPaths)
+    {
+        client.NamespaceRootFolder = root;
+
+        foreach (var missingPath in missingPaths)
+        {
+            client.AbsentFolderPaths.Add(missingPath);
+        }
+    }
+}

--- a/tests/Infrastructure.UnitTests/TestDoubles/FakeImapClient.cs
+++ b/tests/Infrastructure.UnitTests/TestDoubles/FakeImapClient.cs
@@ -95,6 +95,9 @@ internal sealed class FakeImapClient
     /// <summary>Gets or sets the folder the server answers as its inbox.</summary>
     internal IMailFolder? InboxFolder { get; set; }
 
+    /// <summary>Gets or sets the folder the server answers for the root of a namespace, which is the parent a top-level folder is created under.</summary>
+    internal IMailFolder? NamespaceRootFolder { get; set; }
+
     internal IReadOnlyList<string> MechanismsWhenAuthenticated { get; private set; } = [];
 
     internal bool AuthenticateCalled { get; private set; }
@@ -287,6 +290,10 @@ internal sealed class FakeImapClient
         this.Client.PersonalNamespaces.Returns(_ => ToNamespaceCollection(this.PersonalNamespaces));
         this.Client.OtherNamespaces.Returns(_ => ToNamespaceCollection(this.OtherNamespaces));
         this.Client.SharedNamespaces.Returns(_ => ToNamespaceCollection(this.SharedNamespaces));
+        this.Client
+            .GetFolder(Arg.Any<FolderNamespace>())
+            .Returns(_ => this.NamespaceRootFolder
+                ?? throw new InvalidOperationException("No test namespace root folder configured."));
         this.Client
             .GetFoldersAsync(Arg.Any<FolderNamespace>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
             .Returns(call =>

--- a/tests/Infrastructure.UnitTests/TestDoubles/MailKitImapWriteSessionTestContext.cs
+++ b/tests/Infrastructure.UnitTests/TestDoubles/MailKitImapWriteSessionTestContext.cs
@@ -199,7 +199,7 @@ internal static class MailKitImapWriteSessionTestContext
     /// Written out rather than reached through <see cref="LoggerFactory" />, because the framework's
     /// <see cref="Logger{T}" /> takes ownership of a factory that nothing here would ever release.
     /// </remarks>
-    private sealed class RecordingCategoryLogger<TCategory> : ILogger<TCategory>
+    internal sealed class RecordingCategoryLogger<TCategory> : ILogger<TCategory>
     {
         private readonly ILogger inner;
 

--- a/tests/Infrastructure.UnitTests/TestDoubles/MailboxWriteHarness.cs
+++ b/tests/Infrastructure.UnitTests/TestDoubles/MailboxWriteHarness.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Folders;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Domain.Folders;
 using MailFathom.Infrastructure.Mail.MailKit.Writes;
@@ -30,10 +31,16 @@ internal sealed class MailboxWriteHarness : IAsyncDisposable
         this.RecordedLogs = recordedLogs;
         this.ScopeDisposals = scopeDisposals;
         this.Factory = new MailKitImapWriteSessionFactory(pool, telemetry);
+        this.FolderCreator = new MailKitRemoteFolderCreator(
+            pool,
+            new MailKitImapWriteSessionTestContext.RecordingCategoryLogger<MailKitRemoteFolderCreator>(recordedLogs));
     }
 
     /// <summary>Gets the factory under test, which produces sessions over the pool below.</summary>
     internal IMailboxWriteSessionFactory Factory { get; }
+
+    /// <summary>Gets the creator under test, which leases the same one connection per account the sessions do.</summary>
+    internal IRemoteFolderCreator FolderCreator { get; }
 
     /// <summary>Gets the pool the factory leases from, so a test can assert on connection reuse and expiry.</summary>
     internal MailboxWriteConnectionPool Pool { get; }
@@ -52,6 +59,15 @@ internal sealed class MailboxWriteHarness : IAsyncDisposable
         this.Factory.OpenForWritingAsync(
             PrimaryAccount,
             folder,
+            TlsOnConnectWithPlainPolicy,
+            CancellationToken.None);
+
+    /// <summary>Creates the folder one configured alias names, over the same account connection the sessions lease.</summary>
+    internal Task<RemoteFolderPath> CreateFolderAsync(MailFolderAlias alias, string configuredPath) =>
+        this.FolderCreator.CreateFolderAsync(
+            PrimaryAccount,
+            alias,
+            RemoteFolderPath.Create(configuredPath),
             TlsOnConnectWithPlainPolicy,
             CancellationToken.None);
 

--- a/tests/IntegrationTests/Synchronization/OrchestratedRemoteFolderCreationTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedRemoteFolderCreationTests.cs
@@ -1,0 +1,92 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.IntegrationTests.Mailbox;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Synchronization;
+
+/// <summary>
+/// Proves against a real IMAP server that a folder a mapping asked for comes into existence and then holds mail.
+/// </summary>
+/// <remarks>
+/// This is where a real <c>CREATE</c> and the account's single write connection meet, and neither can be established
+/// against a substitute: a unit test proves the adapter issued the command and read the answer, while only a server can
+/// show that the folder it created is one a message can afterwards be filed into. The second creation in the same test
+/// is the idempotence claim, which is likewise the server's answer rather than the adapter's belief — an IMAP
+/// <c>CREATE</c> against an existing folder is an error, and reading it as success is only correct if the folder really
+/// is there.
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedRemoteFolderCreationTests(MailFathomOrchestrationFixture orchestration)
+{
+    private static readonly MailFolderResolution Inbox = MailFolderResolution.FirstBindingOf(
+        MailFolderAlias.Create("inbox"),
+        RemoteFolderPath.Create(OrchestratedMailbox.InboxPath, hierarchyDelimiter: '.'));
+
+    private static readonly MailFolderAlias CreatedAlias = MailFolderAlias.Create("createdarchive");
+
+    [Fact]
+    public async Task CreateFolderAsync_FolderTheServerDoesNotHold_CreatesItAndThenAcceptsAMessageFiledIntoIt()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mailbox = new OrchestratedMailbox(orchestration.MailServer);
+
+        // Named per run, so this test needs no folder to have been cleaned up by a previous one and collides with
+        // nothing another test in the shared mailbox is watching.
+        var folderName = $"CreatedArchive{Guid.NewGuid():N}";
+
+        var subject = $"file-into-created-{Guid.NewGuid():N}";
+        await mailbox.DeliverAsync(subject, cancellationToken);
+        var inbox = await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken);
+        var delivered = Assert.Single(inbox, email => email.Subject == subject);
+        var occurrence = EmailOccurrenceId.Create(
+            SyntheticMailAccount.AccountId,
+            Inbox.Id,
+            await mailbox.ReadUidValidityAsync(OrchestratedMailbox.InboxPath, cancellationToken),
+            delivered.Uid);
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+
+        // Act
+        var createdPaths = await services.InScopeAsync(
+            async (scope, token) =>
+            {
+                var account = SyntheticMailAccount.AccountId;
+                var policy = scope.GetRequiredService<IMailTransportSecurityPolicyReader>().GetPolicy(account);
+                var creator = scope.GetRequiredService<IRemoteFolderCreator>();
+                var configuredPath = RemoteFolderPath.Create(folderName);
+
+                var firstPath = await creator.CreateFolderAsync(account, CreatedAlias, configuredPath, policy, token);
+                var secondPath = await creator.CreateFolderAsync(account, CreatedAlias, configuredPath, policy, token);
+
+                await using var session = await scope.GetRequiredService<IMailboxWriteSessionFactory>()
+                    .OpenForWritingAsync(account, Inbox, policy, token);
+                await session.RelocateAsync(occurrence, firstPath, new InMemoryMailboxMutationJournal(), token);
+
+                return (First: firstPath, Second: secondPath);
+            },
+            cancellationToken);
+
+        // Assert
+        Assert.Equal(folderName, createdPaths.First.Value);
+        Assert.Equal(createdPaths.First, createdPaths.Second);
+
+        var createdFolder = await mailbox.ReadAsync(folderName, cancellationToken);
+        var filedEmail = Assert.Single(createdFolder, email => email.Subject == subject);
+
+        Assert.False(filedEmail.IsSeen);
+        Assert.DoesNotContain(
+            await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken),
+            email => email.Subject == subject);
+    }
+}


### PR DESCRIPTION
A folder mapping that names a remote path may now ask for that path to be created when the account advertises no folder matching it. Until now such a mapping resolved to nothing and the alias stayed unbound for as long as the folder was absent, so an operator had to create the folder by hand on the server before a rule could relocate anything into it.

Closes #714

## What the change does

- `MailFolderMapping` carries the permission as `MayCreateMissingFolder`. A mapping naming a special-use role is constructed with it fixed to `false`, because a folder that does not exist advertises no role.
- `MailFolderResolver` issues the creation where the alias is resolved: exactly when the mapping asks for it and no advertised folder matched. An ambiguous match still refuses before anything is created.
- `IRemoteFolderCreator` is the new application port, implemented by `MailKitRemoteFolderCreator`. It leases the account's existing write connection folder-less rather than opening a second one, walks the configured path level by level under the personal namespace, and creates and subscribes only the levels that are missing. A folder another run created between the `LIST` and the `CREATE` is read as success.
- The alias is bound to the folder **as the server advertises it**, so a server whose delimiter or namespace prefix differs from the configured text does not repoint the alias and start a spurious generation on the next run. A server that places the folder at a different path, hands back a name that cannot hold messages, or refuses the command is reported instead of being bound.
- A refused subscription is logged as a warning and does not fail the creation; the folder exists either way.

## Configuration

`Mail:Accounts:<n>:Folders:<n>:CreateIfMissing` is the new optional boolean, defaulting to `false`. It is rejected at startup beside `SpecialUse`, with a message naming the alias.

## Failures

New error code **26001** `RemoteFolderCreationRefused`, category 2 (mail protocol), subcategory 6 (folder creation), raised as `RemoteFolderCreationRefusedException`. Its message names the account id and the folder alias and never the remote path, per the failure-message rule in `src/AGENTS.md`. It is not classified transient, so a server that permanently refuses the command surfaces the failure rather than retrying inside the run.

## Compatibility

No break. `CreateIfMissing` is optional and absent means the previous behaviour; no configuration key, database column, MCP tool argument, or deployment contract changed.

## Verification

- `scripts/verify-full.sh` — green after the rebase onto `origin/main` (`e7d610e8`): 5381 tests, 0 failed, 148 workflow contracts pass, `Formatted 0 of 1754 files`.
- New unit tests: domain (3), application resolver (5), host configuration validation (3), `MailKitRemoteFolderCreator` (9), connection access separation (3).
- New integration test `OrchestratedRemoteFolderCreationTests` creates a uniquely named folder against GreenMail, calls the creation twice for idempotence, relocates a delivered message into it, and asserts it arrives unread and left the inbox. Not run locally — the suite is pipeline-only.

## Residual risks

- MailKit's `ImapCommandException`, chained as the inner exception, can carry server response text that mentions a mailbox. That is the pre-existing exposure class on the mutation path rather than something this change introduces; MailFathom's own message carries no path.
- A permanently refused creation defers the account's next run by one interval, which follows [ADR 0007](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary.md): an error code requires an exception, and the exception ends the run.

Issue: https://github.com/Krzysztof318/MailFathom/issues/714

Pull request: https://github.com/Krzysztof318/MailFathom/pull/726
