### PR TITLE
[#690] File junk on the server and mark it read, each behind its own switch

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -304,7 +304,7 @@ one of them.
 | `DestinationFolderPath`, `DestinationHierarchyDelimiter` | Where a relocation or a copy was aimed, and null for every other mutation |
 | `PlacementUidValidity`, `PlacementUid` | Where the server said it put the message, where it supplied `COPYUID` |
 | `DesiredSeenState` | Which way a `\Seen` change was asked for, and null for every other mutation |
-| `RequesterOrigin`, `RequesterIdentity` | Who asked — a rule together with the revision that matched, or one invocation |
+| `RequesterOrigin`, `RequesterIdentity` | Who asked — a rule together with the revision that matched, one invocation, or the profile a spam verdict was decided under |
 | `RequestedAt`, `CompletedAt` | When it was asked for and when it ended |
 | `Outcome`, `FailureCode` | `Performed`, or `Abandoned` with the five-digit code it was given up on for |
 

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -410,10 +410,13 @@ message ends up filed once whichever command the stop landed between.
 The record answers three questions with one row.
 
 **Whether asking again is the same request.** Its identity is the email occurrence, the mutation, and who asked — a rule
-together with the revision of it that matched, or the identity of one invocation. Two callers asking for the same change
-at the same moment both reach the database and the unique index refuses one of them, so the same request twice performs
-one change rather than two. That is enforced by the constraint rather than by a check, because no check made between
-reading and writing closes the window two concurrent writers fall through.
+together with the revision of it that matched, the identity of one invocation, or the profile a spam verdict was decided
+under, which is the deciding stage's rule corpus together with the score the operator acts at. The three are told apart
+on the record by their origin, so an operator reading a change knows whether a rule they wrote, something they did, or
+[spam classification](spam-classification.md#what-an-operator-can-let-a-verdict-do) asked for it. Two callers asking for
+the same change at the same moment both reach the database and the unique index refuses one of them, so the same request
+twice performs one change rather than two. That is enforced by the constraint rather than by a check, because no check
+made between reading and writing closes the window two concurrent writers fall through.
 
 **Where to continue from.** A relocation whose copy is confirmed removes its source without copying again; a delete
 whose flag landed reissues only the expunge; a `\Seen` change simply repeats, because the store is idempotent on the

--- a/docs/features/spam-classification.md
+++ b/docs/features/spam-classification.md
@@ -8,8 +8,9 @@ decided what it thought of it — in an `Authentication-Results` header, in a pr
 the message in the junk folder. Spam classification is what keeps that decision rather than discarding it, and records
 it as derived data beside the message.
 
-Two things ship here and are independent of each other: the classification record with the stage that fills it, and the
-junk folder becoming a fact that mailbox reads act on. The second is true of a mailbox with no classification at all.
+Three things ship here and are independent of each other: the classification record with the stage that fills it, the
+two switches that let a verdict reach the mail server, and the junk folder becoming a fact that mailbox reads act on.
+The last is true of a mailbox with no classification at all.
 
 ## The junk folder is left out of listing and search
 
@@ -33,7 +34,8 @@ content written to deceive a reader would reach the model as ordinary correspond
 
 One classification per occurrence, replacing whatever was recorded for it. It is derived data of the same kind as an
 embedding: computed locally, never mirrored to the mail server, and never a statement about where the message lives or
-which flags it carries. Filing a message somewhere is a different feature and is not part of this one.
+which flags it carries. Where a message lives is the server's, which is why acting on a verdict is a separate decision
+behind switches of its own — described in [what an operator can let a verdict do](#what-an-operator-can-let-a-verdict-do).
 
 | What it holds | Why |
 | --- | --- |
@@ -153,6 +155,95 @@ The image is pinned to an exact digest in all four places that name it, and movi
 which is what the recorded corpus revision exists to make visible. `THIRD_PARTY_LICENSES.md` records the image, its
 licences, that whole messages are sent to it, and that it bundles no plugin reporting anything outside the deployment.
 
+## What an operator can let a verdict do
+
+Two switches, independent of each other and **both off by default**. With neither on, a verdict is recorded and no
+mailbox is written to, which is what makes classification safe to watch for a while before it is allowed to act.
+
+**File junk in the junk folder.** The message is moved on the mail server, through the same durable mutation record and
+the same write session that carries a change somebody made by hand — described in
+[IMAP synchronization](imap-synchronization.md#every-change-is-written-down-before-it-is-issued). The local row changes
+afterwards, because synchronization observed the move; nothing writes a folder locally ahead of the server. What an
+operator agrees to by switching this on is that spam moves in every client they open, and that correcting a false
+positive means dragging the message back in any one of them — there is no MailFathom-specific undo to learn, and the
+next section says what happens when they do.
+
+**Mark it read.** The remote `\Seen` flag is set. This is the one authored act that sets it: synchronization and content
+retrieval still never do, so reading mail on the owner's behalf goes on leaving the flag alone. A message the server
+already reports read is not written to at all.
+
+With both on, **the flag is set before the move**. On a server without RFC 6851 `MOVE` a relocation gives the message a
+new UID, so a flag stored afterwards would be aimed at an occurrence the source folder no longer holds.
+
+Nothing else is ever done. No delete, no flag other than `\Seen`, no folder created, nothing sent —
+[ADR 0007](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md)
+refuses the rest and this feature does not reopen that record.
+
+### Where junk is filed, and why it need not be mirrored
+
+The destination is whichever folder the account maps to the `Junk` role, or a folder named explicitly in the
+configuration. **It does not have to be a folder MailFathom mirrors, and for most deployments it should not be**: the
+point of filing spam is to be rid of it rather than to move it around inside the instance. Filing into an unmirrored
+folder takes the local copy with it, under the account's own answer about mail it deletes; filing into a mirrored one
+files identically and leaves the message stored, excluded from listing and search by the rule at the top of this page.
+[IMAP synchronization](imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is) holds what a folder's
+participation decides.
+
+The folder is found the same way a rule's destination is, through the one resolution every author of a filing shares:
+a mirrored folder is read from the binding its own run recorded, and an unmirrored one is resolved against what the
+server advertises the first time a filing needs it. **Classification asks for no folder to be created.** Whether a
+mapping creates its folder when the server advertises none is that mapping's own declaration in the synchronization
+section, decided once for every author rather than by this feature.
+
+An account that maps no destination at all fails startup naming that account, rather than leaving its spam unfiled with
+nothing said about why.
+
+### A message the owner moved back is never filed again
+
+Two rules keep filing from becoming an argument with the person whose mailbox it is.
+
+A message already in the destination is not moved into it. And a message this feature has already asked to have filed,
+which is not in the destination, is **left alone entirely** — not filed again, and not marked read again. Either
+somebody moved it back out, which is exactly the correction a false positive is supposed to have, or the change is
+written down and has not been carried out yet; asking again would argue with the first or duplicate the second. That is
+read from the durable mutation record rather than from the message, because the record is what survives the message
+moving.
+
+The two readings are deliberately not told apart. Doing so would mean treating a change that ran out of attempts as
+licence to file afresh — and a message that sat there failing to move is precisely the one somebody is most likely to
+have moved by hand.
+
+The protection reaches as far as the mirror does. A junk folder MailFathom does not mirror is one it stops seeing into,
+so a message moved back out of *that* folder arrives as new mail and is classified afresh — which is the trade an
+unmirrored destination makes, and the reason a deployment that expects to correct verdicts often may prefer a mirrored
+one.
+
+### The score an operator is willing to act at
+
+A threshold of its own decides whether to act, separate from the one the verdict was reached under, so an operator can
+label at five and move mail only from eight. It judges what a **scanner** scored, in the scanner's own scale, for the
+reason the classification threshold reaches no other stage: a provider's header carries a threshold in a scale this one
+knows nothing about, and a verdict resting on where the receiving server filed the message carries no score at all. Both
+of those are the receiving server's own decision, taken with network context nothing after delivery has, and both are
+acted on.
+
+Raising the threshold is deliberately not the same edit as switching classification off. The verdicts go on being
+recorded and only the acting stops.
+
+### Asking twice is one change
+
+A change is written down under an identity made of the occurrence, the mutation, and what asked for it — and what asked
+here is the **profile the verdict was decided under**: the rule corpus the deciding stage ran against, together with the
+score the operator acts at. Rescanning the same message against the same corpus therefore asks for nothing new, while a
+corpus update or a threshold somebody moved asks afresh. A rule and a classification are told apart on the record by
+their origin, so an operator reading a stuck change knows whether to look at a rule they wrote or at this section.
+
+Where a filing has nowhere to go — a mapping withdrawn while mail was being classified, a mirrored folder no run has
+bound yet, a folder the server advertises none of, or a role two folders carry — **nothing is written down at all**,
+including a `\Seen` change asked for beside it. The same holds for an account a reload stopped declaring, whose answer
+about mail it files away is then nobody's to guess. Marking spam read while leaving it in the inbox takes the unread
+marker off mail that is still there, which is worse than waiting; a later attempt performs the pair whole.
+
 ## Classifying is idempotent, and reclassifying is explicit
 
 Classification is keyed to the occurrence, so repeating it either leaves the existing record alone or replaces it with
@@ -172,6 +263,10 @@ Nothing. Every switch is off by default, and the checks run in the order of what
 on at all is free, the scope and any existing record are one lookup each, and only then is a message's content read. An
 occurrence outside the configured scope therefore costs no read of its mail.
 
+The action switches are the same shape. With both off, deciding what a verdict causes is one property read and nothing
+else: no mailbox is looked at, **no write session is ever obtained**, and no account holds the write connection that
+would carry a change.
+
 ## Configuration
 
 The `SpamClassification` section, in full, is in the
@@ -182,24 +277,28 @@ The `SpamClassification` section, in full, is in the
 - which folder aliases are classified, defaulting to whichever alias each account maps to its inbox;
 - the threshold a scanner's score is judged against, defaulting to the scanner's own.
 
-The scanner's own address and bounds are a block below it, `SpamClassification:Scanner`, read only where the scanner is
-switched on.
+Two blocks sit below it. `SpamClassification:Scanner` holds the daemon's address and bounds and is read only where the
+scanner is switched on. `SpamClassification:Actions` holds the two switches, the folder junk is filed into, and the score
+an operator is willing to act at; it is read per verdict, so switching filing on reaches the next one without a restart.
 
 An operator who switched the scanner on and left classification off is told at startup rather than given the quiet
-answer, and so is one who switched it on and named no address for it. An unusable folder alias, an out-of-range
-threshold, and a bound outside its range each fail startup naming themselves.
+answer, and so is one who switched it on and named no address for it, one who asked for junk to be acted on with
+classification off, and one whose accounts do not all map the folder a filing would go to. An unusable folder alias, an
+out-of-range threshold, and a bound outside its range each fail startup naming themselves.
 
 ## What is not here
 
-No mutation of the remote mailbox, and no on-demand run over a mailbox that is already stored. The classification is
-recorded and read back; nothing yet schedules it as mail arrives, because the durable job model it is to run as an
-execution in is not built.
+No on-demand run over a mailbox that is already stored, and nothing yet schedules classification as mail arrives,
+because the durable job model it is to run as an execution in is not built. Until something calls it, the switches above
+describe what a verdict causes rather than something happening on a schedule.
 
 ## Privacy
 
 A classification is derived from mail content and inherits its classification, retention, and deletion constraints: the
 record hangs off the message occurrence and is removed with it, so whatever erasure and retention already reach the
-message reach the record too.
+message reach the record too. A change a verdict asked for is the same kind of thing and follows the same rule: the
+mutation record says where a person's mail was moved and holds a folder path, a UID, and a decision profile — never
+anything from the message — and it is removed with the email it describes.
 
 Nothing about a message's content reaches a log line or a telemetry attribute from any path here — not a header value,
 not an authentication detail, not a subject. What is safe to report is the occurrence identifier, the folder alias, the

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -412,6 +412,10 @@ described below.
 | `SpamClassification:Scanner:ScanTimeoutSeconds` | int | `30` | 1 – 120 | restart |
 | `SpamClassification:Scanner:MaximumMessageBytes` | int | `512000` | 32 000 – 33 554 432 | restart |
 | `SpamClassification:Scanner:MaximumConcurrentScans` | int | `5` | 1 – 64 | restart |
+| `SpamClassification:Actions:FileInJunkFolder` | bool | `false` | Asking for it while `Enabled` is false fails startup, and so does an account that maps no destination to file into | reload |
+| `SpamClassification:Actions:MarkAsRead` | bool | `false` | Asking for it while `Enabled` is false fails startup | reload |
+| `SpamClassification:Actions:JunkFolder` | string | `role:Junk` | A folder alias, or a role written as `role:<name>`; every configured account has to map it once filing is on | reload |
+| `SpamClassification:Actions:Threshold` | double | unset | 0.1 – 1000; unset acts on every spam verdict, and a value judges what a scanner scored | reload |
 
 `UseScanner` and the `Scanner` block are read once, at startup: whether a scanner exists at all decides what is
 constructed and whether the host refuses to start without a daemon, which a reload cannot revisit. Everything else in
@@ -445,6 +449,23 @@ never does is revisit a message already classified: replacing a verdict is an ex
 Which folder is left out of `list_emails` and `search_emails` is not configured here. It is the folder mapped to the
 `Junk` special use in [`MailSynchronization`](#one-account--mailsynchronizationaccountsn), and it is withheld whether or
 not this section switches anything on.
+
+The `Actions` block is the only part of this section that writes to a mailbox, and both of its switches are off. Each
+works alone: filing moves the message on the server, marking read sets its `\Seen` flag, and turning both on sets the
+flag first, because a relocation can renumber the message. Nothing else is ever done — no delete, no other flag, no
+folder created, nothing sent.
+
+`JunkFolder` **does not have to be a folder MailFathom mirrors, and for most deployments it should not be**: mapping it
+with `synchronize: false` files spam out of the instance entirely, under the account's own
+`AuthoredDeleteEmailDisposition`. What it does have to be is a folder every configured account maps, because
+classification asks for none to be created — an account that maps no destination **fails startup naming that account**,
+rather than leaving its spam unfiled with nothing said about why. A folder the account only maps is resolved against the
+server the first time a filing needs it, exactly as a rule's destination is.
+
+`Threshold` judges what a scanner scored, in the scanner's own scale, so an operator can label at `ScannerThreshold` and
+move mail only from a higher score. It reaches no other stage, exactly as `ScannerThreshold` does not: a verdict resting
+on a provider's header or on where the receiving server filed the message carries no score in this scale, and is acted
+on. Raising it is deliberately not the same edit as switching classification off — the verdicts go on being recorded.
 
 ## `MailboxSearch`
 

--- a/src/Application/Mail/Mutations/IMailboxMutationRecordStore.cs
+++ b/src/Application/Mail/Mutations/IMailboxMutationRecordStore.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
 using MailFathom.Domain.Mutations;
 
@@ -35,6 +36,34 @@ public interface IMailboxMutationRecordStore
     Task<MailboxMutationRecord> OpenAsync(
         IPersistenceSession session,
         MailboxMutationRequest request,
+        CancellationToken cancellationToken);
+
+    /// <summary>Reports whether one local email has ever had a mutation of a given kind asked for by a given kind of requester.</summary>
+    /// <param name="storedEmailId">The local email, which is the identity that survives the email being moved.</param>
+    /// <param name="mutation">The change asked for.</param>
+    /// <param name="origin">The kind of act that asked.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns><see langword="true" /> when at least one such record exists, whatever stage it reached.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="mutation" /> is unspecified.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="origin" /> is not a declared origin.</exception>
+    /// <remarks>
+    /// <para>
+    /// It answers a question the idempotency identity deliberately cannot: whether this email was ever moved by this kind
+    /// of requester, rather than whether one particular request has already been made. The identity is keyed to the
+    /// occurrence and to what asked, so a message that has since moved is a new occurrence and a requester whose terms
+    /// changed is a new requester — both of which ask afresh, which is right for a retry and wrong for deciding whether
+    /// somebody has since undone the change.
+    /// </para>
+    /// <para>
+    /// Every stage counts, including an abandoned one. What the caller is establishing is that MailFathom has already
+    /// acted on this email once, and a change that was attempted and given up on is still a change the owner may have
+    /// seen and reversed.
+    /// </para>
+    /// </remarks>
+    Task<bool> HasRecordAsync(
+        StoredEmailId storedEmailId,
+        MailboxMutation mutation,
+        MailboxMutationOrigin origin,
         CancellationToken cancellationToken);
 
     /// <summary>Counts one attempt against the record before that attempt is made.</summary>

--- a/src/Application/Spam/Actions/ISpamActionOccurrenceReader.cs
+++ b/src/Application/Spam/Actions/ISpamActionOccurrenceReader.cs
@@ -1,0 +1,23 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Spam.Actions;
+
+/// <summary>Reads where a classified email currently is and whether its mail server already reports it read.</summary>
+/// <remarks>
+/// A port of its own rather than a widening of <see cref="IClassifiableEmailReader" />, because the two are asked at
+/// different moments and about different things: that one is asked before a verdict exists and answers what the verdict
+/// is judged from, and this one is asked after and answers what a change would be issued against. Widening the first
+/// would put a remote occurrence and a flag into every classification that never touches a mailbox.
+/// </remarks>
+public interface ISpamActionOccurrenceReader
+{
+    /// <summary>Finds the occurrence one local email currently has.</summary>
+    /// <param name="emailId">The local email a classification was recorded for.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>Where the email is and how it stands, or <see langword="null" /> when nothing is stored under that identifier.</returns>
+    Task<SpamActionOccurrence?> FindAsync(StoredEmailId emailId, CancellationToken cancellationToken);
+}

--- a/src/Application/Spam/Actions/ISpamActionSettingsReader.cs
+++ b/src/Application/Spam/Actions/ISpamActionSettingsReader.cs
@@ -1,0 +1,22 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Spam.Actions;
+
+/// <summary>Answers what an operator asked to happen to mail a classification calls junk.</summary>
+/// <remarks>
+/// It is a port of its own rather than a second property on <see cref="ISpamClassificationSettingsReader" /> because the
+/// two answer for different halves of the feature: that one decides whether a verdict is reached at all, and this one
+/// decides whether anything is done about it. Keeping them apart is what lets the classifier stay a use case that writes
+/// nothing but its own record — it never resolves this reader and cannot reach a mailbox through it.
+/// </remarks>
+public interface ISpamActionSettingsReader
+{
+    /// <summary>Gets what the operator decided, as it stands now.</summary>
+    /// <remarks>
+    /// Read per request rather than captured, so an operator switching filing on reaches the next verdict without a
+    /// restart — and so one switching it off stops the next one.
+    /// </remarks>
+    SpamActionSettings Actions { get; }
+}

--- a/src/Application/Spam/Actions/SpamActionOccurrence.cs
+++ b/src/Application/Spam/Actions/SpamActionOccurrence.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Application.Spam.Actions;
+
+/// <summary>Where a classified email is and how it stands, which is everything an action has to know about it.</summary>
+/// <param name="Id">The local email, which is what a mutation record hangs off and what its filing history is read by.</param>
+/// <param name="Occurrence">
+/// Where the email is on the mail server, which is what an IMAP command is issued against. It is read now rather than
+/// derived from the classification, because a classification is a durable record and the message may have moved since.
+/// </param>
+/// <param name="FolderAlias">
+/// MailFathom's own name for the folder the occurrence is in, which is what decides whether a filing has anywhere left
+/// to move the message to.
+/// </param>
+/// <param name="IsRemotelySeen">
+/// Whether the mail server already reports the message read, as of the last synchronization. A message that is already
+/// read is not written to, which keeps the flag change an act rather than a repeated statement.
+/// </param>
+/// <remarks>
+/// Nothing here is mail content: a local identifier, a remote occurrence, a folder alias, and a flag are MailFathom's own
+/// or the server's own names for things. That is what lets an action be decided and written down without the message it
+/// is about being read again.
+/// </remarks>
+public sealed record SpamActionOccurrence(
+    StoredEmailId Id,
+    EmailOccurrenceId Occurrence,
+    MailFolderAlias FolderAlias,
+    bool IsRemotelySeen);

--- a/src/Application/Spam/Actions/SpamActionOutcome.cs
+++ b/src/Application/Spam/Actions/SpamActionOutcome.cs
@@ -1,0 +1,75 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Spam.Actions;
+
+/// <summary>How one attempt to act on a spam verdict ended.</summary>
+/// <remarks>
+/// Every member but <see cref="Requested" /> is a reason no mailbox was written to, and none of them is a failure. They
+/// are separate members rather than one negative because a caller reporting what a run did — above all a run an operator
+/// asked for over a whole mailbox — has to say why a message was left alone, and <em>nothing to change</em> and <em>the
+/// owner has already moved this back</em> are different answers to that question.
+/// </remarks>
+public enum SpamActionOutcome
+{
+    /// <summary>At least one change was written down for the account's convergence pass to carry out.</summary>
+    Requested = 0,
+
+    /// <summary>Neither switch is on, so nothing was read and nothing was asked for.</summary>
+    NoActionConfigured = 1,
+
+    /// <summary>The verdict is not spam, which includes a classification that concluded nothing either way.</summary>
+    NotSpam = 2,
+
+    /// <summary>A scanner decided the verdict and its score is below the score the operator acts at.</summary>
+    BelowThreshold = 3,
+
+    /// <summary>Nothing is stored under that identifier, which is what an expunged message reaches.</summary>
+    OccurrenceMissing = 4,
+
+    /// <summary>Filing is on and the destination named no folder on the account's server.</summary>
+    /// <remarks>
+    /// <para>
+    /// It is one member for every way <see cref="Mail.Mutations.Destinations.MailboxDestinationOutcome" /> reports a
+    /// destination that resolved to nothing — no mapping answers to the name, no run has bound it, the server advertises
+    /// no such folder, or several folders carry the role. Those are four remedies for an operator and one answer here:
+    /// the folder is not there, so the message waits. Which of the four it was is reported where the resolution happened,
+    /// and startup validation already refuses the configuration that produces the first of them, naming the account.
+    /// </para>
+    /// <para>
+    /// Nothing at all is written down in this case, including a <c>\Seen</c> change asked for beside the filing. Marking
+    /// a message read while leaving it where it is takes the unread marker off spam that is still in the inbox, which is
+    /// worse than waiting: the two switches together describe one intent, and a later attempt performs it whole once the
+    /// folder is there.
+    /// </para>
+    /// </remarks>
+    DestinationUnresolved = 5,
+
+    /// <summary>Filing this message was asked for once already, and it is not in the destination.</summary>
+    /// <remarks>
+    /// <para>
+    /// It is the one outcome that outranks both switches, and it covers two readings that are the same decision: somebody
+    /// moved the message back out, which is the correction a false positive is meant to have, or the change is written
+    /// down and the account's convergence pass has not carried it out yet. Asking again would either argue with the
+    /// person whose mailbox it is or duplicate a change already in flight.
+    /// </para>
+    /// <para>
+    /// The two are deliberately not told apart. Doing so would mean reading how far the earlier record got and treating
+    /// an abandoned one as licence to file afresh — which is precisely the message a person is most likely to have moved
+    /// by hand while it sat there.
+    /// </para>
+    /// </remarks>
+    PreviouslyFiled = 6,
+
+    /// <summary>Everything the switches ask for is already true of the message.</summary>
+    NothingToChange = 7,
+
+    /// <summary>A reload has withdrawn the account, so what it keeps of mail leaving the mirror is unknown.</summary>
+    /// <remarks>
+    /// Reachable only for an unmirrored destination, which is the one case a filing has to carry that answer. Like an
+    /// unresolved destination it withholds both changes, for the same reason: the intent is one, and it is performed
+    /// whole once the account is declared again.
+    /// </remarks>
+    AccountNoLongerConfigured = 8,
+}

--- a/src/Application/Spam/Actions/SpamActionRecorder.cs
+++ b/src/Application/Spam/Actions/SpamActionRecorder.cs
@@ -1,0 +1,302 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Destinations;
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Spam;
+
+namespace MailFathom.Application.Spam.Actions;
+
+/// <summary>Writes down the changes an operator asked a spam verdict to produce, as ordinary mutation records.</summary>
+/// <remarks>
+/// <para>
+/// This is the whole join between a classification and a mailbox. Nothing here issues an IMAP command, opens a write
+/// session, or touches the local row: it opens a durable record per change, and the account's own convergence pass
+/// carries each one exactly as it carries a change somebody authored by hand. The local folder and flags change later,
+/// because synchronization observed the server — never because this decided they should.
+/// </para>
+/// <para>
+/// Two rules keep filing from turning into an argument with the mailbox's owner, and they are the reason this type is
+/// more than a translation of two switches into two requests. A message already in the destination is not moved into it,
+/// and a message this feature has already asked to have filed, which is not in the destination, is left alone entirely:
+/// somebody moved it back, which is exactly the correction a false positive is supposed to have, and repeating the
+/// filing would undo their decision on every pass. The second rule is read from the durable record rather than from the
+/// message, because the record is what survives the message moving — and it holds equally for a filing still in flight,
+/// which the same reading makes idempotent.
+/// </para>
+/// <para>
+/// Both changes are written down in one commit, and the <c>\Seen</c> change is written first so it is issued first. On a
+/// server without <c>MOVE</c> a relocation gives the message a new UID, and a flag stored afterwards would be aimed at an
+/// occurrence the source folder no longer holds.
+/// </para>
+/// <para>
+/// Where the junk folder is is not decided here. A verdict is one author of a filing mutation among others, so the
+/// destination is turned into a folder by <see cref="MailboxDestinationResolver" />, which is the single place any
+/// author reaches one — including the on-demand resolution a junk folder nothing mirrors needs, that being the
+/// destination this feature recommends. Resolving happens before the commit is opened, because it can reach the mail
+/// server.
+/// </para>
+/// <para>
+/// Nothing it reads or reports is mail content. The occurrence, the folder alias, the outcome, and the record identifiers
+/// are safe to report; there is no path from here to a subject, an address, or a body.
+/// </para>
+/// </remarks>
+public sealed class SpamActionRecorder
+{
+    private readonly ISpamActionSettingsReader settingsReader;
+    private readonly ISpamActionOccurrenceReader occurrences;
+    private readonly IMailboxMutationRecordStore records;
+    private readonly MailboxDestinationResolver destinations;
+    private readonly IAuthoredDeleteEmailDispositionReader deleteDispositions;
+    private readonly OptimisticConcurrencyRetryPolicy retryPolicy;
+
+    /// <summary>Initializes the use case from the decisions it has to read and the record it writes.</summary>
+    /// <param name="settingsReader">Answers what the operator asked to happen to junk.</param>
+    /// <param name="occurrences">Reads where the classified email is and whether it is already read.</param>
+    /// <param name="records">Opens the durable record each change is carried by.</param>
+    /// <param name="destinations">Turns the configured junk folder into the folder on the server it currently names.</param>
+    /// <param name="deleteDispositions">Answers what the account keeps locally of mail that leaves the mirror for good.</param>
+    /// <param name="retryPolicy">Commits the records from a fresh read when a concurrent write conflicts.</param>
+    /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
+    public SpamActionRecorder(
+        ISpamActionSettingsReader settingsReader,
+        ISpamActionOccurrenceReader occurrences,
+        IMailboxMutationRecordStore records,
+        MailboxDestinationResolver destinations,
+        IAuthoredDeleteEmailDispositionReader deleteDispositions,
+        OptimisticConcurrencyRetryPolicy retryPolicy)
+    {
+        ArgumentNullException.ThrowIfNull(settingsReader);
+        ArgumentNullException.ThrowIfNull(occurrences);
+        ArgumentNullException.ThrowIfNull(records);
+        ArgumentNullException.ThrowIfNull(destinations);
+        ArgumentNullException.ThrowIfNull(deleteDispositions);
+        ArgumentNullException.ThrowIfNull(retryPolicy);
+
+        this.settingsReader = settingsReader;
+        this.occurrences = occurrences;
+        this.records = records;
+        this.destinations = destinations;
+        this.deleteDispositions = deleteDispositions;
+        this.retryPolicy = retryPolicy;
+    }
+
+    /// <summary>Asks for whatever the switches say should happen to one classified message.</summary>
+    /// <param name="classification">What classification concluded about the occurrence.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>The changes that were written down, or the reason none were.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="classification" /> is <see langword="null" />.</exception>
+    /// <exception cref="PersistenceConcurrencyConflictException">Thrown when every allowed commit attempt conflicted.</exception>
+    /// <remarks>
+    /// The checks run in the order of what they cost and of what they settle. Whether anything is switched on at all is
+    /// free and answers for the whole deployment; the verdict and the threshold are already in hand; only then is the
+    /// mailbox read. A deployment that asked for no action therefore performs one property read per classified message
+    /// and nothing else.
+    /// </remarks>
+    public async Task<SpamActionResult> RecordAsync(
+        SpamClassification classification,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(classification);
+
+        var settings = this.settingsReader.Actions;
+
+        if (!settings.IsAnyActionEnabled)
+        {
+            return SpamActionResult.NotActedOn(SpamActionOutcome.NoActionConfigured);
+        }
+
+        if (classification.Verdict is not SpamVerdict.Spam)
+        {
+            return SpamActionResult.NotActedOn(SpamActionOutcome.NotSpam);
+        }
+
+        if (!ClearsActingThreshold(classification, settings.Threshold))
+        {
+            return SpamActionResult.NotActedOn(SpamActionOutcome.BelowThreshold);
+        }
+
+        var occurrence = await this.occurrences.FindAsync(classification.EmailId, cancellationToken);
+
+        if (occurrence is null)
+        {
+            return SpamActionResult.NotActedOn(SpamActionOutcome.OccurrenceMissing);
+        }
+
+        var filing = await this.DecideFilingAsync(occurrence, settings, cancellationToken);
+
+        if (filing.Refusal is { } refusal)
+        {
+            return SpamActionResult.NotActedOn(refusal);
+        }
+
+        var marksRead = settings.MarksJunkRead && !occurrence.IsRemotelySeen;
+
+        if (!marksRead && filing.Plan is null)
+        {
+            return SpamActionResult.NotActedOn(SpamActionOutcome.NothingToChange);
+        }
+
+        return await this.OpenRecordsAsync(
+            occurrence,
+            MailboxMutationRequester.Classification(DecidedUnder(classification), settings.Threshold),
+            marksRead,
+            filing.Plan,
+            cancellationToken);
+    }
+
+    /// <summary>Re-judges a scanner's score by the score the operator is willing to touch mail at.</summary>
+    /// <remarks>
+    /// Only a scanner's score is judged. A deterministic verdict rests on what the receiving server concluded or on where
+    /// somebody already filed the message, and neither carries a number in a scale this threshold is written in — a
+    /// provider's own score least of all, since two providers scoring the same message agree on nothing but the sign.
+    /// </remarks>
+    private static bool ClearsActingThreshold(SpamClassification classification, double? threshold) =>
+        threshold is not { } acting
+        || classification.DecidedBy is not SpamClassificationStage.Scanner
+        || classification.Assessment is not { } assessment
+        || assessment.Score >= acting;
+
+    /// <summary>Names what the deciding stage ran under, which is half of the requester identity.</summary>
+    /// <remarks>
+    /// A scanner names its rule corpus, so a corpus update asks afresh and a rescan against the same one does not. The
+    /// deterministic stage has no corpus and its inputs are the message's own headers, so what it ran under is the stage
+    /// itself: the same headers reach the same verdict however often they are read.
+    /// </remarks>
+    private static string DecidedUnder(SpamClassification classification) =>
+        classification.CorpusRevision ?? classification.DecidedBy.ToString();
+
+    /// <summary>Decides whether a filing is owed, already satisfied, refused, or switched off.</summary>
+    private async Task<FilingDecision> DecideFilingAsync(
+        SpamActionOccurrence occurrence,
+        SpamActionSettings settings,
+        CancellationToken cancellationToken)
+    {
+        if (!settings.FilesJunk)
+        {
+            return FilingDecision.NothingOwed;
+        }
+
+        var accountId = occurrence.Occurrence.AccountId;
+        var resolved = await this.destinations.ResolveAsync(accountId, [settings.JunkFolder], cancellationToken);
+
+        if (resolved.Find(settings.JunkFolder).Destination is not { } destination)
+        {
+            return FilingDecision.Refused(SpamActionOutcome.DestinationUnresolved);
+        }
+
+        if (destination.Alias == occurrence.FolderAlias)
+        {
+            return FilingDecision.NothingOwed;
+        }
+
+        // Asked after the folder is known and before anything is written, because it is the one answer that outranks
+        // both switches: this feature has already asked for this email to be filed and the email is not in the
+        // destination, so either somebody put it back or the change is still in flight.
+        if (await this.records.HasRecordAsync(
+            occurrence.Id,
+            MailboxMutation.Relocate,
+            MailboxMutationOrigin.Classification,
+            cancellationToken))
+        {
+            return FilingDecision.Refused(SpamActionOutcome.PreviouslyFiled);
+        }
+
+        return this.PlanFiling(accountId, destination);
+    }
+
+    /// <summary>Builds the filing, carrying what becomes of the local copy exactly when the destination is unmirrored.</summary>
+    /// <remarks>
+    /// A junk folder MailFathom does not mirror is the recommended destination, so an unmirrored one is the ordinary case
+    /// rather than the exception: the message leaves the mirror for good, and the account's own answer about mail it
+    /// deletes is what decides whether the local copy is kept, tombstoned, or erased. An account a reload has stopped
+    /// declaring has no such answer, and none invented here would be it, so the message is left alone until it is
+    /// declared again — the same choice the rule path makes, reported rather than raised so a run over one mailbox is not
+    /// ended by it.
+    /// </remarks>
+    private FilingDecision PlanFiling(MailAccountId accountId, MailboxDestination destination)
+    {
+        if (destination.IsMirrored)
+        {
+            return FilingDecision.Owed(new FilingPlan(destination.Path, LocalDisposition: null));
+        }
+
+        try
+        {
+            return FilingDecision.Owed(new FilingPlan(
+                destination.Path,
+                this.deleteDispositions.GetAuthoredDeleteDisposition(accountId)));
+        }
+        catch (InvalidOperationException)
+        {
+            return FilingDecision.Refused(SpamActionOutcome.AccountNoLongerConfigured);
+        }
+    }
+
+    /// <summary>Opens the records, in the order the changes have to be applied, inside one commit.</summary>
+    private Task<SpamActionResult> OpenRecordsAsync(
+        SpamActionOccurrence occurrence,
+        MailboxMutationRequester requester,
+        bool marksRead,
+        FilingPlan? filing,
+        CancellationToken cancellationToken) =>
+        this.retryPolicy.CommitAsync(
+            async (session, attemptCancellationToken) =>
+            {
+                MailboxMutationRecordId? markedReadRecordId = null;
+                MailboxMutationRecordId? filedRecordId = null;
+
+                if (marksRead)
+                {
+                    var seenRecord = await this.records.OpenAsync(
+                        session,
+                        MailboxMutationRequest.SetSeen(occurrence.Id, occurrence.Occurrence, requester, isSeen: true),
+                        attemptCancellationToken);
+
+                    markedReadRecordId = seenRecord.Id;
+                }
+
+                if (filing is { } plan)
+                {
+                    var relocationRecord = await this.records.OpenAsync(
+                        session,
+                        MailboxMutationRequest.Relocate(
+                            occurrence.Id,
+                            occurrence.Occurrence,
+                            requester,
+                            plan.Path,
+                            plan.LocalDisposition),
+                        attemptCancellationToken);
+
+                    filedRecordId = relocationRecord.Id;
+                }
+
+                return SpamActionResult.Requested(markedReadRecordId, filedRecordId);
+            },
+            cancellationToken);
+
+    /// <summary>Where a filing would put the message, and what the account keeps of it locally afterwards.</summary>
+    private sealed record FilingPlan(RemoteFolderPath Path, AuthoredDeleteEmailDisposition? LocalDisposition);
+
+    /// <summary>What was decided about filing: a plan to carry out, nothing to do, or a reason to leave the message alone.</summary>
+    /// <remarks>
+    /// A refusal and an absent plan are held apart deliberately. Both end with no relocation, and only one of them also
+    /// withholds the <c>\Seen</c> change — which is the difference between a message that is already filed and a message
+    /// whose filing has nowhere to go.
+    /// </remarks>
+    private readonly record struct FilingDecision(FilingPlan? Plan, SpamActionOutcome? Refusal)
+    {
+        /// <summary>Gets the decision that owes no relocation and withholds nothing — filing is off, or already done.</summary>
+        internal static FilingDecision NothingOwed => default;
+
+        internal static FilingDecision Owed(FilingPlan plan) => new(plan, Refusal: null);
+
+        internal static FilingDecision Refused(SpamActionOutcome outcome) => new(Plan: null, outcome);
+    }
+}

--- a/src/Application/Spam/Actions/SpamActionResult.cs
+++ b/src/Application/Spam/Actions/SpamActionResult.cs
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Application.Spam.Actions;
+
+/// <summary>What one attempt to act on a spam verdict produced.</summary>
+/// <param name="Outcome">How the attempt ended.</param>
+/// <param name="MarkedReadRecordId">The record carrying the <c>\Seen</c> change, or <see langword="null" /> when none was asked for.</param>
+/// <param name="FiledRecordId">The record carrying the relocation, or <see langword="null" /> when none was asked for.</param>
+/// <remarks>
+/// The record identifiers travel back so a caller reporting what a run did can name the changes it started rather than
+/// reading them out of the store again, and so a run over a whole mailbox can count them. Neither identifier says the
+/// change has happened: a record is opened before the first IMAP command and the account's convergence pass carries it
+/// from there.
+/// </remarks>
+public sealed record SpamActionResult(
+    SpamActionOutcome Outcome,
+    MailboxMutationRecordId? MarkedReadRecordId,
+    MailboxMutationRecordId? FiledRecordId)
+{
+    /// <summary>Records that no mailbox was written to, and why.</summary>
+    /// <param name="outcome">The reason.</param>
+    /// <returns>The result.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="outcome" /> is <see cref="SpamActionOutcome.Requested" />, which records the changes instead.</exception>
+    public static SpamActionResult NotActedOn(SpamActionOutcome outcome) =>
+        outcome is SpamActionOutcome.Requested
+            ? throw new ArgumentOutOfRangeException(
+                nameof(outcome),
+                outcome,
+                "A result that asked for nothing does not carry the requested outcome.")
+            : new SpamActionResult(outcome, MarkedReadRecordId: null, FiledRecordId: null);
+
+    /// <summary>Records the changes that were written down.</summary>
+    /// <param name="markedReadRecordId">The record carrying the <c>\Seen</c> change, or <see langword="null" /> when none was asked for.</param>
+    /// <param name="filedRecordId">The record carrying the relocation, or <see langword="null" /> when none was asked for.</param>
+    /// <returns>The result.</returns>
+    /// <exception cref="ArgumentException">Thrown when neither identifier is supplied, which is <see cref="SpamActionOutcome.NothingToChange" /> rather than a request.</exception>
+    public static SpamActionResult Requested(
+        MailboxMutationRecordId? markedReadRecordId,
+        MailboxMutationRecordId? filedRecordId) =>
+        markedReadRecordId is null && filedRecordId is null
+            ? throw new ArgumentException(
+                "A requested result carries at least one of the two records it asked for.",
+                nameof(markedReadRecordId))
+            : new SpamActionResult(SpamActionOutcome.Requested, markedReadRecordId, filedRecordId);
+}

--- a/src/Application/Spam/Actions/SpamActionSettings.cs
+++ b/src/Application/Spam/Actions/SpamActionSettings.cs
@@ -1,0 +1,102 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Application.Spam.Actions;
+
+/// <summary>What an operator asked to happen to mail a classification calls junk.</summary>
+/// <remarks>
+/// <para>
+/// Both switches are off in <see cref="None" />, which is what a deployment that configured nothing runs with: a verdict
+/// is recorded and no mailbox is written to. They are independent of each other, so an operator can file junk without
+/// marking it read and mark it read without moving it.
+/// </para>
+/// <para>
+/// Neither switch is a decision about classification itself. Turning both off leaves classification recording exactly
+/// what it recorded before, which is the property that lets an operator watch what a scanner concludes for a while
+/// before letting it touch anything.
+/// </para>
+/// </remarks>
+public sealed record SpamActionSettings
+{
+    private SpamActionSettings(
+        bool filesJunk,
+        bool marksJunkRead,
+        MailFolderReference junkFolder,
+        double? threshold)
+    {
+        this.FilesJunk = filesJunk;
+        this.MarksJunkRead = marksJunkRead;
+        this.JunkFolder = junkFolder;
+        this.Threshold = threshold;
+    }
+
+    /// <summary>Gets the settings a deployment that asked for no action runs with.</summary>
+    public static SpamActionSettings None { get; } = new(
+        filesJunk: false,
+        marksJunkRead: false,
+        DefaultJunkFolder,
+        threshold: null);
+
+    /// <summary>Gets the folder a filing goes to when the operator named none: whichever folder the account maps to the junk role.</summary>
+    /// <remarks>
+    /// A role rather than an alias, because the folder junk belongs in is a different name on every server and an account
+    /// already states which of its folders plays that part. An operator whose junk folder is not the one the account
+    /// labelled names it explicitly instead.
+    /// </remarks>
+    public static MailFolderReference DefaultJunkFolder { get; } = MailFolderReference.ToRole(MailFolderSpecialUse.Junk);
+
+    /// <summary>Gets whether junk is moved into the junk folder on the mail server.</summary>
+    public bool FilesJunk { get; }
+
+    /// <summary>Gets whether junk has its remote <c>\Seen</c> flag set.</summary>
+    public bool MarksJunkRead { get; }
+
+    /// <summary>Gets the folder junk is filed into, named by alias or by the role a folder plays.</summary>
+    public MailFolderReference JunkFolder { get; }
+
+    /// <summary>Gets the score a scanner has to reach before mail is touched, or <see langword="null" /> to act on every spam verdict.</summary>
+    /// <remarks>
+    /// It judges what a scanner scored, in the scanner's own scale, and it is a second reading of that score rather than
+    /// a replacement for the one the verdict was reached under: labelling a message spam and moving it are different
+    /// costs to get wrong, so an operator may be stricter about the second. It reaches no other stage, for the reason the
+    /// classification threshold does not — a provider header carries a threshold in a scale this one knows nothing about,
+    /// and a verdict resting on where the receiving server filed the message carries no score at all.
+    /// </remarks>
+    public double? Threshold { get; }
+
+    /// <summary>Gets whether anything at all is acted on.</summary>
+    public bool IsAnyActionEnabled => this.FilesJunk || this.MarksJunkRead;
+
+    /// <summary>Builds the settings an operator's answers describe.</summary>
+    /// <param name="filesJunk">Whether junk is moved into the junk folder.</param>
+    /// <param name="marksJunkRead">Whether junk is marked read.</param>
+    /// <param name="junkFolder">The folder junk is filed into, or <see langword="null" /> to take <see cref="DefaultJunkFolder" />.</param>
+    /// <param name="threshold">The score a scanner has to reach before mail is touched, or <see langword="null" /> to act on every spam verdict.</param>
+    /// <returns>The settings.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="junkFolder" /> is the unspecified struct default.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="threshold" /> is not a finite number.</exception>
+    public static SpamActionSettings Create(
+        bool filesJunk,
+        bool marksJunkRead,
+        MailFolderReference? junkFolder = null,
+        double? threshold = null)
+    {
+        if (junkFolder is { } named && !named.IsSpecified)
+        {
+            throw new ArgumentException("The unspecified default of the struct names no junk folder.", nameof(junkFolder));
+        }
+
+        if (threshold is { } configured && !double.IsFinite(configured))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(threshold),
+                configured,
+                "A configured action threshold is a finite number.");
+        }
+
+        return new SpamActionSettings(filesJunk, marksJunkRead, junkFolder ?? DefaultJunkFolder, threshold);
+    }
+}

--- a/src/Domain/Mutations/MailboxMutationOrigin.cs
+++ b/src/Domain/Mutations/MailboxMutationOrigin.cs
@@ -4,12 +4,13 @@
 
 namespace MailFathom.Domain.Mutations;
 
-/// <summary>Names what kind of authored act asked for a mutation.</summary>
+/// <summary>Names what kind of act asked for a mutation.</summary>
 /// <remarks>
-/// The two differ in what makes a request the same request. A rule asks on its own, repeatedly, so its identity has to
+/// The three differ in what makes a request the same request. A rule asks on its own, repeatedly, so its identity has to
 /// survive the run it was evaluated in and change when the rule itself changes; an invocation asks once, so its identity
-/// is the invocation. Keeping the kind beside the identity is what lets an operator read a stuck mutation and know
-/// whether to look at a rule or at something they did.
+/// is the invocation; a classification asks on its own and repeatedly like a rule, but nobody authored it, so what stands
+/// in for the rule's name is the profile the verdict was decided under. Keeping the kind beside the identity is what lets
+/// an operator read a stuck mutation and know whether to look at a rule, at a scanner, or at something they did.
 /// </remarks>
 public enum MailboxMutationOrigin
 {
@@ -18,4 +19,12 @@ public enum MailboxMutationOrigin
 
     /// <summary>Somebody asked for the mutation directly, through a tool call or an administrative command.</summary>
     Command = 1,
+
+    /// <summary>A spam classification reached a verdict the operator asked to be acted on.</summary>
+    /// <remarks>
+    /// It is a third kind rather than a rule with a reserved name, because neither of the other two describes it: nothing
+    /// was authored, so it is not a rule, and nobody was present, so it is not a command. An operator reading a stuck
+    /// mutation of this kind looks at the classification section rather than at a rule they wrote.
+    /// </remarks>
+    Classification = 2,
 }

--- a/src/Domain/Mutations/MailboxMutationRequester.cs
+++ b/src/Domain/Mutations/MailboxMutationRequester.cs
@@ -61,6 +61,50 @@ public sealed record MailboxMutationRequester
         return new MailboxMutationRequester(MailboxMutationOrigin.Rule, ValidIdentity(identity, nameof(ruleName)));
     }
 
+    /// <summary>Names the profile a spam classification was decided under, which is what asked for the mutation.</summary>
+    /// <param name="decidedUnder">What the deciding stage ran under — a scanner's rule corpus, or the stage's own name where it has none.</param>
+    /// <param name="actingThreshold">The score MailFathom itself requires before it touches mail, or <see langword="null" /> when the operator configured none.</param>
+    /// <returns>A requester naming that profile.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="decidedUnder" /> is blank, carries a control character, or is long enough that the composed identity exceeds <see cref="MaximumIdentityLength" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="actingThreshold" /> is not a finite number.</exception>
+    /// <remarks>
+    /// <para>
+    /// A classification asks the way a rule does — on its own, repeatedly, about mail nobody is looking at — so it needs
+    /// the same kind of identity: one that does not move when the same decision is reached again, and does move when the
+    /// terms of the decision change. What a rule answers with its name and revision, a classification answers with the
+    /// corpus its verdict was reached against and the threshold MailFathom would act at. Rescanning the same message
+    /// against the same corpus therefore asks for nothing new, and a corpus update or a threshold an operator moved asks
+    /// afresh.
+    /// </para>
+    /// <para>
+    /// The occurrence is deliberately not part of this text. It is already the first third of the record's own
+    /// idempotency identity, so repeating it here would spend the identity's length on a value the constraint already
+    /// compares.
+    /// </para>
+    /// </remarks>
+    public static MailboxMutationRequester Classification(string decidedUnder, double? actingThreshold)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(decidedUnder);
+
+        if (actingThreshold is { } threshold && !double.IsFinite(threshold))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(actingThreshold),
+                threshold,
+                "An acting threshold is a finite number.");
+        }
+
+        var identity = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{decidedUnder.Trim()}@{DescribeThreshold(actingThreshold)}");
+
+        // Reported against the corpus rather than against the composed identity, for the reason the rule factory gives:
+        // it is the part the caller supplied and the only part they can shorten.
+        return new MailboxMutationRequester(
+            MailboxMutationOrigin.Classification,
+            ValidIdentity(identity, nameof(decidedUnder)));
+    }
+
     /// <summary>Names one invocation somebody made.</summary>
     /// <param name="invocationIdentity">The identity of the invocation, which is the same for a retry of it and different for a second one.</param>
     /// <returns>A requester naming that invocation.</returns>
@@ -87,6 +131,16 @@ public sealed record MailboxMutationRequester
 
         return new MailboxMutationRequester(origin, ValidIdentity(identity, nameof(identity)));
     }
+
+    /// <summary>Writes the acting threshold into the identity, with a name of its own for the absent case.</summary>
+    /// <remarks>
+    /// An unconfigured threshold is written rather than left out, so that configuring one changes the identity instead of
+    /// producing text that could also be read as a corpus nobody judged. The invariant culture is what keeps two
+    /// instances of one deployment agreeing on the identity whatever locale each process starts under.
+    /// </remarks>
+    private static string DescribeThreshold(double? actingThreshold) => actingThreshold is { } threshold
+        ? threshold.ToString(CultureInfo.InvariantCulture)
+        : "none";
 
     /// <summary>Validates an identity and reports a refusal against the parameter the caller actually supplied.</summary>
     /// <remarks>

--- a/src/Host/Configuration/Spam/ConfiguredSpamActionSettingsReader.cs
+++ b/src/Host/Configuration/Spam/ConfiguredSpamActionSettingsReader.cs
@@ -1,0 +1,35 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Spam.Actions;
+using Microsoft.Extensions.Options;
+
+namespace MailFathom.Host.Configuration.Spam;
+
+/// <summary>Reads what an operator asked to happen to junk out of the bound section.</summary>
+/// <remarks>
+/// <para>
+/// The section is read per request rather than captured, so switching filing on reaches the next verdict and switching
+/// it off stops the next one, neither needing a restart.
+/// </para>
+/// <para>
+/// Classification being switched off answers for the actions too, although validation already refuses that combination.
+/// The two are read from one snapshot here, so a candidate that somehow reached this reader cannot leave the mailbox
+/// being written to on the strength of verdicts nothing is producing.
+/// </para>
+/// </remarks>
+internal sealed class ConfiguredSpamActionSettingsReader(IOptionsMonitor<SpamClassificationOptions> options)
+    : ISpamActionSettingsReader
+{
+    /// <inheritdoc />
+    public SpamActionSettings Actions
+    {
+        get
+        {
+            var current = options.CurrentValue;
+
+            return current.Enabled ? current.Actions.ToSettings() : SpamActionSettings.None;
+        }
+    }
+}

--- a/src/Host/Configuration/Spam/SpamActionOptions.cs
+++ b/src/Host/Configuration/Spam/SpamActionOptions.cs
@@ -1,0 +1,125 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using MailFathom.Application.Spam.Actions;
+using MailFathom.Domain.Folders;
+
+namespace MailFathom.Host.Configuration.Spam;
+
+/// <summary>Configures what happens to mail a classification calls junk.</summary>
+/// <remarks>
+/// <para>
+/// Both switches are off when the block is absent, so a deployment that switches classification on and states nothing
+/// here records verdicts and writes to no mailbox. They are independent keys because they are independent decisions: an
+/// operator may want spam out of the way without it being marked read, or marked read without being moved.
+/// </para>
+/// <para>
+/// Everything either switch can do is a change
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md">ADR 0007</see>
+/// already permits and which a mail client reverses in one drag. Nothing here deletes, creates a folder, sends anything,
+/// or writes a flag other than <c>\Seen</c>.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed class SpamActionOptions
+{
+    /// <summary>Gets or sets whether junk is moved into the junk folder on the mail server.</summary>
+    /// <remarks>
+    /// The move is the ordinary relocation MailFathom already performs for a rule, written down as a durable record and
+    /// carried out by the account's convergence pass. MailFathom never creates the folder, so an account with none is
+    /// refused at startup rather than at the first spam message.
+    /// </remarks>
+    public bool FileInJunkFolder { get; set; }
+
+    /// <summary>Gets or sets whether junk has its remote <c>\Seen</c> flag set.</summary>
+    /// <remarks>
+    /// This is the one authored act that sets that flag. Synchronization and content retrieval still never do, which is
+    /// the invariant this does not touch: reading a message on the owner's behalf must not mark it read, and deciding
+    /// that a message is junk the operator asked to have marked read is a different act entirely.
+    /// </remarks>
+    public bool MarkAsRead { get; set; }
+
+    /// <summary>Gets or sets the folder junk is filed into, or <see langword="null" /> to take whichever folder each account maps to the junk role.</summary>
+    /// <remarks>
+    /// Written the way every folder is named: an alias, or <c>role:Junk</c> for the folder an account labelled with that
+    /// role. It does not have to be a folder MailFathom mirrors, and for most deployments it should not be — the point of
+    /// filing spam is to be rid of it, and an unmirrored destination takes the local copy with it under the account's own
+    /// answer about mail it deletes.
+    /// </remarks>
+    public string? JunkFolder { get; set; }
+
+    /// <summary>Gets or sets the score a scanner has to reach before mail is touched, or <see langword="null" /> to act on every spam verdict.</summary>
+    /// <remarks>
+    /// It is a second reading of a scanner's score rather than a replacement for the one the verdict was reached under,
+    /// so an operator can label at five and move at eight. Raising it is deliberately not the same edit as switching
+    /// classification off: the verdicts go on being recorded and only the acting stops.
+    /// </remarks>
+    public double? Threshold { get; set; }
+
+    /// <summary>Gets whether either switch asks for anything.</summary>
+    internal bool IsAnyActionEnabled => this.FileInJunkFolder || this.MarkAsRead;
+
+    /// <summary>Gets the folder junk is filed into, with the junk role standing in for a destination nobody named.</summary>
+    /// <remarks>
+    /// Text that names neither an alias nor a role reads as unnamed here rather than raising, because validation refuses
+    /// it against the key that wrote it and a lookup must not throw over a candidate a reload has already rejected.
+    /// </remarks>
+    internal MailFolderReference Destination =>
+        MailFolderReference.TryCreate(this.JunkFolder, out var destination)
+            ? destination
+            : SpamActionSettings.DefaultJunkFolder;
+
+    /// <summary>Builds the settings these keys describe.</summary>
+    /// <returns>The settings the recorder reads.</returns>
+    internal SpamActionSettings ToSettings() => SpamActionSettings.Create(
+        this.FileInJunkFolder,
+        this.MarkAsRead,
+        this.Destination,
+        this.Threshold);
+
+    /// <summary>Finds everything about this block that would otherwise be discovered on somebody's mail.</summary>
+    /// <param name="classificationEnabled">Whether the section switches classification on at all.</param>
+    /// <returns>One result per defect, each naming the key that carries it.</returns>
+    internal IEnumerable<ValidationResult> FindErrors(bool classificationEnabled)
+    {
+        if (this.IsAnyActionEnabled && !classificationEnabled)
+        {
+            yield return new ValidationResult(
+                $"{SpamClassificationOptions.SectionName} asks for junk to be acted on while classification is disabled, and there is no verdict to act on. Set Enabled to true, or remove the switches under Actions.",
+                [nameof(this.FileInJunkFolder), nameof(this.MarkAsRead)]);
+        }
+
+        if (this.JunkFolder is not null && !MailFolderReference.TryCreate(this.JunkFolder, out _))
+        {
+            yield return new ValidationResult(
+                $"{SpamClassificationOptions.SectionName} names junk folder '{this.JunkFolder}', which is neither a usable folder alias nor one of the roles {string.Join(", ", Enum.GetNames<MailFolderSpecialUse>())} written as '{MailFolderReference.RoleScheme}<name>'.",
+                [nameof(this.JunkFolder)]);
+        }
+
+        foreach (var result in this.FindThresholdErrors())
+        {
+            yield return result;
+        }
+    }
+
+    private IEnumerable<ValidationResult> FindThresholdErrors()
+    {
+        if (this.Threshold is not { } threshold)
+        {
+            yield break;
+        }
+
+        if (!double.IsFinite(threshold)
+            || threshold < SpamClassificationOptions.SmallestThreshold
+            || threshold > SpamClassificationOptions.LargestThreshold)
+        {
+            yield return new ValidationResult(
+                $"{SpamClassificationOptions.SectionName} declares an action {nameof(this.Threshold)} of {threshold.ToString(CultureInfo.InvariantCulture)}, and a threshold is between {SpamClassificationOptions.SmallestThreshold.ToString(CultureInfo.InvariantCulture)} and {SpamClassificationOptions.LargestThreshold.ToString(CultureInfo.InvariantCulture)}. A value outside that range either acts on every scored message or can never be reached.",
+                [nameof(this.Threshold)]);
+        }
+    }
+}

--- a/src/Host/Configuration/Spam/SpamClassificationOptions.cs
+++ b/src/Host/Configuration/Spam/SpamClassificationOptions.cs
@@ -77,6 +77,14 @@ internal sealed class SpamClassificationOptions : IValidatableObject
     /// </remarks>
     public SpamScannerOptions Scanner { get; set; } = new();
 
+    /// <summary>Gets or sets what happens to mail a verdict calls junk.</summary>
+    /// <remarks>
+    /// Always present so that a deployment which states none of its keys still binds and validates. Both of its switches
+    /// are off, which is what keeps a classification derived data by default: a verdict is recorded and the mailbox is
+    /// left exactly as it was.
+    /// </remarks>
+    public SpamActionOptions Actions { get; set; } = new();
+
     /// <inheritdoc />
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) => this.FindErrors();
 
@@ -101,6 +109,11 @@ internal sealed class SpamClassificationOptions : IValidatableObject
         }
 
         foreach (var result in this.Scanner.FindErrors(this.UseScanner))
+        {
+            yield return result;
+        }
+
+        foreach (var result in this.Actions.FindErrors(this.Enabled))
         {
             yield return result;
         }

--- a/src/Host/Configuration/Spam/SpamJunkFolderRules.cs
+++ b/src/Host/Configuration/Spam/SpamJunkFolderRules.cs
@@ -1,0 +1,64 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.ComponentModel.DataAnnotations;
+using MailFathom.Host.Configuration.Rules;
+
+namespace MailFathom.Host.Configuration.Spam;
+
+/// <summary>Judges the configured junk destination against the accounts that would have to file into it.</summary>
+/// <remarks>
+/// <para>
+/// This is the one claim the classification section makes about another section, and it cannot be checked by an attribute
+/// on the bound graph: whether <c>role:Junk</c> names anything is a question each account answers separately, in the
+/// synchronization section. Asking it here is what turns *this account has no junk folder* into a startup failure naming
+/// the account, instead of a message that sits unfiled with nothing said about why.
+/// </para>
+/// <para>
+/// MailFathom never creates the folder —
+/// <see href="https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0007-remote-mailbox-mutation-boundary-and-write-session.md">ADR 0007</see>
+/// refuses folder management outright — so an account that maps none has no destination that could appear later, and the
+/// only repair is a mapping the operator writes.
+/// </para>
+/// <para>
+/// The destination has to be <em>mapped</em> rather than mirrored. A junk folder MailFathom does not mirror is the
+/// recommended one, because the point of filing spam is to be rid of it; what a mapping supplies is a name that resolves
+/// to a remote folder, which is all a relocation needs.
+/// </para>
+/// </remarks>
+internal static class SpamJunkFolderRules
+{
+    /// <summary>Finds every account the configured filing would have nowhere to file into.</summary>
+    /// <param name="options">The classification section as it currently binds.</param>
+    /// <param name="accounts">The accounts the synchronization section declares.</param>
+    /// <returns>One result per account without a destination, empty when filing is off or every account has one.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    internal static IReadOnlyList<ValidationResult> FindDestinationErrors(
+        SpamClassificationOptions options,
+        IReadOnlyCollection<DeclaredMailAccount> accounts)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(accounts);
+
+        var actions = options.Actions;
+
+        // Nothing is judged unless filing is actually switched on. A destination written beside switches that are off is
+        // an operator preparing a configuration, and refusing it would make staging the change impossible.
+        if (!options.Enabled || !actions.FileInJunkFolder)
+        {
+            return [];
+        }
+
+        var destination = actions.Destination;
+
+        return
+        [
+            .. accounts
+                .Where(account => !account.Maps(destination))
+                .Select(account => new ValidationResult(
+                    $"{SpamClassificationOptions.SectionName} files junk into '{destination}', and account '{account.AccountId}' maps no such folder. Map it in the account's Folders, or name a folder that account has; MailFathom does not create one.",
+                    [nameof(SpamClassificationOptions.Actions)])),
+        ];
+    }
+}

--- a/src/Host/Configuration/Spam/SpamJunkFolderValidator.cs
+++ b/src/Host/Configuration/Spam/SpamJunkFolderValidator.cs
@@ -1,0 +1,32 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Rules;
+using Microsoft.Extensions.Options;
+
+namespace MailFathom.Host.Configuration.Spam;
+
+/// <summary>Refuses a junk destination one of the configured accounts could never file into.</summary>
+/// <remarks>
+/// The accounts are read straight from configuration rather than from the bound synchronization options, so that a defect
+/// in that section is reported by that section rather than raised out of this one. Reading the keys is also what makes
+/// the answer the same at startup and on every reload, since both see the same text.
+/// </remarks>
+internal sealed class SpamJunkFolderValidator(IConfiguration configuration)
+    : IValidateOptions<SpamClassificationOptions>
+{
+    /// <inheritdoc />
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="options" /> is <see langword="null" />.</exception>
+    public ValidateOptionsResult Validate(string? name, SpamClassificationOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var failures = SpamJunkFolderRules
+            .FindDestinationErrors(options, DeclaredMailAccounts.ReadFrom(configuration))
+            .Select(result => result.ErrorMessage ?? string.Empty)
+            .ToArray();
+
+        return failures.Length == 0 ? ValidateOptionsResult.Success : ValidateOptionsResult.Fail(failures);
+    }
+}

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -30,6 +30,7 @@ using MailFathom.Application.Rules.History;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Redaction;
 using MailFathom.Application.Spam;
+using MailFathom.Application.Spam.Actions;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.Synchronization.Reconciliation;
@@ -271,6 +272,11 @@ try
             binderOptions => binderOptions.ErrorOnUnknownConfiguration = true)
         .ValidateDataAnnotations()
         .ValidateOnStart();
+    // Whether the junk folder a filing names exists is a claim about the synchronization section, which no attribute on
+    // this graph can reach. Registered whatever the switches say, because a filing switched on with no folder behind it
+    // is exactly what it refuses.
+    builder.Services.AddSingleton<IValidateOptions<SpamClassificationOptions>>(
+        new SpamJunkFolderValidator(builder.Configuration));
 
     // Read while the services are being registered, for the reason the scanner declarations above are: whether a
     // scanner exists at all decides which services this process has, and that is decided before a container that could
@@ -408,6 +414,7 @@ try
     builder.Services.AddScoped<IJunkMailFolderCatalog>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<IMailFolderMappingReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
     builder.Services.AddScoped<ISpamClassificationSettingsReader, ConfiguredSpamClassificationSettingsReader>();
+    builder.Services.AddScoped<ISpamActionSettingsReader, ConfiguredSpamActionSettingsReader>();
     builder.Services.AddScoped<IImapAccountSettingsProvider, ConfiguredImapAccountSettingsProvider>();
     builder.Services.AddScoped<IMailOAuthSettingsProvider, ConfiguredMailOAuthSettingsProvider>();
     // A singleton, unlike the settings around it, because the pool that reads it is one: the write connection is

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordStore.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordStore.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
 using MailFathom.Domain.Mutations;
 using MailFathom.Infrastructure.Persistence.Entities;
@@ -95,6 +96,44 @@ internal sealed class MailboxMutationRecordStore(
         writeContext.MailboxMutations.Add(entity);
 
         return MailboxMutationRecordMapping.ToRecord(entity, folder);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Read through the scoped context, because it joins no transaction, and narrowed by the local email first: the
+    /// foreign key onto the email is indexed, and the handful of rows one email ever carries is what the two remaining
+    /// comparisons run over. The mutation is compared by its stored name and the origin by the text its conversion
+    /// writes, which is what keeps the predicate translatable rather than evaluated in this process.
+    /// </remarks>
+    public Task<bool> HasRecordAsync(
+        StoredEmailId storedEmailId,
+        MailboxMutation mutation,
+        MailboxMutationOrigin origin,
+        CancellationToken cancellationToken)
+    {
+        if (!mutation.IsSpecified)
+        {
+            throw new ArgumentException("A mutation record is read by a permitted mutation.", nameof(mutation));
+        }
+
+        if (!Enum.IsDefined(origin))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(origin),
+                origin,
+                "The mutation requester origin is not one this system declares.");
+        }
+
+        var emailId = storedEmailId.Value;
+        var mutationName = mutation.Name;
+
+        return readContext.MailboxMutations
+            .AsNoTracking()
+            .AnyAsync(
+                record => record.StoredEmailId == emailId
+                    && record.Mutation == mutationName
+                    && record.RequesterOrigin == origin,
+                cancellationToken);
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Persistence/Spam/SpamActionOccurrenceReader.cs
+++ b/src/Infrastructure/Persistence/Spam/SpamActionOccurrenceReader.cs
@@ -1,0 +1,65 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Spam.Actions;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailFathom.Infrastructure.Persistence.Spam;
+
+/// <summary>Reads where one stored occurrence is and whether its server already reports it read.</summary>
+/// <remarks>
+/// A bounded projection rather than the entity, for the reason every read model here is one: acting on a verdict needs
+/// the occurrence and one flag, and loading the row would put a subject and a set of addresses into memory to answer a
+/// question about a folder.
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class SpamActionOccurrenceReader(MailFathomDbContext dbContext) : ISpamActionOccurrenceReader
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// A tombstoned occurrence is deliberately still readable, exactly as it is for classification. Whether it is acted
+    /// on is settled above this: the mail server no longer holds the message, so the convergence pass finds nothing to
+    /// move and the record ends as the failure it is rather than as a change nobody can explain.
+    /// </remarks>
+    public async Task<SpamActionOccurrence?> FindAsync(StoredEmailId emailId, CancellationToken cancellationToken)
+    {
+        var storedEmailId = emailId.Value;
+        var row = await dbContext.StoredEmails
+            .AsNoTracking()
+            .Where(email => email.Id == storedEmailId)
+            .Select(email => new
+            {
+                email.MailboxAccountId,
+                email.MailFolder.Alias,
+                email.MailFolder.ResolutionGeneration,
+                email.UidValidity,
+                email.Uid,
+                email.IsRemotelySeen,
+            })
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (row is null)
+        {
+            return null;
+        }
+
+        var folderAlias = MailFolderAlias.Create(row.Alias);
+
+        return new SpamActionOccurrence(
+            emailId,
+            EmailOccurrenceId.Create(
+                MailAccountId.Create(row.MailboxAccountId),
+                new MailFolderResolutionId(
+                    folderAlias,
+                    MailFolderResolutionGeneration.Create(row.ResolutionGeneration)),
+                ImapUidValidity.Create(row.UidValidity),
+                ImapUid.Create(row.Uid)),
+            folderAlias,
+            row.IsRemotelySeen);
+    }
+}

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -38,6 +38,7 @@ using MailFathom.Application.Rules.History;
 using MailFathom.Application.SensitiveContent;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.Spam;
+using MailFathom.Application.Spam.Actions;
 using MailFathom.Application.Spam.Scanning;
 using MailFathom.Application.Spam.Signals;
 using MailFathom.Application.Synchronization;
@@ -319,6 +320,7 @@ public static class ServiceCollectionExtensions
         // composition that fails at the moment somebody changes their mind rather than at startup.
         services.AddScoped<IEmailSpamClassificationStore, EmailSpamClassificationStore>();
         services.AddScoped<IClassifiableEmailReader, ClassifiableEmailReader>();
+        services.AddScoped<ISpamActionOccurrenceReader, SpamActionOccurrenceReader>();
 
         // The read side takes no persistence session and joins no transaction, so its ports are registered beside the
         // write repositories rather than through one of them.
@@ -406,6 +408,10 @@ public static class ServiceCollectionExtensions
             provider.GetRequiredService<OptimisticConcurrencyRetryPolicy>(),
             provider.GetRequiredService<TimeProvider>(),
             provider.GetService<ISpamScanner>()));
+        // Registered beside the classifier and independent of it: what a verdict causes is a decision of its own, and the
+        // classifier resolves nothing from here, which is what keeps a deployment that records verdicts and touches
+        // nothing genuinely unable to reach a mailbox through classification.
+        services.AddScoped<SpamActionRecorder>();
         // Registered for every deployment rather than only where a chat endpoint was declared, because what it is is a
         // reading of the search above: an instance that answers no questions simply resolves it and never calls it, and
         // the bounds it hands passages over under are the same wherever the retrieval is reached from.

--- a/tests/Application.UnitTests/Spam/Actions/SpamActionRecorderTests.cs
+++ b/tests/Application.UnitTests/Spam/Actions/SpamActionRecorderTests.cs
@@ -1,0 +1,569 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Folders;
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Destinations;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Spam.Actions;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Spam;
+using MailFathom.Domain.Transport;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Spam.Actions;
+
+public sealed class SpamActionRecorderTests
+{
+    private static readonly StoredEmailId Email =
+        StoredEmailId.Create(Guid.Parse("0199a0c0-0000-7000-8000-0000000090a0"));
+
+    private static readonly MailAccountId Account = MailAccountId.Create("acct-1");
+
+    private static readonly MailFolderAlias Inbox = MailFolderAlias.Create("INBOX");
+
+    private static readonly MailFolderAlias Junk = MailFolderAlias.Create("JUNK");
+
+    private static readonly DateTimeOffset EvaluatedAt = new(2026, 8, 12, 9, 0, 0, TimeSpan.Zero);
+
+    private static readonly MailTransportSecurityPolicy TlsOnConnect = MailTransportSecurityPolicy.Create(
+        MailConnectionSecurity.TlsOnConnect,
+        MailAuthenticationPolicy.Create(
+            [MailAuthenticationMechanism.Plain],
+            allowInsecureConnection: false,
+            allowClearTextAuthenticationOverUnencryptedConnection: false),
+        MailServerCertificateTrust.SystemTrustStore,
+        trustedCertificateAuthorityReference: null);
+
+    private readonly InMemoryMailboxMutationRecordStore records = new();
+
+    private readonly InMemoryMailFolderResolutionStore bindings = new();
+
+    private readonly StubMailFolderMappings mappings = StubMailFolderMappings.Nothing;
+
+    private readonly List<RemoteFolder> advertisedFolders = [];
+
+    private readonly IAuthoredDeleteEmailDispositionReader dispositions =
+        Substitute.For<IAuthoredDeleteEmailDispositionReader>();
+
+    /// <summary>Arranges the answer every test shares, so a test that cares about it overrides it afterwards.</summary>
+    public SpamActionRecorderTests() => this.dispositions
+        .GetAuthoredDeleteDisposition(Arg.Any<MailAccountId>())
+        .Returns(AuthoredDeleteEmailDisposition.RetainLocalCopy);
+
+    [Fact]
+    public async Task RecordAsync_NeitherSwitchOn_AsksForNothingAndReadsNoMailbox()
+    {
+        // Arrange
+        var occurrences = Substitute.For<ISpamActionOccurrenceReader>();
+        var recorder = this.Recorder(SpamActionSettings.None, occurrences);
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.NoActionConfigured, result.Outcome);
+        Assert.Equal(0, this.records.OpenedRecordCount);
+        await occurrences.DidNotReceive().FindAsync(Arg.Any<StoredEmailId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(SpamVerdict.NotSpam)]
+    [InlineData(SpamVerdict.Undetermined)]
+    public async Task RecordAsync_AVerdictThatIsNotSpam_AsksForNothing(SpamVerdict verdict)
+    {
+        // Arrange
+        var recorder = this.Recorder(FilingAndMarkingRead());
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(verdict), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.NotSpam, result.Outcome);
+        Assert.Equal(0, this.records.OpenedRecordCount);
+    }
+
+    [Fact]
+    public async Task RecordAsync_BothSwitchesOn_MarksReadBeforeItRelocates()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var recorder = this.Recorder(FilingAndMarkingRead());
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        MailboxMutation[] appliedInOrder = [MailboxMutation.SetSeen, MailboxMutation.Relocate];
+        MailboxMutation[] recorded = [.. this.records.OpenedRequests.Select(request => request.Mutation)];
+
+        Assert.Equal(SpamActionOutcome.Requested, result.Outcome);
+        Assert.Equal<IReadOnlyList<MailboxMutation>>(appliedInOrder, recorded);
+        Assert.NotNull(result.MarkedReadRecordId);
+        Assert.NotNull(result.FiledRecordId);
+    }
+
+    [Fact]
+    public async Task RecordAsync_FilingIntoAMirroredFolder_AsksForARelocationThatKeepsTheLocalRow()
+    {
+        // Arrange
+        this.MapMirroredJunk("Spam");
+        var recorder = this.Recorder(SpamActionSettings.Create(filesJunk: true, marksJunkRead: false));
+
+        // Act
+        await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal(MailboxMutation.Relocate, request.Mutation);
+        Assert.Equal("Spam", request.DestinationPath?.Value);
+        Assert.Null(request.LocalDisposition);
+    }
+
+    /// <summary>An unmirrored junk folder is the recommended destination, and the account's own answer decides what is kept.</summary>
+    [Fact]
+    public async Task RecordAsync_FilingIntoAnUnmirroredFolder_CarriesTheAccountsLocalDisposition()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        this.dispositions
+            .GetAuthoredDeleteDisposition(Account)
+            .Returns(AuthoredDeleteEmailDisposition.EraseLocalCopy);
+        var recorder = this.Recorder(SpamActionSettings.Create(filesJunk: true, marksJunkRead: false));
+
+        // Act
+        await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal(AuthoredDeleteEmailDisposition.EraseLocalCopy, request.LocalDisposition);
+    }
+
+    [Fact]
+    public async Task RecordAsync_AMessageAlreadyReportedRead_DoesNotWriteTheFlagAgain()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var recorder = this.Recorder(FilingAndMarkingRead(), OccurrenceIn(Inbox, isRemotelySeen: true));
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(result.MarkedReadRecordId);
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal(MailboxMutation.Relocate, request.Mutation);
+    }
+
+    [Fact]
+    public async Task RecordAsync_AMessageAlreadyInTheDestination_DoesNotRelocateItIntoItself()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var recorder = this.Recorder(FilingAndMarkingRead(), OccurrenceIn(Junk, isRemotelySeen: false));
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(result.FiledRecordId);
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal(MailboxMutation.SetSeen, request.Mutation);
+    }
+
+    [Fact]
+    public async Task RecordAsync_EverythingTheSwitchesAskForAlreadyTrue_AsksForNothing()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var recorder = this.Recorder(FilingAndMarkingRead(), OccurrenceIn(Junk, isRemotelySeen: true));
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.NothingToChange, result.Outcome);
+        Assert.Equal(0, this.records.OpenedRecordCount);
+    }
+
+    /// <summary>The rule that keeps filing from arguing with the owner: one undo is enough, and nothing files it again.</summary>
+    [Fact]
+    public async Task RecordAsync_AMessageFiledOnceAndSinceMovedBackOut_IsLeftAloneEntirely()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var settings = FilingAndMarkingRead();
+        var recorder = this.Recorder(settings);
+        await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // The owner drags the message back into the inbox, which reaches this instance as a new occurrence of the same
+        // local email under a new UID.
+        var movedBack = this.Recorder(settings, OccurrenceIn(Inbox, isRemotelySeen: false, uid: 4402));
+
+        // Act
+        var result = await movedBack.RecordAsync(
+            SpamVerdictOf(SpamVerdict.Spam),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.PreviouslyFiled, result.Outcome);
+        Assert.Equal(2, this.records.OpenedRecordCount);
+    }
+
+    /// <summary>The same reading makes a filing still in flight idempotent, which is what a re-classification hits.</summary>
+    [Fact]
+    public async Task RecordAsync_AFilingAlreadyAskedForAndNotYetCarriedOut_AsksForNothingFurther()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var recorder = this.Recorder(SpamActionSettings.Create(filesJunk: true, marksJunkRead: false));
+        await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.PreviouslyFiled, result.Outcome);
+        Assert.Equal(1, this.records.OpenedRecordCount);
+    }
+
+    [Fact]
+    public async Task RecordAsync_TheSameVerdictUnderTheSameProfileTwice_AsksForOneChange()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var recorder = this.Recorder(SpamActionSettings.Create(filesJunk: false, marksJunkRead: true));
+
+        // Act
+        await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+        await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, this.records.OpenedRecordCount);
+    }
+
+    [Fact]
+    public async Task RecordAsync_AChangedActingThreshold_AsksAfresh()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var classification = ScannerVerdictOf(score: 12);
+        await this.Recorder(SpamActionSettings.Create(filesJunk: false, marksJunkRead: true, threshold: 5))
+            .RecordAsync(classification, TestContext.Current.CancellationToken);
+
+        // Act
+        await this.Recorder(SpamActionSettings.Create(filesJunk: false, marksJunkRead: true, threshold: 8))
+            .RecordAsync(classification, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(2, this.records.OpenedRecordCount);
+    }
+
+    [Fact]
+    public async Task RecordAsync_AScannerScoreBelowTheActingThreshold_AsksForNothing()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var recorder = this.Recorder(SpamActionSettings.Create(filesJunk: true, marksJunkRead: true, threshold: 8));
+
+        // Act
+        var result = await recorder.RecordAsync(
+            ScannerVerdictOf(score: 6),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.BelowThreshold, result.Outcome);
+        Assert.Equal(0, this.records.OpenedRecordCount);
+    }
+
+    [Fact]
+    public async Task RecordAsync_AScannerScoreAtTheActingThreshold_ActsBecauseTheThresholdIsInclusive()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var recorder = this.Recorder(SpamActionSettings.Create(filesJunk: false, marksJunkRead: true, threshold: 8));
+
+        // Act
+        var result = await recorder.RecordAsync(
+            ScannerVerdictOf(score: 8),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.Requested, result.Outcome);
+    }
+
+    /// <summary>A verdict the receiving server reached carries no score in this threshold's scale, so the threshold does not judge it.</summary>
+    [Fact]
+    public async Task RecordAsync_ADeterministicVerdictWithAnActingThreshold_IsActedOnAnyway()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var recorder = this.Recorder(SpamActionSettings.Create(filesJunk: false, marksJunkRead: true, threshold: 8));
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.Requested, result.Outcome);
+    }
+
+    [Fact]
+    public async Task RecordAsync_AnOccurrenceNothingIsStoredFor_ReportsItGoneRatherThanFailing()
+    {
+        // Arrange
+        var occurrences = Substitute.For<ISpamActionOccurrenceReader>();
+        occurrences
+            .FindAsync(Arg.Any<StoredEmailId>(), Arg.Any<CancellationToken>())
+            .Returns((SpamActionOccurrence?)null);
+        var recorder = this.Recorder(FilingAndMarkingRead(), occurrences);
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.OccurrenceMissing, result.Outcome);
+        Assert.Equal(0, this.records.OpenedRecordCount);
+    }
+
+    /// <summary>Marking spam read while it stays in the inbox is worse than waiting, so an unresolvable filing holds both back.</summary>
+    [Fact]
+    public async Task RecordAsync_ADestinationTheAccountNoLongerMaps_WithholdsTheFlagChangeToo()
+    {
+        // Arrange
+        var recorder = this.Recorder(FilingAndMarkingRead());
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.DestinationUnresolved, result.Outcome);
+        Assert.Equal(0, this.records.OpenedRecordCount);
+    }
+
+    [Fact]
+    public async Task RecordAsync_ADestinationNothingHasBoundYet_WithholdsBothChanges()
+    {
+        // Arrange
+        this.mappings.With(
+            Account,
+            MailFolderMapping.ToSpecialUse(Junk, MailFolderSpecialUse.Junk, MailFolderParticipation.Full));
+        var recorder = this.Recorder(FilingAndMarkingRead());
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.DestinationUnresolved, result.Outcome);
+        Assert.Equal(0, this.records.OpenedRecordCount);
+    }
+
+    /// <summary>A reload can withdraw an account mid-run, and what it kept of mail it files away is then nobody's to guess.</summary>
+    [Fact]
+    public async Task RecordAsync_AnAccountAReloadHasWithdrawn_WithholdsBothChangesRatherThanFailing()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        this.dispositions
+            .GetAuthoredDeleteDisposition(Account)
+            .Throws(new InvalidOperationException("The account is no longer configured."));
+        var recorder = this.Recorder(FilingAndMarkingRead());
+
+        // Act
+        var result = await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.AccountNoLongerConfigured, result.Outcome);
+        Assert.Equal(0, this.records.OpenedRecordCount);
+    }
+
+    [Fact]
+    public async Task RecordAsync_AnExplicitlyNamedJunkFolder_FilesIntoThatFolderRatherThanTheRole()
+    {
+        // Arrange
+        var elsewhere = MailFolderAlias.Create("QUARANTINE");
+        this.mappings.With(
+            Account,
+            MailFolderMapping.ToRemotePath(elsewhere, RemoteFolderPath.Create("Quarantine")));
+        this.bindings.Bind(Account, elsewhere, "Quarantine");
+        var recorder = this.Recorder(SpamActionSettings.Create(
+            filesJunk: true,
+            marksJunkRead: false,
+            MailFolderReference.ToAlias(elsewhere)));
+
+        // Act
+        await recorder.RecordAsync(SpamVerdictOf(SpamVerdict.Spam), TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal("Quarantine", request.DestinationPath?.Value);
+    }
+
+    [Fact]
+    public async Task RecordAsync_AnyRequest_NamesTheClassificationAsWhatAskedForIt()
+    {
+        // Arrange
+        this.MapUnmirroredJunk("Spam");
+        var recorder = this.Recorder(SpamActionSettings.Create(filesJunk: true, marksJunkRead: false, threshold: 8));
+
+        // Act
+        await recorder.RecordAsync(ScannerVerdictOf(score: 12), TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = Assert.Single(this.records.OpenedRequests);
+        Assert.Equal(MailboxMutationOrigin.Classification, request.Requester.Origin);
+        Assert.Equal("spamassassin.4.0.2+20260801@8", request.Requester.Identity);
+    }
+
+    [Fact]
+    public async Task RecordAsync_NoClassification_IsRefused()
+    {
+        // Arrange
+        var recorder = this.Recorder(FilingAndMarkingRead());
+
+        // Act
+        var refusal = async () => await recorder.RecordAsync(
+            classification: null!,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(refusal);
+    }
+
+    private static SpamActionSettings FilingAndMarkingRead() =>
+        SpamActionSettings.Create(filesJunk: true, marksJunkRead: true);
+
+    private static SpamClassification SpamVerdictOf(SpamVerdict verdict) => SpamClassification.Create(
+        Email,
+        verdict,
+        SpamClassificationStage.Deterministic,
+        assessment: null,
+        corpusRevision: null,
+        [],
+        EvaluatedAt);
+
+    private static SpamClassification ScannerVerdictOf(double score) => SpamClassification.Create(
+        Email,
+        SpamVerdict.Spam,
+        SpamClassificationStage.Scanner,
+        SpamAssessment.Create(score, threshold: 5),
+        "spamassassin.4.0.2+20260801",
+        [],
+        EvaluatedAt);
+
+    private static SpamActionOccurrence OccurrenceIn(
+        MailFolderAlias folderAlias,
+        bool isRemotelySeen,
+        uint uid = 4401) => new(
+        Email,
+        EmailOccurrenceId.Create(
+            Account,
+            new MailFolderResolutionId(folderAlias, MailFolderResolutionGeneration.First),
+            ImapUidValidity.Create(9),
+            ImapUid.Create(uid)),
+        folderAlias,
+        isRemotelySeen);
+
+    /// <summary>Maps the junk role onto a folder the account does not mirror, which is the recommended arrangement.</summary>
+    /// <remarks>
+    /// A folder nothing mirrors has no run to bind it, so it is resolved against what the server advertises at the moment
+    /// a filing first needs it. Advertising it here is therefore part of the arrangement rather than a detail of it.
+    /// </remarks>
+    private void MapUnmirroredJunk(string remotePath)
+    {
+        this.mappings.With(
+            Account,
+            MailFolderMapping.ToSpecialUse(Junk, MailFolderSpecialUse.Junk, MailFolderParticipation.MappedOnly));
+        this.advertisedFolders.Add(new RemoteFolder(
+            RemoteFolderPath.Create(remotePath),
+            [MailFolderSpecialUse.Junk]));
+    }
+
+    /// <summary>Maps the junk role onto a folder the account mirrors, and records the binding its own run would have.</summary>
+    private void MapMirroredJunk(string remotePath)
+    {
+        this.mappings.With(
+            Account,
+            MailFolderMapping.ToSpecialUse(Junk, MailFolderSpecialUse.Junk, MailFolderParticipation.Full));
+        this.bindings.Bind(Account, Junk, remotePath);
+    }
+
+    private SpamActionRecorder Recorder(
+        SpamActionSettings settings,
+        SpamActionOccurrence occurrence) =>
+        this.Recorder(settings, ReaderOf(occurrence));
+
+    private SpamActionRecorder Recorder(
+        SpamActionSettings settings,
+        ISpamActionOccurrenceReader? occurrences = null)
+    {
+        var settingsReader = Substitute.For<ISpamActionSettingsReader>();
+        settingsReader.Actions.Returns(settings);
+
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
+
+        return new SpamActionRecorder(
+            settingsReader,
+            occurrences ?? ReaderOf(OccurrenceIn(Inbox, isRemotelySeen: false)),
+            this.records,
+            this.DestinationResolver(sessionFactory),
+            this.dispositions,
+            new OptimisticConcurrencyRetryPolicy(
+                sessionFactory,
+                new PersistenceConcurrencyOptions(),
+                new FakeTimeProvider(EvaluatedAt)));
+    }
+
+    /// <summary>Builds the one resolver every author of a filing reaches its destination through.</summary>
+    private MailboxDestinationResolver DestinationResolver(IPersistenceSessionFactory sessionFactory)
+    {
+        var remoteFolderCatalog = Substitute.For<IRemoteFolderCatalog>();
+        remoteFolderCatalog
+            .ListFoldersAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailTransportSecurityPolicy>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ => Task.FromResult<IReadOnlyList<RemoteFolder>>([.. this.advertisedFolders]));
+
+        var transportSecurityPolicies = Substitute.For<IMailTransportSecurityPolicyReader>();
+        transportSecurityPolicies.GetPolicy(Arg.Any<MailAccountId>()).Returns(TlsOnConnect);
+
+        return new MailboxDestinationResolver(
+            this.mappings.Resolver,
+            this.bindings,
+            new MailFolderResolver(
+                remoteFolderCatalog,
+                Substitute.For<IRemoteFolderCreator>(),
+                this.bindings,
+                Substitute.For<IMailFolderMappingChangeAuditor>(),
+                sessionFactory,
+                new FakeTimeProvider(EvaluatedAt)),
+            transportSecurityPolicies);
+    }
+
+    private static ISpamActionOccurrenceReader ReaderOf(SpamActionOccurrence occurrence)
+    {
+        var reader = Substitute.For<ISpamActionOccurrenceReader>();
+        reader.FindAsync(Arg.Any<StoredEmailId>(), Arg.Any<CancellationToken>()).Returns(occurrence);
+
+        return reader;
+    }
+
+    private sealed class CommittingSession : IPersistenceSession
+    {
+        public Task<PersistenceCommitResult> CommitAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(PersistenceCommitResult.Committed);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Application.UnitTests/Spam/Actions/SpamActionResultTests.cs
+++ b/tests/Application.UnitTests/Spam/Actions/SpamActionResultTests.cs
@@ -1,0 +1,59 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Spam.Actions;
+using MailFathom.Domain.Mutations;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Spam.Actions;
+
+public sealed class SpamActionResultTests
+{
+    private static readonly MailboxMutationRecordId Record =
+        MailboxMutationRecordId.Create(Guid.Parse("0199a0c0-0000-7000-8000-00000000f00d"));
+
+    [Fact]
+    public void NotActedOn_TheRequestedOutcome_IsRefusedBecauseNothingWasRequested()
+    {
+        // Act
+        var refusal = () => SpamActionResult.NotActedOn(SpamActionOutcome.Requested);
+
+        // Assert
+        Assert.Throws<ArgumentOutOfRangeException>(refusal);
+    }
+
+    [Fact]
+    public void NotActedOn_AReason_CarriesNoRecord()
+    {
+        // Act
+        var result = SpamActionResult.NotActedOn(SpamActionOutcome.PreviouslyFiled);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.PreviouslyFiled, result.Outcome);
+        Assert.Null(result.MarkedReadRecordId);
+        Assert.Null(result.FiledRecordId);
+    }
+
+    [Fact]
+    public void Requested_OneOfTheTwoChanges_ReportsThatChangeAndNoOther()
+    {
+        // Act
+        var result = SpamActionResult.Requested(markedReadRecordId: null, Record);
+
+        // Assert
+        Assert.Equal(SpamActionOutcome.Requested, result.Outcome);
+        Assert.Equal(Record, result.FiledRecordId);
+        Assert.Null(result.MarkedReadRecordId);
+    }
+
+    [Fact]
+    public void Requested_NeitherChange_IsRefusedBecauseThatIsNothingToChange()
+    {
+        // Act
+        var refusal = () => SpamActionResult.Requested(markedReadRecordId: null, filedRecordId: null);
+
+        // Assert
+        Assert.Throws<ArgumentException>(refusal);
+    }
+}

--- a/tests/Application.UnitTests/Spam/Actions/SpamActionSettingsTests.cs
+++ b/tests/Application.UnitTests/Spam/Actions/SpamActionSettingsTests.cs
@@ -1,0 +1,85 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Spam.Actions;
+using MailFathom.Domain.Folders;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Spam.Actions;
+
+public sealed class SpamActionSettingsTests
+{
+    [Fact]
+    public void None_ADeploymentThatConfiguredNothing_AsksForNoChangeToAnyMailbox()
+    {
+        // Act
+        var settings = SpamActionSettings.None;
+
+        // Assert
+        Assert.False(settings.FilesJunk);
+        Assert.False(settings.MarksJunkRead);
+        Assert.False(settings.IsAnyActionEnabled);
+        Assert.Null(settings.Threshold);
+    }
+
+    [Fact]
+    public void Create_NoDestinationNamed_FilesIntoWhicheverFolderPlaysTheJunkRole()
+    {
+        // Act
+        var settings = SpamActionSettings.Create(filesJunk: true, marksJunkRead: false);
+
+        // Assert
+        Assert.Equal(MailFolderSpecialUse.Junk, settings.JunkFolder.Role);
+        Assert.Null(settings.JunkFolder.Alias);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void Create_EitherSwitchOn_ReportsThatSomethingIsActedOn(bool filesJunk, bool marksJunkRead)
+    {
+        // Act
+        var settings = SpamActionSettings.Create(filesJunk, marksJunkRead);
+
+        // Assert
+        Assert.True(settings.IsAnyActionEnabled);
+    }
+
+    [Fact]
+    public void Create_TheUnspecifiedFolderReference_IsRefused()
+    {
+        // Act
+        var refusal = () => SpamActionSettings.Create(
+            filesJunk: true,
+            marksJunkRead: false,
+            default(MailFolderReference));
+
+        // Assert
+        Assert.Throws<ArgumentException>(refusal);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void Create_AThresholdThatIsNotFinite_IsRefused(double threshold)
+    {
+        // Act
+        var refusal = () => SpamActionSettings.Create(filesJunk: true, marksJunkRead: false, threshold: threshold);
+
+        // Assert
+        Assert.Throws<ArgumentOutOfRangeException>(refusal);
+    }
+
+    /// <summary>The default destination is written the way an operator would have written it themselves.</summary>
+    [Fact]
+    public void DefaultJunkFolder_WrittenOut_ReadsBackAsTheJunkRole()
+    {
+        // Act
+        var written = SpamActionSettings.DefaultJunkFolder.ToString();
+
+        // Assert
+        Assert.Equal($"{MailFolderReference.RoleScheme}{MailFolderSpecialUse.Junk}", written);
+    }
+}

--- a/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationRecordStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryMailboxMutationRecordStore.cs
@@ -6,6 +6,7 @@ using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
@@ -77,6 +78,16 @@ internal sealed class InMemoryMailboxMutationRecordStore : IMailboxMutationRecor
 
         return Task.FromResult(record);
     }
+
+    /// <inheritdoc />
+    public Task<bool> HasRecordAsync(
+        StoredEmailId storedEmailId,
+        MailboxMutation mutation,
+        MailboxMutationOrigin origin,
+        CancellationToken cancellationToken) => Task.FromResult(this.recordsById.Values.Any(record =>
+            record.Request.StoredEmailId == storedEmailId
+            && record.Request.Mutation == mutation
+            && record.Request.Requester.Origin == origin));
 
     /// <inheritdoc />
     public Task<int> CountAttemptAsync(

--- a/tests/Domain.UnitTests/Mutations/MailboxMutationRequesterTests.cs
+++ b/tests/Domain.UnitTests/Mutations/MailboxMutationRequesterTests.cs
@@ -24,6 +24,63 @@ public sealed class MailboxMutationRequesterTests
         Assert.Equal(MailboxMutationRequester.Rule("file-newsletters", "3"), third);
     }
 
+    /// <summary>Rescanning under the same corpus asks for nothing new; a corpus update is a fresh reason to act.</summary>
+    [Fact]
+    public void Classification_TwoCorpusRevisions_AreDifferentRequesters()
+    {
+        // Arrange
+        var august = MailboxMutationRequester.Classification("spamassassin.4.0.2+20260801", actingThreshold: 8);
+
+        // Act
+        var september = MailboxMutationRequester.Classification("spamassassin.4.0.2+20260901", actingThreshold: 8);
+
+        // Assert
+        Assert.NotEqual(august, september);
+        Assert.Equal(
+            MailboxMutationRequester.Classification("spamassassin.4.0.2+20260801", actingThreshold: 8),
+            august);
+    }
+
+    /// <summary>An operator moving the score they act at is a decision taken afresh, not a repeat of the previous one.</summary>
+    [Fact]
+    public void Classification_TwoActingThresholds_AreDifferentRequesters()
+    {
+        // Arrange
+        var strict = MailboxMutationRequester.Classification("Deterministic", actingThreshold: 8);
+
+        // Act
+        var unbounded = MailboxMutationRequester.Classification("Deterministic", actingThreshold: null);
+
+        // Assert
+        Assert.NotEqual(strict, unbounded);
+        Assert.Equal(MailboxMutationOrigin.Classification, unbounded.Origin);
+        Assert.Equal("Deterministic@none", unbounded.Identity);
+    }
+
+    [Theory]
+    [InlineData(double.NaN)]
+    [InlineData(double.NegativeInfinity)]
+    public void Classification_AnActingThresholdThatIsNotFinite_IsRefused(double actingThreshold)
+    {
+        // Act
+        var refusal = () => MailboxMutationRequester.Classification("Deterministic", actingThreshold);
+
+        // Assert
+        Assert.Throws<ArgumentOutOfRangeException>(refusal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Classification_NothingNamingWhatDecided_IsRefused(string decidedUnder)
+    {
+        // Act
+        var refusal = () => MailboxMutationRequester.Classification(decidedUnder, actingThreshold: 8);
+
+        // Assert
+        Assert.Throws<ArgumentException>(refusal);
+    }
+
     /// <summary>Two requesters that differ only in kind are different, so an invocation named like a rule is never the same request.</summary>
     [Fact]
     public void Create_SameIdentityUnderDifferentOrigins_AreDifferentRequesters()

--- a/tests/Host.UnitTests/Configuration/Spam/ConfiguredSpamActionSettingsReaderTests.cs
+++ b/tests/Host.UnitTests/Configuration/Spam/ConfiguredSpamActionSettingsReaderTests.cs
@@ -1,0 +1,97 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Folders;
+using MailFathom.Host.Configuration.Spam;
+using MailFathom.Host.UnitTests.TestDoubles;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Spam;
+
+/// <summary>Covers how the bound section becomes the settings an action is decided by.</summary>
+public sealed class ConfiguredSpamActionSettingsReaderTests
+{
+    [Fact]
+    public void Actions_ASectionSettingNothing_AsksForNoChangeToAnyMailbox()
+    {
+        // Arrange
+        var reader = ReaderFor(new SpamClassificationOptions());
+
+        // Act
+        var settings = reader.Actions;
+
+        // Assert
+        Assert.False(settings.IsAnyActionEnabled);
+    }
+
+    [Fact]
+    public void Actions_BothSwitchesOn_CarriesTheDestinationAndTheThreshold()
+    {
+        // Arrange
+        var reader = ReaderFor(new SpamClassificationOptions
+        {
+            Enabled = true,
+            Actions = new SpamActionOptions
+            {
+                FileInJunkFolder = true,
+                MarkAsRead = true,
+                JunkFolder = "quarantine",
+                Threshold = 9,
+            },
+        });
+
+        // Act
+        var settings = reader.Actions;
+
+        // Assert
+        Assert.True(settings.FilesJunk);
+        Assert.True(settings.MarksJunkRead);
+        Assert.Equal(MailFolderAlias.Create("quarantine"), settings.JunkFolder.Alias);
+        Assert.Equal(9, settings.Threshold);
+    }
+
+    /// <summary>Validation refuses this combination, and the reader still cannot be the path that acts on verdicts nobody reaches.</summary>
+    [Fact]
+    public void Actions_SwitchesOnWhileClassificationIsOff_AsksForNothing()
+    {
+        // Arrange
+        var reader = ReaderFor(new SpamClassificationOptions
+        {
+            Enabled = false,
+            Actions = new SpamActionOptions { FileInJunkFolder = true, MarkAsRead = true },
+        });
+
+        // Act
+        var settings = reader.Actions;
+
+        // Assert
+        Assert.False(settings.IsAnyActionEnabled);
+    }
+
+    [Fact]
+    public void Actions_ASectionReloaded_IsReadAgainRatherThanCaptured()
+    {
+        // Arrange
+        var options = new TestOptionsMonitor<SpamClassificationOptions>(new SpamClassificationOptions());
+        var reader = new ConfiguredSpamActionSettingsReader(options);
+
+        // Act
+        var beforeReload = reader.Actions;
+
+        options.ReportReload(new SpamClassificationOptions
+        {
+            Enabled = true,
+            Actions = new SpamActionOptions { FileInJunkFolder = true },
+        });
+
+        var afterReload = reader.Actions;
+
+        // Assert
+        Assert.False(beforeReload.FilesJunk);
+        Assert.True(afterReload.FilesJunk);
+    }
+
+    private static ConfiguredSpamActionSettingsReader ReaderFor(SpamClassificationOptions options) =>
+        new(new TestOptionsMonitor<SpamClassificationOptions>(options));
+}

--- a/tests/Host.UnitTests/Configuration/Spam/SpamActionOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Spam/SpamActionOptionsTests.cs
@@ -1,0 +1,127 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Folders;
+using MailFathom.Host.Configuration.Spam;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Spam;
+
+/// <summary>Covers what the action block refuses, and what it means when an operator writes none of its keys.</summary>
+public sealed class SpamActionOptionsTests
+{
+    [Fact]
+    public void FindErrors_ABlockSettingNothing_ReportsNoErrorAndTouchesNoMailbox()
+    {
+        // Arrange
+        var options = new SpamActionOptions();
+
+        // Act
+        var errors = options.FindErrors(classificationEnabled: true).ToArray();
+
+        // Assert
+        Assert.Empty(errors);
+        Assert.False(options.IsAnyActionEnabled);
+        Assert.Null(options.JunkFolder);
+        Assert.Null(options.Threshold);
+    }
+
+    /// <summary>Acting on a verdict nothing produces is the same shape of contradiction as a scanner with classification off.</summary>
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void FindErrors_AnActionAskedForWhileClassificationIsOff_IsRefused(bool fileInJunkFolder, bool markAsRead)
+    {
+        // Arrange
+        var options = new SpamActionOptions { FileInJunkFolder = fileInJunkFolder, MarkAsRead = markAsRead };
+
+        // Act
+        var error = Assert.Single(options.FindErrors(classificationEnabled: false));
+
+        // Assert
+        Assert.Equal(
+            [nameof(SpamActionOptions.FileInJunkFolder), nameof(SpamActionOptions.MarkAsRead)],
+            error.MemberNames);
+    }
+
+    [Theory]
+    [InlineData("role:NotARole")]
+    [InlineData("   ")]
+    public void FindErrors_AJunkFolderNamingNeitherAnAliasNorARole_IsRefused(string junkFolder)
+    {
+        // Arrange
+        var options = new SpamActionOptions { FileInJunkFolder = true, JunkFolder = junkFolder };
+
+        // Act
+        var error = Assert.Single(options.FindErrors(classificationEnabled: true));
+
+        // Assert
+        Assert.Equal([nameof(SpamActionOptions.JunkFolder)], error.MemberNames);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(100_000)]
+    public void FindErrors_AThresholdOutsideTheUsableRange_IsRefused(double threshold)
+    {
+        // Arrange
+        var options = new SpamActionOptions { MarkAsRead = true, Threshold = threshold };
+
+        // Act
+        var error = Assert.Single(options.FindErrors(classificationEnabled: true));
+
+        // Assert
+        Assert.Equal([nameof(SpamActionOptions.Threshold)], error.MemberNames);
+    }
+
+    [Fact]
+    public void Destination_NoJunkFolderNamed_ReadsAsTheJunkRole()
+    {
+        // Arrange
+        var options = new SpamActionOptions { FileInJunkFolder = true };
+
+        // Act
+        var destination = options.Destination;
+
+        // Assert
+        Assert.Equal(MailFolderSpecialUse.Junk, destination.Role);
+    }
+
+    [Fact]
+    public void Destination_AnAliasNamed_ReadsAsThatFolderRatherThanARole()
+    {
+        // Arrange
+        var options = new SpamActionOptions { FileInJunkFolder = true, JunkFolder = "quarantine" };
+
+        // Act
+        var destination = options.Destination;
+
+        // Assert
+        Assert.Equal(MailFolderAlias.Create("quarantine"), destination.Alias);
+        Assert.Null(destination.Role);
+    }
+
+    [Fact]
+    public void ToSettings_EveryKeyWritten_CarriesEachOneThrough()
+    {
+        // Arrange
+        var options = new SpamActionOptions
+        {
+            FileInJunkFolder = true,
+            MarkAsRead = true,
+            JunkFolder = $"{MailFolderReference.RoleScheme}{MailFolderSpecialUse.Junk}",
+            Threshold = 8,
+        };
+
+        // Act
+        var settings = options.ToSettings();
+
+        // Assert
+        Assert.True(settings.FilesJunk);
+        Assert.True(settings.MarksJunkRead);
+        Assert.Equal(MailFolderSpecialUse.Junk, settings.JunkFolder.Role);
+        Assert.Equal(8, settings.Threshold);
+    }
+}

--- a/tests/Host.UnitTests/Configuration/Spam/SpamJunkFolderRulesTests.cs
+++ b/tests/Host.UnitTests/Configuration/Spam/SpamJunkFolderRulesTests.cs
@@ -1,0 +1,113 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Rules.Actions;
+using MailFathom.Domain.Folders;
+using MailFathom.Host.Configuration.Rules;
+using MailFathom.Host.Configuration.Spam;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Spam;
+
+/// <summary>Covers the one claim the classification section makes about the accounts in another section.</summary>
+public sealed class SpamJunkFolderRulesTests
+{
+    [Fact]
+    public void FindDestinationErrors_AnAccountMappingNoJunkFolder_IsRefusedNamingTheAccount()
+    {
+        // Arrange
+        var options = Filing(junkFolder: null);
+
+        // Act
+        var error = Assert.Single(SpamJunkFolderRules.FindDestinationErrors(options, [AccountMapping()]));
+
+        // Assert
+        Assert.Contains("personal", error.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>An unmirrored junk folder is the recommended destination, so mapping it is enough.</summary>
+    [Fact]
+    public void FindDestinationErrors_AnAccountMappingAnUnmirroredJunkFolder_IsAccepted()
+    {
+        // Arrange
+        var junk = new DeclaredMailFolder(MailFolderAlias.Create("JUNK"), MailFolderSpecialUse.Junk);
+        var account = AccountMapping(mapped: [junk]);
+
+        // Act
+        var errors = SpamJunkFolderRules.FindDestinationErrors(Filing(junkFolder: null), [account]);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void FindDestinationErrors_OneOfTwoAccountsWithoutTheFolder_ReportsOnlyThatAccount()
+    {
+        // Arrange
+        var junk = new DeclaredMailFolder(MailFolderAlias.Create("JUNK"), MailFolderSpecialUse.Junk);
+        var mapped = AccountMapping("work", [junk]);
+
+        // Act
+        var error = Assert.Single(
+            SpamJunkFolderRules.FindDestinationErrors(Filing(junkFolder: null), [mapped, AccountMapping()]));
+
+        // Assert
+        Assert.Contains("personal", error.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindDestinationErrors_AnExplicitAliasNoAccountMaps_IsRefused()
+    {
+        // Arrange
+        var junk = new DeclaredMailFolder(MailFolderAlias.Create("JUNK"), MailFolderSpecialUse.Junk);
+        var account = AccountMapping(mapped: [junk]);
+
+        // Act
+        var errors = SpamJunkFolderRules.FindDestinationErrors(Filing("quarantine"), [account]);
+
+        // Assert
+        Assert.Single(errors);
+    }
+
+    /// <summary>A destination written beside switches that are off is an operator staging a change, not a defect.</summary>
+    [Fact]
+    public void FindDestinationErrors_FilingSwitchedOff_JudgesNothing()
+    {
+        // Arrange
+        var options = new SpamClassificationOptions
+        {
+            Enabled = true,
+            Actions = new SpamActionOptions { MarkAsRead = true, JunkFolder = "quarantine" },
+        };
+
+        // Act
+        var errors = SpamJunkFolderRules.FindDestinationErrors(options, [AccountMapping()]);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void FindDestinationErrors_NoAccountDeclaredAtAll_JudgesNothing()
+    {
+        // Act
+        var errors = SpamJunkFolderRules.FindDestinationErrors(Filing(junkFolder: null), []);
+
+        // Assert
+        Assert.Empty(errors);
+    }
+
+    private static SpamClassificationOptions Filing(string? junkFolder) => new()
+    {
+        Enabled = true,
+        Actions = new SpamActionOptions { FileInJunkFolder = true, JunkFolder = junkFolder },
+    };
+
+    private static DeclaredMailAccount AccountMapping(
+        string accountId = "personal",
+        IReadOnlyCollection<DeclaredMailFolder>? mapped = null) => new(
+        accountId,
+        mapped ?? [],
+        MailRuleActionPermissions.Default);
+}

--- a/tests/Host.UnitTests/Configuration/Spam/SpamJunkFolderValidatorTests.cs
+++ b/tests/Host.UnitTests/Configuration/Spam/SpamJunkFolderValidatorTests.cs
@@ -1,0 +1,77 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Host.Configuration.Spam;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Spam;
+
+/// <summary>Covers the seam between the classification section and the accounts declared in another one.</summary>
+/// <remarks>
+/// The rule itself is covered by <see cref="SpamJunkFolderRulesTests" />. What is worth proving here is the reading: an
+/// account list found under the wrong key would report no account at all, which passes every configuration silently.
+/// </remarks>
+public sealed class SpamJunkFolderValidatorTests
+{
+    [Fact]
+    public void Validate_AnAccountMappingNoJunkFolder_FailsNamingTheAccount()
+    {
+        // Arrange
+        var validator = new SpamJunkFolderValidator(Configuration(new Dictionary<string, string?>
+        {
+            ["MailSynchronization:Accounts:0:AccountId"] = "primary",
+            ["MailSynchronization:Accounts:0:Folders:0:Alias"] = "inbox",
+            ["MailSynchronization:Accounts:0:Folders:0:SpecialUse"] = "Inbox",
+        }));
+
+        // Act
+        var result = validator.Validate(name: null, Filing());
+
+        // Assert
+        Assert.True(result.Failed);
+        Assert.Contains("primary", Assert.Single(result.Failures), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_AnAccountMappingAnUnmirroredJunkFolder_Succeeds()
+    {
+        // Arrange
+        var validator = new SpamJunkFolderValidator(Configuration(new Dictionary<string, string?>
+        {
+            ["MailSynchronization:Accounts:0:AccountId"] = "primary",
+            ["MailSynchronization:Accounts:0:Folders:0:Alias"] = "spam",
+            ["MailSynchronization:Accounts:0:Folders:0:SpecialUse"] = "Junk",
+            ["MailSynchronization:Accounts:0:Folders:0:Synchronize"] = "false",
+        }));
+
+        // Act
+        var result = validator.Validate(name: null, Filing());
+
+        // Assert
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public void Validate_NoOptions_IsRefused()
+    {
+        // Arrange
+        var validator = new SpamJunkFolderValidator(Configuration([]));
+
+        // Act
+        var refusal = () => validator.Validate(name: null, options: null!);
+
+        // Assert
+        Assert.Throws<ArgumentNullException>(refusal);
+    }
+
+    private static SpamClassificationOptions Filing() => new()
+    {
+        Enabled = true,
+        Actions = new SpamActionOptions { FileInJunkFolder = true },
+    };
+
+    private static IConfiguration Configuration(Dictionary<string, string?> keys) =>
+        new ConfigurationBuilder().AddInMemoryCollection(keys).Build();
+}


### PR DESCRIPTION
Closes #690

A spam verdict could be recorded and read, and nothing was ever done about it on the server. This adds the two things an operator can let a verdict do, each behind its own switch and both off by default: file the message into the account's junk folder, and mark it read. Both go through the mutation records #694 already carries, so the account's convergence pass performs them and nothing here opens a write session of its own.

## What was added

- `MailboxMutationOrigin.Classification` — a third requester kind beside `Rule` and `Command`. Its identity is the decision profile the verdict was reached under, `<corpus revision or stage>@<acting threshold>`, so the same message classified again under the same profile reuses the existing record and a changed threshold asks afresh. The occurrence is deliberately not in the identity text: it is already the first third of the record's own key.
- `SpamActionRecorder` in `Application/Spam/Actions` — the use case. It reads the switches, refuses a verdict that is not spam, applies the acting threshold to a scanner-decided score, and opens the records. `\Seen` is written down before the relocation, in one commit. The destination is turned into a folder by `MailboxDestinationResolver`, which #716 made the single place any author of a filing reaches one — so a junk folder the account only maps, the destination this feature recommends, is resolved on demand exactly as a rule's is.
- `SpamActionOutcome` — why a message was left alone, as a closed set rather than a boolean, because a caller reporting a run over a whole mailbox has to say which reason applied.
- `SpamClassification:Actions:*` in the host — `FileInJunkFolder`, `MarkAsRead`, `JunkFolder`, `Threshold`, validated in-section, plus a cross-section validator that refuses the switch when an account maps no folder for the destination and names the account.

## What it refuses to do

- It never relocates a message that is already in the destination folder.
- It never files a message a second time. One recorded filing is enough, whether the owner has since moved it back out or the convergence pass simply has not run yet; the two are not told apart, because telling them apart would mean treating an abandoned record as licence to re-file exactly the message somebody most likely moved by hand.
- A destination that resolves to nothing withholds the `\Seen` change too. Marking spam read while it stays in the inbox is worse than waiting, and a later attempt performs the pair whole once the folder is there.
- Nothing else is ever done: no delete, no other flag, no folder created, nothing sent.

## Contract surfaces

- **Configuration schema:** four new optional keys under `SpamClassification:Actions`. Additive — an existing configuration binds unchanged and both switches read `false`.
- **Database schema:** no migration. `RequesterOrigin` is persisted as text through `HasConversion<string>()` with no check constraint, so a third enum member needs no schema change.
- **MCP tool contract, deployment contract:** untouched.

No breaking change to any of the four surfaces.

## Documentation

`docs/features/spam-classification.md` gains the section stating what an operator agrees to when either switch goes on, including the honest limit: with an unmirrored junk folder MailFathom stops seeing the message, so one moved back out of it arrives as new mail and is classified afresh. `docs/operations/configuration-reference.md`, `docs/features/imap-synchronization.md` and `docs/architecture/stored-email-schema.md` follow the third requester kind and the new keys.

## Rebased onto #716

This branch was rebased onto `main` after #778 landed. That change moved destination resolution into `MailboxDestinationResolver` and collapsed `DeclaredMailAccount`'s two folder collections into the mapped one with a `Maps` reading — both of which this branch had been adding for itself. The duplicates were dropped in favour of upstream's, the recorder now resolves through the shared resolver, and a filing into a mapped-but-unmirrored junk folder therefore works rather than being refused as unbound.

## Verification

- `scripts/verify-full.sh` — green; 5990 passed, 0 failed; aggregate line coverage 95.58% against the 85% gate.
- `scripts/test-agent-workflow.sh` — 148 passed, 0 failed.
- Integration suite not run; nothing here needs it beyond `SpamActionOccurrenceReader`, which carries `[RequiresIntegrationCoverage]`.
