### PR TITLE
[#786] Point an operator and a user at the documentation for the version they are running

### DIFF
--- a/.github/workflows/publish-container-image.yml
+++ b/.github/workflows/publish-container-image.yml
@@ -118,6 +118,8 @@ jobs:
         env:
           REPOSITORY: ${{ github.repository }}
           IMAGE_TAGS: ${{ inputs.tags }}
+          IMAGE_CHANNEL: ${{ inputs.channel }}
+          IMAGE_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
@@ -145,6 +147,18 @@ jobs:
             printf '%s\n' "$tags" | sed "s|^|${docker_hub_image}:|"
             printf 'REFERENCES\n'
           } >> "$GITHUB_OUTPUT"
+
+          # Which directory of the documentation site this image's `org.opencontainers.image.documentation` label sends
+          # a reader to. A release is documented under its own version; a nightly is named after a release that does
+          # not exist yet, and what it carries is `main`, which the site publishes as `latest`. The Dockerfile defaults
+          # to the release form and this is what overrides it, because a Dockerfile cannot read a channel.
+          if [[ "$IMAGE_CHANNEL" == 'nightly' ]]; then
+            documentation_version='latest'
+          else
+            documentation_version="v${IMAGE_VERSION}"
+          fi
+
+          printf 'documentation-version=%s\n' "$documentation_version" >> "$GITHUB_OUTPUT"
 
           # `created` names the instant the source was committed rather than the instant a runner happened to start.
           # A re-run of the same commit then produces the same label instead of a second image that differs only in
@@ -284,6 +298,7 @@ jobs:
             IMAGE_REVISION=${{ inputs.ref }}
             IMAGE_CREATED=${{ steps.reference.outputs.created }}
             IMAGE_RELEASE_CHANNEL=${{ inputs.channel }}
+            IMAGE_DOCUMENTATION_VERSION=${{ steps.reference.outputs.documentation-version }}
             VERSION_SUFFIX=${{ inputs.version-suffix }}
           cache-from: type=gha,scope=publish-${{ inputs.channel }}
           cache-to: type=gha,mode=max,scope=publish-${{ inputs.channel }}
@@ -400,6 +415,7 @@ jobs:
             IMAGE_REVISION=${{ inputs.ref }}
             IMAGE_CREATED=${{ steps.reference.outputs.created }}
             IMAGE_RELEASE_CHANNEL=${{ inputs.channel }}
+            IMAGE_DOCUMENTATION_VERSION=${{ steps.reference.outputs.documentation-version }}
             VERSION_SUFFIX=${{ inputs.version-suffix }}
           provenance: mode=max
           sbom: true
@@ -491,6 +507,7 @@ jobs:
           EXPECTED_VERSION: ${{ inputs.version }}
           EXPECTED_REVISION: ${{ inputs.ref }}
           EXPECTED_CHANNEL: ${{ inputs.channel }}
+          EXPECTED_DOCUMENTATION_VERSION: ${{ steps.reference.outputs.documentation-version }}
         run: |
           set -euo pipefail
 
@@ -526,6 +543,10 @@ jobs:
           assert_label 'org.opencontainers.image.version' "$EXPECTED_VERSION"
           assert_label 'org.opencontainers.image.revision' "$EXPECTED_REVISION"
           assert_label 'io.mailfathom.release-channel' "$EXPECTED_CHANNEL"
+          # Asserted off the manifest like the rest, because this is the label somebody reads instead of asking anyone:
+          # a published image whose documentation address is composed wrong sends every reader of it to a page that
+          # does not exist, and nothing downstream of a publication would ever report that.
+          assert_label 'org.opencontainers.image.documentation' "https://krzysztof318.github.io/MailFathom/${EXPECTED_DOCUMENTATION_VERSION}/"
 
           echo "${DIGEST} is in both registries, carries both platforms, and identifies itself as ${EXPECTED_CHANNEL} ${EXPECTED_VERSION}."
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -120,6 +120,18 @@ ARG IMAGE_CREATED=1970-01-01T00:00:00Z
 # which is the state an image reaches long before anyone asks what it is. Its default is deliberately neither channel:
 # an image nobody published belongs to neither.
 ARG IMAGE_RELEASE_CHANNEL=local
+# The directory the documentation site publishes this build's pages under, which is what
+# `org.opencontainers.image.documentation` below is composed into an address from. It is derived from `IMAGE_VERSION`
+# rather than declared beside it, and its default is the whole derivation for a release: the site names a version's
+# directory after that version's tag.
+#
+# The one build that overrides it is the nightly, which is why this is an argument rather than the interpolation
+# written inline. A nightly is named after the release it will become, and the site publishes no directory for a
+# version nobody has released — what a nightly actually carries is whatever `main` was, which is what `latest`
+# documents. A Dockerfile cannot decide that for itself, so the publication that already knows the channel passes it,
+# exactly as it passes the version and the revision. `MailFathom.Common`'s DocumentationAddress reads the same rule off
+# a version at run time for the surfaces that can.
+ARG IMAGE_DOCUMENTATION_VERSION=v${IMAGE_VERSION}
 
 # `org.opencontainers.image.licenses` is the SPDX identifier a registry and a scanner read without unpacking the
 # image, and it says the same thing as the root LICENSE, the SPDX assembly metadata, and every source header. The
@@ -131,6 +143,11 @@ ARG IMAGE_RELEASE_CHANNEL=local
 # there. Docker Hub accepts 100 bytes for that field and silently truncates a longer one, so this line stays inside that
 # budget and the workflow fails the release if it ever stops fitting — see docs/operations/container-image.md.
 #
+# `org.opencontainers.image.documentation` is where somebody holding only an image reference finds the pages for what
+# they are holding. It names the version's own documentation directory rather than the site root, because the site
+# opens on the newest release and a reader who pulled an older tag would otherwise be shown pages describing settings
+# their image does not accept.
+#
 # `io.artifacthub.package.logo-url` is the one label here that OCI does not define: the specification has no field for a
 # project icon, so a listing reads a vendor label instead. It names the same asset as the Helm chart's `icon`, and it is
 # a URL rather than a copied file because a label carries no payload.
@@ -138,6 +155,7 @@ LABEL org.opencontainers.image.licenses="Apache-2.0" \
       org.opencontainers.image.title="MailFathom" \
       org.opencontainers.image.description="A brain for your mail: self-hosted and AI-native, IMAP synchronized and served over MCP." \
       org.opencontainers.image.source="https://github.com/Krzysztof318/MailFathom" \
+      org.opencontainers.image.documentation="https://krzysztof318.github.io/MailFathom/${IMAGE_DOCUMENTATION_VERSION}/" \
       org.opencontainers.image.version="${IMAGE_VERSION}" \
       org.opencontainers.image.revision="${IMAGE_REVISION}" \
       org.opencontainers.image.created="${IMAGE_CREATED}" \

--- a/deploy/helm/mailfathom/templates/NOTES.txt
+++ b/deploy/helm/mailfathom/templates/NOTES.txt
@@ -1,3 +1,5 @@
+{{- $documentation := include "mailfathom.documentationAddress" . -}}
+{{- $documentationRoot := $documentation | default "https://krzysztof318.github.io/MailFathom/" -}}
 MailFathom {{ include "mailfathom.versionLabel" . }} is installed as release {{ .Release.Name }} in namespace {{ .Release.Namespace }}.
 
 Image:    {{ include "mailfathom.image" . }}
@@ -5,6 +7,9 @@ Database: {{ include "mailfathom.databaseHost" . }}:{{ .Values.database.port }}/
 Secrets:  {{ .Values.secrets.existingSecret }}, mounted read-only at {{ .Values.secrets.mountPath }}
 {{- if .Values.database.deploy.enabled }}
           {{ .Values.database.deploy.superuserPasswordSecret }}, read by the database alone and never by MailFathom
+{{- end }}
+{{- if $documentation }}
+Docs:     {{ $documentation }}
 {{- end }}
 {{ if eq .Values.image.channel "nightly" }}
   ############################################################################
@@ -25,8 +30,8 @@ MailFathom verifies the database schema while starting and refuses to serve agai
 applies a migration itself, in any environment, and neither does this chart: a hook Job would be the automatic
 migration that arrangement prevents, and an initContainer would run one apply per replica. If the pod reports a pending
 migration, back up {{ .Values.database.name }}, read the release's mailfathom-schema-<version>.sql, apply it, and
-let the rollout continue. docs/operations/database-schema.md states the privileges it needs and what each failure
-means.
+let the rollout continue. {{ $documentationRoot }}operations/database-schema.html states the privileges it needs and
+what each failure means.
 {{ if .Values.database.deploy.enabled }}
 The database is this release's own: a single-replica StatefulSet, its claim retained when the release is uninstalled.
 The role MailFathom connects as owns its database and is not a superuser; the schema goes in through the server it runs:

--- a/deploy/helm/mailfathom/templates/_helpers.tpl
+++ b/deploy/helm/mailfathom/templates/_helpers.tpl
@@ -48,6 +48,24 @@ second written version number Chart.yaml exists to avoid.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Where the documentation for the version this release installed is published. The site holds one directory per version,
+so somebody who has just run `helm install` gets the pages describing what they now have rather than whichever release
+the site happens to open on.
+
+The nightly channel resolves to `latest`, for the reason the version label above resolves to the nightly identifier: a
+nightly is named after a release that does not exist yet, and what it carries is `main`, which is what `latest`
+documents. An unpackaged chart renders no address at all, because it states no application version to name one from —
+the notes then say nothing about documentation instead of offering an address assembled from a blank.
+*/}}
+{{- define "mailfathom.documentationAddress" -}}
+{{- if eq .Values.image.channel "nightly" -}}
+https://krzysztof318.github.io/MailFathom/latest/
+{{- else if .Chart.AppVersion -}}
+{{- printf "https://krzysztof318.github.io/MailFathom/v%s/" .Chart.AppVersion -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "mailfathom.labels" -}}
 helm.sh/chart: {{ include "mailfathom.chart" . }}
 {{ include "mailfathom.selectorLabels" . }}

--- a/docs/architecture/solution-structure.md
+++ b/docs/architecture/solution-structure.md
@@ -25,6 +25,7 @@ flowchart TD
     Host --> Common
     Cli --> Common
     Mcp --> Application
+    Mcp --> Common
     Infrastructure --> Application
     Infrastructure --> Common
     AI --> Application
@@ -51,14 +52,15 @@ sections below say what each project is for and why two of them are shaped again
   boundary, because the published file is something an operator types repeatedly; the project, its directory, and its
   namespace stay `Cli`.
 - `Common` is cross-cutting code that belongs to no boundary and depends on nothing but the base class library and
-  `Domain`. It is not a layer and has no place in the dependency ordering above: `Cli`, `Infrastructure`, and `Host`
-  reach it, and it reaches only the innermost project, so that a failure it raises derives from `MailFathomException`
-  like every other. Admission is narrow on purpose — code arrives when a second boundary genuinely needs it, and lives
-  with its one consumer until then — because a project defined by what it is not becomes the drawer everything ends up
-  in. Three things have earned it: the AES-GCM envelope, the mailbox OAuth exchange under `MailboxOAuth/`, and the
-  telemetry name under `Observability/`, with the one activity source and the one meter carrying it, which every
-  subsystem that emits a signal publishes through and the host subscribes, so that no boundary chooses what it is
-  called.
+  `Domain`. It is not a layer and has no place in the dependency ordering above: `Cli`, `Mcp`, `Infrastructure`, and
+  `Host` reach it, and it reaches only the innermost project, so that a failure it raises derives from
+  `MailFathomException` like every other. Admission is narrow on purpose — code arrives when a second boundary genuinely
+  needs it, and lives with its one consumer until then — because a project defined by what it is not becomes the drawer
+  everything ends up in. Four things have earned it: the AES-GCM envelope, the mailbox OAuth exchange under
+  `MailboxOAuth/`, the telemetry name under `Observability/`, with the one activity source and the one meter carrying
+  it, which every subsystem that emits a signal publishes through and the host subscribes, so that no boundary chooses
+  what it is called, and `DocumentationAddress`, which the administrative command and the protocol surface both answer
+  from so that a reader of either is sent to the pages for the version actually in front of them.
 - `AppHost` is the Aspire local-development orchestration host.
 
 `Cli` also authorizes a mailbox, because one thing a headless service structurally cannot do is ask a person to sign

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -804,11 +804,19 @@ address:
 ```console
 $ mfctl status --endpoint production
 'production' (https://mail.example.test:8443) accepts the stored credential as 'workstation' (MailFathom 0.2.0).
+Documentation for that version: https://krzysztof318.github.io/MailFathom/v0.2.0/
 ```
 
 The order is the option, then `MAILFATHOM_ENDPOINT`, then the profile last switched to: what you typed beats what your
 shell was told, and both beat what you chose last time. `status` is what asks a deployment whether the stored credential
 still works, which is how a revoked or expired key is distinguished from an unreachable host.
+
+The documentation line names the **deployment's** version rather than the command's. The two are separate builds — that
+is the whole reason `status` reports the deployment's version at all — and a command from one release line pointed at a
+deployment on another would otherwise name pages for something nobody is running. A deployment on the nightly channel
+resolves to `latest`, which is what a nightly carries, and a deployment reporting a version the command cannot read is
+told nothing about documentation at all: that is the same absence of evidence the version check warns on rather than
+acts on, and naming a directory for it would be a guess printed as a fact.
 
 `mfctl logout` forgets one profile — the selected one, or whichever `--endpoint` names. It does not revoke anything: the
 credential stays valid until the deployment stops accepting it. Forgetting the selected profile leaves none selected

--- a/docs/operations/container-image.md
+++ b/docs/operations/container-image.md
@@ -141,6 +141,15 @@ prerelease identifier and a release never carries one — and this label is what
 reference has been re-tagged, mirrored, or reduced to a digest, which is the state a reference reaches long before
 anyone asks what it is. It arrives as `IMAGE_RELEASE_CHANNEL`, and its default is deliberately neither channel.
 
+`org.opencontainers.image.documentation` names the documentation site's directory for the version this image carries,
+so `docker inspect` answers where to read about what you are holding without anybody having to work out which version's
+pages apply. It is the version's own directory rather than the site root, because the site opens on the newest release
+and an older tag would otherwise be read against pages describing settings it does not accept. `IMAGE_DOCUMENTATION_VERSION`
+is where it comes from, and its default is the whole derivation for a release: the site names a version's directory
+after that version's tag, so a version reads as `v<version>`. The nightly publication is the one build that passes something
+else, `latest`, because a nightly is named after a release the site publishes nothing for yet and what it actually
+carries is `main` — which is what `latest` documents.
+
 `org.opencontainers.image.licenses` is fixed rather than passed in, at `Apache-2.0`, because it states MailFathom's own
 license and a build must not be able to say otherwise. The label is only the claim a registry indexes; the terms
 themselves are `/app/LICENSE` and `/app/NOTICE`, which arrive as part of the publish output the runtime stage copies.
@@ -316,8 +325,11 @@ schema](database-schema.md) is what that artifact is and how it is applied.
 
 Only then is the multi-architecture manifest list built and pushed — once, to both registries, because every reference
 it takes in either of them is in one tag list. After the push it is inspected by digest and required to carry both
-platforms, to identify itself as the channel and version it was published as, and to resolve to the same digest in each
-registry. A failure anywhere above publishes nothing.
+platforms, to identify itself as the channel and version it was published as, to name the documentation address that
+channel and version compose to, and to resolve to the same digest in each registry. A failure anywhere above publishes
+nothing. The documentation address is asserted there rather than trusted because it is the label somebody reads instead
+of asking anyone: composed wrongly, it sends every reader of the image to a page that does not exist, and nothing
+downstream of a publication would ever report that.
 
 A release additionally synchronizes `deploy/docker/README.md` onto the Docker Hub repository page, which is the one
 registry overview that is not rendered from the repository itself, together with the short description that sits above

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -193,6 +193,14 @@ helm install mailfathom deploy/helm/mailfathom --namespace mailfathom --values v
 An unpackaged directory states no `appVersion`, because it is not a release of anything, so the version-drift check
 below stands down for it.
 
+The notes an install prints carry the documentation for the version they installed, as a `Docs:` line naming that
+version's own directory on the documentation site — `https://krzysztof318.github.io/MailFathom/v<version>/`, or
+`latest` on the nightly channel, which is what a nightly actually carries. It is an address rather than a repository
+path because somebody reading `helm install` output has no checkout to resolve one against, which is why the notes'
+pointer to [applying the schema](database-schema.md) is an address as well. The unpackaged directory states no version
+to name a directory from, so it prints no `Docs:` line and its schema pointer is the site's version-agnostic address
+instead.
+
 A digest is preferred over a tag: it is the only reference a registry cannot repoint, so a rollback goes back to the
 same bytes. `values.schema.json` rejects `latest` and the other moving tags outright.
 

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -118,6 +118,15 @@ addresses moves with the pages rather than being maintained beside them: a page 
 address on the next publish. The API reference is left out — it is a thousand generated pages whose names are type
 names, nothing links into it by hand, and mirroring it would treble the file count of the site for nothing.
 
+**A running deployment is the exception, and it names a version deliberately.** Four surfaces print the version
+directory rather than the version-agnostic address: the container image's `org.opencontainers.image.documentation`
+label, the chart's install notes, `mfctl status`, and the instructions an MCP session carries. Each of them knows a
+version at the moment it speaks, and what its reader wants is the pages for the release in front of them rather than
+the one the site currently opens on — an address that follows the newest release would show somebody running an older
+one a setting their deployment does not accept. A prerelease resolves to `latest` there, because a nightly is named
+after a release the site publishes nothing for yet and what it carries is `main`. The rule stands unchanged for
+everything written down: a link in a file names no version, because a file outlives the release it was written in.
+
 ## Building it locally
 
 ```bash

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -1554,6 +1554,26 @@ about why. When a client reports `54001`, the server log is where the reason is.
 A refused call is logged with the five-digit code it was refused with, so an operator can correlate a client's complaint
 against a server record without learning what was searched for.
 
+## What a client learns while connecting
+
+The `initialize` handshake reports this deployment as `MailFathom` and names the version the protocol assembly was built
+with — not the host's assembly name, which would tell a client about a composition detail rather than about the surface
+it is talking to, and not the source revision, which is build provenance an operator reads from the [startup
+record](host-startup-telemetry.md) instead.
+
+Beside that, the handshake carries **instructions**: one sentence naming where the documentation for that running
+version is published, at `https://krzysztof318.github.io/MailFathom/v<version>/`. A client that connected over MCP may
+be the only way its user meets MailFathom at all, so the session itself is what says where to read — otherwise an agent
+asked to consult the documentation reaches whichever version a search engine ranked first. The address is derived from
+the version the same handshake reports and is not configurable, so the pages it names cannot come to describe a
+different build from the one the client was told it is talking to. A deployment running a nightly names `latest`, which
+is what a nightly carries, and a build whose version cannot be read carries no instructions rather than an address that
+goes nowhere.
+
+Nothing else travels in them. The protocol places no bound on what instructions may hold, and a client may put them in
+front of a model, so what belongs there is where to read rather than what to read: this makes the documentation
+findable and never serves it over the protocol.
+
 ## Verifying an enabled endpoint
 
 With the endpoint enabled, the Streamable HTTP transport answers on `/mcp` and advertises four tools, or five. Any MCP

--- a/docs/operations/release-procedure.md
+++ b/docs/operations/release-procedure.md
@@ -61,6 +61,13 @@ All of them come from the same declaration. The runtime paths read the assembly'
 literal restated in code, and unit tests assert that by deriving their expectation from that metadata; a reporting path
 that regressed to a hardcoded string fails them rather than staying plausible while being wrong.
 
+Four of those surfaces go one step further and say what the version *means for the reader*: where to read about it. The
+image's `org.opencontainers.image.documentation` label, the chart's install notes, `mfctl status`, and the instructions
+an MCP session carries each name the documentation site's directory for the version in front of them — one derivation,
+applied by whichever of them is speaking, with no configuration key anywhere in it. [The addresses that outlive a
+release](documentation-site.md#the-addresses-that-outlive-a-release) is where that convention and its one exception for
+a prerelease are stated.
+
 The native process deployment needs nothing further: `dotnet publish` writes the stamped assemblies, so the artifact on
 disk carries its own version and revision without being started.
 

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -3580,6 +3580,8 @@ run_publish_reference_step() {
   local image_tags="$1"
   local output_file="$2"
   local step_output_file="$3"
+  local image_channel="${4:-release}"
+  local image_version="${5:-0.1.0}"
   local step_script="$test_directory/publish-reference-step.sh"
 
   extract_publish_reference_step "$step_script"
@@ -3588,6 +3590,8 @@ run_publish_reference_step() {
   (
     export REPOSITORY='Krzysztof318/MailFathom'
     export IMAGE_TAGS="$image_tags"
+    export IMAGE_CHANNEL="$image_channel"
+    export IMAGE_VERSION="$image_version"
     export GITHUB_OUTPUT="$step_output_file"
     cd "$repository_root"
     bash "$step_script"
@@ -3659,6 +3663,38 @@ publish_qualifies_the_release_tags_and_ignores_a_blank_line() {
   assert_file_content \
     $'ghcr.io/krzysztof318/mailfathom:0.1.0\nghcr.io/krzysztof318/mailfathom:latest\ndocker.io/krzysztof318/mailfathom:0.1.0\ndocker.io/krzysztof318/mailfathom:latest' \
     "$references_file"
+}
+
+# The same step decides which directory of the documentation site the image's
+# `org.opencontainers.image.documentation` label sends a reader to, because a Dockerfile cannot read a
+# channel and the label is the one an operator follows without asking anybody. A release is documented
+# under its own version.
+publish_sends_a_release_to_its_own_documentation_directory() {
+  local output_file="$test_directory/publish-reference-documentation-release-output"
+  local step_output_file="$test_directory/publish-reference-documentation-release-step-output"
+
+  if ! run_publish_reference_step $'0.1.0\nlatest\n' "$output_file" "$step_output_file" 'release' '0.1.0'; then
+    printf 'The publish workflow failed to resolve a release documentation directory\n' >&2
+    return 1
+  fi
+
+  assert_contains 'documentation-version=v0.1.0' "$step_output_file"
+}
+
+# A nightly is named after a release the site publishes nothing for yet, and what it carries is `main`.
+# Labelling it with its own version would hand every reader of a nightly image an address that 404s.
+publish_sends_a_nightly_to_the_default_branch_documentation() {
+  local output_file="$test_directory/publish-reference-documentation-nightly-output"
+  local step_output_file="$test_directory/publish-reference-documentation-nightly-step-output"
+
+  if ! run_publish_reference_step \
+    $'0.1.0-nightly.12-616d0a6\nnightly\n' "$output_file" "$step_output_file" \
+    'nightly' '0.1.0-nightly.12-616d0a6'; then
+    printf 'The publish workflow failed to resolve a nightly documentation directory\n' >&2
+    return 1
+  fi
+
+  assert_contains 'documentation-version=latest' "$step_output_file"
 }
 
 # A tag list that is empty once blank lines are dropped would otherwise push `ghcr.io/<repository>:`,
@@ -4741,6 +4777,8 @@ run_test obligation_index_leaves_migrations_out
 run_test publish_qualifies_every_nightly_tag_with_the_repository_it_resolves
 run_test publish_qualifies_the_release_tags_and_ignores_a_blank_line
 run_test publish_folds_the_owner_login_into_the_docker_hub_namespace
+run_test publish_sends_a_release_to_its_own_documentation_directory
+run_test publish_sends_a_nightly_to_the_default_branch_documentation
 run_test publish_refuses_a_tag_list_with_nothing_to_publish
 run_test release_tag_assertion_accepts_a_tag_that_matches_its_commit
 run_test release_tag_assertion_refuses_a_prerelease_tag

--- a/src/Cli/Commands/StatusCommand.cs
+++ b/src/Cli/Commands/StatusCommand.cs
@@ -4,14 +4,24 @@
 
 using System.CommandLine;
 using MailFathom.Cli.Administration;
+using MailFathom.Common;
 
 namespace MailFathom.Cli.Commands;
 
 /// <summary>Reports what the deployment in use says about the stored credential.</summary>
 /// <remarks>
+/// <para>
 /// It asks the deployment rather than reading the store, which is the point: the store says what was true at sign-in,
 /// and this says whether the credential still works. It is therefore the command that tells an operator their key has
 /// been revoked or has expired.
+/// </para>
+/// <para>
+/// It is also where an operator learns where to read about what they are administering, and the version that decides
+/// that is the deployment's rather than this command's: the two are separate builds, and a command from a nightly
+/// pointed at a released deployment would otherwise name pages for something nobody is running. A deployment that
+/// reports no version it can read is told nothing about documentation, which is the same absence of evidence
+/// <see cref="DeploymentVersionAgreement" /> warns on rather than acts on.
+/// </para>
 /// </remarks>
 internal static class StatusCommand
 {
@@ -50,6 +60,11 @@ internal static class StatusCommand
 
         context.Console.WriteLine(
             $"'{profile.Name}' ({profile.Endpoint.GetLeftPart(UriPartial.Authority)}) accepts the stored credential as '{session.Credential}' (MailFathom {session.Version}).");
+
+        if (DocumentationAddress.ForVersion(session.Version) is { } documentation)
+        {
+            context.Console.WriteLine($"Documentation for that version: {documentation}");
+        }
 
         return CliExitCode.Success;
     }

--- a/src/Common/DocumentationAddress.cs
+++ b/src/Common/DocumentationAddress.cs
@@ -1,0 +1,76 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Common;
+
+/// <summary>Where the documentation for a version MailFathom reports is published.</summary>
+/// <remarks>
+/// <para>
+/// The documentation site holds one directory per version it carries, so where a reader's own pages are is a function
+/// of the version in front of them and of nothing else. That is what lets a surface which already knows its version
+/// hand the address over without being told it: the container image labels it, the chart's notes print it, the
+/// administrative command reports the deployment's, and an MCP session carries it in the handshake. Nothing here is
+/// configurable for the same reason — an address an operator could edit could point a reader at pages describing a
+/// version other than the one they are running, which is the single thing this exists to prevent.
+/// </para>
+/// <para>
+/// A prerelease resolves to the default branch's directory rather than to one of its own. A nightly is named after the
+/// release it will become, which the site does not publish until that release exists, and what a nightly actually
+/// carries is whatever <c>main</c> was the night it was built — which is what <c>latest</c> documents. The same
+/// reading covers a build nobody released.
+/// </para>
+/// <para>
+/// The address is composed from the numbers a version parsed to rather than from the text it arrived as, because one
+/// caller reads that text off a deployment across the network and prints the result. A version this cannot read yields
+/// no address at all, and every caller says nothing rather than offering one that goes somewhere.
+/// </para>
+/// </remarks>
+public static class DocumentationAddress
+{
+    /// <summary>Where the site is served, with the version directories directly beneath it.</summary>
+    private const string Site = "https://krzysztof318.github.io/MailFathom/";
+
+    /// <summary>The directory the site publishes the default branch's documentation under.</summary>
+    private const string DefaultBranchDirectory = "latest";
+
+    /// <summary>Reports where the documentation for a version is published.</summary>
+    /// <param name="version">The semantic version a build reports, which is <see langword="null" /> where it reported none.</param>
+    /// <returns>The address of that version's documentation directory, or <see langword="null" /> where the version is not one this can read.</returns>
+    /// <remarks>
+    /// Build metadata is cut away before anything else, so a version carrying the source revision the SDK stamps after
+    /// SemVer's plus sign reads as the version it is a build of.
+    /// </remarks>
+    public static string? ForVersion(string? version)
+    {
+        var reported = version?.Trim() ?? string.Empty;
+
+        if (reported.Length == 0)
+        {
+            return null;
+        }
+
+        var buildMetadataStart = reported.IndexOf('+', StringComparison.Ordinal);
+        var core = buildMetadataStart < 0 ? reported.AsSpan() : reported.AsSpan(0, buildMetadataStart);
+
+        var prereleaseStart = core.IndexOf('-');
+
+        if (prereleaseStart >= 0)
+        {
+            return ReleaseNumberOf(core[..prereleaseStart]) is null ? null : Site + DefaultBranchDirectory + "/";
+        }
+
+        return ReleaseNumberOf(core) is { } released
+            ? $"{Site}v{released.Major}.{released.Minor}.{released.Build}/"
+            : null;
+    }
+
+    /// <summary>Reads the release number a version names, which is the whole of what an address is composed from.</summary>
+    /// <remarks>
+    /// Three components exactly, because that is what a release tag carries and what the site names a directory after.
+    /// A value naming fewer or more is a version this cannot place on the site rather than one to guess a directory
+    /// for.
+    /// </remarks>
+    private static Version? ReleaseNumberOf(ReadOnlySpan<char> core) =>
+        Version.TryParse(core, out var parsed) && parsed is { Build: >= 0, Revision: < 0 } ? parsed : null;
+}

--- a/src/Host/packages.lock.json
+++ b/src/Host/packages.lock.json
@@ -683,6 +683,7 @@
         "type": "Project",
         "dependencies": {
           "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Common": "[0.6.0, )",
           "MailFathom.Domain": "[0.6.0, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }

--- a/src/Mcp/Mcp.csproj
+++ b/src/Mcp/Mcp.csproj
@@ -6,6 +6,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Application\Application.csproj" />
+    <!-- Where a version's documentation is published is the same answer here as it is to the administrative command,
+         and Common is the only place both boundaries can read one answer from. It carries no capability this project
+         is kept away from: Domain is its whole reference set, so the structural proof in McpDependencyBoundaryTests
+         still holds with it on the list. -->
+    <ProjectReference Include="..\Common\Common.csproj" />
     <ProjectReference Include="..\Domain\Domain.csproj" />
   </ItemGroup>
 

--- a/src/Mcp/McpServiceCollectionExtensions.cs
+++ b/src/Mcp/McpServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Common;
 using MailFathom.Mcp.Observability;
 using MailFathom.Mcp.Serialization;
 using MailFathom.Mcp.Tools;
@@ -36,7 +37,12 @@ public static class McpServiceCollectionExtensions
 
         services.AddSingleton<McpToolCallReporter>();
 
-        return services.AddMcpServer(serverOptions => serverOptions.ServerInfo = ProtocolSurfaceIdentity)
+        return services
+            .AddMcpServer(serverOptions =>
+            {
+                serverOptions.ServerInfo = ProtocolSurfaceIdentity;
+                serverOptions.ServerInstructions = ProtocolSurfaceInstructions;
+            })
             // Stateless without a switch: every MailFathom tool answers one request from the local mailbox copy and sends
             // nothing back on its own, so a session would carry no state and only cost a client something to lose across
             // a restart. A tool that pushes notifications would change this surface rather than a deployment's settings.
@@ -78,6 +84,28 @@ public static class McpServiceCollectionExtensions
         Name = nameof(MailFathom),
         Version = StampedAssemblyVersion.ReadFrom(typeof(McpServiceCollectionExtensions).Assembly).Version,
     };
+
+    /// <summary>What the server tells a client about using it, which is where to read about the version it is talking to.</summary>
+    /// <remarks>
+    /// <para>
+    /// A client that connected over MCP may be the only way its user meets MailFathom at all, so the session itself is
+    /// what has to say where the documentation is: nothing else in that arrangement knows the running version, and an
+    /// agent asked to consult it would otherwise reach whichever version a search engine ranked first. One sentence
+    /// and an address is the whole of it. The protocol places no bound on what instructions may carry, and serving
+    /// documentation through them would put a copy of the pages inside the handshake — this makes them findable and
+    /// nothing more.
+    /// </para>
+    /// <para>
+    /// The version is taken from what the handshake already reports rather than read a second time, so the pages named
+    /// here cannot come to describe a different build from the one the client was told it is talking to. A build whose
+    /// version cannot be read carries no instructions rather than an address that goes nowhere, which is the same
+    /// reading every other surface applies to the same absence.
+    /// </para>
+    /// </remarks>
+    private static string? ProtocolSurfaceInstructions =>
+        DocumentationAddress.ForVersion(ProtocolSurfaceIdentity.Version) is { } address
+            ? $"Documentation for the MailFathom version serving this session is at {address}."
+            : null;
 
     /// <summary>Resolves the reporter from the scope the call arrived in.</summary>
     /// <remarks>

--- a/src/Mcp/packages.lock.json
+++ b/src/Mcp/packages.lock.json
@@ -133,6 +133,12 @@
           "MailFathom.Domain": "[0.6.0, )"
         }
       },
+      "MailFathom.Common": {
+        "type": "Project",
+        "dependencies": {
+          "MailFathom.Domain": "[0.6.0, )"
+        }
+      },
       "MailFathom.Domain": {
         "type": "Project"
       },

--- a/tests/Cli.UnitTests/LoginCommandTests.cs
+++ b/tests/Cli.UnitTests/LoginCommandTests.cs
@@ -359,6 +359,52 @@ public sealed class LoginCommandTests : IDisposable
         Assert.Contains(this.console.Lines, line => line.Contains("production", StringComparison.Ordinal));
     }
 
+    /// <summary>
+    /// The command that tells an operator what they are administering is also where they learn where to read about it,
+    /// and the version that decides which pages those are is the deployment's rather than this command's.
+    /// </summary>
+    [Fact]
+    public async Task Status_ADeploymentReportingAVersion_PointsAtTheDocumentationForThatVersion()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        store.Save("production", EndpointAddress, "not-a-real-key", "workstation");
+        using var handler = FakeAdminEndpoint.Accepting("workstation", FakeAdminEndpoint.AnotherBuildOfThisLine);
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "status");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains(
+                "https://krzysztof318.github.io/MailFathom/latest/",
+                StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// An unreadable version is an absence of evidence rather than evidence of a break, which the version agreement
+    /// already warns on rather than acts on. Naming a documentation directory for it would be a guess printed as fact.
+    /// </summary>
+    [Fact]
+    public async Task Status_ADeploymentReportingNoReadableVersion_SaysNothingAboutDocumentation()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        store.Save("production", EndpointAddress, "not-a-real-key", "workstation");
+        using var handler = FakeAdminEndpoint.Accepting("workstation", "unknown");
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "status");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain(
+            this.console.Lines,
+            line => line.Contains("krzysztof318.github.io", StringComparison.Ordinal));
+    }
+
     /// <summary>The whole point of the override: one invocation goes elsewhere without changing what the next one does.</summary>
     [Fact]
     public async Task Status_WithAnEndpointOverride_ReachesThatProfileAndLeavesTheSelectionAlone()

--- a/tests/Common.UnitTests/DocumentationAddressTests.cs
+++ b/tests/Common.UnitTests/DocumentationAddressTests.cs
@@ -1,0 +1,95 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Xunit;
+
+namespace MailFathom.Common.UnitTests;
+
+/// <summary>
+/// Covers where a version's documentation is said to be. Four surfaces print what this returns and none of them can
+/// check it, so an address composed wrongly reaches a reader as a page that does not exist rather than as a failure
+/// anything reports.
+/// </summary>
+public sealed class DocumentationAddressTests
+{
+    [Fact]
+    public void ForVersion_AReleaseVersion_NamesThatVersionsOwnDirectoryOnTheSite()
+    {
+        // Act
+        var address = DocumentationAddress.ForVersion("0.6.0");
+
+        // Assert
+        Assert.Equal("https://krzysztof318.github.io/MailFathom/v0.6.0/", address);
+    }
+
+    /// <summary>
+    /// A nightly is named after the release it will become, which the site publishes nothing for until that release
+    /// exists. What it carries is the default branch, so that is what its reader is sent to.
+    /// </summary>
+    [Theory]
+    [InlineData("0.7.0-nightly.41")]
+    [InlineData("0.7.0-nightly.41-3f1c9ab")]
+    [InlineData("0.0.0-unversioned")]
+    public void ForVersion_APrerelease_NamesTheDefaultBranchDirectory(string version)
+    {
+        // Act
+        var address = DocumentationAddress.ForVersion(version);
+
+        // Assert
+        Assert.Equal("https://krzysztof318.github.io/MailFathom/latest/", address);
+    }
+
+    /// <summary>The revision an SDK stamps after SemVer's plus sign says which build this is, never which pages describe it.</summary>
+    [Theory]
+    [InlineData("0.6.0+3f1c9abcdef", "https://krzysztof318.github.io/MailFathom/v0.6.0/")]
+    [InlineData("0.7.0-nightly.41+3f1c9abcdef", "https://krzysztof318.github.io/MailFathom/latest/")]
+    public void ForVersion_AVersionCarryingBuildMetadata_ReadsAsTheVersionItIsABuildOf(string version, string expected)
+    {
+        // Act
+        var address = DocumentationAddress.ForVersion(version);
+
+        // Assert
+        Assert.Equal(expected, address);
+    }
+
+    /// <summary>
+    /// One caller reads this version off a deployment across the network and prints what comes back, so nothing a
+    /// deployment sends may reach the address verbatim. Composing it from the parsed numbers is what guarantees that,
+    /// and a version spelled unusually is what shows the composition happened.
+    /// </summary>
+    [Theory]
+    [InlineData("0.06.0")]
+    [InlineData("  0.6.0  ")]
+    public void ForVersion_AVersionSpelledUnusually_IsComposedFromItsNumbersRatherThanItsText(string version)
+    {
+        // Act
+        var address = DocumentationAddress.ForVersion(version);
+
+        // Assert
+        Assert.Equal("https://krzysztof318.github.io/MailFathom/v0.6.0/", address);
+    }
+
+    /// <summary>
+    /// An absence of evidence rather than evidence of a break, exactly as the version agreement treats the same value:
+    /// a build nobody can identify gets no address, and every caller says nothing rather than offering one.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("unknown")]
+    [InlineData("unknown-build")]
+    [InlineData("0.6")]
+    [InlineData("0.6.0.1")]
+    [InlineData("v0.6.0")]
+    [InlineData("../../elsewhere")]
+    public void ForVersion_AVersionItCannotRead_NamesNoAddress(string? version)
+    {
+        // Act
+        var address = DocumentationAddress.ForVersion(version);
+
+        // Assert
+        Assert.Null(address);
+    }
+}

--- a/tests/Host.UnitTests/packages.lock.json
+++ b/tests/Host.UnitTests/packages.lock.json
@@ -879,6 +879,7 @@
         "type": "Project",
         "dependencies": {
           "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Common": "[0.6.0, )",
           "MailFathom.Domain": "[0.6.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"

--- a/tests/Mcp.UnitTests/McpDependencyBoundaryTests.cs
+++ b/tests/Mcp.UnitTests/McpDependencyBoundaryTests.cs
@@ -22,6 +22,12 @@ public sealed class McpDependencyBoundaryTests
     /// this assertion refuses — including the case where somebody adds one to answer a question a tool description
     /// already says the tool does not answer.
     /// </summary>
+    /// <remarks>
+    /// The list is an exact set rather than a prohibition, so a reference added for an ordinary reason lands here for
+    /// review instead of passing unread. <c>MailFathom.Common</c> is on it because the protocol surface and the
+    /// administrative command answer one question — where a version's documentation is — and Common's own reference
+    /// set is Domain alone, so admitting it reaches nothing this assertion exists to keep out.
+    /// </remarks>
     [Fact]
     public void McpAssembly_ReferencesNoAiBoundary()
     {
@@ -38,7 +44,9 @@ public sealed class McpDependencyBoundaryTests
             .ToArray();
 
         // Assert
-        Assert.Equal(["MailFathom.Application", "MailFathom.Domain"], referencedMailFathomAssemblies);
+        Assert.Equal(
+            ["MailFathom.Application", "MailFathom.Common", "MailFathom.Domain"],
+            referencedMailFathomAssemblies);
     }
 
     /// <summary>No tool can obtain the one session able to change a mailbox, so no MCP request can mark mail read.</summary>

--- a/tests/Mcp.UnitTests/McpServerIdentityTests.cs
+++ b/tests/Mcp.UnitTests/McpServerIdentityTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Common;
 using MailFathom.Mcp.UnitTests.TestDoubles;
 using MailFathom.Versioning;
 using Xunit;
@@ -14,6 +15,13 @@ namespace MailFathom.Mcp.UnitTests;
 /// </summary>
 public sealed class McpServerIdentityTests
 {
+    /// <summary>
+    /// How long a hint naming one address can honestly be. The bound is what would catch documentation content being
+    /// moved into the handshake — the pages belong on the site, and instructions a client may put in front of a model
+    /// are the wrong place to serve them from.
+    /// </summary>
+    private const int OneSentenceAndAnAddress = 200;
+
     [Fact]
     public void ServerInfo_ComposedSurface_NamesTheProductRatherThanTheHostAssembly()
     {
@@ -42,6 +50,44 @@ public sealed class McpServerIdentityTests
         // Assert
         Assert.NotNull(serverInfo);
         Assert.Equal(stamped.Version, serverInfo.Version);
+    }
+
+    /// <summary>
+    /// A client that connected over MCP may be the only way its user meets MailFathom, so the handshake is where an
+    /// agent learns where to read about the deployment it is talking to. The address is derived from the version the
+    /// same handshake reports, which is what keeps the pages named here describing the build in front of the client.
+    /// </summary>
+    [Fact]
+    public void ServerInstructions_ComposedSurface_NameTheDocumentationForTheVersionItReports()
+    {
+        // Arrange
+        var stamped = StampedAssemblyVersion.ReadFrom(typeof(McpServiceCollectionExtensions).Assembly);
+        var expectedAddress = DocumentationAddress.ForVersion(stamped.Version);
+
+        // Act
+        var instructions = RegisteredMcpToolSurface.ServerInstructions();
+
+        // Assert
+        Assert.NotNull(expectedAddress);
+        Assert.NotNull(instructions);
+        Assert.Contains(expectedAddress, instructions, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Instructions are a hint a client may put in front of a model, so what belongs in them is where to read rather
+    /// than what to read: the pages themselves stay on the site, and this surface serves mail.
+    /// </summary>
+    [Fact]
+    public void ServerInstructions_ComposedSurface_CarryOneSentenceAndNoDocumentationOfTheirOwn()
+    {
+        // Act
+        var instructions = RegisteredMcpToolSurface.ServerInstructions();
+
+        // Assert
+        Assert.NotNull(instructions);
+        Assert.EndsWith(".", instructions, StringComparison.Ordinal);
+        Assert.DoesNotContain('\n', instructions);
+        Assert.InRange(instructions.Length, 1, OneSentenceAndAnAddress);
     }
 
     /// <summary>

--- a/tests/Mcp.UnitTests/TestDoubles/RegisteredMcpToolSurface.cs
+++ b/tests/Mcp.UnitTests/TestDoubles/RegisteredMcpToolSurface.cs
@@ -51,6 +51,15 @@ internal static class RegisteredMcpToolSurface
         return provider.GetRequiredService<IOptions<McpServerOptions>>().Value.ServerInfo;
     }
 
+    /// <summary>Gets the instructions the registration sends a client during the initialization handshake.</summary>
+    /// <returns>The advertised instructions, or <see langword="null" /> when the registration advertises none.</returns>
+    public static string? ServerInstructions()
+    {
+        using var provider = Compose();
+
+        return provider.GetRequiredService<IOptions<McpServerOptions>>().Value.ServerInstructions;
+    }
+
     /// <summary>Gets the descriptor one tool is advertised with.</summary>
     /// <param name="toolName">The protocol name of the tool.</param>
     /// <returns>The advertised descriptor.</returns>

--- a/tests/Mcp.UnitTests/packages.lock.json
+++ b/tests/Mcp.UnitTests/packages.lock.json
@@ -315,6 +315,12 @@
           "MailFathom.Domain": "[0.6.0, )"
         }
       },
+      "MailFathom.Common": {
+        "type": "Project",
+        "dependencies": {
+          "MailFathom.Domain": "[0.6.0, )"
+        }
+      },
       "MailFathom.Domain": {
         "type": "Project"
       },
@@ -322,6 +328,7 @@
         "type": "Project",
         "dependencies": {
           "MailFathom.Application": "[0.6.0, )",
+          "MailFathom.Common": "[0.6.0, )",
           "MailFathom.Domain": "[0.6.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"


### PR DESCRIPTION
## What this changes

Four surfaces already know a version at the moment they speak, and none of them said where that version's pages are.
Each of them now does, and each of them names the same thing: the documentation site's directory for the version in
front of the reader.

- **`deploy/docker/Dockerfile`** declares `org.opencontainers.image.documentation`, so `docker inspect` answers where to
  read about an image somebody is only holding a reference to.
- **The chart's `NOTES.txt`** prints a `Docs:` line for the version it installed, and its pointer to the schema page
  becomes an address as well — a repository-relative path is unreachable for somebody reading `helm install` output,
  which was a defect on its own terms.
- **`mfctl status`** reports the address for the version *the deployment* reports, not the one the command was stamped
  with, and says nothing where that version could not be read.
- **The MCP server** sets `ServerInstructions`, so an initializing client learns the address for the running version. It
  carries one sentence and an address and no documentation content: this makes the documentation findable, it never
  serves it over the protocol.

## The derivation

`MailFathom.Common.DocumentationAddress` is the one answer, composed from the numbers a version parsed to rather than
from the text it arrived as — `mfctl` reads that text off a deployment across the network and prints the result, so
nothing a deployment sends reaches the address verbatim. No configuration key is added and no part of it is
operator-editable.

- A release version resolves to its own directory, `https://krzysztof318.github.io/MailFathom/v<version>/`.
- **A prerelease resolves to `latest`.** A nightly is named after a release the site publishes nothing for yet, and what
  it actually carries is `main` — which is what `latest` documents. Without this, every reader of a nightly would be
  handed an address that 404s.
- A version that cannot be read yields no address, and every surface says nothing rather than offering one that goes
  nowhere. That is the same absence of evidence `DeploymentVersionAgreement` already warns on rather than acts on.

The image label is the one surface that cannot compute this, because a Dockerfile reads no channel: the new
`IMAGE_DOCUMENTATION_VERSION` argument defaults to the release form and the nightly publication overrides it, exactly as
the version and the revision are already passed in. `publish-container-image.yml` composes it once beside the image
references and then asserts the resulting label off the published manifest, because a wrong address there reaches every
reader of the image and nothing downstream of a publication would ever report it.

## Boundary note

`Mcp` gains a `Common` project reference, and `McpDependencyBoundaryTests` admits it explicitly rather than loosening:
the assertion stays an exact set, and `Common`'s own reference set is `Domain` alone, so the structural proof that no AI
capability is reachable from the protocol surface holds unchanged. `docs/architecture/solution-structure.md` carries the
new arrow and the fourth thing that has earned a place in `Common`.

## No contract breaks

No configuration key, database column, MCP tool argument, or deployment contract changes. `ServerInstructions` is an
addition to the initialization handshake that a client either reads or ignores, and the new image label is an addition
beside the labels already published.

## Verification

- `scripts/verify-full.sh` — green on this branch, based on `origin/main` at 004e7deb: 158 workflow assertions, Release
  build with warnings as errors, 6100 unit tests, aggregate line coverage 95.63%, formatting clean.
- `helm install --dry-run` rendered against `ci/release-values.yaml`, `ci/nightly-values.yaml`, and a chart packaged
  with `--app-version`, covering all three states of the notes: a version directory, `latest`, and the unpackaged
  directory that states no version and therefore prints no `Docs:` line.
- The Dockerfile's argument chain was built and the label read back off the image for both the release default and the
  nightly override.
- Two new workflow contracts cover the channel branch in the publish step; the existing ones for that step pass
  unchanged.

Closes #786

- Issue: https://github.com/Krzysztof318/MailFathom/issues/786
- Pull request: https://github.com/Krzysztof318/MailFathom/pull/798
