### PR TITLE
[#717] Keep a folder's local mail when synchronization is switched off, and resume it when it is switched back on

### DIFF
--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -810,7 +810,7 @@ readable by tools:
 
 | Switch | With it `false` |
 | --- | --- |
-| `Synchronize` | No run schedules the folder, so no connection is opened for it and nothing of it is stored. |
+| `Synchronize` | No run schedules the folder, so no connection is opened for it and nothing further of it is stored. |
 | `GenerateEmbeddings` | What is stored is never cut into passages and never reaches an embedding provider. |
 | `VisibleToTools` | No MCP tool lists, searches, reads, or answers from the folder. |
 
@@ -838,7 +838,8 @@ mirrors, so nothing would ever bind its alias; instead the alias is resolved the
 destination, against the folders the server advertises, and the binding and the mapping-change audit record that a
 mirrored folder produces are the same ones produced here. What is resolved is then reused rather than looked up per
 message, and a server that has since renamed the folder is followed exactly as it is for a mirrored folder — the binding
-is replaced by its next generation, with no checkpoint to invalidate, because a folder nothing mirrors has none.
+is replaced by its next generation. A folder that was mirrored once keeps the checkpoint its own runs left, which is what
+makes switching it back on a resumption; a folder that never was has none to keep.
 
 Four things can go wrong, and each is reported against the one change rather than ending the pass. A name **no mapping
 of the account declares** is refused, naming what was asked for. A mapping the server advertises **no folder for**, and a
@@ -861,14 +862,21 @@ from tools — binds as well, and it is worth naming what it costs: the passages
 for, and no reader reaches them today, since the tools are the only readers there are. It is a mapping to write when the
 folder is expected to become visible, not one to leave in place indefinitely.
 
-**Mail already stored for a folder whose synchronization is switched off is erased**, in bounded passes on the account's
-own runs, through the deletion path an erasing disposition already uses: the row goes and PostgreSQL removes the raw
-MIME, the search document, the passages, their vectors, and any outstanding repair request with it, and the folder's
-checkpoint is cleared once nothing of it is left. That is deliberate rather than tidiness — a folder nothing reads is a
-folder nothing refreshes, so leaving the rows would leave mail answering searches with the flags it had on the day the
-switch was flipped, and never learning that the server had moved or removed it. The binding itself stays, which is what
-keeps the alias resolving as a destination. A pass that fails is logged and repeated by the next run rather than putting
-the account into backoff, since nothing about it is a mail-server failure.
+**Mail already stored for a folder whose synchronization is switched off is kept.** Nothing is removed, no pass runs
+over the folder, and the checkpoint stays exactly where the last run left it. Rows nobody may read are not stale in a
+way anybody observes: an unsynchronized folder is withdrawn from every reader there is, because the mapping derives the
+other two switches from this one, so no tool lists, searches, reads, or answers from it, nothing of it is embedded, and
+no rule pass reaches it. Erasing them would charge an operator a whole remirror for a switch they may flip back the
+same week, so nothing in MailFathom takes local mail away because a configuration value changed.
+
+**Switching the folder back on is an ordinary mirror**, whichever state the folder is in. A folder that never stored
+anything is scheduled, discovered, bound, and backfilled exactly as one mapped mirrored from the start; a folder that
+stored something before resumes from its retained checkpoint, so the run fetches what arrived while it was off and
+nothing else, and the backward pass converges the retained rows — flags that changed, messages that left, and messages
+the server removed during the gap are observed exactly as they are for a folder that simply went unread for a while. A
+`UIDVALIDITY` the server changed meanwhile invalidates the checkpoint on that first run like any other, and
+reconciliation resolves what the invalidation leaves behind. There is no branch anywhere that tells a re-enabled folder
+from a newly mapped one.
 
 The tool switch is applied in exactly one place. `MailboxScopeResolver` resolves the scope every read model is expressed
 in, attaches the withheld folders to it, and answers the same question for the two reads that name an email by its

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -463,12 +463,17 @@ already has everything a rule pass needs — one account at a time, a slot count
 a jittered backoff when something is wrong, and a shutdown that lets work in flight finish — so evaluation joins it
 instead of adding a second thing to configure and watch.
 
-The step is the last of the run's local work: it comes after every folder has synchronized and committed, after mail
-belonging to folders the account no longer mirrors has been erased, and outside the synchronization transaction
-entirely. Two consequences follow that are worth stating rather than inferring. A rule can only ever see mail the run
-before it has already stored, so a provider redelivering a message or a synchronization retry cannot produce a different
-processing boundary than a clean run. And nothing an MCP tool does waits on a rule: reads are served from what is
-already stored, and a pass neither blocks one nor is blocked by one.
+The step is the last of the run's local work: it comes after every folder has synchronized and committed, and outside
+the synchronization transaction entirely. Two consequences follow that are worth stating rather than inferring. A rule
+can only ever see mail the run before it has already stored, so a provider redelivering a message or a synchronization
+retry cannot produce a different processing boundary than a clean run. And nothing an MCP tool does waits on a rule:
+reads are served from what is already stored, and a pass neither blocks one nor is blocked by one.
+
+**A pass reads nothing out of a folder the account does not mirror.** Such a folder keeps whatever it stored before its
+synchronization was switched off, and neither the arrival queue nor a whole-mailbox run walks those rows: their flags
+are whatever they were on the day the switch was flipped and nothing will ever correct them, so a rule reading one
+would act on a mailbox MailFathom stopped observing. The exclusion is applied where the candidates are read rather than
+after they come back, which is what keeps such a message from sitting at the head of the arrival queue forever.
 
 **A rule declaring `Arrival` applies to mail that arrives after the rule exists.** Each message is evaluated once, and
 the record of that

--- a/docs/features/mailbox-queries.md
+++ b/docs/features/mailbox-queries.md
@@ -116,7 +116,7 @@ read rather than left without an account predicate. The two are not the same: re
 leaves its stored rows in place, so an absent predicate would keep publishing mail from an account MailFathom no longer
 serves. Switching `MailSynchronization:Enabled` off is a different matter and hides nothing — it stops runs from fetching
 mail, and the copy already stored stays readable. Switching a single folder's `Synchronize` off is a third thing again:
-that folder's stored mail is erased rather than hidden, which
+that folder's stored mail is kept and withheld from every reader rather than erased, which
 [what a mapping decides beyond where the folder is](imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
 states.
 

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -177,7 +177,7 @@ whether the folder may be created at all, through a fourth that defaults to `fal
 
 | Key | Type | Default | Constraint | Change |
 | --- | --- | --- | --- | --- |
-| `…:Folders:<n>:Synchronize` | bool | `true` | With `false`, no run schedules the folder: no connection is opened for it and nothing of it is stored | reload; the next run stops scheduling it and begins erasing what is stored for it |
+| `…:Folders:<n>:Synchronize` | bool | `true` | With `false`, no run schedules the folder: no connection is opened for it and nothing further of it is stored | reload; the next run stops scheduling it and keeps everything already stored for it |
 | `…:Folders:<n>:GenerateEmbeddings` | bool | `true` | With `false`, stored mail of the folder is never cut into passages and never reaches an embedding provider; refused alongside `Synchronize: false` | reload; governs what is stored from then on, and passages already produced stay |
 | `…:Folders:<n>:VisibleToTools` | bool | `true` | With `false`, no MCP tool lists, searches, reads, or answers from the folder; refused alongside `Synchronize: false` | reload; the next request reads the new value |
 | `…:Folders:<n>:CreateIfMissing` | bool | `false` | With `true`, the folder is created on the mail server when the server advertises none at `RemotePath`; refused on a mapping that names no `RemotePath` | reload; the next resolution of the alias creates it |
@@ -202,10 +202,15 @@ unsubscribing from a folder stay refused outright, and no folder MailFathom did 
 states when the creation happens, what it does with a folder that already exists and with a hierarchical path, and what
 a server's refusal reports.
 
-Switching `Synchronize` off for a folder that was mirrored **erases what is stored for it**, in bounded passes on the
-account's own runs and through the deletion path an erasing disposition already uses. The mapping stays, so the alias
-goes on resolving, any role the mapping names goes on being answered, and the folder stays a destination a rule may file
-mail into — resolved the first time a change names it, since no run schedules it.
+Switching `Synchronize` off for a folder that was mirrored **keeps what is stored for it**. Nothing is removed, and the
+folder's checkpoint stays where the last run left it, so switching the folder back on resumes: the next run fetches
+what arrived while it was off and reconciles the retained mail rather than mirroring the folder again. What is kept is
+inert — no tool lists, searches, reads, or answers from it, nothing of it is embedded, and no rule evaluates it — so
+the only thing an operator gives up by leaving the switch off is the storage it occupies. No configuration value erases
+stored mail: taking a folder's local copy away is an act somebody performs, never something a switch performs on their
+behalf. The mapping stays too, so the alias goes on resolving, any role the mapping names goes on being answered, and
+the folder stays a destination a rule may file mail into — resolved the first time a change names it, since no run
+schedules it.
 [What a mapping decides beyond where the folder is](../features/imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
 states all three switches together, what an unmapped folder is instead, and what becomes of the local copy of a message
 relocated into a folder nothing mirrors.

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -94,7 +94,9 @@ Points worth knowing before you adapt it:
 - **A mapped folder is mirrored, embedded, and readable by tools** unless you say otherwise. `Synchronize`,
   `GenerateEmbeddings`, and `VisibleToTools` each default to `true` on a folder entry, and switching one off is how a
   folder stays nameable while its mail stays out of the local copy, out of an embedding provider, or out of everything
-  an assistant can read.
+  an assistant can read. Mail the folder had already stored is kept when you turn mirroring off, withheld from
+  everything that reads a mailbox, so turning it back on later fetches what arrived meanwhile rather than the whole
+  folder again.
   [What a mapping decides beyond where the folder is](../features/imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
   states what each one costs, including what happens to mail already stored when you turn mirroring off.
 - **A folder you name is created only if you ask for it.** Add `CreateIfMissing: true` beside a `RemotePath` and

--- a/src/Application/Folders/IMailFolderParticipationReader.cs
+++ b/src/Application/Folders/IMailFolderParticipationReader.cs
@@ -16,7 +16,7 @@ namespace MailFathom.Application.Folders;
 /// than from the tools somebody remembered.
 /// </para>
 /// <para>
-/// The two exclusion lists exist beside <see cref="GetParticipation" /> because a query cannot ask one folder at a time.
+/// The exclusion lists exist beside <see cref="GetParticipation" /> because a query cannot ask one folder at a time.
 /// A read narrows a table and needs the whole excluded set as a value it can put into a predicate, while a write path
 /// holds one email and asks about that email's folder; both answers come from the same configuration, so neither can
 /// drift from the other.
@@ -29,6 +29,16 @@ public interface IMailFolderParticipationReader
 
     /// <summary>Gets the folders whose content is never cut into passages and never reaches an embedding provider.</summary>
     IReadOnlyList<MailFolderIdentity> FoldersWithoutEmbeddings { get; }
+
+    /// <summary>Gets the folders no run mirrors, whose stored mail is therefore kept and read by nothing.</summary>
+    /// <remarks>
+    /// Switching a folder's synchronization off keeps what it had already stored, so the rows outlive the decision that
+    /// stopped refreshing them and every read has to leave them out by name. The other two lists already contain such a
+    /// folder, because <see cref="MailFolderParticipation.Create" /> derives both switches from an unmirrored one, and
+    /// neither says what this says: a read excluded for its own reason must not also be the way mail nobody mirrors
+    /// stays out of a walk that has nothing to do with tools or embeddings.
+    /// </remarks>
+    IReadOnlyList<MailFolderIdentity> FoldersNotMirrored { get; }
 
     /// <summary>Gets what one folder takes part in.</summary>
     /// <param name="accountId">The account the folder belongs to.</param>

--- a/src/Application/Folders/IStoredMailFolderMirrorStore.cs
+++ b/src/Application/Folders/IStoredMailFolderMirrorStore.cs
@@ -10,9 +10,9 @@ namespace MailFathom.Application.Folders;
 
 /// <summary>Removes the local copy of a folder MailFathom has stopped mirroring.</summary>
 /// <remarks>
-/// This is the one write that exists because a configuration value changed rather than because a mail server said
-/// something. It is separate from the reconciliation store for that reason: nothing here is an observation, and the rows
-/// it removes are removed whatever the server still holds.
+/// This is the one write that exists because somebody asked for it rather than because a mail server said something. It
+/// is separate from the reconciliation store for that reason: nothing here is an observation, and the rows it removes
+/// are removed whatever the server still holds.
 /// </remarks>
 public interface IStoredMailFolderMirrorStore
 {
@@ -25,9 +25,9 @@ public interface IStoredMailFolderMirrorStore
     /// <returns>What this pass erased, and whether the folder still holds stored mail.</returns>
     /// <remarks>
     /// The checkpoint is cleared in the same pass that empties the folder rather than in the first one, because a
-    /// checkpoint removed while mail remains would make a re-enabled folder resume in front of rows this pass has not
-    /// reached. Clearing it at the end is what makes switching the folder back on a fresh mirror rather than a resumption
-    /// past mail nobody has any more.
+    /// checkpoint removed while mail remains would make a mirrored folder resume in front of rows this pass has not
+    /// reached. Clearing it at the end is what makes a folder somebody erased mirror afresh, while a folder merely
+    /// switched off keeps its checkpoint and resumes from it.
     /// </remarks>
     Task<MailFolderMirrorErasure> EraseFolderMirrorAsync(
         IPersistenceSession session,

--- a/src/Application/Folders/UnmirroredMailFolderEraser.cs
+++ b/src/Application/Folders/UnmirroredMailFolderEraser.cs
@@ -12,18 +12,16 @@ namespace MailFathom.Application.Folders;
 /// <summary>Takes away the local copy of a folder whose mapping has stopped mirroring it.</summary>
 /// <remarks>
 /// <para>
-/// Turning a folder's synchronization off is something an operator may do to a folder that is already mirrored, and the
-/// mail that is already stored is the part configuration alone cannot answer for. Leaving it would leave rows no run
-/// will ever refresh: the folder is no longer read, so its emails would keep whatever flags they had on the day the
-/// switch was flipped, would keep answering searches with them, and would never learn that the server had moved or
-/// removed them.
+/// Nothing runs this because a configuration value changed. Turning a folder's synchronization off keeps what the
+/// folder had already stored, because rows nobody may read are not stale in a way anybody observes and erasing them
+/// would charge an operator a whole remirror for a switch they may flip back the same week. Getting rid of the local
+/// copy is therefore an act somebody performs, and this is what such a command runs.
 /// </para>
 /// <para>
 /// The removal is the deletion path an erasing disposition already uses rather than a second one — the row goes, and
 /// PostgreSQL takes its raw MIME, its search document, its passages, and their vectors with it. It is bounded per pass
-/// and repeated on the account's own runs for the same reason reconciliation is: a mailbox's worth of rows is not one
-/// transaction, and a pass that ended early leaves the rest for the next run rather than half a folder in an
-/// unrepeatable state.
+/// for the same reason reconciliation is: a mailbox's worth of rows is not one transaction, and a pass that ended early
+/// leaves the rest for the next one rather than half a folder in an unrepeatable state.
 /// </para>
 /// </remarks>
 public sealed class UnmirroredMailFolderEraser

--- a/src/Application/Rules/Evaluation/IMailRuleEvaluationStore.cs
+++ b/src/Application/Rules/Evaluation/IMailRuleEvaluationStore.cs
@@ -21,6 +21,11 @@ namespace MailFathom.Application.Rules.Evaluation;
 /// position it reached rather than the implementation remembering one, so a batch that stopped short of its own end
 /// resumes at the email nobody read.
 /// </para>
+/// <para>
+/// Neither walk reaches a folder the account does not mirror. Mail such a folder stored before its synchronization was
+/// switched off is kept rather than erased, and a rule reading it would act on a mailbox MailFathom stopped observing:
+/// the flags are whatever they were on the day the switch was flipped, and nothing will ever correct them.
+/// </para>
 /// </remarks>
 public interface IMailRuleEvaluationStore
 {

--- a/src/Domain/Folders/MailFolderParticipation.cs
+++ b/src/Domain/Folders/MailFolderParticipation.cs
@@ -43,8 +43,10 @@ public sealed record MailFolderParticipation
 
     /// <summary>Gets whether the folder's mail is mirrored locally.</summary>
     /// <remarks>
-    /// Off, no synchronization connection is opened for the folder, nothing of it is stored, and what a previous
-    /// configuration stored is erased. The alias goes on naming the folder, which is what a mutation writes into.
+    /// Off, no synchronization connection is opened for the folder and nothing further of it is stored. What a previous
+    /// configuration stored is kept, inert and read by nothing, so switching the folder back on resumes from the
+    /// checkpoint it left rather than mirroring the folder again; erasing it is a command an operator runs. The alias
+    /// goes on naming the folder, which is what a mutation writes into.
     /// </remarks>
     public bool IsSynchronized { get; }
 

--- a/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
+++ b/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
@@ -490,6 +490,10 @@ internal sealed class MailSynchronizationOptions
         [.. this.ConfiguredFolders().Where(static folder => !folder.Participation.GeneratesEmbeddings).Select(static folder => folder.Identity)];
 
     /// <inheritdoc />
+    public IReadOnlyList<MailFolderIdentity> FoldersNotMirrored =>
+        [.. this.ConfiguredFolders().Where(static folder => !folder.Participation.IsSynchronized).Select(static folder => folder.Identity)];
+
+    /// <inheritdoc />
     /// <remarks>
     /// Read from the configured role rather than from what a server advertised, for the reason
     /// <see cref="MailFolderMappingOptions.ConfiguredSpecialUse" /> gives. A deployment that maps no junk folder answers

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using MailFathom.Application.Folders;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
@@ -185,12 +184,10 @@ internal sealed partial class AccountSynchronizationSupervisor
     {
         // A folder the operator stopped mirroring is not scheduled at all, which is what makes "no connection is opened
         // for it" true rather than merely quiet: the mapping goes on naming the folder for anything that writes into it,
-        // and this run neither discovers nor selects it.
+        // and this run neither discovers nor selects it. It is also the whole of what the run does about such a folder —
+        // what it already stored stays where it is, and erasing that is a command an operator runs.
         var scheduledFolders = account.EffectiveFolders
             .Where(static folder => folder.Participation.IsSynchronized)
-            .ToArray();
-        var unmirroredFolders = account.EffectiveFolders
-            .Where(static folder => !folder.Participation.IsSynchronized)
             .ToArray();
         var resolvedFolders = new ConcurrentBag<MailFolderResolution>();
         var failedFolderCount = 0;
@@ -244,7 +241,6 @@ internal sealed partial class AccountSynchronizationSupervisor
 
             if (!schedulingToken.IsCancellationRequested)
             {
-                await this.EraseUnmirroredFolderContentAsync(runSettings, unmirroredFolders, workUnitToken);
                 await this.EraseExpiredAuditEntriesAsync(runSettings, workUnitToken);
                 await this.EvaluateMailRulesAsync(runSettings, workUnitToken);
             }
@@ -308,64 +304,6 @@ internal sealed partial class AccountSynchronizationSupervisor
             this.LogMutationConvergenceFailed(exception, this.accountId.Value);
 
             return true;
-        }
-    }
-
-    /// <summary>Erases what is still stored for the folders this account has stopped mirroring.</summary>
-    /// <remarks>
-    /// <para>
-    /// It rides the account's own run for the reason audit retention does, and is bounded the same way: an operator who
-    /// turns a mirrored folder off gets it emptied over as many runs as its size needs rather than in one transaction.
-    /// A folder that was never mirrored costs one bounded query that finds nothing, which is what every run of every
-    /// account with such a folder does from then on.
-    /// </para>
-    /// <para>
-    /// A failure never fails the run. The rows are stale rather than wrong — no tool may read them, because a folder
-    /// nothing mirrors is a folder nothing shows — so putting the account into backoff over them would fetch its mail
-    /// less often to fix something that is not about the mail server at all.
-    /// </para>
-    /// </remarks>
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Erasing a folder nothing mirrors is not a mail operation; a pass that failed is logged and repeated by the next run rather than putting the account into backoff.")]
-    private async Task EraseUnmirroredFolderContentAsync(
-        MailSynchronizationOptions runSettings,
-        MailFolderMappingOptions[] unmirroredFolders,
-        CancellationToken cancellationToken)
-    {
-        if (unmirroredFolders.Length == 0)
-        {
-            return;
-        }
-
-        try
-        {
-            using var scope = this.scopeFactory.CreateScope();
-
-            scope.ServiceProvider.GetRequiredService<ScopedMailSynchronizationSettings>().UseRunSnapshot(runSettings);
-
-            var eraser = scope.ServiceProvider.GetRequiredService<UnmirroredMailFolderEraser>();
-
-            foreach (var folder in unmirroredFolders)
-            {
-                var alias = MailFolderAlias.Create(folder.Alias);
-                var erasure = await eraser.EraseAsync(this.accountId, alias, cancellationToken);
-
-                if (erasure.ErasedEmailCount > 0)
-                {
-                    this.LogUnmirroredFolderContentErased(
-                        this.accountId.Value,
-                        alias.Value,
-                        erasure.ErasedEmailCount,
-                        erasure.EmailsRemain);
-                }
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception exception)
-        {
-            this.LogUnmirroredFolderErasureFailed(exception, this.accountId.Value);
         }
     }
 
@@ -442,9 +380,9 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// <para>
     /// Last of the run's local steps, and after the folders rather than beside them, which is what makes "evaluation
     /// never runs inside the synchronization transaction" true rather than merely intended: every message it can reach
-    /// was committed by a folder that has already finished, in a scope and a transaction of its own. It is also after
-    /// the unmirrored erasure, so a folder the operator has stopped mirroring has already given up its rows instead of
-    /// offering them to a rule on the way out.
+    /// was committed by a folder that has already finished, in a scope and a transaction of its own. Mail a folder the
+    /// operator stopped mirroring still holds is out of reach here whichever order the steps ran in, because the pass
+    /// reads no candidate from such a folder.
     /// </para>
     /// <para>
     /// A failure never fails the run. Everything a pass reads about the mail itself was already stored, and the one
@@ -924,21 +862,6 @@ internal sealed partial class AccountSynchronizationSupervisor
         Level = LogLevel.Warning,
         Message = "Erasing the expired audit entries of account {AccountId} ended unexpectedly; the account is not backed off for it and its next run erases what this one did not.")]
     private partial void LogAuditRetentionFailed(Exception exception, string accountId);
-
-    /// <summary>Reported at warning level because it is local mail going away, which an operator must be able to find afterwards.</summary>
-    [LoggerMessage(
-        Level = LogLevel.Warning,
-        Message = "Account {AccountId} erased {ErasedCount} stored emails of folder {FolderAlias}, which its configuration no longer mirrors; emails remaining for a later run: {EmailsRemain}.")]
-    private partial void LogUnmirroredFolderContentErased(
-        string accountId,
-        string folderAlias,
-        int erasedCount,
-        bool emailsRemain);
-
-    [LoggerMessage(
-        Level = LogLevel.Warning,
-        Message = "Erasing the stored mail of the folders account {AccountId} no longer mirrors ended unexpectedly; the account is not backed off for it and its next run erases what this one did not.")]
-    private partial void LogUnmirroredFolderErasureFailed(Exception exception, string accountId);
 
     /// <summary>States what the rules did to mail that has just arrived, naming the revision so an edit is visible in the record.</summary>
     [LoggerMessage(

--- a/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
+++ b/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Folders;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Rules.Facts;
@@ -18,14 +19,24 @@ namespace MailFathom.Infrastructure.Persistence.Rules;
 
 /// <summary>EF Core state for the rule passes that run inside an account's synchronization run.</summary>
 /// <remarks>
+/// <para>
 /// Both walks project straight into the fact surface rather than loading rows, because a condition reads twenty of its
 /// twenty-two facts from metadata and none of them is the raw MIME sitting beside it in the same aggregate. Of the
 /// other two, <c>folderRole</c> is read from configuration rather than from any row, and <c>bodyText</c> is read one
 /// email at a time and only when a condition names it, which is what keeps a rule set that mentions no body text free
 /// of a content read.
+/// </para>
+/// <para>
+/// Both walks also leave out the folders no run mirrors, and it is the walk rather than the pass that leaves them out.
+/// Such a folder keeps the mail it stored before its synchronization was switched off, so the rows are there to be
+/// read; dropping them after the batch came back would leave every one of them at the head of the arrival queue
+/// forever, since what takes an email out of that queue is a pass having evaluated it.
+/// </para>
 /// </remarks>
 [RequiresIntegrationCoverage]
-internal sealed class MailRuleEvaluationStore(MailFathomDbContext dbContext) : IMailRuleEvaluationStore
+internal sealed class MailRuleEvaluationStore(
+    MailFathomDbContext dbContext,
+    IMailFolderParticipationReader folderParticipation) : IMailRuleEvaluationStore
 {
     /// <inheritdoc />
     /// <remarks>
@@ -126,8 +137,8 @@ internal sealed class MailRuleEvaluationStore(MailFathomDbContext dbContext) : I
         var mailboxAccountId = accountId.Value;
         var resumeAfterId = resumeAfter?.Value;
 
-        var candidates = await emails
-            .AsNoTracking()
+        var candidates = await AccountScopedMailFolders
+            .Excluding(emails.AsNoTracking(), folderParticipation.FoldersNotMirrored)
             .Where(StoredEmailTombstone.IsNotTombstoned)
             .Where(email => email.MailboxAccountId == mailboxAccountId
                 && (resumeAfterId == null || email.Id > resumeAfterId))

--- a/tests/Host.UnitTests/Configuration/Mail/MailFolderParticipationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailFolderParticipationOptionsTests.cs
@@ -30,6 +30,7 @@ public sealed class MailFolderParticipationOptionsTests
         Assert.Equal(MailFolderParticipation.Full, participation);
         Assert.Empty(options.FoldersHiddenFromTools);
         Assert.Empty(options.FoldersWithoutEmbeddings);
+        Assert.Empty(options.FoldersNotMirrored);
     }
 
     /// <summary>A folder that names its target and no switch behaves exactly as it did before the switches existed.</summary>
@@ -98,9 +99,13 @@ public sealed class MailFolderParticipationOptionsTests
         Assert.Empty(options.FoldersHiddenFromTools);
     }
 
-    /// <summary>A folder nothing mirrors takes part in nothing, so it appears in both exclusions without either being configured.</summary>
+    /// <summary>
+    /// A folder nothing mirrors takes part in nothing, so it appears in every exclusion without any of them being
+    /// configured. That is what keeps the mail it stored before the switch was flipped inert while it is kept: no tool
+    /// reads it, nothing embeds it, and no rule pass walks it.
+    /// </summary>
     [Fact]
-    public void GetParticipation_AFolderNothingMirrors_IsWithdrawnFromEmbeddingAndFromTools()
+    public void GetParticipation_AFolderNothingMirrors_IsWithdrawnFromEveryReaderThereIs()
     {
         // Arrange
         var options = OptionsFor(CreateAccount(new MailFolderMappingOptions
@@ -118,6 +123,28 @@ public sealed class MailFolderParticipationOptionsTests
         Assert.Equal(MailFolderParticipation.MappedOnly, participation);
         Assert.Equal([junk], options.FoldersHiddenFromTools);
         Assert.Equal([junk], options.FoldersWithoutEmbeddings);
+        Assert.Equal([junk], options.FoldersNotMirrored);
+    }
+
+    /// <summary>
+    /// A mirrored folder withheld from tools is not a folder nothing mirrors, so the list a rule walk narrows by names
+    /// it as little as the list a tool narrows by names a folder that is merely unembedded.
+    /// </summary>
+    [Fact]
+    public void FoldersNotMirrored_AFolderWithdrawnFromToolsOrEmbedding_NamesNeither()
+    {
+        // Arrange
+        var options = OptionsFor(CreateAccount(
+            new MailFolderMappingOptions { Alias = "private", RemotePath = "Private", VisibleToTools = false },
+            new MailFolderMappingOptions
+            {
+                Alias = "newsletters",
+                RemotePath = "Newsletters",
+                GenerateEmbeddings = false,
+            }));
+
+        // Act, Assert
+        Assert.Empty(options.FoldersNotMirrored);
     }
 
     /// <summary>A folder nothing maps is stored mail nobody withdrew anything from, so a removed mapping never hides a mailbox.</summary>

--- a/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
@@ -150,37 +150,74 @@ public sealed class AccountSynchronizationSupervisorTests
             new TaskCompletionSource(),
             expectedFolderCount: 1,
             _ => new InvalidOperationException("connect failed"));
-        var mirrorStore = new RecordingMailFolderMirrorStore();
+        var localStepsReached = new TaskCompletionSource();
         using var harness = CreateHarness(
             CreateOptionsWithArchiveUnmirrored(),
             sessionFactory,
-            folderMirrorStore: mirrorStore);
+            ruleEvaluationStore: CreateRuleStoreReporting(localStepsReached));
 
-        // Act, waiting on the pass that follows every folder the run scheduled.
-        await harness.SuperviseUntilAsync(mirrorStore.FirstErasureReached);
+        // Act, waiting on the last local step, which follows every folder the run scheduled.
+        await harness.SuperviseUntilAsync(localStepsReached.Task);
 
         // Assert
         Assert.Equal(["INBOX"], attemptedFolders);
     }
 
-    /// <summary>Stored mail no run will ever refresh again is taken away rather than left answering with the flags it had.</summary>
+    /// <summary>
+    /// Mail a folder stored before its synchronization was switched off is kept, so turning the folder back on next
+    /// month costs the mail that arrived meanwhile rather than the whole folder again.
+    /// </summary>
     [Fact]
-    public async Task RunAsync_AFolderTheAccountNoLongerMirrors_ErasesWhatIsStoredForIt()
+    public async Task RunAsync_AFolderTheAccountNoLongerMirrors_ErasesNothingOfWhatItStored()
     {
         // Arrange
         var mirrorStore = new RecordingMailFolderMirrorStore();
+        var localStepsReached = new TaskCompletionSource();
         using var harness = CreateHarness(
             CreateOptionsWithArchiveUnmirrored(),
             Substitute.For<IMailboxSessionFactory>(),
-            folderMirrorStore: mirrorStore);
+            folderMirrorStore: mirrorStore,
+            ruleEvaluationStore: CreateRuleStoreReporting(localStepsReached));
 
-        // Act
-        await harness.SuperviseUntilAsync(mirrorStore.FirstErasureReached);
+        // Act, waiting on the last of the run's local steps, which is past where an erasure pass would have run.
+        await harness.SuperviseUntilAsync(localStepsReached.Task);
 
         // Assert
-        Assert.Equal(
-            [new MailFolderIdentity(MailAccountId.Create("primary"), MailFolderAlias.Create("ARCHIVE"))],
-            mirrorStore.ErasedFolders);
+        Assert.Empty(mirrorStore.ErasedFolders);
+    }
+
+    /// <summary>
+    /// No configuration value erases stored mail, which is what makes the erasure machinery something an operator
+    /// reaches for rather than something a switch reaches for on their behalf.
+    /// </summary>
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, false, false)]
+    [InlineData(true, false, true)]
+    [InlineData(true, true, false)]
+    public async Task RunAsync_WhicheverWayTheFolderSwitchesAreSet_ErasesNothing(
+        bool synchronize,
+        bool generateEmbeddings,
+        bool visibleToTools)
+    {
+        // Arrange
+        var options = SynchronizationTestHost.CreateSingleAccountOptions(enabled: true, "INBOX", "Archive");
+        options.Accounts[0].Folders[1].Synchronize = synchronize;
+        options.Accounts[0].Folders[1].GenerateEmbeddings = generateEmbeddings;
+        options.Accounts[0].Folders[1].VisibleToTools = visibleToTools;
+        var mirrorStore = new RecordingMailFolderMirrorStore();
+        var localStepsReached = new TaskCompletionSource();
+        using var harness = CreateHarness(
+            options,
+            Substitute.For<IMailboxSessionFactory>(),
+            folderMirrorStore: mirrorStore,
+            ruleEvaluationStore: CreateRuleStoreReporting(localStepsReached));
+
+        // Act
+        await harness.SuperviseUntilAsync(localStepsReached.Task);
+
+        // Assert
+        Assert.Empty(mirrorStore.ErasedFolders);
     }
 
     /// <summary>An ambiguous role and an alias that matches nothing need different remedies, so they are logged as different things.</summary>
@@ -599,6 +636,65 @@ public sealed class AccountSynchronizationSupervisorTests
             message => message.Contains("Mail server reported a change in primary/INBOX", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// Switching a folder back on is an ordinary mirror: the next run schedules it exactly as it schedules a folder
+    /// that was mapped mirrored from the start, with no branch that tells the two apart. What the folder kept while it
+    /// was off is what makes that run a resumption rather than a remirror.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_AFolderSwitchedBackOn_IsScheduledByTheNextRunLikeAnyOther()
+    {
+        // Arrange
+        var attemptedFolders = new List<string>();
+        var archiveAttempted = new TaskCompletionSource();
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        sessionFactory
+            .OpenReadOnlyAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailFolderResolution>(),
+                Arg.Any<MailTransportSecurityPolicy>(),
+                Arg.Any<CancellationToken>())
+            .Throws(call =>
+            {
+                var folderAlias = call.Arg<MailFolderResolution>()!.Alias.Value;
+
+                lock (attemptedFolders)
+                {
+                    attemptedFolders.Add(folderAlias);
+                }
+
+                if (string.Equals(folderAlias, "ARCHIVE", StringComparison.Ordinal))
+                {
+                    archiveAttempted.TrySetResult();
+                }
+
+                return new InvalidOperationException("connect failed");
+            });
+        var firstRunReached = new TaskCompletionSource();
+        using var harness = CreateHarness(
+            CreateOptionsWithArchiveUnmirrored(),
+            sessionFactory,
+            ruleEvaluationStore: CreateRuleStoreReporting(firstRunReached));
+        var supervision = harness.StartSupervision();
+
+        // Act
+        await firstRunReached.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+        harness.Settings.Current = SynchronizationTestHost.CreateSingleAccountOptions(
+            enabled: true,
+            "INBOX",
+            "Archive");
+        await SynchronizationTestHost.AdvanceUntilAsync(
+            harness.Clock,
+            archiveAttempted.Task,
+            AdvanceStep,
+            DeadlockGuard);
+        await harness.StopSchedulingAsync();
+        await supervision;
+
+        // Assert
+        Assert.Contains("ARCHIVE", attemptedFolders);
+    }
+
     /// <summary>Configures one mirrored folder beside one the operator has switched synchronization off for.</summary>
     private static MailSynchronizationOptions CreateOptionsWithArchiveUnmirrored()
     {
@@ -689,6 +785,29 @@ public sealed class AccountSynchronizationSupervisorTests
         Assert.DoesNotContain(
             harness.Logger.Messages,
             message => message.Contains("runs in a row", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Reports that a run has reached its last local step, which is the signal a test waits on when what it asserts is
+    /// that something did not happen: everything an account run does locally is behind it by then.
+    /// </summary>
+    private static IMailRuleEvaluationStore CreateRuleStoreReporting(TaskCompletionSource localStepsReached)
+    {
+        var ruleStore = Substitute.For<IMailRuleEvaluationStore>();
+        ruleStore
+            .GetEmailsAwaitingFirstEvaluationAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<StoredEmailId?>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                localStepsReached.TrySetResult();
+
+                return Task.FromResult<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>>([]);
+            });
+
+        return ruleStore;
     }
 
     private static IMailboxSessionFactory CreateFailingSessionFactory(

--- a/tests/Host.UnitTests/TestDoubles/RecordingMailFolderMirrorStore.cs
+++ b/tests/Host.UnitTests/TestDoubles/RecordingMailFolderMirrorStore.cs
@@ -10,11 +10,15 @@ using MailFathom.Domain.Folders;
 namespace MailFathom.Host.UnitTests.TestDoubles;
 
 /// <summary>Records which folders a run asked to have erased, and answers with an erasure the test arranged.</summary>
+/// <remarks>
+/// Nothing in an account run reaches this store any more, because a folder whose synchronization was switched off keeps
+/// what it stored. What the recording is for is proving exactly that: an empty list here is the assertion, and it is
+/// worth making against a store a run could have reached rather than against one nothing is registered for.
+/// </remarks>
 internal sealed class RecordingMailFolderMirrorStore(MailFolderMirrorErasure? erasure = null)
     : IStoredMailFolderMirrorStore
 {
     private readonly List<MailFolderIdentity> erasedFolders = [];
-    private readonly TaskCompletionSource firstErasureReached = new();
 
     /// <summary>Gets the folders each pass named, in the order the run reached them.</summary>
     internal IReadOnlyList<MailFolderIdentity> ErasedFolders
@@ -28,9 +32,6 @@ internal sealed class RecordingMailFolderMirrorStore(MailFolderMirrorErasure? er
         }
     }
 
-    /// <summary>Gets a signal a run raises once it has reached the erasure pass, which is after every folder it scheduled.</summary>
-    internal Task FirstErasureReached => this.firstErasureReached.Task;
-
     /// <inheritdoc />
     public Task<MailFolderMirrorErasure> EraseFolderMirrorAsync(
         IPersistenceSession session,
@@ -43,8 +44,6 @@ internal sealed class RecordingMailFolderMirrorStore(MailFolderMirrorErasure? er
         {
             this.erasedFolders.Add(new MailFolderIdentity(accountId, folderAlias));
         }
-
-        this.firstErasureReached.TrySetResult();
 
         return Task.FromResult(erasure ?? MailFolderMirrorErasure.Nothing);
     }

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -82,7 +82,7 @@ internal static class SynchronizationTestHost
     /// <param name="notificationSessionFactory">Stands in for the server's push mechanism; a server that advertises none is the default.</param>
     /// <param name="remoteFolderCatalog">Replaces the catalog that advertises exactly the configured folders.</param>
     /// <param name="mutationRecordStore">Replaces the record store that reports nothing outstanding to converge.</param>
-    /// <param name="folderMirrorStore">Replaces the store a run erases an unmirrored folder's local copy through.</param>
+    /// <param name="folderMirrorStore">Replaces the store an unmirrored folder's local copy would be erased through, which no run reaches.</param>
     /// <param name="ruleEvaluationStore">Replaces the store a rule pass reads its candidates from; one with nothing to evaluate is the default.</param>
     /// <param name="unadvertisedAliases">Aliases the modelled server does not advertise.</param>
     /// <returns>A provider whose scopes resolve a synchronizer over substituted infrastructure.</returns>
@@ -154,8 +154,10 @@ internal static class SynchronizationTestHost
         services.AddScoped<IMailboxMutationAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
         services.AddScoped<MailboxMutationAuditTrailRetention>();
 
-        // A run also takes away what is stored for a folder the account has stopped mirroring, and resolves the eraser
-        // from its own scope. The store below records which folders it was asked about and erases nothing.
+        // No run erases what a folder the account has stopped mirroring stored, and both of these are registered so
+        // that assertion can fail rather than pass by accident: a run that reached for the eraser again would compose,
+        // resolve, and record into the store below instead of throwing into the supervisor's own catch and being
+        // logged as an unexpected failure nobody asserted on.
         services.AddSingleton(folderMirrorStore ?? new RecordingMailFolderMirrorStore());
         services.AddScoped<UnmirroredMailFolderEraser>();
 

--- a/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
+++ b/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
@@ -138,6 +138,10 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
     /// The folders this account withholds from every tool, empty everywhere but the class proving that the narrowing
     /// this produces is one PostgreSQL evaluates.
     /// </param>
+    /// <param name="foldersNotMirrored">
+    /// The folders this account has stopped mirroring, empty everywhere but the class proving that mail such a folder
+    /// still holds reaches no rule pass.
+    /// </param>
     /// <param name="spamClassification">
     /// What this deployment decided about classifying mail, or <see langword="null" /> for the shipped default of
     /// classifying nothing. Stated only by the class that classifies, because the switch decides whether the use case
@@ -159,6 +163,7 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
         IChatClient? answeringChatClient = null,
         IReadOnlyList<MailFolderIdentity>? foldersWithoutEmbeddings = null,
         IReadOnlyList<MailFolderIdentity>? foldersHiddenFromTools = null,
+        IReadOnlyList<MailFolderIdentity>? foldersNotMirrored = null,
         SpamClassificationSettings? spamClassification = null,
         SpamAssassinScannerProfile? spamScanner = null)
     {
@@ -169,7 +174,8 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
             auditTrailEnabled,
             answeringAuditTrailEnabled,
             foldersWithoutEmbeddings,
-            foldersHiddenFromTools);
+            foldersHiddenFromTools,
+            foldersNotMirrored);
 
         builder.Services.AddSingleton(TimeProvider.System);
         builder.Services.AddSecretResolution(SecretValueInterpretation.ReferenceOnly);

--- a/tests/IntegrationTests/Orchestration/SyntheticMailAccount.cs
+++ b/tests/IntegrationTests/Orchestration/SyntheticMailAccount.cs
@@ -44,7 +44,8 @@ internal sealed class SyntheticMailAccount(
     bool auditTrailEnabled = false,
     bool answeringAuditTrailEnabled = false,
     IReadOnlyList<MailFolderIdentity>? foldersWithoutEmbeddings = null,
-    IReadOnlyList<MailFolderIdentity>? foldersHiddenFromTools = null)
+    IReadOnlyList<MailFolderIdentity>? foldersHiddenFromTools = null,
+    IReadOnlyList<MailFolderIdentity>? foldersNotMirrored = null)
     : IImapAccountSettingsProvider,
     IMailTransportSecurityPolicyReader,
     IMailSynchronizationWindowReader,
@@ -97,6 +98,13 @@ internal sealed class SyntheticMailAccount(
     /// because whether a message is cut into passages at all is settled by the rows a real transaction leaves behind.
     /// </remarks>
     public IReadOnlyList<MailFolderIdentity> FoldersWithoutEmbeddings => foldersWithoutEmbeddings ?? [];
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Empty unless a test asks otherwise, for the reason above. The class that does ask names a folder it has already
+    /// stored mail into, because keeping that mail out of a walk is only worth asserting where the rows exist.
+    /// </remarks>
+    public IReadOnlyList<MailFolderIdentity> FoldersNotMirrored => foldersNotMirrored ?? [];
 
     /// <inheritdoc />
     /// <remarks>

--- a/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Rules;
 using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
 using MailFathom.IntegrationTests.Orchestration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -29,6 +30,9 @@ namespace MailFathom.IntegrationTests.Persistence;
 public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationFixture orchestration)
 {
     private const string FolderAlias = "rule-evaluation";
+
+    /// <summary>The folder whose synchronization is switched off after it has stored mail, which is what retention is.</summary>
+    private const string ParkedFolderAlias = "rule-evaluation-parked";
 
     private const string RecipientAddress = "recipient@mailfathom.test";
 
@@ -239,15 +243,62 @@ public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationF
         Assert.Null(afterEnding);
     }
 
+    /// <summary>
+    /// Mail a folder kept after its synchronization was switched off is out of both walks, and out of them because the
+    /// database left it out rather than because the rows are gone: the same mail is stored first under a deployment
+    /// that mirrors the folder, and a message in a folder that stayed mirrored comes back from both walks beside it.
+    /// </summary>
+    /// <remarks>
+    /// The exclusion is a clause PostgreSQL evaluates over an account and an alias together, so only a real database
+    /// settles whether it narrows anything. It matters most to the arrival queue: a message the walk returned and the
+    /// pass then declined to evaluate would sit at the head of that queue for the rest of the deployment's life, since
+    /// recording an evaluation is the only thing that takes an email out of it.
+    /// </remarks>
+    [Fact]
+    public async Task BothWalks_MailAFolderKeptAfterItStoppedBeingMirrored_LeaveItOutAndKeepReadingTheRest()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        StoredEmailId parked;
+        StoredEmailId mirrored;
+
+        await using (var whileMirrored =
+            await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken))
+        {
+            parked = await StoreOneMessageAsync(whileMirrored, uid: 9441, cancellationToken, ParkedFolderAlias);
+            mirrored = await StoreOneMessageAsync(whileMirrored, uid: 9442, cancellationToken);
+        }
+
+        await using var services = await OrchestratedMailFathomServices.StartAsync(
+            orchestration,
+            cancellationToken,
+            foldersNotMirrored:
+            [
+                new MailFolderIdentity(SyntheticMailAccount.AccountId, MailFolderAlias.Create(ParkedFolderAlias)),
+            ]);
+
+        // Act
+        var queued = await ReadArrivalQueueAsync(services, resumeAfter: null, DrainBatchSize, cancellationToken);
+        var walked = await WalkWholeMailboxAsync(services, cancellationToken);
+
+        // Assert
+        var queuedIds = queued.Select(candidate => candidate.StoredEmailId).ToArray();
+        Assert.Contains(mirrored, queuedIds);
+        Assert.DoesNotContain(parked, queuedIds);
+        Assert.Contains(mirrored, walked);
+        Assert.DoesNotContain(parked, walked);
+    }
+
     private static string SubjectOf(uint uid) => $"{FolderAlias}-{uid}";
 
     /// <summary>Stores one synthetic message, whose extraction the same session derives its search document from.</summary>
     private static async Task<StoredEmailId> StoreOneMessageAsync(
         OrchestratedMailFathomServices services,
         uint uid,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string folderAlias = FolderAlias)
     {
-        var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
+        var binding = await OrchestratedFolderBinding.CommitAsync(services, folderAlias, cancellationToken);
         var occurrenceId = SyntheticEmail.OccurrenceIn(binding, uid);
         var subject = SubjectOf(uid);
         var storedEmailId = default(StoredEmailId);

--- a/tests/SharedSources.UnitTests/StubMailFolderParticipationTests.cs
+++ b/tests/SharedSources.UnitTests/StubMailFolderParticipationTests.cs
@@ -1,0 +1,104 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using MailFathom.TestSupport;
+using Xunit;
+
+namespace MailFathom.SharedSources.UnitTests;
+
+/// <summary>Covers the participation reader every suite arranging a withheld folder answers through.</summary>
+/// <remarks>
+/// A fault here reports somebody else's arrangement. A reader that named a folder in the wrong list would let a test
+/// about tool visibility pass on an exclusion a rule walk applies, and one whose derived answer disagreed with its own
+/// lists would prove a narrowing that configuration never produces.
+/// </remarks>
+public sealed class StubMailFolderParticipationTests
+{
+    private static readonly MailAccountId Work = MailAccountId.Create("work");
+
+    private static readonly MailFolderIdentity Archive =
+        new(Work, MailFolderAlias.Create("archive"));
+
+    /// <summary>The supply an existing arrangement takes, which has to keep saying what it said before folder switches existed.</summary>
+    [Fact]
+    public void Everything_AFolderNobodyArranged_WithholdsNothing()
+    {
+        // Arrange
+        var participation = StubMailFolderParticipation.Everything;
+
+        // Act, Assert
+        Assert.Empty(participation.FoldersHiddenFromTools);
+        Assert.Empty(participation.FoldersWithoutEmbeddings);
+        Assert.Empty(participation.FoldersNotMirrored);
+        Assert.Equal(MailFolderParticipation.Full, participation.GetParticipation(Work, Archive.Alias));
+    }
+
+    [Fact]
+    public void Hiding_TheFolderItNames_WithholdsItFromToolsAndFromNothingElse()
+    {
+        // Arrange
+        var participation = StubMailFolderParticipation.Hiding(Archive);
+
+        // Act
+        var arranged = participation.GetParticipation(Work, Archive.Alias);
+
+        // Assert
+        Assert.Equal([Archive], participation.FoldersHiddenFromTools);
+        Assert.Empty(participation.FoldersWithoutEmbeddings);
+        Assert.Empty(participation.FoldersNotMirrored);
+        Assert.False(arranged.IsVisibleToTools);
+        Assert.True(arranged.IsSynchronized);
+        Assert.True(arranged.GeneratesEmbeddings);
+    }
+
+    [Fact]
+    public void WithoutEmbeddingsIn_TheFolderItNames_LeavesItMirroredAndReadable()
+    {
+        // Arrange
+        var participation = StubMailFolderParticipation.WithoutEmbeddingsIn(Archive);
+
+        // Act
+        var arranged = participation.GetParticipation(Work, Archive.Alias);
+
+        // Assert
+        Assert.Equal([Archive], participation.FoldersWithoutEmbeddings);
+        Assert.Empty(participation.FoldersHiddenFromTools);
+        Assert.Empty(participation.FoldersNotMirrored);
+        Assert.False(arranged.GeneratesEmbeddings);
+        Assert.True(arranged.IsVisibleToTools);
+    }
+
+    /// <summary>A folder nothing mirrors is in every list at once, which is what configuration derives for one.</summary>
+    [Fact]
+    public void Unmirroring_TheFolderItNames_WithdrawsItFromEveryReaderThereIs()
+    {
+        // Arrange
+        var participation = StubMailFolderParticipation.Unmirroring(Archive);
+
+        // Act
+        var arranged = participation.GetParticipation(Work, Archive.Alias);
+
+        // Assert
+        Assert.Equal([Archive], participation.FoldersNotMirrored);
+        Assert.Equal([Archive], participation.FoldersHiddenFromTools);
+        Assert.Equal([Archive], participation.FoldersWithoutEmbeddings);
+        Assert.Equal(MailFolderParticipation.MappedOnly, arranged);
+    }
+
+    /// <summary>One account's arrangement is never another account's, which is what makes the identity a pair.</summary>
+    [Fact]
+    public void GetParticipation_TheSameAliasInAnotherAccount_IsNotTheFolderThatWasArranged()
+    {
+        // Arrange
+        var participation = StubMailFolderParticipation.Unmirroring(Archive);
+
+        // Act
+        var elsewhere = participation.GetParticipation(MailAccountId.Create("private"), Archive.Alias);
+
+        // Assert
+        Assert.Equal(MailFolderParticipation.Full, elsewhere);
+    }
+}

--- a/tests/shared/StubMailFolderParticipation.cs
+++ b/tests/shared/StubMailFolderParticipation.cs
@@ -16,16 +16,14 @@ namespace MailFathom.TestSupport;
 /// </remarks>
 internal sealed class StubMailFolderParticipation : IMailFolderParticipationReader
 {
-    private readonly IReadOnlyList<MailFolderIdentity> unsynchronized;
-
     private StubMailFolderParticipation(
         IReadOnlyList<MailFolderIdentity> hiddenFromTools,
         IReadOnlyList<MailFolderIdentity> withoutEmbeddings,
-        IReadOnlyList<MailFolderIdentity> unsynchronized)
+        IReadOnlyList<MailFolderIdentity> notMirrored)
     {
         this.FoldersHiddenFromTools = hiddenFromTools;
         this.FoldersWithoutEmbeddings = withoutEmbeddings;
-        this.unsynchronized = unsynchronized;
+        this.FoldersNotMirrored = notMirrored;
     }
 
     /// <summary>Gets a reader that withholds nothing, which is what a deployment configuring no switch reads like.</summary>
@@ -36,6 +34,9 @@ internal sealed class StubMailFolderParticipation : IMailFolderParticipationRead
 
     /// <inheritdoc />
     public IReadOnlyList<MailFolderIdentity> FoldersWithoutEmbeddings { get; }
+
+    /// <inheritdoc />
+    public IReadOnlyList<MailFolderIdentity> FoldersNotMirrored { get; }
 
     /// <summary>Builds a reader that hides the named folders from every tool.</summary>
     /// <param name="folders">The folders to hide.</param>
@@ -60,7 +61,7 @@ internal sealed class StubMailFolderParticipation : IMailFolderParticipationRead
         var folder = new MailFolderIdentity(accountId, folderAlias);
 
         return MailFolderParticipation.Create(
-            !this.unsynchronized.Contains(folder),
+            !this.FoldersNotMirrored.Contains(folder),
             !this.FoldersWithoutEmbeddings.Contains(folder),
             !this.FoldersHiddenFromTools.Contains(folder));
     }


### PR DESCRIPTION
Closes #717.

Switching a folder's `Synchronize` off used to erase what the folder had already stored, in bounded passes on the account's following runs. The reasoning does not hold: a mapped-but-unsynchronized folder is already withdrawn from every reader there is, because `MailFolderParticipation.Create` derives `GenerateEmbeddings` and `VisibleToTools` from `IsSynchronized`, so rows nobody may read are not stale in a way anybody observes — and erasing them charges an operator a whole remirror for a switch they may flip back the same week.

## What changed

- **The account run does nothing about an unmirrored folder.** `AccountSynchronizationSupervisor` schedules mirrored folders and stops there; its second branch over unmirrored folders is gone, with the two log messages that reported it. `UnmirroredMailFolderEraser` and `IStoredMailFolderMirrorStore` stay, registered and without a caller, for the operator-run erasure that #718 builds.
- **Switching a folder back on is a resumption and needed no code of its own.** The checkpoint is what the erasure used to clear, so a re-enabled folder reads the checkpoint its own runs left, fetches only what arrived while it was off, and converges the retained rows through the reconciliation pass that already exists. A `UIDVALIDITY` that changed meanwhile invalidates it on that first run exactly as it does for a folder that stayed mirrored. There is no branch anywhere that tells a re-enabled folder from a newly mapped one.
- **One reader did have to be closed.** A rule pass walks an account's stored mail rather than its folders, so retained rows would have reached it — a whole-mailbox run would have evaluated mail whose flags stopped being refreshed the day the switch was flipped. `IMailFolderParticipationReader` gains `FoldersNotMirrored`, and both rule-evaluation walks narrow by it through the `AccountScopedMailFolders` clause the embedding backfill already uses. The narrowing is in the query rather than after the batch comes back: a candidate the pass declined to evaluate would sit at the head of the arrival queue for the rest of the deployment's life, since recording an evaluation is what takes an email out of it.

Tools and embeddings needed nothing: both already exclude such a folder, because configuration derives both switches from the unmirrored one.

## Breaking change — configuration surface

`MailSynchronization:Accounts:<n>:Folders:<n>:Synchronize` keeps its name, its type, and its default. What changes is what `false` does to mail the folder had already stored: it is now kept rather than erased.

**Operator action:** an operator who set `Synchronize: false` expecting the storage back gets nothing removed, and the rows go on occupying the database while staying unreadable by every tool, query, embedding pass, and rule. There is no configuration value that erases them; erasing a folder's local copy becomes an operator command in #718.

## Tests

- `AccountSynchronizationSupervisorTests` — a run over an account with an unmirrored folder reaches its last local step and erases nothing; a theory asserts the same whichever way the three folder switches are set; a folder switched back on between runs is scheduled by the next one.
- `MailFolderParticipationOptionsTests` — an unmirrored folder appears in all three exclusion lists at once, and a folder merely withheld from tools or from embedding appears in none of them.
- `StubMailFolderParticipationTests` — new, covering the shared participation stub from `SharedSources.UnitTests` as `tests/AGENTS.md` requires.
- `OrchestratedMailRuleEvaluationTests` — mail stored while the folder was mirrored, then read back under a deployment that no longer mirrors it, is out of both walks while a message in a folder that stayed mirrored comes back from both. The exclusion is a clause PostgreSQL evaluates, so only a real database settles whether it narrows anything.

## Verification

`scripts/verify-full.sh` after rebasing onto `58a62710`: exit 0, 6001 tests, 0 failures, aggregate line coverage 95.58% against the 85% gate. `$check-docs-licenses`: docs `pass`, changelog `n/a`, licenses `n/a` — no dependency, image, service, or sample is added or upgraded.

Part of #709.
