### PR TITLE
[#716] Resolve a mapped-but-unsynchronized folder when it is first needed as a mutation destination

### DIFF
--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -694,9 +694,14 @@ a run having happened. It is answered the same way for a folder nothing mirrors:
 from what MailFathom stores, not from what it is for, so the role still names it and a rule condition still reads
 `folderRole` for it.
 
-What such a folder cannot be is a rule's **destination**. A rule may only file into a folder the account mirrors, and
-startup refuses a rule that names one it does not — by its alias or by its role alike — because nothing would bind the
-name to a folder on the server. Give the destination `Synchronize: true` if a rule is to file into it.
+Such a folder is a **destination** like any other. Mapping the folder is the whole of what makes it reachable, so a rule
+may file into one whether or not the account mirrors it, and startup refuses a destination only when no mapping of that
+account answers to the name — by its alias or by its role alike. What the refusal asks for is a mapping, not
+`Synchronize: true`.
+
+The direction is what differs: **the source of a change has to be mirrored and its destination only has to be mapped.**
+A folder nothing mirrors puts no mail in the local store, so no rule condition ever sees a message in it, no query lists
+one, and nothing authors a change against one. Filing *into* it is the whole of what it takes part in.
 
 Wherever something names a folder — a rule's destination, a rule condition's `folderRole` fact, an MCP tool's `folders`
 argument — the role is written `role:<role>`, for example `role:Junk`. Anything without that prefix is an alias, so a
@@ -716,14 +721,14 @@ folder that already exists from something MailFathom does locally; this one auth
 So a mapping that says nothing behaves exactly as it did before creation existed, and a mistyped `RemotePath` stays the
 unresolved alias above rather than becoming a folder on your server named after the mistake.
 
-Creation happens **where the alias is resolved**, which is before the run of a folder MailFathom mirrors. Nothing is
-created by reading configuration, and nothing is created for a mapping nothing ever resolves. After the first creation
-the server advertises the folder, so resolution finds it and no further `CREATE` is issued.
+Creation happens **where the alias is resolved**, which is before the run of a folder MailFathom mirrors and at the
+moment a change first files into a folder it does not. Nothing is created by reading configuration, and nothing is
+created for a mapping nothing ever resolves. After the first creation the server advertises the folder, so resolution
+finds it and no further `CREATE` is issued.
 
-A run resolves the folders it mirrors and no others, so `CreateIfMissing` on a `Synchronize: false` mapping creates
-nothing: such a folder is a destination for what is already bound to it rather than something a run reaches. A folder to
-be created is therefore one the account mirrors, and a mapping that only files mail into a folder needs that folder to
-be there.
+`CreateIfMissing` therefore reaches a `Synchronize: false` mapping as well, on the same terms: nothing happens until
+something files mail into that folder, and then the folder the mapping named comes into existence exactly as a mirrored
+folder's would. A mapping nothing ever files into stays a mapping and creates nothing.
 
 What the creation does with the awkward parts of IMAP is fixed rather than left to the server that was tested against:
 
@@ -824,6 +829,19 @@ into it over the account's existing write session, through the same commands and
 no capability is added, and what
 [ADR 0007](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md)
 refuses is untouched — the destination is still never searched for the message afterwards.
+
+**A mapped folder resolves when it is needed rather than when a run reaches it.** No run schedules a folder nothing
+mirrors, so nothing would ever bind its alias; instead the alias is resolved the first time a change names it as a
+destination, against the folders the server advertises, and the binding and the mapping-change audit record that a
+mirrored folder produces are the same ones produced here. What is resolved is then reused rather than looked up per
+message, and a server that has since renamed the folder is followed exactly as it is for a mirrored folder — the binding
+is replaced by its next generation, with no checkpoint to invalidate, because a folder nothing mirrors has none.
+
+Four things can go wrong, and each is reported against the one change rather than ending the pass. A name **no mapping
+of the account declares** is refused, naming what was asked for. A mapping the server advertises **no folder for**, and a
+role **two advertised folders carry**, are each refused with a classification of their own: nothing falls back to the
+configured path and nothing picks one of two folders. A mirrored destination **nothing has bound yet** waits for that
+folder's own next run. All four appear in the [rule run history](mail-rules.md) beside the folder the rule wrote.
 
 What differs is what becomes of the local copy. A relocation into a mirrored folder carries the row into that folder and
 decides nothing; a relocation into a folder nothing mirrors has taken the message out of the mirrored mailbox, so its

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -202,13 +202,16 @@ its own.
 
 ### How a change reaches the mail server
 
-**A rule pass opens no connection.** Each action a match asks for is written down as a
+**A rule pass issues no IMAP command a rule asked for.** Each action a match asks for is written down as a
 [durable mutation record](imap-synchronization.md#every-change-is-written-down-before-it-is-issued) inside the same
 transaction that records the evaluation, and the account's own convergence pass — the first thing every account run does
-— is what issues the IMAP commands. Three things follow, and each is the point of the arrangement:
+— is what issues the IMAP commands. The one server call a pass makes for itself is
+[finding a folder the account maps and does not mirror](imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is),
+made before the batch's transaction is opened and only where a rule files into such a folder. Three things follow, and
+each is the point of the arrangement:
 
-- **A pass that fails costs no mail server work.** Evaluation reaches nothing remote, so a local failure never defers the
-  account's fetching.
+- **A pass that fails costs no mail server work.** Nothing the evaluation itself decided is carried remotely, so a local
+  failure never defers the account's fetching.
 - **A change survives a restart.** A record written and not yet carried is picked up by the next run, and
   [a change nobody finished finishes by itself](imap-synchronization.md#a-change-nobody-finished-finishes-by-itself)
   states every way one can be left and what becomes of it.
@@ -493,9 +496,9 @@ queue behind it.
 
 **A rule that cannot answer for one message costs that message's rule and nothing else.** It is recorded as a failed
 rule with a reason, the rules below it still run, the remaining messages of the batch are still evaluated, and the
-message is recorded as evaluated. The account is not put into backoff for it either: a rule pass reaches no mail server,
-so fetching the account's mail less often would answer a local problem by slowing remote work that had nothing to do
-with it. The next section lists the two reasons.
+message is recorded as evaluated. The account is not put into backoff for it either: nothing a rule decided is carried
+remotely, so fetching the account's mail less often would answer a local problem by slowing remote work that had nothing
+to do with it. The next section lists the two reasons.
 
 **Nothing scans on a timer.** The account run recurs already, so anything a scan would find on arrival is found by the
 `Arrival` trigger; a rule whose condition only becomes true with the passage of time — mail older than some age — fires

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -149,15 +149,17 @@ pass with `StopWhenMatched` does to keep the mail it names away from the rules b
 
 A destination is a **folder alias** — one an account declares under `MailSynchronization:Accounts:<n>:Folders` — and
 never a path on the server. What that alias is bound to is resolved when the change is written down, so a rule goes on
-working across a server that renames the folder underneath it, and a rule may only name a folder the account actually
-mirrors. [Folder aliases and discovery](imap-synchronization.md#folder-aliases-and-discovery) states what a binding is
+working across a server that renames the folder underneath it, and a rule may name any folder the account maps —
+including one it deliberately does not mirror, which is how mail is filed somewhere MailFathom keeps no copy of.
+[Folder aliases and discovery](imap-synchronization.md#folder-aliases-and-discovery) states what a binding is
 and when it moves.
 
 A destination may instead name the **role** the folder plays, written `role:<role>` — `role:Junk`, `role:Archive`, and
 the rest. That is what lets one rule file mail correctly across accounts whose folders you named differently, since the
 role is asked of the account the mail belongs to. Anything without the `role:` prefix is an alias, so an alias spelled
 `Junk` still means that alias. Startup refuses a role no folder of a reached account carries, exactly as it refuses an
-alias nothing mirrors, and refuses text that reads as neither an alias nor a role, naming the roles that exist.
+alias the account maps nothing for, and refuses text that reads as neither an alias nor a role, naming the roles that
+exist.
 [What a role says, beside how a folder is found](imap-synchronization.md#what-a-role-says-beside-how-a-folder-is-found)
 states what a role is and why an account has at most one folder per role.
 
@@ -259,11 +261,14 @@ Each is recorded against the rule that asked, and the actions beside it are stil
 
 | Reason | What happened |
 | --- | --- |
-| `DestinationFolderUnresolved` | The destination is bound to no folder on the server — nothing has discovered the alias yet, the folder it named has gone, or the account maps no folder to the role it named |
+| `DestinationFolderUnresolved` | The destination names a folder the account mirrors and no run of that folder has bound it yet |
+| `DestinationFolderUnmapped` | No mapping of the account answers to the name — one was withdrawn between the rule set being read and the change being written |
+| `DestinationFolderNotAdvertised` | The mapping is there and the server holds no folder for it: the folder was deleted or renamed, the path was never right, or one the mapping asked to have created could not be |
+| `DestinationFolderAmbiguous` | The mapping names a role that two advertised folders carry, so which one was meant is yours to state |
 | `AccountNoLongerConfigured` | The account was withdrawn from the configuration between the rule set being read and the change being written |
 | `ActionNoLongerPermitted` | The account has stopped permitting this action since the rule set that declares it was read |
 
-Nothing is written down in any of the three cases: filing into whichever folder looked closest to the name is precisely
+Nothing is written down in any of these cases: filing into whichever folder looked closest to the name is precisely
 what a stale destination must not do. The account run reports how many changes it asked for, how many it withheld because
 another matching rule had already settled the same message, and how many named something that no longer resolves,
 together with the rules involved. Counts and rule names only — nothing derived from a message reaches a log line, a
@@ -407,7 +412,8 @@ and none is repeated.
 So is its `Actions` block, against the rule itself and against every account the rule reaches:
 
 - **The destinations.** Each names something readable as a folder alias or as `role:<role>`, and each names a folder the
-  account actually mirrors — a rule filing into a folder nothing mirrors could never resolve a destination.
+  account maps — a rule filing into a folder no mapping declares has nowhere to file. Mirroring is not asked about: a
+  mapped folder the account does not mirror is resolved when the first change files into it.
 - **The combination.** The actions are ones MailFathom applies together, per [the table above](#which-combinations-a-rule-may-declare).
 - **The permissions.** Every action is one the account permits a rule to take.
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -195,17 +195,17 @@ to nothing, instead of turning the mistake into a folder named after it. Startup
 `RemotePath`, naming the alias, because a folder that does not exist advertises no role and only an explicit path says
 what to create. A mapping naming both a path and a role may ask for the creation: the path is what is created, and the
 role is what the created folder plays. It is issued where the alias is
-resolved, and a run resolves the folders it mirrors and no others, so the switch creates nothing on a mapping that also
-carries `Synchronize: false`. Renaming, deleting, and unsubscribing from a folder stay refused outright, and no folder
-MailFathom did not create is ever subscribed to.
+resolved — before the run of a folder the account mirrors, and at the moment a change first files into one it does not,
+so the switch reaches a `Synchronize: false` mapping the first time something files mail into it. Renaming, deleting, and
+unsubscribing from a folder stay refused outright, and no folder MailFathom did not create is ever subscribed to.
 [A folder the mapping asked for is created](../features/imap-synchronization.md#a-folder-the-mapping-asked-for-is-created)
 states when the creation happens, what it does with a folder that already exists and with a hierarchical path, and what
 a server's refusal reports.
 
 Switching `Synchronize` off for a folder that was mirrored **erases what is stored for it**, in bounded passes on the
 account's own runs and through the deletion path an erasing disposition already uses. The mapping stays, so the alias
-goes on resolving and any role the mapping names goes on being answered — but the folder stops being a destination a
-rule may file mail into, and startup refuses a rule that still names it.
+goes on resolving, any role the mapping names goes on being answered, and the folder stays a destination a rule may file
+mail into — resolved the first time a change names it, since no run schedules it.
 [What a mapping decides beyond where the folder is](../features/imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
 states all three switches together, what an unmapped folder is instead, and what becomes of the local copy of a message
 relocated into a folder nothing mirrors.

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -99,8 +99,8 @@ Points worth knowing before you adapt it:
   states what each one costs, including what happens to mail already stored when you turn mirroring off.
 - **A folder you name is created only if you ask for it.** Add `CreateIfMissing: true` beside a `RemotePath` and
   MailFathom creates that folder on its first run, when your server has none at it — which is what a rule filing mail
-  into an archive folder you decided on needs, without a detour through a mail client. A run reaches the folders it
-  mirrors, so a mapping that also carries `Synchronize: false` has nothing created for it. The switch defaults to
+  into an archive folder you decided on needs, without a detour through a mail client. A mapping that also carries
+  `Synchronize: false` gets its folder the first time something files mail into it. The switch defaults to
   `false`, so leaving it out keeps a mistyped path reporting itself as an alias that resolves to nothing rather than
   becoming a folder named after the typo. Nothing else about your folders is ever changed: MailFathom never renames, deletes, or unsubscribes from one.
   [A folder the mapping asked for is created](../features/imap-synchronization.md#a-folder-the-mapping-asked-for-is-created)

--- a/src/Application/Mail/Mutations/Destinations/MailboxDestination.cs
+++ b/src/Application/Mail/Mutations/Destinations/MailboxDestination.cs
@@ -1,0 +1,19 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Application.Mail.Mutations.Destinations;
+
+/// <summary>The folder a mutation files into, as the account's server currently holds it.</summary>
+/// <param name="Alias">MailFathom's own name for the folder, which is what a history line and a refusal name it by.</param>
+/// <param name="Path">Where the folder is on the server, which is what an IMAP command is issued against.</param>
+/// <param name="IsMirrored">Whether the account mirrors the folder's mail.</param>
+/// <remarks>
+/// All three are carried because three different things need them, and none of them can be derived from another at the
+/// point of use. The request carries the path; the rule history names the alias, which a rule written against a role
+/// never spelled out; and whether the folder is mirrored is what decides the local disposition a relocation is authored
+/// with, because a message moved somewhere MailFathom keeps no copy of has left the mirrored mailbox for good.
+/// </remarks>
+public sealed record MailboxDestination(MailFolderAlias Alias, RemoteFolderPath Path, bool IsMirrored);

--- a/src/Application/Mail/Mutations/Destinations/MailboxDestinationResolution.cs
+++ b/src/Application/Mail/Mutations/Destinations/MailboxDestinationResolution.cs
@@ -1,0 +1,80 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Mail.Mutations.Destinations;
+
+/// <summary>States what happened when what an author named as a destination was turned into a folder on the server.</summary>
+/// <remarks>
+/// The four refusals are separate because their remedies are: one is a configuration to write, one is a run to wait
+/// for, one is a folder to create by hand or a path to correct, and one is a role to give to a single folder. Reporting
+/// them as one reason would leave an operator reading <em>the destination did not resolve</em> for four different facts.
+/// </remarks>
+public enum MailboxDestinationOutcome
+{
+    /// <summary>The destination names a folder the account's server currently holds.</summary>
+    Resolved = 0,
+
+    /// <summary>No mapping of the account answers to that name, so the folder is one MailFathom knows nothing about.</summary>
+    Unmapped = 1,
+
+    /// <summary>The account mirrors the folder and no run has bound its alias to a remote folder yet.</summary>
+    Unbound = 2,
+
+    /// <summary>The server advertises no folder the mapping names, and none was created for it.</summary>
+    NotAdvertised = 3,
+
+    /// <summary>Several advertised folders carry the role the mapping names, so which one is meant is the operator's to state.</summary>
+    Ambiguous = 4,
+}
+
+/// <summary>Carries the folder a destination resolved to, or the reason it resolved to none.</summary>
+/// <remarks>
+/// A destination that resolved to nothing is a result rather than an exception because it fails one action and no more.
+/// The rest of the batch is unaffected, and the author reports the refusal where the operator reads what a rule did.
+/// </remarks>
+public sealed record MailboxDestinationResolution
+{
+    private MailboxDestinationResolution(MailboxDestinationOutcome outcome, MailboxDestination? destination)
+    {
+        this.Outcome = outcome;
+        this.Destination = destination;
+    }
+
+    /// <summary>Gets what happened.</summary>
+    public MailboxDestinationOutcome Outcome { get; }
+
+    /// <summary>Gets the folder, which is present exactly when <see cref="Outcome" /> is <see cref="MailboxDestinationOutcome.Resolved" />.</summary>
+    public MailboxDestination? Destination { get; }
+
+    /// <summary>Reports a destination that names a folder the server holds.</summary>
+    /// <param name="destination">The folder it names.</param>
+    /// <returns>A resolved result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="destination" /> is <see langword="null" />.</exception>
+    public static MailboxDestinationResolution Resolved(MailboxDestination destination)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+
+        return new MailboxDestinationResolution(MailboxDestinationOutcome.Resolved, destination);
+    }
+
+    /// <summary>Reports a destination no mapping of the account answers to.</summary>
+    /// <returns>An unmapped result.</returns>
+    public static MailboxDestinationResolution Unmapped() =>
+        new(MailboxDestinationOutcome.Unmapped, destination: null);
+
+    /// <summary>Reports a mirrored folder nothing has bound to a remote folder yet.</summary>
+    /// <returns>An unbound result.</returns>
+    public static MailboxDestinationResolution Unbound() =>
+        new(MailboxDestinationOutcome.Unbound, destination: null);
+
+    /// <summary>Reports a mapping the server advertises no folder for.</summary>
+    /// <returns>An unadvertised result.</returns>
+    public static MailboxDestinationResolution NotAdvertised() =>
+        new(MailboxDestinationOutcome.NotAdvertised, destination: null);
+
+    /// <summary>Reports a role several advertised folders carry.</summary>
+    /// <returns>An ambiguous result.</returns>
+    public static MailboxDestinationResolution Ambiguous() =>
+        new(MailboxDestinationOutcome.Ambiguous, destination: null);
+}

--- a/src/Application/Mail/Mutations/Destinations/MailboxDestinationResolver.cs
+++ b/src/Application/Mail/Mutations/Destinations/MailboxDestinationResolver.cs
@@ -1,0 +1,203 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Application.Mail.Mutations.Destinations;
+
+/// <summary>Turns what an author named as a mutation's destination into the folder the command will be issued against.</summary>
+/// <remarks>
+/// <para>
+/// This is the single place a destination becomes a remote folder, so every author of a relocation or a copy reaches
+/// the same folder by the same name and meets the same refusal. A rule is one such author and has no resolution of its
+/// own.
+/// </para>
+/// <para>
+/// The two kinds of destination are answered differently, and the difference is the whole of what this type adds. A
+/// folder the account mirrors already has a binding, because the run that synchronizes it resolved the alias before it
+/// read anything, so asking the server again would repoint a binding a checkpoint hangs off. A folder the account only
+/// maps is never scheduled by a run, so nothing would ever bind it: it is resolved here, on demand, through the same
+/// resolver, the same binding record, and the same mapping-change audit a mirrored folder uses. A server that has since
+/// renamed the folder is followed exactly as it is for a mirrored folder — the binding is replaced by the next
+/// generation, with no checkpoint to invalidate, because a folder nothing mirrors has none.
+/// </para>
+/// <para>
+/// Every answer is remembered for the life of this instance, which is one account run. A batch of two hundred emails
+/// matching one filing rule therefore costs one listing rather than two hundred, and the folder a pass began with is
+/// the folder it finishes with.
+/// </para>
+/// </remarks>
+public sealed class MailboxDestinationResolver
+{
+    private readonly MailFolderReferenceResolver folderReferences;
+    private readonly IMailFolderResolutionStore folderResolutions;
+    private readonly MailFolderResolver folderResolver;
+    private readonly IMailTransportSecurityPolicyReader transportSecurityPolicies;
+
+    private readonly Dictionary<(MailAccountId Account, MailFolderReference Destination), MailboxDestinationResolution> answers = [];
+
+    /// <summary>Initializes the resolver from the two ways a destination is turned into a folder.</summary>
+    /// <param name="folderReferences">Turns the alias or the role an author named into the mapping of the account it means.</param>
+    /// <param name="folderResolutions">Reads the binding a mirrored folder's run has already recorded.</param>
+    /// <param name="folderResolver">Resolves a mapped folder against what its server advertises, and records the binding.</param>
+    /// <param name="transportSecurityPolicies">Supplies the connection and authentication policy an on-demand resolution obeys.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
+    public MailboxDestinationResolver(
+        MailFolderReferenceResolver folderReferences,
+        IMailFolderResolutionStore folderResolutions,
+        MailFolderResolver folderResolver,
+        IMailTransportSecurityPolicyReader transportSecurityPolicies)
+    {
+        ArgumentNullException.ThrowIfNull(folderReferences);
+        ArgumentNullException.ThrowIfNull(folderResolutions);
+        ArgumentNullException.ThrowIfNull(folderResolver);
+        ArgumentNullException.ThrowIfNull(transportSecurityPolicies);
+
+        this.folderReferences = folderReferences;
+        this.folderResolutions = folderResolutions;
+        this.folderResolver = folderResolver;
+        this.transportSecurityPolicies = transportSecurityPolicies;
+    }
+
+    /// <summary>Resolves every destination one batch of authored changes names.</summary>
+    /// <param name="accountId">The account the changes are authored for.</param>
+    /// <param name="destinations">What the authors named, in any order and with repetitions.</param>
+    /// <param name="cancellationToken">Cancels the listing and the write that records a new binding.</param>
+    /// <returns>One answer per distinct destination named.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="destinations" /> is <see langword="null" />.</exception>
+    /// <exception cref="PersistenceConcurrencyConflictException">Thrown when a competing writer recorded a binding for the same alias first.</exception>
+    /// <remarks>
+    /// It must be awaited before the transaction the changes are written in is opened, because resolving a folder the
+    /// account only maps reaches the mail server and records a binding in a session of its own.
+    /// </remarks>
+    public async Task<MailboxDestinations> ResolveAsync(
+        MailAccountId accountId,
+        IEnumerable<MailFolderReference> destinations,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(destinations);
+
+        var named = destinations.Where(destination => destination.IsSpecified).Distinct().ToArray();
+        var resolutions = new Dictionary<MailFolderReference, MailboxDestinationResolution>(named.Length);
+
+        foreach (var destination in named)
+        {
+            resolutions[destination] = await this.ResolveOneAsync(accountId, destination, cancellationToken);
+        }
+
+        return new MailboxDestinations(resolutions);
+    }
+
+    /// <summary>Answers one destination, remembering the answer for the rest of this instance's life.</summary>
+    /// <remarks>
+    /// Keyed by the account as well as the destination, because one name means a different folder on each account and
+    /// nothing in this type's contract says a scope holds one account's work.
+    /// </remarks>
+    private async Task<MailboxDestinationResolution> ResolveOneAsync(
+        MailAccountId accountId,
+        MailFolderReference destination,
+        CancellationToken cancellationToken)
+    {
+        if (this.answers.TryGetValue((accountId, destination), out var remembered))
+        {
+            return remembered;
+        }
+
+        var resolution = await this.ReadCurrentAsync(accountId, destination, cancellationToken);
+
+        this.answers[(accountId, destination)] = resolution;
+
+        return resolution;
+    }
+
+    /// <summary>Turns a destination into the folder it currently names, in the two steps a name goes through.</summary>
+    /// <remarks>
+    /// A role no folder of the account plays is caught rather than propagated, because it says the same thing to the
+    /// author as an alias no mapping declares: the change has nowhere to file, the action is refused, and the rest of
+    /// the batch keeps moving.
+    /// </remarks>
+    private async Task<MailboxDestinationResolution> ReadCurrentAsync(
+        MailAccountId accountId,
+        MailFolderReference destination,
+        CancellationToken cancellationToken)
+    {
+        MailFolderMapping? mapping;
+
+        try
+        {
+            mapping = this.folderReferences.Resolve(accountId, destination);
+        }
+        catch (MailFolderRoleUnmappedException)
+        {
+            return MailboxDestinationResolution.Unmapped();
+        }
+
+        if (mapping is null)
+        {
+            return MailboxDestinationResolution.Unmapped();
+        }
+
+        return mapping.Participation.IsSynchronized
+            ? await this.ReadMirroredBindingAsync(accountId, mapping, cancellationToken)
+            : await this.ResolveOnDemandAsync(accountId, mapping, cancellationToken);
+    }
+
+    /// <summary>Reads the binding the folder's own synchronization run recorded.</summary>
+    private async Task<MailboxDestinationResolution> ReadMirroredBindingAsync(
+        MailAccountId accountId,
+        MailFolderMapping mapping,
+        CancellationToken cancellationToken)
+    {
+        var binding = await this.folderResolutions.GetCurrentResolutionAsync(
+            accountId,
+            mapping.Alias,
+            cancellationToken);
+
+        return binding is { RemotePath: var remotePath }
+            ? MailboxDestinationResolution.Resolved(new MailboxDestination(mapping.Alias, remotePath, IsMirrored: true))
+            : MailboxDestinationResolution.Unbound();
+    }
+
+    /// <summary>Resolves a folder no run schedules, at the moment it is needed as a destination.</summary>
+    /// <remarks>
+    /// A creation the server refused is reported as an unadvertised folder rather than raised, for the reason every
+    /// refusal here is a result: the folder is not there either way, and letting it out would end a pass over one
+    /// destination and end the next pass the same way, forever.
+    /// </remarks>
+    private async Task<MailboxDestinationResolution> ResolveOnDemandAsync(
+        MailAccountId accountId,
+        MailFolderMapping mapping,
+        CancellationToken cancellationToken)
+    {
+        var transportSecurityPolicy = this.transportSecurityPolicies.GetPolicy(accountId);
+
+        MailFolderResolutionResult result;
+
+        try
+        {
+            result = await this.folderResolver.ResolveAsync(
+                accountId,
+                mapping,
+                transportSecurityPolicy,
+                cancellationToken);
+        }
+        catch (RemoteFolderCreationRefusedException)
+        {
+            return MailboxDestinationResolution.NotAdvertised();
+        }
+
+        return result switch
+        {
+            { Outcome: MailFolderResolutionOutcome.Resolved, Resolution: { } binding } =>
+                MailboxDestinationResolution.Resolved(
+                    new MailboxDestination(mapping.Alias, binding.RemotePath, IsMirrored: false)),
+            { Outcome: MailFolderResolutionOutcome.AdvertisedFoldersAreAmbiguous } =>
+                MailboxDestinationResolution.Ambiguous(),
+            _ => MailboxDestinationResolution.NotAdvertised(),
+        };
+    }
+}

--- a/src/Application/Mail/Mutations/Destinations/MailboxDestinations.cs
+++ b/src/Application/Mail/Mutations/Destinations/MailboxDestinations.cs
@@ -1,0 +1,40 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Application.Mail.Mutations.Destinations;
+
+/// <summary>Every destination one batch of authored changes names, already turned into folders on the server.</summary>
+/// <remarks>
+/// <para>
+/// It exists so that resolving a destination and writing a mutation down are two steps a caller cannot take in the
+/// wrong order. Resolution can reach the mail server, which must not happen while a local transaction is open, so the
+/// author is handed the answers rather than the resolver and cannot ask for one halfway through a commit.
+/// </para>
+/// <para>
+/// A destination nobody asked to have resolved is reported as <see cref="MailboxDestinationOutcome.Unbound" />, which
+/// is what an author with no answer for a folder truthfully has: nothing here invents a path, and the action fails
+/// visibly rather than filing mail somewhere nobody named.
+/// </para>
+/// </remarks>
+public sealed class MailboxDestinations
+{
+    private readonly IReadOnlyDictionary<MailFolderReference, MailboxDestinationResolution> resolutions;
+
+    internal MailboxDestinations(IReadOnlyDictionary<MailFolderReference, MailboxDestinationResolution> resolutions) =>
+        this.resolutions = resolutions;
+
+    /// <summary>Gets the answers for a batch that named no destination at all.</summary>
+    public static MailboxDestinations None { get; } =
+        new(new Dictionary<MailFolderReference, MailboxDestinationResolution>());
+
+    /// <summary>Finds what one destination resolved to.</summary>
+    /// <param name="destination">The alias or role the author named.</param>
+    /// <returns>The resolution, or an unbound result when this set was never asked about that destination.</returns>
+    public MailboxDestinationResolution Find(MailFolderReference destination) =>
+        this.resolutions.TryGetValue(destination, out var resolution)
+            ? resolution
+            : MailboxDestinationResolution.Unbound();
+}

--- a/src/Application/Rules/Actions/MailRuleActionFailureReason.cs
+++ b/src/Application/Rules/Actions/MailRuleActionFailureReason.cs
@@ -12,11 +12,11 @@ namespace MailFathom.Application.Rules.Actions;
 /// </remarks>
 public enum MailRuleActionFailureReason
 {
-    /// <summary>The destination alias names no folder this account currently has bound.</summary>
+    /// <summary>The destination names a folder this account mirrors and nothing has bound yet.</summary>
     /// <remarks>
-    /// The alias was declared as a mapped folder when the rule set was read, and discovery has not bound it since — the
-    /// server no longer advertises the folder, or has never been asked for it. Filing into the nearest folder whose name
-    /// looks right is precisely what this refuses.
+    /// The alias was declared as a mapped folder when the rule set was read, and no run of the folder has recorded a
+    /// binding for it since. The next run of that folder is what supplies one. Filing into the nearest folder whose
+    /// name looks right is precisely what this refuses.
     /// </remarks>
     DestinationFolderUnresolved = 0,
 
@@ -35,4 +35,28 @@ public enum MailRuleActionFailureReason
     /// has just withdrawn permission to delete is not asking for one more deletion first.
     /// </remarks>
     ActionNoLongerPermitted = 2,
+
+    /// <summary>No mapping of the account answers to the name the rule filed into.</summary>
+    /// <remarks>
+    /// The rule set is refused when it is read if it names a folder the account does not map, so this is the reload
+    /// case: a mapping was withdrawn while a pass over that account's mail was running. Mapping the folder is what makes
+    /// it reachable again, and mirroring it is not part of that.
+    /// </remarks>
+    DestinationFolderUnmapped = 3,
+
+    /// <summary>The account's server advertises no folder the destination's mapping names.</summary>
+    /// <remarks>
+    /// The mapping is there and the folder is not: somebody deleted or renamed it, the configured path was never right,
+    /// or a folder the mapping asked to have created could not be created. Nothing falls back to the configured path and
+    /// nothing searches for a folder whose name looks close, because either would file somebody's mail somewhere they
+    /// did not name.
+    /// </remarks>
+    DestinationFolderNotAdvertised = 4,
+
+    /// <summary>Several advertised folders carry the role the destination's mapping names.</summary>
+    /// <remarks>
+    /// Which of them was meant is the operator's to state, by mapping the role to one folder or by naming the folder's
+    /// path outright. Picking the first of several would let a reordered server response change where mail is filed.
+    /// </remarks>
+    DestinationFolderAmbiguous = 5,
 }

--- a/src/Application/Rules/Actions/MailRuleActionRecorder.cs
+++ b/src/Application/Rules/Actions/MailRuleActionRecorder.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using MailFathom.Application.Folders;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
@@ -33,45 +33,32 @@ namespace MailFathom.Application.Rules.Actions;
 /// same identity.
 /// </para>
 /// <para>
-/// A destination is resolved to a remote folder once per pass and remembered, because a batch of two hundred emails
-/// matching one filing rule would otherwise re-read one binding two hundred times. The binding a pass began with is the
-/// one it finishes with, which is the same contract the rule set itself is read under. A destination named by role is
-/// turned into a folder through the resolution every caller naming a folder shares, so a role the account has stopped
-/// mapping fails here exactly as an alias whose binding went missing does.
+/// Where a destination is is not resolved here. The answers are handed in, already resolved, because resolving one can
+/// reach the mail server and nothing may do that while the batch's transaction is open. A rule is one author of a
+/// filing mutation among others, and the folder it files into is found the same way for all of them.
 /// </para>
 /// </remarks>
 public sealed class MailRuleActionRecorder
 {
     private readonly IMailboxMutationRecordStore records;
-    private readonly IMailFolderResolutionStore folderResolutions;
-    private readonly MailFolderReferenceResolver folderReferences;
     private readonly IAuthoredDeleteEmailDispositionReader deleteDispositions;
     private readonly IMailRuleActionPermissionReader permissions;
-    private readonly Dictionary<(MailAccountId Account, MailFolderReference Destination), ResolvedDestination?> destinations = [];
 
     /// <summary>Initializes the recorder from the record it writes and the decisions it has to read.</summary>
     /// <param name="records">Opens the durable record one action is carried by.</param>
-    /// <param name="folderResolutions">Resolves a destination alias to the remote folder it currently names.</param>
-    /// <param name="folderReferences">Turns the alias or the role a rule named into the folder of the account it means.</param>
-    /// <param name="deleteDispositions">Answers what the account keeps locally of an email a rule deletes.</param>
+    /// <param name="deleteDispositions">Answers what the account keeps locally of an email a rule deletes or files away.</param>
     /// <param name="permissions">Answers which changes the account currently permits a rule to make.</param>
     /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
     public MailRuleActionRecorder(
         IMailboxMutationRecordStore records,
-        IMailFolderResolutionStore folderResolutions,
-        MailFolderReferenceResolver folderReferences,
         IAuthoredDeleteEmailDispositionReader deleteDispositions,
         IMailRuleActionPermissionReader permissions)
     {
         ArgumentNullException.ThrowIfNull(records);
-        ArgumentNullException.ThrowIfNull(folderResolutions);
-        ArgumentNullException.ThrowIfNull(folderReferences);
         ArgumentNullException.ThrowIfNull(deleteDispositions);
         ArgumentNullException.ThrowIfNull(permissions);
 
         this.records = records;
-        this.folderResolutions = folderResolutions;
-        this.folderReferences = folderReferences;
         this.deleteDispositions = deleteDispositions;
         this.permissions = permissions;
     }
@@ -82,6 +69,7 @@ public sealed class MailRuleActionRecorder
     /// <param name="occurrence">Where that email is, which is what an IMAP command will be issued against.</param>
     /// <param name="plan">What the matching rules together ask for.</param>
     /// <param name="revision">The rule set revision the pass ran under, which is part of every request's identity.</param>
+    /// <param name="destinations">Where the folders this batch's actions name currently are, resolved before the transaction opened.</param>
     /// <param name="cancellationToken">Cancels the staging.</param>
     /// <returns>Every action a record was opened for, with the record that carries it, and every action nothing was opened for.</returns>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
@@ -92,11 +80,13 @@ public sealed class MailRuleActionRecorder
         EmailOccurrenceId occurrence,
         MailRuleActionPlan plan,
         MailRuleSetRevision revision,
+        MailboxDestinations destinations,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(session);
         ArgumentNullException.ThrowIfNull(occurrence);
         ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(destinations);
 
         if (!revision.IsSpecified)
         {
@@ -133,13 +123,7 @@ public sealed class MailRuleActionRecorder
                 continue;
             }
 
-            var request = await this.BuildRequestAsync(
-                storedEmailId,
-                occurrence,
-                planned,
-                revision,
-                failures,
-                cancellationToken);
+            var request = this.BuildRequest(storedEmailId, occurrence, planned, revision, destinations, failures);
 
             if (request is null)
             {
@@ -153,7 +137,7 @@ public sealed class MailRuleActionRecorder
                 planned.Position,
                 planned.Action.Mutation,
                 record.Id,
-                this.RecordedDestinationAlias(occurrence.AccountId, planned.Action.Destination)));
+                RecordedDestinationAlias(destinations, planned.Action.Destination)));
         }
 
         return new MailRuleActionRecording(recorded, failures);
@@ -184,13 +168,13 @@ public sealed class MailRuleActionRecorder
     ];
 
     /// <summary>Turns one planned action into the request that carries it, or records why it has none.</summary>
-    private async Task<MailboxMutationRequest?> BuildRequestAsync(
+    private MailboxMutationRequest? BuildRequest(
         StoredEmailId storedEmailId,
         EmailOccurrenceId occurrence,
         PlannedMailRuleAction planned,
         MailRuleSetRevision revision,
-        List<MailRuleActionFailure> failures,
-        CancellationToken cancellationToken)
+        MailboxDestinations destinations,
+        List<MailRuleActionFailure> failures)
     {
         var action = planned.Action;
         var requester = MailboxMutationRequester.Rule(planned.RuleName, revision.Value);
@@ -202,33 +186,69 @@ public sealed class MailRuleActionRecorder
 
         if (action.Destination is { } destination)
         {
-            var resolved = await this.ResolveDestinationAsync(
-                occurrence.AccountId,
-                destination,
-                cancellationToken);
-
-            if (resolved is not { Path: var path })
-            {
-                failures.Add(new MailRuleActionFailure(
-                    planned.RuleName,
-                    planned.Position,
-                    action.Mutation,
-                    MailRuleActionFailureReason.DestinationFolderUnresolved,
-                    destination));
-
-                return null;
-            }
-
-            // No local disposition travels with a relocation here. One is supplied exactly when the destination is a
-            // folder MailFathom does not mirror, and a rule may not name such a folder at all: the rule set is refused
-            // when it is read if it does, so a destination that reaches this point is one whose mail stays mirrored.
-            return action.Mutation == MailboxMutation.Relocate
-                ? MailboxMutationRequest.Relocate(storedEmailId, occurrence, requester, path)
-                : MailboxMutationRequest.Copy(storedEmailId, occurrence, requester, path);
+            return this.BuildFilingRequest(
+                storedEmailId,
+                occurrence,
+                planned,
+                requester,
+                destinations.Find(destination),
+                failures);
         }
 
         return this.BuildDeleteRequest(storedEmailId, occurrence, planned, requester, failures);
     }
+
+    /// <summary>Builds the relocation or the copy one action asked for, against the folder its destination resolved to.</summary>
+    /// <remarks>
+    /// A relocation into a folder the account mirrors carries the local row into that folder and decides nothing about
+    /// it. One into a folder the account only maps has taken the message out of the mirrored mailbox for good, so the
+    /// request carries what the account says becomes of a local copy — the same answer a delete carries, resolved when
+    /// the change is authored rather than when the source occurrence is later seen to be gone. A copy carries none
+    /// either way, because the message it duplicates stays where it is.
+    /// </remarks>
+    private MailboxMutationRequest? BuildFilingRequest(
+        StoredEmailId storedEmailId,
+        EmailOccurrenceId occurrence,
+        PlannedMailRuleAction planned,
+        MailboxMutationRequester requester,
+        MailboxDestinationResolution resolution,
+        List<MailRuleActionFailure> failures)
+    {
+        if (resolution.Destination is not { } destination)
+        {
+            failures.Add(new MailRuleActionFailure(
+                planned.RuleName,
+                planned.Position,
+                planned.Action.Mutation,
+                FailureReasonOf(resolution.Outcome),
+                planned.Action.Destination));
+
+            return null;
+        }
+
+        if (planned.Action.Mutation == MailboxMutation.Copy)
+        {
+            return MailboxMutationRequest.Copy(storedEmailId, occurrence, requester, destination.Path);
+        }
+
+        if (destination.IsMirrored)
+        {
+            return MailboxMutationRequest.Relocate(storedEmailId, occurrence, requester, destination.Path);
+        }
+
+        return this.TryReadDeleteDisposition(occurrence.AccountId, planned, failures) is { } disposition
+            ? MailboxMutationRequest.Relocate(storedEmailId, occurrence, requester, destination.Path, disposition)
+            : null;
+    }
+
+    /// <summary>Names the refusal one unresolved destination is reported to the operator as.</summary>
+    private static MailRuleActionFailureReason FailureReasonOf(MailboxDestinationOutcome outcome) => outcome switch
+    {
+        MailboxDestinationOutcome.Unmapped => MailRuleActionFailureReason.DestinationFolderUnmapped,
+        MailboxDestinationOutcome.NotAdvertised => MailRuleActionFailureReason.DestinationFolderNotAdvertised,
+        MailboxDestinationOutcome.Ambiguous => MailRuleActionFailureReason.DestinationFolderAmbiguous,
+        _ => MailRuleActionFailureReason.DestinationFolderUnresolved,
+    };
 
     /// <summary>Builds a delete, whose local disposition is the account's answer at the moment the request is written.</summary>
     /// <remarks>
@@ -241,13 +261,20 @@ public sealed class MailRuleActionRecorder
         EmailOccurrenceId occurrence,
         PlannedMailRuleAction planned,
         MailboxMutationRequester requester,
+        List<MailRuleActionFailure> failures) =>
+        this.TryReadDeleteDisposition(occurrence.AccountId, planned, failures) is { } disposition
+            ? MailboxMutationRequest.Delete(storedEmailId, occurrence, requester, disposition)
+            : null;
+
+    /// <summary>Reads what becomes of the local copy, or records that the account deciding it is no longer declared.</summary>
+    private AuthoredDeleteEmailDisposition? TryReadDeleteDisposition(
+        MailAccountId accountId,
+        PlannedMailRuleAction planned,
         List<MailRuleActionFailure> failures)
     {
-        AuthoredDeleteEmailDisposition disposition;
-
         try
         {
-            disposition = this.deleteDispositions.GetAuthoredDeleteDisposition(occurrence.AccountId);
+            return this.deleteDispositions.GetAuthoredDeleteDisposition(accountId);
         }
         catch (InvalidOperationException)
         {
@@ -255,83 +282,21 @@ public sealed class MailRuleActionRecorder
                 planned.RuleName,
                 planned.Position,
                 planned.Action.Mutation,
-                MailRuleActionFailureReason.AccountNoLongerConfigured));
+                MailRuleActionFailureReason.AccountNoLongerConfigured,
+                planned.Action.Destination));
 
             return null;
         }
-
-        return MailboxMutationRequest.Delete(storedEmailId, occurrence, requester, disposition);
     }
 
-    /// <summary>Finds the folder a destination currently names, remembering the answer for the rest of the pass.</summary>
-    /// <returns>The folder, or <see langword="null" /> when the account maps no such folder or nothing has bound one yet.</returns>
-    private async Task<ResolvedDestination?> ResolveDestinationAsync(
-        MailAccountId accountId,
-        MailFolderReference destination,
-        CancellationToken cancellationToken)
-    {
-        // Keyed by the account as well as the destination, because one name means a different folder on each account
-        // and nothing in this type's contract says a scope holds one account's pass.
-        if (this.destinations.TryGetValue((accountId, destination), out var remembered))
-        {
-            return remembered;
-        }
-
-        var resolved = await this.ReadCurrentDestinationAsync(accountId, destination, cancellationToken);
-
-        this.destinations[(accountId, destination)] = resolved;
-
-        return resolved;
-    }
-
-    /// <summary>Reads the alias a recorded action names its folder by, which is what this pass resolved the destination to.</summary>
+    /// <summary>Reads the alias a recorded action names its folder by, which is the folder mail was actually filed into.</summary>
     /// <remarks>
-    /// It reads the answer this pass already has rather than resolving again, and it is asked only after the request was
-    /// built — so an action that reaches the history names the folder mail was actually filed into, whether the rule
-    /// wrote that folder's alias or the role it plays.
+    /// It reads the answers the batch was handed rather than resolving again, and it is asked only after the request was
+    /// built — so an action that reaches the history names the folder mail went to, whether the rule wrote that folder's
+    /// alias or the role it plays.
     /// </remarks>
-    private MailFolderAlias? RecordedDestinationAlias(MailAccountId accountId, MailFolderReference? destination) =>
-        destination is { } named && this.destinations.TryGetValue((accountId, named), out var resolved)
-            ? resolved?.Alias
-            : null;
-
-    /// <summary>Turns a destination into the folder it currently names, in the two steps a name goes through.</summary>
-    /// <remarks>
-    /// A role the account no longer maps is caught rather than propagated, because it says the same thing to this pass
-    /// as an alias whose binding is missing: the rule has nowhere to file, the action is reported as failed, and the
-    /// rest of the batch keeps moving. Letting it out would stop every other rule over one rule's destination.
-    /// </remarks>
-    private async Task<ResolvedDestination?> ReadCurrentDestinationAsync(
-        MailAccountId accountId,
-        MailFolderReference destination,
-        CancellationToken cancellationToken)
-    {
-        MailFolderAlias destinationAlias;
-
-        try
-        {
-            destinationAlias = this.folderReferences.ResolveAlias(accountId, destination);
-        }
-        catch (MailFolderRoleUnmappedException)
-        {
-            return null;
-        }
-
-        var resolution = await this.folderResolutions.GetCurrentResolutionAsync(
-            accountId,
-            destinationAlias,
-            cancellationToken);
-
-        return resolution is { RemotePath: var remotePath }
-            ? new ResolvedDestination(destinationAlias, remotePath)
-            : null;
-    }
-
-    /// <summary>One destination as this pass resolved it: the alias it names the folder by, and where that folder is.</summary>
-    /// <remarks>
-    /// Both halves are kept because two different things need them. The request carries the path, which is what a
-    /// mailbox command is issued against; the history names the alias, which is MailFathom's own name for the folder and
-    /// the one a rule written against a role never spelled out.
-    /// </remarks>
-    private sealed record ResolvedDestination(MailFolderAlias Alias, RemoteFolderPath Path);
+    private static MailFolderAlias? RecordedDestinationAlias(
+        MailboxDestinations destinations,
+        MailFolderReference? destination) =>
+        destination is { } named ? destinations.Find(named).Destination?.Alias : null;
 }

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Folders;
+using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules.Actions;
 using MailFathom.Application.Rules.Conditions;
@@ -10,6 +11,7 @@ using MailFathom.Application.Rules.Facts;
 using MailFathom.Application.Rules.History;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
 
 namespace MailFathom.Application.Rules.Evaluation;
 
@@ -41,10 +43,16 @@ namespace MailFathom.Application.Rules.Evaluation;
 /// </para>
 /// <para>
 /// What a match asks the mailbox for is written down in the batch's own transaction, as the durable mutation record
-/// every requester uses, and never issued from here: a pass reaches no mail server, and the account's convergence pass
-/// is what carries each record to a completed or a dead-lettered ending. Committing the requests with the evaluations
-/// is what makes the pair atomic — an email is never recorded as evaluated while the change its rules asked for was
-/// lost, and a rolled-back batch asks again under the same identity.
+/// every requester uses, and never issued from here: no IMAP command a rule asks for leaves this pass, and the account's
+/// convergence pass is what carries each record to a completed or a dead-lettered ending. Committing the requests with
+/// the evaluations is what makes the pair atomic — an email is never recorded as evaluated while the change its rules
+/// asked for was lost, and a rolled-back batch asks again under the same identity.
+/// </para>
+/// <para>
+/// The one thing a pass does reach a mail server for is finding a destination folder the account maps and does not
+/// mirror, which no run of its own ever binds. That happens between evaluating a batch and committing it, deliberately:
+/// a listing is a round trip, and holding the batch's transaction open across one would keep local rows locked for the
+/// length of somebody else's network. Everything the pass reads about the mail itself was already stored.
 /// </para>
 /// <para>
 /// The history of what each rule concluded is written in that same transaction and for the same reason. An explanation
@@ -59,6 +67,7 @@ public sealed class MailRuleEvaluationPass
     private readonly IMailRuleEvaluationStore store;
     private readonly IMailRuleEvaluationRunStore runStore;
     private readonly MailRuleActionRecorder actionRecorder;
+    private readonly MailboxDestinationResolver destinationResolver;
     private readonly IMailRuleExecutionStore executionStore;
     private readonly IMailFolderMappingReader folderMappings;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
@@ -71,6 +80,7 @@ public sealed class MailRuleEvaluationPass
     /// <param name="store">Reads the candidates and records which emails have been evaluated.</param>
     /// <param name="runStore">Reads the requested whole-mailbox run and records how far it has been carried.</param>
     /// <param name="actionRecorder">Writes down the changes a matching rule asks the mailbox for.</param>
+    /// <param name="destinationResolver">Finds the folders those changes file into, before the batch's transaction opens.</param>
     /// <param name="executionStore">Keeps the record of what each rule concluded and what became of what it asked for.</param>
     /// <param name="folderMappings">Answers what the folder an email is in is configured for, which a condition naming the role reads.</param>
     /// <param name="commitPolicy">Commits a batch's evaluations together with the position they account for.</param>
@@ -84,6 +94,7 @@ public sealed class MailRuleEvaluationPass
         IMailRuleEvaluationStore store,
         IMailRuleEvaluationRunStore runStore,
         MailRuleActionRecorder actionRecorder,
+        MailboxDestinationResolver destinationResolver,
         IMailRuleExecutionStore executionStore,
         IMailFolderMappingReader folderMappings,
         OptimisticConcurrencyRetryPolicy commitPolicy,
@@ -95,6 +106,7 @@ public sealed class MailRuleEvaluationPass
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(runStore);
         ArgumentNullException.ThrowIfNull(actionRecorder);
+        ArgumentNullException.ThrowIfNull(destinationResolver);
         ArgumentNullException.ThrowIfNull(executionStore);
         ArgumentNullException.ThrowIfNull(folderMappings);
         ArgumentNullException.ThrowIfNull(commitPolicy);
@@ -108,6 +120,7 @@ public sealed class MailRuleEvaluationPass
         this.store = store;
         this.runStore = runStore;
         this.actionRecorder = actionRecorder;
+        this.destinationResolver = destinationResolver;
         this.executionStore = executionStore;
         this.folderMappings = folderMappings;
         this.commitPolicy = commitPolicy;
@@ -180,6 +193,7 @@ public sealed class MailRuleEvaluationPass
             if (outcome.EvaluatedEmailIds.Count > 0)
             {
                 var evaluatedAt = this.timeProvider.GetUtcNow();
+                var destinations = await this.ResolveDestinationsAsync(accountId, outcome, cancellationToken);
 
                 await this.commitPolicy.CommitAsync(
                     async (session, attemptCancellationToken) =>
@@ -195,6 +209,7 @@ public sealed class MailRuleEvaluationPass
                             boundRuleSet.RuleSet.Revision,
                             outcome,
                             boundRuleSet.Trigger,
+                            destinations,
                             attemptCancellationToken);
                     },
                     cancellationToken);
@@ -286,6 +301,7 @@ public sealed class MailRuleEvaluationPass
         }
 
         var outcome = await this.EvaluateBatchAsync(boundRuleSet, batch, cancellationToken);
+        var destinations = await this.ResolveDestinationsAsync(run.AccountId, outcome, cancellationToken);
         var reachedTheEnd = batch.Count < this.options.BatchSize;
         var recordedAt = this.timeProvider.GetUtcNow();
 
@@ -313,6 +329,7 @@ public sealed class MailRuleEvaluationPass
                     boundRuleSet.RuleSet.Revision,
                     outcome,
                     boundRuleSet.Trigger,
+                    destinations,
                     attemptCancellationToken);
 
                 await this.runStore.SaveAsync(session, carried, attemptCancellationToken);
@@ -340,6 +357,7 @@ public sealed class MailRuleEvaluationPass
         MailRuleSetRevision revision,
         MailRuleEvaluationBatch outcome,
         MailRuleExecutionTrigger trigger,
+        MailboxDestinations destinations,
         CancellationToken cancellationToken)
     {
         outcome.ForgetRecordedActions();
@@ -357,6 +375,7 @@ public sealed class MailRuleEvaluationPass
                     evaluated.Candidate.Occurrence,
                     plan,
                     revision,
+                    destinations,
                     cancellationToken);
 
             outcome.ActionsRecorded(recording);
@@ -371,6 +390,30 @@ public sealed class MailRuleEvaluationPass
         }
 
         await this.executionStore.AppendAsync(session, executions, cancellationToken);
+    }
+
+    /// <summary>Finds every folder this batch's matching rules file into, before the transaction that records them opens.</summary>
+    /// <remarks>
+    /// A batch naming no destination asks nothing, which is what keeps an account whose rules only flag or delete mail
+    /// from ever reaching its mail server here. What one batch resolved the next reuses, so a pass over a mailbox costs
+    /// one answer per destination rather than one per batch.
+    /// </remarks>
+    private async Task<MailboxDestinations> ResolveDestinationsAsync(
+        MailAccountId accountId,
+        MailRuleEvaluationBatch outcome,
+        CancellationToken cancellationToken)
+    {
+        MailFolderReference[] named =
+        [
+            .. outcome.EvaluatedEmails
+                .SelectMany(evaluated => evaluated.Evaluation.ActionPlan.Actions)
+                .Select(planned => planned.Action.Destination)
+                .OfType<MailFolderReference>(),
+        ];
+
+        return named.Length == 0
+            ? MailboxDestinations.None
+            : await this.destinationResolver.ResolveAsync(accountId, named, cancellationToken);
     }
 
     private Task CommitRunAsync(MailRuleEvaluationRun run, CancellationToken cancellationToken) =>

--- a/src/Host/Configuration/Rules/DeclaredMailAccount.cs
+++ b/src/Host/Configuration/Rules/DeclaredMailAccount.cs
@@ -7,27 +7,27 @@ using MailFathom.Domain.Folders;
 
 namespace MailFathom.Host.Configuration.Rules;
 
-/// <summary>One account as a rule set is judged against it: its identifier, its mirrored folders, and what it permits.</summary>
+/// <summary>One account as a rule set is judged against it: its identifier, its mapped folders, and what it permits.</summary>
 /// <param name="AccountId">The identifier a rule's scope names, compared exactly as the synchronization section writes it.</param>
-/// <param name="MirroredFolders">
-/// The folders this account mirrors, which are the folders a rule may name as a destination. A mapped folder the account
-/// does not mirror is deliberately absent: nothing binds such a folder to a remote one, so a rule filing into it could
-/// never resolve a path to file into.
+/// <param name="MappedFolders">
+/// Every folder this account maps, whether or not it mirrors one, because a mapping is all a destination needs. A folder
+/// the account only maps is resolved when a change first files into it rather than by a run of its own, so filing into
+/// one is reachable in exactly the way filing into a mirrored folder is.
 /// </param>
 /// <param name="PermittedRuleActions">Which of the four changes a rule may ask for on this account.</param>
 internal sealed record DeclaredMailAccount(
     string AccountId,
-    IReadOnlyCollection<DeclaredMailFolder> MirroredFolders,
+    IReadOnlyCollection<DeclaredMailFolder> MappedFolders,
     MailRuleActionPermissions PermittedRuleActions)
 {
-    /// <summary>Reports whether a rule's destination names a folder this account mirrors.</summary>
+    /// <summary>Reports whether a rule's destination names a folder this account maps.</summary>
     /// <param name="destination">The alias or role the rule wrote.</param>
-    /// <returns><see langword="true" /> when one mirrored folder of this account answers to that name.</returns>
+    /// <returns><see langword="true" /> when one mapped folder of this account answers to that name.</returns>
     /// <remarks>
     /// The two kinds of name are answered together rather than by two rules that could drift apart, which is what makes
-    /// a rule filing into <c>role:Junk</c> refused for exactly the accounts that map no mirrored junk folder — and
-    /// accepted for the ones that do, whatever each of them called it.
+    /// a rule filing into <c>role:Junk</c> refused for exactly the accounts that map no junk folder — and accepted for
+    /// the ones that do, whatever each of them called it and whether or not they mirror it.
     /// </remarks>
-    internal bool Mirrors(MailFolderReference destination) =>
-        this.MirroredFolders.Any(folder => folder.IsNamedBy(destination));
+    internal bool Maps(MailFolderReference destination) =>
+        this.MappedFolders.Any(folder => folder.IsNamedBy(destination));
 }

--- a/src/Host/Configuration/Rules/DeclaredMailAccounts.cs
+++ b/src/Host/Configuration/Rules/DeclaredMailAccounts.cs
@@ -23,8 +23,9 @@ namespace MailFathom.Host.Configuration.Rules;
 /// again here would name the wrong section.
 /// </para>
 /// <para>
-/// A folder alias that is not a value this system issues is dropped for the same reason, and so is an unmirrored
-/// folder — the second deliberately, because a rule may only file into a folder whose mail this account mirrors.
+/// A folder alias that is not a value this system issues is dropped for the same reason. Every mapped folder is read,
+/// including one the account does not mirror, because a mapping is the whole of what a destination needs: such a folder
+/// is resolved when a change first files into it rather than by a run of its own.
 /// </para>
 /// <para>
 /// Each folder is read with the role it plays beside its alias, because a rule may name its destination either way and
@@ -70,26 +71,24 @@ internal static class DeclaredMailAccounts
                 .Where(account => !string.IsNullOrWhiteSpace(account.AccountId))
                 .Select(account => new DeclaredMailAccount(
                     account.AccountId.Trim(),
-                    ReadMirroredFolders(account),
+                    ReadMappedFolders(account),
                     (account.RuleActions ?? new MailRuleActionPermissionOptions()).ToPermissions())),
         ];
     }
 
-    /// <summary>Reads one account's mirrored folders from the bound folders it is actually run with.</summary>
-    private static IReadOnlyCollection<DeclaredMailFolder> ReadMirroredFolders(MailSynchronizationAccountOptions account) =>
+    /// <summary>Reads one account's mapped folders from the bound folders it is actually run with.</summary>
+    private static IReadOnlyCollection<DeclaredMailFolder> ReadMappedFolders(MailSynchronizationAccountOptions account) =>
     [
         .. account.EffectiveFolders
-            .Where(folder => folder.Participation.IsSynchronized)
             .Select(folder => TryReadFolder(folder.Alias, folder.DeclaredRole))
             .OfType<DeclaredMailFolder>(),
     ];
 
     /// <summary>Reads one account's keys, which is the shape available before anything has been bound.</summary>
     /// <remarks>
-    /// The folder participation is read as <c>Synchronize</c> alone rather than through
-    /// <see cref="MailFolderParticipation" />, because that type derives the other two answers from this one and the
-    /// other two decide nothing about a destination. An account declaring no folder is read as mirroring the inbox,
-    /// which is the mapping it is actually run with.
+    /// No participation switch is read at all: none of the three decides anything about a destination, and reading one
+    /// here would refuse a rule for filing into a folder that is perfectly reachable. An account declaring no folder is
+    /// read as mapping the inbox, which is the mapping it is actually run with.
     /// </remarks>
     private static DeclaredMailAccount? ReadAccount(IConfigurationSection account)
     {
@@ -105,10 +104,9 @@ internal static class DeclaredMailAccounts
             .GetChildren()
             .ToArray();
 
-        var mirroredFolders = folders.Length == 0
+        var mappedFolders = folders.Length == 0
             ? [TryReadFolder(nameof(MailFolderSpecialUse.Inbox), MailFolderSpecialUse.Inbox)]
             : folders
-                .Where(folder => !IsDeclaredFalse(folder[nameof(MailFolderMappingOptions.Synchronize)]))
                 .Select(folder => TryReadFolder(
                     folder[nameof(MailFolderMappingOptions.Alias)],
                     MailFolderMappingOptions.TryParseSpecialUse(folder[nameof(MailFolderMappingOptions.SpecialUse)], out var role)
@@ -118,7 +116,7 @@ internal static class DeclaredMailAccounts
 
         return new DeclaredMailAccount(
             accountId,
-            [.. mirroredFolders.OfType<DeclaredMailFolder>()],
+            [.. mappedFolders.OfType<DeclaredMailFolder>()],
             ReadPermissions(account.GetSection(nameof(MailSynchronizationAccountOptions.RuleActions))));
     }
 

--- a/src/Host/Configuration/Rules/MailRuleDeclarationRules.cs
+++ b/src/Host/Configuration/Rules/MailRuleDeclarationRules.cs
@@ -215,10 +215,11 @@ internal static class MailRuleDeclarationRules
     /// <remarks>
     /// <para>
     /// Three separate claims are checked here. Whether the declared actions can be honored together is a property of
-    /// the rule alone. Whether a destination names a folder the account mirrors — by its alias or by the role it plays
-    /// — and whether the account permits the action at all, are claims about the synchronization section, and both are
+    /// the rule alone. Whether a destination names a folder the account maps — by its alias or by the role it plays —
+    /// and whether the account permits the action at all, are claims about the synchronization section, and both are
     /// refused rather than deferred, because a rule that would be skipped when the mail reached it is indistinguishable
-    /// from a rule nothing matched.
+    /// from a rule nothing matched. Mirroring is deliberately not among the claims: a folder the account only maps is
+    /// resolved when a change first files into it, so it is as reachable a destination as any other.
     /// </para>
     /// <para>
     /// A rule that is switched off is judged like any other, exactly as its scope already is. Only the condition is
@@ -276,10 +277,10 @@ internal static class MailRuleDeclarationRules
         }
 
         foreach (var action in actions.Where(action =>
-            action.Destination is { } destination && !account.Mirrors(destination)))
+            action.Destination is { } destination && !account.Maps(destination)))
         {
             yield return
-                $"Rule '{ruleName}' files into '{action.Destination}', which account '{account.AccountId}' does not declare as a mirrored folder, so nothing would bind it to a folder on the server.";
+                $"Rule '{ruleName}' files into '{action.Destination}', which account '{account.AccountId}' maps no folder for. Map it under MailSynchronization:Accounts:<n>:Folders; mapping the folder is what makes it reachable, and 'Synchronize': false on that mapping still leaves it a destination.";
         }
     }
 

--- a/src/Host/Configuration/Rules/MailRuleDeclarationRules.cs
+++ b/src/Host/Configuration/Rules/MailRuleDeclarationRules.cs
@@ -264,7 +264,7 @@ internal static class MailRuleDeclarationRules
         }
     }
 
-    /// <summary>Judges one rule's actions against one account's mirrored folders and its own permissions.</summary>
+    /// <summary>Judges one rule's actions against one account's mapped folders and its own permissions.</summary>
     private static IEnumerable<string> FindAccountActionErrors(
         string ruleName,
         IReadOnlyList<MailRuleAction> actions,

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -448,13 +448,17 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// </para>
     /// <para>
     /// A failure never fails the run. Everything a pass reads about the mail itself was already stored, and the one
-    /// thing it does ask a mail server — where a folder the account maps and does not mirror currently is — is asked of
-    /// a server the folders above have already reached, so an unreachable one has put the account into backoff before
-    /// this step began. Backing it off again here would slow the remote work over a local problem, or over the same
-    /// remote one twice. What a pass did not finish, the next run resumes from the batches this one committed.
+    /// thing it does ask a mail server — where a folder the account maps and does not mirror currently is — it asks
+    /// only where a rule files into such a folder. Wherever this run has already converged a change or synchronized a
+    /// folder, that server has been reached, so an unreachable one put the account into backoff before this step
+    /// began, and backing it off again here would slow the remote work over a local problem or over the same remote
+    /// one twice. An account that mirrors nothing and had nothing to converge reaches it here first instead, and a
+    /// lookup that fails there leaves the account on its ordinary interval: that lookup is the whole of such a run's
+    /// remote work, so backoff would slow nothing else, and the interval already spaces what is left to retry. What a
+    /// pass did not finish, the next run resumes from the batches this one committed.
     /// </para>
     /// </remarks>
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Rule evaluation is a local pass rather than a mail operation; one that failed is logged and resumed by the next run rather than putting the account into backoff.")]
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "A pass that failed is logged and resumed by the next run rather than putting the account into backoff; the remarks hold why that stays right for the one remote step it takes.")]
     private async Task EvaluateMailRulesAsync(
         MailSynchronizationOptions runSettings,
         CancellationToken cancellationToken)

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -447,10 +447,11 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// offering them to a rule on the way out.
     /// </para>
     /// <para>
-    /// A failure never fails the run. Evaluation reaches no mail server — everything it reads was already stored — so
-    /// backing the account off, which is to say fetching its mail less often, would answer a local problem by slowing
-    /// the remote work that had nothing to do with it. What a pass did not finish, the next run resumes from the
-    /// batches this one committed.
+    /// A failure never fails the run. Everything a pass reads about the mail itself was already stored, and the one
+    /// thing it does ask a mail server — where a folder the account maps and does not mirror currently is — is asked of
+    /// a server the folders above have already reached, so an unreachable one has put the account into backoff before
+    /// this step began. Backing it off again here would slow the remote work over a local problem, or over the same
+    /// remote one twice. What a pass did not finish, the next run resumes from the batches this one committed.
     /// </para>
     /// </remarks>
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Rule evaluation is a local pass rather than a mail operation; one that failed is logged and resumed by the next run rather than putting the account into backoff.")]

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -27,6 +27,7 @@ using MailFathom.Application.Folders;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
+using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
 using MailFathom.Application.Retrieval;
@@ -515,6 +516,7 @@ public static class ServiceCollectionExtensions
         // than to any run, and the counters beside it accumulate across every account.
         services.AddSingleton<MailboxContentVolumeTelemetry>();
         services.AddScoped<MailboxMutationConverger>();
+        services.AddScoped<MailboxDestinationResolver>();
         services.AddScoped<IRemoteFolderCatalog>(provider => new MailKitRemoteFolderCatalog(
             static () => new ImapClient(),
             provider.GetRequiredService<IImapAccountSettingsProvider>(),

--- a/tests/Application.UnitTests/Mail/Mutations/Destinations/MailboxDestinationResolverTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Destinations/MailboxDestinationResolverTests.cs
@@ -1,0 +1,285 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations.Destinations;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Transport;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Mail.Mutations.Destinations;
+
+/// <summary>Covers how a change's destination becomes a folder, for one the account mirrors and one it only maps.</summary>
+public sealed class MailboxDestinationResolverTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+    private static readonly MailFolderAlias Archive = MailFolderAlias.Create("archive");
+    private static readonly MailFolderAlias Junk = MailFolderAlias.Create("junk");
+
+    /// <summary>A folder its own run binds is read from that binding, without a word to the mail server.</summary>
+    [Fact]
+    public async Task ResolveAsync_AMirroredDestination_AnswersFromTheBindingItsRunRecorded()
+    {
+        // Arrange
+        var context = new DestinationContext();
+        context.Mappings.With(Account, MailFolderMapping.ToRemotePath(Archive, RemoteFolderPath.Create("INBOX/Archive")));
+        var binding = context.Bindings.Bind(Account, Archive, "INBOX/Archive");
+
+        // Act
+        var resolution = await context.ResolveAsync(MailFolderReference.ToAlias(Archive));
+
+        // Assert
+        Assert.Equal(MailboxDestinationOutcome.Resolved, resolution.Outcome);
+        MailboxDestination destination = resolution.Destination!;
+        Assert.Equal(Archive, destination.Alias);
+        Assert.Equal(binding.RemotePath, destination.Path);
+        Assert.True(destination.IsMirrored);
+        Assert.Equal(0, context.ListedFolderCount);
+    }
+
+    /// <summary>No run schedules an unmirrored folder, so the moment it is needed as a destination is when it is resolved.</summary>
+    [Fact]
+    public async Task ResolveAsync_AnUnmirroredDestination_ResolvesItAgainstTheServerAndRecordsTheBinding()
+    {
+        // Arrange
+        var context = new DestinationContext(new RemoteFolder(RemoteFolderPath.Create("INBOX.Spam", '.'), []));
+        context.Mappings.With(Account, MappedOnlyPathTo(Junk, "INBOX.Spam"));
+
+        // Act
+        var resolution = await context.ResolveAsync(MailFolderReference.ToAlias(Junk));
+
+        // Assert
+        Assert.Equal(MailboxDestinationOutcome.Resolved, resolution.Outcome);
+        Assert.Equal("INBOX.Spam", resolution.Destination!.Path.Value);
+        Assert.False(resolution.Destination.IsMirrored);
+        Assert.NotNull(await context.Bindings.GetCurrentResolutionAsync(Account, Junk, TestContext.Current.CancellationToken));
+        Assert.Equal(Junk, Assert.Single(context.RecordedChanges).Alias);
+    }
+
+    /// <summary>A batch filing two hundred messages into one folder must cost one listing, not two hundred.</summary>
+    [Fact]
+    public async Task ResolveAsync_TheSameUnmirroredDestinationTwice_ListsTheServerOnce()
+    {
+        // Arrange
+        var context = new DestinationContext(new RemoteFolder(RemoteFolderPath.Create("INBOX.Spam", '.'), []));
+        context.Mappings.With(Account, MappedOnlyPathTo(Junk, "INBOX.Spam"));
+
+        // Act
+        await context.ResolveAsync(MailFolderReference.ToAlias(Junk));
+        var second = await context.ResolveAsync(MailFolderReference.ToAlias(Junk));
+
+        // Assert
+        Assert.Equal(MailboxDestinationOutcome.Resolved, second.Outcome);
+        Assert.Equal(1, context.ListedFolderCount);
+    }
+
+    /// <summary>A server that moved the folder is followed, exactly as a mirrored folder's next run follows it.</summary>
+    [Fact]
+    public async Task ResolveAsync_AnUnmirroredDestinationTheServerRenamed_BindsTheNextGenerationToTheNewFolder()
+    {
+        // Arrange
+        var context = new DestinationContext(new RemoteFolder(RemoteFolderPath.Create("INBOX.Junk", '.'), []));
+        context.Mappings.With(Account, MappedOnlyPathTo(Junk, "INBOX.Junk"));
+        var previous = context.Bindings.Bind(Account, Junk, "INBOX.Spam");
+
+        // Act
+        var resolution = await context.ResolveAsync(MailFolderReference.ToAlias(Junk));
+
+        // Assert
+        Assert.Equal("INBOX.Junk", resolution.Destination!.Path.Value);
+        var replaced = await context.Bindings.GetCurrentResolutionAsync(Account, Junk, TestContext.Current.CancellationToken);
+        Assert.Equal(previous.Generation.Value + 1, replaced!.Generation.Value);
+    }
+
+    /// <summary>Mapping the folder is the whole of what makes it reachable, so an alias no mapping declares reaches nothing.</summary>
+    [Fact]
+    public async Task ResolveAsync_AnAliasNoMappingDeclares_ReportsItAsUnmapped()
+    {
+        // Arrange
+        var context = new DestinationContext();
+        context.Bindings.Bind(Account, Archive, "INBOX/Archive");
+
+        // Act
+        var resolution = await context.ResolveAsync(MailFolderReference.ToAlias(Archive));
+
+        // Assert
+        Assert.Equal(MailboxDestinationOutcome.Unmapped, resolution.Outcome);
+        Assert.Null(resolution.Destination);
+    }
+
+    /// <summary>A role is a question only configuration answers, so one no folder of the account plays names nothing.</summary>
+    [Fact]
+    public async Task ResolveAsync_ARoleTheAccountMapsNoFolderFor_ReportsItAsUnmapped()
+    {
+        // Arrange
+        var context = new DestinationContext();
+
+        // Act
+        var resolution = await context.ResolveAsync(MailFolderReference.ToRole(MailFolderSpecialUse.Junk));
+
+        // Assert
+        Assert.Equal(MailboxDestinationOutcome.Unmapped, resolution.Outcome);
+    }
+
+    /// <summary>Falling back to the configured path would file mail into a folder the server never said it had.</summary>
+    [Fact]
+    public async Task ResolveAsync_AnUnmirroredDestinationTheServerDoesNotAdvertise_ReportsItAsNotAdvertised()
+    {
+        // Arrange
+        var context = new DestinationContext(new RemoteFolder(RemoteFolderPath.Create("INBOX", '.'), []));
+        context.Mappings.With(Account, MappedOnlyPathTo(Junk, "INBOX.Spam"));
+
+        // Act
+        var resolution = await context.ResolveAsync(MailFolderReference.ToAlias(Junk));
+
+        // Assert
+        Assert.Equal(MailboxDestinationOutcome.NotAdvertised, resolution.Outcome);
+        Assert.Null(resolution.Destination);
+    }
+
+    /// <summary>Which of two folders carrying one role was meant is the operator's to state, never this resolver's to pick.</summary>
+    [Fact]
+    public async Task ResolveAsync_ARoleTwoAdvertisedFoldersCarry_ReportsItAsAmbiguous()
+    {
+        // Arrange
+        var context = new DestinationContext(
+            new RemoteFolder(RemoteFolderPath.Create("INBOX.Spam", '.'), [MailFolderSpecialUse.Junk]),
+            new RemoteFolder(RemoteFolderPath.Create("INBOX.Junk", '.'), [MailFolderSpecialUse.Junk]));
+        context.Mappings.With(
+            Account,
+            MailFolderMapping.ToSpecialUse(Junk, MailFolderSpecialUse.Junk, MailFolderParticipation.MappedOnly));
+
+        // Act
+        var resolution = await context.ResolveAsync(MailFolderReference.ToRole(MailFolderSpecialUse.Junk));
+
+        // Assert
+        Assert.Equal(MailboxDestinationOutcome.Ambiguous, resolution.Outcome);
+    }
+
+    /// <summary>A mirrored folder whose run has not bound it yet waits for that run rather than being listed here.</summary>
+    [Fact]
+    public async Task ResolveAsync_AMirroredDestinationNothingHasBound_ReportsItAsUnbound()
+    {
+        // Arrange
+        var context = new DestinationContext(new RemoteFolder(RemoteFolderPath.Create("INBOX/Archive", '/'), []));
+        context.Mappings.With(Account, MailFolderMapping.ToRemotePath(Archive, RemoteFolderPath.Create("INBOX/Archive")));
+
+        // Act
+        var resolution = await context.ResolveAsync(MailFolderReference.ToAlias(Archive));
+
+        // Assert
+        Assert.Equal(MailboxDestinationOutcome.Unbound, resolution.Outcome);
+        Assert.Equal(0, context.ListedFolderCount);
+    }
+
+    /// <summary>An account whose rules only flag or delete mail must never reach its mail server from here.</summary>
+    [Fact]
+    public async Task ResolveAsync_NoDestinationNamed_AsksNothingAndAnswersEveryLookupAsUnbound()
+    {
+        // Arrange
+        var context = new DestinationContext();
+
+        // Act
+        MailboxDestinations destinations = await context.Resolver.ResolveAsync(
+            Account,
+            [],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, context.ListedFolderCount);
+        Assert.Equal(
+            MailboxDestinationOutcome.Unbound,
+            destinations.Find(MailFolderReference.ToAlias(Archive)).Outcome);
+    }
+
+    /// <summary>A folder MailFathom knows by name and mirrors nothing of, which is what this issue's destination is.</summary>
+    private static MailFolderMapping MappedOnlyPathTo(MailFolderAlias alias, string remotePath) =>
+        MailFolderMapping.ToRemotePath(
+            alias,
+            RemoteFolderPath.Create(remotePath),
+            MailFolderParticipation.MappedOnly);
+
+    /// <summary>The collaborators one resolution needs: a server that advertises folders and a store that keeps bindings.</summary>
+    private sealed class DestinationContext
+    {
+        private static readonly MailTransportSecurityPolicy RequiredTlsPolicy = MailTransportSecurityPolicy.Create(
+            MailConnectionSecurity.TlsOnConnect,
+            MailAuthenticationPolicy.Create(
+                [MailAuthenticationMechanism.Plain],
+                allowInsecureConnection: false,
+                allowClearTextAuthenticationOverUnencryptedConnection: false),
+            MailServerCertificateTrust.SystemTrustStore,
+            trustedCertificateAuthorityReference: null);
+
+        internal DestinationContext(params RemoteFolder[] advertisedFolders)
+        {
+            var remoteFolderCatalog = Substitute.For<IRemoteFolderCatalog>();
+            remoteFolderCatalog
+                .ListFoldersAsync(Arg.Any<MailAccountId>(), Arg.Any<MailTransportSecurityPolicy>(), Arg.Any<CancellationToken>())
+                .Returns(_ =>
+                {
+                    this.ListedFolderCount++;
+
+                    return Task.FromResult<IReadOnlyList<RemoteFolder>>(advertisedFolders);
+                });
+
+            var persistenceSession = Substitute.For<IPersistenceSession>();
+            persistenceSession.CommitAsync(Arg.Any<CancellationToken>()).Returns(PersistenceCommitResult.Committed);
+            var persistenceSessionFactory = Substitute.For<IPersistenceSessionFactory>();
+            persistenceSessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(persistenceSession);
+
+            var mappingChangeAuditor = Substitute.For<IMailFolderMappingChangeAuditor>();
+            mappingChangeAuditor
+                .RecordMappingChangeAsync(Arg.Any<MailFolderMappingChange>(), Arg.Any<CancellationToken>())
+                .Returns(call =>
+                {
+                    this.RecordedChanges.Add(call.Arg<MailFolderMappingChange>()!);
+
+                    return Task.CompletedTask;
+                });
+
+            var transportSecurityPolicies = Substitute.For<IMailTransportSecurityPolicyReader>();
+            transportSecurityPolicies.GetPolicy(Arg.Any<MailAccountId>()).Returns(RequiredTlsPolicy);
+
+            this.Resolver = new MailboxDestinationResolver(
+                this.Mappings.Resolver,
+                this.Bindings,
+                new MailFolderResolver(
+                    remoteFolderCatalog,
+                    Substitute.For<IRemoteFolderCreator>(),
+                    this.Bindings,
+                    mappingChangeAuditor,
+                    persistenceSessionFactory,
+                    new FakeTimeProvider(new DateTimeOffset(2026, 8, 12, 9, 0, 0, TimeSpan.Zero))),
+                transportSecurityPolicies);
+        }
+
+        internal StubMailFolderMappings Mappings { get; } = StubMailFolderMappings.Nothing;
+
+        internal InMemoryMailFolderResolutionStore Bindings { get; } = new();
+
+        internal MailboxDestinationResolver Resolver { get; }
+
+        internal List<MailFolderMappingChange> RecordedChanges { get; } = [];
+
+        internal int ListedFolderCount { get; private set; }
+
+        internal async Task<MailboxDestinationResolution> ResolveAsync(MailFolderReference destination)
+        {
+            var destinations = await this.Resolver.ResolveAsync(
+                Account,
+                [destination],
+                TestContext.Current.CancellationToken);
+
+            return destinations.Find(destination);
+        }
+    }
+}

--- a/tests/Application.UnitTests/Rules/Actions/MailRuleActionRecorderTests.cs
+++ b/tests/Application.UnitTests/Rules/Actions/MailRuleActionRecorderTests.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Folders;
+using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules;
 using MailFathom.Application.Rules.Actions;
@@ -11,7 +14,9 @@ using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Transport;
 using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
 
@@ -23,17 +28,30 @@ public sealed class MailRuleActionRecorderTests
     private static readonly MailAccountId Account = MailAccountId.Create("work");
     private static readonly MailFolderAlias Inbox = MailFolderAlias.Create("inbox");
     private static readonly MailFolderAlias Archive = MailFolderAlias.Create("archive");
+    private static readonly MailFolderAlias Junk = MailFolderAlias.Create("junk");
     private static readonly StoredEmailId LocalEmail = StoredEmailId.Create(Guid.CreateVersion7());
     private static readonly MailRuleSetRevision Revision = MailRuleSetRevision.Restore("a1b2c3d4e5f6");
+
+    private static readonly MailTransportSecurityPolicy RequiredTlsPolicy = MailTransportSecurityPolicy.Create(
+        MailConnectionSecurity.TlsOnConnect,
+        MailAuthenticationPolicy.Create(
+            [MailAuthenticationMechanism.Plain],
+            allowInsecureConnection: false,
+            allowClearTextAuthenticationOverUnencryptedConnection: false),
+        MailServerCertificateTrust.SystemTrustStore,
+        trustedCertificateAuthorityReference: null);
 
     private readonly InMemoryMailboxMutationRecordStore records = new();
     private readonly InMemoryMailFolderResolutionStore folders = new();
     private readonly StubMailFolderMappings folderMappings = StubMailFolderMappings.Nothing;
+    private readonly List<RemoteFolder> advertisedFolders = [];
     private readonly IAuthoredDeleteEmailDispositionReader dispositions =
         Substitute.For<IAuthoredDeleteEmailDispositionReader>();
 
     private readonly IMailRuleActionPermissionReader permissions =
         Substitute.For<IMailRuleActionPermissionReader>();
+
+    private readonly MailboxDestinationResolver destinations;
 
     public MailRuleActionRecorderTests()
     {
@@ -44,12 +62,15 @@ public sealed class MailRuleActionRecorderTests
         this.permissions
             .GetRuleActionPermissions(Arg.Any<MailAccountId>())
             .Returns(MailRuleActionPermissions.Default with { PermitsDelete = true });
+
+        this.destinations = this.CreateDestinationResolver();
     }
 
     [Fact]
     public async Task RecordAsync_ARuleFilingMail_WritesARelocationNamingTheBoundFolder()
     {
         // Arrange
+        this.MapMirrored(Archive, "INBOX/Archive");
         var binding = this.folders.Bind(Account, Archive, "INBOX/Archive");
 
         // Act
@@ -68,6 +89,7 @@ public sealed class MailRuleActionRecorderTests
     public async Task RecordAsync_ARuleFilingMail_LeavesTheLocalCopyWhereTheDestinationWillCarryIt()
     {
         // Arrange
+        this.MapMirrored(Archive, "INBOX/Archive");
         this.folders.Bind(Account, Archive);
 
         // Act
@@ -75,6 +97,63 @@ public sealed class MailRuleActionRecorderTests
 
         // Assert
         Assert.Null(Assert.Single(this.records.OpenedRequests).LocalDisposition);
+    }
+
+    /// <summary>A message moved somewhere MailFathom keeps no copy of has left the mirrored mailbox exactly as a delete does.</summary>
+    [Fact]
+    public async Task RecordAsync_ARuleFilingIntoAFolderNothingMirrors_CarriesTheAccountsLocalDisposition()
+    {
+        // Arrange
+        this.MapUnmirrored(Junk, "INBOX.Spam");
+
+        // Act
+        var recording = await this.RecordAsync(Planned("file-spam", MailRuleAction.Relocate(MailFolderReference.ToAlias(Junk))));
+
+        // Assert
+        Assert.Empty(recording.Failures);
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal(MailboxMutation.Relocate, request.Mutation);
+        Assert.Equal("INBOX.Spam", request.DestinationPath!.Value.Value);
+        Assert.Equal(AuthoredDeleteEmailDisposition.RetainTombstone, request.LocalDisposition);
+    }
+
+    /// <summary>A copy leaves the source where it is, so nothing local is disposed of whatever the destination is.</summary>
+    [Fact]
+    public async Task RecordAsync_ARuleCopyingIntoAFolderNothingMirrors_LeavesTheLocalStoreAlone()
+    {
+        // Arrange
+        this.MapUnmirrored(Junk, "INBOX.Spam");
+
+        // Act
+        var recording = await this.RecordAsync(Planned("keep-a-copy", MailRuleAction.Copy(MailFolderReference.ToAlias(Junk))));
+
+        // Assert
+        Assert.Empty(recording.Failures);
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal(MailboxMutation.Copy, request.Mutation);
+        Assert.Null(request.LocalDisposition);
+    }
+
+    /// <summary>A mapping whose folder the server does not have is a refusal of its own, not a path to fall back to.</summary>
+    [Fact]
+    public async Task RecordAsync_AnUnmirroredDestinationTheServerDoesNotAdvertise_WritesNothingAndSaysWhy()
+    {
+        // Arrange
+        this.folderMappings.With(
+            Account,
+            MailFolderMapping.ToRemotePath(
+                Junk,
+                RemoteFolderPath.Create("INBOX.Spam"),
+                MailFolderParticipation.MappedOnly));
+
+        // Act
+        var recording = await this.RecordAsync(Planned("file-spam", MailRuleAction.Relocate(MailFolderReference.ToAlias(Junk))));
+
+        // Assert
+        Assert.Equal(0, this.records.OpenedRecordCount);
+        Assert.Equal(
+            MailRuleActionFailureReason.DestinationFolderNotAdvertised,
+            Assert.Single(recording.Failures).Reason);
     }
 
     [Fact]
@@ -137,6 +216,9 @@ public sealed class MailRuleActionRecorderTests
     [Fact]
     public async Task RecordAsync_ADestinationNothingHasBound_WritesNothingAndSaysWhy()
     {
+        // Arrange
+        this.MapMirrored(Archive, "INBOX/Archive");
+
         // Act
         var recording = await this.RecordAsync(Planned("file-invoices", MailRuleAction.Relocate(MailFolderReference.ToAlias(Archive))));
 
@@ -183,7 +265,7 @@ public sealed class MailRuleActionRecorderTests
         // Assert
         Assert.Equal(0, this.records.OpenedRecordCount);
         var failure = Assert.Single(recording.Failures);
-        Assert.Equal(MailRuleActionFailureReason.DestinationFolderUnresolved, failure.Reason);
+        Assert.Equal(MailRuleActionFailureReason.DestinationFolderUnmapped, failure.Reason);
         Assert.Equal(MailFolderReference.ToRole(MailFolderSpecialUse.Junk), failure.Destination);
     }
 
@@ -229,6 +311,7 @@ public sealed class MailRuleActionRecorderTests
     public async Task RecordAsync_AFlagBesideARevokedRelocation_StillWritesTheFlag()
     {
         // Arrange
+        this.MapMirrored(Archive, "INBOX/Archive");
         this.folders.Bind(Account, Archive);
         this.permissions
             .GetRuleActionPermissions(Arg.Any<MailAccountId>())
@@ -296,6 +379,7 @@ public sealed class MailRuleActionRecorderTests
     public async Task RecordAsync_TheSameDestinationOverSeveralEmails_ResolvesTheBindingOnce()
     {
         // Arrange
+        this.MapMirrored(Archive, "INBOX/Archive");
         this.folders.Bind(Account, Archive);
         var recorder = this.CreateRecorder();
         var plan = MailRuleActionPlan.Compose([RuleNamed("file-invoices", MailRuleAction.Relocate(MailFolderReference.ToAlias(Archive)))]);
@@ -303,13 +387,12 @@ public sealed class MailRuleActionRecorderTests
         // Act
         foreach (var uid in Enumerable.Range(1, 3))
         {
-            await recorder.RecordAsync(
-                Substitute.For<IPersistenceSession>(),
+            await this.RecordAsync(
+                recorder,
                 StoredEmailId.Create(Guid.CreateVersion7()),
                 OccurrenceAt((uint)uid),
                 plan,
-                Revision,
-                TestContext.Current.CancellationToken);
+                Revision);
         }
 
         // Assert
@@ -343,14 +426,75 @@ public sealed class MailRuleActionRecorderTests
         ImapUid.Create(uid));
 
     private Task<MailRuleActionRecording> RecordAsync(MailRuleActionPlan plan, MailRuleSetRevision? revision = null) =>
-        this.CreateRecorder().RecordAsync(
-            Substitute.For<IPersistenceSession>(),
-            LocalEmail,
-            OccurrenceAt(7),
-            plan,
-            revision ?? Revision,
+        this.RecordAsync(this.CreateRecorder(), LocalEmail, OccurrenceAt(7), plan, revision ?? Revision);
+
+    /// <summary>Records one email's plan the way a pass does: the destinations resolved first, the records written after.</summary>
+    private async Task<MailRuleActionRecording> RecordAsync(
+        MailRuleActionRecorder recorder,
+        StoredEmailId storedEmailId,
+        EmailOccurrenceId occurrence,
+        MailRuleActionPlan plan,
+        MailRuleSetRevision revision)
+    {
+        var resolved = await this.destinations.ResolveAsync(
+            Account,
+            [.. plan.Actions.Select(planned => planned.Action.Destination).OfType<MailFolderReference>()],
             TestContext.Current.CancellationToken);
 
-    private MailRuleActionRecorder CreateRecorder() =>
-        new(this.records, this.folders, this.folderMappings.Resolver, this.dispositions, this.permissions);
+        return await recorder.RecordAsync(
+            Substitute.For<IPersistenceSession>(),
+            storedEmailId,
+            occurrence,
+            plan,
+            revision,
+            resolved,
+            TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>Maps a folder the account mirrors, which is what every destination but the unmirrored one here is.</summary>
+    private void MapMirrored(MailFolderAlias alias, string remotePath) =>
+        this.folderMappings.With(Account, MailFolderMapping.ToRemotePath(alias, RemoteFolderPath.Create(remotePath)));
+
+    /// <summary>Maps a folder MailFathom knows by name and mirrors nothing of, and advertises it on the server.</summary>
+    private void MapUnmirrored(MailFolderAlias alias, string remotePath)
+    {
+        this.folderMappings.With(
+            Account,
+            MailFolderMapping.ToRemotePath(
+                alias,
+                RemoteFolderPath.Create(remotePath),
+                MailFolderParticipation.MappedOnly));
+
+        this.advertisedFolders.Add(new RemoteFolder(RemoteFolderPath.Create(remotePath, '.'), []));
+    }
+
+    private MailboxDestinationResolver CreateDestinationResolver()
+    {
+        var remoteFolderCatalog = Substitute.For<IRemoteFolderCatalog>();
+        remoteFolderCatalog
+            .ListFoldersAsync(Arg.Any<MailAccountId>(), Arg.Any<MailTransportSecurityPolicy>(), Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IReadOnlyList<RemoteFolder>>([.. this.advertisedFolders]));
+
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        persistenceSession.CommitAsync(Arg.Any<CancellationToken>()).Returns(PersistenceCommitResult.Committed);
+        var persistenceSessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        persistenceSessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(persistenceSession);
+
+        var transportSecurityPolicies = Substitute.For<IMailTransportSecurityPolicyReader>();
+        transportSecurityPolicies.GetPolicy(Arg.Any<MailAccountId>()).Returns(RequiredTlsPolicy);
+
+        return new MailboxDestinationResolver(
+            this.folderMappings.Resolver,
+            this.folders,
+            new MailFolderResolver(
+                remoteFolderCatalog,
+                Substitute.For<IRemoteFolderCreator>(),
+                this.folders,
+                Substitute.For<IMailFolderMappingChangeAuditor>(),
+                persistenceSessionFactory,
+                new FakeTimeProvider(new DateTimeOffset(2026, 8, 12, 9, 0, 0, TimeSpan.Zero))),
+            transportSecurityPolicies);
+    }
+
+    private MailRuleActionRecorder CreateRecorder() => new(this.records, this.dispositions, this.permissions);
 }

--- a/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationPassTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationPassTests.cs
@@ -2,7 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Folders;
+using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules;
 using MailFathom.Application.Rules.Actions;
@@ -14,6 +17,7 @@ using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Transport;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
@@ -41,12 +45,28 @@ public sealed class MailRuleEvaluationPassTests
     private readonly IMailRuleActionPermissionReader permissions =
         Substitute.For<IMailRuleActionPermissionReader>();
 
+    private readonly StubMailFolderMappings folderMappings = StubMailFolderMappings.Nothing;
+
     private readonly FakeTimeProvider timeProvider = new(EvaluatedAt);
 
-    public MailRuleEvaluationPassTests() =>
+    public MailRuleEvaluationPassTests()
+    {
         this.permissions
             .GetRuleActionPermissions(Arg.Any<MailAccountId>())
             .Returns(MailRuleActionPermissions.Default with { PermitsDelete = true });
+
+        // Both destinations are folders their accounts mirror, so a pass reaching one reads the binding its own run
+        // recorded rather than asking the server, which is what every assertion here is about.
+        foreach (var accountId in new[] { Account, OtherAccount })
+        {
+            foreach (var alias in new[] { Archive, Backup })
+            {
+                this.folderMappings.With(
+                    accountId,
+                    MailFolderMapping.ToRemotePath(alias, RemoteFolderPath.Create($"INBOX/{alias.Value}")));
+            }
+        }
+    }
 
     [Fact]
     public async Task RunAsync_MailNoPassHasEvaluated_EvaluatesItAndRecordsIt()
@@ -626,6 +646,27 @@ public sealed class MailRuleEvaluationPassTests
             [.. rules.Select(rule => new MailRuleDeclaration(rule.Name, "isSeen", [.. rule.Actions.Actions], rule.StopWhenMatched, [.. rule.Accounts], [.. rule.Triggers]))]),
         MailRuleConditionBounds.Default);
 
+    /// <summary>Resolves destinations over a server advertising nothing, so only a recorded binding ever answers.</summary>
+    private MailboxDestinationResolver CreateDestinationResolver()
+    {
+        var remoteFolderCatalog = Substitute.For<IRemoteFolderCatalog>();
+        remoteFolderCatalog
+            .ListFoldersAsync(Arg.Any<MailAccountId>(), Arg.Any<MailTransportSecurityPolicy>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<RemoteFolder>>([]));
+
+        return new MailboxDestinationResolver(
+            this.folderMappings.Resolver,
+            this.folders,
+            new MailFolderResolver(
+                remoteFolderCatalog,
+                Substitute.For<IRemoteFolderCreator>(),
+                this.folders,
+                Substitute.For<IMailFolderMappingChangeAuditor>(),
+                Substitute.For<IPersistenceSessionFactory>(),
+                this.timeProvider),
+            Substitute.For<IMailTransportSecurityPolicyReader>());
+    }
+
     private MailRuleEvaluationPass CreatePass(
         MailRuleSet ruleSet,
         int batchSize = 100,
@@ -642,14 +683,10 @@ public sealed class MailRuleEvaluationPassTests
             new MailRuleSetEvaluator(this.timeProvider),
             this.store,
             this.runStore,
-            new MailRuleActionRecorder(
-                this.mutations,
-                this.folders,
-                StubMailFolderMappings.ResolvingNothing,
-                this.deleteDispositions,
-                this.permissions),
+            new MailRuleActionRecorder(this.mutations, this.deleteDispositions, this.permissions),
+            this.CreateDestinationResolver(),
             this.history,
-            StubMailFolderMappings.Nothing,
+            this.folderMappings,
             new OptimisticConcurrencyRetryPolicy(
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),

--- a/tests/Host.UnitTests/Configuration/Rules/DeclaredMailAccountsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/DeclaredMailAccountsTests.cs
@@ -67,7 +67,7 @@ public sealed class DeclaredMailAccountsTests
 
     /// <summary>An account that configures no folder is run with the inbox mapping, so that is the folder a rule may file into.</summary>
     [Fact]
-    public void ReadFrom_AccountDeclaringNoFolder_MirrorsTheInbox()
+    public void ReadFrom_AccountDeclaringNoFolder_MapsTheInbox()
     {
         // Arrange
         var configuration = Configuration(new Dictionary<string, string?>
@@ -79,12 +79,12 @@ public sealed class DeclaredMailAccountsTests
         var account = Assert.Single(DeclaredMailAccounts.ReadFrom(configuration));
 
         // Assert
-        Assert.Equal(["INBOX"], account.MirroredFolders.Select(folder => folder.Alias.Value));
+        Assert.Equal(["INBOX"], account.MappedFolders.Select(folder => folder.Alias.Value));
     }
 
-    /// <summary>Nothing binds an unmirrored folder to a remote path, so it is not a folder a rule can file into.</summary>
+    /// <summary>A folder is resolved when a change first files into it, so mapping one is all a destination needs.</summary>
     [Fact]
-    public void ReadFrom_FolderTheAccountDoesNotMirror_IsNotADestination()
+    public void ReadFrom_FolderTheAccountDoesNotMirror_IsStillADestination()
     {
         // Arrange
         var configuration = Configuration(new Dictionary<string, string?>
@@ -101,7 +101,7 @@ public sealed class DeclaredMailAccountsTests
         var account = Assert.Single(DeclaredMailAccounts.ReadFrom(configuration));
 
         // Assert
-        Assert.Equal(["INBOX"], account.MirroredFolders.Select(folder => folder.Alias.Value));
+        Assert.Equal(["INBOX", "SPAM"], account.MappedFolders.Select(folder => folder.Alias.Value));
     }
 
     /// <summary>Deletion is opt-in on every account, and the three reversible actions are permitted until refused.</summary>
@@ -193,6 +193,6 @@ public sealed class DeclaredMailAccountsTests
     private static IReadOnlyList<string> Describe(IEnumerable<DeclaredMailAccount> accounts) =>
     [
         .. accounts.Select(account =>
-            $"{account.AccountId}|{string.Join(',', account.MirroredFolders.Select(folder => folder.Alias.Value))}|{account.PermittedRuleActions}"),
+            $"{account.AccountId}|{string.Join(',', account.MappedFolders.Select(folder => folder.Alias.Value))}|{account.PermittedRuleActions}"),
     ];
 }

--- a/tests/Host.UnitTests/Configuration/Rules/MailRuleDeclarationRulesTests.cs
+++ b/tests/Host.UnitTests/Configuration/Rules/MailRuleDeclarationRulesTests.cs
@@ -531,9 +531,9 @@ public sealed class MailRuleDeclarationRulesTests
         Assert.Empty(errors);
     }
 
-    /// <summary>Nothing binds an unmirrored folder to a remote path, so a rule filing into one could never resolve a destination.</summary>
+    /// <summary>A folder no mapping names is one MailFathom knows nothing about, so a rule filing into it has nowhere to file.</summary>
     [Fact]
-    public void FindDeclarationErrors_ARuleFilingIntoAFolderTheAccountDoesNotMirror_IsRefused()
+    public void FindDeclarationErrors_ARuleFilingIntoAFolderTheAccountDoesNotMap_IsRefusedNamingWhatToDoAboutIt()
     {
         // Arrange
         var candidate = new MailRulesOptions
@@ -555,9 +555,10 @@ public sealed class MailRuleDeclarationRulesTests
         var error = Assert.Single(errors);
         Assert.Contains("NOWHERE", error, StringComparison.Ordinal);
         Assert.Contains("primary", error, StringComparison.Ordinal);
+        Assert.Contains("'Synchronize': false", error, StringComparison.Ordinal);
     }
 
-    /// <summary>An unscoped rule reaches every account, so a destination one of them does not mirror is refused for that one.</summary>
+    /// <summary>An unscoped rule reaches every account, so a destination one of them does not map is refused for that one.</summary>
     [Fact]
     public void FindDeclarationErrors_AnUnscopedRuleFilingIntoAFolderOneAccountLacks_IsRefusedForThatAccount()
     {

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -11,6 +11,7 @@ using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
+using MailFathom.Application.Mail.Mutations.Destinations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules;
 using MailFathom.Application.Rules.Actions;
@@ -177,6 +178,9 @@ internal static class SynchronizationTestHost
             provider => provider.GetRequiredService<MailSynchronizationOptions>());
         services.AddScoped<MailFolderReferenceResolver>();
         services.AddScoped<MailRuleActionRecorder>();
+        // A rule may file into a folder the account maps and does not mirror, which nothing binds until a change needs
+        // it, so the pass resolves its destinations through the same service the host registers.
+        services.AddScoped<MailboxDestinationResolver>();
         // One instance across every scope a run opens, so what several scopes appended is readable as one history.
         var ruleHistory = new MailRuleExecutionRecordingStore();
         services.AddSingleton(ruleHistory);

--- a/tests/IntegrationTests/Synchronization/OrchestratedUnmirroredDestinationTests.cs
+++ b/tests/IntegrationTests/Synchronization/OrchestratedUnmirroredDestinationTests.cs
@@ -1,0 +1,112 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.IntegrationTests.Mailbox;
+using MailFathom.IntegrationTests.Orchestration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Synchronization;
+
+/// <summary>
+/// Proves against a real IMAP server that a folder the account maps and never mirrors is resolved when a change first
+/// needs it, and then takes both a relocation and a copy over the account's existing write session.
+/// </summary>
+/// <remarks>
+/// Neither half can be established against a substitute. That an alias resolves on demand is a claim about what a
+/// server advertises and about a binding surviving in the database; that the folder then holds mail is the server's
+/// answer to a <c>MOVE</c> and a <c>COPY</c> issued into a folder no synchronization run has ever opened. The two are
+/// one test because the second is only meaningful against the folder the first resolved.
+/// </remarks>
+[Collection(OrchestratedInfrastructureCollectionDefinition.Name)]
+public sealed class OrchestratedUnmirroredDestinationTests(MailFathomOrchestrationFixture orchestration)
+{
+    private static readonly MailFolderResolution Inbox = MailFolderResolution.FirstBindingOf(
+        MailFolderAlias.Create("inbox"),
+        RemoteFolderPath.Create(OrchestratedMailbox.InboxPath, hierarchyDelimiter: '.'));
+
+    [Fact]
+    public async Task ResolveAsync_ADestinationTheAccountOnlyMaps_BindsItOnDemandAndThenTakesAMoveAndACopy()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var mailbox = new OrchestratedMailbox(orchestration.MailServer);
+
+        // Named per run, so nothing has to have been cleaned up by a previous one and no other test in the shared
+        // mailbox is watching the folder this one files into.
+        var runIdentifier = Guid.NewGuid().ToString("N");
+        var folderName = $"UnmirroredJunk{runIdentifier}";
+        var alias = MailFolderAlias.Create($"unmirrored{runIdentifier}");
+
+        var relocatedSubject = $"relocate-into-unmirrored-{runIdentifier}";
+        var copiedSubject = $"copy-into-unmirrored-{runIdentifier}";
+        await mailbox.DeliverAsync(relocatedSubject, cancellationToken);
+        await mailbox.DeliverAsync(copiedSubject, cancellationToken);
+
+        var inbox = await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken);
+        var uidValidity = await mailbox.ReadUidValidityAsync(OrchestratedMailbox.InboxPath, cancellationToken);
+        var relocated = OccurrenceOf(inbox, relocatedSubject, uidValidity);
+        var copied = OccurrenceOf(inbox, copiedSubject, uidValidity);
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+
+        // Act
+        var binding = await services.InScopeAsync(
+            async (scope, token) =>
+            {
+                var account = SyntheticMailAccount.AccountId;
+                var policy = scope.GetRequiredService<IMailTransportSecurityPolicyReader>().GetPolicy(account);
+                var configuredPath = RemoteFolderPath.Create(folderName);
+
+                await scope.GetRequiredService<IRemoteFolderCreator>()
+                    .CreateFolderAsync(account, alias, configuredPath, policy, token);
+
+                var mapping = MailFolderMapping.ToRemotePath(
+                    alias,
+                    configuredPath,
+                    MailFolderParticipation.MappedOnly);
+                var resolution = await scope.GetRequiredService<MailFolderResolver>()
+                    .ResolveAsync(account, mapping, policy, token);
+
+                var destinationPath = resolution.Resolution!.RemotePath;
+
+                await using var session = await scope.GetRequiredService<IMailboxWriteSessionFactory>()
+                    .OpenForWritingAsync(account, Inbox, policy, token);
+                await session.RelocateAsync(relocated, destinationPath, new InMemoryMailboxMutationJournal(), token);
+                await session.CopyAsync(copied, destinationPath, new InMemoryMailboxMutationJournal(), token);
+
+                return await scope.GetRequiredService<IMailFolderResolutionStore>()
+                    .GetCurrentResolutionAsync(account, alias, token);
+            },
+            cancellationToken);
+
+        // Assert
+        Assert.Equal(folderName, binding!.RemotePath.Value);
+
+        var destinationFolder = await mailbox.ReadAsync(folderName, cancellationToken);
+        var filedSubjects = destinationFolder.Select(email => email.Subject).ToArray();
+        Assert.Contains(relocatedSubject, filedSubjects);
+        Assert.Contains(copiedSubject, filedSubjects);
+        Assert.All(destinationFolder, email => Assert.False(email.IsSeen));
+
+        var remainingInbox = await mailbox.ReadAsync(OrchestratedMailbox.InboxPath, cancellationToken);
+        var remainingSubjects = remainingInbox.Select(email => email.Subject).ToArray();
+        Assert.DoesNotContain(relocatedSubject, remainingSubjects);
+        Assert.Contains(copiedSubject, remainingSubjects);
+    }
+
+    private static EmailOccurrenceId OccurrenceOf(
+        IReadOnlyList<ObservedEmail> inbox,
+        string subject,
+        ImapUidValidity uidValidity) => EmailOccurrenceId.Create(
+            SyntheticMailAccount.AccountId,
+            Inbox.Id,
+            uidValidity,
+            Assert.Single(inbox, email => email.Subject == subject).Uid);
+}


### PR DESCRIPTION
A folder mapped with `Synchronize: false` was documented as resolvable and reachable as a mutation destination, and was neither. `MailFolderResolver` ran only for the folders a synchronization run scheduled, an unmirrored folder is deliberately not among them, so its alias never got a binding — and `MailRuleActionRecorder`, which read that binding, had no remote path to build a request from. The rule set was refused at startup for naming such a destination, which made the refusal look deliberate rather than a gap. The spam case #694 was written for — file junk on the server, mirror none of it — did not work end to end.

## What changed

**Destination resolution becomes one thing.** `MailboxDestinationResolver` (`src/Application/Mail/Mutations/Destinations/`) is the single place a relocation's or a copy's destination becomes a folder on the server, so a rule is one author of a filing mutation rather than the one that owns resolving where it files.

- A destination the account **mirrors** is answered from the binding its own run recorded, without a word to the mail server — asking again would repoint a binding a checkpoint hangs off.
- A destination the account **only maps** is resolved on demand, through the same `MailFolderResolver`, the same binding record, and the same mapping-change audit a mirrored folder uses. No synchronization run performs it, because no run schedules the folder.
- Every answer is remembered for the life of the resolver, which is one account run, so a batch filing two hundred messages into one folder costs one listing. A server that has since renamed the folder is followed at the next run exactly as a mirrored folder's is — the binding is replaced by its next generation, with no checkpoint to invalidate.
- Four refusals, each with its own classification and each naming the folder the rule wrote: `DestinationFolderUnmapped`, `DestinationFolderNotAdvertised`, `DestinationFolderAmbiguous`, and the existing `DestinationFolderUnresolved`, now narrowed to a mirrored folder nothing has bound yet. Nothing falls back to the configured path, nothing picks one of two folders, and nothing fails as an unhandled error.

**A relocation into an unmirrored destination carries the account's `AuthoredDeleteEmailDisposition`**, resolved when the change is authored, because the message has left the mirrored mailbox for good. A copy carries none. Both were already what the record and reconciliation expected; what was missing was an author able to produce one.

**The rule evaluation pass resolves a batch's destinations between evaluating it and committing it**, never inside the batch's transaction — a listing is a network round trip and a local transaction must not be held open across one. A batch naming no destination asks nothing, so an account whose rules only flag or delete mail never reaches its mail server from there.

**Startup validation asks for a mapping rather than for mirroring.** `DeclaredMailAccounts` reads every mapped folder, and the refusal for a destination no mapping declares now says what to do about it, including that `Synchronize: false` still leaves the folder a destination.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves. `CreateIfMissing` now also reaches a `Synchronize: false` mapping — the first time something files mail into that folder — which is a consequence of resolving through the same resolver rather than a second mechanism, and the documentation that said it created nothing there is corrected in this change.

## Verification

- `scripts/verify-full.sh` — pass. 5924 tests, aggregate line coverage 95.54% (required 85%).
- Unit tests: `MailboxDestinationResolverTests` covers on-demand resolution and its recorded binding, reuse across a run, a rename replacing the binding, and each of the five outcomes; `MailRuleActionRecorderTests` covers a relocation and a copy into an unmirrored destination and the refusal classifications; `DeclaredMailAccountsTests` and `MailRuleDeclarationRulesTests` cover the validation change.
- Integration suite: `OrchestratedUnmirroredDestinationTests` resolves an unmirrored destination against the live server and then relocates and copies into it over the existing write session, asserting the source-side inbox and the remote `\Seen` state. It is not run here — the suite is manual-dispatch only.
- The acceptance item *mail in an unsynchronized folder reaches nothing in the other direction* is asserted from the source side by the existing `AccountSynchronizationSupervisorTests.RunAsync_AFolderTheAccountNoLongerMirrors_OpensNoSessionForIt`: no session is opened for such a folder, so nothing of its mail is ever stored, evaluated, queried, or authored against. This change adds no path that reads it — the resolver's only mail port lists folders and never selects one.

Closes #716

https://github.com/Krzysztof318/MailFathom/issues/716
