### PR TITLE
[#718] Erase a folder's local mail on demand through mfctl

### DIFF
--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -836,7 +836,9 @@ configuration value changed, so the rows are kept and read by nothing — nothin
 them, nothing cuts them into passages or embeds them, no rule pass walks them, and no alias of theirs resolves as a
 destination. Mapping the folder again is what makes them readable again, and a folder that was mirrored once keeps its
 checkpoint, so mapping it back is the resumption the section below describes rather than a remirror. What it costs
-meanwhile is storage.
+meanwhile is storage, and [`mfctl folder
+erase`](../operations/admin-endpoint.md#erasing-a-folder-you-have-stopped-mirroring) is how an operator who wants that
+storage back asks for it — an alias no mapping names is exactly what that command accepts.
 
 That distinction is the reason to switch synchronization off rather than delete the mapping. The alias still resolves,
 by remote path or by special-use role, so the folder stays a **destination**: a relocation or a copy files a message
@@ -882,11 +884,19 @@ other two switches from this one, so no tool lists, searches, reads, or answers 
 no rule pass reaches it. Erasing them would charge an operator a whole remirror for a switch they may flip back the
 same week, so nothing in MailFathom takes local mail away because a configuration value changed.
 
+**Getting the storage back is a command rather than a setting.** [`mfctl folder
+erase`](../operations/admin-endpoint.md#erasing-a-folder-you-have-stopped-mirroring) is the one operation that removes
+a folder's local copy, and it exists precisely so that no configuration value has to: it erases in bounded passes
+through the deletion path an erasing disposition already uses, refuses a folder the account still mirrors, accepts an
+alias no mapping names, and clears the folder's checkpoint in the pass that empties it. The binding itself stays, which
+is what keeps the alias resolving as a destination.
+
 **Switching the folder back on is an ordinary mirror**, whichever state the folder is in. A folder that never stored
-anything is scheduled, discovered, bound, and backfilled exactly as one mapped mirrored from the start; a folder that
-stored something before resumes from its retained checkpoint, so the run fetches what arrived while it was off and
-nothing else, and the backward pass converges the retained rows — flags that changed, messages that left, and messages
-the server removed during the gap are observed exactly as they are for a folder that simply went unread for a while. A
+anything — or whose erasure took its checkpoint with the mail — is scheduled, discovered, bound, and backfilled exactly
+as one mapped mirrored from the start; a folder that stored something before resumes from its retained checkpoint, so
+the run fetches what arrived while it was off and nothing else, and the backward pass converges the retained rows —
+flags that changed, messages that left, and messages the server removed during the gap are observed exactly as they are
+for a folder that simply went unread for a while. A
 `UIDVALIDITY` the server changed meanwhile invalidates the checkpoint on that first run like any other, and
 reconciliation resolves what the invalidation leaves behind. There is no branch anywhere that tells a re-enabled folder
 from a newly mapped one.

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -62,9 +62,9 @@ reverse proxy, write the public URL and keep the path: `https://mail.example.tes
 >
 > Weigh that against what the operations are. The endpoint serves reads — who a credential makes the caller, two
 > records of what a mailbox has had done to it and what has been read from it, and where semantic search stands — and
-> writes that store a mailbox refresh token and start a provider bill. Any credential that can do the first can
-> therefore do all of them, so an administrative key is as sensitive as the mailbox credentials it can place, the
-> histories it can read, and the spend it can begin.
+> writes that store a mailbox refresh token, start a provider bill, and erase what a folder has stored. Any credential
+> that can do the first can therefore do all of them, so an administrative key is as sensitive as the mailbox
+> credentials it can place, the histories it can read, the spend it can begin, and the mail it can dispose of.
 
 ## What the endpoint serves
 
@@ -85,6 +85,7 @@ reverse proxy, write the public URL and keep the path: `https://mail.example.tes
 | `POST /api/admin/spam/runs` | Asks for every message already stored for one account to be [classified](../features/spam-classification.md), and answers with the run already under way where there is one. It is a dry run unless the body asks to apply. |
 | `GET /api/admin/spam/runs` | Reports where that run has got to, or how the last one ended. |
 | `GET /api/admin/spam/classifications` | Reads one account's classifications, newest first, and the changes each verdict asked the mailbox for. |
+| `POST /api/admin/folders/erasure` | Erases one bounded pass of the mail stored for a folder the account no longer mirrors. **This is the one route that disposes of mail.** |
 
 The write route's body carries a long-lived credential for a named mailbox owner, which is what makes the clear-text
 warning below matter more here than it does for a session probe. It refuses, with `400` and a sentence naming what was
@@ -429,6 +430,39 @@ answers.
 Nothing any of these three routes answers with is mail: counts, verdicts, scores, signal names, folder aliases,
 mutation names, instants, and identifiers are the whole of it. Every refusal is `400` naming what to change, including
 an account this deployment does not configure, and the run route reads at most 8 KB of body.
+
+### Erasing a folder you have stopped mirroring
+
+**`mfctl folder erase --account <id> --folder <alias>` is the only thing in MailFathom that takes a folder's local mail
+away.** Nothing else does, deliberately: switching a folder's `Synchronize` off keeps what it stored, and removing its
+mapping leaves the rows where they are, so that [editing a configuration
+file](../features/imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is) can never dispose of
+somebody's mail. That leaves an operator who means it with nothing to ask, and this is the ask.
+
+```console
+$ mfctl folder erase --account work --folder archive
+500 stored emails erased so far
+1000 stored emails erased so far
+1043 stored emails erased from ARCHIVE under work. The folder holds none, and its checkpoint went with them, so
+mirroring it again starts from the beginning rather than resuming.
+```
+
+The row goes and PostgreSQL takes its raw MIME, its search document, its passages, their vectors, and any outstanding
+repair request with it — the same deletion path an erasing disposition already uses rather than a second one. The
+folder's checkpoint goes too, in the pass that empties it, which is what makes a folder erased and then switched back
+on mirror from the start instead of resuming in front of mail that is no longer there. **The alias survives**: its
+binding stays, so the folder goes on resolving and goes on being somewhere a rule can file mail into.
+
+**A folder the account still mirrors is refused**, naming the alias and saying what makes it erasable. Erasing one
+would open a hole the next run silently refills, so the two ways to mean it are to switch the folder's `Synchronize`
+off or to remove its mapping — and an alias no mapping names at all is accepted rather than refused, because a mapping
+somebody withdrew is exactly the case that needs erasing and the one case no configuration value can express.
+
+One request is one bounded pass, and the command repeats it until the deployment reports nothing left, printing a
+running total as it goes. That is what makes an interrupted erasure resumable rather than a folder in a state nothing
+can finish: a pass either committed or did not, so interrupting the command leaves the rest where it was and running it
+again continues from there. Running it against a folder that already holds nothing succeeds having removed nothing,
+which is the ordinary end of every erasure.
 
 ## Rate limiting
 
@@ -969,6 +1003,8 @@ encryption answers the copy. Holding the credential in the platform's own secret
 | `answered 429` | The endpoint refused the request for its rate limit rather than for its credential. `Retry-After` on the response says when capacity returns where the limiter can compute one. The whole endpoint shares one bucket, so another caller's burst — including somebody guessing keys — is enough to cause this. |
 | `serves no administrative endpoint at /api/admin/…` | The address answered, but on a listener that serves something else. Check the port, and check that `AdminEndpoint:Enabled` is true. |
 | `This deployment configures no mail account named …` | `mailbox authorize --account` named an identifier no `MailSynchronization:Accounts` entry carries, or you are signed in to the wrong deployment. Nothing was stored. |
+| `is still mirrored, so erasing it would only cost a remirror` | `folder erase` named a folder the account still synchronizes, and nothing was erased. Switch that folder's `Synchronize` off, or remove its mapping, and ask again. |
+| `before the erasure was interrupted` | `folder erase` was stopped part way. What it reported erasing is gone and the rest is still there; run the same command again to continue from where it stopped. |
 | `The deployment refused the grant without saying why.` | The request was refused with no reason in the answer, which is what something in front of the endpoint answering `400` looks like. Check that `--endpoint` reaches the deployment itself. |
 | `rather than storing the token` | The endpoint answered with neither an acceptance nor an explained refusal. The token was not stored and the account is unchanged. A `500` here is most often a deployment with no `DataEncryption` key ring, which is what a stored token is sealed under; its own log names the cause. |
 | `did not identify itself as MailFathom` | Something else is answering on that port — a proxy, or another service. |

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -281,6 +281,29 @@ judged by, and what happens to junk are configuration, so you change them by edi
 concluded](../operations/admin-endpoint.md#classifying-the-mail-you-already-have-and-reading-what-was-concluded) is the
 operator's reference for all three.
 
+## Getting a folder's storage back
+
+MailFathom never takes local mail away because a file changed. Switching a folder's `Synchronize` off stops mirroring it
+and keeps what it already stored; removing its mapping leaves those rows where they are as well. Both are the right
+default — an edit to a configuration file should not dispose of mail — and both leave you with storage you may actually
+want back:
+
+```console
+$ mfctl folder erase --account work --folder archive
+1043 stored emails erased from ARCHIVE under work. The folder holds none, and its checkpoint went with them, so
+mirroring it again starts from the beginning rather than resuming.
+```
+
+This is the only command that erases mail, and it acts on one folder of one account. It refuses a folder your
+deployment still mirrors, because the next synchronization run would simply fetch it all again — switch that folder off,
+or take its mapping out, and ask again. A folder whose mapping you already removed is accepted, which is the case this
+exists for.
+
+Erasing a large folder takes a while and the command prints how far it has got. Stopping it is safe: what it reported
+erasing is gone, the rest is untouched, and running the same command again continues from there. [Erasing a folder you
+have stopped mirroring](../operations/admin-endpoint.md#erasing-a-folder-you-have-stopped-mirroring) is the operator's
+reference, including what goes with the mail and what survives it.
+
 ## Where to go next
 
 - [Administering a deployment](../operations/admin-endpoint.md) — the operator's reference for everything above

--- a/src/Cli/Administration/AdminApiClient.cs
+++ b/src/Cli/Administration/AdminApiClient.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using MailFathom.Cli.Administration.Embeddings;
+using MailFathom.Cli.Administration.Folders;
 using MailFathom.Cli.Administration.Rules;
 using MailFathom.Cli.Administration.Spam;
 using MailFathom.Cli.Transport;
@@ -379,6 +380,39 @@ internal sealed class AdminApiClient
             token,
             CliJsonContext.Default.SpamClassificationPage,
             cancellationToken);
+    }
+
+    /// <summary>Asks the deployment to erase one bounded pass of a folder's stored mail.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="account">The account the folder belongs to, as the deployment's configuration names it.</param>
+    /// <param name="folder">MailFathom's own alias for the folder.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>What the pass erased, and whether the folder still holds stored mail.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the request or the credential, could not be reached, or answered with something that is not an erasure.</exception>
+    /// <remarks>
+    /// One pass per request, and the command sends as many as the folder needs. The work is a local transaction rather
+    /// than anything on a mail server, so the answer arrives when the pass has committed and what it reports is what
+    /// the deployment has already disposed of.
+    /// </remarks>
+    internal Task<MailFolderErasure> EraseFolderMirrorAsync(
+        string token,
+        string account,
+        string folder,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(account);
+        ArgumentNullException.ThrowIfNull(folder);
+
+        return this.RequestAsync(
+            HttpMethod.Post,
+            AdminEndpointRoutes.FolderErasurePath,
+            token,
+            CliJsonContext.Default.MailFolderErasure,
+            cancellationToken,
+            JsonContent.Create(
+                new MailFolderErasureRequest(account, folder),
+                CliJsonContext.Default.MailFolderErasureRequest));
     }
 
     /// <summary>Sends one credentialed request and reads the answer, or turns the refusal into a sentence.</summary>

--- a/src/Cli/Administration/AdminEndpointRoutes.cs
+++ b/src/Cli/Administration/AdminEndpointRoutes.cs
@@ -56,6 +56,14 @@ internal static class AdminEndpointRoutes
     /// <summary>Where a deployment reports what classification concluded about an account's mail.</summary>
     internal const string SpamClassificationsPath = $"{Prefix}/spam/classifications";
 
+    /// <summary>Where a deployment is asked to erase one bounded pass of a folder's stored mail.</summary>
+    /// <remarks>
+    /// One pass per request, so the command repeats it until the folder is empty. That is what makes an erasure the
+    /// operator interrupted resumable: what a pass committed stays committed, and the next invocation continues from
+    /// there rather than starting a folder over.
+    /// </remarks>
+    internal const string FolderErasurePath = $"{Prefix}/folders/erasure";
+
     /// <summary>Where a deployment publishes the document naming its authorization servers, resource, and required scopes.</summary>
     /// <remarks>
     /// Composed rather than discovered from a challenge, because a client that knows which routes it is about to call

--- a/src/Cli/Administration/Folders/MailFolderErasure.cs
+++ b/src/Cli/Administration/Folders/MailFolderErasure.cs
@@ -1,0 +1,25 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Cli.Administration.Folders;
+
+/// <summary>What a deployment is asked when a folder's stored mail is to be erased.</summary>
+/// <param name="Account">The account the folder belongs to, as the deployment's configuration names it.</param>
+/// <param name="Folder">MailFathom's own alias for the folder, which need not be one the deployment still maps.</param>
+internal sealed record MailFolderErasureRequest(
+    [property: JsonPropertyName("account")] string Account,
+    [property: JsonPropertyName("folder")] string Folder);
+
+/// <summary>What one bounded pass of an erasure removed.</summary>
+/// <param name="Account">The account the folder belongs to.</param>
+/// <param name="Folder">The alias the pass ran against, as the deployment normalized it.</param>
+/// <param name="ErasedEmailCount">How many stored emails the pass removed.</param>
+/// <param name="EmailsRemain">Whether the folder still holds mail a further pass would reach.</param>
+internal sealed record MailFolderErasure(
+    [property: JsonPropertyName("account")] string? Account,
+    [property: JsonPropertyName("folder")] string? Folder,
+    [property: JsonPropertyName("erasedEmailCount")] int ErasedEmailCount,
+    [property: JsonPropertyName("emailsRemain")] bool EmailsRemain);

--- a/src/Cli/CliJsonContext.cs
+++ b/src/Cli/CliJsonContext.cs
@@ -5,6 +5,7 @@
 using System.Text.Json.Serialization;
 using MailFathom.Cli.Administration;
 using MailFathom.Cli.Administration.Embeddings;
+using MailFathom.Cli.Administration.Folders;
 using MailFathom.Cli.Administration.Rules;
 using MailFathom.Cli.Administration.Spam;
 using MailFathom.Cli.Authorization;
@@ -47,6 +48,8 @@ namespace MailFathom.Cli;
 [JsonSerializable(typeof(SpamClassificationRunStart))]
 [JsonSerializable(typeof(SpamClassificationRunState))]
 [JsonSerializable(typeof(SpamClassificationPage))]
+[JsonSerializable(typeof(MailFolderErasureRequest))]
+[JsonSerializable(typeof(MailFolderErasure))]
 [JsonSerializable(typeof(StoredCredentials))]
 [JsonSerializable(typeof(ProtectedResourceMetadata))]
 [JsonSerializable(typeof(AuthorizationServerMetadata))]

--- a/src/Cli/CliOptions.cs
+++ b/src/Cli/CliOptions.cs
@@ -44,6 +44,19 @@ internal static class CliOptions
         Required = true,
     };
 
+    /// <summary>Builds the option naming which folder of an account a command acts on.</summary>
+    /// <returns>The option.</returns>
+    /// <remarks>
+    /// An alias rather than a folder reference, so a role such as <c>role:Junk</c> is not accepted. A role is resolved
+    /// through the mapping that declares it, and the folder this names is one whose mapping may have been removed —
+    /// which is precisely the case a role could never reach.
+    /// </remarks>
+    internal static Option<string> MailFolder() => new("--folder")
+    {
+        Description = "The folder to act on, by the alias the deployment's configuration gave it.",
+        Required = true,
+    };
+
     /// <summary>Builds the option naming the profile a sign-in is remembered under.</summary>
     /// <returns>The option.</returns>
     internal static Option<string?> ProfileName() => new("--name")

--- a/src/Cli/Commands/CliRootCommand.cs
+++ b/src/Cli/Commands/CliRootCommand.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.CommandLine;
+using MailFathom.Cli.Commands.Folders;
 using MailFathom.Cli.Commands.Rules;
 using MailFathom.Cli.Commands.Spam;
 using MailFathom.Versioning;
@@ -72,6 +73,14 @@ internal static class CliRootCommand
             ClassificationsCommand.Create(context),
         };
 
+        // The one group that disposes of mail. A folder's local copy outlives both the switch that stopped mirroring it
+        // and the mapping that named it, deliberately, so that no configuration edit can take somebody's mail away —
+        // and this is where an operator who means it says so.
+        Command folderCommand = new("folder", "Administer what a deployment stores for one of an account's folders.")
+        {
+            EraseFolderCommand.Create(context),
+        };
+
         return new RootCommand($"MailFathom administration tool ({version.Version}).")
         {
             LoginCommand.Create(context),
@@ -83,6 +92,7 @@ internal static class CliRootCommand
             embeddingCommand,
             rulesCommand,
             spamCommand,
+            folderCommand,
         };
     }
 }

--- a/src/Cli/Commands/Folders/EraseFolderCommand.cs
+++ b/src/Cli/Commands/Folders/EraseFolderCommand.cs
@@ -1,0 +1,137 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using System.Globalization;
+using MailFathom.Cli.Administration;
+using MailFathom.Cli.Administration.Folders;
+
+namespace MailFathom.Cli.Commands.Folders;
+
+/// <summary>Takes away the mail a deployment stored for a folder it has stopped mirroring.</summary>
+/// <remarks>
+/// <para>
+/// The only thing in MailFathom that erases a folder's local copy, and it exists precisely so that no configuration
+/// value has to. Switching a folder's synchronization off keeps what it stored and removing its mapping leaves the rows
+/// where they are, both so that editing a file cannot dispose of somebody's mail — which leaves an operator who means
+/// it with nothing to ask until this.
+/// </para>
+/// <para>
+/// It refuses a folder the account still mirrors, because the next run would refill what the erasure removed. An alias
+/// no mapping names is accepted rather than refused: a folder whose mapping was withdrawn is the case that most needs
+/// erasing, and it is the one case no configuration value can express.
+/// </para>
+/// <para>
+/// A folder is erased in bounded passes, and the command sends as many as the folder needs. Interrupting it stops it
+/// between passes rather than part way through one: what a pass committed stays gone and the rest waits for the next
+/// invocation, so there is no state this command can leave a folder in that running it again does not finish.
+/// </para>
+/// </remarks>
+internal static class EraseFolderCommand
+{
+    /// <summary>Builds the <c>folder erase</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+        var accountOption = CliOptions.MailAccount();
+        var folderOption = CliOptions.MailFolder();
+
+        Command command = new("erase", "Erase the mail a deployment stored for a folder it no longer mirrors.")
+        {
+            accountOption,
+            folderOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(accountOption) ?? string.Empty,
+            result.GetValue(folderOption) ?? string.Empty,
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            cancellationToken));
+
+        return command;
+    }
+
+    private static async Task<int> RunAsync(
+        CliContext context,
+        string account,
+        string folder,
+        string? requestedDeployment,
+        CancellationToken cancellationToken)
+    {
+        var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
+
+        using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
+        var deployment = new AdminApiClient(transport, context.Console);
+
+        var erasedCount = 0;
+        MailFolderErasure? pass = null;
+
+        try
+        {
+            do
+            {
+                pass = await deployment.EraseFolderMirrorAsync(
+                    profile.Token,
+                    account,
+                    folder,
+                    cancellationToken);
+
+                erasedCount += pass.ErasedEmailCount;
+
+                // A pass that removed nothing and reports more to come would repeat forever, because nothing about the
+                // next request would differ from this one. The deployment's own eraser cannot answer that — a pass
+                // saying mail remains has filled its bound — so this is a deployment answering something else, and
+                // asking it again is the one thing that could not help.
+                if (pass is { ErasedEmailCount: 0, EmailsRemain: true })
+                {
+                    throw new CliFailure(
+                        "The deployment reported that mail remains but erased none of it, so asking again would not make progress. Nothing further was erased.");
+                }
+
+                if (pass.EmailsRemain)
+                {
+                    context.Console.WriteLine(Describe(erasedCount, "erased so far"));
+                }
+            }
+            while (pass.EmailsRemain);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            context.Console.WriteError(
+                $"{Describe(erasedCount, "erased")} before the erasure was interrupted. The rest is still there; run the command again to continue.");
+
+            return CliExitCode.Failure;
+        }
+
+        var erased = Name(pass.Folder, folder);
+        var mailbox = Name(pass.Account, account);
+
+        context.Console.WriteLine(erasedCount == 0
+            ? $"The deployment stored nothing for {erased} under {mailbox}, so nothing was erased."
+            : $"{Describe(erasedCount, "erased")} from {erased} under {mailbox}. The folder holds none, and its checkpoint went with them, so mirroring it again starts from the beginning rather than resuming.");
+
+        return CliExitCode.Success;
+    }
+
+    /// <summary>Names a thing the way the deployment did, falling back to the way the operator wrote it.</summary>
+    /// <remarks>
+    /// The deployment normalizes an alias, so echoing its answer is what confirms that what was erased is what was
+    /// meant. A deployment that named neither back is answered for with the operator's own text rather than with a
+    /// blank, because a sentence reporting erased mail has to say which folder it was about.
+    /// </remarks>
+    private static string Name(string? reported, string requested) =>
+        reported is { Length: > 0 } named ? named : requested;
+
+    /// <summary>Describes a count of erased mail, grouped invariantly for the reason every other figure this tool prints is.</summary>
+    private static string Describe(int erasedCount, string state) => string.Create(
+        CultureInfo.InvariantCulture,
+        $"{erasedCount} stored {(erasedCount == 1 ? "email" : "emails")} {state}");
+}

--- a/src/Domain/Folders/MailFolderAlias.cs
+++ b/src/Domain/Folders/MailFolderAlias.cs
@@ -40,6 +40,33 @@ public readonly record struct MailFolderAlias
         return new MailFolderAlias(trimmed.ToUpperInvariant());
     }
 
+    /// <summary>Reads an alias a caller outside this system wrote, without raising on text that is not one.</summary>
+    /// <param name="value">The text the caller wrote.</param>
+    /// <param name="alias">The alias when the text is one; otherwise the struct default.</param>
+    /// <returns><see langword="true" /> when the text is an alias.</returns>
+    /// <remarks>
+    /// <see cref="Create" /> raises because configuration is refused rather than negotiated with, which is the wrong
+    /// shape at a boundary an operator types into: an administrative route reading a request body owes a stated refusal
+    /// rather than a failure the process reports as its own. Both admit exactly the same text, so an alias that reaches
+    /// one reaches the other.
+    /// </remarks>
+    public static bool TryCreate(string? value, out MailFolderAlias alias)
+    {
+        // Trimmed before the control characters are looked for, in that order, because that is the order
+        // Create applies and a tab is both a control character and whitespace: checking the untrimmed text would
+        // refuse padding Create accepts, which is the one way these two could disagree about what an alias is.
+        if (string.IsNullOrWhiteSpace(value) || value.Trim().Any(char.IsControl))
+        {
+            alias = default;
+
+            return false;
+        }
+
+        alias = Create(value);
+
+        return true;
+    }
+
     /// <inheritdoc />
     public override string ToString() => this.Value;
 }

--- a/src/Host/Api/AdminApiEndpoints.cs
+++ b/src/Host/Api/AdminApiEndpoints.cs
@@ -44,11 +44,16 @@ namespace MailFathom.Host.Api;
 /// over.
 /// </para>
 /// <para>
-/// The last are what an operator does about this deployment's mail rules, which <see cref="MailRuleEndpoints" />
+/// The next are what an operator does about this deployment's mail rules, which <see cref="MailRuleEndpoints" />
 /// describes: reading which rules are loaded, asking for them to be run over a whole mailbox, and reading what they
 /// did. They are here because a pass over a whole mailbox changes mail on the server, and what bounds who may ask for
 /// that should be what bounds everything else administrative — and because the history is an operator's account of an
 /// automation over their mailbox rather than anything a model reasons over.
+/// </para>
+/// <para>
+/// The last takes a folder's local mail away, which <see cref="MailFolderErasureEndpoint" /> describes. It is the only
+/// route that disposes of stored mail, which is why it is bounded by the same credential as everything else here and
+/// reachable from nowhere a model can write to.
 /// </para>
 /// <para>
 /// Every one of them is mapped into one group so a route cannot be added outside the requirement the endpoint attaches
@@ -74,6 +79,7 @@ internal static class AdminApiEndpoints
         api.MapEmbeddingProfile();
         api.MapMailRules();
         api.MapSpamClassification();
+        api.MapMailFolderErasure();
 
         return api;
     }

--- a/src/Host/Api/MailFolderErasureEndpoint.cs
+++ b/src/Host/Api/MailFolderErasureEndpoint.cs
@@ -1,0 +1,153 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Accounts;
+using MailFathom.Application.Folders;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MailFathom.Host.Api;
+
+/// <summary>Serves the one operation in MailFathom that takes a folder's local mail away.</summary>
+/// <remarks>
+/// <para>
+/// Nothing else erases a mirror. Switching a folder's synchronization off keeps what it stored, and a mapping removed
+/// from configuration leaves the rows where they are, both so that a configuration value cannot dispose of somebody's
+/// mail. That leaves an operator who genuinely wants the storage back with nothing to ask, and this is the ask.
+/// </para>
+/// <para>
+/// It is here rather than on the MCP surface for the reason every administrative route is: erasing a mailbox's worth of
+/// mail is not something a model reasons over, and what bounds administrative access is what should bound it.
+/// <strong>Every authenticated caller may perform every administrative operation</strong>, which
+/// <see cref="MailboxRefreshTokenEndpoint" /> states in full.
+/// </para>
+/// <para>
+/// One request is one bounded pass, and the command repeats it. The bound is the one the backward pass over stored mail
+/// already carries, so the transaction that removes the rows is the size reconciliation has always committed; answering
+/// after each pass is what makes an interrupted erasure resumable rather than a half-erased folder nothing can finish.
+/// </para>
+/// </remarks>
+internal static class MailFolderErasureEndpoint
+{
+    /// <summary>The route one bounded pass of an erasure is asked for on, relative to the administrative prefix.</summary>
+    internal const string ErasureRoute = "/folders/erasure";
+
+    /// <summary>The greatest request body the route reads before refusing it.</summary>
+    /// <remarks>
+    /// The body names one account and one folder, so a few hundred bytes is the whole of anything it could mean. Stated
+    /// for the reason the rule run states it: the server's own default is measured in tens of megabytes, which here
+    /// would let an authenticated client make the process buffer a body four orders of magnitude larger than the
+    /// request it is sending.
+    /// </remarks>
+    internal const int MaxErasureRequestBytes = 4 * 1024;
+
+    /// <summary>Maps the erasure route into the administrative group, so it inherits its authorization.</summary>
+    /// <param name="api">The administrative route group.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="api" /> is <see langword="null" />.</exception>
+    internal static void MapMailFolderErasure(this RouteGroupBuilder api)
+    {
+        ArgumentNullException.ThrowIfNull(api);
+
+        // The attribute is reached for its metadata rather than as an MVC filter, exactly as the rule run route reaches
+        // it: it implements IRequestSizeLimitMetadata, which the routing pipeline applies to the request body feature,
+        // so a body over the bound is answered 413 before the handler is reached.
+        api.MapPost(ErasureRoute, EraseAsync)
+            .WithMetadata(new RequestSizeLimitAttribute(MaxErasureRequestBytes));
+    }
+
+    /// <summary>Erases one bounded pass of what is stored for a folder this deployment no longer mirrors.</summary>
+    /// <param name="request">The account and the folder whose stored mail is erased.</param>
+    /// <param name="accounts">Reports whether this deployment serves the named account.</param>
+    /// <param name="mappings">Reports what the account's configuration says about the named folder, where it says anything.</param>
+    /// <param name="eraser">Performs the pass.</param>
+    /// <param name="cancellationToken">Cancels the pass when the client disconnects, leaving what earlier passes committed.</param>
+    /// <returns><c>200</c> with what the pass erased, or <c>400</c> naming what was wrong with the request.</returns>
+    /// <remarks>
+    /// A folder the account still mirrors is refused rather than erased. Removing the rows of a folder a run is about to
+    /// visit would open a hole the next run silently refills, so what the caller would have got is the cost of a
+    /// remirror and none of the storage back — which is a refusal that names the two ways to make the folder erasable
+    /// rather than an operation to perform carefully.
+    /// </remarks>
+    internal static async Task<Results<Ok<MailFolderErasureResponse>, ProblemHttpResult>> EraseAsync(
+        [FromBody] MailFolderErasureRequest? request,
+        [FromServices] IMailAccountCatalog accounts,
+        [FromServices] IMailFolderMappingReader mappings,
+        [FromServices] UnmirroredMailFolderEraser eraser,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(accounts);
+        ArgumentNullException.ThrowIfNull(mappings);
+        ArgumentNullException.ThrowIfNull(eraser);
+
+        if (ResolveAccount(request?.Account, accounts) is not { } accountId)
+        {
+            return UnknownAccount(request?.Account);
+        }
+
+        if (!MailFolderAlias.TryCreate(request?.Folder, out var folderAlias))
+        {
+            return TypedResults.Problem(
+                "The request named no folder. Name the alias of the folder whose stored mail is to be erased.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        if (mappings.FindFolderNamed(accountId, folderAlias) is { Participation.IsSynchronized: true })
+        {
+            return TypedResults.Problem(
+                $"The folder '{folderAlias.Value}' is still mirrored, so erasing it would only cost a remirror. Switch its Synchronize off, or remove its mapping, and ask again.",
+                statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        var erasure = await eraser.EraseAsync(accountId, folderAlias, cancellationToken);
+
+        return TypedResults.Ok(new MailFolderErasureResponse(
+            accountId.Value,
+            folderAlias.Value,
+            erasure.ErasedEmailCount,
+            erasure.EmailsRemain));
+    }
+
+    /// <summary>Reads the account a request named, or nothing when this deployment does not serve it.</summary>
+    private static MailAccountId? ResolveAccount(string? account, IMailAccountCatalog accounts)
+    {
+        if (string.IsNullOrWhiteSpace(account))
+        {
+            return null;
+        }
+
+        var accountId = MailAccountId.Create(account);
+
+        return accounts.ServedAccounts.Any(served => served.Id == accountId) ? accountId : null;
+    }
+
+    /// <summary>States that the request named no account this deployment serves, without echoing an empty one.</summary>
+    private static ProblemHttpResult UnknownAccount(string? account) => TypedResults.Problem(
+        string.IsNullOrWhiteSpace(account)
+            ? "The request named no mail account."
+            : $"This deployment configures no mail account named '{account}'.",
+        statusCode: StatusCodes.Status400BadRequest);
+}
+
+/// <summary>What a deployment is asked when a folder's stored mail is to be erased.</summary>
+/// <param name="Account">The account the folder belongs to, as the deployment's configuration names it.</param>
+/// <param name="Folder">MailFathom's own alias for the folder, which need not be one any mapping still names.</param>
+internal sealed record MailFolderErasureRequest(string? Account, string? Folder);
+
+/// <summary>What one bounded pass of an erasure removed, and whether the folder still holds stored mail.</summary>
+/// <param name="Account">The account the folder belongs to.</param>
+/// <param name="Folder">The normalized alias the pass ran against.</param>
+/// <param name="ErasedEmailCount">How many stored emails this pass removed, with everything declared from them.</param>
+/// <param name="EmailsRemain">Whether the folder still holds mail a further pass would reach.</param>
+/// <remarks>
+/// Counts and MailFathom's own names for things, and nothing a mailbox supplied. What was erased is a number rather
+/// than a list, because a list of what a deployment has just disposed of would be a copy of the part of the mailbox the
+/// operator asked it to stop keeping.
+/// </remarks>
+internal sealed record MailFolderErasureResponse(
+    string Account,
+    string Folder,
+    int ErasedEmailCount,
+    bool EmailsRemain);

--- a/tests/Cli.UnitTests/AdminEndpointRoutesTests.cs
+++ b/tests/Cli.UnitTests/AdminEndpointRoutesTests.cs
@@ -41,6 +41,15 @@ public sealed class AdminEndpointRoutesTests
     }
 
     /// <summary>
+    /// The route the one operation that disposes of mail is asked for on, pinned for the reason every other path here
+    /// is: the deployment's own suite pins the same literal, and a rename on either side would compile cleanly and
+    /// leave the erase command reaching a 404 that reads exactly like an endpoint nobody enabled.
+    /// </summary>
+    [Fact]
+    public void FolderErasurePath_IsTheRouteTheDeploymentErasesAFolderAt() =>
+        Assert.Equal("/api/admin/folders/erasure", AdminEndpointRoutes.FolderErasurePath);
+
+    /// <summary>
     /// RFC 9728 places the document under a well-known segment with the resource's path appended, and the deployment
     /// refuses to start unless its resource path is the route prefix. Composing it here rather than reading it from a
     /// challenge is what makes a sign-in one request instead of two, and this is the assertion that keeps the

--- a/tests/Cli.UnitTests/FakeFolderDeployment.cs
+++ b/tests/Cli.UnitTests/FakeFolderDeployment.cs
@@ -1,0 +1,100 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using System.Net;
+using System.Text;
+using MailFathom.Cli.Administration;
+using MailFathom.TestSupport;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>A deployment answering the folder routes, as the erase command meets one without a server.</summary>
+/// <remarks>
+/// The erasure route is answered from a queue rather than with one body, because what the command is about is the
+/// repetition: a folder larger than one pass is erased by asking again until nothing is left, and a double answering
+/// the same body every time would either never end or hide that the command asked more than once.
+/// </remarks>
+internal static class FakeFolderDeployment
+{
+    /// <summary>Builds a deployment that answers each erasure request with the next pass the caller scripted.</summary>
+    /// <param name="passes">What the erasure route answers, in order; the last is repeated once the script runs out.</param>
+    /// <returns>The deployment.</returns>
+    /// <remarks>
+    /// The session route is answered unconditionally, because every command settles the two versions there before its
+    /// own operation and a double serving the erasure route alone would report a deployment nothing can be
+    /// administered on.
+    /// </remarks>
+    internal static FakeHttpMessageHandler Erasing(params (HttpStatusCode Status, string Body)[] passes)
+    {
+        var remaining = new Queue<(HttpStatusCode Status, string Body)>(passes);
+
+        return new FakeHttpMessageHandler((request, _) => Task.FromResult(Answer(request, remaining, passes)));
+    }
+
+    /// <summary>Writes the body a completed pass answers with.</summary>
+    /// <param name="erasedEmailCount">How many stored emails the pass removed.</param>
+    /// <param name="emailsRemain">Whether the folder still holds mail a further pass would reach.</param>
+    /// <returns>The response body.</returns>
+    internal static (HttpStatusCode Status, string Body) Pass(int erasedEmailCount, bool emailsRemain) => (
+        HttpStatusCode.OK,
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $$"""
+              {"account":"work","folder":"ARCHIVE","erasedEmailCount":{{erasedEmailCount}},"emailsRemain":{{(emailsRemain ? "true" : "false")}}}
+              """));
+
+    /// <summary>Reports how often the command asked the deployment to erase a pass.</summary>
+    /// <param name="deployment">The deployment the command was pointed at.</param>
+    /// <returns>The number of erasure requests it sent.</returns>
+    internal static int ErasureRequestCount(this FakeHttpMessageHandler deployment)
+    {
+        ArgumentNullException.ThrowIfNull(deployment);
+
+        return deployment.RecordedRequests.Count(request =>
+            request.Method == HttpMethod.Post
+            && request.RequestUri?.AbsolutePath == AdminEndpointRoutes.FolderErasurePath);
+    }
+
+    /// <summary>Reports the body of the erasure the command last asked for.</summary>
+    /// <param name="deployment">The deployment the command was pointed at.</param>
+    /// <returns>The request body, or <see langword="null" /> where no erasure was asked for.</returns>
+    internal static string? LastErasureRequest(this FakeHttpMessageHandler deployment)
+    {
+        ArgumentNullException.ThrowIfNull(deployment);
+
+        return deployment.RecordedRequests
+            .LastOrDefault(request => request.RequestUri?.AbsolutePath == AdminEndpointRoutes.FolderErasurePath)?
+            .ContentAsUtf8String();
+    }
+
+    private static HttpResponseMessage Answer(
+        HttpRequestMessage request,
+        Queue<(HttpStatusCode Status, string Body)> remaining,
+        (HttpStatusCode Status, string Body)[] passes)
+    {
+        var path = request.RequestUri?.AbsolutePath;
+
+        if (path == AdminEndpointRoutes.SessionPath)
+        {
+            return Json(
+                HttpStatusCode.OK,
+                FakeAdminEndpoint.SessionBody("workstation", FakeAdminEndpoint.CommandVersion));
+        }
+
+        if (path == AdminEndpointRoutes.FolderErasurePath && passes.Length > 0)
+        {
+            var pass = remaining.Count > 0 ? remaining.Dequeue() : passes[^1];
+
+            return Json(pass.Status, pass.Body);
+        }
+
+        return Json(HttpStatusCode.NotFound, string.Empty);
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) => new(status)
+    {
+        Content = new StringContent(body, Encoding.UTF8, "application/json"),
+    };
+}

--- a/tests/Cli.UnitTests/FolderCommandTests.cs
+++ b/tests/Cli.UnitTests/FolderCommandTests.cs
@@ -1,0 +1,231 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using MailFathom.Cli.Credentials;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers the one command that disposes of mail: how far it goes, when it stops, and what it says it did.</summary>
+/// <remarks>
+/// What is asserted here is the repetition and the reporting. A folder larger than one pass is erased by asking again
+/// until the deployment says nothing is left, so a command that sent one request and reported success would leave mail
+/// behind while claiming the folder was empty — and a deployment's refusal has to reach the terminal as the sentence it
+/// wrote rather than as a status code the operator has to look up.
+/// </remarks>
+public sealed class FolderCommandTests : IDisposable
+{
+    private const string Endpoint = "https://mail.example.test:8443";
+    private const string Account = "work";
+    private const string Folder = "archive";
+
+    private static readonly Uri EndpointAddress = new(Endpoint);
+
+    private readonly string storeDirectory =
+        Path.Combine(Path.GetTempPath(), $"mailfathom-folder-tests-{Guid.NewGuid():N}");
+
+    private readonly RecordingCliConsole console = new();
+
+    private readonly FakeTimeProvider clock = new(new DateTimeOffset(2026, 8, 8, 12, 0, 0, TimeSpan.Zero));
+
+    /// <summary>A folder small enough for one pass is one request, and the command says the folder now holds none.</summary>
+    [Fact]
+    public async Task Erase_AFolderOnePassEmpties_ErasesItInOneRequestAndReportsTheCount()
+    {
+        // Arrange
+        using var deployment = FakeFolderDeployment.Erasing(
+            FakeFolderDeployment.Pass(erasedEmailCount: 12, emailsRemain: false));
+
+        // Act
+        var exitCode = await this.EraseAsync(deployment);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Equal(1, deployment.ErasureRequestCount());
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("12 stored emails erased", StringComparison.Ordinal)
+                && line.Contains("ARCHIVE", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The bounding and the repetition together. One pass is a transaction rather than a mailbox, so a folder larger
+    /// than one is erased by asking again — and a command that stopped after the first would report an empty folder
+    /// that still held mail.
+    /// </summary>
+    [Fact]
+    public async Task Erase_AFolderLargerThanOnePass_KeepsAskingUntilTheDeploymentSaysNothingIsLeft()
+    {
+        // Arrange
+        using var deployment = FakeFolderDeployment.Erasing(
+            FakeFolderDeployment.Pass(erasedEmailCount: 500, emailsRemain: true),
+            FakeFolderDeployment.Pass(erasedEmailCount: 500, emailsRemain: true),
+            FakeFolderDeployment.Pass(erasedEmailCount: 43, emailsRemain: false));
+
+        // Act
+        var exitCode = await this.EraseAsync(deployment);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Equal(3, deployment.ErasureRequestCount());
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("1043 stored emails erased", StringComparison.Ordinal));
+    }
+
+    /// <summary>A long erasure says where it has got to, so a terminal is not silent while a mailbox is disposed of.</summary>
+    [Fact]
+    public async Task Erase_APassThatLeavesMailBehind_ReportsTheRunningTotalBeforeAskingAgain()
+    {
+        // Arrange
+        using var deployment = FakeFolderDeployment.Erasing(
+            FakeFolderDeployment.Pass(erasedEmailCount: 500, emailsRemain: true),
+            FakeFolderDeployment.Pass(erasedEmailCount: 1, emailsRemain: false));
+
+        // Act
+        await this.EraseAsync(deployment);
+
+        // Assert
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("500 stored emails erased so far", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The command repeats until the deployment says nothing is left, so an answer that removed nothing while claiming
+    /// more remains would repeat forever. Nothing this deployment's own eraser can produce says that, which is why it
+    /// is reported rather than retried.
+    /// </summary>
+    [Fact]
+    public async Task Erase_APassThatRemovedNothingWhileClaimingMoreRemains_StopsRatherThanAskingForever()
+    {
+        // Arrange
+        using var deployment = FakeFolderDeployment.Erasing(
+            FakeFolderDeployment.Pass(erasedEmailCount: 0, emailsRemain: true));
+
+        // Act
+        var exitCode = await this.EraseAsync(deployment);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal(1, deployment.ErasureRequestCount());
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains("would not make progress", StringComparison.Ordinal));
+    }
+
+    /// <summary>Running it against a folder that holds nothing is the ordinary end of every erasure, not a failure.</summary>
+    [Fact]
+    public async Task Erase_AFolderHoldingNothing_SucceedsAndSaysNothingWasErased()
+    {
+        // Arrange
+        using var deployment = FakeFolderDeployment.Erasing(
+            FakeFolderDeployment.Pass(erasedEmailCount: 0, emailsRemain: false));
+
+        // Act
+        var exitCode = await this.EraseAsync(deployment);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("stored nothing", StringComparison.Ordinal));
+    }
+
+    /// <summary>The deployment knows why it refused, so the sentence it wrote is what the operator reads.</summary>
+    [Fact]
+    public async Task Erase_AFolderTheDeploymentStillMirrors_ReportsTheRefusalItStated()
+    {
+        // Arrange
+        const string Refusal =
+            "The folder 'ARCHIVE' is still mirrored, so erasing it would only cost a remirror. Switch its Synchronize off, or remove its mapping, and ask again.";
+        using var deployment = FakeFolderDeployment.Erasing((
+            HttpStatusCode.BadRequest,
+            $$"""{"detail":"{{Refusal}}"}"""));
+
+        // Act
+        var exitCode = await this.EraseAsync(deployment);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(Refusal, this.console.Errors);
+    }
+
+    /// <summary>The two names the deployment needs, and nothing else: no rule, no filter, no mail.</summary>
+    [Fact]
+    public async Task Erase_AnAccountAndAFolder_AsksTheDeploymentForExactlyThoseTwo()
+    {
+        // Arrange
+        using var deployment = FakeFolderDeployment.Erasing(
+            FakeFolderDeployment.Pass(erasedEmailCount: 0, emailsRemain: false));
+
+        // Act
+        await this.EraseAsync(deployment);
+
+        // Assert
+        Assert.Equal(
+            $$"""{"account":"{{Account}}","folder":"{{Folder}}"}""",
+            deployment.LastErasureRequest()?.Replace("\n", string.Empty, StringComparison.Ordinal)
+                .Replace(" ", string.Empty, StringComparison.Ordinal));
+    }
+
+    /// <summary>Both names are required, because guessing either would be guessing whose mail is disposed of.</summary>
+    [Theory]
+    [InlineData("--account", Account)]
+    [InlineData("--folder", Folder)]
+    public async Task Erase_OneOfTheTwoNamesLeftOut_RefusesWithoutReachingTheDeployment(string option, string value)
+    {
+        // Arrange
+        using var deployment = FakeFolderDeployment.Erasing(
+            FakeFolderDeployment.Pass(erasedEmailCount: 0, emailsRemain: false));
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "folder", "erase", option, value, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.NotEqual(CliExitCode.Success, exitCode);
+        Assert.Equal(0, deployment.ErasureRequestCount());
+    }
+
+    private Task<int> EraseAsync(FakeHttpMessageHandler deployment) => this.RunAsync(
+        deployment,
+        "folder",
+        "erase",
+        "--account",
+        Account,
+        "--folder",
+        Folder,
+        "--endpoint",
+        Endpoint);
+
+    private Task<int> RunAsync(FakeHttpMessageHandler deployment, params string[] args)
+    {
+        var store = new CredentialStore(
+            Path.Combine(this.storeDirectory, "credentials.json"),
+            new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key")));
+
+        store.Save("production", EndpointAddress, "not-a-real-key", "workstation");
+
+        var context = new CliContext(
+            this.console,
+            store,
+            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
+            FakeMailboxRedirect.Silent(),
+            _ => false,
+            this.clock);
+
+        return CliRunner.RunAsync(context, args);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this.storeDirectory))
+        {
+            Directory.Delete(this.storeDirectory, recursive: true);
+        }
+    }
+}

--- a/tests/Domain.UnitTests/Folders/MailFolderTests.cs
+++ b/tests/Domain.UnitTests/Folders/MailFolderTests.cs
@@ -33,6 +33,41 @@ public sealed class MailFolderTests
         Assert.Throws<ArgumentException>(() => MailFolderAlias.Create(configured));
     }
 
+    /// <summary>
+    /// The boundary form of the same rule. An administrative route reading an alias out of a request body owes a
+    /// stated refusal rather than a failure the process reports as its own, and both factories have to admit exactly
+    /// the same text or the refusal would be about which one the caller happened to reach.
+    /// </summary>
+    [Theory]
+    [InlineData("inbox", "INBOX")]
+    [InlineData("  Archive/2026  ", "ARCHIVE/2026")]
+    [InlineData("\tarchive\n", "ARCHIVE")]
+    public void TryCreate_AliasCreateWouldAccept_ReadsTheSameValue(string written, string expected)
+    {
+        // Arrange, Act
+        var read = MailFolderAlias.TryCreate(written, out var alias);
+
+        // Assert
+        Assert.True(read);
+        Assert.Equal(expected, alias.Value);
+        Assert.Equal(MailFolderAlias.Create(written), alias);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("in\tbox")]
+    public void TryCreate_TextCreateWouldRefuse_ReportsNoAliasWithoutRaising(string? written)
+    {
+        // Arrange, Act
+        var read = MailFolderAlias.TryCreate(written, out var alias);
+
+        // Assert
+        Assert.False(read);
+        Assert.Equal(default, alias);
+    }
+
     /// <summary>RFC 3501 makes the inbox the one folder name a server may spell in any case.</summary>
     [Theory]
     [InlineData("INBOX")]

--- a/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
@@ -112,6 +112,7 @@ public sealed class AdminApiEndpointsTests
                 $"{AdminEndpointOptions.RoutePrefix}{EmbeddingProfileEndpoints.ActivationRoute}",
                 $"{AdminEndpointOptions.RoutePrefix}{EmbeddingProfileEndpoints.ActivationRoute}",
                 $"{AdminEndpointOptions.RoutePrefix}{EmbeddingProfileEndpoints.ReindexCancellationRoute}",
+                $"{AdminEndpointOptions.RoutePrefix}{MailFolderErasureEndpoint.ErasureRoute}",
                 $"{AdminEndpointOptions.RoutePrefix}{MailboxMutationAuditEndpoint.Route}",
                 $"{AdminEndpointOptions.RoutePrefix}{MailboxRefreshTokenEndpoint.Route}",
                 $"{AdminEndpointOptions.RoutePrefix}{MailRuleEndpoints.RulesRoute}",

--- a/tests/Host.UnitTests/Api/MailFolderErasureEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/MailFolderErasureEndpointTests.cs
@@ -1,0 +1,271 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Accounts;
+using MailFathom.Application.Folders;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Synchronization;
+using MailFathom.Host.Api;
+using MailFathom.Host.UnitTests.TestDoubles;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Http.Metadata;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Api;
+
+/// <summary>Covers the one route that disposes of stored mail: what it erases, and what it refuses to.</summary>
+/// <remarks>
+/// The refusal is as much the contract as the erasure. Nothing else in MailFathom takes a folder's local copy away, so
+/// this route is reached by an operator who means it — and a folder the account still mirrors is the one case where
+/// meaning it would buy a remirror rather than the storage back, which is why it is refused rather than performed
+/// carefully.
+/// </remarks>
+public sealed class MailFolderErasureEndpointTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+    private static readonly MailFolderAlias Archive = MailFolderAlias.Create("archive");
+
+    private readonly IMailFolderMappingReader mappings = Substitute.For<IMailFolderMappingReader>();
+
+    /// <summary>
+    /// The deployment's half of an agreement with a command it cannot reference. <c>mfctl</c> composes this path from a
+    /// constant of its own, and a rename on either side compiles cleanly while the erase command reaches a 404 that
+    /// reads exactly like an endpoint nobody enabled.
+    /// </summary>
+    [Fact]
+    public void ErasureRoute_IsThePathTheCommandComposes() =>
+        Assert.Equal("/folders/erasure", MailFolderErasureEndpoint.ErasureRoute);
+
+    /// <summary>The bound on the body, which the route carries as metadata the routing pipeline reads.</summary>
+    [Fact]
+    public void MapMailFolderErasure_TheRoute_CarriesTheRequestBodyBound()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddRouting();
+        services.AddLogging();
+
+        var endpoints = new TestEndpointRouteBuilder(services.BuildServiceProvider());
+
+        // Act
+        endpoints.MapGroup(string.Empty).MapMailFolderErasure();
+
+        // Assert
+        var route = endpoints.DataSources
+            .SelectMany(source => source.Endpoints)
+            .OfType<RouteEndpoint>()
+            .Single(endpoint => endpoint.RoutePattern.RawText == MailFolderErasureEndpoint.ErasureRoute);
+
+        Assert.Equal(["POST"], route.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods);
+        Assert.Equal(
+            MailFolderErasureEndpoint.MaxErasureRequestBytes,
+            route.Metadata.GetMetadata<IRequestSizeLimitMetadata>()!.MaxRequestBodySize);
+    }
+
+    /// <summary>A folder switched off stopped being refreshed, and this is what turns that into the storage back.</summary>
+    [Fact]
+    public async Task EraseAsync_AMappedFolderNothingMirrors_ErasesOneBoundedPassOfIt()
+    {
+        // Arrange
+        this.Maps(MailFolderMapping.ToSpecialUse(
+            Archive,
+            MailFolderSpecialUse.Archive,
+            MailFolderParticipation.MappedOnly));
+
+        var store = new RecordingMirrorStore(new MailFolderMirrorErasure(ErasedEmailCount: 500, EmailsRemain: true));
+
+        // Act
+        var result = await this.EraseAsync(store, new MailFolderErasureRequest("work", "archive"));
+
+        // Assert
+        var erasure = Assert.IsType<Ok<MailFolderErasureResponse>>(result.Result);
+        Assert.Equal((Account.Value, Archive.Value, 500, true), (
+            erasure.Value!.Account,
+            erasure.Value.Folder,
+            erasure.Value.ErasedEmailCount,
+            erasure.Value.EmailsRemain));
+        Assert.Equal([(Account, Archive)], store.Passes);
+    }
+
+    /// <summary>
+    /// The case no configuration value can express, and the one that most needs erasing: a mapping an operator removed
+    /// leaves the rows behind deliberately, so a folder nothing names has to stay erasable.
+    /// </summary>
+    [Fact]
+    public async Task EraseAsync_AnAliasNoMappingNames_ErasesItRatherThanRefusingTheRequest()
+    {
+        // Arrange
+        this.Maps(mapping: null);
+
+        var store = new RecordingMirrorStore(new MailFolderMirrorErasure(ErasedEmailCount: 7, EmailsRemain: false));
+
+        // Act
+        var result = await this.EraseAsync(store, new MailFolderErasureRequest("work", "archive"));
+
+        // Assert
+        var erasure = Assert.IsType<Ok<MailFolderErasureResponse>>(result.Result);
+        Assert.Equal(7, erasure.Value!.ErasedEmailCount);
+        Assert.Equal([(Account, Archive)], store.Passes);
+    }
+
+    /// <summary>Erasing a folder a run is about to visit is a hole the next run silently refills, so it is refused.</summary>
+    [Fact]
+    public async Task EraseAsync_AFolderTheAccountStillMirrors_RefusesAndErasesNothing()
+    {
+        // Arrange
+        this.Maps(MailFolderMapping.ToSpecialUse(Archive, MailFolderSpecialUse.Archive));
+
+        var store = new RecordingMirrorStore(MailFolderMirrorErasure.Nothing);
+
+        // Act
+        var result = await this.EraseAsync(store, new MailFolderErasureRequest("work", "archive"));
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        Assert.Contains(Archive.Value, refusal.ProblemDetails.Detail, StringComparison.Ordinal);
+        Assert.Contains("Synchronize", refusal.ProblemDetails.Detail, StringComparison.Ordinal);
+        Assert.Empty(store.Passes);
+    }
+
+    /// <summary>Running it again after the folder is empty is the ordinary end of every erasure, not an error.</summary>
+    [Fact]
+    public async Task EraseAsync_AFolderHoldingNothing_SucceedsHavingErasedNothing()
+    {
+        // Arrange
+        this.Maps(mapping: null);
+
+        var store = new RecordingMirrorStore(MailFolderMirrorErasure.Nothing);
+
+        // Act
+        var result = await this.EraseAsync(store, new MailFolderErasureRequest("work", "archive"));
+
+        // Assert
+        var erasure = Assert.IsType<Ok<MailFolderErasureResponse>>(result.Result);
+        Assert.Equal(0, erasure.Value!.ErasedEmailCount);
+        Assert.False(erasure.Value.EmailsRemain);
+    }
+
+    /// <summary>An account this deployment does not serve is a mistake in the request rather than a missing resource.</summary>
+    [Theory]
+    [InlineData(null, "archive")]
+    [InlineData("", "archive")]
+    [InlineData("personal", "archive")]
+    public async Task EraseAsync_AnAccountThisDeploymentDoesNotServe_RefusesWithoutReachingTheEraser(
+        string? account,
+        string folder)
+    {
+        // Arrange
+        var store = new RecordingMirrorStore(MailFolderMirrorErasure.Nothing);
+
+        // Act
+        var result = await this.EraseAsync(store, new MailFolderErasureRequest(account, folder));
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        Assert.Empty(store.Passes);
+    }
+
+    /// <summary>
+    /// Text the alias type refuses reaches a stated refusal rather than a failure the process reports as its own,
+    /// which is what a body an operator typed is owed.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("arch\tive")]
+    public async Task EraseAsync_TextThatNamesNoFolder_RefusesWithoutReachingTheEraser(string? folder)
+    {
+        // Arrange
+        var store = new RecordingMirrorStore(MailFolderMirrorErasure.Nothing);
+
+        // Act
+        var result = await this.EraseAsync(store, new MailFolderErasureRequest("work", folder));
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        Assert.Empty(store.Passes);
+    }
+
+    private void Maps(MailFolderMapping? mapping) =>
+        this.mappings.FindFolderNamed(Account, Archive).Returns(mapping);
+
+    private Task<Results<Ok<MailFolderErasureResponse>, ProblemHttpResult>> EraseAsync(
+        IStoredMailFolderMirrorStore store,
+        MailFolderErasureRequest request) =>
+        MailFolderErasureEndpoint.EraseAsync(
+            request,
+            CatalogServing(Account),
+            this.mappings,
+            EraserOver(store),
+            TestContext.Current.CancellationToken);
+
+    private static UnmirroredMailFolderEraser EraserOver(IStoredMailFolderMirrorStore store)
+    {
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
+
+        return new UnmirroredMailFolderEraser(
+            store,
+            new OptimisticConcurrencyRetryPolicy(
+                sessionFactory,
+                new PersistenceConcurrencyOptions(),
+                new FakeTimeProvider()),
+            new MailboxSynchronizationOptions());
+    }
+
+    private static IMailAccountCatalog CatalogServing(params MailAccountId[] accounts)
+    {
+        var catalog = Substitute.For<IMailAccountCatalog>();
+        catalog.ServedAccounts.Returns(
+        [
+            .. accounts.Select(account => new ServedMailAccount(
+                account,
+                MailAccountDisplayName.Create(account.Value),
+                MailSynchronizationMode.Polling)),
+        ]);
+
+        return catalog;
+    }
+
+    /// <summary>Records which folder each pass was asked to erase, and answers with the erasure the test arranged.</summary>
+    private sealed class RecordingMirrorStore(MailFolderMirrorErasure erasure) : IStoredMailFolderMirrorStore
+    {
+        private readonly List<(MailAccountId AccountId, MailFolderAlias FolderAlias)> passes = [];
+
+        public IReadOnlyList<(MailAccountId AccountId, MailFolderAlias FolderAlias)> Passes => this.passes;
+
+        public Task<MailFolderMirrorErasure> EraseFolderMirrorAsync(
+            IPersistenceSession session,
+            MailAccountId accountId,
+            MailFolderAlias folderAlias,
+            int maxEmails,
+            CancellationToken cancellationToken)
+        {
+            this.passes.Add((accountId, folderAlias));
+
+            return Task.FromResult(erasure);
+        }
+    }
+
+    private sealed class CommittingSession : IPersistenceSession
+    {
+        public Task<PersistenceCommitResult> CommitAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(PersistenceCommitResult.Committed);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
Nothing in MailFathom took a folder's local copy away any more. [#717](https://github.com/Krzysztof318/MailFathom/issues/717) made switching `Synchronize` off keep what a folder had stored, and [#719](https://github.com/Krzysztof318/MailFathom/issues/719) made a folder no mapping names cease to exist for every reader while its rows stay. Both are right — an edit to a configuration file should not dispose of somebody's mail — and both left an operator who genuinely wants the storage back with nothing to ask.

This is the ask, and it is the only thing in MailFathom that erases a folder's mirror.

## What it adds

**`POST /api/admin/folders/erasure`** erases one bounded pass of one folder through `UnmirroredMailFolderEraser` and `IStoredMailFolderMirrorStore`, which [#694](https://github.com/Krzysztof318/MailFathom/issues/694) already built and [#717](https://github.com/Krzysztof318/MailFathom/issues/717) left registered without a caller. The rows go by the deletion path an erasing disposition already uses, so the raw MIME, the search document, the passages, their vectors, and any outstanding repair request go with them. The checkpoint goes in the pass that empties the folder, which is what makes a folder erased and then switched back on mirror from the start rather than resuming; the binding stays, so the alias goes on resolving and goes on being a destination.

**`mfctl folder erase --account <id> --folder <alias>`** repeats that request until the deployment reports nothing left, printing a running total as it goes:

```console
$ mfctl folder erase --account work --folder archive
500 stored emails erased so far
1043 stored emails erased from ARCHIVE under work. The folder holds none, and its checkpoint went with them, so
mirroring it again starts from the beginning rather than resuming.
```

One request is one committed transaction rather than a mailbox, so interrupting the command leaves the rest for the next invocation rather than a half-erased folder in an unrepeatable state, and running it against an already-empty folder succeeds having removed nothing.

## What it refuses

A folder the account **still mirrors** is refused with `400`, naming the alias and the two ways to make it erasable, because erasing one would open a hole the next run silently refills. An alias **no mapping names** is accepted rather than refused: a mapping somebody withdrew is the case that most needs erasing and the one case no configuration value can express. A pass that removed nothing while claiming more remains is reported rather than retried, because nothing the deployment's own eraser produces says that and asking again could not help.

`MailFolderAlias` gains `TryCreate` for the same reason every boundary needs one: the route reads an alias out of a request body and owes a stated refusal rather than a failure the process reports as its own.

## Contract surfaces

No break. The administrative route and the `mfctl` command are both additions; the configuration schema, the database schema, the MCP tool contract, and the deployment contract are untouched, and no migration is owed.

## Verification

- `scripts/verify-full.sh` — green: 6108 tests, 0 failed; aggregate line coverage 95.63% (required 85%); `Formatted 0 of 1978 files`.
- `scripts/review-obligations.sh` — every row answered. The rows naming `CliOptions`, `CliJsonContext`, `CliRootCommand`, `EraseFolderCommand`, and `MailFolderErasure` are covered behaviourally by `FolderCommandTests`, which drives the real command tree through `CliRunner` exactly as `RuleCommandTests` does; the documentation rows naming `docs/operations/mailbox-oauth.md` and `docs/operations/configuration-reference.md` say nothing about a folder command and owe nothing.
- New tests: `MailFolderErasureEndpointTests` (the refusal, the unmapped alias, the bounding, the empty folder, the two request refusals, the route and its body bound), `FolderCommandTests` (one pass, the repetition, the running total, the empty folder, the stated refusal, the non-progressing answer, the request body, both required options), and `MailFolderTests` for `MailFolderAlias.TryCreate`.
- Documentation: `docs/operations/admin-endpoint.md` (route table, the security blockquote, a section of its own, two troubleshooting rows), `docs/features/imap-synchronization.md` (both retention paragraphs now point at the command), `docs/users/administering.md` (a section for the person running it).

Closes #718

https://github.com/Krzysztof318/MailFathom/issues/718
