### PR TITLE
[#774] Name the folder-scope bound and its refusal after the argument, not after aliases

### DIFF
--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -125,7 +125,7 @@ configured name for an account and carries nothing the caller did not already wr
 | Code | Meaning | Typical cause |
 |---|---|---|
 | `51001` | A page size outside the range the query serves | A page size of 0 or above 100, refused rather than clamped |
-| `51002` | A filter carries a value, a count, or a length the query does not accept | An unusable address, a subject fragment over 256 characters or carrying a control character, a received range that ends before it starts, more than 64 accounts or folder aliases, an account identifier or folder alias that is blank, over 256 characters, or carrying a control character, a search query that is blank, over 512 characters, or carrying a control character |
+| `51002` | A filter carries a value, a count, or a length the query does not accept | An unusable address, a subject fragment over 256 characters or carrying a control character, a received range that ends before it starts, more than 64 accounts or folders, an account identifier or folder alias that is blank, over 256 characters, or carrying a control character, a search query that is blank, over 512 characters, or carrying a control character |
 | `51003` | A search asked for more ranked results than a search serves | A `resultLimit` of 0 or above 50, refused rather than clamped |
 | `51004` | The call named an email with text that is no identifier this system issues | A `storedEmailIds` element that is blank, not a UUID, or the all-zero UUID, refused before anything is looked up |
 | `51005` | A content read named no emails, or more than one call serves | A `storedEmailIds` list that is empty or holds more than 10 entries, refused rather than truncated |
@@ -250,7 +250,7 @@ Every argument is optional.
 | `cursor` | `string` | The `nextCursor` of a previous call, reused with the same filters and direction |
 
 An unbounded date range is deliberately legal; only an unbounded page is not. The page size stops at 100, and the scope
-stops at 64 accounts and 64 folder aliases counted while the caller's list is read, so a request that repeats one
+stops at 64 accounts and 64 folders counted while the caller's list is read, so a request that repeats one
 identifier a million times is refused after the value that crosses the limit rather than after the list has been
 materialized. Every one of those bounds lives in the use case rather than here, which is what makes them hold for an
 entrypoint added later; naming one served account repeatedly is legal and is read once.

--- a/src/Application/Emails/Mailboxes/MailboxQueryFilterInvalidException.cs
+++ b/src/Application/Emails/Mailboxes/MailboxQueryFilterInvalidException.cs
@@ -50,7 +50,7 @@ public sealed class MailboxQueryFilterInvalidException : MailFathomException
         filterName);
 
     /// <summary>Refuses text that names no identity this system issues, such as an account identifier or a folder alias.</summary>
-    /// <param name="filterName">How this assembly names the filter, for example <c>folder aliases</c>.</param>
+    /// <param name="filterName">How this assembly names the filter, for example <c>folders</c>.</param>
     /// <param name="cause">The validation failure the domain identity raised, kept as the inner exception.</param>
     /// <returns>The failure to raise.</returns>
     /// <remarks>
@@ -66,7 +66,7 @@ public sealed class MailboxQueryFilterInvalidException : MailFathomException
         cause);
 
     /// <summary>Refuses text that names no identity this system issues, where no other failure explains why.</summary>
-    /// <param name="filterName">How this assembly names the filter, for example <c>folder aliases</c>.</param>
+    /// <param name="filterName">How this assembly names the filter, for example <c>folders</c>.</param>
     /// <returns>The failure to raise.</returns>
     /// <remarks>
     /// The overload without a cause exists for the checks an adapter makes itself, before a domain type is asked to read

--- a/src/Application/Emails/Mailboxes/MailboxScope.cs
+++ b/src/Application/Emails/Mailboxes/MailboxScope.cs
@@ -40,11 +40,13 @@ public sealed record MailboxScope
 
     /// <summary>The greatest number of folders one request may name, counted the same way as <see cref="MaximumAccountIds" />.</summary>
     /// <remarks>
-    /// Both bounds are enforced where the caller's own list is read, in <see cref="MailboxScopeResolver" />, rather than
-    /// over the resolved lists this type holds. Resolution can only produce more: a request naming no account resolves
-    /// to every served account, and one role a request named resolves to a folder on each of them.
+    /// It counts what the caller wrote rather than folders, which is the same distinction the bound above makes and one
+    /// a role sharpens: <c>role:Junk</c> is one name however many accounts answer it. Both bounds are enforced where the
+    /// caller's own list is read, in <see cref="MailboxScopeResolver" />, rather than over the resolved lists this type
+    /// holds. Resolution can only produce more: a request naming no account resolves to every served account, and one
+    /// role a request named resolves to a folder on each of them.
     /// </remarks>
-    public const int MaximumFolderAliases = 64;
+    public const int MaximumFolders = 64;
 
     private MailboxScope(IReadOnlyList<MailAccountId> accountIds, IReadOnlyList<MailFolderIdentity> selectedFolders)
     {
@@ -202,5 +204,4 @@ public sealed record MailboxScope
                         .ThenBy(static folder => folder.Alias.Value, StringComparer.Ordinal),
                 ],
         };
-
 }

--- a/src/Application/Emails/Mailboxes/MailboxScopeResolver.cs
+++ b/src/Application/Emails/Mailboxes/MailboxScopeResolver.cs
@@ -122,8 +122,8 @@ public sealed class MailboxScopeResolver
             "accounts");
         MailboxQueryFilterInvalidException.ThrowIfCountExceeded(
             folders.Count,
-            MailboxScope.MaximumFolderAliases,
-            "folder aliases");
+            MailboxScope.MaximumFolders,
+            "folders");
 
         var requestedAccountIds = accountSelectors
             .Select(selector => ResolvedAccountId(selector, servedAccounts))

--- a/src/Mcp/Tools/MailboxScopeArguments.cs
+++ b/src/Mcp/Tools/MailboxScopeArguments.cs
@@ -52,7 +52,7 @@ internal static class MailboxScopeArguments
     /// no folder of any of them meets the same refusal wherever it came from.
     /// </remarks>
     public static IReadOnlyList<MailFolderReference> Folders(string[]? folders) =>
-        Parse(folders, MailFolderReference.Create, MailboxScope.MaximumFolderAliases, "folder aliases");
+        Parse(folders, MailFolderReference.Create, MailboxScope.MaximumFolders, "folders");
 
     /// <summary>Converts one list of caller-supplied text into the domain identity it names.</summary>
     /// <remarks>

--- a/tests/Application.UnitTests/Emails/Mailboxes/MailboxScopeResolverTests.cs
+++ b/tests/Application.UnitTests/Emails/Mailboxes/MailboxScopeResolverTests.cs
@@ -471,7 +471,7 @@ public sealed class MailboxScopeResolverTests
         // Arrange
         var resolver = ResolverServing(Work);
         var tooMany = Enumerable
-            .Range(0, MailboxScope.MaximumFolderAliases + 1)
+            .Range(0, MailboxScope.MaximumFolders + 1)
             .Select(position => MailFolderReference.ToAlias(MailFolderAlias.Create($"folder-{position}")))
             .ToArray();
 

--- a/tests/Application.UnitTests/Emails/Mailboxes/MailboxScopeTests.cs
+++ b/tests/Application.UnitTests/Emails/Mailboxes/MailboxScopeTests.cs
@@ -95,7 +95,7 @@ public sealed class MailboxScopeTests
     {
         // Arrange
         var folders = Enumerable
-            .Range(0, MailboxScope.MaximumFolderAliases + 1)
+            .Range(0, MailboxScope.MaximumFolders + 1)
             .Select(position => Folder(Primary, $"folder-{position}"))
             .ToArray();
 

--- a/tests/Mcp.UnitTests/Tools/ListEmailsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/ListEmailsToolTests.cs
@@ -196,7 +196,7 @@ public sealed class ListEmailsToolTests
 
         // Assert
         Assert.Equal(MailFathomErrorCode.MailboxQueryFilterInvalid, failure.ErrorCode);
-        Assert.Equal("folder aliases", failure.FilterName);
+        Assert.Equal("folders", failure.FilterName);
         Assert.Equal(0, timeline.ReadCount);
     }
 
@@ -228,7 +228,7 @@ public sealed class ListEmailsToolTests
         var timeline = new StubStoredEmailTimelineReader();
         var tool = ToolOver(timeline);
         var namedFolders = Enumerable
-            .Range(0, MailboxScope.MaximumFolderAliases + 1)
+            .Range(0, MailboxScope.MaximumFolders + 1)
             .Select(index => $"folder-{index}")
             .ToArray();
 
@@ -237,7 +237,7 @@ public sealed class ListEmailsToolTests
             () => tool.ListEmailsAsync(folders: namedFolders, cancellationToken: TestContext.Current.CancellationToken));
 
         // Assert
-        Assert.Equal("folder aliases", failure.FilterName);
+        Assert.Equal("folders", failure.FilterName);
         Assert.Equal(0, timeline.ReadCount);
     }
 

--- a/tests/Mcp.UnitTests/Tools/SearchEmailsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/SearchEmailsToolTests.cs
@@ -268,7 +268,7 @@ public sealed class SearchEmailsToolTests
                 cancellationToken: TestContext.Current.CancellationToken));
 
         // Assert
-        Assert.Equal("folder aliases", failure.FilterName);
+        Assert.Equal("folders", failure.FilterName);
         Assert.Equal(0, index.ReadCount);
     }
 


### PR DESCRIPTION
Closes #774

Follow-up to #715 (merged as #729). That change renamed the folder-scope argument of `list_emails`, `search_emails`, and `ask_mail` from `folderAliases` to **`folders`**, because it now accepts a role — `role:Junk` — as well as an alias. Two names for the same thing kept spelling the old concept, and one of them is published to a client.

## What changed

- **`MailboxScope.MaximumFolderAliases` → `MaximumFolders`.** The bound counts what the caller wrote, not folders reached, which is a distinction a role sharpens: `role:Junk` is one name however many accounts answer it. The constant's remarks already said so and its name contradicted them.
- **The filter name becomes `folders`**, passed from `MailboxScopeResolver` and from `MailboxScopeArguments.Folders`. `MailboxQueryFilterInvalidException` publishes it in the message and in `FilterName`, so exceeding the bound now reads `A mailbox query may name at most 64 folders.` instead of naming an argument the tool contract no longer has. The same string reaches `51002` for a folder entry that is blank or carries a control character.
- **`docs/features/mcp-tools.md`** loses the phrase in both places it stated the bound.

Nothing about what the code does changes: the bound is enforced where it was, over the count it counted, and the same refusal is raised for the same input.

## Breaking changes

Against the pre-`1.0.0` allowance in ADR 0004:

- **MCP tool contract.** The message and the `FilterName` of `51002` change wording for the folder argument. The code is unchanged, and no argument, configuration key, or anything else an operator writes moves, so **no operator action is required**. A client that matched on the message text rather than on the stable code sees different text — which is what the code exists so a client need not do.
- **Source.** `MailboxScope.MaximumFolderAliases` is a public constant on a public type, so its rename breaks anything compiling against `MailFathom.Application`. Nothing outside this repository does.

## Tests

`ListEmailsToolTests` and `SearchEmailsToolTests` assert `FilterName` for both the count bound and an unusable folder entry, and now assert `folders`. `MailboxScopeTests`, `MailboxScopeResolverTests`, and `ListEmailsToolTests` build their over-long lists from the renamed constant.

Full suite: 5800 passed, 0 failed. Aggregate line coverage 95.50% (17126/17933), required 85%.
