### PR TITLE
[#708] Declare per rule which triggers may run it, with an empty set meaning a requested run only

### DIFF
--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -23,6 +23,7 @@ MCP, not the administrative endpoint. An owner who wants to change what their in
         "Name": "supplier-invoices",
         "Accounts": [ "work" ],
         "Condition": "senderDomain == 'supplier.test' and attachmentCount > 0",
+        "Triggers": [ "Arrival" ],
         "Actions": { "MoveTo": "invoices", "MarkAsRead": true },
         "StopWhenMatched": true
       },
@@ -43,8 +44,10 @@ part that can be promised to carry no such thing when it reaches a log line.
 `Enabled` defaults to `true`. A rule switched off is left out of the bound set entirely, so it costs nothing and
 changes the set's revision exactly as deleting it would.
 
-`Triggers` defaults to `[ "Arrival" ]` and is what decides when a rule runs; [the section below](#which-triggers-run-a-rule)
-states what each way of writing it means, and why it is a different statement from `Enabled`.
+`Triggers` is what decides when a rule runs, and it defaults to nothing: a rule that should run over arriving mail says
+`[ "Arrival" ]`, and a rule that says nothing is one a whole-mailbox run applies. [The section
+below](#which-triggers-run-a-rule) states what each way of writing it means, and why it is a different statement from
+`Enabled`.
 
 ## Which accounts a rule applies to
 
@@ -77,23 +80,24 @@ decides *when* a rule is reached rather than which mail it matches once it is.
 
 | Written | What the rule takes part in |
 | --- | --- |
-| the key left out | `Arrival`, which is what every rule written before the key existed already did |
-| `[ "Arrival" ]` | The same, said explicitly |
+| `[ "Arrival" ]` | Every message the account's synchronization run commits |
 | `[]` | No automatic occasion at all: nothing fires the rule, and a whole-mailbox run is what applies it |
+| the key left out | The same as `[]` — a rule takes part in the occasions it names and in no others |
 
 **`Arrival` is a message the account's synchronization run has just committed.** It is named after the moment rather
 than after the transport, because `Push` already names a folder's
 [synchronization mode](imap-synchronization.md#choosing-the-mode-per-folder) and a rule is unaffected by which one its
 account uses: mail a polled run commits reaches this trigger exactly as mail a watched one commits does.
 
-**Leaving the key out changes no rule's behaviour**, which is what makes the key an addition to the schema rather than
-something to edit a configuration for. A rule that writes `[ "Arrival" ]` and a rule that says nothing are the same rule
-set, down to [the revision](#the-revision-a-pass-runs-under) both are identified by.
+**A rule that names no trigger runs on no arriving message.** Leaving the key out is a statement rather than an
+omission, and it is the same statement as writing `[]`: the rule is bound, validated, and reported, and a whole-mailbox
+run is what applies it. So a rule meant to file mail as it arrives writes `Arrival` — there is no occasion a rule joins
+without naming it.
 
-**A rule that declares `[]` is a rule you run rather than one that runs.** That is what periodic housekeeping wants —
-file everything older than a quarter, delete what a mailing list left behind — where firing on each arriving message is
-either useless or exactly what the owner is afraid of. The rule is bound, validated, and reported like any other, and
-[a whole-mailbox run](#running-the-rules-over-mail-you-already-have) is what applies it.
+**Such a rule is one you run rather than one that runs**, which is what periodic housekeeping wants — file everything
+older than a quarter, delete what a mailing list left behind — where firing on each arriving message is either useless
+or exactly what the owner is afraid of. [A whole-mailbox
+run](#running-the-rules-over-mail-you-already-have) is what applies it.
 
 **A rule a trigger does not reach is not evaluated and records no outcome**, exactly as a rule scoped to another
 account is not: it did not decline to match, it was not one of that pass's rules. It follows that such a rule cannot end
@@ -457,7 +461,8 @@ before it has already stored, so a provider redelivering a message or a synchron
 processing boundary than a clean run. And nothing an MCP tool does waits on a rule: reads are served from what is
 already stored, and a pass neither blocks one nor is blocked by one.
 
-**A rule applies to mail that arrives after the rule exists.** Each message is evaluated once, and the record of that
+**A rule declaring `Arrival` applies to mail that arrives after the rule exists.** Each message is evaluated once, and
+the record of that
 evaluation is what takes it out of the queue the next pass reads — so editing a rule changes what happens to the mail
 that arrives from then on and does nothing to the mail already in the mailbox. Mail an instance stored before it had
 rule evaluation at all is recorded as evaluated when the schema is applied, for the same reason: an upgrade must not
@@ -470,9 +475,10 @@ evaluated drains over as many runs as its size needs instead of holding up the r
 commits its evaluations together with the position they account for, so a restart resumes at the message nobody read
 rather than replaying a batch or stepping over one.
 
-**A message whose body text has not been extracted yet is skipped and stays eligible.** It applies only where the
-rules that walk actually runs for the account name `bodyText` — so a manual-only rule naming it holds nothing up on
-arrival, and a rule that names it on arrival does: such a message is left in the queue and evaluated once its text has been
+**A message whose body text has not been extracted yet is skipped and stays eligible.** It applies only where the rules
+that walk actually runs for the account name `bodyText`, which is decided per walk — so a rule only a whole-mailbox run
+applies holds nothing up on arrival, and a rule declaring `Arrival` does: such a message is left in the queue and
+evaluated once its text has been
 derived, rather than evaluated against a fact that would answer absent and then never reconsidered. Mail whose payload
 local storage has not had headroom for is waited on the same way, because a later run fetches it as soon as the ceiling
 permits. A message whose content will never yield text — one above the size limit, which every later run refuses for
@@ -602,7 +608,7 @@ senderAddress == 'billing@supplier.test'
 One account's mail only, which is the `Accounts` filter beside the condition rather than anything in it:
 
 ```json
-{ "Name": "work-invoices", "Accounts": [ "work" ], "Condition": "contains(subject, 'invoice')" }
+{ "Name": "work-invoices", "Accounts": [ "work" ], "Condition": "contains(subject, 'invoice')", "Triggers": [ "Arrival" ] }
 ```
 
 Anything from a domain, in one of two folders:
@@ -658,6 +664,7 @@ Filing supplier invoices and marking them read, on one account, so that the rule
   "Name": "supplier-invoices",
   "Accounts": [ "work" ],
   "Condition": "senderDomain == 'supplier.test' and attachmentCount > 0",
+  "Triggers": [ "Arrival" ],
   "Actions": { "MoveTo": "invoices", "MarkAsRead": true },
   "StopWhenMatched": true
 }
@@ -670,6 +677,7 @@ read:
 {
   "Name": "regulator-copies",
   "Condition": "senderDomain == 'regulator.example'",
+  "Triggers": [ "Arrival" ],
   "Actions": { "CopyTo": "compliance" }
 }
 ```
@@ -680,6 +688,7 @@ Putting automated notices back in front of somebody by clearing the flag, and no
 {
   "Name": "unread-alerts",
   "Condition": "contains(subject, 'alert') and isSeen",
+  "Triggers": [ "Arrival" ],
   "Actions": { "MarkAsRead": false }
 }
 ```
@@ -692,6 +701,7 @@ Deleting mail nobody needs — which the account has to permit under
   "Name": "drop-build-notifications",
   "Accounts": [ "work" ],
   "Condition": "senderAddress == 'builds@ci.example' and ageInDays > 7",
+  "Triggers": [ "Arrival" ],
   "Actions": { "Delete": true }
 }
 ```
@@ -713,6 +723,7 @@ Selecting mail and changing nothing, which is what a rule owning a message ahead
 {
   "Name": "leave-family-mail-alone",
   "Condition": "senderDomain == 'family.example'",
+  "Triggers": [ "Arrival" ],
   "StopWhenMatched": true
 }
 ```

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -2,8 +2,9 @@
 
 <!-- describes: src/Application/Rules/**, src/Infrastructure/Rules/**, src/Infrastructure/Persistence/Rules/**, src/Host/Configuration/Rules/** -->
 
-A mail rule selects mail and changes it. It is a name, a condition, the accounts it applies to, what a match leads to,
-and whether a match ends the pass, and an owner writes it in the configuration their deployment already carries. This
+A mail rule selects mail and changes it. It is a name, a condition, the accounts it applies to, the occasions that run
+it, what a match leads to, and whether a match ends the pass, and an owner writes it in the configuration their
+deployment already carries. This
 page documents both halves: every fact a condition can read, every function and operator available to it, the limits it
 is read and run under, the order a set of rules is evaluated in, and the four changes a matching rule can ask for.
 
@@ -42,6 +43,9 @@ part that can be promised to carry no such thing when it reaches a log line.
 `Enabled` defaults to `true`. A rule switched off is left out of the bound set entirely, so it costs nothing and
 changes the set's revision exactly as deleting it would.
 
+`Triggers` defaults to `[ "Arrival" ]` and is what decides when a rule runs; [the section below](#which-triggers-run-a-rule)
+states what each way of writing it means, and why it is a different statement from `Enabled`.
+
 ## Which accounts a rule applies to
 
 `Accounts` is the filter, and it is the one part of a rule that says which mail reaches it at all rather than which mail
@@ -65,6 +69,58 @@ that applies to several.
 
 [Configuration reference](../operations/configuration-reference.md#mailrules) lists every key of the section with its
 type, default, and constraint.
+
+## Which triggers run a rule
+
+`Triggers` is the list of automatic occasions a rule takes part in. It governs automatic firing and nothing else, so it
+decides *when* a rule is reached rather than which mail it matches once it is.
+
+| Written | What the rule takes part in |
+| --- | --- |
+| the key left out | `Arrival`, which is what every rule written before the key existed already did |
+| `[ "Arrival" ]` | The same, said explicitly |
+| `[]` | No automatic occasion at all: nothing fires the rule, and a whole-mailbox run is what applies it |
+
+**`Arrival` is a message the account's synchronization run has just committed.** It is named after the moment rather
+than after the transport, because `Push` already names a folder's
+[synchronization mode](imap-synchronization.md#choosing-the-mode-per-folder) and a rule is unaffected by which one its
+account uses: mail a polled run commits reaches this trigger exactly as mail a watched one commits does.
+
+**Leaving the key out changes no rule's behaviour**, which is what makes the key an addition to the schema rather than
+something to edit a configuration for. A rule that writes `[ "Arrival" ]` and a rule that says nothing are the same rule
+set, down to [the revision](#the-revision-a-pass-runs-under) both are identified by.
+
+**A rule that declares `[]` is a rule you run rather than one that runs.** That is what periodic housekeeping wants —
+file everything older than a quarter, delete what a mailing list left behind — where firing on each arriving message is
+either useless or exactly what the owner is afraid of. The rule is bound, validated, and reported like any other, and
+[a whole-mailbox run](#running-the-rules-over-mail-you-already-have) is what applies it.
+
+**A rule a trigger does not reach is not evaluated and records no outcome**, exactly as a rule scoped to another
+account is not: it did not decline to match, it was not one of that pass's rules. It follows that such a rule cannot end
+a pass either, whatever `StopWhenMatched` says.
+
+**A whole-mailbox run is never a member of the list**, and it applies the whole rule set including the manual-only
+rules. Somebody asking for a run is the request itself, so a rule declining to run because it had not agreed to be asked
+would be surprising in the one place surprise is least affordable. No run selects rules by name either: what a run
+applies is the set the configuration declares.
+
+**A name this system does not recognize is refused when the configuration is read**, naming the rule and the value, and
+so is the same trigger written twice, because the value is a set. Neither is dropped: a list whose only entry was
+mistyped would otherwise arrive as an empty one, which would silently turn an automatic rule into a manual one — and a
+rule that never fires is indistinguishable from a rule nothing matched. The name is read the way the binder reads every
+other closed vocabulary this configuration declares, so `arrival` and `Arrival` are one trigger.
+
+### `Triggers: []` and `Enabled: false` say different things
+
+The two keys sound alike and are not:
+
+| | `Triggers: []` | `Enabled: false` |
+| --- | --- | --- |
+| In the bound rule set | Yes | No |
+| Validated when the configuration is read | Yes | Yes, apart from its condition |
+| Run when mail arrives | No | No |
+| Run by a whole-mailbox run | Yes | No |
+| What it is for | A rule an owner applies deliberately | A rule taken out of service without deleting the condition |
 
 ## What a matching rule does
 
@@ -341,7 +397,8 @@ each is refused with a message naming the rule, what was wrong, and where:
   as truthy, so what a rule means never depends on a coercion nobody wrote down.
 
 The rule's `Accounts` filter is checked beside those four: every identifier names a declared account, none is blank, and
-none is repeated.
+none is repeated. Its `Triggers` list is checked the same way: every name is one this system declares, none is blank,
+and none is repeated.
 
 So is its `Actions` block, against the rule itself and against every account the rule reaches:
 
@@ -367,8 +424,8 @@ would otherwise get an instance still acting under the rules their file no longe
 
 ## Order, and stopping
 
-Rules are evaluated in the order they are written, skipping the ones scoped to other accounts. That order is the whole
-of the contract — nothing sorts, groups, or reorders a set — so two rules that both match one email produce the same
+Rules are evaluated in the order they are written, skipping the ones scoped to other accounts and the ones the walk's
+trigger does not reach. That order is the whole of the contract — nothing sorts, groups, or reorders a set — so two rules that both match one email produce the same
 outcome on every run and on every instance.
 
 `StopWhenMatched` on a rule that matches ends the pass, and the rules below it are not reached. It defaults to `false`.
@@ -414,7 +471,8 @@ commits its evaluations together with the position they account for, so a restar
 rather than replaying a batch or stepping over one.
 
 **A message whose body text has not been extracted yet is skipped and stays eligible.** It applies only where the
-account's rules actually name `bodyText`: such a message is left in the queue and evaluated once its text has been
+rules that walk actually runs for the account name `bodyText` — so a manual-only rule naming it holds nothing up on
+arrival, and a rule that names it on arrival does: such a message is left in the queue and evaluated once its text has been
 derived, rather than evaluated against a fact that would answer absent and then never reconsidered. Mail whose payload
 local storage has not had headroom for is waited on the same way, because a later run fetches it as soon as the ceiling
 permits. A message whose content will never yield text — one above the size limit, which every later run refuses for
@@ -428,8 +486,9 @@ so fetching the account's mail less often would answer a local problem by slowin
 with it. The next section lists the two reasons.
 
 **Nothing scans on a timer.** The account run recurs already, so anything a scan would find on arrival is found by the
-first trigger; a rule whose condition only becomes true with the passage of time — mail older than some age — fires when
-the owner asks for a whole-mailbox run.
+`Arrival` trigger; a rule whose condition only becomes true with the passage of time — mail older than some age — fires
+when the owner asks for a whole-mailbox run. Such a rule is what [`Triggers: []`](#which-triggers-run-a-rule) is for:
+declaring no automatic trigger keeps it out of every arrival pass without taking it out of the set.
 
 ## Running the rules over mail you already have
 
@@ -442,6 +501,8 @@ now in force.
 - **It runs where every other pass runs.** The request records that the run is wanted and nothing more; the work happens
   as a step of the account's synchronization run, bounded by the same two settings. Whoever asked is not what keeps it
   alive, so closing a terminal does not cancel a walk of a mailbox.
+- **It applies the whole rule set.** Every rule the configuration declares for the account is run, including the ones
+  that declare no automatic trigger, and nothing selects a subset of them for one run.
 - **It is bound to one rule set.** The revision in force when the run starts is recorded with it, so a reload cannot
   change what the run is doing halfway through. If the rules do change while a run is outstanding, the run ends as
   **superseded** and says so, because MailFathom keeps only the rule set its configuration currently declares and
@@ -513,8 +574,11 @@ and two instances reading the same file name the same revision.
 
 What moves it and what does not:
 
-- Changing a rule's name, its condition, its actions, its `StopWhenMatched`, or the accounts it applies to moves it.
+- Changing a rule's name, its condition, its actions, its `StopWhenMatched`, the accounts it applies to, or the
+  triggers it takes part in moves it.
 - Adding, removing, or switching off a rule moves it.
+- Writing a rule's default triggers out in full leaves it alone, because a rule that says nothing and a rule that says
+  `[ "Arrival" ]` are the same rule.
 - Reordering the rules moves it, because declared order is part of what a rule set means.
 - Reformatting the file, reordering the keys within one rule, and changing an unrelated configuration section all leave
   it alone.
@@ -629,6 +693,17 @@ Deleting mail nobody needs — which the account has to permit under
   "Accounts": [ "work" ],
   "Condition": "senderAddress == 'builds@ci.example' and ageInDays > 7",
   "Actions": { "Delete": true }
+}
+```
+
+Quarterly housekeeping nothing fires by itself, which the owner applies by asking for a whole-mailbox run:
+
+```json
+{
+  "Name": "retire-old-newsletters",
+  "Condition": "contains(subject, 'newsletter') and ageInDays > 90",
+  "Actions": { "MoveTo": "archive" },
+  "Triggers": []
 }
 ```
 

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -278,9 +278,11 @@ Configuration: accepted. What is running is what the file says.
 
 file-invoices
   Applies to: work
+  Runs on:    Arrival
   A match:    relocate → archive; ends the pass
-mark-newsletters
+retire-old-newsletters
   Applies to: every account
+  Runs on:    nothing automatically; 'mfctl rules run' applies it
   A match:    setSeen → read
 ```
 
@@ -288,6 +290,12 @@ The order is the answer as much as the rules are: which rule reaches a message f
 rule above another that ends the pass is why the one below it never runs. `mfctl rules show <name>` reports one rule in
 full, including the facts its condition can read. Neither prints the condition an operator wrote — a compiled rule
 carries no text, which is what keeps an address somebody typed into a condition out of every record naming the rule.
+
+`Runs on:` is the [triggers](../features/mail-rules.md#which-triggers-run-a-rule) the rule declares, and the second
+line above is what a rule written with `"Triggers": []` reads as. Such a rule is bound, validated, and applied by a
+whole-mailbox run like any other, and no arriving message reaches it — so the wording says what does run it rather than
+reporting an empty list, because a rule nothing fires by itself and a rule that never matches look identical in a
+history that records neither.
 
 **`mfctl rules run --account <id>` applies the rules to mail that arrived before them.** It returns as soon as the
 deployment has written the request down and never waits for the walk; the pass is a step of the account's

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -292,10 +292,10 @@ full, including the facts its condition can read. Neither prints the condition a
 carries no text, which is what keeps an address somebody typed into a condition out of every record naming the rule.
 
 `Runs on:` is the [triggers](../features/mail-rules.md#which-triggers-run-a-rule) the rule declares, and the second
-line above is what a rule written with `"Triggers": []` reads as. Such a rule is bound, validated, and applied by a
-whole-mailbox run like any other, and no arriving message reaches it — so the wording says what does run it rather than
-reporting an empty list, because a rule nothing fires by itself and a rule that never matches look identical in a
-history that records neither.
+line above is what a rule naming none reads as — whether it writes `"Triggers": []` or leaves the key out, which say
+the same thing. Such a rule is bound, validated, and applied by a whole-mailbox run like any other, and no arriving
+message reaches it — so the wording says what does run it rather than reporting an empty list, because a rule nothing
+fires by itself and a rule that never matches look identical in a history that records neither.
 
 **`mfctl rules run --account <id>` applies the rules to mail that arrived before them.** It returns as soon as the
 deployment has written the request down and never waits for the walk; the pass is a step of the account's

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -743,7 +743,7 @@ use — every fact, every function, every operator — and this section document
 | `MailRules:Rules:0:Condition` | string | required | One expression producing a boolean, within the two limits above | reload |
 | `MailRules:Rules:0:StopWhenMatched` | bool | `false` | A match ends the pass and the rules below it are not reached | reload |
 | `MailRules:Rules:0:Enabled` | bool | `true` | A rule switched off is left out of the set entirely | reload |
-| `MailRules:Rules:0:Triggers` | list | `[ "Arrival" ]` | The automatic occasions that run the rule; `Arrival` is the only one, an unknown or repeated name is refused, and an empty list is a rule nothing fires by itself that a whole-mailbox run applies | reload |
+| `MailRules:Rules:0:Triggers` | list | `[]` | The automatic occasions that run the rule; `Arrival` is the only one, an unknown or repeated name is refused, and naming none is a rule nothing fires by itself that a whole-mailbox run applies | reload |
 | `MailRules:Rules:0:Actions:MoveTo` | string | unset | The alias of the folder a match is filed into; the account must mirror it | reload |
 | `MailRules:Rules:0:Actions:CopyTo` | string | unset | The alias of the folder a copy of a match is placed in; the account must mirror it | reload |
 | `MailRules:Rules:0:Actions:Delete` | bool | unset | `true` removes a match from the folder it matched in; the account must permit deletion | reload |

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -743,6 +743,7 @@ use — every fact, every function, every operator — and this section document
 | `MailRules:Rules:0:Condition` | string | required | One expression producing a boolean, within the two limits above | reload |
 | `MailRules:Rules:0:StopWhenMatched` | bool | `false` | A match ends the pass and the rules below it are not reached | reload |
 | `MailRules:Rules:0:Enabled` | bool | `true` | A rule switched off is left out of the set entirely | reload |
+| `MailRules:Rules:0:Triggers` | list | `[ "Arrival" ]` | The automatic occasions that run the rule; `Arrival` is the only one, an unknown or repeated name is refused, and an empty list is a rule nothing fires by itself that a whole-mailbox run applies | reload |
 | `MailRules:Rules:0:Actions:MoveTo` | string | unset | The alias of the folder a match is filed into; the account must mirror it | reload |
 | `MailRules:Rules:0:Actions:CopyTo` | string | unset | The alias of the folder a copy of a match is placed in; the account must mirror it | reload |
 | `MailRules:Rules:0:Actions:Delete` | bool | unset | `true` removes a match from the folder it matched in; the account must permit deletion | reload |

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -244,9 +244,10 @@ already in the mailbox until you ask. That asking is a command, and so is findin
 `mfctl rules list` is the one to run after editing a rule file. A deployment refuses a reload whose rules do not
 validate and goes on running the previous set, which it reports to its log and nowhere else — so this is where you find
 out whether your edit took effect, rather than from mail that kept being filed the old way. Each rule it prints says
-what runs it, on a `Runs on:` line, which is how a rule written with [`"Triggers":
-[]`](../features/mail-rules.md#which-triggers-run-a-rule) is told apart from one that simply never matched: nothing
-fires such a rule by itself, and `mfctl rules run` is how it is run.
+what runs it, on a `Runs on:` line, which is how a rule naming [no
+trigger](../features/mail-rules.md#which-triggers-run-a-rule) is told apart from one that simply never matched: nothing
+fires such a rule by itself, and `mfctl rules run` is how it is run. It is also where a rule you meant to run over
+arriving mail shows that it never says `Arrival`.
 
 None of these writes a rule, and none ever will: rules are configuration, so you change one by editing the file your
 deployment reads. [Reading the rules, running them, and finding out what they

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -243,7 +243,10 @@ already in the mailbox until you ask. That asking is a command, and so is findin
 
 `mfctl rules list` is the one to run after editing a rule file. A deployment refuses a reload whose rules do not
 validate and goes on running the previous set, which it reports to its log and nowhere else — so this is where you find
-out whether your edit took effect, rather than from mail that kept being filed the old way.
+out whether your edit took effect, rather than from mail that kept being filed the old way. Each rule it prints says
+what runs it, on a `Runs on:` line, which is how a rule written with [`"Triggers":
+[]`](../features/mail-rules.md#which-triggers-run-a-rule) is told apart from one that simply never matched: nothing
+fires such a rule by itself, and `mfctl rules run` is how it is run.
 
 None of these writes a rule, and none ever will: rules are configuration, so you change one by editing the file your
 deployment reads. [Reading the rules, running them, and finding out what they

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs
@@ -27,10 +27,12 @@ namespace MailFathom.Application.Rules.Evaluation;
 /// an MCP read does waits on a rule.
 /// </para>
 /// <para>
-/// The two walks are the two triggers. The arrival walk reaches mail no pass has evaluated, and recording an evaluation
-/// is what takes an email out of it, which is what makes a rule apply to mail arriving from now on. The requested walk
-/// is the only way mail already evaluated is evaluated again: reprocessing under a newer rule set is something an owner
-/// asks for, never something an edit sets off.
+/// The two walks reach different mail and different rules. The arrival walk reaches mail no pass has evaluated, and
+/// recording an evaluation is what takes an email out of it, which is what makes a rule apply to mail arriving from now
+/// on; it runs the rules declaring the <see cref="MailRuleTrigger.Arrival" /> trigger and passes over the rest. The
+/// requested walk is the only way mail already evaluated is evaluated again — reprocessing under a newer rule set is
+/// something an owner asks for, never something an edit sets off — and it runs every rule of the set, because asking
+/// for a run is the request itself rather than an occasion a rule opts into.
 /// </para>
 /// <para>
 /// Both walks are bounded per batch and commit each batch with the position it reached, so an interrupted pass resumes
@@ -129,27 +131,19 @@ public sealed class MailRuleEvaluationPass
     public async Task<MailRuleEvaluationReport> RunAsync(MailAccountId accountId, CancellationToken cancellationToken)
     {
         var ruleSet = this.ruleSetSource.Current;
-        var requiresExtractedBodyText = RequiresExtractedBodyText(ruleSet, accountId);
 
-        var arrivals = await this.WalkArrivalsAsync(accountId, ruleSet, requiresExtractedBodyText, cancellationToken);
+        var arrivals = await this.WalkArrivalsAsync(
+            accountId,
+            BoundRuleSet.For(ruleSet, accountId, MailRuleExecutionTrigger.Arrival),
+            cancellationToken);
+
         var requestedRun = await this.WalkRequestedRunAsync(
             accountId,
-            ruleSet,
-            requiresExtractedBodyText,
+            BoundRuleSet.For(ruleSet, accountId, MailRuleExecutionTrigger.RequestedRun),
             cancellationToken);
 
         return new MailRuleEvaluationReport(ruleSet.Revision, arrivals, requestedRun.Walk, requestedRun.Ending);
     }
-
-    /// <summary>Reports whether any rule this account's mail reaches names the one fact that costs a stored-content read.</summary>
-    /// <remarks>
-    /// Answered for the whole pass rather than per email, because it is a property of the rule set and the account
-    /// filter. It is what decides whether an email still awaiting extraction is a message to wait for or one to evaluate
-    /// now with the fact absent: a rule set that never names the body text has nothing to wait for.
-    /// </remarks>
-    private static bool RequiresExtractedBodyText(MailRuleSet ruleSet, MailAccountId accountId) => ruleSet.Rules
-        .Where(rule => rule.AppliesTo(accountId.Value))
-        .Any(rule => rule.Condition.ReferencedFacts.Contains(MailRuleFact.BodyText));
 
     /// <summary>Walks the mail no pass has evaluated, in identity order, until the queue or the batch budget runs out.</summary>
     /// <remarks>
@@ -159,8 +153,7 @@ public sealed class MailRuleEvaluationPass
     /// </remarks>
     private async Task<MailRuleEvaluationWalk> WalkArrivalsAsync(
         MailAccountId accountId,
-        MailRuleSet ruleSet,
-        bool requiresExtractedBodyText,
+        BoundRuleSet boundRuleSet,
         CancellationToken cancellationToken)
     {
         var tally = new EvaluationTally();
@@ -182,11 +175,7 @@ public sealed class MailRuleEvaluationPass
                 break;
             }
 
-            var outcome = await this.EvaluateBatchAsync(
-                ruleSet,
-                requiresExtractedBodyText,
-                batch,
-                cancellationToken);
+            var outcome = await this.EvaluateBatchAsync(boundRuleSet, batch, cancellationToken);
 
             if (outcome.EvaluatedEmailIds.Count > 0)
             {
@@ -203,9 +192,9 @@ public sealed class MailRuleEvaluationPass
 
                         await this.RecordDecisionsAsync(
                             session,
-                            ruleSet.Revision,
+                            boundRuleSet.RuleSet.Revision,
                             outcome,
-                            MailRuleExecutionTrigger.Arrival,
+                            boundRuleSet.Trigger,
                             attemptCancellationToken);
                     },
                     cancellationToken);
@@ -232,8 +221,7 @@ public sealed class MailRuleEvaluationPass
     /// </remarks>
     private async Task<RequestedRunOutcome> WalkRequestedRunAsync(
         MailAccountId accountId,
-        MailRuleSet ruleSet,
-        bool requiresExtractedBodyText,
+        BoundRuleSet boundRuleSet,
         CancellationToken cancellationToken)
     {
         var run = await this.runStore.FindOutstandingAsync(accountId, cancellationToken);
@@ -243,7 +231,7 @@ public sealed class MailRuleEvaluationPass
             return new RequestedRunOutcome(Walk: null, Ending: null);
         }
 
-        if (run.Revision.IsSpecified && run.Revision != ruleSet.Revision)
+        if (run.Revision.IsSpecified && run.Revision != boundRuleSet.RuleSet.Revision)
         {
             await this.CommitRunAsync(
                 run with
@@ -258,14 +246,14 @@ public sealed class MailRuleEvaluationPass
 
         if (!run.Revision.IsSpecified)
         {
-            run = run with { Revision = ruleSet.Revision };
+            run = run with { Revision = boundRuleSet.RuleSet.Revision };
         }
 
         var tally = new EvaluationTally();
 
         for (var batchNumber = 1; batchNumber <= this.options.MaxBatchesPerPass && run.IsOutstanding; batchNumber++)
         {
-            run = await this.CarryRunBatchAsync(run, ruleSet, requiresExtractedBodyText, tally, cancellationToken);
+            run = await this.CarryRunBatchAsync(run, boundRuleSet, tally, cancellationToken);
         }
 
         return new RequestedRunOutcome(tally.ToWalk(run.IsOutstanding), run.Ending);
@@ -274,8 +262,7 @@ public sealed class MailRuleEvaluationPass
     /// <summary>Evaluates one batch of the requested run and commits it together with the position it reached.</summary>
     private async Task<MailRuleEvaluationRun> CarryRunBatchAsync(
         MailRuleEvaluationRun run,
-        MailRuleSet ruleSet,
-        bool requiresExtractedBodyText,
+        BoundRuleSet boundRuleSet,
         EvaluationTally tally,
         CancellationToken cancellationToken)
     {
@@ -298,7 +285,7 @@ public sealed class MailRuleEvaluationPass
             return finished;
         }
 
-        var outcome = await this.EvaluateBatchAsync(ruleSet, requiresExtractedBodyText, batch, cancellationToken);
+        var outcome = await this.EvaluateBatchAsync(boundRuleSet, batch, cancellationToken);
         var reachedTheEnd = batch.Count < this.options.BatchSize;
         var recordedAt = this.timeProvider.GetUtcNow();
 
@@ -323,9 +310,9 @@ public sealed class MailRuleEvaluationPass
 
                 await this.RecordDecisionsAsync(
                     session,
-                    ruleSet.Revision,
+                    boundRuleSet.RuleSet.Revision,
                     outcome,
-                    MailRuleExecutionTrigger.RequestedRun,
+                    boundRuleSet.Trigger,
                     attemptCancellationToken);
 
                 await this.runStore.SaveAsync(session, carried, attemptCancellationToken);
@@ -399,8 +386,7 @@ public sealed class MailRuleEvaluationPass
     /// time it reaches this tally and the emails behind it are unaffected.
     /// </remarks>
     private async Task<MailRuleEvaluationBatch> EvaluateBatchAsync(
-        MailRuleSet ruleSet,
-        bool requiresExtractedBodyText,
+        BoundRuleSet boundRuleSet,
         IReadOnlyList<StoredEmailAwaitingRuleEvaluation> batch,
         CancellationToken cancellationToken)
     {
@@ -414,7 +400,7 @@ public sealed class MailRuleEvaluationPass
             // would answer absent and then never be reconsidered. One whose content will never yield text is evaluated
             // now, because waiting for it would stall this account's queue behind a message that can never become
             // eligible.
-            if (requiresExtractedBodyText && candidate.AwaitsExtraction)
+            if (boundRuleSet.RequiresExtractedBodyText && candidate.AwaitsExtraction)
             {
                 outcome.Skipped();
 
@@ -428,12 +414,70 @@ public sealed class MailRuleEvaluationPass
                 this.folderMappings,
                 evaluatedAt);
 
-            var evaluation = await this.evaluator.EvaluateAsync(ruleSet, facts, cancellationToken);
+            var evaluation = await this.evaluator.EvaluateAsync(
+                boundRuleSet.RuleSet,
+                facts,
+                boundRuleSet.Reach,
+                cancellationToken);
 
             outcome.Evaluated(candidate, evaluation, evaluatedAt);
         }
 
         return outcome;
+    }
+
+    /// <summary>The rule set one walk runs, the rules it reaches, and whether any of them needs extracted body text.</summary>
+    /// <param name="RuleSet">The set the walk was bound to when it began, which a reload cannot change under it.</param>
+    /// <param name="Trigger">Which walk this is, which is both what an execution records and what decides the reach.</param>
+    /// <param name="Reach">Which of its rules the walk runs, derived from the walk rather than chosen beside it.</param>
+    /// <param name="RequiresExtractedBodyText">Whether any rule the walk runs for this account names the body text.</param>
+    private sealed record BoundRuleSet(
+        MailRuleSet RuleSet,
+        MailRuleExecutionTrigger Trigger,
+        MailRuleReach Reach,
+        bool RequiresExtractedBodyText)
+    {
+        /// <summary>Binds a rule set to one walk, answering what the walk needs to know before it reads an email.</summary>
+        /// <remarks>
+        /// The walk is named once and everything else about it is derived, because the trigger an execution is recorded
+        /// under and the rules the walk runs are two readings of one fact: a value chosen twice could disagree, and a
+        /// history recording an arrival for a walk that ran every rule would be wrong about what it was.
+        /// The body-text question is answered per walk rather than per pass, because it is a property of the rules the
+        /// walk actually runs. It decides whether an email still awaiting extraction is one to wait for or one to
+        /// evaluate now with the fact absent, so answering it over rules this walk never reaches would hold arriving
+        /// mail behind a manual-only rule that was never going to be asked about it.
+        /// </remarks>
+        internal static BoundRuleSet For(
+            MailRuleSet ruleSet,
+            MailAccountId accountId,
+            MailRuleExecutionTrigger trigger)
+        {
+            var reach = ReachOf(trigger);
+
+            return new BoundRuleSet(
+                ruleSet,
+                trigger,
+                reach,
+                ruleSet.Rules
+                    .Where(rule => rule.AppliesTo(accountId.Value) && reach.Reaches(rule))
+                    .Any(rule => rule.Condition.ReferencedFacts.Contains(MailRuleFact.BodyText)));
+        }
+
+        /// <summary>Reads which rules one walk runs from which walk it is.</summary>
+        /// <remarks>
+        /// An automatic walk runs the rules that declared its trigger; a run somebody asked for runs every rule of the
+        /// set, because asking for one is the request itself rather than an occasion a rule opts into. An unrecognized
+        /// walk is refused rather than defaulted, so a trigger added later has to say which rules it reaches.
+        /// </remarks>
+        private static MailRuleReach ReachOf(MailRuleExecutionTrigger trigger) => trigger switch
+        {
+            MailRuleExecutionTrigger.Arrival => MailRuleReach.TriggeredBy(MailRuleTrigger.Arrival),
+            MailRuleExecutionTrigger.RequestedRun => MailRuleReach.EveryRule,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(trigger),
+                trigger,
+                "The walk names no trigger this pass knows which rules to run for."),
+        };
     }
 
     /// <summary>What one batch's evaluations produced, before any of them were committed.</summary>

--- a/src/Application/Rules/MailRule.cs
+++ b/src/Application/Rules/MailRule.cs
@@ -72,9 +72,9 @@ public sealed class MailRule
     /// <param name="stopWhenMatched">Whether a match ends the pass.</param>
     /// <param name="accounts">The accounts the rule applies to, or nothing for a rule that applies to every account.</param>
     /// <param name="triggers">
-    /// The automatic triggers the rule takes part in, empty for a rule only a requested walk runs, and
-    /// <see langword="null" /> for a rule that declares none — which is <see cref="MailRuleTrigger.WhenNoneDeclared" />
-    /// rather than nothing, for the reason that value states.
+    /// The automatic triggers the rule takes part in, or nothing for a rule only a requested walk runs. An empty list
+    /// and <see langword="null" /> say the same thing, because a rule takes part in the occasions it names and in no
+    /// others.
     /// </param>
     /// <returns>The rule.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="condition" /> is <see langword="null" />.</exception>
@@ -108,7 +108,7 @@ public sealed class MailRule
             actions ?? MailRuleActionSet.Empty,
             stopWhenMatched,
             accounts is null ? FrozenSet<string>.Empty : accounts.Select(account => account.Trim()).ToFrozenSet(StringComparer.Ordinal),
-            (triggers ?? MailRuleTrigger.WhenNoneDeclared).ToFrozenSet());
+            triggers is null ? FrozenSet<MailRuleTrigger>.Empty : triggers.ToFrozenSet());
     }
 
     /// <summary>Reports whether this rule is one of the rules the given account's mail is passed through.</summary>

--- a/src/Application/Rules/MailRule.cs
+++ b/src/Application/Rules/MailRule.cs
@@ -21,13 +21,15 @@ public sealed class MailRule
         IMailRuleCondition condition,
         MailRuleActionSet actions,
         bool stopWhenMatched,
-        FrozenSet<string> accounts)
+        FrozenSet<string> accounts,
+        FrozenSet<MailRuleTrigger> triggers)
     {
         this.Name = name;
         this.Condition = condition;
         this.Actions = actions;
         this.StopWhenMatched = stopWhenMatched;
         this.Accounts = accounts;
+        this.Triggers = triggers;
     }
 
     /// <summary>Gets the name the rule is declared and reported under.</summary>
@@ -54,21 +56,38 @@ public sealed class MailRule
     /// </remarks>
     public IReadOnlySet<string> Accounts { get; }
 
+    /// <summary>Gets the automatic triggers this rule takes part in, empty for a rule only a requested walk runs.</summary>
+    /// <remarks>
+    /// Empty means no automatic occasion rather than every one, which is the opposite reading to <see cref="Accounts" />
+    /// and is deliberate: a rule reaching no account is a rule nobody would write, while a rule nothing fires by itself
+    /// is exactly what periodic housekeeping wants. The rule stays in the set, is validated like every other, and runs
+    /// when somebody asks for a walk of the whole mailbox.
+    /// </remarks>
+    public IReadOnlySet<MailRuleTrigger> Triggers { get; }
+
     /// <summary>Creates a rule from a condition that has already been proven usable.</summary>
     /// <param name="name">The name the rule is declared and reported under.</param>
     /// <param name="condition">The compiled condition.</param>
     /// <param name="actions">What a match does to the matching email, or nothing for a rule that changes nothing.</param>
     /// <param name="stopWhenMatched">Whether a match ends the pass.</param>
     /// <param name="accounts">The accounts the rule applies to, or nothing for a rule that applies to every account.</param>
+    /// <param name="triggers">
+    /// The automatic triggers the rule takes part in, empty for a rule only a requested walk runs, and
+    /// <see langword="null" /> for a rule that declares none — which is <see cref="MailRuleTrigger.WhenNoneDeclared" />
+    /// rather than nothing, for the reason that value states.
+    /// </param>
     /// <returns>The rule.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="condition" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="name" /> is empty or whitespace, or an account is.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="name" /> is empty or whitespace, an account is, or a trigger is unspecified.
+    /// </exception>
     public static MailRule Create(
         string name,
         IMailRuleCondition condition,
         MailRuleActionSet? actions = null,
         bool stopWhenMatched = false,
-        IReadOnlyList<string>? accounts = null)
+        IReadOnlyList<string>? accounts = null,
+        IReadOnlyList<MailRuleTrigger>? triggers = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(condition);
@@ -78,12 +97,18 @@ public sealed class MailRule
             throw new ArgumentException("A rule cannot be scoped to an account with no identifier.", nameof(accounts));
         }
 
+        if (triggers?.Any(trigger => !trigger.IsSpecified) == true)
+        {
+            throw new ArgumentException("A rule cannot declare a trigger that is unspecified.", nameof(triggers));
+        }
+
         return new MailRule(
             name,
             condition,
             actions ?? MailRuleActionSet.Empty,
             stopWhenMatched,
-            accounts is null ? FrozenSet<string>.Empty : accounts.Select(account => account.Trim()).ToFrozenSet(StringComparer.Ordinal));
+            accounts is null ? FrozenSet<string>.Empty : accounts.Select(account => account.Trim()).ToFrozenSet(StringComparer.Ordinal),
+            (triggers ?? MailRuleTrigger.WhenNoneDeclared).ToFrozenSet());
     }
 
     /// <summary>Reports whether this rule is one of the rules the given account's mail is passed through.</summary>
@@ -101,4 +126,14 @@ public sealed class MailRule
 
         return this.Accounts.Count == 0 || this.Accounts.Contains(account.Trim());
     }
+
+    /// <summary>Reports whether this rule is one an automatic trigger runs.</summary>
+    /// <param name="trigger">The trigger the walk in progress was started by.</param>
+    /// <returns><see langword="true" /> when the rule declares this trigger.</returns>
+    /// <remarks>
+    /// A rule the trigger does not reach is passed over rather than evaluated and leaves no evaluation behind, exactly
+    /// as a rule scoped to another account does: it did not decline to match, it was not one of this walk's rules. It
+    /// follows that such a rule cannot end the pass either, whatever it declares.
+    /// </remarks>
+    public bool RunsOn(MailRuleTrigger trigger) => this.Triggers.Contains(trigger);
 }

--- a/src/Application/Rules/MailRuleDeclaration.cs
+++ b/src/Application/Rules/MailRuleDeclaration.cs
@@ -12,6 +12,7 @@ namespace MailFathom.Application.Rules;
 /// <param name="Actions">What a match does to the matching email, in the order the changes are applied.</param>
 /// <param name="StopWhenMatched">Whether a match ends the pass rather than continuing to the rules below.</param>
 /// <param name="Accounts">The accounts the rule was scoped to, in declared order, empty for a rule that applies to every account.</param>
+/// <param name="Triggers">The automatic triggers the rule takes part in, in declared order, empty for a rule only a requested walk runs.</param>
 /// <remarks>
 /// <para>
 /// Deliberately separate from <see cref="MailRule" />, which carries a compiled condition and no authored text. A
@@ -24,10 +25,16 @@ namespace MailFathom.Application.Rules;
 /// is part of what the rule set means, so editing an action moves the revision and the edited rule asks the mailbox
 /// afresh instead of being read as the request it already performed.
 /// </para>
+/// <para>
+/// The triggers are the resolved set rather than what the file did or did not say, so a rule that leaves the key out
+/// and a rule that writes the default explicitly are one rule set rather than two: they mean the same thing, and a
+/// revision that told them apart would supersede a run over an edit that changed nothing.
+/// </para>
 /// </remarks>
 public sealed record MailRuleDeclaration(
     string Name,
     string ConditionText,
     IReadOnlyList<MailRuleAction> Actions,
     bool StopWhenMatched,
-    IReadOnlyList<string> Accounts);
+    IReadOnlyList<string> Accounts,
+    IReadOnlyList<MailRuleTrigger> Triggers);

--- a/src/Application/Rules/MailRuleDeclaration.cs
+++ b/src/Application/Rules/MailRuleDeclaration.cs
@@ -26,9 +26,10 @@ namespace MailFathom.Application.Rules;
 /// afresh instead of being read as the request it already performed.
 /// </para>
 /// <para>
-/// The triggers are the resolved set rather than what the file did or did not say, so a rule that leaves the key out
-/// and a rule that writes the default explicitly are one rule set rather than two: they mean the same thing, and a
-/// revision that told them apart would supersede a run over an edit that changed nothing.
+/// The triggers are the resolved set rather than the text the file named them with, so a rule that leaves the key out
+/// and a rule that writes an empty list are one rule set rather than two, and so are two spellings of one trigger's
+/// name: they mean the same thing, and a revision that told them apart would supersede a run over an edit that changed
+/// nothing.
 /// </para>
 /// </remarks>
 public sealed record MailRuleDeclaration(

--- a/src/Application/Rules/MailRuleReach.cs
+++ b/src/Application/Rules/MailRuleReach.cs
@@ -1,0 +1,52 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Rules;
+
+/// <summary>Which rules of a set one walk runs: the ones an automatic trigger reaches, or every rule declared.</summary>
+/// <remarks>
+/// <para>
+/// A rule declares the automatic triggers it takes part in, so a walk started by one of them reaches the rules that
+/// named it and passes over the rest. A walk somebody asked for is not a trigger and is never one a rule opts into: an
+/// operator asking for a run is the request itself, and a rule declining to run because it had not agreed to be asked
+/// would be surprising in the one place surprise is least affordable. Such a walk therefore reaches every rule of the
+/// set, manual-only rules included.
+/// </para>
+/// <para>
+/// A type of its own rather than a nullable trigger, because the two are different statements rather than a value and
+/// its absence, and because the paragraph above is a rule that belongs somewhere a reader can find it.
+/// </para>
+/// </remarks>
+public sealed record MailRuleReach
+{
+    private readonly MailRuleTrigger trigger;
+
+    private MailRuleReach(MailRuleTrigger trigger) => this.trigger = trigger;
+
+    /// <summary>Gets the reach of a walk somebody asked for, which is every rule the set declares.</summary>
+    /// <remarks>The unspecified trigger is what carries that here: no trigger started this walk, so none filters it.</remarks>
+    public static MailRuleReach EveryRule { get; } = new(default(MailRuleTrigger));
+
+    /// <summary>Reads the reach of a walk one automatic trigger started.</summary>
+    /// <param name="trigger">The trigger the walk runs for.</param>
+    /// <returns>The reach, which is the rules declaring that trigger.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="trigger" /> is the unspecified struct default.</exception>
+    public static MailRuleReach TriggeredBy(MailRuleTrigger trigger) => trigger.IsSpecified
+        ? new MailRuleReach(trigger)
+        : throw new ArgumentException("A walk cannot be started by a trigger that is unspecified.", nameof(trigger));
+
+    /// <summary>Reports whether one rule takes part in this walk.</summary>
+    /// <param name="rule">The rule the walk has reached in declared order.</param>
+    /// <returns><see langword="true" /> when the walk runs the rule.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rule" /> is <see langword="null" />.</exception>
+    public bool Reaches(MailRule rule)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+
+        return !this.trigger.IsSpecified || rule.RunsOn(this.trigger);
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => this.trigger.IsSpecified ? this.trigger.Name : "every rule";
+}

--- a/src/Application/Rules/MailRuleSetEvaluator.cs
+++ b/src/Application/Rules/MailRuleSetEvaluator.cs
@@ -20,6 +20,8 @@ namespace MailFathom.Application.Rules;
 /// A rule scoped to accounts this email does not belong to is passed over rather than evaluated, and leaves no
 /// evaluation behind: it did not decline to match, it was not one of this account's rules. That also means it cannot end
 /// the pass, whatever it declares, so narrowing a stopping rule to one account is a statement about that account alone.
+/// A rule the walk's reach does not hold is passed over on exactly the same terms, so the history stays a record of
+/// decisions rather than of rules that were never asked.
 /// </para>
 /// <para>
 /// The one place totality is applied. The expression evaluator underneath raises failures rather than returning them,
@@ -55,6 +57,7 @@ public sealed class MailRuleSetEvaluator
     /// <summary>Evaluates every rule of the set against one email until a matching rule ends the pass.</summary>
     /// <param name="ruleSet">The bound rule set, whose declared order is the order the rules are reached in.</param>
     /// <param name="facts">The fact surface for the email, which resolves each fact at most once for the whole pass.</param>
+    /// <param name="reach">Which rules this walk runs: the ones its trigger reaches, or every rule somebody asked for.</param>
     /// <param name="cancellationToken">Cancels the pass, which is reported as cancellation rather than as a failed rule.</param>
     /// <returns>What each rule the pass reached concluded, under the rule set's revision.</returns>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
@@ -62,10 +65,12 @@ public sealed class MailRuleSetEvaluator
     public async Task<MailRuleSetEvaluation> EvaluateAsync(
         MailRuleSet ruleSet,
         MailRuleFacts facts,
+        MailRuleReach reach,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(ruleSet);
         ArgumentNullException.ThrowIfNull(facts);
+        ArgumentNullException.ThrowIfNull(reach);
 
         var evaluations = new List<MailRuleEvaluation>(ruleSet.Rules.Count);
         var matchedRules = new List<MailRule>();
@@ -73,7 +78,7 @@ public sealed class MailRuleSetEvaluator
 
         foreach (var rule in ruleSet.Rules)
         {
-            if (!rule.AppliesTo(facts.Account))
+            if (!rule.AppliesTo(facts.Account) || !reach.Reaches(rule))
             {
                 continue;
             }

--- a/src/Application/Rules/MailRuleSetRevision.cs
+++ b/src/Application/Rules/MailRuleSetRevision.cs
@@ -21,9 +21,10 @@ namespace MailFathom.Application.Rules;
 /// configuration key leaves it alone, and so does reformatting the file or reordering the keys within one rule.
 /// Reordering the rules themselves does move it, because declared order is part of what a rule set means. So is the
 /// scope: narrowing a rule to one account changes which mail it reaches, which is a different rule set rather than the
-/// same one applied differently. So are the actions, for the reason the revision is part of a request's identity at all
-/// — a rule now filing into a different folder must ask afresh rather than be answered by the record of the filing it
-/// asked for before the edit.
+/// same one applied differently. So are the triggers, for the same reason — a rule withdrawn from firing on arrival
+/// reaches different mail from the one that fires on it. So are the actions, for the reason the revision is part of a
+/// request's identity at all — a rule now filing into a different folder must ask afresh rather than be answered by the
+/// record of the filing it asked for before the edit.
 /// </para>
 /// <para>
 /// It carries none of the authored text and no ordering. A record naming a revision therefore holds nothing personal
@@ -49,10 +50,10 @@ public readonly record struct MailRuleSetRevision
     private const char FieldSeparator = '\u001F';
     private const char RuleSeparator = '\u001E';
 
-    /// <summary>Separates the values inside a field holding several of them: the scope, and the declared actions.</summary>
+    /// <summary>Separates the values inside a field holding several: the scope, the actions, and the triggers.</summary>
     /// <remarks>
     /// A third separator rather than a reused one, so that a scope of two accounts cannot render as the same text as a
-    /// rule whose next field begins where the second account would have. Both multi-valued fields use this one, which
+    /// rule whose next field begins where the second account would have. Every multi-valued field uses this one, which
     /// stays unambiguous because a field separator ends each of them.
     /// </remarks>
     private const char ListSeparator = '\u001D';
@@ -109,6 +110,8 @@ public readonly record struct MailRuleSetRevision
                 .Append(declaration.StopWhenMatched ? "stop" : "continue")
                 .Append(FieldSeparator)
                 .AppendJoin(ListSeparator, declaration.Accounts)
+                .Append(FieldSeparator)
+                .AppendJoin(ListSeparator, declaration.Triggers.Select(trigger => trigger.Name))
                 .Append(RuleSeparator);
         }
 

--- a/src/Application/Rules/MailRuleTrigger.cs
+++ b/src/Application/Rules/MailRuleTrigger.cs
@@ -1,0 +1,164 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Application.Rules;
+
+/// <summary>Names one automatic occasion on which a rule takes part in a pass.</summary>
+/// <remarks>
+/// <para>
+/// A closed enumeration rather than a C# <see langword="enum" />, because the name is the identity: it is what an
+/// operator writes under a rule's <c>Triggers</c> key and the form a rule set's revision is derived from. An enum
+/// member's ordinal would mean nothing outside this assembly, and its member name would change with a rename that the
+/// configuration surface and the derived identity both have to survive.
+/// </para>
+/// <para>
+/// One member today, and the set is closed rather than final: a scheduled pass was refused for now rather than forever,
+/// so a second occasion is a member to append. What is deliberately not a member is a run somebody asked for. That is
+/// the request itself rather than an occasion a rule opts into, so it reaches every rule of the set;
+/// <see cref="MailRuleReach" /> is where the two are told apart.
+/// </para>
+/// <para>
+/// Being a struct, <see langword="default" /> is reachable and names no trigger. <see cref="IsSpecified" /> reports
+/// that, <see cref="TryParseName" /> never produces one, and <see cref="MailRule.Create" /> refuses one.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(MailRuleTriggerJsonConverter))]
+public readonly record struct MailRuleTrigger
+{
+    private readonly string? name;
+
+    private MailRuleTrigger(string name) => this.name = name;
+
+    /// <summary>Gets the trigger that runs a rule over a message the account's synchronization run has just committed.</summary>
+    /// <remarks>
+    /// Named after the moment rather than after the transport, because <c>Push</c> already names an account's
+    /// synchronization mode and a rule is unaffected by whether its account is watched or polled: mail committed by a
+    /// polled run reaches this trigger exactly as mail committed by a watched one does.
+    /// </remarks>
+    public static MailRuleTrigger Arrival { get; } = new("Arrival");
+
+    /// <summary>Gets every trigger a rule may declare.</summary>
+    /// <remarks>Declared last so the members it lists are already initialized when this initializer runs.</remarks>
+    public static IReadOnlyList<MailRuleTrigger> All { get; } = [Arrival];
+
+    /// <summary>Gets the triggers a rule that declares none takes part in.</summary>
+    /// <remarks>
+    /// Arrival, which is what every rule written before the key existed already did, so an absent key leaves a rule set
+    /// meaning what it meant. It is a value of its own rather than <see cref="All" /> because the two answer different
+    /// questions and would part company the moment a second trigger exists: a rule that says nothing would still run on
+    /// arrival alone, rather than joining every occasion added since it was written.
+    /// </remarks>
+    public static IReadOnlyList<MailRuleTrigger> WhenNoneDeclared { get; } = [Arrival];
+
+    /// <summary>Gets whether this value names a trigger rather than the unusable struct default.</summary>
+    public bool IsSpecified => this.name is not null;
+
+    /// <summary>Gets the name the trigger is declared and reported under.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a trigger.</exception>
+    public string Name => this.name
+        ?? throw new InvalidOperationException("The value is the default of the struct and names no mail rule trigger.");
+
+    /// <summary>Parses a declared name back into the trigger it names.</summary>
+    /// <param name="name">The name read from a configuration key or a serialized document.</param>
+    /// <param name="trigger">The trigger when the name is one this set holds; otherwise the unspecified default.</param>
+    /// <returns><see langword="true" /> when the name is a declared trigger; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// Surrounding whitespace is ignored and case is not compared, which is how the configuration binder already reads
+    /// every other closed vocabulary this deployment declares. A name this set does not hold is refused rather than
+    /// reconstructed, because a trigger nothing runs is unknown rather than new.
+    /// </remarks>
+    public static bool TryParseName(string? name, out MailRuleTrigger trigger)
+    {
+        trigger = default;
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return false;
+        }
+
+        var declaredName = name.Trim();
+
+        // No declared trigger is the struct default, so an unmatched name yields the unspecified value the caller
+        // already receives when parsing fails.
+        trigger = All.FirstOrDefault(candidate => StringComparer.OrdinalIgnoreCase.Equals(candidate.Name, declaredName));
+
+        return trigger.IsSpecified;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => this.name ?? "(unspecified)";
+}
+
+/// <summary>Serializes <see cref="MailRuleTrigger" /> as its name.</summary>
+/// <remarks>
+/// The type carries this converter through <see cref="JsonConverterAttribute" />, so every serializer that meets the
+/// value uses it without per-call registration. The JSON form is the name for the same reason the value object exists:
+/// it is the identity an operator already writes in a configuration file, and an ordinal would change meaning silently
+/// if the declared set were ever reordered.
+/// </remarks>
+public sealed class MailRuleTriggerJsonConverter : JsonConverter<MailRuleTrigger>
+{
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the token is not a string or does not name a declared trigger.</exception>
+    public override MailRuleTrigger Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException($"A mail rule trigger must be a JSON string, but the token was {reader.TokenType}.");
+        }
+
+        return ParseOrThrow(reader.GetString());
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the value is the unspecified struct default.</exception>
+    public override void Write(
+        Utf8JsonWriter writer,
+        MailRuleTrigger value,
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WriteStringValue(NameOrThrow(value));
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the property name does not name a declared trigger.</exception>
+    public override MailRuleTrigger ReadAsPropertyName(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options) => ParseOrThrow(reader.GetString());
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the value is the unspecified struct default.</exception>
+    public override void WriteAsPropertyName(
+        Utf8JsonWriter writer,
+        MailRuleTrigger value,
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WritePropertyName(NameOrThrow(value));
+    }
+
+    private static MailRuleTrigger ParseOrThrow(string? name)
+    {
+        if (!MailRuleTrigger.TryParseName(name, out var trigger))
+        {
+            throw new JsonException($"'{name}' does not name a declared mail rule trigger.");
+        }
+
+        return trigger;
+    }
+
+    private static string NameOrThrow(MailRuleTrigger trigger) => trigger.IsSpecified
+        ? trigger.Name
+        : throw new JsonException("An unspecified mail rule trigger cannot be serialized.");
+}

--- a/src/Application/Rules/MailRuleTrigger.cs
+++ b/src/Application/Rules/MailRuleTrigger.cs
@@ -45,15 +45,6 @@ public readonly record struct MailRuleTrigger
     /// <remarks>Declared last so the members it lists are already initialized when this initializer runs.</remarks>
     public static IReadOnlyList<MailRuleTrigger> All { get; } = [Arrival];
 
-    /// <summary>Gets the triggers a rule that declares none takes part in.</summary>
-    /// <remarks>
-    /// Arrival, which is what every rule written before the key existed already did, so an absent key leaves a rule set
-    /// meaning what it meant. It is a value of its own rather than <see cref="All" /> because the two answer different
-    /// questions and would part company the moment a second trigger exists: a rule that says nothing would still run on
-    /// arrival alone, rather than joining every occasion added since it was written.
-    /// </remarks>
-    public static IReadOnlyList<MailRuleTrigger> WhenNoneDeclared { get; } = [Arrival];
-
     /// <summary>Gets whether this value names a trigger rather than the unusable struct default.</summary>
     public bool IsSpecified => this.name is not null;
 

--- a/src/Cli/Administration/Rules/LoadedRuleSet.cs
+++ b/src/Cli/Administration/Rules/LoadedRuleSet.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Text.Json.Serialization;
+using MailFathom.Cli.Commands;
 
 namespace MailFathom.Cli.Administration.Rules;
 
@@ -32,18 +33,30 @@ internal sealed record LoadedRuleSet(
 /// <param name="ReadableFacts">The facts its condition names, which is every fact it can cause to be resolved.</param>
 /// <param name="Actions">What a match asks the mailbox for, in the order the rule declares the changes.</param>
 /// <param name="StopWhenMatched">Whether a match ends the pass rather than continuing to the rules below.</param>
+/// <param name="Triggers">The automatic triggers it takes part in, empty for a rule only a requested run applies.</param>
 internal sealed record LoadedRule(
     [property: JsonPropertyName("name")] string? Name,
     [property: JsonPropertyName("accounts")] IReadOnlyList<string>? Accounts,
     [property: JsonPropertyName("readableFacts")] IReadOnlyList<string>? ReadableFacts,
     [property: JsonPropertyName("actions")] IReadOnlyList<LoadedRuleAction>? Actions,
-    [property: JsonPropertyName("stopWhenMatched")] bool StopWhenMatched)
+    [property: JsonPropertyName("stopWhenMatched")] bool StopWhenMatched,
+    [property: JsonPropertyName("triggers")] IReadOnlyList<string>? Triggers)
 {
     /// <summary>Describes what the rule applies to in one line an operator reads.</summary>
     /// <returns>The accounts it names, or that it names none.</returns>
     internal string DescribeScope() => this.Accounts is { Count: > 0 } accounts
         ? string.Join(", ", accounts)
         : "every account";
+
+    /// <summary>Describes what runs the rule in one line an operator reads.</summary>
+    /// <returns>The triggers it takes part in, or that a requested run is the only thing that applies it.</returns>
+    /// <remarks>
+    /// A rule nothing fires by itself is the one an operator is most likely to be asking about — it looks identical to
+    /// a rule that never matched — so the answer says what does run it rather than reporting an empty list.
+    /// </remarks>
+    internal string DescribeTriggers() => this.Triggers is { Count: > 0 } triggers
+        ? string.Join(", ", triggers)
+        : $"nothing automatically; '{CliRootCommand.CommandName} rules run' applies it";
 
     /// <summary>Describes what a match does in one line an operator reads.</summary>
     /// <returns>The changes in declared order, and the fact that a match ends the pass where it does.</returns>

--- a/src/Cli/Commands/Rules/ListRulesCommand.cs
+++ b/src/Cli/Commands/Rules/ListRulesCommand.cs
@@ -74,6 +74,7 @@ internal static class ListRulesCommand
         {
             context.Console.WriteLine($"{rule.Name}");
             context.Console.WriteLine($"  Applies to: {rule.DescribeScope()}");
+            context.Console.WriteLine($"  Runs on:    {rule.DescribeTriggers()}");
             context.Console.WriteLine($"  A match:    {rule.DescribeActions()}");
         }
     }

--- a/src/Cli/Commands/Rules/ShowRuleCommand.cs
+++ b/src/Cli/Commands/Rules/ShowRuleCommand.cs
@@ -87,6 +87,7 @@ internal static class ShowRuleCommand
         context.Console.WriteLine($"{rule.Name}");
         context.Console.WriteLine($"Rule set:    {ruleSet.Revision ?? "unreported"}");
         context.Console.WriteLine($"Applies to:  {rule.DescribeScope()}");
+        context.Console.WriteLine($"Runs on:     {rule.DescribeTriggers()}");
         context.Console.WriteLine($"Reads facts: {DescribeReadableFacts(rule)}");
         context.Console.WriteLine($"A match:     {rule.DescribeActions()}");
         context.Console.WriteLine(

--- a/src/Host/Api/MailRuleResponses.cs
+++ b/src/Host/Api/MailRuleResponses.cs
@@ -51,6 +51,7 @@ internal sealed record MailRuleSetResponse(
 /// <param name="ReadableFacts">The facts its condition names, which is every fact it can cause to be resolved.</param>
 /// <param name="Actions">What a match asks the mailbox for, in the order the rule declares the changes.</param>
 /// <param name="StopWhenMatched">Whether a match ends the pass rather than continuing to the rules below.</param>
+/// <param name="Triggers">The automatic triggers it takes part in, empty for a rule only a requested run applies.</param>
 /// <remarks>
 /// The authored condition is deliberately absent. A compiled rule carries no text — which is what keeps an address the
 /// operator typed into a condition out of every record naming the rule — so what this reports of a condition is the
@@ -61,7 +62,8 @@ internal sealed record MailRuleResponse(
     IReadOnlyList<string> Accounts,
     IReadOnlyList<string> ReadableFacts,
     IReadOnlyList<MailRuleActionResponse> Actions,
-    bool StopWhenMatched)
+    bool StopWhenMatched,
+    IReadOnlyList<string> Triggers)
 {
     /// <summary>Describes one rule for the wire.</summary>
     /// <param name="rule">The bound rule.</param>
@@ -76,7 +78,8 @@ internal sealed record MailRuleResponse(
             [.. rule.Accounts.Order(StringComparer.Ordinal)],
             [.. rule.Condition.ReferencedFacts.Select(fact => fact.Name)],
             [.. rule.Actions.Actions.Select((action, position) => MailRuleActionResponse.For(action, position))],
-            rule.StopWhenMatched);
+            rule.StopWhenMatched,
+            [.. MailRuleTrigger.All.Where(rule.RunsOn).Select(trigger => trigger.Name)]);
     }
 }
 

--- a/src/Host/Configuration/Rules/MailRuleDeclarationRules.cs
+++ b/src/Host/Configuration/Rules/MailRuleDeclarationRules.cs
@@ -175,15 +175,11 @@ internal static class MailRuleDeclarationRules
     /// was mistyped would otherwise arrive as an empty one and silently turn an automatic rule into a manual one, and a
     /// rule that never fires is indistinguishable from a rule nothing matched. A repeated name is refused because the
     /// value is a set, so writing one twice says nothing the rule does not already say and is a mistake rather than an
-    /// intent. An absent key is not judged at all: it is a rule that declares none, which has a meaning of its own.
+    /// intent. A rule naming no trigger is not judged at all: it is a rule only a whole-mailbox run applies, which has
+    /// a meaning of its own.
     /// </remarks>
     private static IEnumerable<string> FindTriggerErrors(MailRuleOptions rule, int position)
     {
-        if (rule.Triggers is null)
-        {
-            yield break;
-        }
-
         var opening =
             $"{MailRulesOptions.SectionName}:{nameof(MailRulesOptions.Rules)}:{position}:{nameof(MailRuleOptions.Triggers)}";
         var declared = rule.Triggers.Select(trigger => trigger?.Trim() ?? string.Empty).ToArray();

--- a/src/Host/Configuration/Rules/MailRuleDeclarationRules.cs
+++ b/src/Host/Configuration/Rules/MailRuleDeclarationRules.cs
@@ -85,6 +85,7 @@ internal static class MailRuleDeclarationRules
     [
         .. FindRuleErrors(rule, position),
         .. FindScopeErrors(rule, position, declaredAccounts),
+        .. FindTriggerErrors(rule, position),
         .. FindActionErrors(rule, position, declaredAccounts),
         .. FindIdentityErrors(rule, position),
     ];
@@ -167,6 +168,52 @@ internal static class MailRuleDeclarationRules
                 $"{opening} — no account named '{unknown}' is declared under MailSynchronization:Accounts, so this rule would reach no mail.";
         }
     }
+
+    /// <summary>Judges the automatic triggers a rule declares, which is the one part of it that decides when it runs.</summary>
+    /// <remarks>
+    /// An unreadable name is refused rather than dropped, which is the whole point of the check: a list whose only entry
+    /// was mistyped would otherwise arrive as an empty one and silently turn an automatic rule into a manual one, and a
+    /// rule that never fires is indistinguishable from a rule nothing matched. A repeated name is refused because the
+    /// value is a set, so writing one twice says nothing the rule does not already say and is a mistake rather than an
+    /// intent. An absent key is not judged at all: it is a rule that declares none, which has a meaning of its own.
+    /// </remarks>
+    private static IEnumerable<string> FindTriggerErrors(MailRuleOptions rule, int position)
+    {
+        if (rule.Triggers is null)
+        {
+            yield break;
+        }
+
+        var opening =
+            $"{MailRulesOptions.SectionName}:{nameof(MailRulesOptions.Rules)}:{position}:{nameof(MailRuleOptions.Triggers)}";
+        var declared = rule.Triggers.Select(trigger => trigger?.Trim() ?? string.Empty).ToArray();
+
+        if (declared.Any(string.IsNullOrEmpty))
+        {
+            yield return $"{opening} — a trigger this rule declares is named by nothing.";
+
+            yield break;
+        }
+
+        var repeated = declared
+            .GroupBy(trigger => trigger, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(group => group.Count() > 1);
+
+        if (repeated is not null)
+        {
+            yield return $"{opening} — the trigger '{repeated.Key}' is named more than once, and the value is a set.";
+        }
+
+        foreach (var unknown in declared.Where(trigger => !MailRuleTrigger.TryParseName(trigger, out _)))
+        {
+            yield return
+                $"{opening} — no trigger is named '{unknown}'. A rule may declare {DescribeDeclarableTriggers()}, and declaring none of them is a rule only a whole-mailbox run applies.";
+        }
+    }
+
+    /// <summary>Names the triggers a rule may declare, so a refusal says what to write instead of only what not to.</summary>
+    private static string DescribeDeclarableTriggers() =>
+        string.Join(", ", MailRuleTrigger.All.Select(trigger => $"'{trigger.Name}'"));
 
     /// <summary>Judges what a rule does to the mail it selects, against the rule itself and against every account it reaches.</summary>
     /// <remarks>

--- a/src/Host/Configuration/Rules/MailRuleOptions.cs
+++ b/src/Host/Configuration/Rules/MailRuleOptions.cs
@@ -65,17 +65,11 @@ internal sealed class MailRuleOptions
     /// <summary>Gets or sets the automatic triggers that may run this rule.</summary>
     /// <remarks>
     /// <para>
-    /// Leaving the key out is <see cref="MailRuleTrigger.WhenNoneDeclared" />, so a rule written before the key existed
-    /// keeps its behaviour. Writing an empty list is a rule nothing fires by itself: it stays in the bound set, it is
-    /// validated like every other rule, and a whole-mailbox run is what applies it. That is a different statement from
-    /// <see cref="Enabled" />, which leaves a rule out of the set altogether and makes it unrunnable.
-    /// </para>
-    /// <para>
-    /// An array rather than the <see cref="IList{T}" /> the scope uses, because it is the one shape the configuration
-    /// binder distinguishes an empty list with. A written <c>[]</c> reaches the binder as a key with an empty value and
-    /// no children, which leaves a list property holding whatever it already held — so an operator asking for a
-    /// manual-only rule and one saying nothing at all would arrive here identically. An array property is rebuilt from
-    /// the section instead, which is what keeps the two apart.
+    /// A rule takes part in the occasions it names here and in no others, so leaving the key out and writing an empty
+    /// list say the same thing: a rule nothing fires by itself. Such a rule stays in the bound set, is validated like
+    /// every other, and a whole-mailbox run is what applies it. That is a different statement from
+    /// <see cref="Enabled" />, which leaves a rule out of the set altogether and makes it unrunnable. A rule that
+    /// should run over arriving mail writes <c>Arrival</c>, which is the whole vocabulary today.
     /// </para>
     /// <para>
     /// The elements are text rather than the trigger itself, for the reason the actions are one key each: the binder
@@ -84,21 +78,19 @@ internal sealed class MailRuleOptions
     /// rule into a manual one. Read as text, every name reaches validation and an unreadable one is refused there.
     /// </para>
     /// </remarks>
-    public string[]? Triggers { get; set; }
+    public IList<string> Triggers { get; set; } = [];
 
-    /// <summary>Reads the declared triggers, resolving an absent key to what a rule declaring none takes part in.</summary>
+    /// <summary>Reads the declared triggers, leaving out a name this system cannot read.</summary>
     /// <returns>The triggers, empty for a rule only a requested walk runs.</returns>
     /// <remarks>
     /// A name this system cannot read is left out rather than thrown over, because it is reported by validation against
     /// the key an operator edits and reading it here would raise instead. <see cref="MailRuleSetMapper" /> refuses a set
     /// that reaches it with one, so the dropped name cannot become a rule nothing runs.
     /// </remarks>
-    internal IReadOnlyList<MailRuleTrigger> ToTriggers() => this.Triggers is null
-        ? MailRuleTrigger.WhenNoneDeclared
-        :
-        [
-            .. this.Triggers
-                .Select(name => MailRuleTrigger.TryParseName(name, out var trigger) ? trigger : default)
-                .Where(trigger => trigger.IsSpecified),
-        ];
+    internal IReadOnlyList<MailRuleTrigger> ToTriggers() =>
+    [
+        .. this.Triggers
+            .Select(name => MailRuleTrigger.TryParseName(name, out var trigger) ? trigger : default)
+            .Where(trigger => trigger.IsSpecified),
+    ];
 }

--- a/src/Host/Configuration/Rules/MailRuleOptions.cs
+++ b/src/Host/Configuration/Rules/MailRuleOptions.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Rules;
 
 namespace MailFathom.Host.Configuration.Rules;
 
@@ -60,4 +61,44 @@ internal sealed class MailRuleOptions
     /// deleted and rewritten from memory later.
     /// </remarks>
     public bool Enabled { get; set; } = true;
+
+    /// <summary>Gets or sets the automatic triggers that may run this rule.</summary>
+    /// <remarks>
+    /// <para>
+    /// Leaving the key out is <see cref="MailRuleTrigger.WhenNoneDeclared" />, so a rule written before the key existed
+    /// keeps its behaviour. Writing an empty list is a rule nothing fires by itself: it stays in the bound set, it is
+    /// validated like every other rule, and a whole-mailbox run is what applies it. That is a different statement from
+    /// <see cref="Enabled" />, which leaves a rule out of the set altogether and makes it unrunnable.
+    /// </para>
+    /// <para>
+    /// An array rather than the <see cref="IList{T}" /> the scope uses, because it is the one shape the configuration
+    /// binder distinguishes an empty list with. A written <c>[]</c> reaches the binder as a key with an empty value and
+    /// no children, which leaves a list property holding whatever it already held — so an operator asking for a
+    /// manual-only rule and one saying nothing at all would arrive here identically. An array property is rebuilt from
+    /// the section instead, which is what keeps the two apart.
+    /// </para>
+    /// <para>
+    /// The elements are text rather than the trigger itself, for the reason the actions are one key each: the binder
+    /// drops an element it cannot convert, so a mistyped name in a bound list of triggers would arrive as a shorter
+    /// list — and a list whose only entry was mistyped would arrive as the empty one, silently turning an automatic
+    /// rule into a manual one. Read as text, every name reaches validation and an unreadable one is refused there.
+    /// </para>
+    /// </remarks>
+    public string[]? Triggers { get; set; }
+
+    /// <summary>Reads the declared triggers, resolving an absent key to what a rule declaring none takes part in.</summary>
+    /// <returns>The triggers, empty for a rule only a requested walk runs.</returns>
+    /// <remarks>
+    /// A name this system cannot read is left out rather than thrown over, because it is reported by validation against
+    /// the key an operator edits and reading it here would raise instead. <see cref="MailRuleSetMapper" /> refuses a set
+    /// that reaches it with one, so the dropped name cannot become a rule nothing runs.
+    /// </remarks>
+    internal IReadOnlyList<MailRuleTrigger> ToTriggers() => this.Triggers is null
+        ? MailRuleTrigger.WhenNoneDeclared
+        :
+        [
+            .. this.Triggers
+                .Select(name => MailRuleTrigger.TryParseName(name, out var trigger) ? trigger : default)
+                .Where(trigger => trigger.IsSpecified),
+        ];
 }

--- a/src/Host/Configuration/Rules/MailRuleSetMapper.cs
+++ b/src/Host/Configuration/Rules/MailRuleSetMapper.cs
@@ -69,7 +69,7 @@ internal static class MailRuleSetMapper
     {
         var triggers = rule.ToTriggers();
 
-        return rule.Triggers is null || triggers.Count == rule.Triggers.Length
+        return triggers.Count == rule.Triggers.Count
             ? triggers
             : throw new InvalidOperationException(
                 $"A mail rule set was mapped before it was validated. Rule '{rule.Name}' declares a trigger this system does not recognize.");

--- a/src/Host/Configuration/Rules/MailRuleSetMapper.cs
+++ b/src/Host/Configuration/Rules/MailRuleSetMapper.cs
@@ -41,7 +41,8 @@ internal static class MailRuleSetMapper
                 rule.Condition,
                 (rule.Actions ?? new MailRuleActionOptions()).ToActions(),
                 rule.StopWhenMatched,
-                [.. rule.Accounts.Select(account => account.Trim())]))
+                [.. rule.Accounts.Select(account => account.Trim())],
+                ReadTriggers(rule)))
             .ToArray();
 
         var rules = declarations
@@ -50,10 +51,28 @@ internal static class MailRuleSetMapper
                 Compile(compiler, declaration, bounds),
                 MailRuleActionSet.Create(declaration.Actions),
                 declaration.StopWhenMatched,
-                declaration.Accounts))
+                declaration.Accounts,
+                declaration.Triggers))
             .ToArray();
 
         return MailRuleSet.Create(rules, MailRuleSetRevision.Create(declarations), bounds);
+    }
+
+    /// <summary>Reads the triggers a rule declares, refusing a name validation would already have reported.</summary>
+    /// <remarks>
+    /// A dropped name would leave a shorter list, and a rule whose only declared trigger was mistyped would become a
+    /// rule nothing runs automatically — the one outcome a typo must never produce quietly. Reaching this means a rule
+    /// set was mapped without having been proven usable, which is a defect in the composition rather than in what an
+    /// operator wrote.
+    /// </remarks>
+    private static IReadOnlyList<MailRuleTrigger> ReadTriggers(MailRuleOptions rule)
+    {
+        var triggers = rule.ToTriggers();
+
+        return rule.Triggers is null || triggers.Count == rule.Triggers.Length
+            ? triggers
+            : throw new InvalidOperationException(
+                $"A mail rule set was mapped before it was validated. Rule '{rule.Name}' declares a trigger this system does not recognize.");
     }
 
     private static IMailRuleCondition Compile(

--- a/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationPassTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationPassTests.cs
@@ -253,6 +253,50 @@ public sealed class MailRuleEvaluationPassTests
         Assert.Null(await this.runStore.FindOutstandingAsync(Account, TestContext.Current.CancellationToken));
     }
 
+    /// <summary>A manual-only rule is the whole point of the key: nothing fires it, and asking for a run does.</summary>
+    [Fact]
+    public async Task RunAsync_ManualOnlyRule_RunsInTheRequestedWalkAndNotInTheArrivalOne()
+    {
+        // Arrange
+        var housekeeping = ScriptedMailRuleCondition.Answering(matches: true);
+        var ruleSet = RuleSetOf(MailRule.Create("housekeeping", housekeeping, triggers: []));
+        this.store.Add(FactsFor(Account));
+
+        // Act
+        var arrivalOnly = await this.CreatePass(ruleSet).RunAsync(Account, TestContext.Current.CancellationToken);
+
+        this.runStore.Arrange(RequestedRun());
+
+        var requested = await this.CreatePass(ruleSet).RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, arrivalOnly.Arrivals.EvaluatedEmailCount);
+        Assert.Empty(arrivalOnly.Arrivals.MatchedRuleNames);
+        Assert.Equal(["housekeeping"], requested.RequestedRun?.MatchedRuleNames);
+    }
+
+    /// <summary>The body-text question is asked of the rules a walk runs, so a manual-only rule holds nothing up.</summary>
+    [Fact]
+    public async Task RunAsync_ManualOnlyRuleNamingTheBodyText_LeavesArrivingMailAwaitingExtractionEvaluated()
+    {
+        // Arrange
+        var ruleSet = RuleSetOf(
+            MailRule.Create(
+                "housekeeping",
+                ScriptedMailRuleCondition.Answering(matches: true, MailRuleFact.BodyText),
+                triggers: []),
+            MailRule.Create("on-arrival", ScriptedMailRuleCondition.Answering(matches: true)));
+        var awaiting = this.store.Add(FactsFor(Account), awaitsExtraction: true);
+
+        // Act
+        var report = await this.CreatePass(ruleSet).RunAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal([awaiting], this.store.Evaluated);
+        Assert.Equal(0, report.Arrivals.SkippedEmailCount);
+        Assert.Equal(["on-arrival"], report.Arrivals.MatchedRuleNames);
+    }
+
     [Fact]
     public async Task RunAsync_RequestedRunPickedUp_BindsTheRevisionItStartedUnder()
     {
@@ -566,7 +610,7 @@ public sealed class MailRuleEvaluationPassTests
     private static MailRuleSet RuleSetOf(params MailRule[] rules) => MailRuleSet.Create(
         rules,
         MailRuleSetRevision.Create(
-            [.. rules.Select(rule => new MailRuleDeclaration(rule.Name, "isSeen", [.. rule.Actions.Actions], rule.StopWhenMatched, [.. rule.Accounts]))]),
+            [.. rules.Select(rule => new MailRuleDeclaration(rule.Name, "isSeen", [.. rule.Actions.Actions], rule.StopWhenMatched, [.. rule.Accounts], [.. rule.Triggers]))]),
         MailRuleConditionBounds.Default);
 
     private MailRuleEvaluationPass CreatePass(

--- a/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationPassTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationPassTests.cs
@@ -54,7 +54,7 @@ public sealed class MailRuleEvaluationPassTests
         // Arrange
         var matching = ScriptedMailRuleCondition.Answering(matches: true);
         var arrived = this.store.Add(FactsFor(Account));
-        var pass = this.CreatePass(RuleSetOf(MailRule.Create("file-it", matching, stopWhenMatched: false)));
+        var pass = this.CreatePass(RuleSetOf(ArrivalRule("file-it", matching, stopWhenMatched: false)));
 
         // Act
         var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -151,7 +151,7 @@ public sealed class MailRuleEvaluationPassTests
         // Arrange
         this.store.Add(FactsFor(Account));
         var pass = this.CreatePass(
-            RuleSetOf(MailRule.Create("select-only", ScriptedMailRuleCondition.Answering(matches: true))));
+            RuleSetOf(ArrivalRule("select-only", ScriptedMailRuleCondition.Answering(matches: true))));
 
         // Act
         var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -168,7 +168,7 @@ public sealed class MailRuleEvaluationPassTests
         // Arrange
         var condition = ScriptedMailRuleCondition.Answering(matches: true);
         this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1));
-        var pass = this.CreatePass(RuleSetOf(MailRule.Create("new-rule", condition, stopWhenMatched: false)));
+        var pass = this.CreatePass(RuleSetOf(ArrivalRule("new-rule", condition, stopWhenMatched: false)));
 
         // Act
         var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -186,7 +186,7 @@ public sealed class MailRuleEvaluationPassTests
         var condition = ScriptedMailRuleCondition.Answering(matches: true);
         var arrived = this.store.Add(FactsFor(Account));
         var pass = this.CreatePass(
-            RuleSetOf(MailRule.Create("other-account", condition, stopWhenMatched: false, accounts: [OtherAccount.Value])));
+            RuleSetOf(ArrivalRule("other-account", condition, stopWhenMatched: false, accounts: [OtherAccount.Value])));
 
         // Act
         await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -202,7 +202,7 @@ public sealed class MailRuleEvaluationPassTests
         // Arrange
         var elsewhere = this.store.Add(FactsFor(OtherAccount));
         var pass = this.CreatePass(RuleSetOf(
-            MailRule.Create("everywhere", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false)));
+            ArrivalRule("everywhere", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false)));
 
         // Act
         await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -220,7 +220,7 @@ public sealed class MailRuleEvaluationPassTests
             .Select(_ => this.store.Add(FactsFor(Account)))
             .ToArray();
         var pass = this.CreatePass(
-            RuleSetOf(MailRule.Create("all", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: false)),
+            RuleSetOf(ArrivalRule("all", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: false)),
             batchSize: 1,
             maxBatchesPerPass: 2);
 
@@ -240,7 +240,7 @@ public sealed class MailRuleEvaluationPassTests
         var already = this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1));
         this.runStore.Arrange(RequestedRun());
         var pass = this.CreatePass(RuleSetOf(
-            MailRule.Create("re-run", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false)));
+            ArrivalRule("re-run", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false)));
 
         // Act
         var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -285,7 +285,7 @@ public sealed class MailRuleEvaluationPassTests
                 "housekeeping",
                 ScriptedMailRuleCondition.Answering(matches: true, MailRuleFact.BodyText),
                 triggers: []),
-            MailRule.Create("on-arrival", ScriptedMailRuleCondition.Answering(matches: true)));
+            ArrivalRule("on-arrival", ScriptedMailRuleCondition.Answering(matches: true)));
         var awaiting = this.store.Add(FactsFor(Account), awaitsExtraction: true);
 
         // Act
@@ -302,7 +302,7 @@ public sealed class MailRuleEvaluationPassTests
     {
         // Arrange
         var ruleSet = RuleSetOf(
-            MailRule.Create("re-run", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: false));
+            ArrivalRule("re-run", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: false));
         this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1));
         this.runStore.Arrange(RequestedRun());
 
@@ -318,7 +318,7 @@ public sealed class MailRuleEvaluationPassTests
     {
         // Arrange
         var ruleSet = RuleSetOf(
-            MailRule.Create("re-run", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: false));
+            ArrivalRule("re-run", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: false));
         var mail = Enumerable
             .Range(0, 3)
             .Select(_ => this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1)))
@@ -348,12 +348,12 @@ public sealed class MailRuleEvaluationPassTests
         this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1));
         this.runStore.Arrange(RequestedRun() with
         {
-            Revision = RuleSetOf(MailRule.Create(
+            Revision = RuleSetOf(ArrivalRule(
                 "the-old-one",
                 ScriptedMailRuleCondition.Answering(matches: false),
                 stopWhenMatched: false)).Revision,
         });
-        var pass = this.CreatePass(RuleSetOf(MailRule.Create("the-new-one", condition, stopWhenMatched: false)));
+        var pass = this.CreatePass(RuleSetOf(ArrivalRule("the-new-one", condition, stopWhenMatched: false)));
 
         // Act
         var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -370,7 +370,7 @@ public sealed class MailRuleEvaluationPassTests
     {
         // Arrange
         var awaiting = this.store.Add(FactsFor(Account), awaitsExtraction: true);
-        var pass = this.CreatePass(RuleSetOf(MailRule.Create(
+        var pass = this.CreatePass(RuleSetOf(ArrivalRule(
             "reads-the-body",
             ScriptedMailRuleCondition.Answering(matches: true, MailRuleFact.BodyText),
             stopWhenMatched: false)));
@@ -390,7 +390,7 @@ public sealed class MailRuleEvaluationPassTests
     {
         // Arrange
         var awaiting = this.store.Add(FactsFor(Account), awaitsExtraction: true);
-        var pass = this.CreatePass(RuleSetOf(MailRule.Create(
+        var pass = this.CreatePass(RuleSetOf(ArrivalRule(
             "reads-the-body",
             ScriptedMailRuleCondition.Answering(matches: true, MailRuleFact.BodyText),
             stopWhenMatched: false)));
@@ -413,7 +413,7 @@ public sealed class MailRuleEvaluationPassTests
     {
         // Arrange
         var withoutText = this.store.Add(FactsFor(Account), awaitsExtraction: false);
-        var pass = this.CreatePass(RuleSetOf(MailRule.Create(
+        var pass = this.CreatePass(RuleSetOf(ArrivalRule(
             "reads-the-body",
             ScriptedMailRuleCondition.Answering(matches: false, MailRuleFact.BodyText),
             stopWhenMatched: false)));
@@ -433,11 +433,11 @@ public sealed class MailRuleEvaluationPassTests
         var unlucky = this.store.Add(FactsFor(Account));
         var next = this.store.Add(FactsFor(Account));
         var pass = this.CreatePass(RuleSetOf(
-            MailRule.Create(
+            ArrivalRule(
                 "raises",
                 ScriptedMailRuleCondition.Raising(new InvalidOperationException("no answer")),
                 stopWhenMatched: false),
-            MailRule.Create("answers", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false)));
+            ArrivalRule("answers", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false)));
 
         // Act
         var report = await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -458,7 +458,7 @@ public sealed class MailRuleEvaluationPassTests
         var first = this.store.Add(FactsFor(Account));
         var second = this.store.Add(FactsFor(Account));
         var pass = this.CreatePass(
-            RuleSetOf(MailRule.Create("withdraws", new CancellingCondition(cancellation), stopWhenMatched: false)),
+            RuleSetOf(ArrivalRule("withdraws", new CancellingCondition(cancellation), stopWhenMatched: false)),
             batchSize: 1);
 
         // Act
@@ -476,8 +476,8 @@ public sealed class MailRuleEvaluationPassTests
         // Arrange
         var arrived = this.store.Add(FactsFor(Account));
         var ruleSet = RuleSetOf(
-            MailRule.Create("file-invoices", ScriptedMailRuleCondition.Answering(matches: false)),
-            MailRule.Create(
+            ArrivalRule("file-invoices", ScriptedMailRuleCondition.Answering(matches: false)),
+            ArrivalRule(
                 "mark-newsletters",
                 ScriptedMailRuleCondition.Answering(matches: true, MailRuleFact.SenderDomain)));
 
@@ -506,7 +506,7 @@ public sealed class MailRuleEvaluationPassTests
         this.store.Add(FactsFor(Account), evaluatedAt: EvaluatedAt.AddDays(-1));
         this.runStore.Arrange(RequestedRun());
         var pass = this.CreatePass(RuleSetOf(
-            MailRule.Create("re-run", ScriptedMailRuleCondition.Answering(matches: true))));
+            ArrivalRule("re-run", ScriptedMailRuleCondition.Answering(matches: true))));
 
         // Act
         await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -524,8 +524,8 @@ public sealed class MailRuleEvaluationPassTests
         // Arrange
         this.store.Add(FactsFor(Account));
         var pass = this.CreatePass(RuleSetOf(
-            MailRule.Create("ends-it", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: true),
-            MailRule.Create("never-reached", ScriptedMailRuleCondition.Answering(matches: true))));
+            ArrivalRule("ends-it", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: true),
+            ArrivalRule("never-reached", ScriptedMailRuleCondition.Answering(matches: true))));
 
         // Act
         await pass.RunAsync(Account, TestContext.Current.CancellationToken);
@@ -541,7 +541,7 @@ public sealed class MailRuleEvaluationPassTests
     {
         // Arrange
         this.store.Add(FactsFor(Account));
-        var pass = this.CreatePass(RuleSetOf(MailRule.Create(
+        var pass = this.CreatePass(RuleSetOf(ArrivalRule(
             "raises",
             ScriptedMailRuleCondition.Raising(new InvalidOperationException("no answer")))));
 
@@ -596,7 +596,20 @@ public sealed class MailRuleEvaluationPassTests
         new() { Account = accountId.Value, Folder = "inbox" };
 
     /// <summary>A rule that matches everything and files it, which is the shape every action assertion here needs.</summary>
-    private static MailRule FilingRule(string name, MailFolderAlias? destination = null) => MailRule.Create(
+    /// <summary>A rule as an operator writes one for arriving mail, which is the walk most of these tests take.</summary>
+    /// <remarks>
+    /// A rule takes part in the occasions it names and in no others, so a rule meant to reach an arrival says so. The
+    /// tests about a rule nothing fires by itself declare their triggers where they stand, because that is their subject.
+    /// </remarks>
+    private static MailRule ArrivalRule(
+        string name,
+        IMailRuleCondition condition,
+        MailRuleActionSet? actions = null,
+        bool stopWhenMatched = false,
+        IReadOnlyList<string>? accounts = null) =>
+        MailRule.Create(name, condition, actions, stopWhenMatched, accounts, [MailRuleTrigger.Arrival]);
+
+    private static MailRule FilingRule(string name, MailFolderAlias? destination = null) => ArrivalRule(
         name,
         ScriptedMailRuleCondition.Answering(matches: true),
         MailRuleActionSet.Create([MailRuleAction.Relocate(MailFolderReference.ToAlias(destination ?? Archive))]));

--- a/tests/Application.UnitTests/Rules/MailRuleReachTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleReachTests.cs
@@ -19,8 +19,8 @@ public sealed class MailRuleReachTests
 
         // Act, Assert
         Assert.True(reach.Reaches(CreateRule("on-arrival", [MailRuleTrigger.Arrival])));
-        Assert.True(reach.Reaches(CreateRule("says-nothing", triggers: null)));
         Assert.False(reach.Reaches(CreateRule("manual-only", [])));
+        Assert.False(reach.Reaches(CreateRule("says-nothing", triggers: null)));
     }
 
     /// <summary>Asking for a run is the request itself, so no rule can decline to take part in one.</summary>

--- a/tests/Application.UnitTests/Rules/MailRuleReachTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleReachTests.cs
@@ -1,0 +1,54 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Rules;
+using MailFathom.Application.UnitTests.TestDoubles;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Rules;
+
+/// <summary>Covers which rules each of the two kinds of walk runs.</summary>
+public sealed class MailRuleReachTests
+{
+    [Fact]
+    public void Reaches_ATriggeredWalk_RunsOnlyTheRulesDeclaringThatTrigger()
+    {
+        // Arrange
+        var reach = MailRuleReach.TriggeredBy(MailRuleTrigger.Arrival);
+
+        // Act, Assert
+        Assert.True(reach.Reaches(CreateRule("on-arrival", [MailRuleTrigger.Arrival])));
+        Assert.True(reach.Reaches(CreateRule("says-nothing", triggers: null)));
+        Assert.False(reach.Reaches(CreateRule("manual-only", [])));
+    }
+
+    /// <summary>Asking for a run is the request itself, so no rule can decline to take part in one.</summary>
+    [Fact]
+    public void Reaches_AWalkSomebodyAskedFor_RunsEveryRule()
+    {
+        // Act, Assert
+        Assert.True(MailRuleReach.EveryRule.Reaches(CreateRule("on-arrival", [MailRuleTrigger.Arrival])));
+        Assert.True(MailRuleReach.EveryRule.Reaches(CreateRule("manual-only", [])));
+    }
+
+    [Fact]
+    public void TriggeredBy_TheUnspecifiedDefault_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() => MailRuleReach.TriggeredBy(default));
+    }
+
+    [Fact]
+    public void ToString_EitherKindOfWalk_NamesWhatItRuns()
+    {
+        // Act, Assert
+        Assert.Equal("Arrival", MailRuleReach.TriggeredBy(MailRuleTrigger.Arrival).ToString());
+        Assert.Equal("every rule", MailRuleReach.EveryRule.ToString());
+    }
+
+    private static MailRule CreateRule(string name, IReadOnlyList<MailRuleTrigger>? triggers) => MailRule.Create(
+        name,
+        ScriptedMailRuleCondition.Answering(matches: true),
+        triggers: triggers);
+}

--- a/tests/Application.UnitTests/Rules/MailRuleSetEvaluatorTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleSetEvaluatorTests.cs
@@ -33,7 +33,7 @@ public sealed class MailRuleSetEvaluatorTests
             .Select(position => ScriptedMailRuleCondition.Answering(position == 1))
             .ToArray();
         var ruleSet = CreateRuleSet(conditions.Select((condition, position) =>
-            MailRule.Create($"rule-{position}", condition, stopWhenMatched: false)));
+            ArrivalRule($"rule-{position}", condition, stopWhenMatched: false)));
 
         // Act
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
@@ -61,8 +61,8 @@ public sealed class MailRuleSetEvaluatorTests
         var below = ScriptedMailRuleCondition.Answering(matches: true);
         var ruleSet = CreateRuleSet(
         [
-            MailRule.Create("stopping", stopping, stopWhenMatched: true),
-            MailRule.Create("below", below, stopWhenMatched: false),
+            ArrivalRule("stopping", stopping, stopWhenMatched: true),
+            ArrivalRule("below", below, stopWhenMatched: false),
         ]);
 
         // Act
@@ -84,8 +84,8 @@ public sealed class MailRuleSetEvaluatorTests
         // Arrange
         var ruleSet = CreateRuleSet(
         [
-            MailRule.Create("stopping", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: true),
-            MailRule.Create("below", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false),
+            ArrivalRule("stopping", ScriptedMailRuleCondition.Answering(matches: false), stopWhenMatched: true),
+            ArrivalRule("below", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false),
         ]);
 
         // Act
@@ -107,11 +107,11 @@ public sealed class MailRuleSetEvaluatorTests
         // Arrange
         var ruleSet = CreateRuleSet(
         [
-            MailRule.Create(
+            ArrivalRule(
                 "raising",
                 ScriptedMailRuleCondition.Raising(new InvalidOperationException("unusable operand")),
                 stopWhenMatched: true),
-            MailRule.Create("below", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false),
+            ArrivalRule("below", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false),
         ]);
 
         // Act
@@ -135,7 +135,7 @@ public sealed class MailRuleSetEvaluatorTests
     {
         // Arrange
         var stalling = ScriptedMailRuleCondition.NeverAnswering();
-        var ruleSet = CreateRuleSet([MailRule.Create("stalling", stalling, stopWhenMatched: false)]);
+        var ruleSet = CreateRuleSet([ArrivalRule("stalling", stalling, stopWhenMatched: false)]);
         var evaluator = this.CreateEvaluator();
 
         // Act
@@ -158,7 +158,7 @@ public sealed class MailRuleSetEvaluatorTests
     {
         // Arrange
         var ruleSet = CreateRuleSet(
-            [MailRule.Create("stalling", ScriptedMailRuleCondition.NeverAnswering(), stopWhenMatched: false)]);
+            [ArrivalRule("stalling", ScriptedMailRuleCondition.NeverAnswering(), stopWhenMatched: false)]);
         using var cancellation = new CancellationTokenSource();
         await cancellation.CancelAsync();
 
@@ -175,9 +175,9 @@ public sealed class MailRuleSetEvaluatorTests
         var elsewhere = ScriptedMailRuleCondition.Answering(matches: true);
         var ruleSet = CreateRuleSet(
         [
-            MailRule.Create("other-account", elsewhere, stopWhenMatched: false, accounts: ["primary"]),
-            MailRule.Create("this-account", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false, accounts: ["work"]),
-            MailRule.Create("every-account", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false),
+            ArrivalRule("other-account", elsewhere, stopWhenMatched: false, accounts: ["primary"]),
+            ArrivalRule("this-account", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false, accounts: ["work"]),
+            ArrivalRule("every-account", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false),
         ]);
 
         // Act
@@ -201,8 +201,8 @@ public sealed class MailRuleSetEvaluatorTests
         // Arrange
         var ruleSet = CreateRuleSet(
         [
-            MailRule.Create("stopping-elsewhere", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: true, accounts: ["primary"]),
-            MailRule.Create("below", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false),
+            ArrivalRule("stopping-elsewhere", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: true, accounts: ["primary"]),
+            ArrivalRule("below", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false),
         ]);
 
         // Act
@@ -223,7 +223,7 @@ public sealed class MailRuleSetEvaluatorTests
     {
         // Arrange
         var ruleSet = CreateRuleSet(
-            [MailRule.Create("mistyped", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false, accounts: ["Work"])]);
+            [ArrivalRule("mistyped", ScriptedMailRuleCondition.Answering(matches: true), stopWhenMatched: false, accounts: ["Work"])]);
 
         // Act
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
@@ -245,7 +245,7 @@ public sealed class MailRuleSetEvaluatorTests
         var ruleSet = CreateRuleSet(
         [
             MailRule.Create("housekeeping", manualOnly, stopWhenMatched: true, triggers: []),
-            MailRule.Create("on-arrival", ScriptedMailRuleCondition.Answering(matches: true)),
+            ArrivalRule("on-arrival", ScriptedMailRuleCondition.Answering(matches: true)),
         ]);
 
         // Act
@@ -269,7 +269,7 @@ public sealed class MailRuleSetEvaluatorTests
         var ruleSet = CreateRuleSet(
         [
             MailRule.Create("housekeeping", ScriptedMailRuleCondition.Answering(matches: true), triggers: []),
-            MailRule.Create("on-arrival", ScriptedMailRuleCondition.Answering(matches: true)),
+            ArrivalRule("on-arrival", ScriptedMailRuleCondition.Answering(matches: true)),
         ]);
 
         // Act
@@ -283,12 +283,13 @@ public sealed class MailRuleSetEvaluatorTests
         Assert.Equal(["housekeeping", "on-arrival"], evaluation.MatchedRuleNames);
     }
 
-    /// <summary>A rule that declares no trigger takes part in the one every rule written before the key existed did.</summary>
+    /// <summary>A rule takes part in the occasions it names, so one that names none is reached by no arrival.</summary>
     [Fact]
-    public async Task EvaluateAsync_RuleDeclaringNoTrigger_IsReachedOnArrival()
+    public async Task EvaluateAsync_RuleDeclaringNoTrigger_IsNotReachedOnArrival()
     {
         // Arrange
-        var ruleSet = CreateRuleSet([MailRule.Create("says-nothing", ScriptedMailRuleCondition.Answering(matches: true))]);
+        var ruleSet = CreateRuleSet(
+            [MailRule.Create("says-nothing", ScriptedMailRuleCondition.Answering(matches: true))]);
 
         // Act
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
@@ -298,7 +299,8 @@ public sealed class MailRuleSetEvaluatorTests
             TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal(["says-nothing"], evaluation.MatchedRuleNames);
+        Assert.Empty(evaluation.Evaluations);
+        Assert.Empty(evaluation.MatchedRuleNames);
     }
 
     /// <summary>A rule that could not answer did not match, so what it declared is not something the mailbox is asked for.</summary>
@@ -309,11 +311,11 @@ public sealed class MailRuleSetEvaluatorTests
         var filing = MailRuleActionSet.Create([MailRuleAction.Relocate(MailFolderReference.ToAlias(MailFolderAlias.Create("archive")))]);
         var ruleSet = CreateRuleSet(
         [
-            MailRule.Create(
+            ArrivalRule(
                 "raising",
                 ScriptedMailRuleCondition.Raising(new InvalidOperationException("unusable operand")),
                 MailRuleActionSet.Create([MailRuleAction.Delete()])),
-            MailRule.Create("below", ScriptedMailRuleCondition.Answering(matches: true), filing),
+            ArrivalRule("below", ScriptedMailRuleCondition.Answering(matches: true), filing),
         ]);
 
         // Act
@@ -349,6 +351,19 @@ public sealed class MailRuleSetEvaluatorTests
         Assert.False(evaluation.HasFailures);
         Assert.Equal(ruleSet.Revision, evaluation.Revision);
     }
+
+    /// <summary>A rule as an operator writes one for arriving mail, which is the walk most of these tests take.</summary>
+    /// <remarks>
+    /// A rule takes part in the occasions it names and in no others, so a rule meant to reach an arrival says so. The
+    /// tests about a rule nothing fires by itself declare their triggers where they stand, because that is their subject.
+    /// </remarks>
+    private static MailRule ArrivalRule(
+        string name,
+        IMailRuleCondition condition,
+        MailRuleActionSet? actions = null,
+        bool stopWhenMatched = false,
+        IReadOnlyList<string>? accounts = null) =>
+        MailRule.Create(name, condition, actions, stopWhenMatched, accounts, [MailRuleTrigger.Arrival]);
 
     private static MailRuleSet CreateRuleSet(IEnumerable<MailRule> rules)
     {

--- a/tests/Application.UnitTests/Rules/MailRuleSetEvaluatorTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleSetEvaluatorTests.cs
@@ -20,6 +20,8 @@ public sealed class MailRuleSetEvaluatorTests
 {
     private static readonly DateTimeOffset EvaluatedAt = new(2026, 3, 31, 9, 30, 0, TimeSpan.Zero);
 
+    private static readonly MailRuleReach OnArrival = MailRuleReach.TriggeredBy(MailRuleTrigger.Arrival);
+
     private readonly FakeTimeProvider timeProvider = new(EvaluatedAt);
 
     [Fact]
@@ -37,6 +39,7 @@ public sealed class MailRuleSetEvaluatorTests
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
             ruleSet,
             CreateFacts(),
+            OnArrival,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -66,6 +69,7 @@ public sealed class MailRuleSetEvaluatorTests
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
             ruleSet,
             CreateFacts(),
+            OnArrival,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -88,6 +92,7 @@ public sealed class MailRuleSetEvaluatorTests
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
             ruleSet,
             CreateFacts(),
+            OnArrival,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -113,6 +118,7 @@ public sealed class MailRuleSetEvaluatorTests
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
             ruleSet,
             CreateFacts(),
+            OnArrival,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -133,7 +139,7 @@ public sealed class MailRuleSetEvaluatorTests
         var evaluator = this.CreateEvaluator();
 
         // Act
-        var pass = evaluator.EvaluateAsync(ruleSet, CreateFacts(), TestContext.Current.CancellationToken);
+        var pass = evaluator.EvaluateAsync(ruleSet, CreateFacts(), OnArrival, TestContext.Current.CancellationToken);
 
         await stalling.Started;
         this.timeProvider.Advance(MailRuleConditionBounds.Default.EvaluationTimeout);
@@ -158,7 +164,7 @@ public sealed class MailRuleSetEvaluatorTests
 
         // Act, Assert
         await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => this.CreateEvaluator().EvaluateAsync(ruleSet, CreateFacts(), cancellation.Token));
+            () => this.CreateEvaluator().EvaluateAsync(ruleSet, CreateFacts(), OnArrival, cancellation.Token));
     }
 
     /// <summary>A rule scoped elsewhere is not this account's rule, so it is passed over rather than recorded as unmatched.</summary>
@@ -178,6 +184,7 @@ public sealed class MailRuleSetEvaluatorTests
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
             ruleSet,
             CreateFacts(),
+            OnArrival,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -202,6 +209,7 @@ public sealed class MailRuleSetEvaluatorTests
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
             ruleSet,
             CreateFacts(),
+            OnArrival,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -221,10 +229,76 @@ public sealed class MailRuleSetEvaluatorTests
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
             ruleSet,
             CreateFacts(),
+            OnArrival,
             TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Empty(evaluation.Evaluations);
+    }
+
+    /// <summary>A rule the trigger does not reach is not this walk's rule, so it leaves no record of having declined.</summary>
+    [Fact]
+    public async Task EvaluateAsync_ManualOnlyRuleOnAnArrivalWalk_IsNotReachedAtAll()
+    {
+        // Arrange
+        var manualOnly = ScriptedMailRuleCondition.Answering(matches: true);
+        var ruleSet = CreateRuleSet(
+        [
+            MailRule.Create("housekeeping", manualOnly, stopWhenMatched: true, triggers: []),
+            MailRule.Create("on-arrival", ScriptedMailRuleCondition.Answering(matches: true)),
+        ]);
+
+        // Act
+        var evaluation = await this.CreateEvaluator().EvaluateAsync(
+            ruleSet,
+            CreateFacts(),
+            OnArrival,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(["on-arrival"], evaluation.Evaluations.Select(result => result.RuleName));
+        Assert.Equal(0, manualOnly.EvaluationCount);
+        Assert.False(evaluation.StoppedEarly);
+    }
+
+    /// <summary>Asking for a run is the request itself, so the walk it starts applies every rule the set declares.</summary>
+    [Fact]
+    public async Task EvaluateAsync_ManualOnlyRuleOnARequestedWalk_IsReachedLikeEveryOtherRule()
+    {
+        // Arrange
+        var ruleSet = CreateRuleSet(
+        [
+            MailRule.Create("housekeeping", ScriptedMailRuleCondition.Answering(matches: true), triggers: []),
+            MailRule.Create("on-arrival", ScriptedMailRuleCondition.Answering(matches: true)),
+        ]);
+
+        // Act
+        var evaluation = await this.CreateEvaluator().EvaluateAsync(
+            ruleSet,
+            CreateFacts(),
+            MailRuleReach.EveryRule,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(["housekeeping", "on-arrival"], evaluation.MatchedRuleNames);
+    }
+
+    /// <summary>A rule that declares no trigger takes part in the one every rule written before the key existed did.</summary>
+    [Fact]
+    public async Task EvaluateAsync_RuleDeclaringNoTrigger_IsReachedOnArrival()
+    {
+        // Arrange
+        var ruleSet = CreateRuleSet([MailRule.Create("says-nothing", ScriptedMailRuleCondition.Answering(matches: true))]);
+
+        // Act
+        var evaluation = await this.CreateEvaluator().EvaluateAsync(
+            ruleSet,
+            CreateFacts(),
+            OnArrival,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(["says-nothing"], evaluation.MatchedRuleNames);
     }
 
     /// <summary>A rule that could not answer did not match, so what it declared is not something the mailbox is asked for.</summary>
@@ -246,6 +320,7 @@ public sealed class MailRuleSetEvaluatorTests
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
             ruleSet,
             CreateFacts(),
+            OnArrival,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -265,6 +340,7 @@ public sealed class MailRuleSetEvaluatorTests
         var evaluation = await this.CreateEvaluator().EvaluateAsync(
             ruleSet,
             CreateFacts(),
+            OnArrival,
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -281,7 +357,7 @@ public sealed class MailRuleSetEvaluatorTests
         return MailRuleSet.Create(
             materialized,
             MailRuleSetRevision.Create(
-                [.. materialized.Select(rule => new MailRuleDeclaration(rule.Name, "isSeen", [.. rule.Actions.Actions], rule.StopWhenMatched, [.. rule.Accounts]))]),
+                [.. materialized.Select(rule => new MailRuleDeclaration(rule.Name, "isSeen", [.. rule.Actions.Actions], rule.StopWhenMatched, [.. rule.Accounts], [.. rule.Triggers]))]),
             MailRuleConditionBounds.Default);
     }
 

--- a/tests/Application.UnitTests/Rules/MailRuleSetRevisionTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleSetRevisionTests.cs
@@ -24,10 +24,10 @@ public sealed class MailRuleSetRevisionTests
     };
 
     private static readonly MailRuleDeclaration FileInvoices =
-        new("file-invoices", "senderDomain == 'supplier.test'", Actions: [], StopWhenMatched: true, Accounts: []);
+        new("file-invoices", "senderDomain == 'supplier.test'", Actions: [], StopWhenMatched: true, Accounts: [], Triggers: [MailRuleTrigger.Arrival]);
 
     private static readonly MailRuleDeclaration ArchiveOld =
-        new("archive-old", "ageInDays > 365", Actions: [], StopWhenMatched: false, Accounts: []);
+        new("archive-old", "ageInDays > 365", Actions: [], StopWhenMatched: false, Accounts: [], Triggers: [MailRuleTrigger.Arrival]);
 
     [Fact]
     public void Create_SameRulesInSameOrder_ProducesTheSameIdentity()
@@ -66,10 +66,43 @@ public sealed class MailRuleSetRevisionTests
     {
         // Act
         var changed = MailRuleSetRevision.Create(
-            [new MailRuleDeclaration(name, conditionText, FileInvoices.Actions, stopWhenMatched, accounts)]);
+        [
+            new MailRuleDeclaration(
+                name,
+                conditionText,
+                FileInvoices.Actions,
+                stopWhenMatched,
+                accounts,
+                FileInvoices.Triggers),
+        ]);
 
         // Assert
         Assert.NotEqual(MailRuleSetRevision.Create([FileInvoices]), changed);
+    }
+
+    /// <summary>Which occasions run a rule is part of what the rule set means, so withdrawing one is a different set.</summary>
+    [Fact]
+    public void Create_ARuleWithdrawnFromEveryAutomaticTrigger_ProducesADifferentIdentity()
+    {
+        // Act
+        var manualOnly = MailRuleSetRevision.Create([FileInvoices with { Triggers = [] }]);
+
+        // Assert
+        Assert.NotEqual(MailRuleSetRevision.Create([FileInvoices]), manualOnly);
+    }
+
+    /// <summary>A rule that says nothing and one that writes the default mean the same, so they are one rule set.</summary>
+    [Fact]
+    public void Create_TheDefaultTriggerWrittenOut_ProducesTheSameIdentityAsDeclaringNone()
+    {
+        // Arrange
+        var declaringNone = FileInvoices with { Triggers = MailRuleTrigger.WhenNoneDeclared };
+
+        // Act
+        var writtenOut = MailRuleSetRevision.Create([FileInvoices with { Triggers = [MailRuleTrigger.Arrival] }]);
+
+        // Assert
+        Assert.Equal(MailRuleSetRevision.Create([declaringNone]), writtenOut);
     }
 
     /// <summary>A request's identity carries the revision, so an edited action has to ask afresh rather than be answered by the old record.</summary>
@@ -106,13 +139,13 @@ public sealed class MailRuleSetRevisionTests
         // Act
         var first = MailRuleSetRevision.Create(
         [
-            new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: []),
-            new MailRuleDeclaration("b", "isDraft", Actions: [], StopWhenMatched: false, Accounts: []),
+            new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: [], Triggers: [MailRuleTrigger.Arrival]),
+            new MailRuleDeclaration("b", "isDraft", Actions: [], StopWhenMatched: false, Accounts: [], Triggers: [MailRuleTrigger.Arrival]),
         ]);
         var second = MailRuleSetRevision.Create(
         [
-            new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: []),
-            new MailRuleDeclaration("bisDraft", "continue", Actions: [], StopWhenMatched: false, Accounts: []),
+            new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: [], Triggers: [MailRuleTrigger.Arrival]),
+            new MailRuleDeclaration("bisDraft", "continue", Actions: [], StopWhenMatched: false, Accounts: [], Triggers: [MailRuleTrigger.Arrival]),
         ]);
 
         // Assert
@@ -125,9 +158,9 @@ public sealed class MailRuleSetRevisionTests
     {
         // Act
         var twoAccounts = MailRuleSetRevision.Create(
-            [new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: ["primary", "work"])]);
+            [new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: ["primary", "work"], Triggers: [MailRuleTrigger.Arrival])]);
         var oneAccount = MailRuleSetRevision.Create(
-            [new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: ["primarywork"])]);
+            [new MailRuleDeclaration("a", "isSeen", Actions: [], StopWhenMatched: false, Accounts: ["primarywork"], Triggers: [MailRuleTrigger.Arrival])]);
 
         // Assert
         Assert.NotEqual(twoAccounts, oneAccount);

--- a/tests/Application.UnitTests/Rules/MailRuleSetRevisionTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleSetRevisionTests.cs
@@ -91,20 +91,6 @@ public sealed class MailRuleSetRevisionTests
         Assert.NotEqual(MailRuleSetRevision.Create([FileInvoices]), manualOnly);
     }
 
-    /// <summary>A rule that says nothing and one that writes the default mean the same, so they are one rule set.</summary>
-    [Fact]
-    public void Create_TheDefaultTriggerWrittenOut_ProducesTheSameIdentityAsDeclaringNone()
-    {
-        // Arrange
-        var declaringNone = FileInvoices with { Triggers = MailRuleTrigger.WhenNoneDeclared };
-
-        // Act
-        var writtenOut = MailRuleSetRevision.Create([FileInvoices with { Triggers = [MailRuleTrigger.Arrival] }]);
-
-        // Assert
-        Assert.Equal(MailRuleSetRevision.Create([declaringNone]), writtenOut);
-    }
-
     /// <summary>A request's identity carries the revision, so an edited action has to ask afresh rather than be answered by the old record.</summary>
     [Theory]
     [MemberData(nameof(ActionEdits))]

--- a/tests/Application.UnitTests/Rules/MailRuleSetTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleSetTests.cs
@@ -13,7 +13,7 @@ namespace MailFathom.Application.UnitTests.Rules;
 public sealed class MailRuleSetTests
 {
     private static readonly MailRuleSetRevision Revision =
-        MailRuleSetRevision.Create([new MailRuleDeclaration("rule", "isSeen", Actions: [], StopWhenMatched: false, Accounts: [])]);
+        MailRuleSetRevision.Create([new MailRuleDeclaration("rule", "isSeen", Actions: [], StopWhenMatched: false, Accounts: [], Triggers: [MailRuleTrigger.Arrival])]);
 
     [Fact]
     public void Create_Rules_KeepsThemInTheOrderTheyWereDeclared()

--- a/tests/Application.UnitTests/Rules/MailRuleTriggerTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleTriggerTests.cs
@@ -71,7 +71,7 @@ public sealed class MailRuleTriggerTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]
-    [InlineData("Arival")]
+    [InlineData("Schedule")]
     [InlineData("OnDemand")]
     public void TryParseName_AnUndeclaredName_ProducesTheUnspecifiedDefault(string? name)
     {
@@ -121,7 +121,7 @@ public sealed class MailRuleTriggerTests
     }
 
     [Theory]
-    [InlineData("\"Arival\"")]
+    [InlineData("\"Schedule\"")]
     [InlineData("7")]
     public void JsonConverter_AValueThatNamesNoTrigger_IsRefused(string json)
     {

--- a/tests/Application.UnitTests/Rules/MailRuleTriggerTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleTriggerTests.cs
@@ -1,0 +1,140 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Reflection;
+using System.Text.Json;
+using MailFathom.Application.Rules;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Rules;
+
+/// <summary>Covers the trigger vocabulary an operator writes and a rule set's identity is derived from.</summary>
+public sealed class MailRuleTriggerTests
+{
+    /// <summary>Two triggers sharing a name would be indistinguishable in a configuration file and in a digest.</summary>
+    [Fact]
+    public void All_NamesAreUnique()
+    {
+        // Act
+        var distinctNames = MailRuleTrigger.All
+            .Select(trigger => trigger.Name)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Count();
+
+        // Assert
+        Assert.Equal(MailRuleTrigger.All.Count, distinctNames);
+    }
+
+    /// <summary>A declared trigger left out of the registry could be written nowhere: parsing resolves through it alone.</summary>
+    [Fact]
+    public void All_ListsEveryDeclaredTrigger()
+    {
+        // Arrange
+        var declaredTriggers = typeof(MailRuleTrigger)
+            .GetProperties(BindingFlags.Public | BindingFlags.Static)
+            .Where(property => property.PropertyType == typeof(MailRuleTrigger))
+            .Select(property => (MailRuleTrigger)property.GetValue(null)!);
+
+        // Act
+        var unregistered = declaredTriggers.Where(trigger => !MailRuleTrigger.All.Contains(trigger)).ToArray();
+
+        // Assert
+        Assert.Empty(unregistered);
+    }
+
+    /// <summary>The default of a rule that says nothing is what every rule written before the key existed already did.</summary>
+    [Fact]
+    public void WhenNoneDeclared_IsArrivalAlone()
+    {
+        // Act, Assert
+        Assert.Equal([MailRuleTrigger.Arrival], MailRuleTrigger.WhenNoneDeclared);
+    }
+
+    [Theory]
+    [InlineData("Arrival")]
+    [InlineData("arrival")]
+    [InlineData("  Arrival  ")]
+    public void TryParseName_ADeclaredName_ProducesTheTrigger(string name)
+    {
+        // Act
+        var parsed = MailRuleTrigger.TryParseName(name, out var trigger);
+
+        // Assert
+        Assert.True(parsed);
+        Assert.Equal(MailRuleTrigger.Arrival, trigger);
+        Assert.Equal("Arrival", trigger.Name);
+    }
+
+    /// <summary>A name this set does not hold is unknown rather than new, so nothing reconstructs a trigger from it.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Arival")]
+    [InlineData("OnDemand")]
+    public void TryParseName_AnUndeclaredName_ProducesTheUnspecifiedDefault(string? name)
+    {
+        // Act
+        var parsed = MailRuleTrigger.TryParseName(name, out var trigger);
+
+        // Assert
+        Assert.False(parsed);
+        Assert.False(trigger.IsSpecified);
+    }
+
+    [Fact]
+    public void Name_UnspecifiedDefault_IsRefusedRatherThanAnswered()
+    {
+        // Arrange
+        var trigger = default(MailRuleTrigger);
+
+        // Act, Assert
+        Assert.False(trigger.IsSpecified);
+        Assert.Throws<InvalidOperationException>(() => trigger.Name);
+        Assert.Equal("(unspecified)", trigger.ToString());
+    }
+
+    [Fact]
+    public void JsonConverter_ADeclaredTrigger_RoundTripsAsItsName()
+    {
+        // Act
+        var written = JsonSerializer.Serialize(MailRuleTrigger.Arrival);
+
+        // Assert
+        Assert.Equal("\"Arrival\"", written);
+        Assert.Equal(MailRuleTrigger.Arrival, JsonSerializer.Deserialize<MailRuleTrigger>(written));
+    }
+
+    [Fact]
+    public void JsonConverter_ADeclaredTrigger_RoundTripsAsAPropertyName()
+    {
+        // Arrange
+        var counts = new Dictionary<MailRuleTrigger, int> { [MailRuleTrigger.Arrival] = 3 };
+
+        // Act
+        var written = JsonSerializer.Serialize(counts);
+
+        // Assert
+        Assert.Equal("{\"Arrival\":3}", written);
+        Assert.Equal(counts, JsonSerializer.Deserialize<Dictionary<MailRuleTrigger, int>>(written));
+    }
+
+    [Theory]
+    [InlineData("\"Arival\"")]
+    [InlineData("7")]
+    public void JsonConverter_AValueThatNamesNoTrigger_IsRefused(string json)
+    {
+        // Act, Assert
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MailRuleTrigger>(json));
+    }
+
+    [Fact]
+    public void JsonConverter_TheUnspecifiedDefault_IsRefusedRatherThanSerialized()
+    {
+        // Act, Assert
+        Assert.Throws<JsonException>(() => JsonSerializer.Serialize(default(MailRuleTrigger)));
+        Assert.Throws<JsonException>(
+            () => JsonSerializer.Serialize(new Dictionary<MailRuleTrigger, int> { [default] = 1 }));
+    }
+}

--- a/tests/Application.UnitTests/Rules/MailRuleTriggerTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleTriggerTests.cs
@@ -43,14 +43,6 @@ public sealed class MailRuleTriggerTests
         Assert.Empty(unregistered);
     }
 
-    /// <summary>The default of a rule that says nothing is what every rule written before the key existed already did.</summary>
-    [Fact]
-    public void WhenNoneDeclared_IsArrivalAlone()
-    {
-        // Act, Assert
-        Assert.Equal([MailRuleTrigger.Arrival], MailRuleTrigger.WhenNoneDeclared);
-    }
-
     [Theory]
     [InlineData("Arrival")]
     [InlineData("arrival")]

--- a/tests/Cli.UnitTests/RuleCommandTests.cs
+++ b/tests/Cli.UnitTests/RuleCommandTests.cs
@@ -38,14 +38,16 @@ public sealed class RuleCommandTests : IDisposable
               "accounts": ["work"],
               "readableFacts": ["senderDomain", "subject"],
               "actions": [{"position":0,"mutation":"relocate","destination":"archive","desiredSeenState":null}],
-              "stopWhenMatched": true
+              "stopWhenMatched": true,
+              "triggers": ["Arrival"]
             },
             {
               "name": "mark-newsletters",
               "accounts": [],
               "readableFacts": ["senderDomain"],
               "actions": [{"position":0,"mutation":"setSeen","destination":null,"desiredSeenState":true}],
-              "stopWhenMatched": false
+              "stopWhenMatched": false,
+              "triggers": []
             }
           ]
         }
@@ -78,6 +80,26 @@ public sealed class RuleCommandTests : IDisposable
                 || line.StartsWith("mark-", StringComparison.Ordinal)));
         Assert.Contains(this.console.Lines, line => line.Contains("relocate → archive", StringComparison.Ordinal));
         Assert.Contains(this.console.Lines, line => line.Contains("ends the pass", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A rule nothing fires by itself reads exactly like a rule that never matched, so the listing says what does run
+    /// it rather than reporting an empty list beside the rules that name a trigger.
+    /// </summary>
+    [Fact]
+    public async Task List_ARuleOnlyARequestedRunApplies_SaysWhatRunsItRatherThanNothing()
+    {
+        // Arrange
+        using var deployment = FakeRuleDeployment.Answering(rules: LoadedRules);
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "rules", "list", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Equal(
+            ["  Runs on:    Arrival", "  Runs on:    nothing automatically; 'mfctl rules run' applies it"],
+            this.console.Lines.Where(line => line.Contains("Runs on:", StringComparison.Ordinal)));
     }
 
     /// <summary>
@@ -133,6 +155,7 @@ public sealed class RuleCommandTests : IDisposable
         // Assert
         Assert.Equal(CliExitCode.Success, exitCode);
         Assert.Contains(this.console.Lines, line => line.Contains("senderDomain, subject", StringComparison.Ordinal));
+        Assert.Contains(this.console.Lines, line => line.Contains("Runs on:     Arrival", StringComparison.Ordinal));
         Assert.Contains(this.console.Lines, line => line.Contains("MailRules", StringComparison.Ordinal));
     }
 

--- a/tests/Host.UnitTests/Api/MailRuleEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/MailRuleEndpointsTests.cs
@@ -116,6 +116,30 @@ public sealed class MailRuleEndpointsTests
             (action.Position, action.Mutation, action.Destination));
     }
 
+    /// <summary>
+    /// What runs a rule is part of what the rule is, and a rule nothing fires by itself is the one an operator asks
+    /// about, so the answer distinguishes it rather than leaving both looking like a rule that never matched.
+    /// </summary>
+    [Fact]
+    public async Task ReadRules_ARuleOnlyARequestedRunApplies_ReportsItAsTakingPartInNoTrigger()
+    {
+        // Arrange
+        var ruleSet = RuleSetOf(
+            MailRule.Create("file-invoices", ConditionReading(MailRuleFact.SenderDomain)),
+            MailRule.Create(
+                "retire-old-newsletters",
+                ConditionReading(MailRuleFact.Subject),
+                triggers: []));
+        await using var settings = CreateSettings();
+
+        // Act
+        var result = MailRuleEndpoints.ReadRules(SourceOf(ruleSet), settings);
+
+        // Assert
+        Assert.Equal(["Arrival"], result.Value!.Rules[0].Triggers);
+        Assert.Empty(result.Value.Rules[1].Triggers);
+    }
+
     /// <summary>A deployment nobody has edited says its configuration is the one the running set was read from.</summary>
     [Fact]
     public async Task ReadRules_ConfigurationNothingHasRefused_ReportsTheSetAsCurrent()
@@ -479,7 +503,8 @@ public sealed class MailRuleEndpointsTests
                 "isSeen",
                 [.. rule.Actions.Actions],
                 rule.StopWhenMatched,
-                [.. rule.Accounts])),
+                [.. rule.Accounts],
+                [.. rule.Triggers])),
         ]),
         MailRuleConditionBounds.Default);
 

--- a/tests/Host.UnitTests/Api/MailRuleEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/MailRuleEndpointsTests.cs
@@ -125,7 +125,10 @@ public sealed class MailRuleEndpointsTests
     {
         // Arrange
         var ruleSet = RuleSetOf(
-            MailRule.Create("file-invoices", ConditionReading(MailRuleFact.SenderDomain)),
+            MailRule.Create(
+                "file-invoices",
+                ConditionReading(MailRuleFact.SenderDomain),
+                triggers: [MailRuleTrigger.Arrival]),
             MailRule.Create(
                 "retire-old-newsletters",
                 ConditionReading(MailRuleFact.Subject),

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleDeclarationRulesTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleDeclarationRulesTests.cs
@@ -735,7 +735,7 @@ public sealed class MailRuleDeclarationRulesTests
     public void FindDeclarationErrors_ATriggerNothingDeclares_IsRefusedNamingTheRuleAndTheValue()
     {
         // Arrange
-        var candidate = new MailRulesOptions { Rules = [CreateRule("housekeeping", "isSeen", triggers: ["Arival"])] };
+        var candidate = new MailRulesOptions { Rules = [CreateRule("housekeeping", "isSeen", triggers: ["Schedule"])] };
 
         // Act
         var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
@@ -743,7 +743,7 @@ public sealed class MailRuleDeclarationRulesTests
         // Assert
         var error = Assert.Single(errors);
         Assert.Contains("MailRules:Rules:0:Triggers", error, StringComparison.Ordinal);
-        Assert.Contains("Arival", error, StringComparison.Ordinal);
+        Assert.Contains("Schedule", error, StringComparison.Ordinal);
         Assert.Contains("'Arrival'", error, StringComparison.Ordinal);
     }
 

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleDeclarationRulesTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleDeclarationRulesTests.cs
@@ -817,7 +817,7 @@ public sealed class MailRuleDeclarationRulesTests
             Enabled = enabled,
             Accounts = accounts ?? [],
             Actions = actions ?? new MailRuleActionOptions(),
-            Triggers = triggers,
+            Triggers = triggers ?? [],
         };
 
     /// <summary>One declared account, mirroring an archive folder and permitting whatever the caller says it does.</summary>

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleDeclarationRulesTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleDeclarationRulesTests.cs
@@ -695,12 +695,121 @@ public sealed class MailRuleDeclarationRulesTests
             error => error.Contains("MailRules:Rules:0:Actions", StringComparison.Ordinal));
     }
 
+    /// <summary>The name is read the way the binder reads every other closed vocabulary this configuration declares.</summary>
+    [Fact]
+    public void FindDeclarationErrors_TheTriggerNamedInEitherSpelling_ReportsNothing()
+    {
+        // Arrange
+        var candidate = new MailRulesOptions
+        {
+            Rules =
+            [
+                CreateRule("as-documented", "isSeen", triggers: ["Arrival"]),
+                CreateRule("in-another-case", "isDraft", triggers: ["arrival"]),
+            ],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>An empty list is a usable declaration rather than a rule that forgot to say something.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ARuleDeclaringNoTriggerAtAll_ReportsNothing()
+    {
+        // Arrange
+        var candidate = new MailRulesOptions { Rules = [CreateRule("housekeeping", "isSeen", triggers: [])] };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    /// <summary>A mistyped name dropped in silence would turn an automatic rule into one only a requested run applies.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ATriggerNothingDeclares_IsRefusedNamingTheRuleAndTheValue()
+    {
+        // Arrange
+        var candidate = new MailRulesOptions { Rules = [CreateRule("housekeeping", "isSeen", triggers: ["Arival"])] };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.Contains("MailRules:Rules:0:Triggers", error, StringComparison.Ordinal);
+        Assert.Contains("Arival", error, StringComparison.Ordinal);
+        Assert.Contains("'Arrival'", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>The value is a set, so naming one trigger twice says nothing the rule does not already say.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ATriggerNamedTwice_IsRefused()
+    {
+        // Arrange
+        var candidate = new MailRulesOptions
+        {
+            Rules = [CreateRule("housekeeping", "isSeen", triggers: ["Arrival", "arrival"])],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.Contains("MailRules:Rules:0:Triggers", error, StringComparison.Ordinal);
+        Assert.Contains("more than once", error, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FindDeclarationErrors_ATriggerNamedByNothing_IsRefused(string trigger)
+    {
+        // Arrange
+        var candidate = new MailRulesOptions
+        {
+            Rules = [CreateRule("housekeeping", "isSeen", triggers: ["Arrival", trigger])],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        var error = Assert.Single(errors);
+        Assert.Contains("MailRules:Rules:0:Triggers", error, StringComparison.Ordinal);
+        Assert.Contains("named by nothing", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>A rule switched off is judged like any other, exactly as its scope and its actions already are.</summary>
+    [Fact]
+    public void FindDeclarationErrors_ADisabledRuleDeclaringAnUnknownTrigger_IsStillRefused()
+    {
+        // Arrange
+        var candidate = new MailRulesOptions
+        {
+            Rules = [CreateRule("switched-off", "isSeen", enabled: false, triggers: ["Whenever"])],
+        };
+
+        // Act
+        var errors = MailRuleDeclarationRules.FindDeclarationErrors(candidate, this.compiler, DeclaredAccounts);
+
+        // Assert
+        Assert.Contains(errors, error => error.Contains("MailRules:Rules:0:Triggers", StringComparison.Ordinal));
+    }
+
     private static MailRuleOptions CreateRule(
         string name,
         string conditionText,
         bool enabled = true,
         string[]? accounts = null,
-        MailRuleActionOptions? actions = null) =>
+        MailRuleActionOptions? actions = null,
+        string[]? triggers = null) =>
         new()
         {
             Name = name,
@@ -708,6 +817,7 @@ public sealed class MailRuleDeclarationRulesTests
             Enabled = enabled,
             Accounts = accounts ?? [],
             Actions = actions ?? new MailRuleActionOptions(),
+            Triggers = triggers,
         };
 
     /// <summary>One declared account, mirroring an archive folder and permitting whatever the caller says it does.</summary>

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleOptionsBindingTests.cs
@@ -10,36 +10,35 @@ using Xunit;
 
 namespace MailFathom.Host.UnitTests.Configuration.Rules;
 
-/// <summary>Covers what the binder makes of a rule's <c>Triggers</c> key, which is what its two readings rest on.</summary>
+/// <summary>Covers what the binder makes of a rule's <c>Triggers</c> key, which is what decides when the rule runs.</summary>
 /// <remarks>
-/// A written <c>[]</c> reaches the binder as a key holding an empty value and no children, and a list property left
-/// alone by that is indistinguishable from one nobody wrote. The key is therefore an array, which the binder rebuilds
-/// from the section, and this is where that claim is checked rather than assumed — the whole meaning of a manual-only
-/// rule depends on it, and nothing else in the suite would notice the day it stopped holding.
+/// A rule takes part in the occasions it names and in no others, so an absent key and a written <c>[]</c> have to
+/// arrive as the same thing — a rule only a whole-mailbox run applies. The names are bound as text so that one this
+/// system cannot read reaches validation instead of being dropped into a shorter list, and this is where both claims
+/// are checked rather than assumed: nothing else in the suite would notice the day either stopped holding.
 /// </remarks>
 public sealed class MailRuleOptionsBindingTests
 {
     [Fact]
-    public void Bind_ARuleWithNoTriggersKey_LeavesTheTriggersUndeclared()
+    public void Bind_ARuleWithNoTriggersKey_LeavesItRunByNoAutomaticOccasion()
     {
         // Act
         var bound = BindRules("""{ "MailRules": { "Rules": [ { "Name": "says-nothing", "Condition": "isSeen" } ] } }""");
 
         // Assert
-        Assert.Null(bound.Rules[0].Triggers);
-        Assert.Equal(MailRuleTrigger.WhenNoneDeclared, bound.Rules[0].ToTriggers());
+        Assert.Empty(bound.Rules[0].Triggers);
+        Assert.Empty(bound.Rules[0].ToTriggers());
     }
 
     [Fact]
-    public void Bind_ARuleDeclaringAnEmptyTriggerList_KeepsItApartFromDeclaringNone()
+    public void Bind_ARuleDeclaringAnEmptyTriggerList_SaysWhatAnAbsentKeySays()
     {
         // Act
         var bound = BindRules(
             """{ "MailRules": { "Rules": [ { "Name": "housekeeping", "Condition": "isSeen", "Triggers": [] } ] } }""");
 
         // Assert
-        Assert.NotNull(bound.Rules[0].Triggers);
-        Assert.Empty(bound.Rules[0].Triggers!);
+        Assert.Empty(bound.Rules[0].Triggers);
         Assert.Empty(bound.Rules[0].ToTriggers());
     }
 
@@ -57,7 +56,8 @@ public sealed class MailRuleOptionsBindingTests
             """);
 
         // Assert
-        Assert.Equal(["Arrival", "Schedule"], bound.Rules[0].Triggers ?? []);
+        Assert.Equal(["Arrival", "Schedule"], bound.Rules[0].Triggers);
+        Assert.Equal([MailRuleTrigger.Arrival], bound.Rules[0].ToTriggers());
     }
 
     /// <summary>The section binds strictly, so a key nothing declares fails rather than being read past.</summary>

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleOptionsBindingTests.cs
@@ -1,0 +1,74 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text;
+using MailFathom.Application.Rules;
+using MailFathom.Host.Configuration.Rules;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Rules;
+
+/// <summary>Covers what the binder makes of a rule's <c>Triggers</c> key, which is what its two readings rest on.</summary>
+/// <remarks>
+/// A written <c>[]</c> reaches the binder as a key holding an empty value and no children, and a list property left
+/// alone by that is indistinguishable from one nobody wrote. The key is therefore an array, which the binder rebuilds
+/// from the section, and this is where that claim is checked rather than assumed — the whole meaning of a manual-only
+/// rule depends on it, and nothing else in the suite would notice the day it stopped holding.
+/// </remarks>
+public sealed class MailRuleOptionsBindingTests
+{
+    [Fact]
+    public void Bind_ARuleWithNoTriggersKey_LeavesTheTriggersUndeclared()
+    {
+        // Act
+        var bound = BindRules("""{ "MailRules": { "Rules": [ { "Name": "says-nothing", "Condition": "isSeen" } ] } }""");
+
+        // Assert
+        Assert.Null(bound.Rules[0].Triggers);
+        Assert.Equal(MailRuleTrigger.WhenNoneDeclared, bound.Rules[0].ToTriggers());
+    }
+
+    [Fact]
+    public void Bind_ARuleDeclaringAnEmptyTriggerList_KeepsItApartFromDeclaringNone()
+    {
+        // Act
+        var bound = BindRules(
+            """{ "MailRules": { "Rules": [ { "Name": "housekeeping", "Condition": "isSeen", "Triggers": [] } ] } }""");
+
+        // Assert
+        Assert.NotNull(bound.Rules[0].Triggers);
+        Assert.Empty(bound.Rules[0].Triggers!);
+        Assert.Empty(bound.Rules[0].ToTriggers());
+    }
+
+    [Fact]
+    public void Bind_ARuleDeclaringTriggers_ReadsEveryNameAsItWasWritten()
+    {
+        // Act
+        var bound = BindRules(
+            """
+            {
+              "MailRules": {
+                "Rules": [ { "Name": "on-arrival", "Condition": "isSeen", "Triggers": [ "Arrival", "Arival" ] } ]
+              }
+            }
+            """);
+
+        // Assert
+        Assert.Equal(["Arrival", "Arival"], bound.Rules[0].Triggers ?? []);
+    }
+
+    /// <summary>The section binds strictly, so a key nothing declares fails rather than being read past.</summary>
+    private static MailRulesOptions BindRules(string document)
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(document));
+
+        var configuration = new ConfigurationBuilder().AddJsonStream(stream).Build();
+
+        return configuration
+            .GetSection(MailRulesOptions.SectionName)
+            .Get<MailRulesOptions>(binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)!;
+    }
+}

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleOptionsBindingTests.cs
@@ -51,13 +51,13 @@ public sealed class MailRuleOptionsBindingTests
             """
             {
               "MailRules": {
-                "Rules": [ { "Name": "on-arrival", "Condition": "isSeen", "Triggers": [ "Arrival", "Arival" ] } ]
+                "Rules": [ { "Name": "on-arrival", "Condition": "isSeen", "Triggers": [ "Arrival", "Schedule" ] } ]
               }
             }
             """);
 
         // Assert
-        Assert.Equal(["Arrival", "Arival"], bound.Rules[0].Triggers ?? []);
+        Assert.Equal(["Arrival", "Schedule"], bound.Rules[0].Triggers ?? []);
     }
 
     /// <summary>The section binds strictly, so a key nothing declares fails rather than being read past.</summary>

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleSetMappingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleSetMappingTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Rules;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
 using MailFathom.Host.Configuration.Rules;
@@ -284,13 +285,86 @@ public sealed class MailRuleSetMappingTests
         Assert.NotEqual(beforeEdit.Revision, afterEdit.Revision);
     }
 
+    /// <summary>An absent key leaves a rule set meaning what it meant, which is what makes the key an addition.</summary>
+    [Fact]
+    public void Map_RuleDeclaringNoTrigger_TakesPartInArrivalAlone()
+    {
+        // Arrange
+        var settings = new MailRulesOptions { Rules = [CreateRule("says-nothing", "isSeen")] };
+
+        // Act
+        var ruleSet = MailRuleSetMapper.Map(settings, this.compiler);
+
+        // Assert
+        Assert.Equal([MailRuleTrigger.Arrival], ruleSet.Rules[0].Triggers);
+        Assert.True(ruleSet.Rules[0].RunsOn(MailRuleTrigger.Arrival));
+    }
+
+    /// <summary>An empty list is a rule in the set that nothing fires, which is a different thing from a rule switched off.</summary>
+    [Fact]
+    public void Map_RuleDeclaringAnEmptyTriggerList_StaysInTheSetAndTakesPartInNoTrigger()
+    {
+        // Arrange
+        var settings = new MailRulesOptions { Rules = [CreateRule("housekeeping", "ageInDays > 90", triggers: [])] };
+
+        // Act
+        var ruleSet = MailRuleSetMapper.Map(settings, this.compiler);
+
+        // Assert
+        Assert.Equal(["housekeeping"], ruleSet.Rules.Select(rule => rule.Name));
+        Assert.Empty(ruleSet.Rules[0].Triggers);
+        Assert.False(ruleSet.Rules[0].RunsOn(MailRuleTrigger.Arrival));
+    }
+
+    /// <summary>Withdrawing a rule from every trigger changes what the rule set does, so it changes what it is called.</summary>
+    [Fact]
+    public void Map_WithdrawingARuleFromEveryTrigger_MovesTheRevision()
+    {
+        // Arrange
+        var onArrival = new MailRulesOptions { Rules = [CreateRule("housekeeping", "isSeen")] };
+        var manualOnly = new MailRulesOptions { Rules = [CreateRule("housekeeping", "isSeen", triggers: [])] };
+
+        // Act
+        var mapped = MailRuleSetMapper.Map(manualOnly, this.compiler);
+
+        // Assert
+        Assert.NotEqual(MailRuleSetMapper.Map(onArrival, this.compiler).Revision, mapped.Revision);
+    }
+
+    /// <summary>Writing the default out says what leaving the key out says, so the two are one rule set.</summary>
+    [Fact]
+    public void Map_TheDefaultTriggerWrittenOut_ProducesTheSameRevisionAsDeclaringNone()
+    {
+        // Arrange
+        var writtenOut = new MailRulesOptions { Rules = [CreateRule("says-it", "isSeen", triggers: ["arrival"])] };
+        var declaringNone = new MailRulesOptions { Rules = [CreateRule("says-it", "isSeen")] };
+
+        // Act
+        var mapped = MailRuleSetMapper.Map(writtenOut, this.compiler);
+
+        // Assert
+        Assert.Equal(MailRuleSetMapper.Map(declaringNone, this.compiler).Revision, mapped.Revision);
+    }
+
+    /// <summary>A dropped name would turn an automatic rule into a manual one, which is the one outcome a typo must not have.</summary>
+    [Fact]
+    public void Map_RuleDeclaringATriggerNothingRecognizes_IsRefusedRatherThanMappedAsManualOnly()
+    {
+        // Arrange
+        var settings = new MailRulesOptions { Rules = [CreateRule("mistyped", "isSeen", triggers: ["Arival"])] };
+
+        // Act, Assert
+        Assert.Throws<InvalidOperationException>(() => MailRuleSetMapper.Map(settings, this.compiler));
+    }
+
     private static MailRuleOptions CreateRule(
         string name,
         string conditionText,
         bool stopWhenMatched = false,
         bool enabled = true,
         string[]? accounts = null,
-        MailRuleActionOptions? actions = null) =>
+        MailRuleActionOptions? actions = null,
+        string[]? triggers = null) =>
         new()
         {
             Name = name,
@@ -299,5 +373,6 @@ public sealed class MailRuleSetMappingTests
             Enabled = enabled,
             Accounts = accounts ?? [],
             Actions = actions ?? new MailRuleActionOptions(),
+            Triggers = triggers,
         };
 }

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleSetMappingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleSetMappingTests.cs
@@ -285,9 +285,9 @@ public sealed class MailRuleSetMappingTests
         Assert.NotEqual(beforeEdit.Revision, afterEdit.Revision);
     }
 
-    /// <summary>An absent key leaves a rule set meaning what it meant, which is what makes the key an addition.</summary>
+    /// <summary>A rule takes part in the occasions it names, so an absent key is a rule no arrival reaches.</summary>
     [Fact]
-    public void Map_RuleDeclaringNoTrigger_TakesPartInArrivalAlone()
+    public void Map_RuleDeclaringNoTrigger_TakesPartInNoAutomaticOccasion()
     {
         // Arrange
         var settings = new MailRulesOptions { Rules = [CreateRule("says-nothing", "isSeen")] };
@@ -296,8 +296,8 @@ public sealed class MailRuleSetMappingTests
         var ruleSet = MailRuleSetMapper.Map(settings, this.compiler);
 
         // Assert
-        Assert.Equal([MailRuleTrigger.Arrival], ruleSet.Rules[0].Triggers);
-        Assert.True(ruleSet.Rules[0].RunsOn(MailRuleTrigger.Arrival));
+        Assert.Empty(ruleSet.Rules[0].Triggers);
+        Assert.False(ruleSet.Rules[0].RunsOn(MailRuleTrigger.Arrival));
     }
 
     /// <summary>An empty list is a rule in the set that nothing fires, which is a different thing from a rule switched off.</summary>
@@ -321,7 +321,7 @@ public sealed class MailRuleSetMappingTests
     public void Map_WithdrawingARuleFromEveryTrigger_MovesTheRevision()
     {
         // Arrange
-        var onArrival = new MailRulesOptions { Rules = [CreateRule("housekeeping", "isSeen")] };
+        var onArrival = new MailRulesOptions { Rules = [CreateRule("housekeeping", "isSeen", triggers: ["Arrival"])] };
         var manualOnly = new MailRulesOptions { Rules = [CreateRule("housekeeping", "isSeen", triggers: [])] };
 
         // Act
@@ -331,19 +331,19 @@ public sealed class MailRuleSetMappingTests
         Assert.NotEqual(MailRuleSetMapper.Map(onArrival, this.compiler).Revision, mapped.Revision);
     }
 
-    /// <summary>Writing the default out says what leaving the key out says, so the two are one rule set.</summary>
+    /// <summary>A trigger is read as the trigger it names rather than as the text of it, so its case says nothing.</summary>
     [Fact]
-    public void Map_TheDefaultTriggerWrittenOut_ProducesTheSameRevisionAsDeclaringNone()
+    public void Map_ATriggerWrittenInAnotherCase_ProducesTheSameRevision()
     {
         // Arrange
-        var writtenOut = new MailRulesOptions { Rules = [CreateRule("says-it", "isSeen", triggers: ["arrival"])] };
-        var declaringNone = new MailRulesOptions { Rules = [CreateRule("says-it", "isSeen")] };
+        var lowercase = new MailRulesOptions { Rules = [CreateRule("says-it", "isSeen", triggers: ["arrival"])] };
+        var declared = new MailRulesOptions { Rules = [CreateRule("says-it", "isSeen", triggers: ["Arrival"])] };
 
         // Act
-        var mapped = MailRuleSetMapper.Map(writtenOut, this.compiler);
+        var mapped = MailRuleSetMapper.Map(lowercase, this.compiler);
 
         // Assert
-        Assert.Equal(MailRuleSetMapper.Map(declaringNone, this.compiler).Revision, mapped.Revision);
+        Assert.Equal(MailRuleSetMapper.Map(declared, this.compiler).Revision, mapped.Revision);
     }
 
     /// <summary>A dropped name would turn an automatic rule into a manual one, which is the one outcome a typo must not have.</summary>
@@ -376,6 +376,6 @@ public sealed class MailRuleSetMappingTests
             Enabled = enabled,
             Accounts = accounts ?? [],
             Actions = actions ?? new MailRuleActionOptions(),
-            Triggers = triggers,
+            Triggers = triggers ?? [],
         };
 }

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleSetMappingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleSetMappingTests.cs
@@ -351,7 +351,10 @@ public sealed class MailRuleSetMappingTests
     public void Map_RuleDeclaringATriggerNothingRecognizes_IsRefusedRatherThanMappedAsManualOnly()
     {
         // Arrange
-        var settings = new MailRulesOptions { Rules = [CreateRule("mistyped", "isSeen", triggers: ["Arival"])] };
+        var settings = new MailRulesOptions
+        {
+            Rules = [CreateRule("names-a-trigger-that-does-not-exist", "isSeen", triggers: ["Schedule"])],
+        };
 
         // Act, Assert
         Assert.Throws<InvalidOperationException>(() => MailRuleSetMapper.Map(settings, this.compiler));


### PR DESCRIPTION
Closes #708

A rule now declares `Triggers`, the automatic occasions it takes part in. `Arrival` is the only member today, and a
rule takes part in the occasions it names and in no others: an absent key and an empty list both say that nothing
fires the rule by itself, which leaves it bound, validated, and applied by a whole-mailbox run rather than by arriving
mail.

## What it does

- **`MailRuleTrigger`** is a closed enumeration: the name is what an operator writes in configuration and what the rule
  set's revision is derived from, so it must survive a rename of the C# member.
- **`MailRuleReach`** tells a triggered walk from a requested one. A whole-mailbox run is deliberately not a trigger — an
  operator asking for a run is the request itself — so it reaches every rule of the set, manual-only rules included, and
  nothing selects a subset of rules for one run.
- **A rule a walk's reach does not hold is passed over and records no outcome**, exactly as a rule scoped to another
  account is, and it cannot end the pass whatever `StopWhenMatched` says.
- **The body-text question is asked per walk** rather than per pass, so a manual-only rule naming `bodyText` does not
  hold arriving mail behind extraction.
- **`Triggers` is part of the revision.** Withdrawing a rule from arrival moves it; the case a trigger's name was
  written in does not, because the digest reads the trigger rather than the text naming it.
- **The reporting surface says what runs a rule.** `MailRuleResponse` carries the triggers, and `mfctl rules list` and
  `mfctl rules show` print a `Runs on:` line. A rule nothing fires by itself says what does run it instead of reporting
  an empty list, because it is otherwise indistinguishable from a rule that never matched.

## The trap the shape exists for

**The elements are text, not the trigger.** The binder drops an element it cannot convert, so a mistyped name in a
bound list of triggers would arrive as a shorter list — and a list whose only entry was mistyped would arrive as the
empty one, silently turning an automatic rule into a manual one. Read as text, every name reaches validation, an
unknown or repeated one is refused naming the rule and the value, and the mapper refuses a set that reaches it with
one. `MailRuleOptionsBindingTests` is where that claim is checked rather than assumed.

## Contract notes

- **Breaking, configuration schema.** `MailRules:Rules:<n>:Triggers` has no default: a rule that should run over
  arriving mail declares `[ "Arrival" ]`. **Operator action:** add the key to every rule meant to fire on arrival. A
  rule left without it stays in the set and is applied by `mfctl rules run` alone; `mfctl rules list` shows which is
  which on its `Runs on:` line. Nothing has shipped that reads the key, so this affects a configuration written against
  this branch rather than against a release.
- **Every rule set's revision moves**, because the digest gains a field. A whole-mailbox run outstanding across the
  upgrade therefore ends as `superseded` and is asked for again — the documented behaviour for a rule set that moved
  while a run was in flight.
- `MailRule.Create` and `MailRuleDeclaration` gain a parameter, and `MailRuleSetEvaluator.EvaluateAsync` gains the
  reach. Both are internal cross-project contracts rather than published surfaces.

## Verification

- `scripts/verify-full.sh` — green on the rebased branch (5525 unit tests, 148 agent-workflow assertions, formatting
  made no change).
- `dotnet msbuild .config/CodeCoverage.proj -t:Collect` — 95.31% aggregate line coverage, above the 85% gate.
- `$check-docs-licenses` — Docs pass, Changelog n/a, Licenses n/a (no new dependency, tool, service, image, or copied
  code).

## The acceptance item #458 owed

#458 has merged, so this change satisfies it here rather than carrying it forward: `docs/users/administering.md` and
`docs/operations/admin-endpoint.md` both state that a whole-mailbox run is how a rule naming no trigger is run.

https://github.com/Krzysztof318/MailFathom/issues/708
