### PR TITLE
[#662] Guard every egress point with the sensitive-content scanner and fail closed when it cannot run

### DIFF
--- a/docs/features/chat-generation.md
+++ b/docs/features/chat-generation.md
@@ -265,6 +265,11 @@ classifies this group as reloadable for new operations and states the rules a re
   is a registration of its own rather than a second consumer of the embedding client's, because an answer's size follows
   the output budget while an embedding response's is fixed by the declared geometry, and one client would have to take
   the larger ceiling and would then bound neither.
+- **A sensitive-content guard, where one is switched on.** Every turn is scanned and redacted before the request is
+  sent, above the retry layer, so one call costs one scan whatever the pipeline does and a scanner that cannot answer
+  refuses the call as itself rather than arriving as a fault of the provider's. Both switches are off by default, and
+  nothing is scanned then. [Sensitive-content scanning § the guarded egress
+  points](sensitive-content-scanning.md#the-guarded-egress-points) holds the contract.
 
 ## An answer that was cut short is still an answer
 

--- a/docs/features/email-search.md
+++ b/docs/features/email-search.md
@@ -107,6 +107,13 @@ produced them, and `SearchEmailsResult` adds the retrieval mode the whole window
 - **Whether junk mail took part** says which of the two searches the caller got, so an absent result is never
   ambiguous between missing and withheld.
 
+The subject and the snippets are the two things a result carries that a message's author wrote, so where a
+sensitive-content scanner is switched on both are redacted before the window is served, each value scanned on its own
+rather than as one composed result. A scanner that cannot answer refuses the search. Both switches are off by default,
+and nothing on this path is scanned then. [Sensitive-content scanning § the guarded egress
+points](sensitive-content-scanning.md#the-guarded-egress-points) holds the contract; the ranking is unaffected, because
+it ran over the stored index before anything was redacted.
+
 The search vector carries no lexeme weights, so the lexical rank reflects how often and how densely a message's document
 mentions the query's words rather than where in the message they appear. A subject match and a body match count the
 same.

--- a/docs/features/email-search.md
+++ b/docs/features/email-search.md
@@ -107,9 +107,11 @@ produced them, and `SearchEmailsResult` adds the retrieval mode the whole window
 - **Whether junk mail took part** says which of the two searches the caller got, so an absent result is never
   ambiguous between missing and withheld.
 
-The subject and the snippets are the two things a result carries that a message's author wrote, so where a
-sensitive-content scanner is switched on both are redacted before the window is served, each value scanned on its own
-rather than as one composed result. A scanner that cannot answer refuses the search. Both switches are off by default,
+The subject, the snippets, and the sender's display name are what a result carries that a message's author wrote, so
+where a sensitive-content scanner is switched on all three are redacted before the window is served, each value scanned
+on its own rather than as one composed result. The display name is scanned rather than treated as part of the address it
+accompanies, because an address is a routing identity a server issued while the name in front of it is free text the
+sending side wrote. A scanner that cannot answer refuses the search. Both switches are off by default,
 and nothing on this path is scanned then. [Sensitive-content scanning § the guarded egress
 points](sensitive-content-scanning.md#the-guarded-egress-points) holds the contract; the ranking is unaffected, because
 it ran over the stored index before anything was redacted.

--- a/docs/features/embedding-generation.md
+++ b/docs/features/embedding-generation.md
@@ -351,6 +351,13 @@ rather than a row the database rejects later with no provider in sight.
   rather than add.
 - **A bounded response.** The transport refuses a body larger than the declared geometry could fill, and refuses
   redirects — a moved endpoint answering with one would carry the key or the bearer token to whatever host it named.
+- **A sensitive-content guard, where one is switched on.** Every passage is scanned and redacted before the request is
+  sent, once for the whole chain rather than once per endpoint it falls through, and a scanner that cannot answer
+  refuses the call. It applies to every declared endpoint, a model server inside the deployment included: nothing in a
+  declaration distinguishes a local address from a hosted one, and text leaving the process is text leaving the process.
+  The deterministic in-process generator sends nothing and is the one path with no guard on it. Both switches are off by
+  default, and nothing is scanned then. [Sensitive-content scanning § the guarded egress
+  points](sensitive-content-scanning.md#the-guarded-egress-points) holds the contract.
 
 ## What an instance is willing to spend
 

--- a/docs/features/embedding-generation.md
+++ b/docs/features/embedding-generation.md
@@ -353,8 +353,10 @@ rather than a row the database rejects later with no provider in sight.
   redirects — a moved endpoint answering with one would carry the key or the bearer token to whatever host it named.
 - **A sensitive-content guard, where one is switched on.** Every passage is scanned and redacted before the request is
   sent, once for the whole chain rather than once per endpoint it falls through, and a scanner that cannot answer
-  refuses the call. It applies to every declared endpoint, a model server inside the deployment included: nothing in a
-  declaration distinguishes a local address from a hosted one, and text leaving the process is text leaving the process.
+  refuses the call. The vector that comes back is therefore computed from the guarded passage while the chunk it was
+  cut from is stored as it was extracted, which is the one place the two are derived from different text. It applies to
+  every declared endpoint, a model server inside the deployment included: nothing in a declaration distinguishes a local
+  address from a hosted one, and text leaving the process is text leaving the process.
   The deterministic in-process generator sends nothing and is the one path with no guard on it. Both switches are off by
   default, and nothing is scanned then. [Sensitive-content scanning § the guarded egress
   points](sensitive-content-scanning.md#the-guarded-egress-points) holds the contract.

--- a/docs/features/mail-answering.md
+++ b/docs/features/mail-answering.md
@@ -417,6 +417,15 @@ An answer with no text at all is a failure rather than an empty answer, classifi
 generation is. [Chat generation § What a failing call is classified
 as](chat-generation.md#what-a-failing-call-is-classified-as) holds the table.
 
+Where a sensitive-content scanner is switched on, the answer and each citation's subject pass it before they are
+published, and the extracts pass it on their way to the model — two egress points rather than one, because text sent to
+a provider and text returned to a caller leave this deployment in different directions. The answer is guarded before
+what one response carries is cut, so it is bounded after every placeholder is in it, and a scanner that cannot answer
+refuses the question rather than serving a response nothing scanned.
+[Sensitive-content scanning § the guarded egress
+points](sensitive-content-scanning.md#the-guarded-egress-points) holds the contract, and it applies to nothing on a
+deployment with both switches off, which is the default.
+
 ## What a caller may ask, and what one response publishes
 
 The use case between a caller and the run owns three things the composition does not: what a question may be, whether

--- a/docs/features/mailbox-queries.md
+++ b/docs/features/mailbox-queries.md
@@ -197,10 +197,12 @@ it summarizes.
 `Cc` and `Reply-To` are stored and filterable but not listed. A listing exists to let a reader recognize a message; the
 full participant set belongs to reading it.
 
-The subject is the one thing a summary carries that a message's author wrote, so it is the one thing a switched-on
-sensitive-content scanner redacts before a listing is served; the identifiers, addresses, timestamps, and flags beside
-it are what a caller acts on, and are protected by who may reach this deployment rather than by redaction. A scanner
-that cannot answer refuses the listing. Both switches are off by default, and nothing on this path is scanned then.
+The subject and the sender's display name are what a summary carries that a message's author wrote, so they are what a
+switched-on sensitive-content scanner redacts before a listing is served. The display name goes with the subject rather
+than with the address it accompanies: an address is a routing identity a server issued, while the name in front of it is
+free text whoever sent the message chose. The identifiers, addresses, timestamps, and flags beside them are what a
+caller acts on, and are protected by who may reach this deployment rather than by redaction. A scanner that cannot
+answer refuses the listing. Both switches are off by default, and nothing on this path is scanned then.
 [Sensitive-content scanning § the guarded egress
 points](sensitive-content-scanning.md#the-guarded-egress-points) holds the contract.
 

--- a/docs/features/mailbox-queries.md
+++ b/docs/features/mailbox-queries.md
@@ -197,6 +197,13 @@ it summarizes.
 `Cc` and `Reply-To` are stored and filterable but not listed. A listing exists to let a reader recognize a message; the
 full participant set belongs to reading it.
 
+The subject is the one thing a summary carries that a message's author wrote, so it is the one thing a switched-on
+sensitive-content scanner redacts before a listing is served; the identifiers, addresses, timestamps, and flags beside
+it are what a caller acts on, and are protected by who may reach this deployment rather than by redaction. A scanner
+that cannot answer refuses the listing. Both switches are off by default, and nothing on this path is scanned then.
+[Sensitive-content scanning § the guarded egress
+points](sensitive-content-scanning.md#the-guarded-egress-points) holds the contract.
+
 ### The remote flag snapshot
 
 `RemoteEmailFlagSnapshot` reports the flags a server last showed, together with when they were read. The timestamp is

--- a/docs/features/sensitive-content-scanning.md
+++ b/docs/features/sensitive-content-scanning.md
@@ -40,11 +40,13 @@ entirely rather than accept the second.
 All four combinations are supported configurations. With both off nothing is scanned, nothing is constructed, and no
 cost lands on any path.
 
-> **Egress redacts through the contract; derived data does not yet.** The second row of the table above is covered at
-> the points the next section names, with one exception: the mail body an MCP client asks for by identity is served as
-> it was stored. The first row states the path the contract is written for rather than one that is covered — a chunk and
-> its vector are still built from unredacted text. The rest arrive with their own changes, and this note narrows as they
-> do.
+> **Egress redacts through the contract; the derived write does not yet.** The second row of the table above is covered
+> at the points the next section names, with one exception: the mail body an MCP client asks for by identity is served
+> as it was stored. The first row is narrower than it reads. A chunk is still stored as it was extracted, so nothing
+> writes a placeholder into the derived text yet — but a vector a hosted endpoint produced is computed from the guarded
+> passage, because the passage was redacted on its way out of the process. On a deployment with a scanner on and an
+> embedding endpoint declared, the chunk and the vector beside it are therefore derived from different text. The rest
+> arrives with its own change, and this note narrows as it does.
 
 ## The guarded egress points
 
@@ -56,19 +58,36 @@ list below answerable by reading it.
 | --- | --- |
 | `chat_prompt` | Everything a model is sent: the question a client asked, and the subjects and passages of the mail retrieved to answer it |
 | `hosted_embedding_input` | Every passage sent to a hosted embedding endpoint |
-| `mcp_snippet` | The mail text an MCP tool answers with: the subjects of a listing, the subjects and extracts of a search, and an answer with its citations |
+| `mcp_snippet` | The mail text an MCP tool answers with: the subjects and sender display names of a listing, the same plus the extracts of a search, and an answer with its citations |
 
 **A value is guarded, never a composed document.** A snippet, a subject, and a question are each scanned on their own
 and the result is composed afterwards. Scanning the composed thing instead would let one detection cover the end of one
 field and the beginning of the next, and replacing that region would take the boundary between them with it — an XML
 envelope handed to a model would stop being one.
 
+**The single-request chat port is the one exception, and it is one on purpose.** A conversation arrives there already
+built, and nothing at that boundary can tell which turn a mailbox reached, so every turn is scanned whole — including
+one MailFathom composed itself, such as the judgement a model-judged retrieval sends per candidate. The cost is the one
+the rule names: a detection covering the tail of an extract and the element closing it is replaced by a single
+placeholder, and the envelope in that turn stops closing. That is a degraded prompt rather than a leak, and it is the
+price of a port that guarantees nothing leaves it unscanned whatever its caller composed. Where MailFathom builds a
+document it also owns the values, it guards them first and composes afterwards, which is why the retrieval envelope an
+answering run sends is assembled from guarded extracts.
+
+**One text is scanned once, at the point it actually crosses.** An answering run looks mail up through the same ranked
+window `search_emails` publishes, and that window is guarded where it is published rather than where it is searched — so
+a lookup made on behalf of a model is scanned once, at `chat_prompt`, instead of twice under two different tags. The
+same reasoning bounds what is scanned at all: a citation the answer's own ceiling drops is never scanned, because it is
+never published.
+
 **The guard sits above the retry boundary**, so one call costs one scan whatever the provider does, and a scanner that
 cannot answer surfaces as its own refusal rather than being reclassified as a provider fault and retried. What it never
 sits above is the identifiers beside the text: an account, a folder alias, an address, a stored identity, and a cursor
 are what a caller acts on rather than text to read, and redacting the address a reply has to go to would remove a
 result's whole use while protecting nothing the message body did not already carry. Those are protected by who may
-reach this deployment.
+reach this deployment. The line falls between a routing identity and free text rather than between fields that look
+structured and fields that do not, which is why a sender's display name is guarded while the address it sits in front of
+is not.
 
 **Three paths carry no guard because they carry no mail.** A log line and an audit record hold identifiers, aliases,
 counts, and outcomes and never message text, which is the rule the [telemetry](../operations/telemetry.md) and audit

--- a/docs/features/sensitive-content-scanning.md
+++ b/docs/features/sensitive-content-scanning.md
@@ -40,9 +40,46 @@ entirely rather than accept the second.
 All four combinations are supported configurations. With both off nothing is scanned, nothing is constructed, and no
 cost lands on any path.
 
-> Both scanners have a detector behind them and both are described below. **No consumer redacts through the contract
-> yet**: none of the rows in the table above redacts today, so each states the path the contract is written for rather
-> than one that is covered. The consumers arrive with their own changes, and this note narrows as they do.
+> **Egress redacts through the contract; derived data does not yet.** The second row of the table above is covered at
+> the points the next section names, with one exception: the mail body an MCP client asks for by identity is served as
+> it was stored. The first row states the path the contract is written for rather than one that is covered — a chunk and
+> its vector are still built from unredacted text. The rest arrive with their own changes, and this note narrows as they
+> do.
+
+## The guarded egress points
+
+Every place text leaves this deployment goes through one guard, and the guard is told which place it is. There are
+three, and the register is closed: a fourth is a code change rather than a configuration one, which is what makes the
+list below answerable by reading it.
+
+| Egress point | What crosses it |
+| --- | --- |
+| `chat_prompt` | Everything a model is sent: the question a client asked, and the subjects and passages of the mail retrieved to answer it |
+| `hosted_embedding_input` | Every passage sent to a hosted embedding endpoint |
+| `mcp_snippet` | The mail text an MCP tool answers with: the subjects of a listing, the subjects and extracts of a search, and an answer with its citations |
+
+**A value is guarded, never a composed document.** A snippet, a subject, and a question are each scanned on their own
+and the result is composed afterwards. Scanning the composed thing instead would let one detection cover the end of one
+field and the beginning of the next, and replacing that region would take the boundary between them with it — an XML
+envelope handed to a model would stop being one.
+
+**The guard sits above the retry boundary**, so one call costs one scan whatever the provider does, and a scanner that
+cannot answer surfaces as its own refusal rather than being reclassified as a provider fault and retried. What it never
+sits above is the identifiers beside the text: an account, a folder alias, an address, a stored identity, and a cursor
+are what a caller acts on rather than text to read, and redacting the address a reply has to go to would remove a
+result's whole use while protecting nothing the message body did not already carry. Those are protected by who may
+reach this deployment.
+
+**Three paths carry no guard because they carry no mail.** A log line and an audit record hold identifiers, aliases,
+counts, and outcomes and never message text, which is the rule the [telemetry](../operations/telemetry.md) and audit
+contracts already hold rather than something redaction would enforce. MailFathom sends no webhook at all. The
+deterministic in-process embedding generator is exempt for a different reason: nothing leaves the process, so there is
+nothing for a guard to sit in front of.
+
+A refusal at any of the three fails the operation it guards, as [failing closed](#failing-closed) describes — the
+question is not answered, the passages are not embedded, the listing is not served. What each guarded call found,
+refused, and cost is published; [telemetry § what guarding an egress point
+publishes](../operations/telemetry.md#what-guarding-an-egress-point-publishes) names the instruments.
 
 ## A finding names a position, never a value
 

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -275,6 +275,34 @@ and the history of what it read is missing, which is exactly the gap an audit ca
 because writing an entry may never fail the answer it describes, so swallowing the failure is only defensible while it
 is counted.
 
+### What guarding an egress point publishes
+
+Sensitive-content scanning publishes five instruments, all of them tagged with
+`mailfathom.sensitive_content.egress_point` — `chat_prompt`, `hosted_embedding_input`, or `mcp_snippet`. The egress
+point is on every one of them because it is what an operator acts on: "something was redacted" says nothing, while a
+scanner finding credentials in retrieved extracts and nothing in subjects, or adding two seconds to a listing and
+nothing to an embedding call, is where a category list or a bound gets changed.
+
+| Instrument | What it answers |
+| --- | --- |
+| `mailfathom.sensitive_content.guarded` | How many texts were scanned before they crossed out of the deployment |
+| `mailfathom.sensitive_content.findings` | How many detections were replaced, split by `mailfathom.sensitive_content.category` |
+| `mailfathom.sensitive_content.omitted` | How many characters the analyzed ceiling dropped rather than hand on unscanned |
+| `mailfathom.sensitive_content.refusals` | How many operations a scanner that could not answer refused, by `mailfathom.sensitive_content.scanner` |
+| `mailfathom.sensitive_content.scan.duration` | What scanning added to one guarded operation |
+
+The findings are split by category rather than totalled because which kind of material a mailbox is producing is what
+decides whether a category list is right, and a total says only that the feature is switched on. The omitted count is
+recorded only when the ceiling actually cut something: a zero on every guarded text would make the series say the
+ceiling is in play on ordinary mail, which is the one question that instrument exists to answer. All five read zero on a
+deployment with both switches off, because nothing is constructed there.
+
+Nothing published here is mail or derived from it. The three tags are MailFathom's own closed sets, and the values are
+counts and durations — never a rule's match, a position, a message identity, or any part of what was found, each of
+which would put the credential in the telemetry written to prove it never left.
+[Sensitive-content scanning](../features/sensitive-content-scanning.md#the-guarded-egress-points) names the points
+themselves and what a refusal does to each.
+
 What such a signal may carry is bounded by the same rule that governs the log lines, and it is a cardinality rule as
 much as a privacy one. Counts, sizes, durations, outcomes, error codes, and MailFathom's own configured account and
 folder aliases are permitted. Mail content, an address, a subject, a remote folder path, a message identifier, a UID, a

--- a/src/AI/Orchestration/MailAnsweringAgent.cs
+++ b/src/AI/Orchestration/MailAnsweringAgent.cs
@@ -11,6 +11,7 @@ using MailFathom.Application.Chat;
 using MailFathom.Application.Resilience;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Domain.Answering.Audit;
 using Microsoft.Extensions.Logging;
 
@@ -28,6 +29,13 @@ namespace MailFathom.AI.Orchestration;
 /// same lifetime the single-request chat adapter uses and for the same reasons: a rotated key is picked up by the next
 /// question rather than at the next restart, and one caller's retrieved mail cannot outlive the call that retrieved it.
 /// </para>
+/// <para>
+/// A prompt this run sends is composed from three things and no others: the instruction, which is a constant of this
+/// build; the question, which is guarded here; and the extracts a lookup returns, which are guarded where the retrieval
+/// writes them. Guarding the composed conversation instead would rescan every earlier turn on every turn, and would
+/// leave the guarantee resting on which content kinds a framework release happens to publish rather than on where mail
+/// enters the run.
+/// </para>
 /// </remarks>
 internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
 {
@@ -40,6 +48,7 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
     private readonly IOutboundOperationRunner operationRunner;
     private readonly IAiProviderHealthRecorder healthRecorder;
     private readonly IMailAnsweringSpendLedger spendLedger;
+    private readonly SensitiveContentEgressGuard egressGuard;
     private readonly ILoggerFactory loggerFactory;
     private readonly ILogger<MailAnsweringAgent> logger;
 
@@ -53,6 +62,7 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
     /// <param name="operationRunner">Applies the provider resilience budget to every call the run makes.</param>
     /// <param name="healthRecorder">Records what each call established about the provider.</param>
     /// <param name="spendLedger">Counts what every call of this run added to the current period.</param>
+    /// <param name="egressGuard">Scans the question and every retrieved extract before either reaches the provider.</param>
     /// <param name="loggerFactory">Creates the loggers the framework's own components record through.</param>
     /// <param name="logger">Records the outcome without recording any question, answer, or passage.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
@@ -66,6 +76,7 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
         IOutboundOperationRunner operationRunner,
         IAiProviderHealthRecorder healthRecorder,
         IMailAnsweringSpendLedger spendLedger,
+        SensitiveContentEgressGuard egressGuard,
         ILoggerFactory loggerFactory,
         ILogger<MailAnsweringAgent> logger)
     {
@@ -78,6 +89,7 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
         ArgumentNullException.ThrowIfNull(operationRunner);
         ArgumentNullException.ThrowIfNull(healthRecorder);
         ArgumentNullException.ThrowIfNull(spendLedger);
+        ArgumentNullException.ThrowIfNull(egressGuard);
         ArgumentNullException.ThrowIfNull(loggerFactory);
         ArgumentNullException.ThrowIfNull(logger);
 
@@ -90,6 +102,7 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
         this.operationRunner = operationRunner;
         this.healthRecorder = healthRecorder;
         this.spendLedger = spendLedger;
+        this.egressGuard = egressGuard;
         this.loggerFactory = loggerFactory;
         this.logger = logger;
     }
@@ -118,7 +131,11 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
             this.plan.MaximumRequestCharacters);
 
         var runLedger = new MailAnsweringRunLedger(this.runBounds);
-        var retrieval = new ScopedMailKnowledgeRetrieval(this.knowledgeSearch, question.Scope, runLedger);
+        var retrieval = new ScopedMailKnowledgeRetrieval(
+            this.knowledgeSearch,
+            question.Scope,
+            runLedger,
+            this.egressGuard);
 
         try
         {
@@ -159,8 +176,16 @@ internal sealed class MailAnsweringAgent : IMailQuestionAnswerer
         // reaches the endpoint's circuit, its concurrency budget, or its health record.
         using var chatClient = new BudgetedChatClient(resilientClient, runLedger, this.spendLedger);
 
+        // The question is the one turn of the prompt a person wrote, so it is guarded like every other text that leaves
+        // this deployment: somebody asking what to do about the key a colleague sent them has put that key into the
+        // request. Guarded here rather than where the run is admitted, so a question refused by a ceiling costs no scan.
+        var questionText = await this.egressGuard.GuardAsync(
+            SensitiveContentEgressPoint.ChatPrompt,
+            question.Text.Value,
+            cancellationToken);
+
         var agent = MailAnsweringAgentComposition.Compose(chatClient, this.plan, retrieval, this.loggerFactory);
-        var response = await agent.RunAsync(question.Text.Value, session: null, options: null, cancellationToken);
+        var response = await agent.RunAsync(questionText, session: null, options: null, cancellationToken);
         var report = retrieval.Report;
 
         if (string.IsNullOrWhiteSpace(response.Text))

--- a/src/AI/ProviderAdapters/ProviderChatModelClient.cs
+++ b/src/AI/ProviderAdapters/ProviderChatModelClient.cs
@@ -7,6 +7,7 @@ using MailFathom.AI.Providers;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Chat;
 using MailFathom.Application.Resilience;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Domain.Failures;
 using Microsoft.Extensions.Logging;
 
@@ -21,8 +22,8 @@ namespace MailFathom.AI.ProviderAdapters;
 /// </para>
 /// <para>
 /// It composes nothing. The conversation arrives built, the model and its parameters arrive validated in the plan, and
-/// what this adds is the deadline, the resilience budget, the classification of a failure, and the refusal to let any
-/// prompt or answer reach a log.
+/// what this adds is the deadline, the resilience budget, the classification of a failure, the sensitive-content guard
+/// every turn passes through, and the refusal to let any prompt or answer reach a log.
 /// </para>
 /// <para>
 /// The client library's namespace is written out at every use rather than imported, because it publishes a
@@ -47,6 +48,7 @@ internal sealed class ProviderChatModelClient : IChatModelClient
     private readonly IHttpClientFactory transportFactory;
     private readonly IOutboundOperationRunner operationRunner;
     private readonly IAiProviderHealthRecorder healthRecorder;
+    private readonly SensitiveContentEgressGuard egressGuard;
     private readonly ILogger<ProviderChatModelClient> logger;
 
     /// <summary>Initializes a client over the declared endpoint, its credentials, its transport, and its resilience budget.</summary>
@@ -56,6 +58,7 @@ internal sealed class ProviderChatModelClient : IChatModelClient
     /// <param name="transportFactory">Opens the transport a request is sent over, one per attempt.</param>
     /// <param name="operationRunner">Applies the provider resilience budget.</param>
     /// <param name="healthRecorder">Records what each call established about the provider.</param>
+    /// <param name="egressGuard">Scans every turn before it is sent, where this deployment scans anything.</param>
     /// <param name="logger">Records the outcome without recording any prompt, answer, or credential.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
     public ProviderChatModelClient(
@@ -65,6 +68,7 @@ internal sealed class ProviderChatModelClient : IChatModelClient
         IHttpClientFactory transportFactory,
         IOutboundOperationRunner operationRunner,
         IAiProviderHealthRecorder healthRecorder,
+        SensitiveContentEgressGuard egressGuard,
         ILogger<ProviderChatModelClient> logger)
     {
         ArgumentNullException.ThrowIfNull(plan);
@@ -73,6 +77,7 @@ internal sealed class ProviderChatModelClient : IChatModelClient
         ArgumentNullException.ThrowIfNull(transportFactory);
         ArgumentNullException.ThrowIfNull(operationRunner);
         ArgumentNullException.ThrowIfNull(healthRecorder);
+        ArgumentNullException.ThrowIfNull(egressGuard);
         ArgumentNullException.ThrowIfNull(logger);
 
         this.plan = plan;
@@ -81,6 +86,7 @@ internal sealed class ProviderChatModelClient : IChatModelClient
         this.transportFactory = transportFactory;
         this.operationRunner = operationRunner;
         this.healthRecorder = healthRecorder;
+        this.egressGuard = egressGuard;
         this.logger = logger;
     }
 
@@ -94,9 +100,11 @@ internal sealed class ProviderChatModelClient : IChatModelClient
             this.plan.MaximumMessagesPerRequest,
             this.plan.MaximumRequestCharacters);
 
+        var guarded = await this.GuardedAsync(conversation, cancellationToken);
+
         try
         {
-            var answer = await this.RequestAnswerAsync(conversation, cancellationToken);
+            var answer = await this.RequestAnswerAsync(guarded, cancellationToken);
 
             this.healthRecorder.RecordServed(AiProviderRole.Chat);
 
@@ -110,6 +118,51 @@ internal sealed class ProviderChatModelClient : IChatModelClient
 
             throw;
         }
+    }
+
+    /// <summary>Scans every turn of a conversation before any of it is sent to a third party.</summary>
+    /// <remarks>
+    /// <para>
+    /// Applied here rather than inside the send, so one scan covers one call however many attempts the resilience
+    /// pipeline makes of it, and so a scanner that cannot answer refuses the call as itself instead of arriving at the
+    /// pipeline as a fault of the provider's.
+    /// </para>
+    /// <para>
+    /// Every turn is scanned rather than only the ones a caller composed from mail, because a conversation reaching
+    /// this port is already built and nothing here can tell which turn a mailbox reached. That includes the one a
+    /// person typed: a question is text somebody wrote into a client, and it leaves this deployment as completely as an
+    /// extract does.
+    /// </para>
+    /// <para>
+    /// The bounds above run first and are checked against what the caller composed. Redaction can only make a turn
+    /// longer — a placeholder is wider than most of what it replaces — so a conversation admitted at the boundary may
+    /// be sent slightly wider than the boundary allows; cutting it afterwards would drop text a scan had just made
+    /// safe, which is the wrong thing to lose.
+    /// </para>
+    /// </remarks>
+    private async Task<IReadOnlyList<ChatMessage>> GuardedAsync(
+        IReadOnlyList<ChatMessage> conversation,
+        CancellationToken cancellationToken)
+    {
+        if (!this.egressGuard.IsActive)
+        {
+            return conversation;
+        }
+
+        var guarded = new List<ChatMessage>(conversation.Count);
+
+        foreach (var turn in conversation)
+        {
+            guarded.Add(turn with
+            {
+                Text = await this.egressGuard.GuardAsync(
+                    SensitiveContentEgressPoint.ChatPrompt,
+                    turn.Text,
+                    cancellationToken),
+            });
+        }
+
+        return guarded;
     }
 
     private async Task<ChatAnswer> RequestAnswerAsync(

--- a/src/AI/ProviderAdapters/ProviderTextEmbeddingGenerator.cs
+++ b/src/AI/ProviderAdapters/ProviderTextEmbeddingGenerator.cs
@@ -7,6 +7,7 @@ using MailFathom.AI.Providers;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Resilience;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Domain.Failures;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
@@ -26,6 +27,13 @@ namespace MailFathom.AI.ProviderAdapters;
 /// them, and no read path has to know which endpoint produced which. See
 /// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0006-embedding-profile-identity-lifecycle-and-activation-cost.md">ADR 0006</see>.
 /// </para>
+/// <para>
+/// Every passage is scanned before it is sent, where this deployment scans anything, and a scanner that cannot answer
+/// refuses the call rather than letting it go unscanned. The guard applies to every declared endpoint: an address
+/// inside the deployment is still a configured endpoint reached over HTTP, nothing in the declaration distinguishes a
+/// local provider from a hosted one, and text leaving the process is text leaving the process. The one embedding
+/// generator that is exempt is the deterministic one, which computes a vector in this process and sends nothing.
+/// </para>
 /// </remarks>
 internal sealed class ProviderTextEmbeddingGenerator : ITextEmbeddingGenerator
 {
@@ -44,6 +52,7 @@ internal sealed class ProviderTextEmbeddingGenerator : ITextEmbeddingGenerator
     private readonly IHttpClientFactory transportFactory;
     private readonly IOutboundOperationRunner operationRunner;
     private readonly IAiProviderHealthRecorder healthRecorder;
+    private readonly SensitiveContentEgressGuard egressGuard;
     private readonly ILogger<ProviderTextEmbeddingGenerator> logger;
 
     /// <summary>Initializes a generator over the declared chain, its credentials, its transport, and its resilience budget.</summary>
@@ -53,6 +62,7 @@ internal sealed class ProviderTextEmbeddingGenerator : ITextEmbeddingGenerator
     /// <param name="transportFactory">Opens the transport a request is sent over, one per attempt.</param>
     /// <param name="operationRunner">Applies the provider resilience budget.</param>
     /// <param name="healthRecorder">Records what each call established about the embedding provider.</param>
+    /// <param name="egressGuard">Scans every passage before it is sent, where this deployment scans anything.</param>
     /// <param name="logger">Records the outcome without recording any passage, vector, or credential.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
     public ProviderTextEmbeddingGenerator(
@@ -62,6 +72,7 @@ internal sealed class ProviderTextEmbeddingGenerator : ITextEmbeddingGenerator
         IHttpClientFactory transportFactory,
         IOutboundOperationRunner operationRunner,
         IAiProviderHealthRecorder healthRecorder,
+        SensitiveContentEgressGuard egressGuard,
         ILogger<ProviderTextEmbeddingGenerator> logger)
     {
         ArgumentNullException.ThrowIfNull(plan);
@@ -70,6 +81,7 @@ internal sealed class ProviderTextEmbeddingGenerator : ITextEmbeddingGenerator
         ArgumentNullException.ThrowIfNull(transportFactory);
         ArgumentNullException.ThrowIfNull(operationRunner);
         ArgumentNullException.ThrowIfNull(healthRecorder);
+        ArgumentNullException.ThrowIfNull(egressGuard);
         ArgumentNullException.ThrowIfNull(logger);
 
         this.plan = plan;
@@ -78,6 +90,7 @@ internal sealed class ProviderTextEmbeddingGenerator : ITextEmbeddingGenerator
         this.transportFactory = transportFactory;
         this.operationRunner = operationRunner;
         this.healthRecorder = healthRecorder;
+        this.egressGuard = egressGuard;
         this.logger = logger;
     }
 
@@ -94,9 +107,18 @@ internal sealed class ProviderTextEmbeddingGenerator : ITextEmbeddingGenerator
     {
         EmbeddingRequestBounds.Require(passages, this.plan.MaximumPassagesPerCall);
 
+        // Scanned before the chain rather than before each endpoint, so one call costs one scan however many endpoints
+        // it falls through and however many attempts the resilience pipeline makes at each. A scanner that cannot
+        // answer refuses the call here, where the refusal is still itself rather than a fault attributed to a provider
+        // that was never reached.
+        var guarded = await this.egressGuard.GuardAllAsync(
+            SensitiveContentEgressPoint.HostedEmbeddingInput,
+            passages,
+            cancellationToken);
+
         try
         {
-            var vectors = await this.GenerateAcrossChainAsync(passages, cancellationToken);
+            var vectors = await this.GenerateAcrossChainAsync(guarded, cancellationToken);
 
             // Recorded once the chain has produced vectors, not once an endpoint has: an endpoint that fell through to
             // a working fallback is a chain that served, and reporting the fall-through as ill health would describe

--- a/src/AI/Retrieval/ScopedMailKnowledgeRetrieval.cs
+++ b/src/AI/Retrieval/ScopedMailKnowledgeRetrieval.cs
@@ -7,6 +7,7 @@ using MailFathom.AI.Orchestration;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Domain.Answering.Audit;
 using Microsoft.Extensions.AI;
 
@@ -85,6 +86,7 @@ internal sealed class ScopedMailKnowledgeRetrieval
     private readonly IEmailKnowledgeSearch knowledgeSearch;
     private readonly MailboxScope scope;
     private readonly MailAnsweringRunLedger runLedger;
+    private readonly SensitiveContentEgressGuard egressGuard;
     private readonly Lock gate = new();
     private readonly List<EmailKnowledgePassage> retrieved = [];
     private int candidateCount;
@@ -95,19 +97,23 @@ internal sealed class ScopedMailKnowledgeRetrieval
     /// <param name="knowledgeSearch">Finds the mail relevant to a query.</param>
     /// <param name="scope">The accounts and folders every retrieval of this run is answered from.</param>
     /// <param name="runLedger">Decides how much of what a lookup found this run may still send.</param>
+    /// <param name="egressGuard">Scans every extract before it is written into the envelope a model reads.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
     internal ScopedMailKnowledgeRetrieval(
         IEmailKnowledgeSearch knowledgeSearch,
         MailboxScope scope,
-        MailAnsweringRunLedger runLedger)
+        MailAnsweringRunLedger runLedger,
+        SensitiveContentEgressGuard egressGuard)
     {
         ArgumentNullException.ThrowIfNull(knowledgeSearch);
         ArgumentNullException.ThrowIfNull(scope);
         ArgumentNullException.ThrowIfNull(runLedger);
+        ArgumentNullException.ThrowIfNull(egressGuard);
 
         this.knowledgeSearch = knowledgeSearch;
         this.scope = scope;
         this.runLedger = runLedger;
+        this.egressGuard = egressGuard;
     }
 
     /// <summary>Gets what this run's retrieval has reached so far, across every lookup it has made.</summary>
@@ -224,7 +230,58 @@ internal sealed class ScopedMailKnowledgeRetrieval
             this.relevanceFilterFellBack |= found.RelevanceFilterFellBack;
         }
 
-        return RetrievedMailContextFormatter.Format(admitted, found.RetrievalMode, this.WasTruncated);
+        return RetrievedMailContextFormatter.Format(
+            await this.GuardedAsync(admitted, cancellationToken),
+            found.RetrievalMode,
+            this.WasTruncated);
+    }
+
+    /// <summary>Scans every extract this lookup is about to hand to a model.</summary>
+    /// <remarks>
+    /// <para>
+    /// This is where mail reaches a chat provider. The instruction the run carries is a constant of the build and the
+    /// question is guarded where the run begins, so the extracts are the remaining half of what a prompt is composed
+    /// from — and a tool this agent gains later is a new egress point that takes a guard of its own rather than
+    /// inheriting this one.
+    /// </para>
+    /// <para>
+    /// The extract and the subject are guarded, and the envelope is written afterwards from the guarded values. Guarding
+    /// the written envelope instead would let one detection cover the end of an extract and the element that closes it,
+    /// and replacing that region would take the document's structure with it.
+    /// </para>
+    /// <para>
+    /// What the run reports having retrieved is left as it was found. The report is read in this process — by the record
+    /// of what the run read, and by the citations the answer publishes, which are guarded where they are published — so
+    /// redacting it here would guard nothing and would make one message read two ways inside one run.
+    /// </para>
+    /// </remarks>
+    private async Task<IReadOnlyList<EmailKnowledgePassage>> GuardedAsync(
+        IReadOnlyList<EmailKnowledgePassage> passages,
+        CancellationToken cancellationToken)
+    {
+        if (!this.egressGuard.IsActive)
+        {
+            return passages;
+        }
+
+        var guarded = new List<EmailKnowledgePassage>(passages.Count);
+
+        foreach (var passage in passages)
+        {
+            guarded.Add(passage with
+            {
+                Subject = await this.egressGuard.GuardOptionalAsync(
+                    SensitiveContentEgressPoint.ChatPrompt,
+                    passage.Subject,
+                    cancellationToken),
+                Text = await this.egressGuard.GuardAsync(
+                    SensitiveContentEgressPoint.ChatPrompt,
+                    passage.Text,
+                    cancellationToken),
+            });
+        }
+
+        return guarded;
     }
 
     /// <summary>Names the ways this run read less of the mailbox than an undegraded run of the same question would.</summary>

--- a/src/Application/Emails/ListEmails/MailboxTimelineReader.cs
+++ b/src/Application/Emails/ListEmails/MailboxTimelineReader.cs
@@ -5,6 +5,8 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Emails;
 
@@ -22,30 +24,40 @@ namespace MailFathom.Application.Emails.ListEmails;
 /// It reaches no mail server. A listing answers from what synchronization has already stored, which is what keeps an
 /// MCP read independent of IMAP availability, and it reports how current that copy is instead of pretending it is live.
 /// </para>
+/// <para>
+/// A page is one of the points mail content leaves this deployment, so where a sensitive-content scanner is switched on
+/// the subject of every summary is scanned before the page is returned, and a scanner that cannot answer refuses the
+/// listing rather than serving it unscanned.
+/// </para>
 /// </remarks>
 public sealed class MailboxTimelineReader
 {
     private readonly IStoredEmailTimelineReader timelineReader;
     private readonly ISynchronizationFreshnessReader freshnessReader;
     private readonly MailboxScopeResolver scopeResolver;
+    private readonly SensitiveContentEgressGuard egressGuard;
 
     /// <summary>Initializes the use case.</summary>
     /// <param name="timelineReader">Reads bounded pages of stored email summaries.</param>
     /// <param name="freshnessReader">Reads how current the local copy of each folder is.</param>
     /// <param name="scopeResolver">Decides which accounts and folders the listing runs against.</param>
+    /// <param name="egressGuard">Scans what the page is about to publish, where this deployment scans anything.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public MailboxTimelineReader(
         IStoredEmailTimelineReader timelineReader,
         ISynchronizationFreshnessReader freshnessReader,
-        MailboxScopeResolver scopeResolver)
+        MailboxScopeResolver scopeResolver,
+        SensitiveContentEgressGuard egressGuard)
     {
         ArgumentNullException.ThrowIfNull(timelineReader);
         ArgumentNullException.ThrowIfNull(freshnessReader);
         ArgumentNullException.ThrowIfNull(scopeResolver);
+        ArgumentNullException.ThrowIfNull(egressGuard);
 
         this.timelineReader = timelineReader;
         this.freshnessReader = freshnessReader;
         this.scopeResolver = scopeResolver;
+        this.egressGuard = egressGuard;
     }
 
     /// <summary>Lists one page of emails.</summary>
@@ -58,6 +70,7 @@ public sealed class MailboxTimelineReader
     /// <exception cref="MailboxQueryPageSizeOutOfRangeException">Thrown when the request names a page size outside the accepted range.</exception>
     /// <exception cref="MailboxQueryCursorMalformedException">Thrown when the request carries a cursor this system did not issue.</exception>
     /// <exception cref="MailboxQueryCursorFilterMismatchException">Thrown when the cursor was issued for different filters than the request carries.</exception>
+    /// <exception cref="SensitiveContentScannerUnavailableException">Thrown when a switched-on scanner could not establish what the page carries, which refuses the listing rather than serving it unscanned.</exception>
     /// <remarks>
     /// Nothing here writes, and the operation is therefore safe to repeat. It also never sets the remote <c>\Seen</c>
     /// flag or any other remote state, because it speaks to no mail server at all.
@@ -94,7 +107,46 @@ public sealed class MailboxTimelineReader
         // operation at a time, so starting them together would fault instead of overlapping.
         var folderFreshness = await this.freshnessReader.ReadAsync(filter.Selection.Scope, cancellationToken);
 
-        return new ListEmailsResult(page, nextCursor, folderFreshness, filter.Selection.Scope.IncludesJunkMail);
+        // Guarded after the cursor is issued rather than before it. The cursor names a position in the timeline, which
+        // is the received instant and the stored identity, and redaction touches neither — issuing it from the guarded
+        // page would be the same value arrived at through more work.
+        return new ListEmailsResult(
+            await this.GuardedAsync(page, cancellationToken),
+            nextCursor,
+            folderFreshness,
+            filter.Selection.Scope.IncludesJunkMail);
+    }
+
+    /// <summary>Scans the one thing a summary carries that a message's author wrote.</summary>
+    /// <remarks>
+    /// A listing publishes no body, so the subject is the whole of its mail content and the whole of what is scanned.
+    /// Everything else on a summary is what a caller acts on — the identity a later request names, the folder alias,
+    /// the participants a reply goes to, the sizes and the flags — and those are protected by who may reach this
+    /// deployment rather than by redaction, which would leave a listing nobody could act on.
+    /// </remarks>
+    private async Task<IReadOnlyList<EmailSummary>> GuardedAsync(
+        IReadOnlyList<EmailSummary> page,
+        CancellationToken cancellationToken)
+    {
+        if (!this.egressGuard.IsActive)
+        {
+            return page;
+        }
+
+        var guarded = new List<EmailSummary>(page.Count);
+
+        foreach (var summary in page)
+        {
+            guarded.Add(summary with
+            {
+                Subject = await this.egressGuard.GuardOptionalAsync(
+                    SensitiveContentEgressPoint.McpSnippet,
+                    summary.Subject,
+                    cancellationToken),
+            });
+        }
+
+        return guarded;
     }
 
     /// <summary>Validates the request's filters and restricts the query to the accounts this deployment serves.</summary>

--- a/src/Application/Emails/ListEmails/MailboxTimelineReader.cs
+++ b/src/Application/Emails/ListEmails/MailboxTimelineReader.cs
@@ -117,12 +117,20 @@ public sealed class MailboxTimelineReader
             filter.Selection.Scope.IncludesJunkMail);
     }
 
-    /// <summary>Scans the one thing a summary carries that a message's author wrote.</summary>
+    /// <summary>Scans the two things a summary carries that a message's author wrote.</summary>
     /// <remarks>
-    /// A listing publishes no body, so the subject is the whole of its mail content and the whole of what is scanned.
+    /// <para>
+    /// A listing publishes no body, so the subject and the sender's display name are the whole of its mail content and
+    /// the whole of what is scanned. The display name is beside the subject rather than beside the address it
+    /// accompanies: an address is a routing identity a server issued, while the name in front of it is free text the
+    /// sending side wrote, and a header reading <c>"&lt;a credential&gt; &lt;someone@example.test&gt;"</c> would
+    /// otherwise be served whole while the subject beside it was redacted.
+    /// </para>
+    /// <para>
     /// Everything else on a summary is what a caller acts on — the identity a later request names, the folder alias,
-    /// the participants a reply goes to, the sizes and the flags — and those are protected by who may reach this
+    /// the addresses a reply goes to, the sizes and the flags — and those are protected by who may reach this
     /// deployment rather than by redaction, which would leave a listing nobody could act on.
+    /// </para>
     /// </remarks>
     private async Task<IReadOnlyList<EmailSummary>> GuardedAsync(
         IReadOnlyList<EmailSummary> page,
@@ -142,6 +150,10 @@ public sealed class MailboxTimelineReader
                 Subject = await this.egressGuard.GuardOptionalAsync(
                     SensitiveContentEgressPoint.McpSnippet,
                     summary.Subject,
+                    cancellationToken),
+                SenderDisplayName = await this.egressGuard.GuardOptionalAsync(
+                    SensitiveContentEgressPoint.McpSnippet,
+                    summary.SenderDisplayName,
                     cancellationToken),
             });
         }

--- a/src/Application/Emails/SearchEmails/MailboxSearchReader.cs
+++ b/src/Application/Emails/SearchEmails/MailboxSearchReader.cs
@@ -103,7 +103,7 @@ public sealed class MailboxSearchReader
         this.egressGuard = egressGuard;
     }
 
-    /// <summary>Searches for one window of ranked emails.</summary>
+    /// <summary>Searches for one window of ranked emails and publishes it to a caller outside this process.</summary>
     /// <param name="request">What the caller asked for.</param>
     /// <param name="cancellationToken">Propagates caller cancellation.</param>
     /// <returns>The ranked window, how it was ranked, and the scope's synchronization freshness.</returns>
@@ -113,12 +113,43 @@ public sealed class MailboxSearchReader
     /// <exception cref="EmailSearchResultLimitOutOfRangeException">Thrown when the request names a result count outside the accepted range.</exception>
     /// <exception cref="SensitiveContentScannerUnavailableException">Thrown when a switched-on scanner could not establish what the window carries, which refuses the search rather than serving it unscanned.</exception>
     /// <remarks>
+    /// The guard belongs to publishing rather than to searching, which is why it is here and not in
+    /// <see cref="SearchWindowAsync" />: this window becomes an MCP tool's answer, while the one that method returns is
+    /// read inside the process by something that guards it at its own egress point.
+    /// </remarks>
+    public async Task<SearchEmailsResult> SearchEmailsAsync(
+        SearchEmailsRequest request,
+        CancellationToken cancellationToken)
+    {
+        var window = await this.SearchWindowAsync(request, cancellationToken);
+
+        return window with { Matches = await this.GuardedAsync(window.Matches, cancellationToken) };
+    }
+
+    /// <summary>Searches for one window of ranked emails, for a reader inside this process.</summary>
+    /// <param name="request">What the caller asked for.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>The ranked window, how it was ranked, and the scope's synchronization freshness.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="request" /> is <see langword="null" />.</exception>
+    /// <exception cref="MailboxQueryFilterInvalidException">Thrown when the query text is blank or unusable, or a structured filter carries a value, a count, or a length the query does not accept.</exception>
+    /// <exception cref="MailAccountNotAccessibleException">Thrown when the request names an account this deployment does not serve.</exception>
+    /// <exception cref="EmailSearchResultLimitOutOfRangeException">Thrown when the request names a result count outside the accepted range.</exception>
+    /// <remarks>
+    /// <para>
+    /// The window comes back as it was found, with no sensitive-content guard on it, because nothing has left this
+    /// deployment yet. Its one caller is the retrieval an answering run makes, which sends the extracts to a model and
+    /// guards them there under the egress point they actually cross. Guarding here as well would scan every extract
+    /// twice — a remote round trip apiece under the personal-data scanner — and would count text against an MCP series
+    /// no MCP caller ever sees.
+    /// </para>
+    /// <para>
     /// Nothing here writes, and the operation is therefore safe to repeat. It also never sets the remote <c>\Seen</c>
     /// flag or any other remote state, because it speaks to no mail server at all. A query that matches nothing returns
     /// an empty window rather than a failure, so a search cannot be used to establish that a folder or an account holds
     /// mail the caller was not already entitled to see.
+    /// </para>
     /// </remarks>
-    public async Task<SearchEmailsResult> SearchEmailsAsync(
+    internal async Task<SearchEmailsResult> SearchWindowAsync(
         SearchEmailsRequest request,
         CancellationToken cancellationToken)
     {
@@ -160,7 +191,7 @@ public sealed class MailboxSearchReader
         var folderFreshness = await this.freshnessReader.ReadAsync(selection.Scope, cancellationToken);
 
         return new SearchEmailsResult(
-            await this.GuardedAsync(matches, cancellationToken),
+            matches,
             retrievalMode,
             semanticSearchCapability,
             folderFreshness,
@@ -170,8 +201,10 @@ public sealed class MailboxSearchReader
     /// <summary>Scans the mail content of a window before the window becomes somebody else's.</summary>
     /// <remarks>
     /// <para>
-    /// A snippet and a subject are the two things a result carries that a message's author wrote, so they are what is
-    /// scanned. The identifiers beside them — the account, the folder alias, the addresses, the stored identity — are
+    /// A snippet, a subject, and the sender's display name are what a result carries that a message's author wrote, so
+    /// they are what is scanned. The display name is scanned rather than treated as part of the address it accompanies:
+    /// an address is a routing identity a server issued, while the name in front of it is free text the sending side
+    /// wrote. The identifiers beside them — the account, the folder alias, the addresses, the stored identity — are
     /// what a caller acts on rather than text to read, and redacting the address a reply has to go to would remove the
     /// result's whole use while protecting nothing the message body did not already carry.
     /// </para>
@@ -198,6 +231,10 @@ public sealed class MailboxSearchReader
                 SensitiveContentEgressPoint.McpSnippet,
                 match.Summary.Subject,
                 cancellationToken);
+            var senderDisplayName = await this.egressGuard.GuardOptionalAsync(
+                SensitiveContentEgressPoint.McpSnippet,
+                match.Summary.SenderDisplayName,
+                cancellationToken);
             var snippets = await this.egressGuard.GuardAllAsync(
                 SensitiveContentEgressPoint.McpSnippet,
                 match.Snippets,
@@ -205,7 +242,7 @@ public sealed class MailboxSearchReader
 
             guarded.Add(match with
             {
-                Summary = match.Summary with { Subject = subject },
+                Summary = match.Summary with { Subject = subject, SenderDisplayName = senderDisplayName },
                 Snippets = snippets,
             });
         }

--- a/src/Application/Emails/SearchEmails/MailboxSearchReader.cs
+++ b/src/Application/Emails/SearchEmails/MailboxSearchReader.cs
@@ -5,6 +5,8 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 
 namespace MailFathom.Application.Emails.SearchEmails;
@@ -37,6 +39,12 @@ namespace MailFathom.Application.Emails.SearchEmails;
 /// here. That is a deliberate limit of text extraction rather than something this use case works
 /// around, and the feature documentation states it so the behavior is not surprising.
 /// </para>
+/// <para>
+/// A window is one of the points mail content leaves this deployment, so where a sensitive-content scanner is switched
+/// on the content of a result is scanned before the result is returned, and a scanner that cannot answer refuses the
+/// search rather than serving it unscanned. The guard is here rather than at the protocol boundary for the reason the
+/// authorization above it is: a second entrypoint over this use case inherits it instead of repeating it.
+/// </para>
 /// </remarks>
 public sealed class MailboxSearchReader
 {
@@ -62,6 +70,7 @@ public sealed class MailboxSearchReader
     private readonly ISynchronizationFreshnessReader freshnessReader;
     private readonly MailboxScopeResolver scopeResolver;
     private readonly EmailSearchSnippetBounds snippetBounds;
+    private readonly SensitiveContentEgressGuard egressGuard;
 
     /// <summary>Initializes the use case.</summary>
     /// <param name="searchIndexReader">Ranks mail against the query text and reads the window a ranking selected.</param>
@@ -69,25 +78,29 @@ public sealed class MailboxSearchReader
     /// <param name="freshnessReader">Reads how current the local copy of each folder is.</param>
     /// <param name="scopeResolver">Decides which accounts and folders the search runs against.</param>
     /// <param name="snippetBounds">How much of a message's body one result may show.</param>
+    /// <param name="egressGuard">Scans what the window is about to publish, where this deployment scans anything.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public MailboxSearchReader(
         IEmailSearchIndexReader searchIndexReader,
         SemanticEmailSearch semanticSearch,
         ISynchronizationFreshnessReader freshnessReader,
         MailboxScopeResolver scopeResolver,
-        EmailSearchSnippetBounds snippetBounds)
+        EmailSearchSnippetBounds snippetBounds,
+        SensitiveContentEgressGuard egressGuard)
     {
         ArgumentNullException.ThrowIfNull(searchIndexReader);
         ArgumentNullException.ThrowIfNull(semanticSearch);
         ArgumentNullException.ThrowIfNull(freshnessReader);
         ArgumentNullException.ThrowIfNull(scopeResolver);
         ArgumentNullException.ThrowIfNull(snippetBounds);
+        ArgumentNullException.ThrowIfNull(egressGuard);
 
         this.searchIndexReader = searchIndexReader;
         this.semanticSearch = semanticSearch;
         this.freshnessReader = freshnessReader;
         this.scopeResolver = scopeResolver;
         this.snippetBounds = snippetBounds;
+        this.egressGuard = egressGuard;
     }
 
     /// <summary>Searches for one window of ranked emails.</summary>
@@ -98,6 +111,7 @@ public sealed class MailboxSearchReader
     /// <exception cref="MailboxQueryFilterInvalidException">Thrown when the query text is blank or unusable, or a structured filter carries a value, a count, or a length the query does not accept.</exception>
     /// <exception cref="MailAccountNotAccessibleException">Thrown when the request names an account this deployment does not serve.</exception>
     /// <exception cref="EmailSearchResultLimitOutOfRangeException">Thrown when the request names a result count outside the accepted range.</exception>
+    /// <exception cref="SensitiveContentScannerUnavailableException">Thrown when a switched-on scanner could not establish what the window carries, which refuses the search rather than serving it unscanned.</exception>
     /// <remarks>
     /// Nothing here writes, and the operation is therefore safe to repeat. It also never sets the remote <c>\Seen</c>
     /// flag or any other remote state, because it speaks to no mail server at all. A query that matches nothing returns
@@ -146,11 +160,57 @@ public sealed class MailboxSearchReader
         var folderFreshness = await this.freshnessReader.ReadAsync(selection.Scope, cancellationToken);
 
         return new SearchEmailsResult(
-            matches,
+            await this.GuardedAsync(matches, cancellationToken),
             retrievalMode,
             semanticSearchCapability,
             folderFreshness,
             selection.Scope.IncludesJunkMail);
+    }
+
+    /// <summary>Scans the mail content of a window before the window becomes somebody else's.</summary>
+    /// <remarks>
+    /// <para>
+    /// A snippet and a subject are the two things a result carries that a message's author wrote, so they are what is
+    /// scanned. The identifiers beside them — the account, the folder alias, the addresses, the stored identity — are
+    /// what a caller acts on rather than text to read, and redacting the address a reply has to go to would remove the
+    /// result's whole use while protecting nothing the message body did not already carry.
+    /// </para>
+    /// <para>
+    /// Each value is scanned on its own and the window is composed afterwards. Scanning the composed result instead
+    /// would let one detection cover the end of a snippet and the beginning of the next field, and replacing that
+    /// region would take the boundary between them with it.
+    /// </para>
+    /// </remarks>
+    private async Task<IReadOnlyList<EmailSearchMatch>> GuardedAsync(
+        IReadOnlyList<EmailSearchMatch> matches,
+        CancellationToken cancellationToken)
+    {
+        if (!this.egressGuard.IsActive)
+        {
+            return matches;
+        }
+
+        var guarded = new List<EmailSearchMatch>(matches.Count);
+
+        foreach (var match in matches)
+        {
+            var subject = await this.egressGuard.GuardOptionalAsync(
+                SensitiveContentEgressPoint.McpSnippet,
+                match.Summary.Subject,
+                cancellationToken);
+            var snippets = await this.egressGuard.GuardAllAsync(
+                SensitiveContentEgressPoint.McpSnippet,
+                match.Snippets,
+                cancellationToken);
+
+            guarded.Add(match with
+            {
+                Summary = match.Summary with { Subject = subject },
+                Snippets = snippets,
+            });
+        }
+
+        return guarded;
     }
 
     /// <summary>Ranks the eligible mail by whichever method this instance can apply to this query.</summary>

--- a/src/Application/Retrieval/AskMail/MailboxQuestionReader.cs
+++ b/src/Application/Retrieval/AskMail/MailboxQuestionReader.cs
@@ -264,38 +264,41 @@ public sealed class MailboxQuestionReader
             SensitiveContentEgressPoint.McpSnippet,
             answer.Text,
             cancellationToken);
-        var citations = await this.CitedAsync(retrieval.Passages, cancellationToken);
+
+        // Collapsed and counted before anything is scanned, because the count decides the truncation flag while only
+        // the citations that survive the bound are published — and a subject nobody will read is a scan nobody needs.
+        EmailKnowledgePassage[] citable = [.. retrieval.Passages.DistinctBy(static passage => passage.StoredEmailId)];
+        var citations = await this.CitedAsync(citable.Take(maximumCitations), cancellationToken);
 
         return new AskMailResult(
             Bounded(answerText, maximumAnswerCharacters),
-            [.. citations.Take(maximumCitations)],
+            citations,
             answerText.Length > maximumAnswerCharacters,
-            citations.Count > maximumCitations,
+            citable.Length > maximumCitations,
             retrieval.Degradation.HasFlag(MailAnsweringRunDegradation.RetrievalCeilingReached));
     }
 
-    /// <summary>Reads the passages a run retrieved into one citation per email, with the one text a citation carries scanned.</summary>
+    /// <summary>Reads the passages one answer cites into citations, with the one text a citation carries scanned.</summary>
     /// <remarks>
     /// <para>
-    /// A run makes several lookups and one message can answer more than one of them, so the passages are collapsed by
-    /// the identity they are traced through. The first occurrence is kept, which leaves the citations in the order the
-    /// run first reached each message rather than in an order nothing produced.
+    /// The passages arrive collapsed by the identity they are traced through and cut to what one response carries, so
+    /// this scans exactly what is published: a message reached by three lookups costs one scan, and a message the bound
+    /// dropped costs none. The order is the one the run first reached each message in, rather than one nothing produced.
     /// </para>
     /// <para>
     /// The subject is the whole of a citation's mail content: the identity, the account, the folder alias, and the
-    /// received instant are what a reader opens the message by. Collapsing happens before the scan so one message
-    /// reached by three lookups costs one, and the scan is here rather than left to the retrieval because a citation is
-    /// published to the caller while an extract is sent to a model, which are two egress points that happen to share a
-    /// value.
+    /// received instant are what a reader opens the message by. The scan is here rather than left to the retrieval
+    /// because a citation is published to the caller while an extract is sent to a model, which are two egress points
+    /// that happen to share a value.
     /// </para>
     /// </remarks>
     private async Task<IReadOnlyList<MailAnswerCitation>> CitedAsync(
-        IReadOnlyList<EmailKnowledgePassage> passages,
+        IEnumerable<EmailKnowledgePassage> passages,
         CancellationToken cancellationToken)
     {
         var cited = new List<MailAnswerCitation>();
 
-        foreach (var passage in passages.DistinctBy(static passage => passage.StoredEmailId))
+        foreach (var passage in passages)
         {
             cited.Add(new MailAnswerCitation(
                 passage.StoredEmailId,

--- a/src/Application/Retrieval/AskMail/MailboxQuestionReader.cs
+++ b/src/Application/Retrieval/AskMail/MailboxQuestionReader.cs
@@ -7,6 +7,8 @@ using MailFathom.Application.Accounts;
 using MailFathom.Application.Chat;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Retrieval.AskMail.Audit;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Domain.Answering.Audit;
 
 namespace MailFathom.Application.Retrieval.AskMail;
@@ -41,6 +43,12 @@ namespace MailFathom.Application.Retrieval.AskMail;
 /// Neither the question nor the answer nor a citation's subject is written to a log, a span, or the record by anything on
 /// this path. A question is personal data of a particularly revealing kind, and an answer is mail content restated.
 /// </para>
+/// <para>
+/// An answer and its citations are the last point at which a run's mail content leaves this deployment, so where a
+/// sensitive-content scanner is switched on both are scanned before they are published, and a scanner that cannot
+/// answer refuses the response rather than serving it unscanned. What reached the model on the way there was scanned as
+/// it was retrieved, which is a different egress point with a guard of its own.
+/// </para>
 /// </remarks>
 public sealed class MailboxQuestionReader
 {
@@ -51,6 +59,7 @@ public sealed class MailboxQuestionReader
     private readonly IMailAnsweringRunTelemetry runTelemetry;
     private readonly IMailAnsweringAuditTrail auditTrail;
     private readonly TimeProvider timeProvider;
+    private readonly SensitiveContentEgressGuard egressGuard;
 
     /// <summary>Initializes the use case.</summary>
     /// <param name="capability">Decides whether a question may run, and hands over what runs it.</param>
@@ -60,6 +69,7 @@ public sealed class MailboxQuestionReader
     /// <param name="runTelemetry">Publishes the run beside the request it happened inside.</param>
     /// <param name="auditTrail">Keeps the durable record of what the run read, for the accounts that asked for one.</param>
     /// <param name="timeProvider">Stamps when the run began and when it ended.</param>
+    /// <param name="egressGuard">Scans what the answer is about to publish, where this deployment scans anything.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public MailboxQuestionReader(
         MailAnsweringCapability capability,
@@ -68,7 +78,8 @@ public sealed class MailboxQuestionReader
         MailAnswerBounds answerBounds,
         IMailAnsweringRunTelemetry runTelemetry,
         IMailAnsweringAuditTrail auditTrail,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        SensitiveContentEgressGuard egressGuard)
     {
         ArgumentNullException.ThrowIfNull(capability);
         ArgumentNullException.ThrowIfNull(scopeResolver);
@@ -77,6 +88,7 @@ public sealed class MailboxQuestionReader
         ArgumentNullException.ThrowIfNull(runTelemetry);
         ArgumentNullException.ThrowIfNull(auditTrail);
         ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(egressGuard);
 
         this.capability = capability;
         this.scopeResolver = scopeResolver;
@@ -85,6 +97,7 @@ public sealed class MailboxQuestionReader
         this.runTelemetry = runTelemetry;
         this.auditTrail = auditTrail;
         this.timeProvider = timeProvider;
+        this.egressGuard = egressGuard;
     }
 
     /// <summary>Answers one question from the mail within its scope.</summary>
@@ -97,6 +110,7 @@ public sealed class MailboxQuestionReader
     /// <exception cref="MailAnsweringUnavailableException">Thrown when this deployment answers no questions, or answers them and currently cannot.</exception>
     /// <exception cref="MailAnsweringBudgetExhaustedException">Thrown when the current period has spent what this deployment allows answering to cost, or when the run reached what one question may spend.</exception>
     /// <exception cref="ChatGenerationFailedException">Thrown when the run produced no answer, naming which kind of failure ended it.</exception>
+    /// <exception cref="SensitiveContentScannerUnavailableException">Thrown when a switched-on scanner could not establish what the answer carries, which refuses the response rather than serving it unscanned.</exception>
     /// <remarks>
     /// <para>
     /// The request is validated before the capability is read, so a deployment that answers questions and one that does
@@ -183,7 +197,7 @@ public sealed class MailboxQuestionReader
         try
         {
             var answer = await answerer.AnswerAsync(question, observation, cancellationToken);
-            var published = this.Published(answer, observation.Retrieval);
+            var published = await this.PublishedAsync(answer, observation.Retrieval, cancellationToken);
 
             observation.RecordOutcome(
                 MailAnsweringRunOutcome.Answered,
@@ -227,37 +241,75 @@ public sealed class MailboxQuestionReader
         observation.RecordOutcome(outcome, [], this.timeProvider.GetUtcNow());
 
     /// <summary>Cuts one run's outcome down to what a single answer publishes, and says what it cut.</summary>
-    private AskMailResult Published(MailAnswer answer, MailAnsweringRetrievalReport retrieval)
+    /// <remarks>
+    /// <para>
+    /// An answer is the last point at which a run's mail content leaves this deployment, and it is scanned here even
+    /// though the extracts it was written from were scanned on their way to the model. A model restates what it read,
+    /// and an answer is the one text in a run that nothing else has looked at.
+    /// </para>
+    /// <para>
+    /// Scanning happens before the answer is cut to what one response carries, so the published text is bounded after
+    /// every placeholder is in it. Cutting first would bound a text that is not the one published.
+    /// </para>
+    /// </remarks>
+    private async Task<AskMailResult> PublishedAsync(
+        MailAnswer answer,
+        MailAnsweringRetrievalReport retrieval,
+        CancellationToken cancellationToken)
     {
-        var citations = Cited(retrieval.Passages);
         var maximumCitations = this.answerBounds.MaximumCitations;
         var maximumAnswerCharacters = this.answerBounds.MaximumAnswerCharacters;
 
+        var answerText = await this.egressGuard.GuardAsync(
+            SensitiveContentEgressPoint.McpSnippet,
+            answer.Text,
+            cancellationToken);
+        var citations = await this.CitedAsync(retrieval.Passages, cancellationToken);
+
         return new AskMailResult(
-            Bounded(answer.Text, maximumAnswerCharacters),
+            Bounded(answerText, maximumAnswerCharacters),
             [.. citations.Take(maximumCitations)],
-            answer.Text.Length > maximumAnswerCharacters,
+            answerText.Length > maximumAnswerCharacters,
             citations.Count > maximumCitations,
             retrieval.Degradation.HasFlag(MailAnsweringRunDegradation.RetrievalCeilingReached));
     }
 
-    /// <summary>Reads the passages a run retrieved into one citation per email.</summary>
+    /// <summary>Reads the passages a run retrieved into one citation per email, with the one text a citation carries scanned.</summary>
     /// <remarks>
+    /// <para>
     /// A run makes several lookups and one message can answer more than one of them, so the passages are collapsed by
     /// the identity they are traced through. The first occurrence is kept, which leaves the citations in the order the
     /// run first reached each message rather than in an order nothing produced.
+    /// </para>
+    /// <para>
+    /// The subject is the whole of a citation's mail content: the identity, the account, the folder alias, and the
+    /// received instant are what a reader opens the message by. Collapsing happens before the scan so one message
+    /// reached by three lookups costs one, and the scan is here rather than left to the retrieval because a citation is
+    /// published to the caller while an extract is sent to a model, which are two egress points that happen to share a
+    /// value.
+    /// </para>
     /// </remarks>
-    private static IReadOnlyList<MailAnswerCitation> Cited(IReadOnlyList<EmailKnowledgePassage> passages) =>
-    [
-        .. passages
-            .DistinctBy(static passage => passage.StoredEmailId)
-            .Select(static passage => new MailAnswerCitation(
+    private async Task<IReadOnlyList<MailAnswerCitation>> CitedAsync(
+        IReadOnlyList<EmailKnowledgePassage> passages,
+        CancellationToken cancellationToken)
+    {
+        var cited = new List<MailAnswerCitation>();
+
+        foreach (var passage in passages.DistinctBy(static passage => passage.StoredEmailId))
+        {
+            cited.Add(new MailAnswerCitation(
                 passage.StoredEmailId,
                 passage.AccountId,
                 passage.FolderAlias,
-                passage.Subject,
-                passage.ReceivedAt)),
-    ];
+                await this.egressGuard.GuardOptionalAsync(
+                    SensitiveContentEgressPoint.McpSnippet,
+                    passage.Subject,
+                    cancellationToken),
+                passage.ReceivedAt));
+        }
+
+        return cited;
+    }
 
     /// <summary>Cuts an answer longer than one response carries.</summary>
     /// <remarks>

--- a/src/Application/Retrieval/MailboxKnowledgeSearch.cs
+++ b/src/Application/Retrieval/MailboxKnowledgeSearch.cs
@@ -83,7 +83,9 @@ public sealed class MailboxKnowledgeSearch : IEmailKnowledgeSearch
             ResultLimit = this.bounds.MaximumPassages,
         };
 
-        var result = await this.searchReader.SearchEmailsAsync(request, cancellationToken);
+        // Deliberately the unguarded window: an extract reaches a model rather than an MCP caller, and the retrieval
+        // that sends it guards it there, under the egress point it actually crosses.
+        var result = await this.searchReader.SearchWindowAsync(request, cancellationToken);
 
         return EmailKnowledgeLookup.Unfiltered(
             [

--- a/src/Application/SensitiveContent/Egress/ISensitiveContentEgressTelemetry.cs
+++ b/src/Application/SensitiveContent/Egress/ISensitiveContentEgressTelemetry.cs
@@ -1,0 +1,36 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent.Redaction;
+
+namespace MailFathom.Application.SensitiveContent.Egress;
+
+/// <summary>Reports what guarding one egress point found and what it cost, without reporting any of it.</summary>
+/// <remarks>
+/// <para>
+/// The three questions an operator has about a switched-on scanner are whether it is finding anything, whether it is
+/// refusing anything, and what it is adding to a response. All three are answered per egress point, because a scanner
+/// that is quick on a subject and slow on a retrieved extract is one fact rather than two deployments.
+/// </para>
+/// <para>
+/// <b>Nothing recorded through this port is mail or derived from it.</b> A category name, a rule name, a detector
+/// identity, and an egress point are MailFathom's own closed sets; a count, a character count, and a duration are
+/// numbers. The detected value, the text it sat in, and the position it sat at are none of an instrument's business —
+/// recording them would put the credential in the telemetry written to prove it never left.
+/// </para>
+/// </remarks>
+public interface ISensitiveContentEgressTelemetry
+{
+    /// <summary>Records one text that passed a guard, whatever the guard had to remove from it.</summary>
+    /// <param name="egressPoint">Where the text was about to go.</param>
+    /// <param name="redacted">What the redaction produced, read for its findings and its dropped remainder.</param>
+    /// <param name="elapsed">How long the scan added to the operation being guarded.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="redacted" /> is <see langword="null" />.</exception>
+    void RecordGuarded(SensitiveContentEgressPoint egressPoint, RedactedText redacted, TimeSpan elapsed);
+
+    /// <summary>Records one egress refused because the scanner guarding it could not answer.</summary>
+    /// <param name="egressPoint">Where the text was about to go, and did not.</param>
+    /// <param name="scanner">Which switched-on scanner could not answer.</param>
+    void RecordRefused(SensitiveContentEgressPoint egressPoint, SensitiveContentScannerKind scanner);
+}

--- a/src/Application/SensitiveContent/Egress/SensitiveContentEgressGuard.cs
+++ b/src/Application/SensitiveContent/Egress/SensitiveContentEgressGuard.cs
@@ -20,8 +20,14 @@ namespace MailFathom.Application.SensitiveContent.Egress;
 /// <b>Guard a value, never a composed document.</b> A detected region is replaced wherever it was found, so a scan of a
 /// document this system assembled — an XML envelope, a JSON payload, a formatted listing — can report a region that
 /// covers a delimiter as well as the text beside it, and replacing that region would destroy the structure while
-/// leaving the value's neighbours in it. Every consumer therefore guards the field it is about to write and composes
-/// afterwards.
+/// leaving the value's neighbours in it. Every consumer that owns the values therefore guards the field it is about to
+/// write and composes afterwards.
+/// </para>
+/// <para>
+/// One consumer cannot: a port handed a conversation somebody else built has no way to tell which turn a mailbox
+/// reached, so it guards each turn whole and accepts the structural cost above on a turn that happens to be a document.
+/// That is the exception rather than a second rule, and it is bounded by the guarantee that makes it necessary — every
+/// text leaves that port scanned, whatever its caller composed.
 /// </para>
 /// <para>
 /// <b>With both switches off this guard is inert.</b> It is registered whatever a deployment configured, so no consumer

--- a/src/Application/SensitiveContent/Egress/SensitiveContentEgressGuard.cs
+++ b/src/Application/SensitiveContent/Egress/SensitiveContentEgressGuard.cs
@@ -1,0 +1,177 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Redaction;
+
+namespace MailFathom.Application.SensitiveContent.Egress;
+
+/// <summary>The one thing every egress point calls before it hands text to somebody else.</summary>
+/// <remarks>
+/// <para>
+/// One guard rather than a redaction per consumer, for the reason there is one redactor behind it: a placeholder a
+/// caller composed itself would drift from the shared one the first time either gained a rule, and a consumer holding
+/// the redactor directly would decide for itself what to do with a finding. What a consumer gets here is guarded text
+/// and nothing else — the findings stay inside, are counted by category, and are never handed to a caller that might
+/// log one.
+/// </para>
+/// <para>
+/// <b>Guard a value, never a composed document.</b> A detected region is replaced wherever it was found, so a scan of a
+/// document this system assembled — an XML envelope, a JSON payload, a formatted listing — can report a region that
+/// covers a delimiter as well as the text beside it, and replacing that region would destroy the structure while
+/// leaving the value's neighbours in it. Every consumer therefore guards the field it is about to write and composes
+/// afterwards.
+/// </para>
+/// <para>
+/// <b>With both switches off this guard is inert.</b> It is registered whatever a deployment configured, so no consumer
+/// carries a null check or a second code path, and with no redactor behind it every call returns its argument without
+/// constructing a detector, taking a concurrency permit, or touching an instrument. That is what makes an opt-in nobody
+/// took cost nothing on any of these paths.
+/// </para>
+/// </remarks>
+public sealed class SensitiveContentEgressGuard
+{
+    private readonly SensitiveContentRedactor? redactor;
+    private readonly ISensitiveContentEgressTelemetry telemetry;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes the guard of a deployment, whether or not it scans anything.</summary>
+    /// <param name="redactor">The one redaction every consumer shares, or <see langword="null" /> where both switches are off.</param>
+    /// <param name="telemetry">Reports what each guarded call found and what it cost.</param>
+    /// <param name="timeProvider">Measures what the scan added to the operation being guarded.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="telemetry" /> or <paramref name="timeProvider" /> is <see langword="null" />.</exception>
+    public SensitiveContentEgressGuard(
+        SensitiveContentRedactor? redactor,
+        ISensitiveContentEgressTelemetry telemetry,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(telemetry);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.redactor = redactor;
+        this.telemetry = telemetry;
+        this.timeProvider = timeProvider;
+    }
+
+    /// <summary>Gets whether this deployment scans anything at all.</summary>
+    /// <remarks>
+    /// Read by a consumer deciding whether work only a scan makes necessary is worth doing — never as permission to
+    /// hand text on unguarded, which is what calling the guard already does when it is inactive.
+    /// </remarks>
+    public bool IsActive => this.redactor is not null;
+
+    /// <summary>Guards one text about to cross out of this deployment.</summary>
+    /// <param name="egressPoint">Where the text is going.</param>
+    /// <param name="text">The text to guard, which must be a value rather than a document composed around one.</param>
+    /// <param name="cancellationToken">Cancels the scan.</param>
+    /// <returns>The text with every detected region replaced, or the text itself where nothing is scanned.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="text" /> is <see langword="null" />.</exception>
+    /// <exception cref="SensitiveContentScannerUnavailableException">Thrown when a switched-on scanner could not establish what the text carries, which refuses the egress.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken" /> is cancelled.</exception>
+    public Task<string> GuardAsync(
+        SensitiveContentEgressPoint egressPoint,
+        string text,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        return this.redactor is { } active
+            ? this.RedactAsync(active, egressPoint, text, cancellationToken)
+            : Task.FromResult(text);
+    }
+
+    /// <summary>Guards a text that a message need not carry at all.</summary>
+    /// <param name="egressPoint">Where the text is going.</param>
+    /// <param name="text">The text to guard, or <see langword="null" /> where the message carried none.</param>
+    /// <param name="cancellationToken">Cancels the scan.</param>
+    /// <returns>The guarded text, or <see langword="null" /> where there was none.</returns>
+    /// <exception cref="SensitiveContentScannerUnavailableException">Thrown when a switched-on scanner could not establish what the text carries, which refuses the egress.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken" /> is cancelled.</exception>
+    /// <remarks>
+    /// Absence is carried through rather than turned into an empty string, because a subject nobody wrote and a subject
+    /// redacted to nothing are different facts and a reader acts differently on each.
+    /// </remarks>
+    public async Task<string?> GuardOptionalAsync(
+        SensitiveContentEgressPoint egressPoint,
+        string? text,
+        CancellationToken cancellationToken)
+    {
+        if (text is null || this.redactor is not { } active)
+        {
+            return text;
+        }
+
+        return await this.RedactAsync(active, egressPoint, text, cancellationToken);
+    }
+
+    /// <summary>Guards every text of one publication about to cross out of this deployment.</summary>
+    /// <param name="egressPoint">Where the texts are going.</param>
+    /// <param name="texts">The texts to guard, in the order they are published.</param>
+    /// <param name="cancellationToken">Cancels the scan.</param>
+    /// <returns>The guarded texts, in the same order and the same number.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="texts" /> is <see langword="null" />.</exception>
+    /// <exception cref="SensitiveContentScannerUnavailableException">Thrown when a switched-on scanner could not establish what one of them carries, which refuses the whole egress.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when <paramref name="cancellationToken" /> is cancelled.</exception>
+    /// <remarks>
+    /// Each text is scanned on its own rather than joined into one pass, because a joined scan would let a detection
+    /// straddle the join and redact across two publications that have nothing to do with each other. The concurrency
+    /// bound the redactor holds is what keeps a wide publication from opening a connection per text.
+    /// </remarks>
+    public Task<IReadOnlyList<string>> GuardAllAsync(
+        SensitiveContentEgressPoint egressPoint,
+        IReadOnlyList<string> texts,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(texts);
+
+        return this.redactor is { } active && texts.Count > 0
+            ? this.RedactAllAsync(active, egressPoint, texts, cancellationToken)
+            : Task.FromResult(texts);
+    }
+
+    private async Task<IReadOnlyList<string>> RedactAllAsync(
+        SensitiveContentRedactor active,
+        SensitiveContentEgressPoint egressPoint,
+        IReadOnlyList<string> texts,
+        CancellationToken cancellationToken)
+    {
+        var guarded = new List<string>(texts.Count);
+
+        foreach (var text in texts)
+        {
+            guarded.Add(await this.RedactAsync(active, egressPoint, text, cancellationToken));
+        }
+
+        return guarded;
+    }
+
+    /// <summary>Runs the shared redaction and reports what it found, or reports the refusal and re-raises it.</summary>
+    /// <remarks>
+    /// The refusal reaches the caller unchanged. It already names the scanner and no text, and translating it here would
+    /// cost the error code an operator reads the failure by while adding nothing this layer knows.
+    /// </remarks>
+    private async Task<string> RedactAsync(
+        SensitiveContentRedactor active,
+        SensitiveContentEgressPoint egressPoint,
+        string text,
+        CancellationToken cancellationToken)
+    {
+        var startedAt = this.timeProvider.GetTimestamp();
+
+        try
+        {
+            var redacted = await active.RedactAsync(text, cancellationToken);
+
+            this.telemetry.RecordGuarded(egressPoint, redacted, this.timeProvider.GetElapsedTime(startedAt));
+
+            return redacted.Text;
+        }
+        catch (SensitiveContentScannerUnavailableException refusal)
+        {
+            this.telemetry.RecordRefused(egressPoint, refusal.Scanner);
+
+            throw;
+        }
+    }
+}

--- a/src/Application/SensitiveContent/Egress/SensitiveContentEgressPoint.cs
+++ b/src/Application/SensitiveContent/Egress/SensitiveContentEgressPoint.cs
@@ -1,0 +1,40 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.SensitiveContent.Egress;
+
+/// <summary>Names a point at which text crosses out of this deployment and is therefore scanned before it does.</summary>
+/// <remarks>
+/// <para>
+/// <b>This enumeration is the register of guarded egress.</b> A prompt is the point everybody thinks of and the least
+/// likely to be the leak: a credential reaches a third party just as completely through an embedding request or a tool
+/// result, and those paths are written by people who are not thinking about redaction at the time. A path that hands
+/// text to somebody else and is not a member here is unguarded, so adding one is part of adding the path rather than a
+/// follow-up to it.
+/// </para>
+/// <para>
+/// Three paths the design names carry no member, and each absence is a fact about this deployment rather than an
+/// omission. <b>Logs</b> and <b>audit events</b> carry no message text at all — every event of both is composed from
+/// identifiers, this deployment's own configured aliases, counts, and outcomes, which is a rule the whole repository is
+/// written under and the reason a finding is recorded here by category and rule rather than by value. Recording what was
+/// found, where, and in which message would recreate the leak inside the record written to prevent it. <b>Webhook
+/// payloads</b> have no member because MailFathom sends no webhook; the day it does, the payload is composed from mail
+/// and the member arrives with it.
+/// </para>
+/// <para>
+/// A member is a metric tag rather than a stored value, so the numbers are free to be reassigned only in the sense every
+/// enum here is: allocated once, in declaration order, and never reordered or reused.
+/// </para>
+/// </remarks>
+public enum SensitiveContentEgressPoint
+{
+    /// <summary>Text composed into a request to a chat provider, including a retrieved extract and a tool result.</summary>
+    ChatPrompt = 0,
+
+    /// <summary>Text sent to an embedding provider, which is a configured endpoint whether or not it is inside the deployment.</summary>
+    HostedEmbeddingInput = 1,
+
+    /// <summary>Text an MCP tool returns: a search snippet, a subject a listing publishes, and an answer a run produced.</summary>
+    McpSnippet = 2,
+}

--- a/src/Infrastructure/Observability/SensitiveContentEgressTelemetry.cs
+++ b/src/Infrastructure/Observability/SensitiveContentEgressTelemetry.cs
@@ -1,0 +1,126 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using MailFathom.Application.SensitiveContent;
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.Application.SensitiveContent.Redaction;
+using MailFathom.Common.Observability;
+
+namespace MailFathom.Infrastructure.Observability;
+
+/// <summary>Reports what guarding each egress point found, refused, and cost.</summary>
+/// <remarks>
+/// <para>
+/// The egress point is on every instrument because it is what an operator acts on. "Something was redacted" says
+/// nothing; a scanner finding credentials in retrieved extracts and nothing in subjects, or adding two seconds to a
+/// listing and nothing to an embedding call, is where a category list or a bound gets changed.
+/// </para>
+/// <para>
+/// Nothing recorded here is mail or derived from it. The tags are an egress point, a category name, and a scanner name,
+/// all three of them MailFathom's own closed sets, and the values are counts and durations — never a rule's match, a
+/// position, a message identity, or any part of what was found, each of which would put the credential in the
+/// telemetry written to prove it never left.
+/// </para>
+/// </remarks>
+public sealed class SensitiveContentEgressTelemetry : ISensitiveContentEgressTelemetry
+{
+    private const string EgressPointTagName = "mailfathom.sensitive_content.egress_point";
+    private const string CategoryTagName = "mailfathom.sensitive_content.category";
+    private const string ScannerTagName = "mailfathom.sensitive_content.scanner";
+
+    private readonly Counter<long> guardedTextCount;
+    private readonly Counter<long> findingCount;
+    private readonly Counter<long> omittedCharacterCount;
+    private readonly Counter<long> refusalCount;
+    private readonly Histogram<double> scanDuration;
+
+    /// <summary>Initializes the instruments every guarded egress reports through.</summary>
+    public SensitiveContentEgressTelemetry()
+    {
+        this.guardedTextCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.sensitive_content.guarded",
+            unit: "{text}",
+            description: "Texts scanned before they crossed out of the deployment, by egress point.");
+        this.findingCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.sensitive_content.findings",
+            unit: "{finding}",
+            description: "Sensitive-content findings redacted before egress, by egress point and category.");
+        this.omittedCharacterCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.sensitive_content.omitted",
+            unit: "{character}",
+            description: "Characters dropped at the analyzed ceiling rather than handed on unscanned, by egress point.");
+        this.refusalCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.sensitive_content.refusals",
+            unit: "{refusal}",
+            description: "Egress operations refused because a switched-on scanner could not answer, by egress point and scanner.");
+        this.scanDuration = Telemetry.Meter.CreateHistogram<double>(
+            "mailfathom.sensitive_content.scan.duration",
+            unit: "s",
+            description: "How long scanning added to one guarded operation, by egress point.");
+    }
+
+    /// <inheritdoc />
+    public void RecordGuarded(SensitiveContentEgressPoint egressPoint, RedactedText redacted, TimeSpan elapsed)
+    {
+        ArgumentNullException.ThrowIfNull(redacted);
+
+        var tags = new TagList { { EgressPointTagName, TagOf(egressPoint) } };
+
+        this.guardedTextCount.Add(1, tags);
+        this.scanDuration.Record(elapsed.TotalSeconds, tags);
+
+        // Recorded per category rather than as one total, because which kind of material a mailbox is producing is what
+        // decides whether a category list is right — and a total says only that the feature is switched on.
+        foreach (var category in redacted.Findings.GroupBy(finding => finding.Category.Name, StringComparer.Ordinal))
+        {
+            this.findingCount.Add(
+                category.Count(),
+                new TagList
+                {
+                    { EgressPointTagName, TagOf(egressPoint) },
+                    { CategoryTagName, category.Key },
+                });
+        }
+
+        // Only when the ceiling actually cut something. A zero on every guarded text would make the series say the
+        // ceiling is in play on ordinary mail, which is exactly the question this instrument exists to answer.
+        if (redacted.OmittedCharacterCount > 0)
+        {
+            this.omittedCharacterCount.Add(redacted.OmittedCharacterCount, tags);
+        }
+    }
+
+    /// <inheritdoc />
+    public void RecordRefused(SensitiveContentEgressPoint egressPoint, SensitiveContentScannerKind scanner) =>
+        this.refusalCount.Add(
+            1,
+            new TagList
+            {
+                { EgressPointTagName, TagOf(egressPoint) },
+                { ScannerTagName, TagOf(scanner) },
+            });
+
+    /// <summary>Names an egress point as a tag value.</summary>
+    /// <remarks>
+    /// A closed mapping rather than the member's own name, for the reason every published mapping here is closed: the
+    /// tag value is what a dashboard and an alert are written against, so a member added without one has to fail rather
+    /// than silently rename a series.
+    /// </remarks>
+    private static string TagOf(SensitiveContentEgressPoint egressPoint) => egressPoint switch
+    {
+        SensitiveContentEgressPoint.ChatPrompt => "chat_prompt",
+        SensitiveContentEgressPoint.HostedEmbeddingInput => "hosted_embedding_input",
+        SensitiveContentEgressPoint.McpSnippet => "mcp_snippet",
+        _ => "unknown",
+    };
+
+    private static string TagOf(SensitiveContentScannerKind scanner) => scanner switch
+    {
+        SensitiveContentScannerKind.Secrets => "secrets",
+        SensitiveContentScannerKind.Pii => "pii",
+        _ => "unknown",
+    };
+}

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -36,6 +36,8 @@ using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Rules.History;
 using MailFathom.Application.SensitiveContent;
 using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.Application.SensitiveContent.Redaction;
 using MailFathom.Application.Spam;
 using MailFathom.Application.Spam.Scanning;
 using MailFathom.Application.Spam.Signals;
@@ -385,6 +387,16 @@ public static class ServiceCollectionExtensions
         services.AddScoped<StoredEmailExtractionBackfill>();
         services.AddScoped<MailboxScopeResolver>();
         services.AddScoped<MailAccountDirectoryReader>();
+        // The guard every egress point calls, registered for every deployment rather than only where a scanner is
+        // switched on. What is conditional is the redaction behind it: with both switches off the provider hands over
+        // no redactor, no detector is constructed, and every call returns its argument. Registering it conditionally
+        // instead would put a null check and a second code path into each consumer, which is how two of them end up
+        // disagreeing about what an unguarded egress looks like.
+        services.AddSingleton<ISensitiveContentEgressTelemetry, SensitiveContentEgressTelemetry>();
+        services.AddSingleton(provider => new SensitiveContentEgressGuard(
+            provider.GetService<SensitiveContentRedactor>(),
+            provider.GetRequiredService<ISensitiveContentEgressTelemetry>(),
+            provider.GetRequiredService<TimeProvider>()));
         services.AddScoped<MailboxTimelineReader>();
         services.AddScoped<EmailContentReader>();
         services.AddScoped<EmailAttachmentDownloadReader>();

--- a/tests/AI.UnitTests/AI.UnitTests.csproj
+++ b/tests/AI.UnitTests/AI.UnitTests.csproj
@@ -11,6 +11,12 @@
     <Compile Include="..\shared\FakeHttpMessageHandler.cs" Link="FakeHttpMessageHandler.cs" />
     <Compile Include="..\shared\RecordedHttpRequest.cs" Link="RecordedHttpRequest.cs" />
     <Compile Include="..\shared\RecordingLoggerProvider.cs" Link="RecordingLoggerProvider.cs" />
+    <!-- Every boundary holding a guarded egress point asserts the same three states of the guard, so the three are
+         built once and linked into each suite that has one. -->
+    <Compile Include="..\shared\MarkerSensitiveContentScanner.cs" Link="MarkerSensitiveContentScanner.cs" />
+    <Compile Include="..\shared\RecordingSensitiveContentEgressTelemetry.cs" Link="RecordingSensitiveContentEgressTelemetry.cs" />
+    <Compile Include="..\shared\SensitiveContentEgressGuards.cs" Link="SensitiveContentEgressGuards.cs" />
+    <Compile Include="..\shared\ScanningSensitiveContentEgress.cs" Link="ScanningSensitiveContentEgress.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/AI.UnitTests/AiServiceCollectionExtensionsTests.cs
+++ b/tests/AI.UnitTests/AiServiceCollectionExtensionsTests.cs
@@ -14,6 +14,7 @@ using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Resilience;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
 using NSubstitute;
 using Xunit;
@@ -106,6 +107,7 @@ public sealed class AiServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IProviderEndpointCredentialSource>());
         services.AddSingleton(Substitute.For<IOutboundOperationRunner>());
         services.AddSingleton(Substitute.For<IAiProviderHealthRecorder>());
+        services.AddSingleton(SensitiveContentEgressGuards.Inactive());
 
         // Act
         services.AddEmbeddingProviderAdapter();
@@ -146,6 +148,7 @@ public sealed class AiServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IProviderEndpointCredentialSource>());
         services.AddSingleton(Substitute.For<IOutboundOperationRunner>());
         services.AddSingleton(Substitute.For<IAiProviderHealthRecorder>());
+        services.AddSingleton(SensitiveContentEgressGuards.Inactive());
 
         // Act
         services.AddChatProviderAdapter();
@@ -182,6 +185,7 @@ public sealed class AiServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IProviderEndpointCredentialSource>());
         services.AddSingleton(Substitute.For<IOutboundOperationRunner>());
         services.AddSingleton(Substitute.For<IAiProviderHealthRecorder>());
+        services.AddSingleton(SensitiveContentEgressGuards.Inactive());
 
         // Act
         services.AddChatProviderAdapter();
@@ -213,6 +217,7 @@ public sealed class AiServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IProviderEndpointCredentialSource>());
         services.AddSingleton(Substitute.For<IOutboundOperationRunner>());
         services.AddSingleton(Substitute.For<IAiProviderHealthRecorder>());
+        services.AddSingleton(SensitiveContentEgressGuards.Inactive());
 
         // Act
         services.AddEmbeddingProviderAdapter();
@@ -251,6 +256,7 @@ public sealed class AiServiceCollectionExtensionsTests
         services.AddSingleton(Substitute.For<IProviderEndpointCredentialSource>());
         services.AddSingleton(Substitute.For<IOutboundOperationRunner>());
         services.AddSingleton(Substitute.For<IAiProviderHealthRecorder>());
+        services.AddSingleton(SensitiveContentEgressGuards.Inactive());
         services.AddSingleton(Substitute.For<IMailAnsweringSpendLedger>());
         services.AddScoped<IEmailKnowledgeSearch, RecordingEmailKnowledgeSearch>();
 

--- a/tests/AI.UnitTests/Orchestration/MailAnsweringAgentCompositionTests.cs
+++ b/tests/AI.UnitTests/Orchestration/MailAnsweringAgentCompositionTests.cs
@@ -227,7 +227,8 @@ public sealed class MailAnsweringAgentCompositionTests
         var retrieval = new ScopedMailKnowledgeRetrieval(
             knowledgeSearch,
             OnePrimaryAccount,
-            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default));
+            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
+            SensitiveContentEgressGuards.Inactive());
         var agent = MailAnsweringAgentComposition.Compose(
             chatClient,
             plan,
@@ -313,7 +314,8 @@ public sealed class MailAnsweringAgentCompositionTests
         var retrieval = new ScopedMailKnowledgeRetrieval(
             knowledgeSearch,
             OnePrimaryAccount,
-            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default));
+            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
+            SensitiveContentEgressGuards.Inactive());
         var agent = MailAnsweringAgentComposition.Compose(
             chatClient,
             plan,
@@ -475,7 +477,8 @@ public sealed class MailAnsweringAgentCompositionTests
         var retrieval = new ScopedMailKnowledgeRetrieval(
             knowledgeSearch,
             OnePrimaryAccount,
-            new MailAnsweringRunLedger(MailAnsweringRunBounds.Create(100, 8, 80_000)));
+            new MailAnsweringRunLedger(MailAnsweringRunBounds.Create(100, 8, 80_000)),
+            SensitiveContentEgressGuards.Inactive());
         var agent = MailAnsweringAgentComposition.Compose(
             chatClient,
             ChatDeclarations.Plan(),
@@ -522,7 +525,8 @@ public sealed class MailAnsweringAgentCompositionTests
         retrieval = new ScopedMailKnowledgeRetrieval(
             knowledgeSearch,
             scope,
-            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default));
+            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
+            SensitiveContentEgressGuards.Inactive());
 
         return MailAnsweringAgentComposition.Compose(
             chatClient,

--- a/tests/AI.UnitTests/Orchestration/MailAnsweringAgentTests.cs
+++ b/tests/AI.UnitTests/Orchestration/MailAnsweringAgentTests.cs
@@ -16,6 +16,8 @@ using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Resilience;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Answering.Audit;
 using MailFathom.TestSupport;
@@ -36,6 +38,9 @@ public sealed class MailAnsweringAgentTests
     private static readonly MailQuestion Question = new(
         MailQuestionText.Create("was the invoice attached"),
         MailboxScope.Create([MailAccountId.Create("primary")], []));
+
+    /// <summary>The literal the scanner in the guarded-egress tests reports, standing in for a credential in mail.</summary>
+    private const string Marker = "AKIAEXAMPLEKEY";
 
     private static readonly DateTimeOffset RunStartedAt = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
 
@@ -134,6 +139,63 @@ public sealed class MailAnsweringAgentTests
         Assert.Equal(0, provider.RequestCount);
     }
 
+    /// <summary>A question is text somebody typed into a client, and it leaves this deployment as completely as an extract does.</summary>
+    [Fact]
+    public async Task AnswerAsync_ASwitchedOnScanner_RedactsTheQuestionBeforeItReachesTheProvider()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        using var provider = ScriptedTransport.Answering(Completion("It is rotated now."));
+        var agent = provider.AgentOver(new RecordingEmailKnowledgeSearch(), egressGuard: egress.Guard);
+
+        // Act
+        await agent.AnswerAsync(
+            Question with { Text = MailQuestionText.Create($"is the key {Marker} still valid") },
+            Observation(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var body = Assert.Single(provider.RequestBodies);
+
+        Assert.DoesNotContain(Marker, body, StringComparison.Ordinal);
+        Assert.Contains("[redacted:CloudKey]", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>Sending a prompt a scanner could not read would be the leak the switch was turned on to prevent.</summary>
+    [Fact]
+    public async Task AnswerAsync_ADetectorThatCannotAnswer_RefusesTheRunWithoutReachingTheProvider()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Unavailable(TimeProvider.System);
+        using var provider = ScriptedTransport.Answering(Completion("never reached"));
+        var agent = provider.AgentOver(new RecordingEmailKnowledgeSearch(), egressGuard: egress.Guard);
+
+        // Act
+        await Assert.ThrowsAsync<SensitiveContentScannerUnavailableException>(() =>
+            agent.AnswerAsync(Question, Observation(), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(0, provider.RequestCount);
+    }
+
+    /// <summary>An opt-in nobody took must not appear on this path at all.</summary>
+    [Fact]
+    public async Task AnswerAsync_ADeploymentThatScansNothing_SendsTheQuestionAsItWasAsked()
+    {
+        // Arrange
+        using var provider = ScriptedTransport.Answering(Completion("It is rotated now."));
+        var agent = provider.AgentOver(new RecordingEmailKnowledgeSearch());
+
+        // Act
+        await agent.AnswerAsync(
+            Question with { Text = MailQuestionText.Create($"is the key {Marker} still valid") },
+            Observation(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Contains(Marker, Assert.Single(provider.RequestBodies), StringComparison.Ordinal);
+    }
+
     /// <summary>Opens the record of one run, over the same scope every question here carries.</summary>
     private static MailAnsweringRunObservation Observation() => new(
         MailAnsweringRunId.Create(Guid.CreateVersion7()),
@@ -151,17 +213,21 @@ public sealed class MailAnsweringAgentTests
     private sealed class ScriptedTransport : IDisposable
     {
         private readonly FakeHttpMessageHandler handler;
+        private readonly List<string> requestBodies = [];
         private string payload = string.Empty;
 
         private ScriptedTransport() =>
-            this.handler = new FakeHttpMessageHandler((_, _) =>
+            this.handler = new FakeHttpMessageHandler(async (request, cancellationToken) =>
             {
                 this.RequestCount++;
+                this.requestBodies.Add(request.Content is null
+                    ? string.Empty
+                    : await request.Content.ReadAsStringAsync(cancellationToken));
 
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(this.payload, Encoding.UTF8, "application/json"),
-                });
+                };
             });
 
         /// <summary>The health state every call this provider serves reports into, so a test can read what the run established.</summary>
@@ -172,12 +238,16 @@ public sealed class MailAnsweringAgentTests
 
         public int RequestCount { get; private set; }
 
+        /// <summary>What the provider was actually sent, which is where a test reads whether anything left unredacted.</summary>
+        public IReadOnlyList<string> RequestBodies => this.requestBodies;
+
         public static ScriptedTransport Answering(string payload) => new() { payload = payload };
 
         public MailAnsweringAgent AgentOver(
             IEmailKnowledgeSearch knowledgeSearch,
             ChatGenerationPlan? plan = null,
-            MailAnsweringRunBounds? runBounds = null)
+            MailAnsweringRunBounds? runBounds = null,
+            SensitiveContentEgressGuard? egressGuard = null)
         {
             var transportFactory = Substitute.For<IHttpClientFactory>();
             transportFactory
@@ -216,6 +286,7 @@ public sealed class MailAnsweringAgentTests
                 operationRunner,
                 this.HealthRecorder,
                 this.SpendLedger,
+                egressGuard ?? SensitiveContentEgressGuards.Inactive(),
                 NullLoggerFactory.Instance,
                 NullLogger<MailAnsweringAgent>.Instance);
         }

--- a/tests/AI.UnitTests/ProviderAdapters/ProviderChatModelClientTests.cs
+++ b/tests/AI.UnitTests/ProviderAdapters/ProviderChatModelClientTests.cs
@@ -12,6 +12,8 @@ using MailFathom.AI.UnitTests.TestDoubles;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Chat;
 using MailFathom.Application.Resilience;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Domain.Failures;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Logging;
@@ -30,6 +32,9 @@ namespace MailFathom.AI.UnitTests.ProviderAdapters;
 /// </remarks>
 public sealed class ProviderChatModelClientTests
 {
+    /// <summary>The literal the scanner in the guarded-egress tests reports, standing in for a credential in mail.</summary>
+    private const string Marker = "AKIAEXAMPLEKEY";
+
     private static readonly IReadOnlyList<ChatMessage> Conversation = [new(ChatRole.User, "what did they say")];
 
     /// <summary>The distinguishing text of each turn the ordering test sends, in the order it sends them.</summary>
@@ -300,6 +305,64 @@ public sealed class ProviderChatModelClientTests
 
         // Assert
         Assert.Equal(0, provider.RequestCount);
+    }
+
+    /// <summary>A conversation reaching this port is already built, so every turn of it is scanned before any is sent.</summary>
+    [Fact]
+    public async Task AnswerAsync_ASwitchedOnScanner_RedactsEveryTurnBeforeTheRequestIsSent()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        using var provider = ScriptedProvider.Answering(Completion("an answer", "stop"));
+        var client = provider.ClientOver(ChatDeclarations.Plan(), egressGuard: egress.Guard);
+
+        // Act
+        await client.AnswerAsync(
+            [
+                new(ChatRole.System, "answer briefly"),
+                new(ChatRole.User, $"is {Marker} still valid"),
+            ],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var sent = provider.LastRequestBody;
+
+        Assert.DoesNotContain(Marker, sent, StringComparison.Ordinal);
+        Assert.Contains("[redacted:CloudKey]", sent, StringComparison.Ordinal);
+    }
+
+    /// <summary>Sending a prompt a scanner could not read would be the leak the switch was turned on to prevent.</summary>
+    [Fact]
+    public async Task AnswerAsync_ADetectorThatCannotAnswer_RefusesTheCallWithoutReachingTheProvider()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Unavailable(TimeProvider.System);
+        using var provider = ScriptedProvider.Answering(Completion("never reached", "stop"));
+        var client = provider.ClientOver(ChatDeclarations.Plan(), egressGuard: egress.Guard);
+
+        // Act
+        await Assert.ThrowsAsync<SensitiveContentScannerUnavailableException>(() =>
+            client.AnswerAsync(Conversation, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(0, provider.RequestCount);
+    }
+
+    /// <summary>An opt-in nobody took must not appear on this path at all.</summary>
+    [Fact]
+    public async Task AnswerAsync_ADeploymentThatScansNothing_SendsEveryTurnAsItWasComposed()
+    {
+        // Arrange
+        using var provider = ScriptedProvider.Answering(Completion("an answer", "stop"));
+        var client = provider.ClientOver(ChatDeclarations.Plan());
+
+        // Act
+        await client.AnswerAsync(
+            [new(ChatRole.User, $"is {Marker} still valid")],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Contains(Marker, provider.LastRequestBody, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -751,7 +814,8 @@ public sealed class ProviderChatModelClientTests
         public ProviderChatModelClient ClientOver(
             ChatGenerationPlan plan,
             bool declineTheCall = false,
-            ILogger? logger = null)
+            ILogger? logger = null,
+            SensitiveContentEgressGuard? egressGuard = null)
         {
             var transportFactory = Substitute.For<IHttpClientFactory>();
             transportFactory
@@ -792,6 +856,7 @@ public sealed class ProviderChatModelClientTests
                 transportFactory,
                 operationRunner,
                 this.HealthRecorder,
+                egressGuard ?? SensitiveContentEgressGuards.Inactive(),
                 // Wrapped rather than required, because only the no-log test reads what was written and every other
                 // test would otherwise carry a recorder it never asserts on.
                 logger is null

--- a/tests/AI.UnitTests/ProviderAdapters/ProviderTextEmbeddingGeneratorTests.cs
+++ b/tests/AI.UnitTests/ProviderAdapters/ProviderTextEmbeddingGeneratorTests.cs
@@ -13,6 +13,8 @@ using MailFathom.AI.UnitTests.TestDoubles;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Resilience;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Domain.Failures;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.AI;
@@ -26,6 +28,9 @@ namespace MailFathom.AI.UnitTests.ProviderAdapters;
 public sealed class ProviderTextEmbeddingGeneratorTests
 {
     private const int Dimension = EmbeddingDeclarations.Dimension;
+
+    /// <summary>The literal the scanner in the guarded-egress tests reports, standing in for a credential in mail.</summary>
+    private const string Marker = "AKIAEXAMPLEKEY";
 
     [Fact]
     public async Task GenerateAsync_AProviderAnsweringInTheDeclaredSpace_ReturnsOneVectorPerPassage()
@@ -271,6 +276,59 @@ public sealed class ProviderTextEmbeddingGeneratorTests
         Assert.Equal(0, provider.RequestCount);
     }
 
+    /// <summary>A passage reaching a hosted endpoint leaves the deployment, so every one of a batch is scanned first.</summary>
+    [Fact]
+    public async Task GenerateAsync_ASwitchedOnScanner_RedactsEveryPassageBeforeTheRequestIsSent()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        using var provider = ScriptedProvider.Answering(VectorsOfWidth(Dimension, 2));
+        var generator = provider.GeneratorOver(EmbeddingDeclarations.Plan(), egressGuard: egress.Guard);
+
+        // Act
+        await generator.GenerateAsync(
+            [$"the key is {Marker}", "nothing here"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var sent = provider.LastRequestBody();
+
+        Assert.DoesNotContain(Marker, sent, StringComparison.Ordinal);
+        Assert.Contains("[redacted:CloudKey]", sent, StringComparison.Ordinal);
+    }
+
+    /// <summary>Embedding a passage nothing could scan would leave the deployment carrying whatever it held.</summary>
+    [Fact]
+    public async Task GenerateAsync_ADetectorThatCannotAnswer_RefusesTheCallWithoutReachingTheProvider()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Unavailable(TimeProvider.System);
+        using var provider = ScriptedProvider.Answering(VectorsOfWidth(Dimension, 1));
+        var generator = provider.GeneratorOver(EmbeddingDeclarations.Plan(), egressGuard: egress.Guard);
+
+        // Act
+        await Assert.ThrowsAsync<SensitiveContentScannerUnavailableException>(() =>
+            generator.GenerateAsync(["first"], TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(0, provider.RequestCount);
+    }
+
+    /// <summary>An opt-in nobody took must not appear on this path at all.</summary>
+    [Fact]
+    public async Task GenerateAsync_ADeploymentThatScansNothing_SendsEveryPassageAsItWasComposed()
+    {
+        // Arrange
+        using var provider = ScriptedProvider.Answering(VectorsOfWidth(Dimension, 1));
+        var generator = provider.GeneratorOver(EmbeddingDeclarations.Plan());
+
+        // Act
+        await generator.GenerateAsync([$"the key is {Marker}"], TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Contains(Marker, provider.LastRequestBody(), StringComparison.Ordinal);
+    }
+
     private static double Length(EmbeddingVector vector) =>
         Math.Sqrt(vector.Components.ToArray().Sum(component => (double)component * component));
 
@@ -370,7 +428,8 @@ public sealed class ProviderTextEmbeddingGeneratorTests
         /// </remarks>
         public ProviderTextEmbeddingGenerator GeneratorOver(
             EmbeddingGenerationPlan plan,
-            IReadOnlyCollection<string>? declinedInstances = null)
+            IReadOnlyCollection<string>? declinedInstances = null,
+            SensitiveContentEgressGuard? egressGuard = null)
         {
             var transportFactory = Substitute.For<IHttpClientFactory>();
             transportFactory
@@ -414,6 +473,7 @@ public sealed class ProviderTextEmbeddingGeneratorTests
                 transportFactory,
                 operationRunner,
                 this.HealthRecorder,
+                egressGuard ?? SensitiveContentEgressGuards.Inactive(),
                 NullLogger<ProviderTextEmbeddingGenerator>.Instance);
         }
 

--- a/tests/AI.UnitTests/Retrieval/PromptInjectionResistanceTests.cs
+++ b/tests/AI.UnitTests/Retrieval/PromptInjectionResistanceTests.cs
@@ -163,7 +163,8 @@ public sealed class PromptInjectionResistanceTests
             new ScopedMailKnowledgeRetrieval(
                 knowledgeSearch,
                 OnePrimaryAccount,
-                new MailAnsweringRunLedger(MailAnsweringRunBounds.Default)),
+                new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
+                SensitiveContentEgressGuards.Inactive()),
             NullLoggerFactory.Instance);
 
     private static IReadOnlyList<XElement> MessagesIn(string envelope) =>

--- a/tests/AI.UnitTests/Retrieval/ScopedMailKnowledgeRetrievalTests.cs
+++ b/tests/AI.UnitTests/Retrieval/ScopedMailKnowledgeRetrievalTests.cs
@@ -11,8 +11,10 @@ using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
+using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.AI;
 using Xunit;
 
@@ -27,6 +29,9 @@ namespace MailFathom.AI.UnitTests.Retrieval;
 public sealed class ScopedMailKnowledgeRetrievalTests
 {
     private const string Query = "what did the insurer agree to pay";
+
+    /// <summary>The literal the scanner in the guarded-egress tests reports, standing in for a credential in mail.</summary>
+    private const string Marker = "AKIAEXAMPLEKEY";
 
     private static readonly MailboxScope OnePrimaryAccount = MailboxScope.Create(
         [MailAccountId.Create("primary")],
@@ -166,7 +171,8 @@ public sealed class ScopedMailKnowledgeRetrievalTests
         var retrieval = new ScopedMailKnowledgeRetrieval(
             knowledgeSearch,
             OnePrimaryAccount,
-            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default));
+            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
+            SensitiveContentEgressGuards.Inactive());
 
         // Act
         await InvokeAsync(retrieval.CreateSearchTool(), OneQuery);
@@ -193,7 +199,8 @@ public sealed class ScopedMailKnowledgeRetrievalTests
             new MailAnsweringRunLedger(MailAnsweringRunBounds.Create(
                 maximumRetrievedCharacters: 60,
                 maximumProviderCalls: 8,
-                maximumTokens: 80_000)));
+                maximumTokens: 80_000)),
+            SensitiveContentEgressGuards.Inactive());
 
         // Act
         var envelope = await InvokeAsync(retrieval.CreateSearchTool(), OneQuery);
@@ -218,7 +225,8 @@ public sealed class ScopedMailKnowledgeRetrievalTests
         var retrieval = new ScopedMailKnowledgeRetrieval(
             knowledgeSearch,
             OnePrimaryAccount,
-            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default));
+            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
+            SensitiveContentEgressGuards.Inactive());
         var tool = retrieval.CreateSearchTool();
 
         // Act
@@ -234,6 +242,99 @@ public sealed class ScopedMailKnowledgeRetrievalTests
         Assert.Equal(2, report.CandidateCount);
     }
 
+    /// <summary>The extracts are where mail reaches a chat provider, so they are scanned before the envelope is written.</summary>
+    [Fact]
+    public async Task SearchTool_ASwitchedOnScanner_RedactsTheExtractAndTheSubjectBeforeTheyReachTheModel()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch().Returning(
+            Query,
+            KnowledgePassages.Create($"sign in with {Marker} today", subject: $"re: {Marker}"));
+        var retrieval = new ScopedMailKnowledgeRetrieval(
+            knowledgeSearch,
+            OnePrimaryAccount,
+            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
+            egress.Guard);
+
+        // Act
+        var envelope = await InvokeAsync(retrieval.CreateSearchTool(), OneQuery);
+
+        // Assert
+        var message = Assert.Single(
+            RootOf(envelope).Elements(RetrievedMailContextFormatter.MessageElementName));
+
+        Assert.Equal(
+            "sign in with [redacted:CloudKey] today",
+            message.Element(RetrievedMailContextFormatter.ExtractElementName)?.Value);
+        Assert.Equal(
+            "re: [redacted:CloudKey]",
+            message.Element(RetrievedMailContextFormatter.SubjectElementName)?.Value);
+    }
+
+    /// <summary>Handing a model mail a scanner could not read would be the leak the switch was turned on to prevent.</summary>
+    [Fact]
+    public async Task SearchTool_ADetectorThatCannotAnswer_RefusesTheLookupRatherThanSendingItUnscanned()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Unavailable(TimeProvider.System);
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch().Returning(
+            Query,
+            KnowledgePassages.Create("an ordinary extract"));
+        var retrieval = new ScopedMailKnowledgeRetrieval(
+            knowledgeSearch,
+            OnePrimaryAccount,
+            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
+            egress.Guard);
+        var tool = retrieval.CreateSearchTool();
+
+        // Act, Assert
+        await Assert.ThrowsAsync<SensitiveContentScannerUnavailableException>(() => InvokeAsync(tool, OneQuery));
+    }
+
+    /// <summary>What a run reports having retrieved is read inside this process, so redacting it would guard nothing.</summary>
+    [Fact]
+    public async Task SearchTool_ASwitchedOnScanner_LeavesWhatTheRunRecordsAsItWasFound()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch().Returning(
+            Query,
+            KnowledgePassages.Create($"sign in with {Marker} today"));
+        var retrieval = new ScopedMailKnowledgeRetrieval(
+            knowledgeSearch,
+            OnePrimaryAccount,
+            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
+            egress.Guard);
+
+        // Act
+        await InvokeAsync(retrieval.CreateSearchTool(), OneQuery);
+
+        // Assert
+        Assert.Equal($"sign in with {Marker} today", Assert.Single(retrieval.Report.Passages).Text);
+    }
+
+    /// <summary>An opt-in nobody took must not appear on this path at all.</summary>
+    [Fact]
+    public async Task SearchTool_ADeploymentThatScansNothing_WritesTheExtractUntouched()
+    {
+        // Arrange
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch().Returning(
+            Query,
+            KnowledgePassages.Create($"sign in with {Marker} today"));
+
+        // Act
+        var envelope = await InvokeAsync(ToolOver(knowledgeSearch), OneQuery);
+
+        // Assert
+        Assert.Equal(
+            $"sign in with {Marker} today",
+            RootOf(envelope)
+                .Elements(RetrievedMailContextFormatter.MessageElementName)
+                .Single()
+                .Element(RetrievedMailContextFormatter.ExtractElementName)?.Value);
+    }
+
     private static Dictionary<string, object?> OneQuery =>
         new() { [ScopedMailKnowledgeRetrieval.QueryArgumentName] = Query };
 
@@ -241,7 +342,8 @@ public sealed class ScopedMailKnowledgeRetrievalTests
         new ScopedMailKnowledgeRetrieval(
             knowledgeSearch,
             OnePrimaryAccount,
-            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default)).CreateSearchTool();
+            new MailAnsweringRunLedger(MailAnsweringRunBounds.Default),
+            SensitiveContentEgressGuards.Inactive()).CreateSearchTool();
 
     /// <summary>Calls the tool the way the framework's tool loop does, and reads the document it answered with.</summary>
     /// <remarks>

--- a/tests/Application.UnitTests/Application.UnitTests.csproj
+++ b/tests/Application.UnitTests/Application.UnitTests.csproj
@@ -14,6 +14,12 @@
     <!-- The body text is the one mail-rule fact whose resolution costs a read, and both this project and
          Infrastructure.UnitTests prove a claim about how often it happens. -->
     <Compile Include="..\shared\RecordingMailRuleBodyTextReader.cs" Link="RecordingMailRuleBodyTextReader.cs" />
+    <!-- Every boundary holding a guarded egress point asserts the same three states of the guard, so the three are
+         built once and linked into each suite that has one. -->
+    <Compile Include="..\shared\MarkerSensitiveContentScanner.cs" Link="MarkerSensitiveContentScanner.cs" />
+    <Compile Include="..\shared\RecordingSensitiveContentEgressTelemetry.cs" Link="RecordingSensitiveContentEgressTelemetry.cs" />
+    <Compile Include="..\shared\SensitiveContentEgressGuards.cs" Link="SensitiveContentEgressGuards.cs" />
+    <Compile Include="..\shared\ScanningSensitiveContentEgress.cs" Link="ScanningSensitiveContentEgress.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Application.UnitTests/Emails/ListEmails/MailboxTimelineReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/ListEmails/MailboxTimelineReaderTests.cs
@@ -735,6 +735,37 @@ public sealed class MailboxTimelineReaderTests
             result.Emails.Select(summary => summary.Subject));
     }
 
+    /// <summary>
+    /// The name in front of an address is free text whoever sent the message chose, so it is scanned like the subject.
+    /// The address beside it is a routing identity a server issued and is left alone, because a reply has to reach it.
+    /// </summary>
+    [Fact]
+    public async Task ListEmailsAsync_ASwitchedOnScanner_RedactsTheSenderDisplayNameAndLeavesTheAddress()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        var timeline = new InMemoryStoredEmailTimeline().WithAll(
+        [
+            SyntheticEmailSummaries.Create(
+                FirstJuly,
+                subject: "an ordinary subject",
+                senderAddress: "sender@example.test") with
+            {
+                SenderDisplayName = $"deploy bot {Marker}",
+            },
+        ]);
+        var reader = ReaderOver(timeline, egressGuard: egress.Guard);
+
+        // Act
+        var result = await reader.ListEmailsAsync(new ListEmailsRequest(), TestContext.Current.CancellationToken);
+
+        // Assert
+        var published = Assert.Single(result.Emails);
+
+        Assert.Equal("deploy bot [redacted:CloudKey]", published.SenderDisplayName);
+        Assert.Equal("sender@example.test", published.SenderAddress);
+    }
+
     /// <summary>Serving a page a scanner could not read would be the leak the switch was turned on to prevent.</summary>
     [Fact]
     public async Task ListEmailsAsync_ADetectorThatCannotAnswer_RefusesTheListingRatherThanServingItUnscanned()

--- a/tests/Application.UnitTests/Emails/ListEmails/MailboxTimelineReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/ListEmails/MailboxTimelineReaderTests.cs
@@ -8,6 +8,8 @@ using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.ListEmails;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
@@ -22,6 +24,9 @@ namespace MailFathom.Application.UnitTests.Emails.ListEmails;
 /// <summary>Covers the mailbox listing use case: its filters, its bounds, and the keyset walk it issues cursors for.</summary>
 public sealed class MailboxTimelineReaderTests
 {
+    /// <summary>The literal the scanner in the guarded-egress tests reports, standing in for a credential in mail.</summary>
+    private const string Marker = "AKIAEXAMPLEKEY";
+
     private static readonly DateTimeOffset FirstJuly = new(2026, 7, 1, 8, 0, 0, TimeSpan.Zero);
 
     /// <summary>What the default catalog serves, so an unscoped request reaches every email a test arranged.</summary>
@@ -708,17 +713,72 @@ public sealed class MailboxTimelineReaderTests
         return visited;
     }
 
+    /// <summary>A page is one of the points mail content leaves the deployment, so the one text it carries is scanned first.</summary>
+    [Fact]
+    public async Task ListEmailsAsync_ASwitchedOnScanner_RedactsEverySubjectBeforeThePageIsPublished()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        var timeline = new InMemoryStoredEmailTimeline().WithAll(
+        [
+            SyntheticEmailSummaries.Create(FirstJuly, subject: $"the key is {Marker}"),
+            SyntheticEmailSummaries.Create(FirstJuly.AddDays(1), subject: "an ordinary subject"),
+        ]);
+        var reader = ReaderOver(timeline, egressGuard: egress.Guard);
+
+        // Act
+        var result = await reader.ListEmailsAsync(new ListEmailsRequest(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            ["an ordinary subject", "the key is [redacted:CloudKey]"],
+            result.Emails.Select(summary => summary.Subject));
+    }
+
+    /// <summary>Serving a page a scanner could not read would be the leak the switch was turned on to prevent.</summary>
+    [Fact]
+    public async Task ListEmailsAsync_ADetectorThatCannotAnswer_RefusesTheListingRatherThanServingItUnscanned()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Unavailable(TimeProvider.System);
+        var timeline = new InMemoryStoredEmailTimeline().WithAll(
+            [SyntheticEmailSummaries.Create(FirstJuly, subject: "an ordinary subject")]);
+        var reader = ReaderOver(timeline, egressGuard: egress.Guard);
+
+        // Act, Assert
+        await Assert.ThrowsAsync<SensitiveContentScannerUnavailableException>(() =>
+            reader.ListEmailsAsync(new ListEmailsRequest(), TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>An opt-in nobody took must not appear on this path at all.</summary>
+    [Fact]
+    public async Task ListEmailsAsync_ADeploymentThatScansNothing_PublishesThePageUntouched()
+    {
+        // Arrange
+        var timeline = new InMemoryStoredEmailTimeline().WithAll(
+            [SyntheticEmailSummaries.Create(FirstJuly, subject: $"the key is {Marker}")]);
+        var reader = ReaderOver(timeline);
+
+        // Act
+        var result = await reader.ListEmailsAsync(new ListEmailsRequest(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal($"the key is {Marker}", Assert.Single(result.Emails).Subject);
+    }
+
     private static MailboxTimelineReader ReaderOver(
         InMemoryStoredEmailTimeline timeline,
         IMailAccountCatalog? accountCatalog = null,
-        ISynchronizationFreshnessReader? freshnessReader = null) => new(
+        ISynchronizationFreshnessReader? freshnessReader = null,
+        SensitiveContentEgressGuard? egressGuard = null) => new(
         timeline,
         freshnessReader ?? FreshnessReaderReturning(InboxFreshness),
         new MailboxScopeResolver(
             accountCatalog ?? CatalogServing(EveryAccountTheSyntheticTimelineUses),
             StubMailFolderParticipation.Everything,
             StubJunkMailFolderCatalog.None,
-            StubMailFolderMappings.ResolvingNothing));
+            StubMailFolderMappings.ResolvingNothing),
+        egressGuard ?? SensitiveContentEgressGuards.Inactive());
 
     /// <summary>Builds a catalog that serves exactly the accounts named, in the order the port promises.</summary>
     private static IMailAccountCatalog CatalogServing(params MailAccountId[] servedAccountIds)

--- a/tests/Application.UnitTests/Emails/SearchEmails/MailboxSearchReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/SearchEmails/MailboxSearchReaderTests.cs
@@ -538,6 +538,35 @@ public sealed class MailboxSearchReaderTests
         Assert.Equal(["use [redacted:CloudKey] to sign in"], match.Snippets);
     }
 
+    /// <summary>
+    /// The name in front of an address is free text whoever sent the message chose, so it is scanned like the subject.
+    /// The address beside it is a routing identity a server issued and is left alone, because a reply has to reach it.
+    /// </summary>
+    [Fact]
+    public async Task SearchEmailsAsync_ASwitchedOnScanner_RedactsTheSenderDisplayNameAndLeavesTheAddress()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        var matched = SyntheticEmailSummaries.Create(
+            FirstJuly,
+            subject: "an ordinary subject",
+            senderAddress: "sender@example.test") with
+        {
+            SenderDisplayName = $"deploy bot {Marker}",
+        };
+        var index = new InMemoryEmailSearchIndex().With(matched, 0.9f, "invoice", "an ordinary extract");
+        var reader = ReaderOver(index, egressGuard: egress.Guard);
+
+        // Act
+        var result = await reader.SearchEmailsAsync(RequestFor("invoice"), TestContext.Current.CancellationToken);
+
+        // Assert
+        var published = Assert.Single(result.Matches).Summary;
+
+        Assert.Equal("deploy bot [redacted:CloudKey]", published.SenderDisplayName);
+        Assert.Equal("sender@example.test", published.SenderAddress);
+    }
+
     /// <summary>Serving a window a scanner could not read would be the leak the switch was turned on to prevent.</summary>
     [Fact]
     public async Task SearchEmailsAsync_ADetectorThatCannotAnswer_RefusesTheSearchRatherThanServingItUnscanned()

--- a/tests/Application.UnitTests/Emails/SearchEmails/MailboxSearchReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/SearchEmails/MailboxSearchReaderTests.cs
@@ -8,6 +8,8 @@ using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Emails.SearchEmails;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
@@ -22,6 +24,9 @@ namespace MailFathom.Application.UnitTests.Emails.SearchEmails;
 /// <summary>Covers the search use case: what it validates, how it ranks, how it orders, and what it bounds.</summary>
 public sealed class MailboxSearchReaderTests
 {
+    /// <summary>The literal the scanner in the guarded-egress tests reports, standing in for a credential in mail.</summary>
+    private const string Marker = "AKIAEXAMPLEKEY";
+
     private static readonly DateTimeOffset FirstJuly = new(2026, 7, 1, 8, 0, 0, TimeSpan.Zero);
 
     private static readonly DateTimeOffset SearchedAt = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
@@ -514,13 +519,66 @@ public sealed class MailboxSearchReaderTests
         Assert.Equal(SemanticSearchCapability.Available, result.SemanticSearch);
     }
 
+    /// <summary>A window is one of the points mail content leaves the deployment, so what it publishes is scanned first.</summary>
+    [Fact]
+    public async Task SearchEmailsAsync_ASwitchedOnScanner_RedactsTheSubjectAndTheSnippetsBeforeTheyArePublished()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        var matched = SyntheticEmailSummaries.Create(FirstJuly, subject: $"the key is {Marker}");
+        var index = new InMemoryEmailSearchIndex().With(matched, 0.9f, "invoice", $"use {Marker} to sign in");
+        var reader = ReaderOver(index, egressGuard: egress.Guard);
+
+        // Act
+        var result = await reader.SearchEmailsAsync(RequestFor("invoice"), TestContext.Current.CancellationToken);
+
+        // Assert
+        var match = Assert.Single(result.Matches);
+        Assert.Equal("the key is [redacted:CloudKey]", match.Summary.Subject);
+        Assert.Equal(["use [redacted:CloudKey] to sign in"], match.Snippets);
+    }
+
+    /// <summary>Serving a window a scanner could not read would be the leak the switch was turned on to prevent.</summary>
+    [Fact]
+    public async Task SearchEmailsAsync_ADetectorThatCannotAnswer_RefusesTheSearchRatherThanServingItUnscanned()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Unavailable(TimeProvider.System);
+        var index = new InMemoryEmailSearchIndex()
+            .With(SyntheticEmailSummaries.Create(FirstJuly, subject: "an ordinary subject"), 0.9f, "invoice");
+        var reader = ReaderOver(index, egressGuard: egress.Guard);
+
+        // Act, Assert
+        await Assert.ThrowsAsync<SensitiveContentScannerUnavailableException>(() =>
+            reader.SearchEmailsAsync(RequestFor("invoice"), TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>An opt-in nobody took must not appear on this path at all.</summary>
+    [Fact]
+    public async Task SearchEmailsAsync_ADeploymentThatScansNothing_PublishesTheWindowUntouched()
+    {
+        // Arrange
+        var matched = SyntheticEmailSummaries.Create(FirstJuly, subject: $"the key is {Marker}");
+        var index = new InMemoryEmailSearchIndex().With(matched, 0.9f, "invoice", $"use {Marker} to sign in");
+        var reader = ReaderOver(index);
+
+        // Act
+        var result = await reader.SearchEmailsAsync(RequestFor("invoice"), TestContext.Current.CancellationToken);
+
+        // Assert
+        var match = Assert.Single(result.Matches);
+        Assert.Equal($"the key is {Marker}", match.Summary.Subject);
+        Assert.Equal([$"use {Marker} to sign in"], match.Snippets);
+    }
+
     private static SearchEmailsRequest RequestFor(string? queryText) => new() { QueryText = queryText };
 
     private static MailboxSearchReader ReaderOver(
         InMemoryEmailSearchIndex index,
         IMailAccountCatalog? accountCatalog = null,
         EmailSearchSnippetBounds? snippetBounds = null,
-        SemanticEmailSearch? semanticSearch = null) => new(
+        SemanticEmailSearch? semanticSearch = null,
+        SensitiveContentEgressGuard? egressGuard = null) => new(
         index,
         semanticSearch ?? LexicalOnlySemanticSearch(),
         FreshnessReaderReturning(InboxFreshness),
@@ -529,7 +587,8 @@ public sealed class MailboxSearchReaderTests
             StubMailFolderParticipation.Everything,
             StubJunkMailFolderCatalog.None,
             StubMailFolderMappings.ResolvingNothing),
-        snippetBounds ?? EmailSearchSnippetBounds.Default);
+        snippetBounds ?? EmailSearchSnippetBounds.Default,
+        egressGuard ?? SensitiveContentEgressGuards.Inactive());
 
     /// <summary>Builds the semantic half of a deployment that configured no embedding provider and activated nothing.</summary>
     private static SemanticEmailSearch LexicalOnlySemanticSearch() => new(

--- a/tests/Application.UnitTests/Retrieval/AskMail/MailboxQuestionReaderTests.cs
+++ b/tests/Application.UnitTests/Retrieval/AskMail/MailboxQuestionReaderTests.cs
@@ -11,6 +11,8 @@ using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
 using MailFathom.Application.Retrieval.AskMail.Audit;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Answering.Audit;
@@ -32,6 +34,9 @@ namespace MailFathom.Application.UnitTests.Retrieval.AskMail;
 public sealed class MailboxQuestionReaderTests
 {
     private const string ServedAccountId = "personal";
+
+    /// <summary>The literal the scanner in the guarded-egress tests reports, standing in for a credential in mail.</summary>
+    private const string Marker = "AKIAEXAMPLEKEY";
 
     private static readonly DateTimeOffset Now = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
 
@@ -522,6 +527,69 @@ public sealed class MailboxQuestionReaderTests
         Assert.Empty(auditTrail.Runs);
     }
 
+    /// <summary>An answer is mail content restated, and it is the one text of a run nothing else has looked at.</summary>
+    [Fact]
+    public async Task AnswerQuestionAsync_ASwitchedOnScanner_RedactsTheAnswerBeforeItIsPublished()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        var answerer = new RecordingMailQuestionAnswerer().Answering($"they sent the key {Marker} on Tuesday");
+        var reader = ReaderOver(answerer, egressGuard: egress.Guard);
+
+        // Act
+        var result = await AnswerAsync(reader, new AskMailRequest { QuestionText = "what key did they send" });
+
+        // Assert
+        Assert.Equal("they sent the key [redacted:CloudKey] on Tuesday", result.AnswerText);
+    }
+
+    /// <summary>A citation carries one text of the message it names, and it is published to the caller like any other.</summary>
+    [Fact]
+    public async Task AnswerQuestionAsync_ASwitchedOnScanner_RedactsTheSubjectEveryCitationCarries()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        var answerer = new RecordingMailQuestionAnswerer().Answering(
+            "an answer",
+            PassageOf(1, "the extract") with { Subject = $"re: {Marker}" });
+        var reader = ReaderOver(answerer, egressGuard: egress.Guard);
+
+        // Act
+        var result = await AnswerAsync(reader, new AskMailRequest { QuestionText = "what key did they send" });
+
+        // Assert
+        Assert.Equal("re: [redacted:CloudKey]", Assert.Single(result.Citations).Subject);
+    }
+
+    /// <summary>Serving an answer a scanner could not read would be the leak the switch was turned on to prevent.</summary>
+    [Fact]
+    public async Task AnswerQuestionAsync_ADetectorThatCannotAnswer_RefusesTheResponseRatherThanServingItUnscanned()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Unavailable(TimeProvider.System);
+        var answerer = new RecordingMailQuestionAnswerer().Answering("an ordinary answer");
+        var reader = ReaderOver(answerer, egressGuard: egress.Guard);
+
+        // Act, Assert
+        await Assert.ThrowsAsync<SensitiveContentScannerUnavailableException>(() =>
+            AnswerAsync(reader, new AskMailRequest { QuestionText = "what was agreed" }));
+    }
+
+    /// <summary>An opt-in nobody took must not appear on this path at all.</summary>
+    [Fact]
+    public async Task AnswerQuestionAsync_ADeploymentThatScansNothing_PublishesTheAnswerUntouched()
+    {
+        // Arrange
+        var answerer = new RecordingMailQuestionAnswerer().Answering($"they sent the key {Marker} on Tuesday");
+        var reader = ReaderOver(answerer);
+
+        // Act
+        var result = await AnswerAsync(reader, new AskMailRequest { QuestionText = "what key did they send" });
+
+        // Assert
+        Assert.Equal($"they sent the key {Marker} on Tuesday", result.AnswerText);
+    }
+
     private static Task<AskMailResult> AnswerAsync(MailboxQuestionReader reader, AskMailRequest request) =>
         reader.AnswerQuestionAsync(request, TestContext.Current.CancellationToken);
 
@@ -544,7 +612,8 @@ public sealed class MailboxQuestionReaderTests
         MailAnswerBounds? bounds = null,
         IMailAnsweringSpendLedger? spendLedger = null,
         IMailAnsweringRunTelemetry? runTelemetry = null,
-        IMailAnsweringAuditTrail? auditTrail = null)
+        IMailAnsweringAuditTrail? auditTrail = null,
+        SensitiveContentEgressGuard? egressGuard = null)
     {
         var healthReader = Substitute.For<IAiProviderHealthReader>();
         healthReader.Read(AiProviderRole.Embedding)
@@ -586,7 +655,8 @@ public sealed class MailboxQuestionReaderTests
             bounds ?? MailAnswerBounds.Default,
             runTelemetry ?? new RecordingMailAnsweringRunTelemetry(),
             auditTrail ?? new RecordingMailAnsweringAuditTrail(),
-            timeProvider);
+            timeProvider,
+            egressGuard ?? SensitiveContentEgressGuards.Inactive());
     }
 
     /// <summary>A ledger with an allowance for whatever a test asks it.</summary>

--- a/tests/Application.UnitTests/Retrieval/AskMail/MailboxQuestionReaderTests.cs
+++ b/tests/Application.UnitTests/Retrieval/AskMail/MailboxQuestionReaderTests.cs
@@ -561,6 +561,27 @@ public sealed class MailboxQuestionReaderTests
         Assert.Equal("re: [redacted:CloudKey]", Assert.Single(result.Citations).Subject);
     }
 
+    /// <summary>A subject no response will publish is a scan nobody needs, and under the analyzer it is a round trip too.</summary>
+    [Fact]
+    public async Task AnswerQuestionAsync_MoreCitationsThanOneResponseNames_ScansOnlyTheOnesItPublishes()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, TimeProvider.System);
+        var answerer = new RecordingMailQuestionAnswerer().Answering(
+            "an answer",
+            [.. Enumerable.Range(1, 4).Select(position =>
+                PassageOf(position, "an extract") with { Subject = $"re: {position}" })]);
+        var reader = ReaderOver(answerer, bounds: MailAnswerBounds.Create(20_000, 2), egressGuard: egress.Guard);
+
+        // Act
+        var result = await AnswerAsync(reader, new AskMailRequest { QuestionText = "what was agreed" });
+
+        // Assert
+        Assert.Equal(2, result.Citations.Count);
+        Assert.True(result.CitationsWereTruncated);
+        Assert.Equal(["an answer", "re: 1", "re: 2"], egress.Scanner.ScannedTexts);
+    }
+
     /// <summary>Serving an answer a scanner could not read would be the leak the switch was turned on to prevent.</summary>
     [Fact]
     public async Task AnswerQuestionAsync_ADetectorThatCannotAnswer_RefusesTheResponseRatherThanServingItUnscanned()

--- a/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
+++ b/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
@@ -416,7 +416,8 @@ public sealed class MailboxKnowledgeSearchTests
                 StubMailFolderParticipation.Everything,
                 StubJunkMailFolderCatalog.None,
                 StubMailFolderMappings.ResolvingNothing),
-            EmailSearchSnippetBounds.Default),
+            EmailSearchSnippetBounds.Default,
+            SensitiveContentEgressGuards.Inactive()),
         bounds ?? EmailKnowledgeBounds.Default);
 
     /// <summary>Builds the semantic half of a deployment that configured no embedding provider and activated nothing.</summary>

--- a/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
+++ b/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Emails.SearchEmails;
 using MailFathom.Application.Retrieval;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
@@ -25,6 +26,10 @@ public sealed class MailboxKnowledgeSearchTests
 {
     /// <summary>Stands for a filter the selection carries no value for, so a null never reads as a failed comparison.</summary>
     private const string Absent = "-";
+
+    /// <summary>The literal the scanner in the guarded-egress tests reports, standing in for a credential in mail.</summary>
+    private const string Marker = "AKIAEXAMPLEKEY";
+
 
     private static readonly DateTimeOffset FirstJuly = new(2026, 7, 1, 8, 0, 0, TimeSpan.Zero);
 
@@ -404,9 +409,37 @@ public sealed class MailboxKnowledgeSearchTests
         Assert.Equal(inArchive.StoredEmailId, Assert.Single(passages).StoredEmailId);
     }
 
+    /// <summary>
+    /// This lookup answers an agent rather than an MCP caller, so the window it reads is deliberately unguarded: the
+    /// retrieval that sends these extracts to a model scans them there, under the egress point they actually cross.
+    /// Scanning here as well would cost a second scan of every extract and would count text against a series no MCP
+    /// caller ever sees.
+    /// </summary>
+    [Fact]
+    public async Task FindPassagesAsync_AScannerSwitchedOn_LeavesTheWindowToBeGuardedWhereItReachesAModel()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, new FakeTimeProvider(SearchedAt));
+        var matched = SyntheticEmailSummaries.Create(FirstJuly, subject: $"the key {Marker}");
+        var index = new InMemoryEmailSearchIndex().With(matched, snippets: $"the key is {Marker}");
+        var search = SearchOver(index, egressGuard: egress.Guard);
+
+        // Act
+        var passage = Assert.Single((await search.FindPassagesAsync(
+            EveryAccount,
+            EmailKnowledgeQuery.ForText("key"),
+            TestContext.Current.CancellationToken)).Passages);
+
+        // Assert
+        Assert.Contains(Marker, passage.Text, StringComparison.Ordinal);
+        Assert.Empty(egress.Telemetry.Guarded);
+        Assert.Empty(egress.Scanner.ScannedTexts);
+    }
+
     private static MailboxKnowledgeSearch SearchOver(
         InMemoryEmailSearchIndex index,
-        EmailKnowledgeBounds? bounds = null) => new(
+        EmailKnowledgeBounds? bounds = null,
+        SensitiveContentEgressGuard? egressGuard = null) => new(
         new MailboxSearchReader(
             index,
             LexicalOnlySemanticSearch(),
@@ -417,7 +450,7 @@ public sealed class MailboxKnowledgeSearchTests
                 StubJunkMailFolderCatalog.None,
                 StubMailFolderMappings.ResolvingNothing),
             EmailSearchSnippetBounds.Default,
-            SensitiveContentEgressGuards.Inactive()),
+            egressGuard ?? SensitiveContentEgressGuards.Inactive()),
         bounds ?? EmailKnowledgeBounds.Default);
 
     /// <summary>Builds the semantic half of a deployment that configured no embedding provider and activated nothing.</summary>

--- a/tests/Application.UnitTests/SensitiveContent/Egress/SensitiveContentEgressGuardTests.cs
+++ b/tests/Application.UnitTests/SensitiveContent/Egress/SensitiveContentEgressGuardTests.cs
@@ -1,0 +1,199 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.SensitiveContent.Egress;
+
+/// <summary>Covers the one thing every egress point calls before it hands text to somebody else.</summary>
+public sealed class SensitiveContentEgressGuardTests
+{
+    private const string Marker = "AKIAEXAMPLEKEY";
+
+    private readonly FakeTimeProvider timeProvider = new(new DateTimeOffset(2026, 8, 12, 9, 0, 0, TimeSpan.Zero));
+
+    [Fact]
+    public async Task GuardAsync_ADetectedValue_IsReplacedBeforeTheTextIsHandedOn()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, this.timeProvider);
+
+        // Act
+        var guarded = await egress.Guard.GuardAsync(
+            SensitiveContentEgressPoint.ChatPrompt,
+            $"the key is {Marker} and it works",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("the key is [redacted:CloudKey] and it works", guarded);
+    }
+
+    /// <summary>An opt-in nobody took must not appear on any path, so an inactive guard constructs nothing and scans nothing.</summary>
+    [Fact]
+    public async Task GuardAsync_ADeploymentThatScansNothing_HandsTheTextBackUnchanged()
+    {
+        // Arrange
+        var guard = SensitiveContentEgressGuards.Inactive();
+
+        // Act
+        var guarded = await guard.GuardAsync(
+            SensitiveContentEgressPoint.McpSnippet,
+            $"the key is {Marker}",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(guard.IsActive);
+        Assert.Equal($"the key is {Marker}", guarded);
+    }
+
+    /// <summary>An opt-in that degraded to handing the text on under load would be worse than no switch at all.</summary>
+    [Fact]
+    public async Task GuardAsync_ADetectorThatCannotAnswer_RefusesTheEgressRatherThanServingItUnscanned()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Unavailable(this.timeProvider);
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<SensitiveContentScannerUnavailableException>(() =>
+            egress.Guard.GuardAsync(
+                SensitiveContentEgressPoint.HostedEmbeddingInput,
+                "whatever the message said",
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(SensitiveContentScannerKind.Secrets, refusal.Scanner);
+        Assert.DoesNotContain("whatever the message said", refusal.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>A refusal an operator cannot see is a protection nobody can tell is in force.</summary>
+    [Fact]
+    public async Task GuardAsync_ADetectorThatCannotAnswer_ReportsTheRefusalAgainstTheEgressPoint()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Unavailable(this.timeProvider);
+
+        // Act
+        await Assert.ThrowsAsync<SensitiveContentScannerUnavailableException>(() =>
+            egress.Guard.GuardAsync(
+                SensitiveContentEgressPoint.HostedEmbeddingInput,
+                "whatever the message said",
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        var refused = Assert.Single(egress.Telemetry.Refused);
+        Assert.Equal(SensitiveContentEgressPoint.HostedEmbeddingInput, refused.EgressPoint);
+        Assert.Equal(SensitiveContentScannerKind.Secrets, refused.Scanner);
+        Assert.Empty(egress.Telemetry.Guarded);
+    }
+
+    /// <summary>The findings are what an operator splits by category, and none of them may carry what was found.</summary>
+    [Fact]
+    public async Task GuardAsync_ADetectedValue_ReportsTheFindingAgainstTheEgressPointAndItsCategory()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, this.timeProvider);
+
+        // Act
+        await egress.Guard.GuardAsync(
+            SensitiveContentEgressPoint.ChatPrompt,
+            $"{Marker} and {Marker}",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var guarded = Assert.Single(egress.Telemetry.Guarded);
+        Assert.Equal(SensitiveContentEgressPoint.ChatPrompt, guarded.EgressPoint);
+        Assert.Equal(
+            ["CloudKey", "CloudKey"],
+            guarded.Redacted.Findings.Select(finding => finding.Category.Name));
+    }
+
+    /// <summary>A publication is several values, and each is scanned on its own so no detection can straddle two of them.</summary>
+    [Fact]
+    public async Task GuardAllAsync_SeveralTexts_GuardsEachOneOnItsOwnAndKeepsTheOrder()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, this.timeProvider);
+
+        // Act
+        var guarded = await egress.Guard.GuardAllAsync(
+            SensitiveContentEgressPoint.McpSnippet,
+            [$"first {Marker}", "second", $"third {Marker}"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            ["first [redacted:CloudKey]", "second", "third [redacted:CloudKey]"],
+            guarded);
+        Assert.Equal([$"first {Marker}", "second", $"third {Marker}"], egress.Scanner.ScannedTexts);
+    }
+
+    [Fact]
+    public async Task GuardAllAsync_ADeploymentThatScansNothing_HandsTheTextsBackUnchanged()
+    {
+        // Arrange
+        var guard = SensitiveContentEgressGuards.Inactive();
+        IReadOnlyList<string> texts = [$"first {Marker}", "second"];
+
+        // Act
+        var guarded = await guard.GuardAllAsync(
+            SensitiveContentEgressPoint.McpSnippet,
+            texts,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(texts, guarded);
+    }
+
+    /// <summary>A subject nobody wrote and a subject redacted to nothing are different facts, and a reader acts differently on each.</summary>
+    [Fact]
+    public async Task GuardOptionalAsync_NoTextAtAll_StaysAbsentRatherThanBecomingEmpty()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, this.timeProvider);
+
+        // Act
+        var guarded = await egress.Guard.GuardOptionalAsync(
+            SensitiveContentEgressPoint.McpSnippet,
+            text: null,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(guarded);
+        Assert.Empty(egress.Scanner.ScannedTexts);
+    }
+
+    [Fact]
+    public async Task GuardOptionalAsync_ADetectedValue_IsReplacedBeforeTheTextIsHandedOn()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, this.timeProvider);
+
+        // Act
+        var guarded = await egress.Guard.GuardOptionalAsync(
+            SensitiveContentEgressPoint.McpSnippet,
+            $"re: {Marker}",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("re: [redacted:CloudKey]", guarded);
+    }
+
+    [Fact]
+    public async Task GuardAsync_NoText_IsRefusedAsAnArgument()
+    {
+        // Arrange
+        var guard = SensitiveContentEgressGuards.Inactive();
+
+        // Act, Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() => guard.GuardAsync(
+            SensitiveContentEgressPoint.ChatPrompt,
+            null!,
+            TestContext.Current.CancellationToken));
+    }
+}

--- a/tests/Infrastructure.UnitTests/Observability/SensitiveContentEgressTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/SensitiveContentEgressTelemetryTests.cs
@@ -1,0 +1,206 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using MailFathom.Application.SensitiveContent;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.Application.SensitiveContent.Redaction;
+using MailFathom.Common.Observability;
+using MailFathom.Infrastructure.Observability;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Observability;
+
+/// <summary>Covers what an operator reads to tell that a switched-on scanner is guarding anything.</summary>
+/// <remarks>
+/// Each test names an egress point of its own, because the instruments live on the application's one meter and a
+/// series is told apart by its tags rather than by which test published it.
+/// </remarks>
+public sealed class SensitiveContentEgressTelemetryTests
+{
+    private const string GuardedInstrumentName = "mailfathom.sensitive_content.guarded";
+    private const string FindingsInstrumentName = "mailfathom.sensitive_content.findings";
+    private const string OmittedInstrumentName = "mailfathom.sensitive_content.omitted";
+    private const string RefusalsInstrumentName = "mailfathom.sensitive_content.refusals";
+    private const string DurationInstrumentName = "mailfathom.sensitive_content.scan.duration";
+
+    private const string EgressPointTagName = "mailfathom.sensitive_content.egress_point";
+    private const string CategoryTagName = "mailfathom.sensitive_content.category";
+    private const string ScannerTagName = "mailfathom.sensitive_content.scanner";
+
+    private static readonly DateTimeOffset DetectedAt = new(2026, 8, 12, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly SensitiveContentEgressTelemetry telemetry = new();
+
+    /// <summary>What a scan cost and how much of it there was are the two series a bound is changed from.</summary>
+    [Fact]
+    public void RecordGuarded_AScannedText_CountsItAndTimesItAgainstItsEgressPoint()
+    {
+        // Arrange
+        using var collector = new MeasurementCollector();
+
+        // Act
+        this.telemetry.RecordGuarded(
+            SensitiveContentEgressPoint.McpSnippet,
+            RedactedText.Create("nothing here", [], omittedCharacterCount: 0),
+            TimeSpan.FromMilliseconds(250));
+
+        // Assert
+        var guarded = Assert.Single(collector.Read(GuardedInstrumentName, "mcp_snippet"));
+        var duration = Assert.Single(collector.Read(DurationInstrumentName, "mcp_snippet"));
+
+        Assert.Equal(1, guarded.Value);
+        Assert.Equal(0.25, duration.Value);
+    }
+
+    /// <summary>Which kind of material a mailbox produces is what decides whether a category list is right.</summary>
+    [Fact]
+    public void RecordGuarded_FindingsOfSeveralCategories_CountsEachCategoryOnItsOwnSeries()
+    {
+        // Arrange
+        using var collector = new MeasurementCollector();
+
+        // Act
+        this.telemetry.RecordGuarded(
+            SensitiveContentEgressPoint.ChatPrompt,
+            RedactedText.Create(
+                "[redacted:CloudKey] and [redacted:CloudKey] and [redacted:EmailAddress]",
+                [
+                    FindingOf("CloudKey", start: 0),
+                    FindingOf("CloudKey", start: 24),
+                    FindingOf("EmailAddress", start: 48),
+                ],
+                omittedCharacterCount: 0),
+            TimeSpan.FromMilliseconds(10));
+
+        // Assert
+        var findings = collector.Read(FindingsInstrumentName, "chat_prompt");
+
+        Assert.Equal(
+            [("CloudKey", 2d), ("EmailAddress", 1d)],
+            findings.Select(finding => (finding.Tags[CategoryTagName] as string, finding.Value)).Order());
+    }
+
+    /// <summary>A zero on every guarded text would make the series say the ceiling is in play on ordinary mail.</summary>
+    [Fact]
+    public void RecordGuarded_ATextTheCeilingDidNotCut_ReportsNoOmission()
+    {
+        // Arrange
+        using var collector = new MeasurementCollector();
+
+        // Act
+        this.telemetry.RecordGuarded(
+            SensitiveContentEgressPoint.HostedEmbeddingInput,
+            RedactedText.Create("nothing here", [], omittedCharacterCount: 0),
+            TimeSpan.FromMilliseconds(10));
+
+        // Assert
+        Assert.Empty(collector.Read(OmittedInstrumentName, "hosted_embedding_input"));
+    }
+
+    /// <summary>Text nothing analyzed is exactly the text that must not leave, so an operator is told how much of it there was.</summary>
+    [Fact]
+    public void RecordGuarded_ATextTheCeilingCut_ReportsHowMuchWasDropped()
+    {
+        // Arrange
+        using var collector = new MeasurementCollector();
+
+        // Act
+        this.telemetry.RecordGuarded(
+            SensitiveContentEgressPoint.McpSnippet,
+            RedactedText.Create("as far as the ceiling reached", [], omittedCharacterCount: 4096),
+            TimeSpan.FromMilliseconds(10));
+
+        // Assert
+        var omitted = Assert.Single(collector.Read(OmittedInstrumentName, "mcp_snippet"));
+
+        Assert.Equal(4096, omitted.Value);
+    }
+
+    /// <summary>A refusal an operator cannot see is a protection nobody can tell is in force.</summary>
+    [Theory]
+    [InlineData(nameof(SensitiveContentScannerKind.Secrets), "secrets")]
+    [InlineData(nameof(SensitiveContentScannerKind.Pii), "pii")]
+    public void RecordRefused_AScannerThatCouldNotAnswer_CountsTheRefusalAgainstThatScanner(
+        string scannerName,
+        string expectedTag)
+    {
+        // Arrange
+        using var collector = new MeasurementCollector();
+        var scanner = Enum.Parse<SensitiveContentScannerKind>(scannerName);
+
+        // Act
+        this.telemetry.RecordRefused(SensitiveContentEgressPoint.ChatPrompt, scanner);
+
+        // Assert
+        var refusal = Assert.Single(
+            collector.Read(RefusalsInstrumentName, "chat_prompt"),
+            measurement => Equals(measurement.Tags[ScannerTagName], expectedTag));
+
+        Assert.Equal(1, refusal.Value);
+    }
+
+    private static SensitiveContentFinding FindingOf(string category, int start) =>
+        SensitiveContentFinding.Create(
+            SensitiveContentRule.Create(SensitiveContentCategory.Create(category), $"{category}-rule"),
+            SensitiveContentSpan.Create(start, length: 8),
+            confidence: 1,
+            SensitiveContentDetector.Create("test", "1"),
+            DetectedAt);
+
+    /// <summary>Reads what the counters and the histogram on MailFathom's own meter published.</summary>
+    private sealed class MeasurementCollector : IDisposable
+    {
+        private readonly MeterListener listener = new();
+
+        // Concurrent because the listener is enabled for every instrument on MailFathom's one meter, so any other test
+        // class publishing to it writes here while this one reads — which a plain list reports as a modified collection.
+        private readonly ConcurrentQueue<PublishedMeasurement> measurements = [];
+
+        internal MeasurementCollector()
+        {
+            this.listener.InstrumentPublished = (instrument, activeListener) =>
+            {
+                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
+                {
+                    activeListener.EnableMeasurementEvents(instrument);
+                }
+            };
+            this.listener.SetMeasurementEventCallback<long>(this.Record);
+            this.listener.SetMeasurementEventCallback<double>(this.Record);
+            this.listener.Start();
+        }
+
+        public void Dispose() => this.listener.Dispose();
+
+        /// <summary>Returns what one instrument published for one egress point, in order.</summary>
+        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName, string egressPoint) =>
+            [
+                .. this.measurements.ToArray().Where(measurement =>
+                    StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)
+                    && measurement.Tags.TryGetValue(EgressPointTagName, out var point)
+                    && Equals(point, egressPoint)),
+            ];
+
+        private void Record<TMeasurement>(
+            Instrument instrument,
+            TMeasurement measurement,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags,
+            object? state)
+            where TMeasurement : struct =>
+            this.measurements.Enqueue(new PublishedMeasurement(
+                instrument.Name,
+                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
+                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
+    }
+
+    /// <summary>One measurement an instrument published, with the dimensions it carried.</summary>
+    private sealed record PublishedMeasurement(
+        string InstrumentName,
+        double Value,
+        IReadOnlyDictionary<string, object?> Tags);
+}

--- a/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -10,6 +10,8 @@ using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
 using MailFathom.Application.SensitiveContent;
 using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.Application.SensitiveContent.Redaction;
 using MailFathom.Infrastructure.Persistence;
 using MailFathom.Infrastructure.Persistence.Connections;
 using MailFathom.Infrastructure.Secrets.Resolution;
@@ -258,6 +260,60 @@ public sealed class ServiceCollectionExtensionsTests
         // The answering agent belongs to the AI boundary and arrives only where a chat endpoint was declared, which is
         // what the capability above resolves optionally rather than requires.
         Assert.DoesNotContain(services, descriptor => descriptor.ServiceType == typeof(IMailQuestionAnswerer));
+    }
+
+    /// <summary>
+    /// The guard every egress point calls is registered whatever a deployment configured, so no consumer of it carries
+    /// a null check or a second code path. With both scanner switches off there is no redactor to resolve, and the
+    /// guard has to come back inert rather than fail to compose the readers that take it.
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_WithoutAScanner_StillResolvesAnEgressGuardThatScansNothing()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(TimeProvider.System);
+
+        // Act
+        services.AddInfrastructure(
+            _ => new PostgresConnectionSettings("Host=localhost;Database=mailfathom", null, null),
+            PostgresTextSearchConfiguration.Default,
+            MailAnsweringBudget.Default);
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+
+        Assert.False(provider.GetRequiredService<SensitiveContentEgressGuard>().IsActive);
+    }
+
+    /// <summary>The other half: a deployment that switched a scanner on gets a guard that redacts through it.</summary>
+    [Fact]
+    public void AddInfrastructure_WithARedactor_ResolvesAnEgressGuardThatScansThroughIt()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton(SensitiveContentPlan.Create(
+            SensitiveContentScanBounds.Default,
+            [
+                SensitiveContentScannerPlan.Create(
+                    SensitiveContentScannerKind.Secrets,
+                    [SensitiveContentCategory.Create("ProviderToken")],
+                    []),
+            ])!);
+        services.AddSingleton<SensitiveContentRedactor>();
+        services.AddSecretContentScanning();
+
+        // Act
+        services.AddInfrastructure(
+            _ => new PostgresConnectionSettings("Host=localhost;Database=mailfathom", null, null),
+            PostgresTextSearchConfiguration.Default,
+            MailAnsweringBudget.Default);
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+
+        Assert.True(provider.GetRequiredService<SensitiveContentEgressGuard>().IsActive);
     }
 
     /// <summary>

--- a/tests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/IntegrationTests/IntegrationTests.csproj
@@ -30,6 +30,11 @@
     <Compile Include="..\shared\TestCertificates.cs" Link="TestCertificates.cs" />
     <Compile Include="..\shared\SyntheticServedAccount.cs" Link="SyntheticServedAccount.cs" />
     <Compile Include="..\shared\StubMailFolderMappings.cs" Link="StubMailFolderMappings.cs" />
+    <!-- The provider contract tests compose the adapters by hand, so they build the guard those adapters take. -->
+    <Compile Include="..\shared\MarkerSensitiveContentScanner.cs" Link="MarkerSensitiveContentScanner.cs" />
+    <Compile Include="..\shared\RecordingSensitiveContentEgressTelemetry.cs" Link="RecordingSensitiveContentEgressTelemetry.cs" />
+    <Compile Include="..\shared\SensitiveContentEgressGuards.cs" Link="SensitiveContentEgressGuards.cs" />
+    <Compile Include="..\shared\ScanningSensitiveContentEgress.cs" Link="ScanningSensitiveContentEgress.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/IntegrationTests/Orchestration/ComposedMailQuestionAnswerer.cs
+++ b/tests/IntegrationTests/Orchestration/ComposedMailQuestionAnswerer.cs
@@ -8,6 +8,7 @@ using MailFathom.AI.Retrieval;
 using MailFathom.Application.Chat;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -46,7 +47,11 @@ internal sealed class ComposedMailQuestionAnswerer(
         observation.RecordComposition(plan.Endpoint.Alias, MailAnsweringInstructions.Version);
 
         var runLedger = new MailAnsweringRunLedger(runBounds);
-        var retrieval = new ScopedMailKnowledgeRetrieval(knowledgeSearch, question.Scope, runLedger);
+        var retrieval = new ScopedMailKnowledgeRetrieval(
+            knowledgeSearch,
+            question.Scope,
+            runLedger,
+            SensitiveContentEgressGuards.Inactive());
 
         try
         {

--- a/tests/IntegrationTests/ProviderAdapters/ChatProviderContractTests.cs
+++ b/tests/IntegrationTests/ProviderAdapters/ChatProviderContractTests.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.AiProviders;
 using MailFathom.Application.Chat;
 using MailFathom.Application.Resilience;
 using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -172,6 +173,7 @@ public sealed class ChatProviderContractTests
             composition.GetRequiredService<IHttpClientFactory>(),
             new PassThroughOutboundOperationRunner(),
             composition.GetRequiredService<IAiProviderHealthRecorder>(),
+            SensitiveContentEgressGuards.Inactive(),
             NullLogger<ProviderChatModelClient>.Instance);
 
     private sealed class FixedChatCredentialSource(string apiKey) : IProviderEndpointCredentialSource

--- a/tests/IntegrationTests/ProviderAdapters/EmbeddingProviderContractTests.cs
+++ b/tests/IntegrationTests/ProviderAdapters/EmbeddingProviderContractTests.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.AiProviders;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Resilience;
 using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -152,6 +153,7 @@ public sealed class EmbeddingProviderContractTests
             composition.GetRequiredService<IHttpClientFactory>(),
             new PassThroughOutboundOperationRunner(),
             composition.GetRequiredService<IAiProviderHealthRecorder>(),
+            SensitiveContentEgressGuards.Inactive(),
             NullLogger<ProviderTextEmbeddingGenerator>.Instance);
 
     private sealed class FixedEmbeddingCredentialSource(string apiKey) : IProviderEndpointCredentialSource

--- a/tests/Mcp.UnitTests/Mcp.UnitTests.csproj
+++ b/tests/Mcp.UnitTests/Mcp.UnitTests.csproj
@@ -14,6 +14,12 @@
     <Compile Include="..\shared\StubJunkMailFolderCatalog.cs" Link="StubJunkMailFolderCatalog.cs" />
     <Compile Include="..\shared\StubMailFolderMappings.cs" Link="StubMailFolderMappings.cs" />
     <Compile Include="..\shared\SyntheticServedAccount.cs" Link="SyntheticServedAccount.cs" />
+    <!-- Every boundary holding a guarded egress point asserts the same three states of the guard, so the three are
+         built once and linked into each suite that has one. -->
+    <Compile Include="..\shared\MarkerSensitiveContentScanner.cs" Link="MarkerSensitiveContentScanner.cs" />
+    <Compile Include="..\shared\RecordingSensitiveContentEgressTelemetry.cs" Link="RecordingSensitiveContentEgressTelemetry.cs" />
+    <Compile Include="..\shared\SensitiveContentEgressGuards.cs" Link="SensitiveContentEgressGuards.cs" />
+    <Compile Include="..\shared\ScanningSensitiveContentEgress.cs" Link="ScanningSensitiveContentEgress.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mcp.UnitTests/TestDoubles/AnsweringDeployment.cs
+++ b/tests/Mcp.UnitTests/TestDoubles/AnsweringDeployment.cs
@@ -10,6 +10,7 @@ using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
 using MailFathom.Application.Retrieval.AskMail.Audit;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
@@ -67,11 +68,13 @@ internal static class AnsweringDeployment
     /// <param name="answerer">The answering port, or <see langword="null" /> for a deployment that declared no chat endpoint.</param>
     /// <param name="bounds">How much of one run's outcome a single answer publishes.</param>
     /// <param name="spendLedger">What the current period may still spend, or <see langword="null" /> for one that admits every question.</param>
+    /// <param name="egressGuard">The guard the answer passes through, or <see langword="null" /> for a deployment that scans nothing.</param>
     /// <returns>The use case.</returns>
     public static MailboxQuestionReader QuestionReader(
         IMailQuestionAnswerer? answerer,
         MailAnswerBounds? bounds = null,
-        IMailAnsweringSpendLedger? spendLedger = null)
+        IMailAnsweringSpendLedger? spendLedger = null,
+        SensitiveContentEgressGuard? egressGuard = null)
     {
         return new MailboxQuestionReader(
             Capability(answerer),
@@ -87,7 +90,8 @@ internal static class AnsweringDeployment
             // and what it records are the use case's own contract, asserted where that contract lives.
             Substitute.For<IMailAnsweringRunTelemetry>(),
             Substitute.For<IMailAnsweringAuditTrail>(),
-            new FakeTimeProvider(Now));
+            new FakeTimeProvider(Now),
+            egressGuard ?? SensitiveContentEgressGuards.Inactive());
     }
 
     /// <summary>Builds a ledger with an allowance for whatever a test asks it.</summary>

--- a/tests/Mcp.UnitTests/Tools/ListEmailsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/ListEmailsToolTests.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Emails.ListEmails;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
@@ -629,14 +630,16 @@ public sealed class ListEmailsToolTests
     private static ListEmailsTool ToolOver(
         StubStoredEmailTimelineReader timeline,
         StubSynchronizationFreshnessReader? freshness = null,
-        StubJunkMailFolderCatalog? junkFolders = null) =>
-        ToolMapping(StubMailFolderMappings.Nothing, timeline, freshness, junkFolders);
+        StubJunkMailFolderCatalog? junkFolders = null,
+        SensitiveContentEgressGuard? egressGuard = null) =>
+        ToolMapping(StubMailFolderMappings.Nothing, timeline, freshness, junkFolders, egressGuard);
 
     private static ListEmailsTool ToolMapping(
         StubMailFolderMappings folderMappings,
         StubStoredEmailTimelineReader timeline,
         StubSynchronizationFreshnessReader? freshness = null,
-        StubJunkMailFolderCatalog? junkFolders = null) => new(
+        StubJunkMailFolderCatalog? junkFolders = null,
+        SensitiveContentEgressGuard? egressGuard = null) => new(
         new MailboxTimelineReader(
             timeline,
             freshness ?? new StubSynchronizationFreshnessReader(),
@@ -644,6 +647,7 @@ public sealed class ListEmailsToolTests
                 new StubMailAccountCatalog(ServedAccountId),
                 StubMailFolderParticipation.Everything,
                 junkFolders ?? StubJunkMailFolderCatalog.None,
-                folderMappings.Resolver)),
+                folderMappings.Resolver),
+            egressGuard ?? SensitiveContentEgressGuards.Inactive()),
         new StubMailAccountCatalog(ServedAccountId));
 }

--- a/tests/Mcp.UnitTests/Tools/SearchEmailsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/SearchEmailsToolTests.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Emails.SearchEmails;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
@@ -569,7 +570,8 @@ public sealed class SearchEmailsToolTests
         StubEmailSearchIndexReader index,
         StubSynchronizationFreshnessReader? freshness = null,
         EmailSearchSnippetBounds? snippetBounds = null,
-        StubJunkMailFolderCatalog? junkFolders = null)
+        StubJunkMailFolderCatalog? junkFolders = null,
+        SensitiveContentEgressGuard? egressGuard = null)
     {
         // One instance for both, as the host composes them: the use case asks the index to cut extracts by these bounds
         // and the boundary publishes what came back under the same ones.
@@ -585,7 +587,8 @@ public sealed class SearchEmailsToolTests
                     StubMailFolderParticipation.Everything,
                     junkFolders ?? StubJunkMailFolderCatalog.None,
                     StubMailFolderMappings.ResolvingNothing),
-                bounds),
+                bounds,
+                egressGuard ?? SensitiveContentEgressGuards.Inactive()),
             bounds,
             new StubMailAccountCatalog(ServedAccountId));
     }

--- a/tests/SharedSources.UnitTests/MarkerSensitiveContentScannerTests.cs
+++ b/tests/SharedSources.UnitTests/MarkerSensitiveContentScannerTests.cs
@@ -1,0 +1,116 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.SharedSources.UnitTests;
+
+/// <summary>Covers the detector every guarded-egress test puts a "credential" through.</summary>
+public sealed class MarkerSensitiveContentScannerTests
+{
+    private const string Marker = "AKIAEXAMPLEKEY";
+
+    private static readonly DateTimeOffset ScannedAt = new(2026, 8, 12, 9, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task ScanAsync_TextCarryingTheMarkerTwice_ReportsBothOccurrencesWhereTheyAre()
+    {
+        // Arrange
+        var scanner = ScannerOver(Marker);
+
+        // Act
+        var findings = await scanner.ScanAsync(
+            $"{Marker} and then {Marker}",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            [(0, Marker.Length), (Marker.Length + 10, Marker.Length)],
+            findings.Select(finding => (finding.Span.Start, finding.Span.Length)));
+        Assert.All(findings, finding => Assert.Equal("CloudKey", finding.Category.Name));
+    }
+
+    [Fact]
+    public async Task ScanAsync_TextCarryingNothingTheScannerKnows_ReportsNoFinding()
+    {
+        // Arrange
+        var scanner = ScannerOver(Marker);
+
+        // Act
+        var findings = await scanner.ScanAsync("nothing here", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(findings);
+    }
+
+    /// <summary>Every text a guard handed on is recorded, which is how a test proves a value was scanned on its own.</summary>
+    [Fact]
+    public async Task ScanAsync_SeveralTexts_RecordsEachOneInTheOrderItArrived()
+    {
+        // Arrange
+        var scanner = ScannerOver(Marker);
+
+        // Act
+        await scanner.ScanAsync("first", TestContext.Current.CancellationToken);
+        await scanner.ScanAsync("second", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(["first", "second"], scanner.ScannedTexts);
+    }
+
+    /// <summary>The failure is what makes this scanner the one thing a fail-closed test needs.</summary>
+    [Fact]
+    public async Task ScanAsync_AScannerGivenAFailure_RaisesItInsteadOfAnswering()
+    {
+        // Arrange
+        var scanner = ScannerOver(Marker);
+        scanner.Failure = new InvalidOperationException("The detector is not answering.");
+
+        // Act, Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            scanner.ScanAsync(Marker, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ScanAsync_ACallerThatCancelled_StopsBeforeItScans()
+    {
+        // Arrange
+        var scanner = ScannerOver(Marker);
+        using var cancellation = new CancellationTokenSource();
+
+        await cancellation.CancelAsync();
+
+        // Act, Assert
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => scanner.ScanAsync(Marker, cancellation.Token));
+        Assert.Empty(scanner.ScannedTexts);
+    }
+
+    [Fact]
+    public void Constructor_NoMarkerToLookFor_IsRefusedAsAnArgument() =>
+
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() => ScannerOver(string.Empty));
+
+    /// <summary>Which switch a scanner answers for is what a refusal names, so it is carried rather than assumed.</summary>
+    [Theory]
+    [InlineData(nameof(SensitiveContentScannerKind.Secrets))]
+    [InlineData(nameof(SensitiveContentScannerKind.Pii))]
+    public void Scanner_TheKindItWasBuiltFor_IsWhatItReports(string scannerName)
+    {
+        // Arrange
+        var expected = Enum.Parse<SensitiveContentScannerKind>(scannerName);
+
+        // Act
+        var scanner = new MarkerSensitiveContentScanner(Marker, expected, TimeProvider.System);
+
+        // Assert
+        Assert.Equal(expected, scanner.Scanner);
+    }
+
+    private static MarkerSensitiveContentScanner ScannerOver(string marker) =>
+        new(marker, SensitiveContentScannerKind.Secrets, new FakeTimeProvider(ScannedAt));
+}

--- a/tests/SharedSources.UnitTests/RecordingSensitiveContentEgressTelemetryTests.cs
+++ b/tests/SharedSources.UnitTests/RecordingSensitiveContentEgressTelemetryTests.cs
@@ -1,0 +1,67 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent;
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.Application.SensitiveContent.Redaction;
+using MailFathom.TestSupport;
+using Xunit;
+
+namespace MailFathom.SharedSources.UnitTests;
+
+/// <summary>Covers the recorder every guarded-egress test reads its assertions out of.</summary>
+public sealed class RecordingSensitiveContentEgressTelemetryTests
+{
+    [Fact]
+    public void RecordGuarded_SeveralGuardedTexts_AreKeptInTheOrderTheGuardsRan()
+    {
+        // Arrange
+        var telemetry = new RecordingSensitiveContentEgressTelemetry();
+        var redacted = RedactedText.Create("nothing here", [], omittedCharacterCount: 0);
+
+        // Act
+        telemetry.RecordGuarded(SensitiveContentEgressPoint.ChatPrompt, redacted, TimeSpan.FromMilliseconds(5));
+        telemetry.RecordGuarded(SensitiveContentEgressPoint.McpSnippet, redacted, TimeSpan.FromMilliseconds(9));
+
+        // Assert
+        Assert.Equal(
+            [
+                (SensitiveContentEgressPoint.ChatPrompt, TimeSpan.FromMilliseconds(5)),
+                (SensitiveContentEgressPoint.McpSnippet, TimeSpan.FromMilliseconds(9)),
+            ],
+            telemetry.Guarded.Select(guarded => (guarded.EgressPoint, guarded.Elapsed)));
+        Assert.All(telemetry.Guarded, guarded => Assert.Same(redacted, guarded.Redacted));
+    }
+
+    [Fact]
+    public void RecordRefused_SeveralRefusals_AreKeptInTheOrderTheyHappened()
+    {
+        // Arrange
+        var telemetry = new RecordingSensitiveContentEgressTelemetry();
+
+        // Act
+        telemetry.RecordRefused(SensitiveContentEgressPoint.HostedEmbeddingInput, SensitiveContentScannerKind.Secrets);
+        telemetry.RecordRefused(SensitiveContentEgressPoint.ChatPrompt, SensitiveContentScannerKind.Pii);
+
+        // Assert
+        Assert.Equal(
+            [
+                (SensitiveContentEgressPoint.HostedEmbeddingInput, SensitiveContentScannerKind.Secrets),
+                (SensitiveContentEgressPoint.ChatPrompt, SensitiveContentScannerKind.Pii),
+            ],
+            telemetry.Refused.Select(refused => (refused.EgressPoint, refused.Scanner)));
+        Assert.Empty(telemetry.Guarded);
+    }
+
+    [Fact]
+    public void RecordGuarded_NoRedaction_IsRefusedAsAnArgument()
+    {
+        // Arrange
+        var telemetry = new RecordingSensitiveContentEgressTelemetry();
+
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            telemetry.RecordGuarded(SensitiveContentEgressPoint.ChatPrompt, null!, TimeSpan.Zero));
+    }
+}

--- a/tests/SharedSources.UnitTests/ScanningSensitiveContentEgressTests.cs
+++ b/tests/SharedSources.UnitTests/ScanningSensitiveContentEgressTests.cs
@@ -1,0 +1,92 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent;
+using MailFathom.Application.SensitiveContent.Detection;
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.SharedSources.UnitTests;
+
+/// <summary>Covers the switched-on deployment every guarded egress point is exercised against.</summary>
+public sealed class ScanningSensitiveContentEgressTests
+{
+    private const string Marker = "AKIAEXAMPLEKEY";
+
+    private readonly FakeTimeProvider timeProvider = new(new DateTimeOffset(2026, 8, 12, 9, 0, 0, TimeSpan.Zero));
+
+    [Fact]
+    public async Task Finding_ADeploymentThatDetectsTheMarker_ReplacesItAndReportsWhatItFound()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Finding(Marker, this.timeProvider);
+
+        // Act
+        var guarded = await egress.Guard.GuardAsync(
+            SensitiveContentEgressPoint.ChatPrompt,
+            $"the key is {Marker}",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(egress.Guard.IsActive);
+        Assert.Equal("the key is [redacted:CloudKey]", guarded);
+        Assert.Equal([$"the key is {Marker}"], egress.Scanner.ScannedTexts);
+
+        var recorded = Assert.Single(egress.Telemetry.Guarded);
+
+        Assert.Equal(SensitiveContentEgressPoint.ChatPrompt, recorded.EgressPoint);
+    }
+
+    [Fact]
+    public async Task Unavailable_ADeploymentWhoseDetectorCannotAnswer_RefusesEveryTextItIsHanded()
+    {
+        // Arrange
+        using var egress = ScanningSensitiveContentEgress.Unavailable(this.timeProvider);
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<SensitiveContentScannerUnavailableException>(() =>
+            egress.Guard.GuardAsync(
+                SensitiveContentEgressPoint.McpSnippet,
+                "whatever the message said",
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(SensitiveContentScannerKind.Secrets, refusal.Scanner);
+        Assert.Equal(
+            [SensitiveContentEgressPoint.McpSnippet],
+            egress.Telemetry.Refused.Select(recorded => recorded.EgressPoint));
+    }
+
+    /// <summary>The redactor holds a deployment's concurrency permits, so the holder releases it rather than the test.</summary>
+    [Fact]
+    public async Task Dispose_ADeploymentATestFinishedWith_ReleasesTheRedactionItHeld()
+    {
+        // Arrange
+        var egress = ScanningSensitiveContentEgress.Finding(Marker, this.timeProvider);
+
+        // Act
+        egress.Dispose();
+
+        // Assert
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            egress.Guard.GuardAsync(
+                SensitiveContentEgressPoint.ChatPrompt,
+                Marker,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void Finding_NoClock_IsRefusedAsAnArgument() =>
+
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => ScanningSensitiveContentEgress.Finding(Marker, null!));
+
+    [Fact]
+    public void Unavailable_NoClock_IsRefusedAsAnArgument() =>
+
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => ScanningSensitiveContentEgress.Unavailable(null!));
+}

--- a/tests/SharedSources.UnitTests/SensitiveContentEgressGuardsTests.cs
+++ b/tests/SharedSources.UnitTests/SensitiveContentEgressGuardsTests.cs
@@ -1,0 +1,45 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.TestSupport;
+using Xunit;
+
+namespace MailFathom.SharedSources.UnitTests;
+
+/// <summary>Covers the guard a consumer of an egress point meets when both switches are off.</summary>
+public sealed class SensitiveContentEgressGuardsTests
+{
+    private const string Marker = "AKIAEXAMPLEKEY";
+
+    /// <summary>A deployment with both switches off has no redactor at all, which is what a consumer must see.</summary>
+    [Fact]
+    public async Task Inactive_ADeploymentWithBothSwitchesOff_GuardsNothingAndReportsItself()
+    {
+        // Arrange
+        var guard = SensitiveContentEgressGuards.Inactive();
+
+        // Act
+        var guarded = await guard.GuardAsync(
+            SensitiveContentEgressPoint.McpSnippet,
+            $"the key is {Marker}",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(guard.IsActive);
+        Assert.Equal($"the key is {Marker}", guarded);
+    }
+
+    /// <summary>Each call builds its own, so a suite reusing the helper cannot leak one test's recorder into another's.</summary>
+    [Fact]
+    public void Inactive_CalledTwice_BuildsTwoGuards()
+    {
+        // Act
+        var first = SensitiveContentEgressGuards.Inactive();
+        var second = SensitiveContentEgressGuards.Inactive();
+
+        // Assert
+        Assert.NotSame(first, second);
+    }
+}

--- a/tests/SharedSources.UnitTests/SharedSources.UnitTests.csproj
+++ b/tests/SharedSources.UnitTests/SharedSources.UnitTests.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>
 

--- a/tests/SharedSources.UnitTests/packages.lock.json
+++ b/tests/SharedSources.UnitTests/packages.lock.json
@@ -35,6 +35,12 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[10.8.0, )",
+        "resolved": "10.8.0",
+        "contentHash": "xXcxGfXSO/8o7IfYK36r3eZTl9RMKAl5K6x3x6o/QQBolI0t8vsLIGmhc3HJBTd11u1uPLHz61VnOTSTmY7ZVA=="
+      },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Direct",
         "requested": "[17.14.15, )",

--- a/tests/shared/MarkerSensitiveContentScanner.cs
+++ b/tests/shared/MarkerSensitiveContentScanner.cs
@@ -1,0 +1,98 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent;
+using MailFathom.Application.SensitiveContent.Detection;
+
+namespace MailFathom.TestSupport;
+
+/// <summary>A detector that finds one literal, so a test can put a "credential" in mail and watch where it stops.</summary>
+/// <remarks>
+/// <para>
+/// Shared because every boundary holding a guarded egress point asserts the same three things about it — that a
+/// detected value is replaced before the text leaves, that a detector which cannot answer refuses the operation, and
+/// that a deployment scanning nothing is untouched — and a scanner written per suite would let those three drift into
+/// three slightly different claims.
+/// </para>
+/// <para>
+/// It finds a literal rather than a pattern deliberately. What these tests are about is where a guard sits, so the
+/// detection has to be uninteresting: a test asserting an egress point must not be able to fail because a regular
+/// expression did or did not match.
+/// </para>
+/// </remarks>
+internal sealed class MarkerSensitiveContentScanner : ISensitiveContentScanner
+{
+    /// <summary>The category every finding this scanner reports belongs to, and therefore the placeholder it produces.</summary>
+    internal static readonly SensitiveContentCategory Category = SensitiveContentCategory.Create("CloudKey");
+
+    private static readonly SensitiveContentRule Rule = SensitiveContentRule.Create(Category, "marker");
+
+    private static readonly SensitiveContentDetector Detector =
+        SensitiveContentDetector.Create("marker", "2026.08.12");
+
+    private readonly string marker;
+    private readonly TimeProvider timeProvider;
+
+    /// <summary>Initializes a scanner that reports the given literal wherever it occurs.</summary>
+    /// <param name="marker">The literal a finding covers.</param>
+    /// <param name="scanner">Which of the two switches this scanner answers for.</param>
+    /// <param name="timeProvider">Stamps when a finding was evaluated.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="marker" /> is empty.</exception>
+    internal MarkerSensitiveContentScanner(
+        string marker,
+        SensitiveContentScannerKind scanner,
+        TimeProvider timeProvider)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(marker);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.marker = marker;
+        this.Scanner = scanner;
+        this.timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public SensitiveContentScannerKind Scanner { get; }
+
+    /// <summary>Gets or sets the failure raised instead of findings, or <see langword="null" /> to answer.</summary>
+    /// <remarks>Set to make the scanner the one thing a fail-closed test needs: a detector that cannot say what a text carries.</remarks>
+    public Exception? Failure { get; set; }
+
+    /// <summary>Gets the texts this scanner was handed, in order.</summary>
+    public IReadOnlyList<string> ScannedTexts => this.Scanned;
+
+    private List<string> Scanned { get; } = [];
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<SensitiveContentFinding>> ScanAsync(string text, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        this.Scanned.Add(text);
+
+        if (this.Failure is { } failure)
+        {
+            throw failure;
+        }
+
+        var findings = new List<SensitiveContentFinding>();
+        var detectedAt = this.timeProvider.GetUtcNow();
+
+        for (var at = text.IndexOf(this.marker, StringComparison.Ordinal);
+            at >= 0;
+            at = text.IndexOf(this.marker, at + this.marker.Length, StringComparison.Ordinal))
+        {
+            findings.Add(SensitiveContentFinding.Create(
+                Rule,
+                SensitiveContentSpan.Create(at, this.marker.Length),
+                confidence: 1,
+                Detector,
+                detectedAt));
+        }
+
+        return Task.FromResult<IReadOnlyList<SensitiveContentFinding>>(findings);
+    }
+}

--- a/tests/shared/RecordingSensitiveContentEgressTelemetry.cs
+++ b/tests/shared/RecordingSensitiveContentEgressTelemetry.cs
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent;
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.Application.SensitiveContent.Redaction;
+
+namespace MailFathom.TestSupport;
+
+/// <summary>Records what the egress guard reported, so a test can assert it without a metric listener.</summary>
+/// <remarks>
+/// Hand-written rather than substituted because what these tests assert is a sequence — which egress points were
+/// guarded, in which order, and which of them were refused — and a recorded list reports that without a matcher. It is
+/// shared because every boundary holding a guarded egress point needs the same one.
+/// </remarks>
+internal sealed class RecordingSensitiveContentEgressTelemetry : ISensitiveContentEgressTelemetry
+{
+    private readonly List<GuardedEgress> guarded = [];
+    private readonly List<RefusedEgress> refused = [];
+
+    /// <summary>Gets every text that passed a guard, in the order the guards ran.</summary>
+    public IReadOnlyList<GuardedEgress> Guarded => this.guarded;
+
+    /// <summary>Gets every egress a scanner refused, in the order the refusals happened.</summary>
+    public IReadOnlyList<RefusedEgress> Refused => this.refused;
+
+    /// <inheritdoc />
+    public void RecordGuarded(SensitiveContentEgressPoint egressPoint, RedactedText redacted, TimeSpan elapsed)
+    {
+        ArgumentNullException.ThrowIfNull(redacted);
+
+        this.guarded.Add(new GuardedEgress(egressPoint, redacted, elapsed));
+    }
+
+    /// <inheritdoc />
+    public void RecordRefused(SensitiveContentEgressPoint egressPoint, SensitiveContentScannerKind scanner) =>
+        this.refused.Add(new RefusedEgress(egressPoint, scanner));
+
+    /// <summary>One text that passed a guard.</summary>
+    /// <param name="EgressPoint">Where it was going.</param>
+    /// <param name="Redacted">What the redaction produced.</param>
+    /// <param name="Elapsed">What the scan added to the operation.</param>
+    internal sealed record GuardedEgress(
+        SensitiveContentEgressPoint EgressPoint,
+        RedactedText Redacted,
+        TimeSpan Elapsed);
+
+    /// <summary>One egress a scanner refused.</summary>
+    /// <param name="EgressPoint">Where the text was going, and did not.</param>
+    /// <param name="Scanner">The scanner that could not answer.</param>
+    internal sealed record RefusedEgress(SensitiveContentEgressPoint EgressPoint, SensitiveContentScannerKind Scanner);
+}

--- a/tests/shared/ScanningSensitiveContentEgress.cs
+++ b/tests/shared/ScanningSensitiveContentEgress.cs
@@ -1,0 +1,87 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent;
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.Application.SensitiveContent.Redaction;
+
+namespace MailFathom.TestSupport;
+
+/// <summary>A deployment with one scanner switched on, as an egress point's consumer meets it.</summary>
+/// <remarks>
+/// <para>
+/// Every boundary that hands text to somebody else asserts the same two things about a switched-on scanner — that a
+/// detected value is replaced before the text leaves, and that a detector which cannot answer refuses the operation —
+/// so both are built here rather than assembled per suite out of a plan, a redactor, and a scanner.
+/// </para>
+/// <para>
+/// It holds the redactor the guard runs through, which is what makes it disposable: the redactor owns the concurrency
+/// permits of a whole deployment, and a suite that left one per test behind would be leaking the thing the bound exists
+/// to hold.
+/// </para>
+/// </remarks>
+internal sealed class ScanningSensitiveContentEgress : IDisposable
+{
+    private readonly SensitiveContentRedactor redactor;
+
+    private ScanningSensitiveContentEgress(MarkerSensitiveContentScanner scanner, TimeProvider timeProvider)
+    {
+        this.Scanner = scanner;
+        this.Telemetry = new RecordingSensitiveContentEgressTelemetry();
+        this.redactor = new SensitiveContentRedactor(
+            SensitiveContentPlan.Create(
+                SensitiveContentScanBounds.Default,
+                [
+                    SensitiveContentScannerPlan.Create(
+                        scanner.Scanner,
+                        [MarkerSensitiveContentScanner.Category],
+                        []),
+                ]),
+            [scanner],
+            timeProvider);
+        this.Guard = new SensitiveContentEgressGuard(this.redactor, this.Telemetry, timeProvider);
+    }
+
+    /// <summary>Gets the guard a consumer is handed.</summary>
+    public SensitiveContentEgressGuard Guard { get; }
+
+    /// <summary>Gets what the guard reported, so a test can read which egress points were guarded and which refused.</summary>
+    public RecordingSensitiveContentEgressTelemetry Telemetry { get; }
+
+    /// <summary>Gets the detector behind the guard, which records every text it was handed.</summary>
+    public MarkerSensitiveContentScanner Scanner { get; }
+
+    /// <summary>Builds a deployment whose scanner reports one literal wherever it occurs.</summary>
+    /// <param name="marker">The literal a finding covers, which the placeholder replaces.</param>
+    /// <param name="timeProvider">Times the per-call budget and stamps the findings.</param>
+    /// <returns>The deployment, which the test disposes.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeProvider" /> is <see langword="null" />.</exception>
+    public static ScanningSensitiveContentEgress Finding(string marker, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        return new ScanningSensitiveContentEgress(
+            new MarkerSensitiveContentScanner(marker, SensitiveContentScannerKind.Secrets, timeProvider),
+            timeProvider);
+    }
+
+    /// <summary>Builds a deployment whose scanner cannot say what a text carries.</summary>
+    /// <param name="timeProvider">Times the per-call budget.</param>
+    /// <returns>The deployment, whose guard refuses every text it is handed.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeProvider" /> is <see langword="null" />.</exception>
+    public static ScanningSensitiveContentEgress Unavailable(TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        return new ScanningSensitiveContentEgress(
+            new MarkerSensitiveContentScanner("unreachable", SensitiveContentScannerKind.Secrets, timeProvider)
+            {
+                Failure = new InvalidOperationException("The detector is not answering."),
+            },
+            timeProvider);
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => this.redactor.Dispose();
+}

--- a/tests/shared/SensitiveContentEgressGuards.cs
+++ b/tests/shared/SensitiveContentEgressGuards.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.SensitiveContent.Egress;
+
+namespace MailFathom.TestSupport;
+
+/// <summary>Builds the guard a consumer of an egress point is exercised against.</summary>
+/// <remarks>
+/// The inactive guard is here rather than on <see cref="ScanningSensitiveContentEgress" /> because it owns nothing and
+/// is therefore written as an argument rather than as something a test holds: a deployment scanning nothing has no
+/// redactor to release. A guard that does scan is built by that type instead, which holds the redactor it runs through.
+/// </remarks>
+internal static class SensitiveContentEgressGuards
+{
+    /// <summary>Builds the guard of a deployment with both switches off.</summary>
+    /// <returns>A guard that returns every text it is handed and constructs no detector.</returns>
+    internal static SensitiveContentEgressGuard Inactive() =>
+        new(redactor: null, new RecordingSensitiveContentEgressTelemetry(), TimeProvider.System);
+}


### PR DESCRIPTION
Closes #662

Every point at which mail text crosses out of this deployment now goes through one guard, and the register of those points is a closed enum a reader meets before the code that calls it.

## The register

`SensitiveContentEgressPoint` has three members, and each is what a telemetry series is tagged with:

| Egress point | What crosses it | Where it is guarded |
|---|---|---|
| `ChatPrompt` | The question a client asked, and the subjects and extracts retrieved to answer it | `MailAnsweringAgent`, `ScopedMailKnowledgeRetrieval`, `ProviderChatModelClient` |
| `HostedEmbeddingInput` | Every passage sent to an embedding endpoint | `ProviderTextEmbeddingGenerator` |
| `McpSnippet` | The subjects and sender display names of a listing, the same plus the snippets of a search, and an answer with its citations | `MailboxTimelineReader`, `MailboxSearchReader`, `MailboxQuestionReader` |

Three rows of the issue's table have no member, and that is the finding rather than an omission:

- **Webhooks do not exist in MailFathom.** There is no outbound webhook of any kind; the only occurrences of the word are a deployment option name and a gitleaks rule.
- **Logs and audit events carry no message text by construction.** `MailAnsweringAuditEntry` and the mutation trail hold identifiers, aliases, counts, and outcomes; the logging rules under `src/AGENTS.md` and `docs/operations/telemetry.md` already refuse content. A guard there would redact nothing and would suggest text is expected to be present.

Both absences are written into the enum's own remarks and onto the feature page, so the next person adding an egress point reads why the list is three rather than six.

## How the guard behaves

- **One shared redaction.** `SensitiveContentEgressGuard` wraps the single `SensitiveContentRedactor` from #659, so the placeholder is the shared `[redacted:<category>]` and no consumer holds the redactor or sees a finding.
- **A value is guarded, never a composed document.** Each subject, display name, snippet, extract, and turn is scanned on its own and the result composed afterwards. Scanning the retrieval envelope instead would let one detection cover the end of an extract and the element closing it, and replacing that region would take the document's structure with it. The single-request chat port is the one exception and is documented as one: a conversation arrives there already built, nothing at that boundary can tell which turn mail reached, so every turn is scanned whole — including the judgement a model-judged retrieval composes per candidate. The cost is a degraded prompt rather than a leak.
- **One text is scanned once, at the point it actually crosses.** An answering run looks mail up through the same ranked window `search_emails` publishes, so `MailboxSearchReader` splits publishing from searching: `SearchEmailsAsync` guards the window it serves, and `internal SearchWindowAsync` returns it unguarded for `MailboxKnowledgeSearch`, which sends the extracts to a model and guards them at `ChatPrompt`. A citation the answer's own ceiling drops is never scanned, because it is never published.
- **Above the retry boundary.** Both provider adapters guard before the resilience pipeline, so one call costs one scan whatever the pipeline does, and a scanner that cannot answer surfaces as `81001` instead of being reclassified as a provider fault and retried.
- **Fails closed everywhere.** A refusal blocks the question, the embedding call, the listing, the search, and the answer, and is counted against its egress point before it is re-raised unchanged.
- **Inert when both switches are off.** The guard is registered on every deployment and holds no redactor there, so every call returns its argument without constructing a detector, taking a permit, or touching an instrument — and no consumer carries a null check or a second code path.
- **A self-hosted embedding endpoint is still guarded.** Nothing in a declaration distinguishes a local address from a hosted one, and text leaving the process is text leaving the process. The one exempt path is the deterministic in-process generator, which sends nothing.

## Telemetry

Five instruments, all tagged with the egress point: `guarded`, `findings` (also by category), `omitted` (only when the ceiling cut something), `refusals` (also by scanner), and `scan.duration`. The tags are three closed sets of MailFathom's own and the values are counts and durations — never a match, a position, or a message identity.

## What an operator sees change

On a deployment with a scanner switched on, two MCP tool results carry redacted text where they previously carried it whole: `list_emails` and `search_emails` now return the **sender display name** as `[redacted:<category>]` when a detection covers it, beside the subject and the snippets. `SenderAddress` is unchanged. On a deployment with both switches off — the default — nothing on any of these paths changes at all.

## The judgement call worth naming

**The line falls between a routing identity a server issued and the free text in front of it**, not between fields that look structured and fields that do not. So the sender's display name is guarded, because whoever sent the message chose it, while the address it sits in front of is not, because a reply has to reach it. The same reasoning leaves the account, the folder alias, the stored identity, the timestamps, the sizes, the flags, and the cursor unredacted: they are what a caller acts on rather than text to read, and redacting them would remove a result's whole use while protecting nothing the message body did not already carry. They are protected by who may reach this deployment. This is stated in `MailboxTimelineReader`, `MailboxSearchReader`, `MailboxQuestionReader`, and on three documentation pages; if the reading should be the other way, it is a small change in one place per reader.

## Contracts

No break. No configuration key, database column, MCP tool argument, or deployment contract moves. What changes for an operator who has switched a scanner on is the redacted display name above, and that a guarded call can now fail with `81001` where it previously could not — which is the fail-closed contract #659 already published.

## Tests

Per egress point, the three the issue asks for — a true positive redacted before it leaves, the fail-closed path with the detector unavailable, and a disabled scanner leaving the path untouched — asserted against what the provider actually received where the path reaches one. Plus the guard's own contract, the telemetry's five instruments and their tags, the two DI registrations, the display name being redacted while the address is not, the answering lookup being left for `ChatPrompt` to guard, the citation bound cutting before the scan, and `SharedSources.UnitTests` coverage of the four new `tests/shared` helpers.

Full verification: 5974 tests, 0 failed; aggregate line coverage 95.52% against a gate of 85%; `scripts/test-agent-workflow.sh` 148 passed, 0 failed.

## Out of scope, as the issue states

The derived-data path and `get_email_content` remain their own siblings; the feature page's note now narrows to exactly those two, and records the one place they already interact — a vector a hosted endpoint produced is computed from the guarded passage while the chunk it was cut from is stored as it was extracted.
