### PR TITLE
[#801] Point a reader's agent at the documentation map from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,20 @@ To evaluate MailFathom from the checkout instead of deploying it, the local Aspi
 | Deciding whether MailFathom is for you | [What it does well](https://github.com/Krzysztof318/MailFathom#what-it-does-well) below, then [the user guide](https://krzysztof318.github.io/MailFathom/users/README.html) |
 | Installing or operating it | [Installing MailFathom](https://krzysztof318.github.io/MailFathom/users/installation.html), then [getting started](https://krzysztof318.github.io/MailFathom/users/getting-started.html) |
 | Connecting an agent to a running instance | [Using the tools](https://krzysztof318.github.io/MailFathom/users/usage.html) |
+| Reading any of that with an AI assistant beside you | [Hand it the documentation](https://github.com/Krzysztof318/MailFathom#hand-the-documentation-to-your-agent) below |
 | Contributing | [CONTRIBUTING.md](https://github.com/Krzysztof318/MailFathom/blob/main/CONTRIBUTING.md) |
+
+### Hand the documentation to your agent
+
+If an AI assistant is helping you install, configure, or use MailFathom, give it the documentation rather than a search over the site. One line is the whole of it:
+
+```text
+Read https://krzysztof318.github.io/MailFathom/llms.txt and follow it to the pages that answer my question.
+```
+
+That address is the current release's map: every published page, its title, and one line saying what it answers, linking each page's Markdown source. The agent loads the map in full and then fetches only the page that owns your question, so its answer comes from the page carrying the contract instead of from fragments of several. The map also names the two bundles beside it — the operator path, from choosing an installation to administering the deployment, and the mailbox user path, from connecting a client to what each tool returns — for when the question is a whole path rather than one page of it. Every version the site documents carries its own copy of all three, and the address above is the version the site opens on.
+
+→ [Handing this guide to your own agent](https://krzysztof318.github.io/MailFathom/users/README.html#handing-this-guide-to-your-own-agent)
 
 ## What exists today
 


### PR DESCRIPTION
Closes #801

The documentation is published a second time as artifacts an AI agent reads, and until now they were named only where a reader who is already inside the documentation finds them: the site's landing page and the user guide's *Handing this guide to your own agent*. Somebody arriving at the repository with an assistant beside them has opened neither, so the artifacts existed and the reader who most needed them never learned they did.

The root README now says it above the sections describing what MailFathom does — one line to paste, the address of the map, and what the agent does with it — and links the guide for the rest rather than restating what each artifact holds.

## What this decides

**The address is the version-agnostic one**, `https://krzysztof318.github.io/MailFathom/llms.txt`, which is the map of the release the site opens on. That address begins resolving with the first release built after the artifacts existed: `scripts/compose-docs-site.sh` mirrors the map to the site root only when the default version carries one, and the current release predates it. The same promise is already made by `docs/users/README.md`, and the alternative — naming a version, or pointing at `latest` — would be wrong for longer than the gap is.

**The two bundles are named but not linked.** Only the map is mirrored to the site root; `llms-operator.txt` and `llms-mailbox-user.txt` sit under each version's own directory, and the root map links them there with every link resolved into the version it came from. A README link to either at the root would be a 404 that no build could catch.

## Verification

- `scripts/test-agent-workflow.sh` — 167 passed, 0 failed, re-run after the rebase. It carries the README link checks: every site address names a page the site would generate, and no link reaches a published page through the repository.
- `scripts/review-obligations.sh` — no obligation. No file under `src/` changed and no `describes:` marker covers `README.md`.
- `scripts/verify-full.sh` was waived by the owner for a change that touches no C#.

## Surfaces

No break. The MCP tool contract, the configuration schema, the database schema, and the deployment contract are untouched; the diff is thirteen lines of Markdown in one file.
