### PR TITLE
[#719] Treat a folder no mapping names as a folder that does not exist

### DIFF
--- a/docs/features/automatic-embedding.md
+++ b/docs/features/automatic-embedding.md
@@ -18,8 +18,9 @@ records why the switch is an operation rather than a setting.
 That state is read per message rather than once at startup, so activating a profile takes effect on the next message
 without a restart.
 
-One thing narrows what an active profile reaches: mail of a folder mapped with `GenerateEmbeddings: false` is cut into
-no passages, so there is nothing to embed and nothing of it is ever sent to a provider.
+One thing narrows what an active profile reaches: what is cut into passages. Mail of a folder mapped with
+`GenerateEmbeddings: false`, and mail of a folder no mapping names at all, is cut into none, so there is nothing to embed
+and nothing of it is ever sent to a provider.
 [What a mapping decides beyond where the folder is](imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
 states that switch beside the other two, and [message chunks](message-chunks.md#when-chunking-runs) what happens to
 passages cut before it was set.

--- a/docs/features/email-content.md
+++ b/docs/features/email-content.md
@@ -398,11 +398,12 @@ a second fetch fixes the first three and may well reproduce the fourth. Which on
 message.
 
 An email the local copy holds no row for, one belonging to an account this deployment no longer serves, and one stored in
-a folder mapped with `VisibleToTools: false` are all reported as `53002 StoredEmailNotFound`. One failure covers all
-three, for the reason `53001 MailAccountNotAccessible` covers both of its cases: a caller that could tell them apart
-could learn which identifiers exist by asking. An attachment link minted before the folder was withheld stops serving
-the same way, because the question is asked where the download is served;
-[folders withheld from tools](mailbox-queries.md#folders-withheld-from-tools) states the switch and what it withholds.
+a folder mapped with `VisibleToTools: false` or in a folder no mapping names at all are all reported as
+`53002 StoredEmailNotFound`. One failure covers them, for the reason `53001 MailAccountNotAccessible` covers both of its
+cases: a caller that could tell them apart could learn which identifiers exist by asking. An attachment link minted
+before the folder was withheld — or before its mapping was removed — stops serving the same way, because the question is
+asked where the download is served;
+[folders withheld from tools](mailbox-queries.md#folders-withheld-from-tools) states both cases and what they withhold.
 
 The two codes are distinct on purpose. `StoredEmailNotFound` names an email that was never stored here;
 `EmailContentUnavailable` names one that is stored and whose body cannot currently be served, and only the second is

--- a/docs/features/email-search.md
+++ b/docs/features/email-search.md
@@ -55,8 +55,9 @@ The structured filters are the ones `ListEmails` takes and they mean exactly the
 apply one validated `MailboxEmailSelection` and one SQL predicate.
 [Mailbox queries](mailbox-queries.md#what-each-filter-accepts-and-what-it-refuses) documents what each of them accepts
 and refuses, including the attachment-presence rule and the account-scope resolution; nothing about them changes here.
-A folder mapped with `VisibleToTools: false` is outside a search for the same reason it is outside a listing, and by the
-same single decision — [folders withheld from tools](mailbox-queries.md#folders-withheld-from-tools).
+A folder mapped with `VisibleToTools: false`, and a folder no mapping names at all, are outside a search for the same
+reason each is outside a listing, and by the same single decision —
+[folders withheld from tools](mailbox-queries.md#folders-withheld-from-tools).
 The account's junk folder is left out by the same one decision and lifted by the same caller override, which the
 result reports back — [the junk folder, withheld by default](mailbox-queries.md#the-junk-folder-withheld-by-default-and-reachable-on-request).
 

--- a/docs/features/embedding-backfill.md
+++ b/docs/features/embedding-backfill.md
@@ -39,10 +39,14 @@ A message a tombstone hides is in neither group. Vectors nothing may retrieve ar
 message whose local copy was deliberately kept after MailFathom deleted it on the server is not that: nothing may
 retrieve it from the server any more, and everything may still retrieve it here, so the walk reaches it like any other.
 
-A message of a folder mapped with `GenerateEmbeddings: false` is in neither group either, and the exclusion is on the
-query rather than on what it does with a row: a folder whose passages are deliberately never cut would otherwise look
-like the first group on every run forever. What was embedded before the switch was set stays and is retrieved like any
-other vector.
+The walk asks the query for the folders configuration maps and leaves embedded, so a message of a folder mapped with
+`GenerateEmbeddings: false` is in neither group, and neither is a message of a folder **no mapping names**. The
+narrowing is on the query rather than on what it does with a row: a folder whose passages are deliberately never cut
+would otherwise look like the first group on every run forever, and mail retained under a removed mapping would be
+re-embedded — paid for at a provider — for a folder this deployment no longer has. What was embedded before either
+change stays and is retrieved like any other vector, subject to what the reading side admits.
+[What a mapping decides beyond where the folder is](imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
+states both cases.
 
 Once a message is selected, what happens to it is exactly what happens to a newly synchronized one — the same unit of
 work, described under [embedding one message](automatic-embedding.md#embedding-one-message). Nothing is remembered

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -821,9 +821,22 @@ read from the configured role rather than from what a server advertised for the 
 what an operator decided, and a folder is withheld by their decision rather than by a `LIST` response. An account
 mapping no junk folder withholds nothing, and every mailbox read behaves as it did before this existed.
 
-None of them changes what an **unmapped** folder is. A folder no mapping names is not discovered into a binding, stores
-nothing, and has no alias anything can name it by — which is a different thing from `Synchronize: false`, where the
-mapping goes on naming the folder and the alias goes on resolving.
+None of them changes what an **unmapped** folder is, because an unmapped folder is not a folder with its switches turned
+down. A folder no mapping names is not discovered into a binding, stores nothing, and has no alias anything can name it
+by: it does not exist for this deployment. Every reader is expressed over the folders configuration maps — the tools and
+the two reads that name an email by its identifier over the ones a mapping also leaves visible, chunking and the
+embedding backfill over the ones a mapping also leaves embedded, and both rule passes over the ones a mapping mirrors —
+so a folder outside that list is outside the answer, and an account mapping nothing has nothing any of them can read.
+That is a different thing from `Synchronize: false`, where the mapping goes on naming the folder and the alias goes on
+resolving.
+
+**Rows already stored under an alias whose mapping was removed stay in the table, and nothing reaches them.** That is the
+same answer removing the `Synchronize` switch gets, for the same reason: nothing here takes local mail away because a
+configuration value changed, so the rows are kept and read by nothing — nothing lists, searches, reads, or answers from
+them, nothing cuts them into passages or embeds them, no rule pass walks them, and no alias of theirs resolves as a
+destination. Mapping the folder again is what makes them readable again, and a folder that was mirrored once keeps its
+checkpoint, so mapping it back is the resumption the section below describes rather than a remirror. What it costs
+meanwhile is storage.
 
 That distinction is the reason to switch synchronization off rather than delete the mapping. The alias still resolves,
 by remote path or by special-use role, so the folder stays a **destination**: a relocation or a copy files a message
@@ -879,8 +892,10 @@ reconciliation resolves what the invalidation leaves behind. There is no branch 
 from a newly mapped one.
 
 The tool switch is applied in exactly one place. `MailboxScopeResolver` resolves the scope every read model is expressed
-in, attaches the withheld folders to it, and answers the same question for the two reads that name an email by its
-identifier, so a tool added later inherits the exclusion instead of having to remember it.
+in, attaches to it the folders a mapping both names and leaves visible, and answers the same question for the two reads
+that name an email by its identifier, so a tool added later inherits the whole rule — the withheld folder and the
+unmapped one alike — instead of having to remember either. What it attaches is the list of what may be read rather than
+a list of what may not, which is what makes an account with no mapped folder read as nothing rather than as everything.
 [Mailbox queries](mailbox-queries.md#folders-withheld-from-tools) states what a caller sees.
 
 ## Session resilience

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -475,6 +475,15 @@ are whatever they were on the day the switch was flipped and nothing will ever c
 would act on a mailbox MailFathom stopped observing. The exclusion is applied where the candidates are read rather than
 after they come back, which is what keeps such a message from sitting at the head of the arrival queue forever.
 
+**Both passes reach only the folders the account's configuration mirrors.** A rule is evaluated against mail in a folder
+a mapping names and leaves synchronized, and against no other mail. Two kinds of stored mail are outside that, and both
+are mail this deployment keeps: a folder whose `Synchronize` was switched off keeps what it had already stored, and a
+folder whose mapping was removed keeps it as well. Neither is evaluated again, by an arrival pass or by a whole-mailbox
+run, because nothing refreshes either — a rule acting on such a message would flag, file, or delete mail against a
+mailbox state nobody here is still reading.
+[What a mapping decides beyond where the folder is](imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
+states what each of the two is and what makes both unreachable everywhere else too.
+
 **A rule declaring `Arrival` applies to mail that arrives after the rule exists.** Each message is evaluated once, and
 the record of that
 evaluation is what takes it out of the queue the next pass reads — so editing a rule changes what happens to the mail
@@ -513,8 +522,8 @@ declaring no automatic trigger keeps it out of every arrival pass without taking
 ## Running the rules over mail you already have
 
 Editing a rule is only useful if the rules can be applied to mail that arrived before the edit, and that is what a
-**whole-mailbox run** is: a walk over everything stored for one account, evaluating each message again under the rules
-now in force.
+**whole-mailbox run** is: a walk over everything stored for the folders one account mirrors, evaluating each message
+again under the rules now in force.
 
 - **One per account, and asking twice is asking once.** A request that finds a run already outstanding is answered with
   that run rather than starting a second walk of the same mailbox.

--- a/docs/features/mailbox-queries.md
+++ b/docs/features/mailbox-queries.md
@@ -26,7 +26,7 @@ divergence neither copy would look wrong for on its own.
 | Field | Meaning | Absent means |
 |---|---|---|
 | `Accounts` | The accounts to list from, each named by its identifier or by its display name | every account this deployment serves |
-| `Folders` | The folders to list from, each named by its alias or by the role it plays | every folder of those accounts |
+| `Folders` | The folders to list from, each named by its alias or by the role it plays | every folder those accounts map and let tools read |
 | `SenderAddress` | The address the sender must carry, in any case | any sender |
 | `RecipientAddress` | The address a `To` or `Cc` recipient must carry | any recipient |
 | `SubjectFragment` | Text the subject must contain, compared without regard to case | any subject |
@@ -50,7 +50,8 @@ folders. A role no account in scope maps is refused with `53003 MailFolderRoleUn
 which selects nothing — an alias is already a name the caller chose to use, while a role that reached no folder anywhere
 would leave a caller reading an empty page as an empty folder.
 
-A listing that names no folder reads every folder, so a message that exists in two of them — because it was copied, by
+A listing that names no folder reads every folder the account maps and lets tools read, so a message that exists in two
+of them — because it was copied, by
 the mailbox owner or by MailFathom — is two entries, one per folder. Nothing collapses them, because a stored row is one
 occurrence and no identity spans two;
 [what a message MailFathom copied becomes locally](imap-synchronization.md#what-a-message-mailfathom-copied-becomes-locally)
@@ -138,15 +139,22 @@ stops serving for the same reason, because the question is asked where the downl
 was issued. None of those answers says the folder exists, because a refusal naming it would publish exactly what the
 switch withholds.
 
-The exclusion is applied once, where the scope every read model is expressed in is resolved, and it narrows by the
-account and the alias **together** — one account's withheld folder never hides another account's folder of the same
-name. It deliberately takes no part in the cursor's fingerprint: a cursor stays valid across the change, and the pages
-after it simply stop admitting the folder, which is what an operator asking for it to be withheld meant.
+A folder **no mapping names** gives the same answers, and for a stronger reason: the scope carries the folders a mapping
+names and leaves visible, so a read admits that list and nothing else. Mail stored under an alias whose mapping was
+later removed is therefore mail no page reaches, no search matches, and no identifier resolves — the rows stay in the
+table and stop being readable the moment configuration stops naming their folder. An account whose configuration maps no
+folder at all reads as empty rather than as unrestricted, which is what "a folder MailFathom does not have" has to mean
+for it to mean anything.
 
-Freshness follows the same exclusion, so a withheld folder is absent from the entries a listing reports rather than
-present with a timestamp nothing may read behind it.
+The decision is made once, where the scope every read model is expressed in is resolved, and it narrows by the account
+and the alias **together** — one account's mapping never admits or withholds another account's folder of the same name.
+It deliberately takes no part in the cursor's fingerprint: a cursor stays valid across the change, and the pages after it
+simply stop admitting the folder, which is what an operator withholding it or removing its mapping meant.
+
+Freshness follows the same rule, so a folder a mapping withholds or does not name is absent from the entries a listing
+reports rather than present with a timestamp nothing may read behind it.
 [What a mapping decides beyond where the folder is](imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
-states the switch beside the other two and what an unmapped folder is instead.
+states the switch beside the other two, what an unmapped folder is instead, and how to empty one.
 
 ### The junk folder, withheld by default and reachable on request
 

--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -33,10 +33,12 @@ the boundary owns is the one thing a use case cannot: turning a caller's text in
 alias, and refusing text that names neither.
 
 Where a table below says a tool reads every folder of the accounts in scope, "every folder" means every folder the
-deployment lets tools read. A folder mapped with `VisibleToTools: false` is outside all four mailbox tools and is never
-mentioned by one — a request naming its alias comes back empty rather than refused, and an email of it reads as not
-found. The exclusion is applied once, where the scope a read is expressed in is resolved, so it holds for a tool added
-later without that tool doing anything;
+deployment lets tools read: a folder configuration maps and does not withhold. A folder mapped with
+`VisibleToTools: false` and a folder **no mapping names** are both outside all four mailbox tools and are never
+mentioned by one — a request naming such an alias comes back empty rather than refused, and an email of it reads as not
+found. The decision is made once, where the scope a read is expressed in is resolved, and what it carries is the list of
+folders that may be read, so it holds for a tool added later without that tool doing anything, and an account whose
+configuration maps no folder reads as empty;
 [folders withheld from tools](mailbox-queries.md#folders-withheld-from-tools) states what a caller sees and why nothing
 says the folder exists.
 
@@ -198,7 +200,7 @@ the deployment is refreshing its local copy at all.
 | `accountId` | The configured identifier. It is what every other result reports as `accountId`, and it is stable across a change of the display name |
 | `displayName` | The readable name the operator gave the account |
 | `synchronizationMode` | `polling` or `push`, stating what the operator asked to start the account's next pass |
-| `folders` | One entry per folder local state knows of, in the same shape `folderFreshness` takes elsewhere: the alias, when synchronization last committed progress for it, and whether it ever has |
+| `folders` | One entry per folder this deployment maps and lets tools read, in the same shape `folderFreshness` takes elsewhere: the alias, when synchronization last committed progress for it, and whether it ever has |
 
 **Either name may be used to select the account.** The identifier is matched exactly and the display name without regard
 to case, and configuration refuses a display name that another account's identifier or display name already carries, so
@@ -209,10 +211,15 @@ cursor issued for one stays valid for the other.
 folder against what the mail server advertises and how recent attempts went, which is an observation about a run rather
 than a property of the account.
 
-**An empty `folders` list is a statement.** It says synchronization has never reached the account, which means its mail
-may be absent entirely rather than merely out of date — a distinction an empty listing cannot make for itself.
-`synchronizationEnabled` answers the other half: `false` means the timestamps below it are as current as any answer will
-get, because nothing is advancing them.
+**An empty `folders` list is a statement.** It says synchronization has never reached a folder this account lets tools
+read — or that it lets them read none — which means its mail may be absent entirely rather than merely out of date, a
+distinction an empty listing cannot make for itself. `synchronizationEnabled` answers the other half: `false` means the
+timestamps below it are as current as any answer will get, because nothing is advancing them.
+
+**The list is the same set every other tool reads.** It is resolved through the one scope every mailbox read is
+expressed in, so a folder mapped with `VisibleToTools: false` and a folder no mapping names are both absent from it —
+naming a folder here is publishing that it exists, which is the whole of what this answer does. The account's junk
+folder is present, because withholding that one is about not returning its mail unasked and no mail is returned here.
 
 ### What it deliberately does not publish
 

--- a/docs/features/message-chunks.md
+++ b/docs/features/message-chunks.md
@@ -28,8 +28,12 @@ one, which is what keeps its content from reaching an embedding provider at all.
 unchanged — it is mirrored, listed, searched lexically, and read like any other. Passages cut before the switch was set
 stay where they are; nothing removes them, and the embedding backfill stops selecting the folder rather than sweeping
 for the vectors it now never produces.
+A message of a folder **no mapping names** is cut into nothing for a different reason: cutting is offered to the folders
+configuration maps and leaves embedded, so a folder outside that list is outside the offer rather than switched off
+inside it. Mail stored under an alias whose mapping was later removed therefore gains no further passages, and an
+account mapping no folder at all gains none anywhere.
 [What a mapping decides beyond where the folder is](imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
-states the switch beside the other two.
+states the switch beside the other two and what an unmapped folder is instead.
 
 A run that could not read a message's body at all — because the raw MIME was never stored, or because nothing could parse
 it — leaves the passages alone rather than removing them. A remote message is immutable, so a run that failed this time is

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -161,6 +161,15 @@ A folder entry names `Alias` (required — your stable name for the folder) and 
 server's own path) or `SpecialUse` (`Inbox`, `Archive`, `Drafts`, `Sent`, `Junk`, `Trash`, `All`, `Flagged`,
 `Important`). Configuring no folder synchronizes the inbox by role.
 
+**This list is what the deployment has.** A folder no entry names does not exist for any reader: nothing lists, searches,
+reads, or answers from it, no rule is evaluated against its mail, nothing cuts it into passages or embeds it, and no
+alias of it resolves as a rule's destination. That holds for mail an earlier configuration had already stored — removing
+an entry makes its rows unreachable and leaves them in the database, since removing a mapping is an edit rather than an
+act against stored mail, exactly as `Synchronize: false` is. Naming the folder again is what makes its mail readable
+again, and the folder resumes from the checkpoint it kept rather than mirroring afresh.
+[What a mapping decides beyond where the folder is](../features/imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
+states it beside the three switches.
+
 `SpecialUse` says what the folder is *for*, and where the folder is found is a separate question. Named alone it
 answers both: discovery resolves the folder the server advertises with that role. Named beside a `RemotePath`, the path
 is what finds the folder and the role is what the folder plays, which is how a server that advertises nothing still

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -91,6 +91,11 @@ Points worth knowing before you adapt it:
   nothing. One role belongs to one folder per account.
   [What a role says, beside how a folder is found](../features/imap-synchronization.md#what-a-role-says-beside-how-a-folder-is-found)
   states what naming a role buys you everywhere else.
+- **A folder left out of the list is a folder MailFathom does not have.** The list is not a filter over your mailbox; it
+  is the whole of what this deployment knows about. A folder no entry names is never mirrored, never listed, searched,
+  read, or answered from, never embedded, and never evaluated by a rule — and so is mail an earlier configuration had
+  already stored under an entry you later removed, which stays in the database and stops being reachable.
+  *Working out the list* below is how to arrive at one you meant.
 - **A mapped folder is mirrored, embedded, and readable by tools** unless you say otherwise. `Synchronize`,
   `GenerateEmbeddings`, and `VisibleToTools` each default to `true` on a folder entry, and switching one off is how a
   folder stays nameable while its mail stays out of the local copy, out of an embedding provider, or out of everything
@@ -124,6 +129,45 @@ Points worth knowing before you adapt it:
   neither — which is polled instead and says so in the log. Push **adds** to the schedule rather than replacing it — the
   account still runs on its `Interval`, and a notification only starts the next run sooner.
   [Push synchronization](../features/imap-synchronization.md#push-synchronization) records the whole model.
+
+### Working out the list
+
+Nothing discovers folders into that list for you, so writing it is a step of its own. From an empty configuration:
+
+1. **Look at what the server actually holds.** Any mail client you already use lists the account's folders, and the paths
+   it shows are the paths `RemotePath` takes — including their separator, which is `/` on some servers and `.` on
+   others. [Configuring a mailbox at your provider](mailbox-providers.md) names the folders the popular services create
+   and which of them carry a role, so a Gmail account is a different starting list from a Fastmail one.
+2. **Name by role whatever carries one.** `Inbox`, `Sent`, `Drafts`, `Junk`, `Trash`, `Archive`, `All`, `Flagged`, and
+   `Important` are the roles a server can advertise; a mapping that names one finds the folder whatever it is called and
+   keeps working when the localization or the path changes. Each role belongs to one folder per account.
+3. **Name the rest by path.** A project folder, a mailing-list folder, a folder a filter on the server files into —
+   none of these carries a role, so each takes a `RemotePath` and an alias of your own.
+4. **Create the folder that is not there yet.** A folder you want a rule to file into — an archive of your own, say —
+   does not have to be made in a mail client first: give the mapping its `RemotePath` and `CreateIfMissing: true`, and
+   MailFathom creates it on the first run that resolves the alias. It is the only thing MailFathom ever changes about
+   your mailbox's shape.
+5. **Leave out what you do not want mirrored.** Leaving a folder out is the way to keep its mail out of MailFathom
+   entirely, and it stays out until an entry names it.
+
+The account's `Folders` then grows from the two entries above into the list you meant, mixing the three kinds of entry:
+
+```json
+{
+  "Folders": [
+    { "Alias": "inbox", "SpecialUse": "Inbox" },
+    { "Alias": "sent", "SpecialUse": "Sent" },
+    { "Alias": "spam", "RemotePath": "INBOX.Spam", "SpecialUse": "Junk" },
+    { "Alias": "projects", "RemotePath": "INBOX.Work.Projects" },
+    { "Alias": "archive", "RemotePath": "INBOX.Archive", "SpecialUse": "Archive", "CreateIfMissing": true }
+  ]
+}
+```
+
+Once the service is running, `list_accounts` reports one entry per folder this deployment mapped and lets tools read,
+with when each last synchronized — so a mistyped path shows up as a folder missing from that answer rather than as one
+holding no mail. The log names an alias that resolved to nothing or to more than one folder, in both cases naming the
+remedy.
 
 The Compose deployment reads this from `config/10-mailfathom.json`; Kubernetes mounts it as a ConfigMap key; a native
 process names the file through [`ConfigurationSources`](../operations/configuration-sources.md).

--- a/docs/users/mailbox-providers.md
+++ b/docs/users/mailbox-providers.md
@@ -95,7 +95,8 @@ per provider here:
   service that advertises no role for a folder loses none of this — name the path and the role together, and everything
   that asks for `role:Junk` still reaches it.
   [Folder aliases and discovery](../features/imap-synchronization.md#folder-aliases-and-discovery) covers the matching,
-  and [what a role says](../features/imap-synchronization.md#what-a-role-says-beside-how-a-folder-is-found) the rest.
+  [what a role says](../features/imap-synchronization.md#what-a-role-says-beside-how-a-folder-is-found) the rest, and
+  [the folders, and what each service calls them](#the-folders-and-what-each-service-calls-them) what you are naming.
 - **Reading never marks mail read.** MailFathom does not set the remote `\Seen` flag while synchronizing, reconciling,
   fetching content, or answering a tool call — the sessions those run on hold no operation capable of writing a flag.
   If mail is turning up read at your service, it is another client or a rule at the service, not this one.
@@ -125,6 +126,43 @@ gives. Everything else takes the account block above with the address and the cr
 
 *Not documented as required* is the honest answer rather than a *no*: the service's own setup documentation names no
 switch, and this review made no connection that would establish one.
+
+## The folders, and what each service calls them
+
+**MailFathom mirrors the folders your configuration names and nothing else.** Nothing discovers a folder into that list,
+so a folder left out of it is a folder this deployment does not have — not one it holds and hides.
+[Getting started § working out the list](getting-started.md#working-out-the-list) is how to arrive at one; this table is
+the part of it that depends on where the mailbox lives.
+
+| Service | What its own folders are called | Roles the server advertises | Evidence |
+| --- | --- | --- | --- |
+| Gmail, personal and Workspace alike | `INBOX`, and the system labels under a `[Gmail]` prefix: `[Gmail]/All Mail`, `[Gmail]/Drafts`, `[Gmail]/Important`, `[Gmail]/Sent Mail`, `[Gmail]/Spam`, `[Gmail]/Starred`, `[Gmail]/Trash` | Documented: `\All`, `\Drafts`, `\Important`, `\Sent`, `\Junk`, `\Flagged`, `\Trash` | Documented, 2026-08-12 |
+| Outlook.com, Exchange Online, Microsoft 365 | Inbox, Drafts, Sent Items, Deleted Items, Junk Email, Archive | Not documented in the pages this review read | Documented, 2026-08-12 |
+| Yahoo Mail | Inbox, Draft, Sent, Archive, Spam, Trash | Not documented in the pages this review read | Documented, 2026-08-12 |
+| iCloud Mail | Inbox, VIP, Drafts, Sent, Archive, Trash (Bin in some regions), Junk | Not documented in the pages this review read | Documented, 2026-08-12 |
+| Proton Mail, through the bridge | All Mail, Inbox, Drafts, Sent, Starred, Archive, Spam, Trash, and each of your labels as a folder under `Labels` | Not documented in the pages this review read | Documented, 2026-08-12 |
+| Fastmail | Inbox, Archive, Drafts, Sent, Spam, Trash | Not documented in the pages this review read | Documented, 2026-08-12 |
+| Zoho Mail | Inbox, Drafts, Sent, Spam, Trash | Not documented in the pages this review read | Documented, 2026-08-12 |
+
+**A name in that middle column is what the service calls the folder, not necessarily the IMAP path.** A service may serve
+its folders under a prefix, translate them into the account's language, or rewrite a character its own interface allows —
+Gmail's prefix and Fastmail's replacement of `.` in a custom folder name are both documented behaviours. That is the
+argument for naming a folder by its role wherever it has one: `SpecialUse` finds the folder whatever path it is at, and
+the configuration survives a rename, a language change, and a move to another service.
+
+**"Not documented" is not "not advertised".** Only Google publishes which RFC 6154 attributes its server sends, so the
+other rows say what this review could establish rather than what the server does. Where a role matters and the service
+documents no attribute, name the folder's path and its role together — `{ "Alias": "spam", "RemotePath": "Junk Email",
+"SpecialUse": "Junk" }` — and everything that asks for `role:Junk` reaches it regardless of what the server advertised.
+A mapping whose role finds nothing reports the alias as unresolved in the log rather than failing the account.
+
+Sources: [Gmail IMAP extensions](https://developers.google.com/workspace/gmail/imap/imap-extensions),
+[Working with message folders in Outlook.com](https://support.microsoft.com/en-US/Outlook/working-with-message-folders-in-outlook-com),
+[Archive and un-archive messages in Yahoo Mail](https://help.yahoo.com/kb/SLN26466.html),
+[Organize email with folders in Mail on iCloud.com](https://support.apple.com/guide/icloud/mm6b1a6730/icloud),
+[Labels in Bridge](https://proton.me/support/labels-in-bridge),
+[Setting up and using folders](https://www.fastmail.help/hc/en-us/articles/1500000280301-Setting-up-and-using-folders),
+[Using folders](https://www.zoho.com/mail/help/using-folders.html).
 
 ## Gmail, on a personal account
 

--- a/docs/users/usage.md
+++ b/docs/users/usage.md
@@ -43,7 +43,8 @@ Nothing about how MailFathom reaches a mailbox is returned: no server, no port, 
 
 Returns a page of summaries, newest received first by default, filtered by any combination of account, folder, sender,
 recipient, subject fragment, received range, seen state, and attachment presence. Every argument is optional; a bare
-call reads every folder of every served account.
+call reads every folder every served account maps and lets tools read — configuration is what says which folders those
+are, and a folder it does not name is one this deployment does not have.
 
 A summary is enough to recognize a message — subject, sender, recipients, timestamps, size, attachment counts, remote
 flags — and carries `storedEmailId`, the identifier a content read uses. It names its account both ways, as `accountId`

--- a/src/Application/Accounts/MailAccountDirectoryReader.cs
+++ b/src/Application/Accounts/MailAccountDirectoryReader.cs
@@ -29,20 +29,25 @@ public sealed class MailAccountDirectoryReader
 {
     private readonly IMailAccountCatalog accountCatalog;
     private readonly ISynchronizationFreshnessReader freshnessReader;
+    private readonly MailboxScopeResolver scopeResolver;
 
     /// <summary>Initializes the use case.</summary>
     /// <param name="accountCatalog">Describes the accounts this deployment serves.</param>
     /// <param name="freshnessReader">Reads how current the local copy of each folder is.</param>
+    /// <param name="scopeResolver">Answers which folders of those accounts a tool may see.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public MailAccountDirectoryReader(
         IMailAccountCatalog accountCatalog,
-        ISynchronizationFreshnessReader freshnessReader)
+        ISynchronizationFreshnessReader freshnessReader,
+        MailboxScopeResolver scopeResolver)
     {
         ArgumentNullException.ThrowIfNull(accountCatalog);
         ArgumentNullException.ThrowIfNull(freshnessReader);
+        ArgumentNullException.ThrowIfNull(scopeResolver);
 
         this.accountCatalog = accountCatalog;
         this.freshnessReader = freshnessReader;
+        this.scopeResolver = scopeResolver;
     }
 
     /// <summary>Reads the served accounts and their synchronization freshness.</summary>
@@ -61,12 +66,12 @@ public sealed class MailAccountDirectoryReader
             return new MailAccountDirectory(this.accountCatalog.SynchronizationEnabled, []);
         }
 
-        // Scoped to the served accounts rather than read unscoped, for the reason every other read is: local state holds
-        // folders of accounts an operator has since removed, and an account this deployment no longer serves must not
-        // reappear in the one answer that lists them.
-        var scope = MailboxScope.Create(
-            servedAccounts.Select(static account => account.Id),
-            []);
+        // Resolved rather than built here, for the reason every other read is: local state holds folders of accounts an
+        // operator has since removed and folders no mapping names any more, and neither may reappear in the one answer
+        // that lists them. Naming a folder is publishing that it exists, which is the whole of what this answer does.
+        // Junk is included because it is a mapped folder whose freshness the operator asked to see; withholding it is
+        // about not returning its mail unasked, and no mail is returned here.
+        var scope = this.scopeResolver.ReadableScope([], [], JunkMailInclusion.Included);
 
         var folderFreshness = await this.freshnessReader.ReadAsync(scope, cancellationToken);
         var foldersByAccount = folderFreshness

--- a/src/Application/Emails/Mailboxes/MailboxScope.cs
+++ b/src/Application/Emails/Mailboxes/MailboxScope.cs
@@ -18,8 +18,9 @@ namespace MailFathom.Application.Emails.Mailboxes;
 /// </para>
 /// <para>
 /// A request that names no folder is restricted to none: an empty folder list means every folder of the accounts in
-/// scope. An account in scope that appears in no pair while others do is the opposite case — it maps no folder the
-/// request named, and contributes nothing.
+/// scope, which is every folder configuration admits rather than every folder the store holds rows for. An account in
+/// scope that appears in no pair while others do is the opposite case — it maps no folder the request named, and
+/// contributes nothing.
 /// </para>
 /// <para>
 /// Both lists are deduplicated and ordered when the scope is created, so two requests that name the same accounts in a
@@ -54,13 +55,13 @@ public sealed record MailboxScope
         this.SelectedFolders = selectedFolders;
     }
 
-    /// <summary>Gets the scope that restricts nothing, which is what a deployment serving no account resolves to.</summary>
+    /// <summary>Gets the scope that names no account, no folder, and nothing readable, which is what a deployment serving no account resolves to.</summary>
     /// <remarks>
     /// A read never runs against it in a deployment that serves accounts, because resolution replaces an unnamed account
-    /// list with the served ones before the scope is built. A use case handed it therefore answers with nothing rather
-    /// than reading the store unrestricted.
+    /// list with the served ones and names every readable folder before the scope is built. A use case handed it
+    /// answers with nothing, which is what a deployment holding no mapping has to mean: there is no folder to read.
     /// </remarks>
-    public static MailboxScope Unrestricted { get; } = new([], []);
+    public static MailboxScope NothingReadable { get; } = new([], []);
 
     /// <summary>Gets the accounts the query is restricted to, deduplicated and ordered, or empty when the request named none.</summary>
     public IReadOnlyList<MailAccountId> AccountIds { get; }
@@ -73,7 +74,7 @@ public sealed record MailboxScope
     /// because a role means a different folder on each account: <c>role:Junk</c> across two accounts is two pairs
     /// rather than two names either account might carry. Reading the aliases alone would admit a folder of the second
     /// account that happens to share the first account's junk alias and plays no role at all — the same mistake
-    /// <c>AccountScopedMailFolders</c> exists to prevent on the withholding side.
+    /// <c>AccountScopedMailFolders</c> exists to prevent on the admitting side.
     /// </para>
     /// <para>
     /// An account of <see cref="AccountIds" /> that appears in no pair while the list is non-empty contributes nothing,
@@ -83,45 +84,42 @@ public sealed record MailboxScope
     /// </remarks>
     public IReadOnlyList<MailFolderIdentity> SelectedFolders { get; }
 
-    /// <summary>Gets the folders no query built from this scope may return anything from, ordered, or empty when none is withheld.</summary>
+    /// <summary>Gets the only folders a query built from this scope may return anything from, ordered, or empty when none may.</summary>
     /// <remarks>
-    /// It is the opposite kind of value from the two above: those are what a caller asked for, this is what configuration
-    /// withholds whatever the caller asked for. A request that names a hidden folder explicitly is therefore answered
-    /// with nothing from it rather than refused, which is the same answer a folder that holds no matching mail gives — a
-    /// refusal would tell the caller the folder is there.
+    /// <para>
+    /// It is the opposite kind of value from the two above: those are what a caller asked for, this is what
+    /// configuration admits whatever the caller asked for. A request that names a folder outside it is therefore
+    /// answered with nothing from that folder rather than refused, which is the same answer a folder that holds no
+    /// matching mail gives — a refusal would tell the caller the folder is there.
+    /// </para>
+    /// <para>
+    /// Empty means no folder is readable, never that every folder is. A mapping is what makes MailFathom have a folder
+    /// at all, so a scope nothing narrowed is a scope over a deployment that maps nothing, and reading it as an open
+    /// mailbox would publish the rows of every folder an operator ever removed. <see cref="MailboxScopeResolver" />
+    /// is what fills it, and a scope built any other way reads nothing by construction rather than by convention.
+    /// </para>
     /// </remarks>
-    public IReadOnlyList<MailFolderIdentity> HiddenFolders { get; private init; } = [];
+    public IReadOnlyList<MailFolderIdentity> ReadableFolders { get; private init; } = [];
 
     /// <summary>Gets the junk folders this read returns nothing from, ordered, or empty when the caller asked for junk or no account maps one.</summary>
     /// <remarks>
-    /// Kept apart from <see cref="HiddenFolders" /> although both narrow the same query, because the two answer different
-    /// questions and only one of them can be overridden. A hidden folder is withheld from every tool by an operator's
-    /// decision and no caller may reach it; the junk folder is withheld by default and reached by a caller that asks.
-    /// Merging them would make the override able to reveal a folder the operator withheld.
+    /// Kept apart from <see cref="ReadableFolders" /> although both narrow the same query, because the two answer
+    /// different questions and only one of them can be overridden. A folder outside the readable set is withheld by an
+    /// operator's decision, or absent from configuration altogether, and no caller may reach it; the junk folder is
+    /// mapped, readable, and withheld by default, and a caller that asks reaches it. Merging them would make the
+    /// override able to reveal a folder the operator withheld.
     /// </remarks>
     public IReadOnlyList<MailFolderIdentity> WithheldJunkFolders { get; private init; } = [];
 
     /// <summary>Gets whether the caller asked for the junk folder's mail.</summary>
     /// <remarks>
-    /// Unlike the two withheld lists, this is the caller's own decision, so it takes part in a continuation cursor's
-    /// fingerprint: including junk adds rows in the middle of an ordering, which a walk resumed under the other answer
-    /// would either skip or repeat. The lists themselves stay out of the fingerprint for the reason
-    /// <see cref="Hiding" /> gives — they are configuration, and a reload must not invalidate an outstanding cursor.
+    /// Unlike the readable and the withheld lists, this is the caller's own decision, so it takes part in a continuation
+    /// cursor's fingerprint: including junk adds rows in the middle of an ordering, which a walk resumed under the other
+    /// answer would either skip or repeat. The lists themselves stay out of the fingerprint for the reason
+    /// <see cref="RestrictedTo" /> gives — they are configuration, and a reload must not invalidate an outstanding
+    /// cursor.
     /// </remarks>
     public bool IncludesJunkMail { get; private init; }
-
-    /// <summary>Gets every folder this read returns nothing from, whichever decision withheld it.</summary>
-    /// <remarks>
-    /// What a query needs is the union, because a predicate does not care why a folder is out. Both callers of it — the
-    /// stored-email predicate and the folder freshness read — take this rather than either list, so a folder cannot be
-    /// withheld from the mail and still named in the freshness beside it.
-    /// </remarks>
-    public IReadOnlyList<MailFolderIdentity> WithheldFolders =>
-    [
-        .. this.HiddenFolders
-            .Concat(this.WithheldJunkFolders)
-            .DistinctBy(static folder => (folder.AccountId.Value, folder.Alias.Value)),
-    ];
 
     /// <summary>Creates the scope a query runs with, from identities already resolved against configuration.</summary>
     /// <param name="accountIds">The accounts the query runs against, which are the served ones when a request named none.</param>
@@ -152,28 +150,28 @@ public sealed record MailboxScope
         ];
 
         return accounts.Length is 0 && folders.Length is 0
-            ? Unrestricted
+            ? NothingReadable
             : new MailboxScope(accounts, folders);
     }
 
-    /// <summary>Withholds the folders configuration says no tool may read from.</summary>
-    /// <param name="hiddenFolders">The folders to withhold, empty when none is.</param>
-    /// <returns>The same scope with the folders withheld, or this scope unchanged when none is.</returns>
+    /// <summary>Admits the folders configuration says a tool may read from, and nothing else.</summary>
+    /// <param name="readableFolders">The folders a tool may read, empty when none may.</param>
+    /// <returns>The same scope restricted to those folders, or this scope unchanged when none is readable.</returns>
     /// <remarks>
     /// Ordered and deduplicated so one configuration produces one predicate, whichever order the folders were read in.
     /// It deliberately does not take part in a continuation cursor's fingerprint, unlike the two requested lists: those
     /// are the caller's filters, and a walk resumed under different ones would return a page that does not follow the
-    /// previous one. Hiding a folder only removes rows from an unchanged ordering, so an outstanding cursor stays
-    /// consistent, and unhiding one adds rows the walk may already have passed — which is what a keyset walk over a
+    /// previous one. Withdrawing a folder only removes rows from an unchanged ordering, so an outstanding cursor stays
+    /// consistent, and admitting one adds rows the walk may already have passed — which is what a keyset walk over a
     /// live mailbox does about newly arrived mail anyway.
     /// </remarks>
-    internal MailboxScope Hiding(IReadOnlyList<MailFolderIdentity> hiddenFolders) => hiddenFolders.Count == 0
+    internal MailboxScope RestrictedTo(IReadOnlyList<MailFolderIdentity> readableFolders) => readableFolders.Count == 0
         ? this
         : this with
         {
-            HiddenFolders =
+            ReadableFolders =
             [
-                .. hiddenFolders
+                .. readableFolders
                     .DistinctBy(static folder => (folder.AccountId.Value, folder.Alias.Value))
                     .OrderBy(static folder => folder.AccountId.Value, StringComparer.Ordinal)
                     .ThenBy(static folder => folder.Alias.Value, StringComparer.Ordinal),

--- a/src/Application/Emails/Mailboxes/MailboxScopeResolver.cs
+++ b/src/Application/Emails/Mailboxes/MailboxScopeResolver.cs
@@ -24,7 +24,7 @@ public sealed class MailboxScopeResolver
 
     /// <summary>Initializes the resolver.</summary>
     /// <param name="accountCatalog">Answers which accounts this deployment serves.</param>
-    /// <param name="folderParticipation">Answers which folders no tool may read from.</param>
+    /// <param name="folderParticipation">Answers which folders a tool may read from.</param>
     /// <param name="junkFolders">Answers which folder each account advertises as its junk folder.</param>
     /// <param name="folderReferences">Turns the alias or the role a request named into the folder of an account it means.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
@@ -74,10 +74,13 @@ public sealed class MailboxScopeResolver
     /// requested ones, take part in a continuation cursor's fingerprint.
     /// </para>
     /// <para>
-    /// A folder an operator withheld from tools is withheld here, once, rather than by each read model — which is what
-    /// makes "no tool lists, searches, reads, or answers from it" a property of the system instead of a list of places
-    /// somebody has to keep complete. A tool that read the mailbox some other way would bypass it, which is why the two
-    /// reads that reach an email by its identifier ask the same configuration directly rather than building a scope.
+    /// The folders a tool may read are named here, once, rather than by each read model — which is what makes "no tool
+    /// lists, searches, reads, or answers from it" a property of the system instead of a list of places somebody has to
+    /// keep complete. It is stated as what is admitted rather than as what is withheld, because the store holds rows of
+    /// folders configuration no longer names and no list of withheld names reaches those: a folder nobody mapped is a
+    /// folder MailFathom does not have, and it stays out by not being admitted. A tool that read the mailbox some other
+    /// way would bypass this, which is why the two reads that reach an email by its identifier ask the same
+    /// configuration directly rather than building a scope.
     /// </para>
     /// <para>
     /// The junk folder is withheld here too, and it is a different kind of decision from the one above: an operator did
@@ -138,20 +141,22 @@ public sealed class MailboxScopeResolver
             this.ResolvedFolders(accountsInScope, folders));
 
         return resolvedScope
-            .Hiding(this.folderParticipation.FoldersHiddenFromTools)
+            .RestrictedTo(this.folderParticipation.FoldersVisibleToTools)
             .WithJunkMail(junkMail, this.junkFolders.JunkFolders);
     }
 
     /// <summary>Reports whether a tool may read one email, given the mailbox it was stored from.</summary>
     /// <param name="accountId">The account the email was read from.</param>
     /// <param name="folderAlias">The folder the email was read from.</param>
-    /// <returns><see langword="true" /> when the deployment serves that account and no configuration withholds that folder.</returns>
+    /// <returns><see langword="true" /> when the deployment serves that account and a mapping admits that folder to tools.</returns>
     /// <remarks>
     /// This is <see cref="ReadableScope" /> asked about one email instead of about a query, and it exists because two
     /// reads reach an email by its identifier and build no scope at all. Both questions are answered from the same two
     /// pieces of configuration here, so a folder an operator withheld cannot be readable through one entry point and
-    /// withheld through another. A caller that may not read the email is told it was not found rather than refused, for
-    /// the reason an account this deployment no longer serves is: a refusal would confirm the identifier exists.
+    /// withheld through another. It is a mapping being asked to admit the folder rather than a list being asked whether
+    /// it names it, so an email stored under an alias no mapping names is unreadable by the same answer that withholds a
+    /// mapped folder. A caller that may not read the email is told it was not found rather than refused, for the reason
+    /// an account this deployment no longer serves is: a refusal would confirm the identifier exists.
     /// </remarks>
     public bool IsReadableByTools(MailAccountId accountId, MailFolderAlias folderAlias) =>
         this.accountCatalog.ServedAccounts.Any(account => account.Id == accountId)

--- a/src/Application/Folders/IMailFolderParticipationReader.cs
+++ b/src/Application/Folders/IMailFolderParticipationReader.cs
@@ -16,37 +16,43 @@ namespace MailFathom.Application.Folders;
 /// than from the tools somebody remembered.
 /// </para>
 /// <para>
-/// The exclusion lists exist beside <see cref="GetParticipation" /> because a query cannot ask one folder at a time.
-/// A read narrows a table and needs the whole excluded set as a value it can put into a predicate, while a write path
-/// holds one email and asks about that email's folder; both answers come from the same configuration, so neither can
-/// drift from the other.
+/// The three lists exist beside <see cref="GetParticipation" /> because a query cannot ask one folder at a time. A read
+/// narrows a table and needs the whole admitted set as a value it can put into a predicate, while a write path holds
+/// one email and asks about that email's folder; both answers come from the same configuration, so neither can drift
+/// from the other.
+/// </para>
+/// <para>
+/// Every list names what is admitted rather than what is withheld, because a set of names cannot exclude a folder nobody
+/// named. Configuration enumerates the folders MailFathom has, so anything outside it is not a folder that was left in
+/// by an exclusion that failed to mention it — it is a folder this deployment does not have.
 /// </para>
 /// </remarks>
 public interface IMailFolderParticipationReader
 {
-    /// <summary>Gets the folders no MCP tool may list, search, read, or answer from.</summary>
-    IReadOnlyList<MailFolderIdentity> FoldersHiddenFromTools { get; }
-
-    /// <summary>Gets the folders whose content is never cut into passages and never reaches an embedding provider.</summary>
-    IReadOnlyList<MailFolderIdentity> FoldersWithoutEmbeddings { get; }
-
-    /// <summary>Gets the folders no run mirrors, whose stored mail is therefore kept and read by nothing.</summary>
+    /// <summary>Gets the folders whose mail this deployment mirrors, and no others.</summary>
     /// <remarks>
-    /// Switching a folder's synchronization off keeps what it had already stored, so the rows outlive the decision that
-    /// stopped refreshing them and every read has to leave them out by name. The other two lists already contain such a
-    /// folder, because <see cref="MailFolderParticipation.Create" /> derives both switches from an unmirrored one, and
-    /// neither says what this says: a read excluded for its own reason must not also be the way mail nobody mirrors
-    /// stays out of a walk that has nothing to do with tools or embeddings.
+    /// It is what a pass over stored mail runs against — rule evaluation today — rather than what a synchronization run
+    /// schedules, which reads the same decision one account at a time. Switching a folder's synchronization off keeps
+    /// what it had already stored, so such a walk meets rows nothing refreshes and rows of folders configuration no
+    /// longer names at all; admitting the mirrored folders is what leaves both out, and it is one list rather than two
+    /// because a walk asking which folders it may act on is asking one question.
     /// </remarks>
-    IReadOnlyList<MailFolderIdentity> FoldersNotMirrored { get; }
+    IReadOnlyList<MailFolderIdentity> FoldersSynchronized { get; }
+
+    /// <summary>Gets the folders an MCP tool may list, search, read, or answer from, and no others.</summary>
+    IReadOnlyList<MailFolderIdentity> FoldersVisibleToTools { get; }
+
+    /// <summary>Gets the folders whose content is cut into passages and embedded, and no others.</summary>
+    IReadOnlyList<MailFolderIdentity> FoldersGeneratingEmbeddings { get; }
 
     /// <summary>Gets what one folder takes part in.</summary>
     /// <param name="accountId">The account the folder belongs to.</param>
     /// <param name="folderAlias">MailFathom's own name for the folder.</param>
     /// <returns>
-    /// The configured participation, or <see cref="MailFolderParticipation.Full" /> when nothing maps that alias.
-    /// A folder configuration no longer names is stored mail nobody withdrew anything from, and treating it as withheld
-    /// would hide a mailbox because an operator removed a mapping.
+    /// The configured participation, or <see cref="MailFolderParticipation.Unmapped" /> when nothing maps that alias.
+    /// A folder configuration does not name is a folder MailFathom does not have, so what it stored earlier is inert
+    /// rather than readable: an operator who removes a mapping withdraws the folder, and one who wants its mail back
+    /// maps it again.
     /// </returns>
     MailFolderParticipation GetParticipation(MailAccountId accountId, MailFolderAlias folderAlias);
 }

--- a/src/Domain/Folders/MailFolderParticipation.cs
+++ b/src/Domain/Folders/MailFolderParticipation.cs
@@ -4,26 +4,38 @@
 
 namespace MailFathom.Domain.Folders;
 
-/// <summary>States how far into MailFathom one mapped folder is admitted.</summary>
+/// <summary>States how far into MailFathom one folder is admitted, starting with whether MailFathom has it at all.</summary>
 /// <remarks>
 /// <para>
 /// Mapping a folder and mirroring it are two decisions rather than one. A mapping makes the folder known: it is
 /// nameable by its alias, resolvable by the role its server advertises, and reachable as the destination of a change
-/// MailFathom is asked to make. What this adds is what happens to the mail inside it, which costs storage, a provider's
-/// tokens, and — for some folders — the discretion of never having an agent read them.
+/// MailFathom is asked to make. What the other three answers add is what happens to the mail inside it, which costs
+/// storage, a provider's tokens, and — for some folders — the discretion of never having an agent read them.
 /// </para>
 /// <para>
-/// The three answers are not independent, and the dependency runs one way: a folder nothing mirrors has no local
-/// content, so there is nothing to embed and nothing a tool could read whatever the other two say. This type derives
-/// that rather than trusting a caller with it, which is why every value is built through <see cref="Create" />.
+/// A folder no mapping names is not one of those decisions taken quietly: it is <see cref="Unmapped" />, which is a
+/// folder MailFathom does not have. That is why <see cref="IsMapped" /> is a state of its own rather than something a
+/// reader infers from the other three being off — <see cref="MappedOnly" /> answers those three identically and means
+/// something else entirely, and two values that compare equal could not tell an operator's decision to stop mirroring a
+/// folder apart from their decision to stop having it.
+/// </para>
+/// <para>
+/// The answers are not independent, and the dependency runs one way: a folder nothing mirrors has no local content, so
+/// there is nothing to embed and nothing a tool could read whatever the other two say. This type derives that rather
+/// than trusting a caller with it, which is why every mapped value is built through <see cref="Create" />.
 /// Configuration refuses the contradiction separately, so an operator who asked for embeddings on an unmirrored folder
 /// is told rather than quietly given the normalized answer.
 /// </para>
 /// </remarks>
 public sealed record MailFolderParticipation
 {
-    private MailFolderParticipation(bool isSynchronized, bool generatesEmbeddings, bool isVisibleToTools)
+    private MailFolderParticipation(
+        bool isMapped,
+        bool isSynchronized,
+        bool generatesEmbeddings,
+        bool isVisibleToTools)
     {
+        this.IsMapped = isMapped;
         this.IsSynchronized = isSynchronized;
         this.GeneratesEmbeddings = generatesEmbeddings;
         this.IsVisibleToTools = isVisibleToTools;
@@ -31,15 +43,37 @@ public sealed record MailFolderParticipation
 
     /// <summary>Gets the participation of a folder that takes part in everything, which is what a mapping means by default.</summary>
     public static MailFolderParticipation Full { get; } = new(
+        isMapped: true,
         isSynchronized: true,
         generatesEmbeddings: true,
         isVisibleToTools: true);
 
     /// <summary>Gets the participation of a folder MailFathom knows by name and mirrors nothing of.</summary>
     public static MailFolderParticipation MappedOnly { get; } = new(
+        isMapped: true,
         isSynchronized: false,
         generatesEmbeddings: false,
         isVisibleToTools: false);
+
+    /// <summary>Gets the participation of a folder no mapping names, which takes part in nothing because it does not exist here.</summary>
+    /// <remarks>
+    /// Mail stored under such an alias is inert rather than readable, and it is kept rather than erased for the reason
+    /// <see cref="MappedOnly" />'s is: nothing here takes local mail away because a configuration value changed. What
+    /// makes the mail readable again is mapping the folder again, which is the same resumption switching mirroring back
+    /// on is.
+    /// </remarks>
+    public static MailFolderParticipation Unmapped { get; } = new(
+        isMapped: false,
+        isSynchronized: false,
+        generatesEmbeddings: false,
+        isVisibleToTools: false);
+
+    /// <summary>Gets whether a mapping names the folder at all.</summary>
+    /// <remarks>
+    /// Nothing discovers folders into mappings, so this is an operator's statement rather than a reading of what the
+    /// server publishes. Off, every other answer here is off with it and no configuration can raise one of them.
+    /// </remarks>
+    public bool IsMapped { get; }
 
     /// <summary>Gets whether the folder's mail is mirrored locally.</summary>
     /// <remarks>
@@ -58,11 +92,16 @@ public sealed record MailFolderParticipation
     /// <remarks>Off, the folder is still mirrored, so anything operating on the mailbox rather than answering about it still reaches it.</remarks>
     public bool IsVisibleToTools { get; }
 
-    /// <summary>Builds the participation an operator's three answers describe.</summary>
+    /// <summary>Builds the participation an operator's three answers describe, for a folder their mapping names.</summary>
     /// <param name="isSynchronized">Whether the folder's mail is mirrored locally.</param>
     /// <param name="generatesEmbeddings">Whether the mirrored content is embedded.</param>
     /// <param name="isVisibleToTools">Whether MCP tools may read the folder.</param>
     /// <returns>The participation, with everything an unmirrored folder cannot take part in already withdrawn.</returns>
+    /// <remarks>
+    /// Every value this builds is mapped, because the three answers are what a mapping says and there is nowhere else
+    /// to write them. <see cref="Unmapped" /> is therefore reached by a folder having no mapping rather than by an
+    /// argument here.
+    /// </remarks>
     public static MailFolderParticipation Create(
         bool isSynchronized,
         bool generatesEmbeddings,
@@ -70,6 +109,10 @@ public sealed record MailFolderParticipation
         {
             (false, _, _) => MappedOnly,
             (true, true, true) => Full,
-            _ => new MailFolderParticipation(isSynchronized: true, generatesEmbeddings, isVisibleToTools),
+            _ => new MailFolderParticipation(
+                isMapped: true,
+                isSynchronized: true,
+                generatesEmbeddings,
+                isVisibleToTools),
         };
 }

--- a/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
+++ b/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
@@ -482,16 +482,16 @@ internal sealed class MailSynchronizationOptions
     ];
 
     /// <inheritdoc />
-    public IReadOnlyList<MailFolderIdentity> FoldersHiddenFromTools =>
-        [.. this.ConfiguredFolders().Where(static folder => !folder.Participation.IsVisibleToTools).Select(static folder => folder.Identity)];
+    public IReadOnlyList<MailFolderIdentity> FoldersSynchronized =>
+        [.. this.ConfiguredFolders().Where(static folder => folder.Participation.IsSynchronized).Select(static folder => folder.Identity)];
 
     /// <inheritdoc />
-    public IReadOnlyList<MailFolderIdentity> FoldersWithoutEmbeddings =>
-        [.. this.ConfiguredFolders().Where(static folder => !folder.Participation.GeneratesEmbeddings).Select(static folder => folder.Identity)];
+    public IReadOnlyList<MailFolderIdentity> FoldersVisibleToTools =>
+        [.. this.ConfiguredFolders().Where(static folder => folder.Participation.IsVisibleToTools).Select(static folder => folder.Identity)];
 
     /// <inheritdoc />
-    public IReadOnlyList<MailFolderIdentity> FoldersNotMirrored =>
-        [.. this.ConfiguredFolders().Where(static folder => !folder.Participation.IsSynchronized).Select(static folder => folder.Identity)];
+    public IReadOnlyList<MailFolderIdentity> FoldersGeneratingEmbeddings =>
+        [.. this.ConfiguredFolders().Where(static folder => folder.Participation.GeneratesEmbeddings).Select(static folder => folder.Identity)];
 
     /// <inheritdoc />
     /// <remarks>
@@ -525,7 +525,7 @@ internal sealed class MailSynchronizationOptions
         this.ConfiguredFolders()
             .FirstOrDefault(folder => folder.Identity.AccountId == accountId && folder.Identity.Alias == folderAlias)
             ?.Participation
-        ?? MailFolderParticipation.Full;
+        ?? MailFolderParticipation.Unmapped;
 
     /// <inheritdoc />
     public MailFolderMapping? FindFolderPlayingRole(MailAccountId accountId, MailFolderSpecialUse role) =>

--- a/src/Infrastructure/Persistence/Emails/AccountScopedMailFolders.cs
+++ b/src/Infrastructure/Persistence/Emails/AccountScopedMailFolders.cs
@@ -13,8 +13,13 @@ namespace MailFathom.Infrastructure.Persistence.Emails;
 /// A folder decision is made about an account and an alias together, and no column holds that pair, so the narrowing is
 /// written once here rather than at each query that needs it. One clause is composed per account the decision reaches —
 /// <c>account &lt;&gt; 'a' OR alias &lt;&gt; ALL(…)</c> to withhold, <c>account &lt;&gt; 'a' OR alias = ANY(…)</c> to
-/// select — which is bounded by how many accounts are configured and disappears entirely when the decision reaches
-/// none, so the common deployment pays nothing for it.
+/// select or to admit — which is bounded by how many accounts are configured.
+/// </para>
+/// <para>
+/// What an empty list means is the one thing that differs between the three, and it follows from what each list is. A
+/// withheld set that is empty withholds nothing and a selected set that is empty is a caller who named no folder, so
+/// both disappear and the query is unnarrowed; an admitted set that is empty admits nothing, because a folder is
+/// readable by being mapped rather than by not being mentioned.
 /// </para>
 /// <para>
 /// Narrowing by the alias alone would be the silent mistake this exists to prevent, and it fails differently on each
@@ -55,6 +60,53 @@ internal static class AccountScopedMailFolders
         {
             folders = folders.Where(folder =>
                 folder.MailboxAccountId != accountId || !aliases.Contains(folder.Alias));
+        }
+
+        return folders;
+    }
+
+    /// <summary>Narrows stored emails to the folders configuration admits, each within its own account.</summary>
+    /// <param name="emails">The emails to narrow.</param>
+    /// <param name="admitted">The folders a read may return mail from, empty when none may.</param>
+    /// <returns>The narrowed query, which PostgreSQL evaluates in full.</returns>
+    /// <remarks>
+    /// The same shape as <see cref="Selecting(IQueryable{StoredEmailEntity}, IReadOnlyList{MailFolderIdentity})" /> and
+    /// one difference that is the whole point of having two: an empty list admits nothing rather than everything. A
+    /// caller's folder filter is absent when they named no folder, and configuration's admission is empty when the
+    /// deployment maps no folder a tool may read — which has to mean no mail rather than all of it, since the store
+    /// holds rows of folders no mapping names any more.
+    /// </remarks>
+    internal static IQueryable<StoredEmailEntity> Admitting(
+        IQueryable<StoredEmailEntity> emails,
+        IReadOnlyList<MailFolderIdentity> admitted)
+    {
+        var admittedAccounts = AccountsOf(admitted);
+        emails = emails.Where(email => admittedAccounts.Contains(email.MailboxAccountId));
+
+        foreach (var (accountId, aliases) in AliasesByAccount(admitted))
+        {
+            emails = emails.Where(email =>
+                email.MailboxAccountId != accountId || aliases.Contains(email.MailFolder.Alias));
+        }
+
+        return emails;
+    }
+
+    /// <summary>Narrows folder bindings to the folders configuration admits, read the same way as above.</summary>
+    /// <param name="folders">The bindings to narrow.</param>
+    /// <param name="admitted">The folders a read may report on, empty when none may.</param>
+    /// <returns>The narrowed query, which PostgreSQL evaluates in full.</returns>
+    internal static IQueryable<MailFolderEntity> Admitting(
+        IQueryable<MailFolderEntity> folders,
+        IReadOnlyList<MailFolderIdentity> admitted)
+    {
+        var admittedAccounts = AccountsOf(admitted);
+        folders = folders.Where(folder => admittedAccounts.Contains(folder.MailboxAccountId));
+
+        foreach (var (accountId, aliases) in AliasesByAccount(admitted))
+        {
+            folders = folders.Where(folder =>
+                folder.MailboxAccountId != accountId || aliases.Contains(folder.Alias));
         }
 
         return folders;
@@ -118,15 +170,15 @@ internal static class AccountScopedMailFolders
         return folders;
     }
 
-    /// <summary>Reports whether the excluded set names one folder.</summary>
-    /// <param name="excluded">The excluded folders.</param>
+    /// <summary>Reports whether a set of folder decisions names one folder.</summary>
+    /// <param name="decided">The folders the decision reaches, whichever direction it runs in.</param>
     /// <param name="accountId">The account the folder belongs to.</param>
     /// <param name="folderAlias">MailFathom's own name for the folder.</param>
-    /// <returns><see langword="true" /> when the pair is excluded.</returns>
+    /// <returns><see langword="true" /> when the set names that pair.</returns>
     internal static bool Contains(
-        IReadOnlyList<MailFolderIdentity> excluded,
+        IReadOnlyList<MailFolderIdentity> decided,
         string accountId,
-        string folderAlias) => excluded.Any(folder =>
+        string folderAlias) => decided.Any(folder =>
             StringComparer.Ordinal.Equals(folder.AccountId.Value, accountId)
             && StringComparer.Ordinal.Equals(folder.Alias.Value, folderAlias));
 

--- a/src/Infrastructure/Persistence/Emails/EmailChunkWriter.cs
+++ b/src/Infrastructure/Persistence/Emails/EmailChunkWriter.cs
@@ -113,20 +113,22 @@ internal sealed class EmailChunkWriter(
 
     /// <summary>Reports whether the folder this message was read from is one an operator asked to have embedded.</summary>
     /// <remarks>
-    /// The excluded set is read first so a deployment that excludes nothing — which is every deployment that has not
-    /// configured a folder otherwise — pays neither a lookup nor a query. Where something is excluded, the binding is
-    /// read from the message's own row: the live path arrives with it loaded, and both backfills reach a message through
-    /// its primary key alone, so the alias has to be fetched rather than assumed present.
+    /// The question is which folders a mapping admits rather than which ones it withheld, so a message stored under an
+    /// alias configuration does not name is not embedded — the answer an exclusion could never give, since no list of
+    /// names carries a folder nobody named. That is also why the alias is always resolved rather than skipped where a
+    /// deployment withholds nothing: there is no longer a set whose emptiness means everything. The binding is read from
+    /// the message's own row, since the live path arrives with it loaded while both backfills reach a message through
+    /// its primary key alone.
     /// </remarks>
     private async Task<bool> FolderGeneratesEmbeddingsAsync(
         MailFathomDbContext dbContext,
         StoredEmailEntity storedEmail,
         CancellationToken cancellationToken)
     {
-        var excluded = folderParticipation.FoldersWithoutEmbeddings;
-        if (excluded.Count == 0)
+        var admitted = folderParticipation.FoldersGeneratingEmbeddings;
+        if (admitted.Count == 0)
         {
-            return true;
+            return false;
         }
 
         var folderAlias = storedEmail.MailFolder is { } loadedFolder
@@ -136,7 +138,7 @@ internal sealed class EmailChunkWriter(
                 .Select(folder => folder.Alias)
                 .SingleAsync(cancellationToken);
 
-        return !AccountScopedMailFolders.Contains(excluded, storedEmail.MailboxAccountId, folderAlias);
+        return AccountScopedMailFolders.Contains(admitted, storedEmail.MailboxAccountId, folderAlias);
     }
 
     private static EmailChunkEntity[] FindStaged(MailFathomDbContext dbContext, Guid storedEmailId) =>

--- a/src/Infrastructure/Persistence/Emails/StoredEmailSelectionPredicate.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailSelectionPredicate.cs
@@ -61,11 +61,12 @@ internal static class StoredEmailSelectionPredicate
 
         emails = AccountScopedMailFolders.Selecting(emails, selection.Scope.SelectedFolders);
 
-        // Withheld after the requested narrowing rather than before it, because the two are different statements: the
-        // filters above are what the caller asked for, and this is what the scope withholds whatever they asked for.
-        // Which folders those are was settled before the selection was built — an operator's hidden folders, which no
-        // caller can turn off, together with the junk folder unless the caller asked for it — so nothing here decides it.
-        emails = AccountScopedMailFolders.Excluding(emails, selection.Scope.WithheldFolders);
+        // Applied after the requested narrowing rather than before it, because the two are different statements: the
+        // filters above are what the caller asked for, and these are what the scope admits and withholds whatever they
+        // asked for. Both were settled before the selection was built — the folders a mapping admits to tools, which no
+        // caller can widen, and the junk folder unless the caller asked for it — so nothing here decides either.
+        emails = AccountScopedMailFolders.Admitting(emails, selection.Scope.ReadableFolders);
+        emails = AccountScopedMailFolders.Excluding(emails, selection.Scope.WithheldJunkFolders);
 
         if (selection.SenderNormalizedAddress is { } senderAddress)
         {

--- a/src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs
+++ b/src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs
@@ -162,12 +162,14 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
     /// bill with no reader.
     /// </remarks>
     /// <remarks>
-    /// A folder configured not to embed is left out here as well as where its passages would have been cut, and the two
-    /// answer different halves of one decision. The cut is what stops the passages existing; this is what stops the walk
-    /// finding those messages outstanding on every sweep for the rest of the deployment's life, since a message with a
-    /// body and no passages is exactly what the second group selects.
+    /// The walk is scoped to the folders a mapping admits to embedding, which is the same decision that stops their
+    /// passages being cut and the same shape that decision takes everywhere: a folder configuration does not name at
+    /// all is outside the walk rather than left in it by an exclusion that could not mention it. Both halves are needed.
+    /// The cut is what stops the passages existing; this is what stops the walk finding those messages outstanding on
+    /// every sweep for the rest of the deployment's life, since a message with a body and no passages is exactly what
+    /// the second group selects.
     /// </remarks>
-    private IQueryable<StoredEmailEntity> EmailsAwaitingEmbedding(Guid profileId) => AccountScopedMailFolders.Excluding(
+    private IQueryable<StoredEmailEntity> EmailsAwaitingEmbedding(Guid profileId) => AccountScopedMailFolders.Admitting(
         dbContext.StoredEmails
             .AsNoTracking()
             .Where(StoredEmailTombstone.IsNotTombstoned)
@@ -176,7 +178,7 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
                 || (!email.Chunks.Any()
                     && email.SearchDocument != null
                     && email.SearchDocument.BodyText != null)),
-        folderParticipation.FoldersWithoutEmbeddings);
+        folderParticipation.FoldersGeneratingEmbeddings);
 
     /// <summary>Rebuilds the extraction the chunker reads from the two readings the search document stored.</summary>
     /// <remarks>

--- a/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
+++ b/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
@@ -27,10 +27,11 @@ namespace MailFathom.Infrastructure.Persistence.Rules;
 /// of a content read.
 /// </para>
 /// <para>
-/// Both walks also leave out the folders no run mirrors, and it is the walk rather than the pass that leaves them out.
-/// Such a folder keeps the mail it stored before its synchronization was switched off, so the rows are there to be
-/// read; dropping them after the batch came back would leave every one of them at the head of the arrival queue
-/// forever, since what takes an email out of that queue is a pass having evaluated it.
+/// Both walks also admit the folders a mapping mirrors and no others, and it is the walk rather than the pass that
+/// narrows. A folder whose synchronization was switched off keeps the mail it had stored, and a folder whose mapping
+/// was removed keeps it too, so the rows are there to be read; dropping them after the batch came back would leave
+/// every one of them at the head of the arrival queue forever, since what takes an email out of that queue is a pass
+/// having evaluated it.
 /// </para>
 /// </remarks>
 [RequiresIntegrationCoverage]
@@ -137,8 +138,14 @@ internal sealed class MailRuleEvaluationStore(
         var mailboxAccountId = accountId.Value;
         var resumeAfterId = resumeAfter?.Value;
 
+        // Scoped to the folders a mapping mirrors, which withdraws two kinds of row at once from a pass that walks
+        // stored mail rather than a request's scope: mail of a folder whose synchronization was switched off, which is
+        // retained and refreshed by nothing, and mail of a folder configuration no longer names at all. Only an
+        // admission reaches the second — no list of withheld names carries a folder nobody named — and a rule acting on
+        // either would move or flag mail nothing here is still reading.
         var candidates = await AccountScopedMailFolders
-            .Excluding(emails.AsNoTracking(), folderParticipation.FoldersNotMirrored)
+            .Admitting(emails, folderParticipation.FoldersSynchronized)
+            .AsNoTracking()
             .Where(StoredEmailTombstone.IsNotTombstoned)
             .Where(email => email.MailboxAccountId == mailboxAccountId
                 && (resumeAfterId == null || email.Id > resumeAfterId))

--- a/src/Infrastructure/Persistence/Synchronization/SynchronizationFreshnessReader.cs
+++ b/src/Infrastructure/Persistence/Synchronization/SynchronizationFreshnessReader.cs
@@ -77,7 +77,10 @@ internal sealed class SynchronizationFreshnessReader(MailFathomDbContext dbConte
 
         // A folder this read returns nothing from is withheld from how fresh it is as well. The timestamp says a folder
         // exists and when it was last read, which is exactly what a caller must not learn about a folder they may not
-        // read — and what would name the junk folder to a caller who did not ask for it.
-        return AccountScopedMailFolders.Excluding(folders, scope.WithheldFolders);
+        // read — and what would name the junk folder to a caller who did not ask for it, or a folder no mapping names
+        // to a caller whose deployment no longer has it.
+        folders = AccountScopedMailFolders.Admitting(folders, scope.ReadableFolders);
+
+        return AccountScopedMailFolders.Excluding(folders, scope.WithheldJunkFolders);
     }
 }

--- a/tests/Application.UnitTests/Accounts/MailAccountDirectoryReaderTests.cs
+++ b/tests/Application.UnitTests/Accounts/MailAccountDirectoryReaderTests.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Synchronization;
+using MailFathom.TestSupport;
 using NSubstitute;
 using Xunit;
 
@@ -145,7 +146,14 @@ public sealed class MailAccountDirectoryReaderTests
         catalog.SynchronizationEnabled.Returns(synchronizationEnabled);
         catalog.ServedAccounts.Returns([.. servedAccounts]);
 
-        return new MailAccountDirectoryReader(catalog, freshnessReader);
+        return new MailAccountDirectoryReader(
+            catalog,
+            freshnessReader,
+            new MailboxScopeResolver(
+                catalog,
+                StubMailFolderParticipation.Nothing,
+                StubJunkMailFolderCatalog.None,
+                StubMailFolderMappings.ResolvingNothing));
     }
 
     /// <summary>Answers the folders local state knows of, in an order the reader is expected to correct.</summary>

--- a/tests/Application.UnitTests/Emails/DownloadAttachment/EmailAttachmentDownloadReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/DownloadAttachment/EmailAttachmentDownloadReaderTests.cs
@@ -135,8 +135,30 @@ public sealed class EmailAttachmentDownloadReaderTests
         var summary = SyntheticEmailSummaries.Create();
         var reader = ReaderOver(
             summary,
-            folderParticipation: StubMailFolderParticipation.Hiding(
-                new MailFolderIdentity(summary.AccountId, summary.FolderAlias)));
+            folderParticipation: StubMailFolderParticipation
+                .Mapping(new MailFolderIdentity(summary.AccountId, summary.FolderAlias))
+                .Hiding(new MailFolderIdentity(summary.AccountId, summary.FolderAlias)));
+
+        // Act
+        await using var attachment = await reader.OpenAsync(
+            new AttachmentDownloadTicket(summary.StoredEmailId, AttachmentPosition: 0),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(attachment);
+    }
+
+    /// <summary>
+    /// A mapping an operator removed withdraws the folder, so a capability minted while it was mapped opens nothing
+    /// afterwards. It is refused exactly as a withheld folder is, because the deployment no longer has the folder at
+    /// all.
+    /// </summary>
+    [Fact]
+    public async Task OpenAsync_EmailOfAFolderNoMappingNames_Refuses()
+    {
+        // Arrange
+        var summary = SyntheticEmailSummaries.Create();
+        var reader = ReaderOver(summary, folderParticipation: StubMailFolderParticipation.Nothing);
 
         // Act
         await using var attachment = await reader.OpenAsync(
@@ -243,9 +265,18 @@ public sealed class EmailAttachmentDownloadReaderTests
         repairRequestStore ?? new RecordingEmailContentRepairRequestStore(),
         new MailboxScopeResolver(
             accountCatalog ?? CatalogServing(MailAccountId.Create(summary?.AccountId.Value ?? ServedAccountId)),
-            folderParticipation ?? StubMailFolderParticipation.Everything,
+            folderParticipation ?? MappingFolderOf(summary),
             StubJunkMailFolderCatalog.None,
             StubMailFolderMappings.ResolvingNothing));
+
+    /// <summary>Maps the folder this email was stored from, which is what a deployment holding it has configured.</summary>
+    /// <remarks>
+    /// A folder no mapping names does not exist as far as MailFathom is concerned, so a reader arranged without one
+    /// refuses every download. Stating the mapping is therefore part of arranging stored mail at all.
+    /// </remarks>
+    private static StubMailFolderParticipation MappingFolderOf(EmailSummary? summary) => summary is null
+        ? StubMailFolderParticipation.Nothing
+        : StubMailFolderParticipation.Mapping(new MailFolderIdentity(summary.AccountId, summary.FolderAlias));
 
     private static IStoredEmailSummaryReader SummaryReaderReturning(EmailSummary? summary)
     {

--- a/tests/Application.UnitTests/Emails/GetEmailContent/EmailContentReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/GetEmailContent/EmailContentReaderTests.cs
@@ -692,8 +692,33 @@ public sealed class EmailContentReaderTests
         var reader = ReaderOver(
             summary,
             RendererReturning(RenderingOf()),
-            folderParticipation: StubMailFolderParticipation.Hiding(
-                new MailFolderIdentity(summary.AccountId, summary.FolderAlias)));
+            folderParticipation: StubMailFolderParticipation
+                .Mapping(new MailFolderIdentity(summary.AccountId, summary.FolderAlias))
+                .Hiding(new MailFolderIdentity(summary.AccountId, summary.FolderAlias)));
+
+        // Act
+        var result = await reader.ReadContentAsync(
+            RequestFor([summary.StoredEmailId]),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var failure = FailureOf(Assert.Single(result.Emails));
+        Assert.Equal(MailFathomErrorCode.StoredEmailNotFound, failure.ErrorCode);
+    }
+
+    /// <summary>
+    /// Stored mail under an alias no mapping names is a folder this deployment does not have, so it is answered exactly
+    /// as mail that is not there — which is what stops a removed mapping from leaving a mailbox readable and unrefreshed.
+    /// </summary>
+    [Fact]
+    public async Task ReadContentAsync_EmailOfAFolderNoMappingNames_IsReportedAsNotFound()
+    {
+        // Arrange
+        var summary = SyntheticEmailSummaries.Create();
+        var reader = ReaderOver(
+            summary,
+            RendererReturning(RenderingOf()),
+            folderParticipation: StubMailFolderParticipation.Nothing);
 
         // Act
         var result = await reader.ReadContentAsync(
@@ -980,7 +1005,7 @@ public sealed class EmailContentReaderTests
         repairRequestStore ?? new RecordingEmailContentRepairRequestStore(),
         new MailboxScopeResolver(
             accountCatalog ?? CatalogServing(MailAccountId.Create(summary?.AccountId.Value ?? SyntheticEmailSummaries.DefaultAccountId)),
-            folderParticipation ?? StubMailFolderParticipation.Everything,
+            folderParticipation ?? MappingFoldersOf(summary is null ? [] : [summary]),
             StubJunkMailFolderCatalog.None,
             StubMailFolderMappings.ResolvingNothing),
         linkIssuer ?? new RecordingAttachmentDownloadLinkIssuer(),
@@ -1000,11 +1025,21 @@ public sealed class EmailContentReaderTests
         repairRequestStore ?? new RecordingEmailContentRepairRequestStore(),
         new MailboxScopeResolver(
             accountCatalog ?? CatalogServing(MailAccountId.Create(SyntheticEmailSummaries.DefaultAccountId)),
-            StubMailFolderParticipation.Everything,
+            MappingFoldersOf(summaries),
             StubJunkMailFolderCatalog.None,
             StubMailFolderMappings.ResolvingNothing),
         linkIssuer ?? new RecordingAttachmentDownloadLinkIssuer(),
         readOptions ?? new EmailContentReadOptions());
+
+    /// <summary>Maps the folders these emails were stored from, which is what a deployment holding them has configured.</summary>
+    /// <remarks>
+    /// A folder no mapping names does not exist as far as MailFathom is concerned, so a reader arranged without one
+    /// answers every read with nothing. Stating the mapping is therefore part of arranging stored mail at all, rather
+    /// than something only a test about folder participation does.
+    /// </remarks>
+    private static StubMailFolderParticipation MappingFoldersOf(IReadOnlyList<EmailSummary> summaries) =>
+        StubMailFolderParticipation.Mapping(
+            [.. summaries.Select(summary => new MailFolderIdentity(summary.AccountId, summary.FolderAlias))]);
 
     private static IStoredEmailSummaryReader SummaryReaderReturning(EmailSummary? summary)
     {

--- a/tests/Application.UnitTests/Emails/ListEmails/MailboxTimelineReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/ListEmails/MailboxTimelineReaderTests.cs
@@ -806,7 +806,7 @@ public sealed class MailboxTimelineReaderTests
         freshnessReader ?? FreshnessReaderReturning(InboxFreshness),
         new MailboxScopeResolver(
             accountCatalog ?? CatalogServing(EveryAccountTheSyntheticTimelineUses),
-            StubMailFolderParticipation.Everything,
+            StubMailFolderParticipation.Nothing,
             StubJunkMailFolderCatalog.None,
             StubMailFolderMappings.ResolvingNothing),
         egressGuard ?? SensitiveContentEgressGuards.Inactive());

--- a/tests/Application.UnitTests/Emails/Mailboxes/EmailTimelineFilterTests.cs
+++ b/tests/Application.UnitTests/Emails/Mailboxes/EmailTimelineFilterTests.cs
@@ -151,7 +151,7 @@ public sealed class EmailTimelineFilterTests
         bool? isRemotelySeen = null,
         bool? hasAttachments = null,
         EmailTimelineDirection direction = EmailTimelineDirection.NewestFirst) => EmailTimelineFilter.Create(
-        scope ?? MailboxScope.Unrestricted,
+        scope ?? MailboxScope.NothingReadable,
         senderAddress,
         recipientAddress,
         subjectFragment,

--- a/tests/Application.UnitTests/Emails/Mailboxes/MailboxEmailSelectionTests.cs
+++ b/tests/Application.UnitTests/Emails/Mailboxes/MailboxEmailSelectionTests.cs
@@ -249,7 +249,7 @@ public sealed class MailboxEmailSelectionTests
 
         return new MailboxScopeResolver(
             catalog,
-            StubMailFolderParticipation.Everything,
+            StubMailFolderParticipation.Nothing,
             junkFolders ?? StubJunkMailFolderCatalog.Naming(
                 new MailFolderIdentity(Account, MailFolderAlias.Create("JUNK"))),
             StubMailFolderMappings.ResolvingNothing);
@@ -264,7 +264,7 @@ public sealed class MailboxEmailSelectionTests
         DateTimeOffset? receivedBefore = null,
         bool? isRemotelySeen = null,
         bool? hasAttachments = null) => MailboxEmailSelection.Create(
-        scope ?? MailboxScope.Unrestricted,
+        scope ?? MailboxScope.NothingReadable,
         senderAddress,
         recipientAddress,
         subjectFragment,

--- a/tests/Application.UnitTests/Emails/Mailboxes/MailboxScopeResolverTests.cs
+++ b/tests/Application.UnitTests/Emails/Mailboxes/MailboxScopeResolverTests.cs
@@ -159,11 +159,15 @@ public sealed class MailboxScopeResolverTests
 
     /// <summary>A withheld folder reaches every read model through the scope, which is what makes one decision cover four tools.</summary>
     [Fact]
-    public void ReadableScope_AFolderWithheldFromTools_CarriesItAsHiddenWhateverTheRequestNamed()
+    public void ReadableScope_AFolderWithheldFromTools_LeavesItOutOfTheReadableFoldersWhateverTheRequestNamed()
     {
         // Arrange
         var privateFolder = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("PRIVATE"));
-        var resolver = ResolverServing(StubMailFolderParticipation.Hiding(privateFolder), Work, Private);
+        var inbox = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("INBOX"));
+        var resolver = ResolverServing(
+            StubMailFolderParticipation.Mapping(inbox, privateFolder).Hiding(privateFolder),
+            Work,
+            Private);
 
         // Act
         var scope = resolver.ReadableScope(
@@ -172,31 +176,52 @@ public sealed class MailboxScopeResolverTests
             JunkMailInclusion.Excluded);
 
         // Assert
-        Assert.Equal([privateFolder], scope.HiddenFolders);
+        Assert.Equal([inbox], scope.ReadableFolders);
         Assert.Contains(privateFolder, scope.SelectedFolders);
     }
 
-    /// <summary>Configuration that withholds nothing leaves the scope exactly as it was, so nothing pays for a switch it never set.</summary>
+    /// <summary>A folder no mapping names is not a folder this deployment has, so nothing admits it and no read reaches its stored mail.</summary>
     [Fact]
-    public void ReadableScope_NothingWithheld_CarriesNoHiddenFolder()
+    public void ReadableScope_AnAliasNoMappingNames_IsNotAmongTheReadableFolders()
     {
         // Arrange
-        var resolver = ResolverServing(Work);
+        var inbox = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("INBOX"));
+        var removed = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("ARCHIVE"));
+        var resolver = ResolverServing(StubMailFolderParticipation.Mapping(inbox), Work);
+
+        // Act
+        var scope = resolver.ReadableScope(
+            [],
+            [MailFolderReference.ToAlias(MailFolderAlias.Create("ARCHIVE"))],
+            JunkMailInclusion.Excluded);
+
+        // Assert
+        Assert.Equal([inbox], scope.ReadableFolders);
+        Assert.DoesNotContain(removed, scope.ReadableFolders);
+        Assert.Contains(removed, scope.SelectedFolders);
+    }
+
+    /// <summary>A deployment whose configuration maps nothing has no folder to read, which is the opposite of reading every folder.</summary>
+    [Fact]
+    public void ReadableScope_ConfigurationMappingNoFolder_ReadsNoFolderAtAll()
+    {
+        // Arrange
+        var resolver = ResolverServing(StubMailFolderParticipation.Nothing, Work);
 
         // Act
         var scope = resolver.ReadableScope([], [], JunkMailInclusion.Excluded);
 
         // Assert
-        Assert.Empty(scope.HiddenFolders);
+        Assert.Empty(scope.ReadableFolders);
     }
 
-    /// <summary>Two readings of one configuration must produce one predicate, so the hidden folders are ordered rather than left as read.</summary>
+    /// <summary>Two readings of one configuration must produce one predicate, so the readable folders are ordered rather than left as read.</summary>
     [Fact]
-    public void ReadableScope_SeveralFoldersWithheld_OrdersThemByAccountAndAlias()
+    public void ReadableScope_SeveralFoldersAdmitted_OrdersThemByAccountAndAlias()
     {
         // Arrange
         var resolver = ResolverServing(
-            StubMailFolderParticipation.Hiding(
+            StubMailFolderParticipation.Mapping(
                 new MailFolderIdentity(Private.Id, MailFolderAlias.Create("PRIVATE")),
                 new MailFolderIdentity(Work.Id, MailFolderAlias.Create("SPAM")),
                 new MailFolderIdentity(Work.Id, MailFolderAlias.Create("DRAFTS"))),
@@ -213,7 +238,7 @@ public sealed class MailboxScopeResolverTests
                 new MailFolderIdentity(Work.Id, MailFolderAlias.Create("SPAM")),
                 new MailFolderIdentity(Private.Id, MailFolderAlias.Create("PRIVATE")),
             ],
-            scope.HiddenFolders);
+            scope.ReadableFolders);
     }
 
     /// <summary>The reads that reach an email by its identifier ask the same question, so a withheld folder is unreadable through them too.</summary>
@@ -221,12 +246,28 @@ public sealed class MailboxScopeResolverTests
     public void IsReadableByTools_AFolderWithheldFromTools_IsNotReadable()
     {
         // Arrange
+        var inbox = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("INBOX"));
+        var privateFolder = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("PRIVATE"));
         var resolver = ResolverServing(
-            StubMailFolderParticipation.Hiding(new MailFolderIdentity(Work.Id, MailFolderAlias.Create("PRIVATE"))),
+            StubMailFolderParticipation.Mapping(inbox, privateFolder).Hiding(privateFolder),
             Work);
 
         // Act, Assert
         Assert.False(resolver.IsReadableByTools(Work.Id, MailFolderAlias.Create("PRIVATE")));
+        Assert.True(resolver.IsReadableByTools(Work.Id, MailFolderAlias.Create("INBOX")));
+    }
+
+    /// <summary>Stored mail under an alias no mapping names is unreachable through the two reads that name an email by its identifier.</summary>
+    [Fact]
+    public void IsReadableByTools_AnAliasNoMappingNames_IsNotReadable()
+    {
+        // Arrange
+        var resolver = ResolverServing(
+            StubMailFolderParticipation.Mapping(new MailFolderIdentity(Work.Id, MailFolderAlias.Create("INBOX"))),
+            Work);
+
+        // Act, Assert
+        Assert.False(resolver.IsReadableByTools(Work.Id, MailFolderAlias.Create("ARCHIVE")));
         Assert.True(resolver.IsReadableByTools(Work.Id, MailFolderAlias.Create("INBOX")));
     }
 
@@ -254,7 +295,6 @@ public sealed class MailboxScopeResolverTests
 
         // Assert
         Assert.Equal([junkFolder], scope.WithheldJunkFolders);
-        Assert.Equal([junkFolder], scope.WithheldFolders);
         Assert.False(scope.IncludesJunkMail);
     }
 
@@ -272,18 +312,17 @@ public sealed class MailboxScopeResolverTests
 
         // Assert
         Assert.Empty(scope.WithheldJunkFolders);
-        Assert.Empty(scope.WithheldFolders);
         Assert.True(scope.IncludesJunkMail);
     }
 
     /// <summary>The caller's answer may add mail back, never a folder the operator withheld from every tool.</summary>
     [Fact]
-    public void ReadableScope_AJunkFolderAlsoWithheldFromTools_StaysWithheldWhenTheCallerAsksForJunk()
+    public void ReadableScope_AJunkFolderAlsoWithheldFromTools_StaysUnreadableWhenTheCallerAsksForJunk()
     {
         // Arrange
         var junkFolder = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("JUNK"));
         var resolver = ResolverServing(
-            StubMailFolderParticipation.Hiding(junkFolder),
+            StubMailFolderParticipation.Mapping(junkFolder).Hiding(junkFolder),
             StubJunkMailFolderCatalog.Naming(junkFolder),
             Work);
 
@@ -291,19 +330,20 @@ public sealed class MailboxScopeResolverTests
         var scope = resolver.ReadableScope([], [], JunkMailInclusion.Included);
 
         // Assert
-        Assert.Equal([junkFolder], scope.WithheldFolders);
+        Assert.DoesNotContain(junkFolder, scope.ReadableFolders);
         Assert.True(scope.IncludesJunkMail);
     }
 
-    /// <summary>A predicate does not care why a folder is out, so what a read consumes is the union of both decisions.</summary>
+    /// <summary>The two decisions narrow one query from opposite directions, and a read has to apply both.</summary>
     [Fact]
-    public void ReadableScope_AHiddenFolderBesideAJunkFolder_WithholdsBothAsOneList()
+    public void ReadableScope_AWithheldFolderBesideAJunkFolder_AdmitsNeitherThroughTheOthersDecision()
     {
         // Arrange
+        var inbox = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("INBOX"));
         var privateFolder = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("PRIVATE"));
         var junkFolder = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("JUNK"));
         var resolver = ResolverServing(
-            StubMailFolderParticipation.Hiding(privateFolder),
+            StubMailFolderParticipation.Mapping(inbox, privateFolder, junkFolder).Hiding(privateFolder),
             StubJunkMailFolderCatalog.Naming(junkFolder),
             Work);
 
@@ -311,29 +351,8 @@ public sealed class MailboxScopeResolverTests
         var scope = resolver.ReadableScope([], [], JunkMailInclusion.Excluded);
 
         // Assert
-        Assert.Equal([privateFolder], scope.HiddenFolders);
+        Assert.Equal([inbox, junkFolder], scope.ReadableFolders);
         Assert.Equal([junkFolder], scope.WithheldJunkFolders);
-        Assert.Equal(
-            [junkFolder, privateFolder],
-            scope.WithheldFolders.OrderBy(folder => folder.Alias.Value, StringComparer.Ordinal));
-    }
-
-    /// <summary>One folder both decisions withhold is one folder, so a query is not handed the same exclusion twice.</summary>
-    [Fact]
-    public void ReadableScope_AFolderBothDecisionsWithhold_NamesItOnce()
-    {
-        // Arrange
-        var junkFolder = new MailFolderIdentity(Work.Id, MailFolderAlias.Create("JUNK"));
-        var resolver = ResolverServing(
-            StubMailFolderParticipation.Hiding(junkFolder),
-            StubJunkMailFolderCatalog.Naming(junkFolder),
-            Work);
-
-        // Act
-        var scope = resolver.ReadableScope([], [], JunkMailInclusion.Excluded);
-
-        // Assert
-        Assert.Equal([junkFolder], scope.WithheldFolders);
     }
 
     /// <summary>Two readings of one configuration have to produce one predicate, whichever order the folders were read in.</summary>
@@ -482,7 +501,7 @@ public sealed class MailboxScopeResolverTests
 
     private static MailboxScopeResolver ResolverServing(params ServedMailAccount[] servedAccounts) =>
         Resolver(
-            StubMailFolderParticipation.Everything,
+            StubMailFolderParticipation.Nothing,
             StubJunkMailFolderCatalog.None,
             StubMailFolderMappings.Nothing,
             servedAccounts);
@@ -500,7 +519,7 @@ public sealed class MailboxScopeResolverTests
         IJunkMailFolderCatalog junkFolders,
         params ServedMailAccount[] servedAccounts) =>
         Resolver(
-            StubMailFolderParticipation.Everything,
+            StubMailFolderParticipation.Nothing,
             junkFolders,
             StubMailFolderMappings.Nothing,
             servedAccounts);
@@ -515,7 +534,7 @@ public sealed class MailboxScopeResolverTests
         StubMailFolderMappings folderMappings,
         params ServedMailAccount[] servedAccounts) =>
         Resolver(
-            StubMailFolderParticipation.Everything,
+            StubMailFolderParticipation.Nothing,
             StubJunkMailFolderCatalog.None,
             folderMappings,
             servedAccounts);

--- a/tests/Application.UnitTests/Emails/Mailboxes/MailboxScopeTests.cs
+++ b/tests/Application.UnitTests/Emails/Mailboxes/MailboxScopeTests.cs
@@ -24,7 +24,7 @@ public sealed class MailboxScopeTests
         // Assert
         Assert.Empty(scope.AccountIds);
         Assert.Empty(scope.SelectedFolders);
-        Assert.Same(MailboxScope.Unrestricted, scope);
+        Assert.Same(MailboxScope.NothingReadable, scope);
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public sealed class MailboxScopeTests
         var scope = MailboxScope.Create([], []);
 
         // Assert
-        Assert.Same(MailboxScope.Unrestricted, scope);
+        Assert.Same(MailboxScope.NothingReadable, scope);
     }
 
     /// <summary>Deduplicated and ordered, so two spellings of one scope are one query with one cursor.</summary>
@@ -73,7 +73,7 @@ public sealed class MailboxScopeTests
         var scope = MailboxScope.Create(accountIds: null, [Folder(Primary, "INBOX")]);
 
         // Assert
-        Assert.NotSame(MailboxScope.Unrestricted, scope);
+        Assert.NotSame(MailboxScope.NothingReadable, scope);
         Assert.Empty(scope.AccountIds);
     }
 

--- a/tests/Application.UnitTests/Emails/Search/SemanticEmailSearchTests.cs
+++ b/tests/Application.UnitTests/Emails/Search/SemanticEmailSearchTests.cs
@@ -344,7 +344,7 @@ public sealed class SemanticEmailSearchTests
             EmbeddingInputPreparation.Create(2_000, passageInstruction: null, normalizesVector: true));
 
     private static MailboxEmailSelection UnfilteredSelection() => MailboxEmailSelection.Create(
-        MailboxScope.Unrestricted,
+        MailboxScope.NothingReadable,
         senderAddress: null,
         recipientAddress: null,
         subjectFragment: null,

--- a/tests/Application.UnitTests/Emails/SearchEmails/MailboxSearchReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/SearchEmails/MailboxSearchReaderTests.cs
@@ -613,7 +613,7 @@ public sealed class MailboxSearchReaderTests
         FreshnessReaderReturning(InboxFreshness),
         new MailboxScopeResolver(
             accountCatalog ?? CatalogServing(EveryAccountTheSyntheticIndexUses),
-            StubMailFolderParticipation.Everything,
+            StubMailFolderParticipation.Nothing,
             StubJunkMailFolderCatalog.None,
             StubMailFolderMappings.ResolvingNothing),
         snippetBounds ?? EmailSearchSnippetBounds.Default,

--- a/tests/Application.UnitTests/Retrieval/AskMail/MailboxQuestionReaderTests.cs
+++ b/tests/Application.UnitTests/Retrieval/AskMail/MailboxQuestionReaderTests.cs
@@ -669,7 +669,7 @@ public sealed class MailboxQuestionReaderTests
                 answerer),
             new MailboxScopeResolver(
                 CatalogServing(MailAccountId.Create(ServedAccountId)),
-                StubMailFolderParticipation.Everything,
+                StubMailFolderParticipation.Nothing,
                 StubJunkMailFolderCatalog.None,
                 StubMailFolderMappings.ResolvingNothing),
             spendLedger ?? LedgerAdmitting(),

--- a/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
+++ b/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
@@ -43,7 +43,7 @@ public sealed class MailboxKnowledgeSearchTests
 
     /// <summary>The scope a question carrying no narrowing of its own arrives with, which is every served account.</summary>
     /// <remarks>
-    /// Never <see cref="MailboxScope.Unrestricted" />: this retrieval is handed a scope somebody already resolved, and
+    /// Never <see cref="MailboxScope.NothingReadable" />: this retrieval is handed a scope somebody already resolved, and
     /// the unrestricted one is what a deployment serving no account at all resolves to.
     /// </remarks>
     private static readonly MailboxScope EveryAccount = MailboxScope.Create(EveryServedAccount, selectedFolders: null);
@@ -446,7 +446,7 @@ public sealed class MailboxKnowledgeSearchTests
             FreshnessReaderReturningNothing(),
             new MailboxScopeResolver(
                 CatalogServing(EveryServedAccount),
-                StubMailFolderParticipation.Everything,
+                StubMailFolderParticipation.Nothing,
                 StubJunkMailFolderCatalog.None,
                 StubMailFolderMappings.ResolvingNothing),
             EmailSearchSnippetBounds.Default,

--- a/tests/Domain.UnitTests/Folders/MailFolderParticipationTests.cs
+++ b/tests/Domain.UnitTests/Folders/MailFolderParticipationTests.cs
@@ -17,9 +17,33 @@ public sealed class MailFolderParticipationTests
         var participation = MailFolderParticipation.Full;
 
         // Assert
+        Assert.True(participation.IsMapped);
         Assert.True(participation.IsSynchronized);
         Assert.True(participation.GeneratesEmbeddings);
         Assert.True(participation.IsVisibleToTools);
+    }
+
+    /// <summary>A folder no mapping names does not exist here, so nothing it once stored takes part in anything.</summary>
+    [Fact]
+    public void Unmapped_ByItself_TakesPartInNothing()
+    {
+        // Act
+        var participation = MailFolderParticipation.Unmapped;
+
+        // Assert
+        Assert.False(participation.IsMapped);
+        Assert.False(participation.IsSynchronized);
+        Assert.False(participation.GeneratesEmbeddings);
+        Assert.False(participation.IsVisibleToTools);
+    }
+
+    /// <summary>A folder an operator stopped mirroring and a folder they stopped mapping are two decisions, so one value cannot stand for both.</summary>
+    [Fact]
+    public void Unmapped_AgainstMappedOnly_IsADifferentValue()
+    {
+        // Act, Assert
+        Assert.NotEqual(MailFolderParticipation.MappedOnly, MailFolderParticipation.Unmapped);
+        Assert.True(MailFolderParticipation.MappedOnly.IsMapped);
     }
 
     /// <summary>An unmirrored folder stores nothing, so neither of the other two answers can be anything but no.</summary>
@@ -76,5 +100,25 @@ public sealed class MailFolderParticipationTests
         Assert.Equal(
             MailFolderParticipation.MappedOnly,
             MailFolderParticipation.Create(isSynchronized: false, generatesEmbeddings: true, isVisibleToTools: true));
+    }
+
+    /// <summary>The three switches are what a mapping says, so every value built from them is a mapped folder's.</summary>
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(false, false, false)]
+    public void Create_AnyThreeAnswers_DescribeAMappedFolder(
+        bool isSynchronized,
+        bool generatesEmbeddings,
+        bool isVisibleToTools)
+    {
+        // Act
+        var participation = MailFolderParticipation.Create(
+            isSynchronized,
+            generatesEmbeddings,
+            isVisibleToTools);
+
+        // Assert
+        Assert.True(participation.IsMapped);
     }
 }

--- a/tests/Host.UnitTests/Api/EmailAttachmentDownloadEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/EmailAttachmentDownloadEndpointTests.cs
@@ -300,7 +300,12 @@ public sealed class EmailAttachmentDownloadEndpointTests
             Substitute.For<IEmailContentRepairRequestStore>(),
             new MailboxScopeResolver(
                 accountCatalog,
-                StubMailFolderParticipation.Everything,
+
+                // The folder the summary was stored in is mapped, because a folder no mapping names does not exist as
+                // far as MailFathom is concerned and every download of it would be refused before the endpoint is
+                // reached — which is not the refusal any test here is about.
+                StubMailFolderParticipation.Mapping(
+                    new MailFolderIdentity(summary.AccountId, summary.FolderAlias)),
                 StubJunkMailFolderCatalog.None,
                 StubMailFolderMappings.ResolvingNothing));
     }

--- a/tests/Host.UnitTests/Configuration/Mail/MailFolderParticipationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/MailFolderParticipationOptionsTests.cs
@@ -27,10 +27,10 @@ public sealed class MailFolderParticipationOptionsTests
         var participation = options.GetParticipation(Primary, MailFolderAlias.Create("INBOX"));
 
         // Assert
+        var inbox = new MailFolderIdentity(Primary, MailFolderAlias.Create("INBOX"));
         Assert.Equal(MailFolderParticipation.Full, participation);
-        Assert.Empty(options.FoldersHiddenFromTools);
-        Assert.Empty(options.FoldersWithoutEmbeddings);
-        Assert.Empty(options.FoldersNotMirrored);
+        Assert.Equal([inbox], options.FoldersVisibleToTools);
+        Assert.Equal([inbox], options.FoldersGeneratingEmbeddings);
     }
 
     /// <summary>A folder that names its target and no switch behaves exactly as it did before the switches existed.</summary>
@@ -53,7 +53,7 @@ public sealed class MailFolderParticipationOptionsTests
 
     /// <summary>Withholding a folder from tools leaves everything else about it alone, which is the whole point of the switch being its own.</summary>
     [Fact]
-    public void FoldersHiddenFromTools_AFolderWithdrawnFromTools_NamesThatFolderAndKeepsItMirrored()
+    public void FoldersVisibleToTools_AFolderWithdrawnFromTools_LeavesItOutAndKeepsItMirrored()
     {
         // Arrange
         var options = OptionsFor(CreateAccount(new MailFolderMappingOptions
@@ -62,22 +62,24 @@ public sealed class MailFolderParticipationOptionsTests
             RemotePath = "Private",
             VisibleToTools = false,
         }));
+        var privateFolder = new MailFolderIdentity(Primary, MailFolderAlias.Create("PRIVATE"));
 
         // Act
-        var hidden = options.FoldersHiddenFromTools;
+        var visible = options.FoldersVisibleToTools;
         var participation = options.GetParticipation(Primary, MailFolderAlias.Create("PRIVATE"));
 
         // Assert
-        Assert.Equal([new MailFolderIdentity(Primary, MailFolderAlias.Create("PRIVATE"))], hidden);
+        Assert.DoesNotContain(privateFolder, visible);
         Assert.True(participation.IsSynchronized);
         Assert.True(participation.GeneratesEmbeddings);
         Assert.False(participation.IsVisibleToTools);
-        Assert.Empty(options.FoldersWithoutEmbeddings);
+        Assert.Equal([privateFolder], options.FoldersGeneratingEmbeddings);
+        Assert.Equal([privateFolder], options.FoldersSynchronized);
     }
 
     /// <summary>A noisy folder can stay listed and filterable while costing no provider tokens.</summary>
     [Fact]
-    public void FoldersWithoutEmbeddings_AFolderWithdrawnFromEmbedding_NamesThatFolderAndKeepsItReadable()
+    public void FoldersGeneratingEmbeddings_AFolderWithdrawnFromEmbedding_LeavesItOutAndKeepsItReadable()
     {
         // Arrange
         var options = OptionsFor(CreateAccount(new MailFolderMappingOptions
@@ -86,26 +88,22 @@ public sealed class MailFolderParticipationOptionsTests
             RemotePath = "Newsletters",
             GenerateEmbeddings = false,
         }));
+        var newsletters = new MailFolderIdentity(Primary, MailFolderAlias.Create("NEWSLETTERS"));
 
         // Act
         var participation = options.GetParticipation(Primary, MailFolderAlias.Create("NEWSLETTERS"));
 
         // Assert
-        Assert.Equal(
-            [new MailFolderIdentity(Primary, MailFolderAlias.Create("NEWSLETTERS"))],
-            options.FoldersWithoutEmbeddings);
+        Assert.DoesNotContain(newsletters, options.FoldersGeneratingEmbeddings);
         Assert.False(participation.GeneratesEmbeddings);
         Assert.True(participation.IsVisibleToTools);
-        Assert.Empty(options.FoldersHiddenFromTools);
+        Assert.Equal([newsletters], options.FoldersVisibleToTools);
+        Assert.Equal([newsletters], options.FoldersSynchronized);
     }
 
-    /// <summary>
-    /// A folder nothing mirrors takes part in nothing, so it appears in every exclusion without any of them being
-    /// configured. That is what keeps the mail it stored before the switch was flipped inert while it is kept: no tool
-    /// reads it, nothing embeds it, and no rule pass walks it.
-    /// </summary>
+    /// <summary>A folder nothing mirrors takes part in nothing, so it is admitted to neither without either switch being configured.</summary>
     [Fact]
-    public void GetParticipation_AFolderNothingMirrors_IsWithdrawnFromEveryReaderThereIs()
+    public void GetParticipation_AFolderNothingMirrors_IsWithdrawnFromEmbeddingAndFromTools()
     {
         // Arrange
         var options = OptionsFor(CreateAccount(new MailFolderMappingOptions
@@ -114,42 +112,35 @@ public sealed class MailFolderParticipationOptionsTests
             SpecialUse = "Junk",
             Synchronize = false,
         }));
-        var junk = new MailFolderIdentity(Primary, MailFolderAlias.Create("JUNK"));
 
         // Act
         var participation = options.GetParticipation(Primary, MailFolderAlias.Create("JUNK"));
 
         // Assert
         Assert.Equal(MailFolderParticipation.MappedOnly, participation);
-        Assert.Equal([junk], options.FoldersHiddenFromTools);
-        Assert.Equal([junk], options.FoldersWithoutEmbeddings);
-        Assert.Equal([junk], options.FoldersNotMirrored);
+        Assert.True(participation.IsMapped);
+        Assert.Empty(options.FoldersVisibleToTools);
+        Assert.Empty(options.FoldersGeneratingEmbeddings);
     }
 
-    /// <summary>
-    /// A mirrored folder withheld from tools is not a folder nothing mirrors, so the list a rule walk narrows by names
-    /// it as little as the list a tool narrows by names a folder that is merely unembedded.
-    /// </summary>
+    /// <summary>A pass over stored mail runs against the folders a mapping mirrors, which is neither an unmirrored one nor an unmapped one.</summary>
     [Fact]
-    public void FoldersNotMirrored_AFolderWithdrawnFromToolsOrEmbedding_NamesNeither()
+    public void FoldersSynchronized_AnUnmirroredFolderBesideAMirroredOne_NamesOnlyTheMirroredOne()
     {
         // Arrange
         var options = OptionsFor(CreateAccount(
-            new MailFolderMappingOptions { Alias = "private", RemotePath = "Private", VisibleToTools = false },
-            new MailFolderMappingOptions
-            {
-                Alias = "newsletters",
-                RemotePath = "Newsletters",
-                GenerateEmbeddings = false,
-            }));
+            new MailFolderMappingOptions { Alias = "archive", RemotePath = "Archive" },
+            new MailFolderMappingOptions { Alias = "junk", SpecialUse = "Junk", Synchronize = false }));
 
         // Act, Assert
-        Assert.Empty(options.FoldersNotMirrored);
+        Assert.Equal(
+            [new MailFolderIdentity(Primary, MailFolderAlias.Create("ARCHIVE"))],
+            options.FoldersSynchronized);
     }
 
-    /// <summary>A folder nothing maps is stored mail nobody withdrew anything from, so a removed mapping never hides a mailbox.</summary>
+    /// <summary>A folder no mapping names is a folder MailFathom does not have, so what it stored earlier takes part in nothing.</summary>
     [Fact]
-    public void GetParticipation_AnAliasNothingMaps_TakesPartInEverything()
+    public void GetParticipation_AnAliasNothingMaps_TakesPartInNothingAndIsNotMapped()
     {
         // Arrange
         var options = OptionsFor(CreateAccount(new MailFolderMappingOptions
@@ -163,12 +154,36 @@ public sealed class MailFolderParticipationOptionsTests
         var participation = options.GetParticipation(Primary, MailFolderAlias.Create("ARCHIVE"));
 
         // Assert
-        Assert.Equal(MailFolderParticipation.Full, participation);
+        Assert.Equal(MailFolderParticipation.Unmapped, participation);
+        Assert.False(participation.IsMapped);
+        Assert.False(participation.IsSynchronized);
+        Assert.False(participation.GeneratesEmbeddings);
+        Assert.False(participation.IsVisibleToTools);
+    }
+
+    /// <summary>Removing a mapping is not the same decision as switching a mapped folder off, so the two answers are not one value.</summary>
+    [Fact]
+    public void GetParticipation_AnUnmappedAliasBesideAnUnmirroredFolder_AnswersWithTwoDifferentValues()
+    {
+        // Arrange
+        var options = OptionsFor(CreateAccount(new MailFolderMappingOptions
+        {
+            Alias = "junk",
+            SpecialUse = "Junk",
+            Synchronize = false,
+        }));
+
+        // Act
+        var unmirrored = options.GetParticipation(Primary, MailFolderAlias.Create("JUNK"));
+        var unmapped = options.GetParticipation(Primary, MailFolderAlias.Create("ARCHIVE"));
+
+        // Assert
+        Assert.NotEqual(unmirrored, unmapped);
     }
 
     /// <summary>One account's decision is never another account's, which is what makes the identity a pair rather than an alias.</summary>
     [Fact]
-    public void FoldersHiddenFromTools_TheSameAliasInTwoAccounts_NamesOnlyTheAccountThatWithheldIt()
+    public void FoldersVisibleToTools_TheSameAliasInTwoAccounts_NamesOnlyTheAccountThatDidNotWithholdIt()
     {
         // Arrange
         var options = new MailSynchronizationOptions
@@ -190,10 +205,12 @@ public sealed class MailFolderParticipationOptionsTests
         };
 
         // Act
-        var hidden = options.FoldersHiddenFromTools;
+        var visible = options.FoldersVisibleToTools;
 
         // Assert
-        Assert.Equal([new MailFolderIdentity(Primary, MailFolderAlias.Create("PRIVATE"))], hidden);
+        Assert.Equal(
+            [new MailFolderIdentity(MailAccountId.Create("secondary"), MailFolderAlias.Create("PRIVATE"))],
+            visible);
         Assert.True(options
             .GetParticipation(MailAccountId.Create("secondary"), MailFolderAlias.Create("PRIVATE"))
             .IsVisibleToTools);

--- a/tests/Infrastructure.UnitTests/Persistence/Emails/AccountScopedMailFoldersTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Emails/AccountScopedMailFoldersTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace MailFathom.Infrastructure.UnitTests.Persistence.Emails;
 
-/// <summary>Covers the narrowing every read applies to the folders a configuration decision took out of it.</summary>
+/// <summary>Covers the narrowing every read applies to the folders a configuration decision admitted or took out of it.</summary>
 /// <remarks>
 /// The predicate is composed here and evaluated by PostgreSQL, so what these tests establish is which rows it selects
 /// rather than what SQL it becomes. That distinction is the whole point of the account-and-alias pair: a predicate
@@ -189,6 +189,76 @@ public sealed class AccountScopedMailFoldersTests
         Assert.Equal(
             [("work", "SPAM"), ("home", "JUNK")],
             selectedFolders.AsEnumerable().Select(folder => (folder.MailboxAccountId, folder.Alias)));
+    }
+
+    /// <summary>An admission is the folders configuration maps, so a folder it stopped naming is no longer read.</summary>
+    [Fact]
+    public void Admitting_AFolderConfigurationNoLongerMaps_LeavesItsStoredMailUnreadable()
+    {
+        // Arrange
+        var emails = Emails(("work", "INBOX"), ("work", "REMOVED"), ("home", "INBOX"));
+        var admitted = new[]
+        {
+            new MailFolderIdentity(MailAccountId.Create("work"), MailFolderAlias.Create("INBOX")),
+            new MailFolderIdentity(MailAccountId.Create("home"), MailFolderAlias.Create("INBOX")),
+        };
+
+        // Act
+        var readable = AccountScopedMailFolders.Admitting(emails, admitted);
+
+        // Assert
+        Assert.Equal(
+            [("work", "INBOX"), ("home", "INBOX")],
+            readable.AsEnumerable().Select(email => (email.MailboxAccountId, email.MailFolder.Alias)));
+    }
+
+    /// <summary>The empty admission is the one that separates this from a caller's filter: it admits nothing.</summary>
+    [Fact]
+    public void Admitting_NoFolderAdmitted_LeavesNothingReadable()
+    {
+        // Arrange
+        var emails = Emails(("work", "INBOX"), ("home", "INBOX"));
+
+        // Act
+        var readable = AccountScopedMailFolders.Admitting(emails, []);
+
+        // Assert
+        Assert.Empty(readable);
+    }
+
+    /// <summary>An admission belongs to one account, so the same alias elsewhere is admitted by that account or not at all.</summary>
+    [Fact]
+    public void Admitting_AFolderOfOneAccount_LeavesOutTheSameAliasOfAnotherAccount()
+    {
+        // Arrange
+        var emails = Emails(("work", "PRIVATE"), ("home", "PRIVATE"));
+
+        // Act
+        var readable = AccountScopedMailFolders.Admitting(emails, [WorkPrivate]);
+
+        // Assert
+        Assert.Equal(["work"], readable.AsEnumerable().Select(email => email.MailboxAccountId));
+    }
+
+    /// <summary>The freshness a tool reports is read from the bindings, so an unmapped folder may not be named there either.</summary>
+    [Fact]
+    public void Admitting_FolderBindings_KeepsTheAdmittedPairsOnly()
+    {
+        // Arrange
+        var folders = new[]
+        {
+            Folder("work", "PRIVATE"),
+            Folder("work", "REMOVED"),
+            Folder("home", "PRIVATE"),
+        }.AsQueryable();
+
+        // Act
+        var readable = AccountScopedMailFolders.Admitting(folders, [WorkPrivate]);
+
+        // Assert
+        Assert.Equal(
+            [("work", "PRIVATE")],
+            readable.AsEnumerable().Select(folder => (folder.MailboxAccountId, folder.Alias)));
     }
 
     /// <summary>A read that has already found one email asks about that pair, and an alias alone would answer for two accounts.</summary>

--- a/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailSearchIndexReaderCommandTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailSearchIndexReaderCommandTests.cs
@@ -158,7 +158,7 @@ public sealed class StoredEmailSearchIndexReaderCommandTests
     {
         // Arrange
         var selection = MailboxEmailSelection.Create(
-            MailboxScope.Unrestricted,
+            MailboxScope.NothingReadable,
             senderAddress: null,
             recipientAddress: null,
             subjectFragment: null,
@@ -185,7 +185,7 @@ public sealed class StoredEmailSearchIndexReaderCommandTests
     {
         // Arrange
         var selection = MailboxEmailSelection.Create(
-            MailboxScope.Unrestricted,
+            MailboxScope.NothingReadable,
             senderAddress: "anna@example.test",
             recipientAddress: null,
             subjectFragment: null,
@@ -204,7 +204,7 @@ public sealed class StoredEmailSearchIndexReaderCommandTests
 
     /// <summary>Gets the selection that narrows nothing, which is what a command test uses unless the filters are its subject.</summary>
     private static MailboxEmailSelection UnfilteredSelection => MailboxEmailSelection.Create(
-        MailboxScope.Unrestricted,
+        MailboxScope.NothingReadable,
         senderAddress: null,
         recipientAddress: null,
         subjectFragment: null,

--- a/tests/Infrastructure.UnitTests/Persistence/Embeddings/EmailVectorSearchIndexReaderCommandTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Embeddings/EmailVectorSearchIndexReaderCommandTests.cs
@@ -102,7 +102,7 @@ public sealed class EmailVectorSearchIndexReaderCommandTests
     {
         // Arrange
         var selection = MailboxEmailSelection.Create(
-            MailboxScope.Unrestricted,
+            MailboxScope.NothingReadable,
             senderAddress: "anna@example.test",
             recipientAddress: null,
             subjectFragment: null,
@@ -192,7 +192,7 @@ public sealed class EmailVectorSearchIndexReaderCommandTests
 
     /// <summary>Gets the selection that narrows nothing, which is what a command test uses unless the filters are its subject.</summary>
     private static MailboxEmailSelection UnfilteredSelection => MailboxEmailSelection.Create(
-        MailboxScope.Unrestricted,
+        MailboxScope.NothingReadable,
         senderAddress: null,
         recipientAddress: null,
         subjectFragment: null,

--- a/tests/IntegrationTests/Orchestration/OrchestratedMailboxScope.cs
+++ b/tests/IntegrationTests/Orchestration/OrchestratedMailboxScope.cs
@@ -1,0 +1,40 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Domain.Folders;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MailFathom.IntegrationTests.Orchestration;
+
+/// <summary>Resolves the scope a mailbox read runs with, the way a deployment resolves it.</summary>
+/// <remarks>
+/// A scope names the folders configuration admits a tool to, so one built by hand names none and every read through it
+/// answers with nothing whatever the store holds. Resolving it through the registered resolver is what a production
+/// read does as well, which keeps a test's arrangement from describing a scope no deployment could produce.
+/// </remarks>
+internal static class OrchestratedMailboxScope
+{
+    /// <summary>Resolves the scope a read of the named folders runs with.</summary>
+    /// <param name="services">The composed services the read runs through.</param>
+    /// <param name="folderAliases">The aliases the read names, or none for every folder this deployment maps.</param>
+    /// <param name="cancellationToken">Cancels the resolution.</param>
+    /// <returns>The scope, with the readable folders configuration admits already applied.</returns>
+    internal static Task<MailboxScope> ReadableAsync(
+        OrchestratedMailFathomServices services,
+        IReadOnlyList<string> folderAliases,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+        (scope, _) => Task.FromResult(Readable(scope, folderAliases)),
+        cancellationToken);
+
+    /// <summary>Resolves the same scope inside a service scope a test already opened.</summary>
+    /// <param name="scope">The service scope the read runs in.</param>
+    /// <param name="folderAliases">The aliases the read names, or none for every folder this deployment maps.</param>
+    /// <returns>The scope.</returns>
+    internal static MailboxScope Readable(IServiceProvider scope, IReadOnlyList<string> folderAliases) =>
+        scope.GetRequiredService<MailboxScopeResolver>().ReadableScope(
+            [],
+            [.. folderAliases.Select(alias => MailFolderReference.ToAlias(MailFolderAlias.Create(alias)))],
+            JunkMailInclusion.Excluded);
+}

--- a/tests/IntegrationTests/Orchestration/SyntheticMailAccount.cs
+++ b/tests/IntegrationTests/Orchestration/SyntheticMailAccount.cs
@@ -57,9 +57,87 @@ internal sealed class SyntheticMailAccount(
     IMailFolderParticipationReader,
     IMailFolderMappingReader
 {
+    /// <summary>Every folder alias this suite's configuration maps, which is every alias its tests bind one to.</summary>
+    /// <remarks>
+    /// <para>
+    /// A folder no mapping names does not exist as far as MailFathom is concerned, so a harness that named none would
+    /// make every read answer with nothing and every message reach the chunker unembedded. This is that configuration:
+    /// one entry per alias a test class owns, which is what an operator's <c>…:Folders</c> list would hold for the same
+    /// mailbox.
+    /// </para>
+    /// <para>
+    /// A test class that introduces an alias adds it here. Forgetting shows up in that class alone and shows up as
+    /// emptiness — a listing that returns no mail the same run stored, or a message cut into no passages — which is why
+    /// the aliases are kept together rather than derived from whatever a run happened to bind.
+    /// </para>
+    /// </remarks>
+    internal static readonly IReadOnlyList<string> MappedFolderAliases =
+    [
+        nameof(MailFolderSpecialUse.Inbox),
+        "inbox",
+        "a-folder-nobody-bound",
+        "answering-audit-inbox",
+        "ask-mail",
+        "ask-mail-elsewhere",
+        "audit-trail-inbox",
+        "authored-delete",
+        "content-inventory",
+        "content-read",
+        "content-store",
+        "convergence-inbox",
+        "createdarchive",
+        "email-chunks",
+        "email-chunks-unembedded",
+        "email-embeddings",
+        "embedding-backfill",
+        "embedding-generation",
+        "embedding-generations",
+        "embedding-workload",
+        "extraction-backfill",
+        "hybrid-retrieval",
+        "lexical-search",
+        "manual-move-source",
+        "manual-move-target",
+        "mcp-tool-contract",
+        "mutation-identity",
+        "mutation-reconciliation",
+        "mutation-record-inbox",
+        "occurrence-identity",
+        "persistence-session",
+        "persistence-session-race",
+        "persistence-session-retry",
+        "push-watched",
+        "reconciliation-erasure",
+        "reconciliation-tombstone",
+        "reconciliation-window",
+        "relocation-source",
+        "relocation-target",
+        "rule-evaluation",
+        "seen-state-provenance",
+        "spam-scan",
+        "synchronized",
+        "timeline-and-search",
+        "timeline-read-model",
+        "vector-search",
+    ];
+
+    /// <summary>An alias this configuration deliberately maps nothing to, which is what a folder MailFathom does not have looks like.</summary>
+    /// <remarks>
+    /// Kept beside the mapped aliases and deliberately absent from them, so a test that needs the unmapped case names
+    /// this rather than inventing an alias somebody could later add to the list without noticing what it was for.
+    /// </remarks>
+    internal const string UnmappedFolderAlias = "no-mapping-names-this";
+
     private static readonly MailFolderMapping Inbox = MailFolderMapping.ToSpecialUse(
         MailFolderAlias.Create(nameof(MailFolderSpecialUse.Inbox)),
         MailFolderSpecialUse.Inbox);
+
+    private static readonly IReadOnlyList<MailFolderIdentity> MappedFolders =
+    [
+        .. MappedFolderAliases
+            .Select(static alias => new MailFolderIdentity(AccountId, MailFolderAlias.Create(alias)))
+            .Distinct(),
+    ];
 
     /// <summary>The window this account keeps an answering entry for, which a retention test writes an older entry than.</summary>
     internal static readonly TimeSpan AnsweringAuditRetention = TimeSpan.FromDays(30);
@@ -86,25 +164,33 @@ internal sealed class SyntheticMailAccount(
 
     /// <inheritdoc />
     /// <remarks>
-    /// Empty unless a test asks otherwise, which is what a deployment that configures none of the folder switches
-    /// behaves like; arranging one for every test would silently narrow every other read. The one class that does ask
-    /// needs it, because whether the narrowing translates to SQL at all is settled by a real database and nothing else.
+    /// Every folder this suite maps, less the ones a test stopped mirroring. That is the list a pass over stored mail
+    /// runs against, so it is what keeps two kinds of row out of one: mail of a folder whose synchronization was
+    /// switched off, which a test arranges here, and mail of a folder outside <see cref="MappedFolderAliases" />, which
+    /// no arrangement can put back because an unmapped alias is not a folder this deployment has.
     /// </remarks>
-    public IReadOnlyList<MailFolderIdentity> FoldersHiddenFromTools => foldersHiddenFromTools ?? [];
+    public IReadOnlyList<MailFolderIdentity> FoldersSynchronized =>
+        [.. MappedFolders.Where(folder => !(foldersNotMirrored ?? []).Contains(folder))];
 
     /// <inheritdoc />
     /// <remarks>
-    /// Empty unless a test asks otherwise, for the reason above. The one class that does ask names a folder of its own,
-    /// because whether a message is cut into passages at all is settled by the rows a real transaction leaves behind.
+    /// Every folder this suite maps, less the ones a test withheld. The subtraction is stated that way round because a
+    /// withholding is what a test arranges, while being mapped at all is what makes MailFathom have the folder: an
+    /// alias outside <see cref="MappedFolderAliases" /> is not a folder this deployment has, and every read of it
+    /// answers with nothing. The one class that withholds a mapped folder needs it, because whether the narrowing
+    /// translates to SQL at all is settled by a real database and nothing else.
     /// </remarks>
-    public IReadOnlyList<MailFolderIdentity> FoldersWithoutEmbeddings => foldersWithoutEmbeddings ?? [];
+    public IReadOnlyList<MailFolderIdentity> FoldersVisibleToTools =>
+        [.. this.FoldersSynchronized.Where(folder => !(foldersHiddenFromTools ?? []).Contains(folder))];
 
     /// <inheritdoc />
     /// <remarks>
-    /// Empty unless a test asks otherwise, for the reason above. The class that does ask names a folder it has already
-    /// stored mail into, because keeping that mail out of a walk is only worth asserting where the rows exist.
+    /// Read the same way as the folders above. The one class that leaves a mapped folder unembedded names a folder of
+    /// its own, because whether a message is cut into passages at all is settled by the rows a real transaction leaves
+    /// behind.
     /// </remarks>
-    public IReadOnlyList<MailFolderIdentity> FoldersNotMirrored => foldersNotMirrored ?? [];
+    public IReadOnlyList<MailFolderIdentity> FoldersGeneratingEmbeddings =>
+        [.. this.FoldersSynchronized.Where(folder => !(foldersWithoutEmbeddings ?? []).Contains(folder))];
 
     /// <inheritdoc />
     /// <remarks>
@@ -133,8 +219,22 @@ internal sealed class SyntheticMailAccount(
     public MailSynchronizationWindow GetWindow(MailAccountId accountId) => MailSynchronizationWindow.Unbounded;
 
     /// <inheritdoc />
-    public MailFolderParticipation GetParticipation(MailAccountId accountId, MailFolderAlias folderAlias) =>
-        MailFolderParticipation.Full;
+    /// <remarks>
+    /// Answered from the same mapped set the two lists above are read from, so the per-folder question and the
+    /// per-query one cannot disagree — which is the property the production reader has and the one a read that reaches
+    /// an email by its identifier depends on.
+    /// </remarks>
+    public MailFolderParticipation GetParticipation(MailAccountId accountId, MailFolderAlias folderAlias)
+    {
+        var folder = new MailFolderIdentity(accountId, folderAlias);
+
+        return MappedFolders.Contains(folder)
+            ? MailFolderParticipation.Create(
+                this.FoldersSynchronized.Contains(folder),
+                this.FoldersGeneratingEmbeddings.Contains(folder),
+                this.FoldersVisibleToTools.Contains(folder))
+            : MailFolderParticipation.Unmapped;
+    }
 
     /// <inheritdoc />
     /// <remarks>

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailChunkTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailChunkTests.cs
@@ -141,6 +141,39 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
     }
 
     /// <summary>
+    /// A folder no mapping names is cut into no passages either, which is the case an exclusion could never have
+    /// covered: no list of configured folders carries a folder nobody configured.
+    /// </summary>
+    /// <remarks>
+    /// It is a separate test from the one above rather than a second case of it, because the two arrangements differ in
+    /// what configuration says: there the folder is mapped and its embedding switch is off, here nothing names it at
+    /// all. The mapped folder beside it is the control the absence needs.
+    /// </remarks>
+    [Fact]
+    public async Task UpsertMetadataAsync_AFolderNoMappingNames_CutsNoPassagesAndLeavesTheRestCut()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var unmappedBinding = await OrchestratedFolderBinding.CommitAsync(
+            services,
+            SyntheticMailAccount.UnmappedFolderAlias,
+            cancellationToken);
+        var mappedBinding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
+        var uncutOccurrenceId = SyntheticEmail.OccurrenceIn(unmappedBinding, uid: 9005);
+        var cutOccurrenceId = SyntheticEmail.OccurrenceIn(mappedBinding, uid: 9005);
+        var body = BodyOfSeveralPassages("unmapped");
+
+        // Act
+        await StoreAsync(services, uncutOccurrenceId, "chunks-unmapped", body, cancellationToken);
+        await StoreAsync(services, cutOccurrenceId, "chunks-mapped", body, cancellationToken);
+
+        // Assert
+        Assert.Empty(await ReadPassagesAsync(services, uncutOccurrenceId, cancellationToken));
+        Assert.NotEmpty(await ReadPassagesAsync(services, cutOccurrenceId, cancellationToken));
+    }
+
+    /// <summary>
     /// An oversized message is bounded rather than refused, and what the ceiling left out is written on the message in
     /// the same transaction as the passages it did cut.
     /// </summary>

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingBackfillTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingBackfillTests.cs
@@ -111,6 +111,41 @@ public sealed class OrchestratedEmailEmbeddingBackfillTests(MailFathomOrchestrat
         Assert.Null(positionAfterSweep);
     }
 
+    /// <summary>
+    /// Mail stored under an alias no mapping names is outside the walk, so a folder an operator withdrew never becomes
+    /// a bill: nothing of it is cut and nothing of it is embedded, however long the deployment runs.
+    /// </summary>
+    /// <remarks>
+    /// The walk is where this has to be proved rather than at the cut, because the two answer different halves. A
+    /// message with a body and no passages is exactly what the sweep's second group selects, so a folder left out only
+    /// at the cut would be found outstanding on every sweep for the rest of the deployment's life. The mapped message
+    /// beside it is the control: without it, zero passages would report a query that selected nothing at all.
+    /// </remarks>
+    [Fact]
+    public async Task Sweeping_MailInAFolderNoMappingNames_CutsNothingAndEmbedsNothingOfIt()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var unmapped = await StoreOneMessageAsync(
+            services,
+            uid: 9321,
+            cancellationToken,
+            SyntheticMailAccount.UnmappedFolderAlias);
+        var mapped = await StoreOneMessageAsync(services, uid: 9322, cancellationToken);
+        await RemovePassagesAsync(services, mapped, cancellationToken);
+        var profileId = await OrchestratedEmbeddingProfile.EnsureActiveDeterministicAsync(services, cancellationToken);
+
+        // Act
+        await SweepAsync(services, cancellationToken);
+
+        // Assert
+        Assert.Equal(0, await CountPassagesAsync(services, unmapped, cancellationToken));
+        Assert.Equal(0, await CountVectorsAsync(services, unmapped, profileId, cancellationToken));
+        Assert.True(await CountPassagesAsync(services, mapped, cancellationToken) > 0);
+        Assert.True(await CountVectorsAsync(services, mapped, profileId, cancellationToken) > 0);
+    }
+
     /// <summary>Runs the backfill until the sweep ends, and answers with the last run that did any work.</summary>
     private static async Task<StoredEmailEmbeddingBackfillResult> SweepAsync(
         OrchestratedMailFathomServices services,
@@ -182,9 +217,10 @@ public sealed class OrchestratedEmailEmbeddingBackfillTests(MailFathomOrchestrat
     private static async Task<StoredEmailId> StoreOneMessageAsync(
         OrchestratedMailFathomServices services,
         uint uid,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        string folderAlias = FolderAlias)
     {
-        var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
+        var binding = await OrchestratedFolderBinding.CommitAsync(services, folderAlias, cancellationToken);
         var occurrenceId = SyntheticEmail.OccurrenceIn(binding, uid);
         var subject = $"embedding-backfill-{uid}";
         var storedEmailId = default(StoredEmailId);

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailSearchIndexReaderTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailSearchIndexReaderTests.cs
@@ -182,7 +182,7 @@ public sealed class OrchestratedEmailSearchIndexReaderTests(MailFathomOrchestrat
         EmailSearchSnippetBounds? snippetBounds = null) => services.InScopeAsync(
             (scope, token) => RankedWindowAsync(
                 scope.GetRequiredService<IEmailSearchIndexReader>(),
-                selection ?? SeededSelection(),
+                selection ?? SeededSelection(scope),
                 queryText,
                 snippetBounds ?? EmailSearchSnippetBounds.Default,
                 token),
@@ -212,10 +212,8 @@ public sealed class OrchestratedEmailSearchIndexReaderTests(MailFathomOrchestrat
             cancellationToken);
     }
 
-    private static MailboxEmailSelection SeededSelection() => MailboxEmailSelection.Create(
-        MailboxScope.Create(
-            [SyntheticMailAccount.AccountId],
-            [new MailFolderIdentity(SyntheticMailAccount.AccountId, MailFolderAlias.Create(FolderAlias))]),
+    private static MailboxEmailSelection SeededSelection(IServiceProvider scope) => MailboxEmailSelection.Create(
+        OrchestratedMailboxScope.Readable(scope, [FolderAlias]),
         senderAddress: null,
         recipientAddress: null,
         subjectFragment: null,
@@ -233,7 +231,9 @@ public sealed class OrchestratedEmailSearchIndexReaderTests(MailFathomOrchestrat
 
         await EnsureSeededAsync(services, binding, cancellationToken);
 
-        return SeededSelection();
+        return await services.InScopeAsync(
+            (scope, _) => Task.FromResult(SeededSelection(scope)),
+            cancellationToken);
     }
 
     /// <summary>Writes the seeded volume once, through the production write path that derives the search documents.</summary>

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailVectorSearchTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailVectorSearchTests.cs
@@ -62,7 +62,7 @@ public sealed class OrchestratedEmailVectorSearchTests(MailFathomOrchestrationFi
         // Act
         var candidates = await services.InScopeAsync(
             (scope, token) => scope.GetRequiredService<IEmailVectorSearchIndexReader>().ReadNearestCandidatesAsync(
-                SelectionOf(binding),
+                SelectionOf(scope, binding),
                 profile,
                 QueryVector(),
                 limit: 50,
@@ -93,10 +93,9 @@ public sealed class OrchestratedEmailVectorSearchTests(MailFathomOrchestrationFi
         return EmbeddingVector.Create(components);
     }
 
-    private static MailboxEmailSelection SelectionOf(MailFolderResolution binding) => MailboxEmailSelection.Create(
-        MailboxScope.Create(
-            [SyntheticMailAccount.AccountId],
-            [new MailFolderIdentity(SyntheticMailAccount.AccountId, binding.Alias)]),
+    private static MailboxEmailSelection SelectionOf(IServiceProvider scope, MailFolderResolution binding) =>
+        MailboxEmailSelection.Create(
+        OrchestratedMailboxScope.Readable(scope, [binding.Alias.Value]),
         senderAddress: null,
         recipientAddress: null,
         subjectFragment: null,

--- a/tests/IntegrationTests/Persistence/OrchestratedHybridRetrievalTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedHybridRetrievalTests.cs
@@ -124,9 +124,7 @@ public sealed class OrchestratedHybridRetrievalTests(MailFathomOrchestrationFixt
         // Act
         var lookup = await services.InScopeAsync(
             (scope, token) => scope.GetRequiredService<MailboxKnowledgeSearch>().FindPassagesAsync(
-                MailboxScope.Create(
-            [SyntheticMailAccount.AccountId],
-            [new MailFolderIdentity(SyntheticMailAccount.AccountId, MailFolderAlias.Create(FolderAlias))]),
+                OrchestratedMailboxScope.Readable(scope, [FolderAlias]),
                 EmailKnowledgeQuery.ForText(QueryTerm),
                 token),
             cancellationToken);
@@ -159,7 +157,7 @@ public sealed class OrchestratedHybridRetrievalTests(MailFathomOrchestrationFixt
             async (scope, token) =>
             {
                 var candidates = await scope.GetRequiredService<IEmailSearchIndexReader>().ReadRankedCandidatesAsync(
-                    SeededSelection(),
+                    SeededSelection(scope),
                     EmailSearchQueryText.Create(QueryTerm),
                     limit: 50,
                     token);
@@ -176,10 +174,8 @@ public sealed class OrchestratedHybridRetrievalTests(MailFathomOrchestrationFixt
         ResultLimit = 10,
     };
 
-    private static MailboxEmailSelection SeededSelection() => MailboxEmailSelection.Create(
-        MailboxScope.Create(
-            [SyntheticMailAccount.AccountId],
-            [new MailFolderIdentity(SyntheticMailAccount.AccountId, MailFolderAlias.Create(FolderAlias))]),
+    private static MailboxEmailSelection SeededSelection(IServiceProvider scope) => MailboxEmailSelection.Create(
+        OrchestratedMailboxScope.Readable(scope, [FolderAlias]),
         senderAddress: null,
         recipientAddress: null,
         subjectFragment: null,

--- a/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
@@ -382,6 +382,40 @@ public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationF
         Assert.Empty(queued);
     }
 
+    /// <summary>
+    /// Neither walk reaches mail stored under an alias no mapping names, so a folder an operator withdrew is not mail
+    /// a rule may move, file, or flag.
+    /// </summary>
+    /// <remarks>
+    /// Both walks are asserted because they select different mail — one the arrival queue, the other the whole mailbox
+    /// — and a narrowing applied to only one of them would leave a requested run acting on exactly the folder the
+    /// account run left alone. The mapped message beside it is the control the two absences need.
+    /// </remarks>
+    [Fact]
+    public async Task BothWalks_MailInAFolderNoMappingNames_LeaveItOutWhileItStaysStored()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        await DrainArrivalQueueAsync(services, cancellationToken);
+        var unmapped = await StoreOneMessageAsync(
+            services,
+            uid: 9441,
+            cancellationToken,
+            SyntheticMailAccount.UnmappedFolderAlias);
+        var mapped = await StoreOneMessageAsync(services, uid: 9442, cancellationToken);
+
+        // Act
+        var queued = await ReadArrivalQueueAsync(services, resumeAfter: null, DrainBatchSize, cancellationToken);
+        var walked = await WalkWholeMailboxAsync(services, cancellationToken);
+
+        // Assert
+        Assert.DoesNotContain(unmapped, queued.Select(candidate => candidate.StoredEmailId));
+        Assert.DoesNotContain(unmapped, walked);
+        Assert.Contains(mapped, queued.Select(candidate => candidate.StoredEmailId));
+        Assert.Contains(mapped, walked);
+    }
+
     /// <summary>Pages the whole-mailbox walk to its end, the way a requested run does across account runs.</summary>
     private static async Task<IReadOnlyList<StoredEmailId>> WalkWholeMailboxAsync(
         OrchestratedMailFathomServices services,

--- a/tests/IntegrationTests/Persistence/OrchestratedStoredEmailReconciliationTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedStoredEmailReconciliationTests.cs
@@ -371,7 +371,7 @@ public sealed class OrchestratedStoredEmailReconciliationTests(MailFathomOrchest
         CancellationToken cancellationToken) => services.InScopeAsync(
             (scope, token) => scope.GetRequiredService<IStoredEmailTimelineReader>().ReadPageAsync(
                 EmailTimelineFilter.Create(
-                    ScopeOf(binding),
+                    ScopeOf(scope, binding),
                     senderAddress: null,
                     recipientAddress: null,
                     subjectFragment: null,
@@ -393,7 +393,7 @@ public sealed class OrchestratedStoredEmailReconciliationTests(MailFathomOrchest
             {
                 var reader = scope.GetRequiredService<IEmailSearchIndexReader>();
                 var selection = MailboxEmailSelection.Create(
-                    ScopeOf(binding),
+                    ScopeOf(scope, binding),
                     senderAddress: null,
                     recipientAddress: null,
                     subjectFragment: null,
@@ -414,10 +414,8 @@ public sealed class OrchestratedStoredEmailReconciliationTests(MailFathomOrchest
             },
             cancellationToken);
 
-    private static MailboxScope ScopeOf(MailFolderResolution binding) =>
-        MailboxScope.Create(
-            [SyntheticMailAccount.AccountId],
-            [new MailFolderIdentity(SyntheticMailAccount.AccountId, binding.Alias)]);
+    private static MailboxScope ScopeOf(IServiceProvider scope, MailFolderResolution binding) =>
+        OrchestratedMailboxScope.Readable(scope, [binding.Alias.Value]);
 
     /// <summary>Reads every row one folder holds, keyed by UID so an assertion names a message rather than an identifier.</summary>
     private static async Task<IReadOnlyDictionary<uint, StoredEmailEntity>> ReadRowsAsync(

--- a/tests/IntegrationTests/Persistence/OrchestratedStoredEmailTimelineReaderTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedStoredEmailTimelineReaderTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
-using MailFathom.Application.Folders;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Checkpoints;
@@ -106,10 +104,11 @@ public sealed class OrchestratedStoredEmailTimelineReaderTests(MailFathomOrchest
 
     /// <summary>A folder withheld from tools is narrowed out by the server, whatever the request named.</summary>
     /// <remarks>
-    /// The narrowing is composed per excluded account rather than written as a filter over one column, so whether it
+    /// The narrowing is composed per admitted account rather than written as a filter over one column, so whether it
     /// translates at all is settled here and nowhere else: a predicate that does not is an exception at runtime. The
-    /// control is the same mail read through a scope that withholds nothing, so an empty answer reports the exclusion
-    /// rather than a folder nothing was seeded into.
+    /// control is the same mail read through a deployment that withholds nothing, which is a second composition because
+    /// the folder decision belongs to the configuration a deployment was started with — so an empty answer reports the
+    /// withholding rather than a folder nothing was seeded into.
     /// </remarks>
     [Fact]
     public async Task ReadPageAsync_AFolderWithheldFromTools_IsNarrowedOutWhileItsMailStaysStored()
@@ -117,13 +116,19 @@ public sealed class OrchestratedStoredEmailTimelineReaderTests(MailFathomOrchest
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
         var withheld = new MailFolderIdentity(SyntheticMailAccount.AccountId, MailFolderAlias.Create(FolderAlias));
-        await using var services = await OrchestratedMailFathomServices.StartAsync(
+        await using var readableDeployment = await OrchestratedMailFathomServices.StartAsync(
+            orchestration,
+            cancellationToken);
+        var readableFilter = await SeededFilterAsync(
+            readableDeployment,
+            EmailTimelineDirection.NewestFirst,
+            cancellationToken);
+        await using var withholdingDeployment = await OrchestratedMailFathomServices.StartAsync(
             orchestration,
             cancellationToken,
             foldersHiddenFromTools: [withheld]);
-        var readableFilter = await SeededFilterAsync(services, EmailTimelineDirection.NewestFirst, cancellationToken);
         var withheldFilter = EmailTimelineFilter.Create(
-            await ReadableScopeAsync(services, cancellationToken),
+            await ReadableScopeAsync(withholdingDeployment, cancellationToken),
             senderAddress: "sender@mailfathom.test",
             recipientAddress: null,
             subjectFragment: null,
@@ -134,14 +139,60 @@ public sealed class OrchestratedStoredEmailTimelineReaderTests(MailFathomOrchest
             EmailTimelineDirection.NewestFirst);
 
         // Act
-        var throughTheWithheldScope = await ReadAllAsync(services, withheldFilter, cancellationToken);
+        var throughTheWithheldScope = await ReadAllAsync(withholdingDeployment, withheldFilter, cancellationToken);
 
         // Assert
         Assert.Empty(throughTheWithheldScope);
-        Assert.Equal([withheld], withheldFilter.Selection.Scope.HiddenFolders);
+        Assert.DoesNotContain(withheld, withheldFilter.Selection.Scope.ReadableFolders);
 
-        // The control: the same mail is there to be read through a scope that withholds nothing.
-        Assert.NotEmpty(await ReadAllAsync(services, readableFilter, cancellationToken));
+        // The control: the same mail is there to be read through a deployment that withholds nothing.
+        Assert.NotEmpty(await ReadAllAsync(readableDeployment, readableFilter, cancellationToken));
+    }
+
+    /// <summary>Mail stored under an alias no mapping names is unreachable, and stays stored.</summary>
+    /// <remarks>
+    /// This is the case that used to read as full participation: an operator who removed a folder's mapping got its
+    /// stored mail published by every tool and refreshed by nothing. The rows are counted afterwards through the
+    /// context rather than through a read model, because what has to be true is both halves at once — nothing is
+    /// published, and nothing was erased for a configuration value having changed.
+    /// </remarks>
+    [Fact]
+    public async Task ReadPageAsync_AFolderNoMappingNames_ReturnsNothingWhileItsRowsStay()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var binding = await OrchestratedFolderBinding.CommitAsync(
+            services,
+            SyntheticMailAccount.UnmappedFolderAlias,
+            cancellationToken);
+        await EnsureSeededAsync(services, binding, cancellationToken);
+        var unmappedScope = await OrchestratedMailboxScope.ReadableAsync(
+            services,
+            [SyntheticMailAccount.UnmappedFolderAlias],
+            cancellationToken);
+
+        // Act
+        var listed = await ReadAllAsync(
+            services,
+            EmailTimelineFilter.Create(
+                unmappedScope,
+                senderAddress: null,
+                recipientAddress: null,
+                subjectFragment: null,
+                receivedOnOrAfter: null,
+                receivedBefore: null,
+                isRemotelySeen: null,
+                hasAttachments: null,
+                EmailTimelineDirection.NewestFirst),
+            cancellationToken);
+        var freshness = await ReadFreshnessAsync(services, unmappedScope, cancellationToken);
+
+        // Assert
+        Assert.Empty(listed);
+        Assert.Empty(freshness);
+        Assert.Empty(unmappedScope.ReadableFolders);
+        Assert.Equal(SeededEmailCount, await CountSeededEmailsAsync(services, binding, cancellationToken));
     }
 
     /// <summary>Applies every filter the read model publishes, which is what proves each one translates and selects.</summary>
@@ -297,20 +348,18 @@ public sealed class OrchestratedStoredEmailTimelineReaderTests(MailFathomOrchest
         // Act
         var withinScope = await ReadFreshnessAsync(
             services,
-            MailboxScope.Create(
-            [SyntheticMailAccount.AccountId],
-            [new MailFolderIdentity(SyntheticMailAccount.AccountId, seededAlias)]),
+            await OrchestratedMailboxScope.ReadableAsync(services, [FolderAlias], cancellationToken),
             cancellationToken);
-        var acrossEveryFolder = await ReadFreshnessAsync(services, MailboxScope.Unrestricted, cancellationToken);
+        var acrossEveryFolder = await ReadFreshnessAsync(
+            services,
+            await OrchestratedMailboxScope.ReadableAsync(services, [], cancellationToken),
+            cancellationToken);
         var outsideScope = await ReadFreshnessAsync(
             services,
-            MailboxScope.Create(
-                null,
-                [
-                    new MailFolderIdentity(
-                        SyntheticMailAccount.AccountId,
-                        MailFolderAlias.Create("a-folder-nobody-bound")),
-                ]),
+            await OrchestratedMailboxScope.ReadableAsync(
+                services,
+                ["a-folder-nobody-bound"],
+                cancellationToken),
             cancellationToken);
 
         // Assert
@@ -369,7 +418,7 @@ public sealed class OrchestratedStoredEmailTimelineReaderTests(MailFathomOrchest
             cancellationToken);
 
     /// <summary>Reads every email one filter selects, scoped to the folder this class seeded.</summary>
-    private static Task<IReadOnlyList<EmailSummary>> ReadFilteredAsync(
+    private static async Task<IReadOnlyList<EmailSummary>> ReadFilteredAsync(
         OrchestratedMailFathomServices services,
         string? recipientAddress = null,
         string? subjectFragment = null,
@@ -377,12 +426,10 @@ public sealed class OrchestratedStoredEmailTimelineReaderTests(MailFathomOrchest
         DateTimeOffset? receivedBefore = null,
         bool? isRemotelySeen = null,
         bool? hasAttachments = null,
-        CancellationToken cancellationToken = default) => ReadAllAsync(
+        CancellationToken cancellationToken = default) => await ReadAllAsync(
             services,
             EmailTimelineFilter.Create(
-                MailboxScope.Create(
-                    [SyntheticMailAccount.AccountId],
-                    [new MailFolderIdentity(SyntheticMailAccount.AccountId, MailFolderAlias.Create(FolderAlias))]),
+                await ReadableScopeAsync(services, cancellationToken),
                 senderAddress: "sender@mailfathom.test",
                 recipientAddress,
                 subjectFragment,
@@ -396,18 +443,8 @@ public sealed class OrchestratedStoredEmailTimelineReaderTests(MailFathomOrchest
     /// <summary>Resolves the scope a tool reads through, which is where a withheld folder is attached to it.</summary>
     private static Task<MailboxScope> ReadableScopeAsync(
         OrchestratedMailFathomServices services,
-        CancellationToken cancellationToken) => services.InScopeAsync(
-            (scope, _) => Task.FromResult(
-                new MailboxScopeResolver(
-                    scope.GetRequiredService<IMailAccountCatalog>(),
-                    scope.GetRequiredService<IMailFolderParticipationReader>(),
-                    scope.GetRequiredService<IJunkMailFolderCatalog>(),
-                    scope.GetRequiredService<MailFolderReferenceResolver>())
-                    .ReadableScope(
-                        [],
-                        [MailFolderReference.ToAlias(MailFolderAlias.Create(FolderAlias))],
-                        JunkMailInclusion.Excluded)),
-            cancellationToken);
+        CancellationToken cancellationToken) =>
+        OrchestratedMailboxScope.ReadableAsync(services, [FolderAlias], cancellationToken);
 
     /// <summary>Ensures the seeded folder exists and returns the filter every test in this class reads it through.</summary>
     private static async Task<EmailTimelineFilter> SeededFilterAsync(
@@ -420,9 +457,7 @@ public sealed class OrchestratedStoredEmailTimelineReaderTests(MailFathomOrchest
         await EnsureSeededAsync(services, binding, cancellationToken);
 
         return EmailTimelineFilter.Create(
-            MailboxScope.Create(
-            [SyntheticMailAccount.AccountId],
-            [new MailFolderIdentity(SyntheticMailAccount.AccountId, binding.Alias)]),
+            await ReadableScopeAsync(services, cancellationToken),
             senderAddress: "sender@mailfathom.test",
             recipientAddress: null,
             subjectFragment: null,

--- a/tests/Mcp.UnitTests/TestDoubles/AnsweringDeployment.cs
+++ b/tests/Mcp.UnitTests/TestDoubles/AnsweringDeployment.cs
@@ -80,7 +80,7 @@ internal static class AnsweringDeployment
             Capability(answerer),
             new MailboxScopeResolver(
                 AccountCatalog(),
-                StubMailFolderParticipation.Everything,
+                StubMailFolderParticipation.Nothing,
                 StubJunkMailFolderCatalog.None,
                 StubMailFolderMappings.ResolvingNothing),
             spendLedger ?? LedgerAdmitting(),

--- a/tests/Mcp.UnitTests/Tools/GetEmailContentToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/GetEmailContentToolTests.cs
@@ -911,11 +911,19 @@ public sealed class GetEmailContentToolTests
             repairRequestStore ?? Substitute.For<IEmailContentRepairRequestStore>(),
             new MailboxScopeResolver(
                 new StubMailAccountCatalog(ServedAccountId),
-                StubMailFolderParticipation.Everything,
+                MappedInbox,
                 StubJunkMailFolderCatalog.None,
                 StubMailFolderMappings.ResolvingNothing),
             linkIssuer ?? new StubAttachmentDownloadLinkIssuer(),
             new EmailContentReadOptions()));
+
+    /// <summary>The one folder this deployment maps, which is what makes the mail these tests store readable at all.</summary>
+    /// <remarks>
+    /// A folder no mapping names does not exist as far as MailFathom is concerned, so a tool arranged over an unmapped
+    /// alias answers every read with a refusal. Every summary here is stored in the inbox, so the mapping is one entry.
+    /// </remarks>
+    private static StubMailFolderParticipation MappedInbox => StubMailFolderParticipation.Mapping(
+        new MailFolderIdentity(MailAccountId.Create(ServedAccountId), MailFolderAlias.Create("INBOX")));
 
     private static EmailSummary SummaryOf(
         DateTimeOffset? sentAt = null,

--- a/tests/Mcp.UnitTests/Tools/ListAccountsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/ListAccountsToolTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Accounts;
+using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
@@ -10,6 +11,7 @@ using MailFathom.Domain.Synchronization;
 using MailFathom.Mcp.Tools;
 using MailFathom.Mcp.Tools.Results;
 using MailFathom.Mcp.UnitTests.TestDoubles;
+using MailFathom.TestSupport;
 using Xunit;
 
 namespace MailFathom.Mcp.UnitTests.Tools;
@@ -168,6 +170,13 @@ public sealed class ListAccountsToolTests
         StubMailAccountCatalog catalog,
         params MailboxFolderFreshness[] folderFreshness) =>
         new(
-            new MailAccountDirectoryReader(catalog, new StubSynchronizationFreshnessReader(folderFreshness)),
+            new MailAccountDirectoryReader(
+                catalog,
+                new StubSynchronizationFreshnessReader(folderFreshness),
+                new MailboxScopeResolver(
+                    catalog,
+                    StubMailFolderParticipation.Nothing,
+                    StubJunkMailFolderCatalog.None,
+                    StubMailFolderMappings.ResolvingNothing)),
             catalog);
 }

--- a/tests/Mcp.UnitTests/Tools/ListEmailsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/ListEmailsToolTests.cs
@@ -589,7 +589,7 @@ public sealed class ListEmailsToolTests
 
         // Assert
         Assert.NotNull(timeline.LastFilter);
-        Assert.Equal([junkFolder], timeline.LastFilter.Selection.Scope.WithheldFolders);
+        Assert.Equal([junkFolder], timeline.LastFilter.Selection.Scope.WithheldJunkFolders);
         Assert.False(result.IncludedJunkMail);
     }
 
@@ -609,7 +609,7 @@ public sealed class ListEmailsToolTests
 
         // Assert
         Assert.NotNull(timeline.LastFilter);
-        Assert.Empty(timeline.LastFilter.Selection.Scope.WithheldFolders);
+        Assert.Empty(timeline.LastFilter.Selection.Scope.WithheldJunkFolders);
         Assert.True(result.IncludedJunkMail);
     }
 
@@ -645,7 +645,7 @@ public sealed class ListEmailsToolTests
             freshness ?? new StubSynchronizationFreshnessReader(),
             new MailboxScopeResolver(
                 new StubMailAccountCatalog(ServedAccountId),
-                StubMailFolderParticipation.Everything,
+                StubMailFolderParticipation.Nothing,
                 junkFolders ?? StubJunkMailFolderCatalog.None,
                 folderMappings.Resolver),
             egressGuard ?? SensitiveContentEgressGuards.Inactive()),

--- a/tests/Mcp.UnitTests/Tools/SearchEmailsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/SearchEmailsToolTests.cs
@@ -541,7 +541,7 @@ public sealed class SearchEmailsToolTests
 
         // Assert
         Assert.NotNull(index.LastSelection);
-        Assert.Equal([junkFolder], index.LastSelection.Scope.WithheldFolders);
+        Assert.Equal([junkFolder], index.LastSelection.Scope.WithheldJunkFolders);
         Assert.False(result.IncludedJunkMail);
     }
 
@@ -562,7 +562,7 @@ public sealed class SearchEmailsToolTests
 
         // Assert
         Assert.NotNull(index.LastSelection);
-        Assert.Empty(index.LastSelection.Scope.WithheldFolders);
+        Assert.Empty(index.LastSelection.Scope.WithheldJunkFolders);
         Assert.True(result.IncludedJunkMail);
     }
 
@@ -584,7 +584,7 @@ public sealed class SearchEmailsToolTests
                 freshness ?? new StubSynchronizationFreshnessReader(),
                 new MailboxScopeResolver(
                     new StubMailAccountCatalog(ServedAccountId),
-                    StubMailFolderParticipation.Everything,
+                    StubMailFolderParticipation.Nothing,
                     junkFolders ?? StubJunkMailFolderCatalog.None,
                     StubMailFolderMappings.ResolvingNothing),
                 bounds,

--- a/tests/SharedSources.UnitTests/StubMailFolderParticipationTests.cs
+++ b/tests/SharedSources.UnitTests/StubMailFolderParticipationTests.cs
@@ -9,96 +9,114 @@ using Xunit;
 
 namespace MailFathom.SharedSources.UnitTests;
 
-/// <summary>Covers the participation reader every suite arranging a withheld folder answers through.</summary>
+/// <summary>Covers the participation reader every suite arranging a folder decision answers through.</summary>
 /// <remarks>
-/// A fault here reports somebody else's arrangement. A reader that named a folder in the wrong list would let a test
-/// about tool visibility pass on an exclusion a rule walk applies, and one whose derived answer disagreed with its own
-/// lists would prove a narrowing that configuration never produces.
+/// A fault here reports somebody else's arrangement. A reader that admitted a folder no test mapped would make a
+/// mailbox read return mail the deployment does not have while the test read as proof that it does; one whose two lists
+/// disagreed with its per-folder answer would let a folder be readable through a query and unreadable through an
+/// identifier, which is exactly the divergence the production reader exists to prevent.
 /// </remarks>
 public sealed class StubMailFolderParticipationTests
 {
     private static readonly MailAccountId Work = MailAccountId.Create("work");
+    private static readonly MailAccountId Private = MailAccountId.Create("private");
 
-    private static readonly MailFolderIdentity Archive =
-        new(Work, MailFolderAlias.Create("archive"));
+    private static readonly MailFolderIdentity WorkInbox = new(Work, MailFolderAlias.Create("inbox"));
+    private static readonly MailFolderIdentity WorkArchive = new(Work, MailFolderAlias.Create("archive"));
+    private static readonly MailFolderIdentity PrivateInbox = new(Private, MailFolderAlias.Create("inbox"));
 
-    /// <summary>The supply an existing arrangement takes, which has to keep saying what it said before folder switches existed.</summary>
     [Fact]
-    public void Everything_AFolderNobodyArranged_WithholdsNothing()
+    public void Mapping_TheFoldersItNames_AdmitsEachOfThemToEverything()
+    {
+        // Act
+        var participation = StubMailFolderParticipation.Mapping(WorkInbox, PrivateInbox);
+
+        // Assert
+        Assert.Equal([WorkInbox, PrivateInbox], participation.FoldersSynchronized);
+        Assert.Equal([WorkInbox, PrivateInbox], participation.FoldersVisibleToTools);
+        Assert.Equal([WorkInbox, PrivateInbox], participation.FoldersGeneratingEmbeddings);
+        Assert.Equal(MailFolderParticipation.Full, participation.GetParticipation(Work, WorkInbox.Alias));
+    }
+
+    /// <summary>A folder no arrangement mapped is a folder the deployment does not have, which is what the reader has to say.</summary>
+    [Fact]
+    public void GetParticipation_AFolderNothingMapped_AnswersUnmapped()
     {
         // Arrange
-        var participation = StubMailFolderParticipation.Everything;
+        var participation = StubMailFolderParticipation.Mapping(WorkInbox);
 
         // Act, Assert
-        Assert.Empty(participation.FoldersHiddenFromTools);
-        Assert.Empty(participation.FoldersWithoutEmbeddings);
-        Assert.Empty(participation.FoldersNotMirrored);
-        Assert.Equal(MailFolderParticipation.Full, participation.GetParticipation(Work, Archive.Alias));
+        Assert.Equal(MailFolderParticipation.Unmapped, participation.GetParticipation(Work, WorkArchive.Alias));
+        Assert.Equal(MailFolderParticipation.Unmapped, participation.GetParticipation(Private, WorkInbox.Alias));
+        Assert.Empty(StubMailFolderParticipation.Nothing.FoldersVisibleToTools);
+        Assert.Empty(StubMailFolderParticipation.Nothing.FoldersGeneratingEmbeddings);
     }
 
     [Fact]
-    public void Hiding_TheFolderItNames_WithholdsItFromToolsAndFromNothingElse()
+    public void Hiding_AMappedFolder_LeavesItOutOfTheToolsListAndKeepsItEmbedded()
     {
-        // Arrange
-        var participation = StubMailFolderParticipation.Hiding(Archive);
-
         // Act
-        var arranged = participation.GetParticipation(Work, Archive.Alias);
+        var participation = StubMailFolderParticipation.Mapping(WorkInbox, WorkArchive).Hiding(WorkArchive);
 
         // Assert
-        Assert.Equal([Archive], participation.FoldersHiddenFromTools);
-        Assert.Empty(participation.FoldersWithoutEmbeddings);
-        Assert.Empty(participation.FoldersNotMirrored);
-        Assert.False(arranged.IsVisibleToTools);
-        Assert.True(arranged.IsSynchronized);
-        Assert.True(arranged.GeneratesEmbeddings);
+        Assert.Equal([WorkInbox], participation.FoldersVisibleToTools);
+        Assert.Equal([WorkInbox, WorkArchive], participation.FoldersGeneratingEmbeddings);
+        Assert.False(participation.GetParticipation(Work, WorkArchive.Alias).IsVisibleToTools);
+        Assert.True(participation.GetParticipation(Work, WorkArchive.Alias).GeneratesEmbeddings);
     }
 
     [Fact]
-    public void WithoutEmbeddingsIn_TheFolderItNames_LeavesItMirroredAndReadable()
+    public void WithoutEmbeddingsIn_AMappedFolder_LeavesItOutOfTheEmbeddingListAndKeepsItReadable()
     {
-        // Arrange
-        var participation = StubMailFolderParticipation.WithoutEmbeddingsIn(Archive);
-
         // Act
-        var arranged = participation.GetParticipation(Work, Archive.Alias);
+        var participation = StubMailFolderParticipation
+            .Mapping(WorkInbox, WorkArchive)
+            .WithoutEmbeddingsIn(WorkArchive);
 
         // Assert
-        Assert.Equal([Archive], participation.FoldersWithoutEmbeddings);
-        Assert.Empty(participation.FoldersHiddenFromTools);
-        Assert.Empty(participation.FoldersNotMirrored);
-        Assert.False(arranged.GeneratesEmbeddings);
-        Assert.True(arranged.IsVisibleToTools);
+        Assert.Equal([WorkInbox, WorkArchive], participation.FoldersVisibleToTools);
+        Assert.Equal([WorkInbox], participation.FoldersGeneratingEmbeddings);
     }
 
-    /// <summary>A folder nothing mirrors is in every list at once, which is what configuration derives for one.</summary>
+    /// <summary>A folder nothing mirrors takes part in nothing, so it is admitted to no list while staying mapped.</summary>
     [Fact]
-    public void Unmirroring_TheFolderItNames_WithdrawsItFromEveryReaderThereIs()
+    public void Unmirroring_AMappedFolder_AdmitsItToNoListAndKeepsItMapped()
     {
-        // Arrange
-        var participation = StubMailFolderParticipation.Unmirroring(Archive);
-
         // Act
-        var arranged = participation.GetParticipation(Work, Archive.Alias);
+        var participation = StubMailFolderParticipation.Mapping(WorkInbox, WorkArchive).Unmirroring(WorkArchive);
 
         // Assert
-        Assert.Equal([Archive], participation.FoldersNotMirrored);
-        Assert.Equal([Archive], participation.FoldersHiddenFromTools);
-        Assert.Equal([Archive], participation.FoldersWithoutEmbeddings);
-        Assert.Equal(MailFolderParticipation.MappedOnly, arranged);
+        Assert.Equal([WorkInbox], participation.FoldersSynchronized);
+        Assert.Equal([WorkInbox], participation.FoldersVisibleToTools);
+        Assert.Equal([WorkInbox], participation.FoldersGeneratingEmbeddings);
+        Assert.Equal(MailFolderParticipation.MappedOnly, participation.GetParticipation(Work, WorkArchive.Alias));
     }
 
-    /// <summary>One account's arrangement is never another account's, which is what makes the identity a pair.</summary>
+    /// <summary>An arrangement states one decision per folder, so the last thing a test said about one is what it answers.</summary>
     [Fact]
-    public void GetParticipation_TheSameAliasInAnotherAccount_IsNotTheFolderThatWasArranged()
+    public void With_AFolderArrangedTwice_KeepsTheDecisionStatedLast()
     {
-        // Arrange
-        var participation = StubMailFolderParticipation.Unmirroring(Archive);
-
         // Act
-        var elsewhere = participation.GetParticipation(MailAccountId.Create("private"), Archive.Alias);
+        var participation = StubMailFolderParticipation.Mapping(WorkInbox).Hiding(WorkInbox);
 
         // Assert
-        Assert.Equal(MailFolderParticipation.Full, elsewhere);
+        Assert.Empty(participation.FoldersVisibleToTools);
+        Assert.Equal([WorkInbox], participation.FoldersGeneratingEmbeddings);
+    }
+
+    /// <summary>The arrangement is per reader, so a test that took the default answer never sees a folder another one mapped.</summary>
+    [Fact]
+    public void Nothing_ReadTwice_AnswersFromTwoSeparateArrangements()
+    {
+        // Arrange
+        var arranged = StubMailFolderParticipation.Nothing;
+        arranged.With(WorkInbox, MailFolderParticipation.Full);
+
+        // Act
+        var untouched = StubMailFolderParticipation.Nothing;
+
+        // Assert
+        Assert.NotEmpty(arranged.FoldersVisibleToTools);
+        Assert.Empty(untouched.FoldersVisibleToTools);
     }
 }

--- a/tests/shared/StubMailFolderParticipation.cs
+++ b/tests/shared/StubMailFolderParticipation.cs
@@ -8,61 +8,99 @@ using MailFathom.Domain.Folders;
 
 namespace MailFathom.TestSupport;
 
-/// <summary>Answers what folders take part in, from a list a test wrote rather than from configuration.</summary>
+/// <summary>Answers what folders take part in, from mappings a test wrote rather than from configuration.</summary>
 /// <remarks>
 /// Every boundary that has to obey a folder decision reads it through one port, so a test that is not about folder
-/// participation still has to supply one. <see cref="Everything" /> is that supply: it withholds nothing, which is what
-/// a deployment configuring no switch behaves like, so an existing test's arrangement keeps saying what it said.
+/// participation still has to supply one. What it supplies is the folders its own arrangement uses, because a folder no
+/// mapping names takes part in nothing: <see cref="Nothing" /> answers for a deployment that maps no folder at all, and
+/// <see cref="Mapping" /> is the ordinary supply — the named folders, each taking part in everything, which is what a
+/// mapping means when it sets no switch.
 /// </remarks>
 internal sealed class StubMailFolderParticipation : IMailFolderParticipationReader
 {
-    private StubMailFolderParticipation(
-        IReadOnlyList<MailFolderIdentity> hiddenFromTools,
-        IReadOnlyList<MailFolderIdentity> withoutEmbeddings,
-        IReadOnlyList<MailFolderIdentity> notMirrored)
+    private readonly List<ConfiguredFolder> folders = [];
+
+    /// <summary>Gets a reader mapping no folder, which is what a deployment whose configuration names none reads like.</summary>
+    /// <remarks>A new instance each time, because the reader is built by adding folders to it and a shared one would carry another test's arrangement.</remarks>
+    public static StubMailFolderParticipation Nothing => new();
+
+    /// <inheritdoc />
+    public IReadOnlyList<MailFolderIdentity> FoldersSynchronized =>
+        [.. this.folders.Where(static folder => folder.Participation.IsSynchronized).Select(static folder => folder.Identity)];
+
+    /// <inheritdoc />
+    public IReadOnlyList<MailFolderIdentity> FoldersVisibleToTools =>
+        [.. this.folders.Where(static folder => folder.Participation.IsVisibleToTools).Select(static folder => folder.Identity)];
+
+    /// <inheritdoc />
+    public IReadOnlyList<MailFolderIdentity> FoldersGeneratingEmbeddings =>
+        [.. this.folders.Where(static folder => folder.Participation.GeneratesEmbeddings).Select(static folder => folder.Identity)];
+
+    /// <summary>Builds a reader mapping the named folders, each taking part in everything.</summary>
+    /// <param name="folders">The folders configuration names.</param>
+    /// <returns>The reader.</returns>
+    public static StubMailFolderParticipation Mapping(params MailFolderIdentity[] folders)
     {
-        this.FoldersHiddenFromTools = hiddenFromTools;
-        this.FoldersWithoutEmbeddings = withoutEmbeddings;
-        this.FoldersNotMirrored = notMirrored;
+        var participation = new StubMailFolderParticipation();
+
+        foreach (var folder in folders)
+        {
+            participation.With(folder, MailFolderParticipation.Full);
+        }
+
+        return participation;
     }
 
-    /// <summary>Gets a reader that withholds nothing, which is what a deployment configuring no switch reads like.</summary>
-    public static StubMailFolderParticipation Everything { get; } = new([], [], []);
+    /// <summary>Maps one folder with the participation a test chose, replacing what this reader said about it.</summary>
+    /// <param name="folder">The folder the mapping names.</param>
+    /// <param name="participation">What that mapping admits the folder to.</param>
+    /// <returns>The same reader, so an arrangement reads as one expression.</returns>
+    public StubMailFolderParticipation With(MailFolderIdentity folder, MailFolderParticipation participation)
+    {
+        this.folders.RemoveAll(configured => configured.Identity == folder);
+        this.folders.Add(new ConfiguredFolder(folder, participation));
 
-    /// <inheritdoc />
-    public IReadOnlyList<MailFolderIdentity> FoldersHiddenFromTools { get; }
+        return this;
+    }
 
-    /// <inheritdoc />
-    public IReadOnlyList<MailFolderIdentity> FoldersWithoutEmbeddings { get; }
+    /// <summary>Maps the named folders and withholds each of them from every tool.</summary>
+    /// <param name="folders">The folders to withhold.</param>
+    /// <returns>The same reader.</returns>
+    public StubMailFolderParticipation Hiding(params MailFolderIdentity[] folders) => this.WithAll(
+        folders,
+        MailFolderParticipation.Create(isSynchronized: true, generatesEmbeddings: true, isVisibleToTools: false));
 
-    /// <inheritdoc />
-    public IReadOnlyList<MailFolderIdentity> FoldersNotMirrored { get; }
-
-    /// <summary>Builds a reader that hides the named folders from every tool.</summary>
-    /// <param name="folders">The folders to hide.</param>
-    /// <returns>The reader.</returns>
-    public static StubMailFolderParticipation Hiding(params MailFolderIdentity[] folders) => new(folders, [], []);
-
-    /// <summary>Builds a reader that embeds nothing of the named folders.</summary>
+    /// <summary>Maps the named folders and embeds nothing of them.</summary>
     /// <param name="folders">The folders to leave unembedded.</param>
-    /// <returns>The reader.</returns>
-    public static StubMailFolderParticipation WithoutEmbeddingsIn(params MailFolderIdentity[] folders) =>
-        new([], folders, []);
+    /// <returns>The same reader.</returns>
+    public StubMailFolderParticipation WithoutEmbeddingsIn(params MailFolderIdentity[] folders) => this.WithAll(
+        folders,
+        MailFolderParticipation.Create(isSynchronized: true, generatesEmbeddings: false, isVisibleToTools: true));
 
-    /// <summary>Builds a reader for folders nothing mirrors, which withdraws all three answers at once.</summary>
+    /// <summary>Maps the named folders and mirrors nothing of them, which withdraws all three answers at once.</summary>
     /// <param name="folders">The folders nothing mirrors.</param>
-    /// <returns>The reader.</returns>
-    public static StubMailFolderParticipation Unmirroring(params MailFolderIdentity[] folders) =>
-        new(folders, folders, folders);
+    /// <returns>The same reader.</returns>
+    public StubMailFolderParticipation Unmirroring(params MailFolderIdentity[] folders) =>
+        this.WithAll(folders, MailFolderParticipation.MappedOnly);
 
     /// <inheritdoc />
-    public MailFolderParticipation GetParticipation(MailAccountId accountId, MailFolderAlias folderAlias)
-    {
-        var folder = new MailFolderIdentity(accountId, folderAlias);
+    public MailFolderParticipation GetParticipation(MailAccountId accountId, MailFolderAlias folderAlias) =>
+        this.folders
+            .FirstOrDefault(folder => folder.Identity == new MailFolderIdentity(accountId, folderAlias))
+            ?.Participation
+        ?? MailFolderParticipation.Unmapped;
 
-        return MailFolderParticipation.Create(
-            !this.FoldersNotMirrored.Contains(folder),
-            !this.FoldersWithoutEmbeddings.Contains(folder),
-            !this.FoldersHiddenFromTools.Contains(folder));
+    private StubMailFolderParticipation WithAll(
+        IReadOnlyList<MailFolderIdentity> named,
+        MailFolderParticipation participation)
+    {
+        foreach (var folder in named)
+        {
+            this.With(folder, participation);
+        }
+
+        return this;
     }
+
+    private sealed record ConfiguredFolder(MailFolderIdentity Identity, MailFolderParticipation Participation);
 }


### PR DESCRIPTION
`IMailFolderParticipationReader.GetParticipation` answered `Full` for an alias configuration does not map, so a folder
list read as a filter over the mailbox rather than as the whole of what the deployment has. Mail stored under a mapping
an operator later removed went on being listed, searched, read, answered from, cut into passages, embedded, and
evaluated by rules — the rows outlived the decision that stopped refreshing them, and nothing withheld them, because a
list of withheld names cannot carry a folder nobody named.

Every folder decision is now stated as what configuration **admits**. That is the only shape that reaches an unmapped
folder, and it is what makes an account mapping nothing read as nothing rather than as everything.

## What changed

- `MailFolderParticipation` gains `Unmapped` beside `MappedOnly`, so a folder this deployment does not have never
  compares equal to one an operator stopped mirroring. `IsMapped` is a state of its own rather than something inferred
  from the other three being off.
- The port's exclusion lists become three inclusions — `FoldersSynchronized`, `FoldersVisibleToTools`,
  `FoldersGeneratingEmbeddings` — and the fallback answers `Unmapped`.
- `FoldersNotMirrored`, added by #781 while this was in flight, goes with them: admitting the mirrored folders answers
  what excluding the unmirrored ones answered, and reaches the unmapped folder the exclusion could not. One list rather
  than two, and the narrowing stays in the query for the reason #781 gave.
- `MailboxScope` carries `ReadableFolders` in place of `HiddenFolders` (`WithheldFolders` is gone), empty meaning
  nothing readable, and `Unrestricted` is renamed `NothingReadable` after what it now means.
- `AccountScopedMailFolders` gains `Admitting`, whose empty list admits nothing — the one difference from `Selecting`,
  where empty is a caller who named no folder.
- Narrowed reads: the mailbox scope, the two reads that name an email by its identifier, `EmailChunkWriter`,
  `StoredEmailEmbeddingBackfillStore`, the folder-freshness read, and **both rule walks**. The rule walks are beyond the
  five paths the issue names and are what makes "no rule evaluates it" true; without them a rule would file, flag, or
  delete mail in a folder the deployment no longer has any notion of.
- `list_accounts` now reports the folders the deployment maps and lets tools read, resolved through the same scope every
  other read is expressed in. It previously named a folder mapped `VisibleToTools: false`.
- Mail of an unmapped folder is **kept** rather than erased, exactly as mail of an unmirrored one is since #781.
  Mapping the folder again is what makes it readable, and a folder that was mirrored once resumes from its checkpoint.

## Breaking change

**Surface: configuration.** `MailSynchronization:Accounts:<n>:Folders` keeps its name, its type, and its default, and
what it means changes: it is the whole of the folders the deployment has, not a list of folders it treats specially. A
folder no entry names is unreachable for every reader — no tool lists, searches, reads, or answers from it, no rule is
evaluated against its mail, nothing embeds or re-embeds it, and no alias of it resolves as a destination.

**The operator's action.** Anyone whose deployment holds mail under an alias its current configuration does not name —
a folder mapped once and later removed, or renamed in configuration — adds an entry for it to read that mail again.
Nothing is deleted: the rows stay in the database and become readable the moment a mapping names them, with the folder
resuming from its retained checkpoint. The default is untouched, so an account that configures no folder still mirrors
its inbox by role, and a deployment whose configuration still names every folder it uses needs no action at all.

## Verification

- `scripts/verify-full.sh` — green on this branch, rebased onto `origin/main` at e54d9cd5 (156 workflow assertions,
  Release build with warnings as errors, 6079 unit tests, formatting clean).
- The integration suite is not run locally. Its changes are the harness's folder catalogue
  (`SyntheticMailAccount.MappedFolderAliases`, a reserved `UnmappedFolderAlias`), a scope helper that resolves through
  the registered `MailboxScopeResolver`, and per-class arrangements that now map the folders they seed.

Closes #719

- Issue: https://github.com/Krzysztof318/MailFathom/issues/719
