### PR TITLE
[#732] Cut a message's passages after classification and the rules, not inside the storing transaction

### DIFF
--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -137,7 +137,10 @@ defect that is invisible when it happens.
 
 ## The paths that re-derive the same data
 
-Three paths produce derived data, and all three obey the order above rather than a version of it.
+Three paths produce derived data, and all three obey the order above rather than a version of it. Two of them wait for
+a stamp only an account run writes — the record that the rule pass has finished with a message — so on a deployment with
+`MailSynchronization:Enabled` set to `false` neither cuts anything: no run starts, nothing is stamped, and mail stored
+before that keeps whatever passages it already had until synchronization is switched on again.
 
 - **The live path** is the run drawn here.
 - **The extraction backfill** re-reads raw MIME stored before extraction existed. It redacts through the same guard,

--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -144,10 +144,11 @@ defect that is invisible when it happens.
 ## The paths that re-derive the same data
 
 Three paths produce derived data, and all three obey the order above rather than a version of it. Two of them wait for
-a stamp only an account run writes — the record that the rule pass has finished with a message — so on a deployment with
-`MailSynchronization:Enabled` set to `false` neither cuts a *first* set of passages: no run starts, nothing is stamped,
-and mail stored without them gains none until synchronization is switched on again. What the stamp holds back is that
-first cut alone, so a rebuild is not covered by it: the extraction backfill runs whether or not synchronization does,
+the record that the rule pass has finished with a message. That record is written by an account run's rule pass and once
+besides, by the migration that added the column, which stamped every message the previous version had already stored —
+so a deployment running with `MailSynchronization:Enabled` set to `false` does cut and embed the mail it upgraded with,
+and what the stamp holds back there is mail an account run stored and no rule pass reached. Only a *first* cut waits on
+it at all, so a rebuild is outside it in either case: the extraction backfill runs whether or not synchronization does,
 and with `SensitiveContent:RebuildStaleDerivedData` switched on it replaces the passages a message already carries —
 and, through them, the vectors the replacement cascades away.
 

--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -15,7 +15,7 @@ reconstruction has one shape: a new derived step placed on the wrong side of a g
 
 ```mermaid
 flowchart TD
-    subgraph run["One account's synchronization run, one folder at a time"]
+    subgraph run["One account's synchronization run, MaxConcurrentFoldersPerAccount folders at a time"]
         direction TB
         converge["Converge the previous run's mutations"]
         fetch["Fetch raw MIME, without setting the remote Seen flag"]
@@ -68,10 +68,16 @@ classification existed.
 
 ## What the run waits for, and what it hands off
 
-Everything inside the account run is sequential and the run waits for all of it. The one hand-off is the last arrow:
-offering a message to the embedding backlog is a non-blocking enqueue into a bounded in-process queue, and **a full
-backlog is not an error**. An initial synchronization of a large mailbox produces work faster than any provider accepts
-it, so the bound refuses rather than waits; the message is stored with its passages, and the
+The run waits for everything inside it, and the order drawn is the order each message meets. What the drawing does not
+say is how many messages are in it at once: the steps at the top and the bottom of the run happen once per run, while
+the folders between them are walked by `MaxConcurrentFoldersPerAccount` at a time — one by default, and up to twenty, so
+a deployment that raises it has several folders fetching, extracting, and committing side by side.
+[Synchronizing a mailbox](../features/imap-synchronization.md) states that bound and what else it costs.
+
+The one hand-off is the last arrow: offering a message to the embedding backlog is a non-blocking enqueue into a
+bounded in-process queue, and **a full backlog is not an error**. An initial synchronization of a large mailbox produces
+work faster than any provider accepts it, so the bound refuses rather than waits; the message is stored with its
+passages, and the
 [embedding backfill](../features/embedding-backfill.md) is what reaches mail the live path did not.
 
 Nothing else about the pipeline crosses a process boundary while a transaction is open. The two sidecar calls happen

--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -1,0 +1,172 @@
+# The arrival pipeline
+
+<!-- describes: src/Application/Synchronization/MailboxSynchronizer.cs, src/Application/Emails/Chunking/MailChunkingPass.cs, src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs, src/Application/Emails/Extraction/RedactingEmailMimeReader.cs, src/Application/Spam/Gating/**, src/Application/Spam/Runs/SpamClassificationPass.cs, src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs, src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs, src/Host/Hosting/Workers/MailEmbeddingWorker.cs -->
+
+Six features decide what happens to a message between the moment synchronization commits it and the moment everything
+derived from it exists. Each of them documents its own half, and none of them can state the order, because the order is
+what they have between them. This page is that order, drawn once.
+
+It is a graph rather than a list. A message branches at its classification verdict, two of the stages are calls into
+sidecars, and one of them — redaction — is a guard on the way into a derived store rather than a stage every message
+walks through. The reason to draw it is that prose describing a graph is reconstructed wrongly, and the wrong
+reconstruction has one shape: a new derived step placed on the wrong side of a gate.
+
+## The order
+
+```mermaid
+flowchart TD
+    subgraph run["One account's synchronization run, one folder at a time"]
+        direction TB
+        converge["Converge the previous run's mutations"]
+        fetch["Fetch raw MIME, without setting the remote Seen flag"]
+        extract["Extract the body text"]
+        commit[("Commit: metadata, raw MIME, search document")]
+        classify["Classification pass — only when somebody asked for a run"]
+        rules["Rule evaluation pass"]
+        cut["Cut the passages"]
+        offer(["Offer the message to the embedding backlog"])
+    end
+
+    subgraph sidecars["Sidecars, each optional and each declared apart"]
+        direction TB
+        presidio["Personal-data analyzer — shown the extracted body text"]
+        spamd["Spam scanner — shown the raw MIME, deliberately unredacted"]
+    end
+
+    subgraph elsewhere["Executions outside the run"]
+        worker["Embedding worker — one message at a time"]
+        sweeps["Extraction and embedding backfills"]
+    end
+
+    converge --> fetch --> extract
+    extract -. "redaction, fails closed" .-> presidio
+    presidio -. "placeholders replace every finding" .-> extract
+    extract --> commit
+    commit --> classify
+    classify -. "one scan per message" .-> spamd
+    classify --> gate{"What does classification say?"}
+    gate -- "junk" --> withheld["Nothing further runs, and passages already cut are removed"]
+    gate -- "not junk, or no classification covers the folder" --> rules
+    gate -- "still waiting for a verdict" --> held["Held; the next run or a sweep asks again"]
+    gate -- "released: unclassifiable, or waited longer than allowed" --> rules
+    rules --> cut
+    cut --> offer
+    offer -.-> worker
+    sweeps --> cut
+    sweeps --> worker
+
+    classDef seam stroke-dasharray: 5 3;
+    class classify seam;
+```
+
+The dashed border on the classification pass is the one stage that is a seam rather than a running job in this release:
+the call site sits where the order requires it, and what reaches it today is an operator asking for a run over a
+mailbox. Nothing classifies a message because it arrived. The trigger that will is
+[issue 730](https://github.com/Krzysztof318/MailFathom/issues/730), and until it ships the gate below releases mail that
+has waited longer than a verdict is allowed to take, so an unclassified deployment indexes exactly as it did before
+classification existed.
+
+## What the run waits for, and what it hands off
+
+Everything inside the account run is sequential and the run waits for all of it. The one hand-off is the last arrow:
+offering a message to the embedding backlog is a non-blocking enqueue into a bounded in-process queue, and **a full
+backlog is not an error**. An initial synchronization of a large mailbox produces work faster than any provider accepts
+it, so the bound refuses rather than waits; the message is stored with its passages, and the
+[embedding backfill](../features/embedding-backfill.md) is what reaches mail the live path did not.
+
+Nothing else about the pipeline crosses a process boundary while a transaction is open. The two sidecar calls happen
+outside the commit that follows them, and the embedding provider is reached only by the worker, which consumes committed
+state.
+
+## The two sidecars, and why one of them sees unredacted mail
+
+Both are optional, both are declared apart from each other, and a deployment that configures neither runs the whole
+pipeline unchanged.
+
+| Sidecar | What it is shown | What its silence does |
+| --- | --- | --- |
+| Personal-data analyzer | The extracted body text of one message | **Fails closed.** The derivation is refused, nothing derived is written, and the run retries the message later |
+| Spam scanner | The raw MIME of one message | **Fails open.** No verdict is recorded, the message keeps waiting, and the wait's own bound eventually releases it |
+
+The asymmetry is deliberate and it is the single most important thing on this page. Redaction is an egress guard: text
+that reached a derived store unscanned is text a retrieval hit can hand back months later, and putting it back costs a
+re-derivation from raw MIME. Classification is an opinion about a message: a scanner that cannot answer must not be able
+to stop a mailbox from being indexed, which is why every path releases mail that has waited too long.
+
+The spam scanner is shown the message as it arrived, placeholders and all absent, because a classifier scoring redacted
+text would be scoring a different message from the one the sender wrote —
+[spam classification](../features/spam-classification.md) records that decision. Redaction covers the body and only the
+body; a subject, an address, and a thread identifier are routing metadata, and what protects those on the way out is the
+[egress guard](../features/sensitive-content-scanning.md) rather than the derived store.
+
+## What each classification outcome permits
+
+The gate reads where the message is now and what was decided about it, and it writes nothing down — which is what makes
+mail an owner drags out of the junk folder ordinary mail from that moment.
+
+| Outcome | Rules | Passages | Vectors |
+| --- | --- | --- | --- |
+| Junk — a verdict, or the message is in the account's junk folder | No | No, and any already cut are removed | No |
+| Not junk, or the folder is outside the configured scope | Yes | Yes | Yes |
+| Still waiting for a verdict | No, held | No, held | No, held |
+| Released — the message carries nothing classifiable, or it waited longer than allowed | Yes | Yes | Yes |
+
+A held message is held rather than dropped. The same four facts are read again by the next account run and by both
+sweeps, so a verdict that arrives late, a wait that runs out, and a message moved out of the junk folder all admit it
+without any stored state having to say it was once withheld. What the outcome does reach is a counter: the run records
+the gate's answer as each message arrives, because work that never starts leaves no other trace and a mailbox held
+behind classification would otherwise read exactly like a mailbox with no mail in it.
+
+## Why the cut is not part of the commit
+
+The transaction that stores a message contains its metadata, its raw MIME, and its search document — and deliberately
+not its passages. Two stages run after that commit and before the cut, and both can change what the cut should produce:
+classification can decide the message is not derived from at all, and the owner's rules can file it into a folder mapped
+differently from the one it arrived in. Passages are not undone by a message moving afterwards, so cutting inside the
+commit would write passages of a placement and a verdict that had not been settled yet.
+
+What the ordering costs is one extra local transaction per message and nothing else: the cut reads the search document
+the commit already wrote, so it reaches no mail server, no provider, and no sidecar. What it removes is a whole class of
+defect that is invisible when it happens.
+
+## The paths that re-derive the same data
+
+Three paths produce derived data, and all three obey the order above rather than a version of it.
+
+- **The live path** is the run drawn here.
+- **The extraction backfill** re-reads raw MIME stored before extraction existed. It redacts through the same guard,
+  writes the same search document, and cuts through the same writer, so a message it reaches arrives at the state a
+  newly synchronized one reaches rather than at a state a second walk has to finish.
+- **The embedding backfill** sweeps for messages with extracted text and no passages, and for passages with no vector.
+  It cuts through the same writer and is narrowed by the same classification predicate and the same folder switch, so it
+  reaches whatever one account run's batch budget did not. A held message needs no sweep to be released: the account's
+  own next run asks the gate again and cuts it in the same run the verdict admits it.
+
+## What the two folder switches decide
+
+`GenerateEmbeddings` and `VisibleToTools` are set per folder mapping;
+[what a mapping decides beyond where the folder is](../features/imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
+states both. What they decide about this pipeline is the cut:
+
+| `GenerateEmbeddings` | `VisibleToTools` | Passages |
+| --- | --- | --- |
+| `true` | `true` | Cut |
+| `true` | `false` | **Cut** — a folder withheld from tools is still embedded, from the same redacted text |
+| `false` | `true` | Not cut; the folder is still mirrored, listed, read, and searched lexically |
+| `false` | `false` | Not cut |
+
+Extraction runs for every mirrored folder whatever the switches say, because the extracted text is what a lexical search
+matches on and what a read hands back. Redaction therefore runs for every mirrored folder too, on every deployment that
+has a scanner switched on.
+
+## Where each stage is documented
+
+| Stage | Page |
+| --- | --- |
+| Fetching and committing a message | [IMAP synchronization](../features/imap-synchronization.md) |
+| Classification, its verdicts, and the gate | [Spam classification](../features/spam-classification.md) |
+| The owner's rules and what a match asks for | [Mail rules](../features/mail-rules.md) |
+| Redaction, the stamp, and the egress guard | [Sensitive-content scanning](../features/sensitive-content-scanning.md) |
+| The boundary rules a cut obeys | [Message chunks](../features/message-chunks.md) |
+| Offering, embedding, and what a ceiling does | [Automatic embedding](../features/automatic-embedding.md) |
+| Reaching mail the live path missed | [Embedding backfill](../features/embedding-backfill.md) |

--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -125,6 +125,12 @@ classification can decide the message is not derived from at all, and the owner'
 differently from the one it arrived in. Passages are not undone by a message moving afterwards, so cutting inside the
 commit would write passages of a placement and a verdict that had not been settled yet.
 
+The rules are the slower of the two, because a rule declares a move rather than performing one: the record is durable
+when the pass ends and the account's **next** run carries it to the mail server. So waiting for the pass is not enough
+on its own, and the cut passes over a message whose relocation is still converging — cutting it once the message is in
+the folder it ended up in, under that folder's mapping. A relocation that completed or was abandoned holds nothing
+back, since neither will move the message again.
+
 What the ordering costs is one extra local transaction per message and nothing else: the cut reads the search document
 the commit already wrote, so it reaches no mail server, no provider, and no sidecar. What it removes is a whole class of
 defect that is invisible when it happens.
@@ -136,11 +142,17 @@ Three paths produce derived data, and all three obey the order above rather than
 - **The live path** is the run drawn here.
 - **The extraction backfill** re-reads raw MIME stored before extraction existed. It redacts through the same guard,
   writes the same search document, and cuts through the same writer, so a message it reaches arrives at the state a
-  newly synchronized one reaches rather than at a state a second walk has to finish.
+  newly synchronized one reaches rather than at a state a second walk has to finish. It cuts only what both stages in
+  front of the cut have finished with, which is what keeps *the same state* true: the text it has just written is
+  exactly what lets the rule pass read a message it had been skipping, and cutting in this transaction would cut before
+  that pass ever saw it. Such a message is cut by the account's next run instead.
 - **The embedding backfill** sweeps for messages with extracted text and no passages, and for passages with no vector.
-  It cuts through the same writer and is narrowed by the same classification predicate and the same folder switch, so it
-  reaches whatever one account run's batch budget did not. A held message needs no sweep to be released: the account's
-  own next run asks the gate again and cuts it in the same run the verdict admits it.
+  It cuts through the same writer and is narrowed by the same classification predicate, the same rule stamp, and the
+  same folder switch, so it reaches whatever one account run's batch budget did not. The rule stamp is what stops it
+  being a way around the order: it runs on its own interval while a run is still fetching a mailbox, so a first
+  synchronization would otherwise have its mail cut here before the rules had read any of it. A held message needs no
+  sweep to be released either: the account's own next run asks the gate again and cuts it in the same run the verdict
+  admits it.
 
 ## What the two folder switches decide
 

--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -148,7 +148,10 @@ before that keeps whatever passages it already had until synchronization is swit
   newly synchronized one reaches rather than at a state a second walk has to finish. It cuts only what both stages in
   front of the cut have finished with, which is what keeps *the same state* true: the text it has just written is
   exactly what lets the rule pass read a message it had been skipping, and cutting in this transaction would cut before
-  that pass ever saw it. Such a message is cut by the account's next run instead.
+  that pass ever saw it. Such a message is cut by the account's next run instead. Both stages are waited for a *first*
+  cut alone, so a message that already carries passages is re-cut whatever they say: this walk is the only path that
+  can replace a passage, and withholding one here would leave the passages — and the vectors built from them — derived
+  under exactly the configuration a rebuild exists to replace, beside stored text reporting the new one.
 - **The embedding backfill** sweeps for messages with extracted text and no passages, and for passages with no vector.
   It cuts through the same writer and is narrowed by the same classification predicate, the same rule stamp, and the
   same folder switch, so it reaches whatever one account run's batch budget did not. The rule stamp is what stops it

--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -163,8 +163,9 @@ and, through them, the vectors the replacement cascades away.
   can replace a passage, and withholding one here would leave the passages — and the vectors built from them — derived
   under exactly the configuration a rebuild exists to replace, beside stored text reporting the new one.
 - **The embedding backfill** sweeps for messages with extracted text and no passages, and for passages with no vector.
-  It cuts through the same writer and is narrowed by the same classification predicate, the same rule stamp, and the
-  same folder switch, so it reaches whatever one account run's batch budget did not. The rule stamp is what stops it
+  It cuts through the same writer and is narrowed by the same classification predicate, the same rule stamp, the same
+  reading of a relocation still converging, and the same folder switch, so it reaches whatever one account run's batch
+  budget did not. The rule stamp is what stops it
   being a way around the order: it runs on its own interval while a run is still fetching a mailbox, so a first
   synchronization would otherwise have its mail cut here before the rules had read any of it. A held message needs no
   sweep to be released either: the account's own next run asks the gate again and cuts it in the same run the verdict

--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -139,8 +139,11 @@ defect that is invisible when it happens.
 
 Three paths produce derived data, and all three obey the order above rather than a version of it. Two of them wait for
 a stamp only an account run writes — the record that the rule pass has finished with a message — so on a deployment with
-`MailSynchronization:Enabled` set to `false` neither cuts anything: no run starts, nothing is stamped, and mail stored
-before that keeps whatever passages it already had until synchronization is switched on again.
+`MailSynchronization:Enabled` set to `false` neither cuts a *first* set of passages: no run starts, nothing is stamped,
+and mail stored without them gains none until synchronization is switched on again. What the stamp holds back is that
+first cut alone, so a rebuild is not covered by it: the extraction backfill runs whether or not synchronization does,
+and with `SensitiveContent:RebuildStaleDerivedData` switched on it replaces the passages a message already carries —
+and, through them, the vectors the replacement cascades away.
 
 - **The live path** is the run drawn here.
 - **The extraction backfill** re-reads raw MIME stored before extraction existed. It redacts through the same guard,

--- a/docs/architecture/toc.yml
+++ b/docs/architecture/toc.yml
@@ -8,6 +8,9 @@
 - name: Solution structure
   href: solution-structure.md
   description: The projects, which way their dependencies point, and what belongs inside each boundary.
+- name: The arrival pipeline
+  href: arrival-pipeline.md
+  description: The order a newly arrived message passes through — classification, rules, redaction, chunking, embedding — drawn once, with what each stage waits for and what each classification outcome permits.
 - name: The stored email schema
   href: stored-email-schema.md
   description: The columns, constraints, and indexes the mail timeline is read from, and why raw MIME and search text live in tables of their own.

--- a/docs/features/automatic-embedding.md
+++ b/docs/features/automatic-embedding.md
@@ -27,7 +27,9 @@ passages cut before it was set.
 
 A second narrowing applies wherever spam classification is switched on: junk is never embedded and its content never
 reaches a provider, and a message no verdict has been reached about is neither cut nor offered here while it waits. The
-[backfill](embedding-backfill.md) sweep is what reaches such a message once a verdict admits it or its wait runs out.
+account's own next run is what reaches such a message once a verdict admits it or its wait runs out — the same two
+steps in the same order, one interval later — and the [backfill](embedding-backfill.md) sweep is what reaches whatever
+a run's batch budget left behind.
 [Junk is kept out of what a deployment derives from mail](spam-classification.md#junk-is-kept-out-of-what-a-deployment-derives-from-mail)
 holds the whole of it, and none of it applies with classification off.
 

--- a/docs/features/automatic-embedding.md
+++ b/docs/features/automatic-embedding.md
@@ -26,16 +26,17 @@ states that switch beside the other two, and [message chunks](message-chunks.md#
 passages cut before it was set.
 
 A second narrowing applies wherever spam classification is switched on: junk is never embedded and its content never
-reaches a provider, and a message no verdict has been reached about is not offered here while it waits. The consequence
-for this path is that a message of a classified folder is not cut or offered as it arrives — the
-[backfill](embedding-backfill.md) sweep is what reaches it once a verdict admits it or its wait runs out.
+reaches a provider, and a message no verdict has been reached about is neither cut nor offered here while it waits. The
+[backfill](embedding-backfill.md) sweep is what reaches such a message once a verdict admits it or its wait runs out.
 [Junk is kept out of what a deployment derives from mail](spam-classification.md#junk-is-kept-out-of-what-a-deployment-derives-from-mail)
 holds the whole of it, and none of it applies with classification off.
 
 ## The backlog between synchronization and the provider
 
-A message is offered for embedding **after** it and its passages are committed, never inside the transaction that
-stored them. Two things follow from that ordering, and both are the reason for it:
+A message is offered for embedding by the last local step of its account's synchronization run — the step that cuts its
+passages, after classification and after the owner's rules have had their turn — and never inside the transaction that
+stored the message. [The arrival pipeline](../architecture/arrival-pipeline.md) draws that order in full. Two things
+follow from it, and both are the reason for it:
 
 - **A provider outage cannot stall a mailbox fetch.** The embedding worker consumes committed local state, so the
   slowest thing it can make slower is itself.

--- a/docs/features/embedding-backfill.md
+++ b/docs/features/embedding-backfill.md
@@ -34,7 +34,11 @@ Two conditions select a message, and they are the two halves of what a pre-exist
   walk reaches ends up cut exactly as the same message arriving today would be. Requiring that the rules have finished
   is part of that sameness rather than a narrowing beside it: this sweep runs on its own interval while an account run
   is still fetching a mailbox, so without it a first synchronization would have its mail cut here before a single rule
-  had read it — which is the one order [the arrival pipeline](../architecture/arrival-pipeline.md) exists to fix.
+  had read it — which is the one order [the arrival pipeline](../architecture/arrival-pipeline.md) exists to fix. The
+  stamp is written by an account run's rule pass and by nothing else, so **a deployment running with
+  `MailSynchronization:Enabled` set to `false` cuts nothing here**: no run starts, no message is ever stamped, and mail
+  that has no passages keeps none until synchronization is switched on again. Mail that already carries passages is
+  embedded either way, since that is the other group and it waits on nothing.
 - **A message with a passage that carries no vector** under the generation being walked towards was stored before that
   generation existed, or was turned away by `Embeddings:MaxQueuedEmails`, or was left part-way through by a provider
   call that failed. For a generation being built from nothing, that is every message the instance holds.
@@ -52,13 +56,13 @@ change stays and is retrieved like any other vector, subject to what the reading
 [What a mapping decides beyond where the folder is](imap-synchronization.md#what-a-mapping-decides-beyond-where-the-folder-is)
 states both cases.
 
-**This sweep is where spam classification lets a held message through.** Where classification is switched on, the query
-leaves out junk entirely and leaves out a message no verdict has been reached about, so a message of a classified folder
-appears here the moment its verdict admits it or its wait runs out — and the cut it gets is the one the account run's
-own last step passed over. That makes the sweep both the thing that keeps spam away from a provider and the thing that
-stops a wedged classifier turning the index into one that quietly stopped filling; cutting a message's first passages is
-also the one
-place a release is countable per message, which is what
+**A message classification was holding is released by an account run rather than by this sweep.** The rule pass is
+narrowed by the same admission, so a message waiting on a verdict is never stamped — and with the stamp required here,
+such a message cannot appear in this query at all while it waits. What admits it is the next account run: its rule pass
+stamps the message, and the cut one step later in that same run cuts it. This sweep still leaves out junk entirely and
+still cannot reach a message no verdict has been reached about, so it never carries spam to a provider; what it reaches
+is what a run's own batch budget left behind. Cutting a message's first passages is still where a release is countable
+per message wherever this sweep is what performs it, which is what
 `mailfathom.spam.derived_work.admissions` reports.
 [Junk is kept out of what a deployment derives from mail](spam-classification.md#junk-is-kept-out-of-what-a-deployment-derives-from-mail)
 holds the rule, and with classification off this query is exactly what it was.

--- a/docs/features/embedding-backfill.md
+++ b/docs/features/embedding-backfill.md
@@ -26,11 +26,15 @@ none.
 
 Two conditions select a message, and they are the two halves of what a pre-existing mailbox looks like.
 
-- **A message with extracted text and no passages** was stored before [message chunks](message-chunks.md) existed, or
-  was held back by spam classification while it waited for a verdict. Nothing can be embedded for it until they are cut,
-  so the walk cuts them first — from the text an earlier extraction already stored, which costs a database write and no
+- **A message with extracted text and no passages that the owner's rules have finished with** was stored before
+  [message chunks](message-chunks.md) existed, or was held back by spam classification while it waited for a verdict, or
+  was simply left behind by one account run's batch budget. Nothing can be embedded for it until they are cut, so the
+  walk cuts them first — from the text an earlier extraction already stored, which costs a database write and no
   provider call and reaches no mail server. The rules applied are the ones synchronization applies, so a message this
-  walk reaches ends up cut exactly as the same message arriving today would be.
+  walk reaches ends up cut exactly as the same message arriving today would be. Requiring that the rules have finished
+  is part of that sameness rather than a narrowing beside it: this sweep runs on its own interval while an account run
+  is still fetching a mailbox, so without it a first synchronization would have its mail cut here before a single rule
+  had read it — which is the one order [the arrival pipeline](../architecture/arrival-pipeline.md) exists to fix.
 - **A message with a passage that carries no vector** under the generation being walked towards was stored before that
   generation existed, or was turned away by `Embeddings:MaxQueuedEmails`, or was left part-way through by a provider
   call that failed. For a generation being built from nothing, that is every message the instance holds.
@@ -50,9 +54,10 @@ states both cases.
 
 **This sweep is where spam classification lets a held message through.** Where classification is switched on, the query
 leaves out junk entirely and leaves out a message no verdict has been reached about, so a message of a classified folder
-appears here the moment its verdict admits it or its wait runs out — and the cut it gets is the one the account run's own
-last step passed over. That makes the sweep both the thing that keeps spam away from a provider and the thing that stops a wedged
-classifier turning the index into one that quietly stopped filling; cutting a message's first passages is also the one
+appears here the moment its verdict admits it or its wait runs out — and the cut it gets is the one the account run's
+own last step passed over. That makes the sweep both the thing that keeps spam away from a provider and the thing that
+stops a wedged classifier turning the index into one that quietly stopped filling; cutting a message's first passages is
+also the one
 place a release is countable per message, which is what
 `mailfathom.spam.derived_work.admissions` reports.
 [Junk is kept out of what a deployment derives from mail](spam-classification.md#junk-is-kept-out-of-what-a-deployment-derives-from-mail)

--- a/docs/features/embedding-backfill.md
+++ b/docs/features/embedding-backfill.md
@@ -50,8 +50,8 @@ states both cases.
 
 **This sweep is where spam classification lets a held message through.** Where classification is switched on, the query
 leaves out junk entirely and leaves out a message no verdict has been reached about, so a message of a classified folder
-appears here the moment its verdict admits it or its wait runs out — and the cut it gets is the one the arrival path did
-not make. That makes the sweep both the thing that keeps spam away from a provider and the thing that stops a wedged
+appears here the moment its verdict admits it or its wait runs out — and the cut it gets is the one the account run's own
+last step passed over. That makes the sweep both the thing that keeps spam away from a provider and the thing that stops a wedged
 classifier turning the index into one that quietly stopped filling; cutting a message's first passages is also the one
 place a release is countable per message, which is what
 `mailfathom.spam.derived_work.admissions` reports.

--- a/docs/features/embedding-backfill.md
+++ b/docs/features/embedding-backfill.md
@@ -38,7 +38,11 @@ Two conditions select a message, and they are the two halves of what a pre-exist
   stamp is written by an account run's rule pass and once besides, by the migration that added the column, which stamped
   every message the previous version had already stored. So **a deployment running with `MailSynchronization:Enabled`
   set to `false` still cuts and embeds the mail it upgraded with** — that mail carries the stamp already — and what the
-  switch holds back here is mail a later run stored and no rule pass reached, which on such a deployment is none. Mail
+  switch holds back here is mail a later run stored and no rule pass reached, which on such a deployment is none. A
+  message a rule is still *moving* is passed over as well, however long it has been stamped: a rule declares a move
+  rather than performing one, so until the account's next run carries the relocation to the mail server the message is
+  sitting in a folder it is leaving, and passages cut there describe a mapping it is about to leave. The wait ends when
+  that run converges the move, and a relocation that completed or was abandoned holds nothing back at all. Mail
   that already carries passages is embedded either way, since that is the other group and it waits on nothing.
 - **A message with a passage that carries no vector** under the generation being walked towards was stored before that
   generation existed, or was turned away by `Embeddings:MaxQueuedEmails`, or was left part-way through by a provider

--- a/docs/features/embedding-backfill.md
+++ b/docs/features/embedding-backfill.md
@@ -35,10 +35,11 @@ Two conditions select a message, and they are the two halves of what a pre-exist
   is part of that sameness rather than a narrowing beside it: this sweep runs on its own interval while an account run
   is still fetching a mailbox, so without it a first synchronization would have its mail cut here before a single rule
   had read it — which is the one order [the arrival pipeline](../architecture/arrival-pipeline.md) exists to fix. The
-  stamp is written by an account run's rule pass and by nothing else, so **a deployment running with
-  `MailSynchronization:Enabled` set to `false` cuts nothing here**: no run starts, no message is ever stamped, and mail
-  that has no passages keeps none until synchronization is switched on again. Mail that already carries passages is
-  embedded either way, since that is the other group and it waits on nothing.
+  stamp is written by an account run's rule pass and once besides, by the migration that added the column, which stamped
+  every message the previous version had already stored. So **a deployment running with `MailSynchronization:Enabled`
+  set to `false` still cuts and embeds the mail it upgraded with** — that mail carries the stamp already — and what the
+  switch holds back here is mail a later run stored and no rule pass reached, which on such a deployment is none. Mail
+  that already carries passages is embedded either way, since that is the other group and it waits on nothing.
 - **A message with a passage that carries no vector** under the generation being walked towards was stored before that
   generation existed, or was turned away by `Embeddings:MaxQueuedEmails`, or was left part-way through by a provider
   call that failed. For a generation being built from nothing, that is every message the instance holds.

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -1163,20 +1163,25 @@ The walk reaches no mail server — every byte it reads was fetched and stored b
 
 ### Offering a stored message for embedding
 
-Once a message and the passages derived beside it are committed, the run offers it to the embedding backlog and moves
-on. The offer is deliberately outside the transaction that stored them: a provider call inside it would hold a database
-transaction open for as long as a remote model takes to answer, and a provider outage would stall the mailbox fetch
-behind it. It also never waits — the run is holding an open IMAP session, so a full backlog refuses the offer rather
-than making a mailbox as slow as the provider is.
+The offer is made by the run's last local step rather than by the commit that stored the message. That step runs after
+the classification and rule passes and after every folder has finished, and it names a message whose passages are
+already durable in a transaction of their own — so what is offered is committed work, cut under the folder mapping the
+message actually ended up in. [The arrival pipeline](../architecture/arrival-pipeline.md) draws that order and says why
+the cut is not part of the storing commit.
+
+The offer is deliberately outside a transaction: a provider call inside one would hold a database transaction open for
+as long as a remote model takes to answer, and a provider outage would stall the run behind it. It also never waits — a
+full backlog refuses the offer rather than making a mailbox as slow as the provider is.
 
 Nothing about that changes what a run reports or how far it gets. A message the backlog turned away is stored with its
 passages exactly as one it accepted, and an instance that has activated no embedding profile offers into a backlog
 nothing drains. [Automatic embedding](automatic-embedding.md) is what happens on the other side of it.
 
 Where spam classification is switched on over the folder, both halves of that are decided one step earlier: the message
-is neither cut nor offered while no verdict exists for it, junk is neither cut nor offered at all, and the
-[embedding backfill](embedding-backfill.md) sweep is what cuts and embeds it once a verdict admits it or its wait runs
-out.
+is neither cut nor offered while no verdict exists for it, and junk is neither cut nor offered at all. What releases a
+held message is the account's own next run — its rule pass and the cut behind it ask the gate again — rather than the
+[embedding backfill](embedding-backfill.md) sweep, which is narrowed by the same admission and therefore never sees a
+message no rule pass has stamped.
 [Junk is kept out of what a deployment derives from mail](spam-classification.md#junk-is-kept-out-of-what-a-deployment-derives-from-mail)
 holds the rule and the bound. With classification off, which is the default, the paragraphs above describe every message.
 

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -43,6 +43,8 @@ MailFathom synchronizes mailboxes read-only, on a bounded schedule, and — for 
 `MailSynchronizationCoordinator` is a hosted service that reaches no mail server and holds no scoped service. It
 starts one `AccountSynchronizationSupervisor` per configured account and supervises those supervisors; everything a
 run actually does belongs to the supervisor of the account it runs for.
+[The arrival pipeline](../architecture/arrival-pipeline.md) draws what a run does after its folders have finished — the
+classification pass, the rules, and the cut that produces a message's passages — and in what order.
 
 Each supervisor owns its own schedule, its own consecutive-failure count, and its own backoff, and creates a scope per
 folder work unit. That is what a server which stops answering can no longer reach: no other account inherits its

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -466,8 +466,10 @@ instead of adding a second thing to configure and watch.
 The step comes after every folder has synchronized and committed, after the classification pass, and outside the
 synchronization transaction entirely. Only one thing runs after it, and it runs after it because of this pass: the cut
 that gives a message its passages, which waits until the rules have finished so that nothing derived describes a folder
-a rule was about to move the message out of. [The arrival pipeline](../architecture/arrival-pipeline.md) draws the whole
-order. Two consequences of this step's own position follow that are worth stating rather than inferring. A rule
+a rule was about to move the message out of. Waiting for the rules is not by itself enough for that, because a rule
+declares a move rather than performing one and the account's *next* run is what carries it to the mail server — so the
+cut also passes over a message whose relocation is still converging, and cuts it once it is in the folder it ended up
+in. [The arrival pipeline](../architecture/arrival-pipeline.md) draws the whole order. Two consequences of this step's own position follow that are worth stating rather than inferring. A rule
 can only ever see mail the run before it has already stored, so a provider redelivering a message or a synchronization
 retry cannot produce a different processing boundary than a clean run. And nothing an MCP tool does waits on a rule:
 reads are served from what is already stored, and a pass neither blocks one nor is blocked by one.

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -463,8 +463,11 @@ already has everything a rule pass needs — one account at a time, a slot count
 a jittered backoff when something is wrong, and a shutdown that lets work in flight finish — so evaluation joins it
 instead of adding a second thing to configure and watch.
 
-The step is the last of the run's local work: it comes after every folder has synchronized and committed, and outside
-the synchronization transaction entirely. Two consequences follow that are worth stating rather than inferring. A rule
+The step comes after every folder has synchronized and committed, after the classification pass, and outside the
+synchronization transaction entirely. Only one thing runs after it, and it runs after it because of this pass: the cut
+that gives a message its passages, which waits until the rules have finished so that nothing derived describes a folder
+a rule was about to move the message out of. [The arrival pipeline](../architecture/arrival-pipeline.md) draws the whole
+order. Two consequences of this step's own position follow that are worth stating rather than inferring. A rule
 can only ever see mail the run before it has already stored, so a provider redelivering a message or a synchronization
 retry cannot produce a different processing boundary than a clean run. And nothing an MCP tool does waits on a rule:
 reads are served from what is already stored, and a pass neither blocks one nor is blocked by one.

--- a/docs/features/message-chunks.md
+++ b/docs/features/message-chunks.md
@@ -15,18 +15,22 @@ describes the table they are stored in.
 
 ## When chunking runs
 
-A message is cut in the same database transaction that stores what was extracted from it, on both paths that extract:
-the synchronization run that has just fetched a message, and the backfill that re-derives text for mail stored before
-extraction existed. A committed message is therefore never one whose passages something else still has to produce.
+A message is cut **after** it has been stored and never in the transaction that stored it. Two stages stand between the
+two, and both can change what the cut should produce: spam classification can decide the message is not derived from at
+all, and the owner's rules can file it into a folder mapped differently from the one it arrived in. Passages are not
+undone by a message moving afterwards, so the account's synchronization run cuts as its last local step — after the
+classification pass and after the rule pass — and offers each message it cut for embedding.
+[The arrival pipeline](../architecture/arrival-pipeline.md) draws the whole order and states what each stage waits for.
 
-**Unless spam classification is deciding whether it may be cut at all.** With classification configured over a folder,
-whether that folder's mail is cut is a question the message's verdict answers, and the verdict does not exist while the
-message is being stored — so the cut is not made on the arrival path and the
-[embedding backfill](embedding-backfill.md) sweep makes it once the message is admitted. A message classification files
-as junk is never cut on any path, and one already cut when a junk verdict arrives has its passages removed.
+Both paths that extract text obey it. The backfill that re-derives text for mail stored before extraction existed cuts
+through the same writer, and the [embedding backfill](embedding-backfill.md) sweep cuts whatever the account run's own
+batch budget did not reach. A message classification was holding needs neither of them: the account's next run
+re-evaluates it and cuts it in the same run, once a verdict admits it or its wait runs out.
+
+A message classification files as junk is never cut on any path, and one already cut when a junk verdict arrives has its
+passages removed.
 [Junk is kept out of what a deployment derives from mail](spam-classification.md#junk-is-kept-out-of-what-a-deployment-derives-from-mail)
-holds all of it, including what a message waiting on a verdict costs. None of it applies with classification off, which
-is the default: the sentence above then describes every message.
+holds all of it, including what a message waiting on a verdict costs.
 
 A message that yielded no text is cut into nothing. That covers a body that carried no words and a body that arrived
 encrypted: both keep the search document that makes them findable on their subject and participants, and neither gains a

--- a/docs/features/sensitive-content-scanning.md
+++ b/docs/features/sensitive-content-scanning.md
@@ -142,6 +142,8 @@ Everything MailFathom derives from a message's body — the extracted text, the 
 built from those passages — is derived from redacted text while a scanner is on. The redaction happens once, where the
 body is read out of the stored MIME, so a placeholder is what is stored, what is embedded, and what a search or an
 answer later returns; nothing downstream scans a second time and nothing downstream sees the original.
+[The arrival pipeline](../architecture/arrival-pipeline.md) draws where that read sits among the stages around it, and
+why the spam scanner beside it is deliberately shown the message unredacted.
 
 **Only the body goes through it.** A subject, a display name, an address, a folder alias, and a thread identity are
 routing identity rather than free text, exactly as the egress rule above draws the line, and they are guarded where they

--- a/docs/features/spam-classification.md
+++ b/docs/features/spam-classification.md
@@ -313,14 +313,16 @@ mail content.
 
 ### Where in-scope mail is cut and embedded instead
 
-Withholding a message from chunking on the arrival path means the arrival path is over by the time its verdict exists,
-so something else has to cut it. That is the [embedding backfill](embedding-backfill.md) sweep, which already selects a
-message with extracted text and no passages, and whose selection this gate narrows: junk never appears in it, and a
-message waiting on a verdict appears the moment the verdict admits it or the wait runs out. Such a message ends up cut
-and embedded exactly as it would have been on arrival, later by at most a sweep.
+The cut is the last local step of the account's synchronization run, after this pass and after the rule pass, so a
+message whose verdict this gate is still waiting for reaches that step and is passed over. Nothing else has to remember
+it: the same run repeats on the account's next interval, and the moment the verdict admits the message or its wait runs
+out, the rule pass evaluates it and the cut that follows in that same run cuts it. The
+[embedding backfill](embedding-backfill.md) sweep is the second reader of the same condition and what reaches whatever
+one run's batch budget did not. Such a message ends up cut and embedded exactly as it would have been on arrival, later
+by at most an interval.
 
-This is the one behavior change a deployment that switches classification on will notice. With classification off, mail
-is still cut in the transaction that stores it, as it always was.
+This is the one behavior change a deployment that switches classification on will notice.
+[The arrival pipeline](../architecture/arrival-pipeline.md) draws where this gate sits among the stages it orders.
 
 ### What an operator can see
 

--- a/src/Application/Emails/Chunking/IEmailChunkStore.cs
+++ b/src/Application/Emails/Chunking/IEmailChunkStore.cs
@@ -2,51 +2,27 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Emails.Chunking;
 
-/// <summary>Cuts one message into the passages retrieval is built from, and removes them again.</summary>
+/// <summary>Takes away the passages retrieval is built from, for a message that turned out not to deserve them.</summary>
 /// <remarks>
 /// <para>
-/// The two halves are one port because they are the two ends of one decision. Cutting is the first thing that happens
-/// to a message downstream of classification, and it is deliberately a call the synchronization run makes rather than
-/// something the metadata write does on its way past: what decides whether a message is cut is what classification says
-/// about it, and a write that cut every message it stored would have decided before anything could score it.
+/// Removal is the one end of the cut that ordering cannot supply. Everything else about a passage is decided before it
+/// exists — <see cref="IStoredEmailChunkingStore" /> cuts a message only once classification and the owner's rules have
+/// finished with it — but a message chunked and embedded before anybody scored it is what an on-demand classification
+/// run over an existing mailbox produces, and what it leaves behind is vectors nothing may retrieve, derived from the
+/// most adversarial text in the mailbox and kept under the message's own retention obligations for no reader.
 /// </para>
 /// <para>
-/// Removing is the other end of the same decision, for the one case the ordering cannot reach — a message chunked and
-/// embedded before anybody scored it, which an on-demand run over an existing mailbox produces. What it leaves behind is
-/// vectors nothing may retrieve, derived from the most adversarial text in the mailbox and kept under the message's own
-/// retention obligations for no reader.
-/// </para>
-/// <para>
-/// Neither half touches the message, its content, or its search document. Passages are derived data and this port says
+/// It touches neither the message, its content, nor its search document. Passages are derived data and this port says
 /// nothing about whether the mailbox should still hold what they were derived from.
 /// </para>
 /// </remarks>
 public interface IEmailChunkStore
 {
-    /// <summary>Stages the passages one extraction yields for a message, leaving an unchanged message's passages alone.</summary>
-    /// <param name="session">The explicit persistence session this write participates in.</param>
-    /// <param name="emailId">The message the passages belong to, which the session may still be holding uncommitted.</param>
-    /// <param name="text">The text an extraction derived from the message's body.</param>
-    /// <param name="cancellationToken">Propagates caller cancellation.</param>
-    /// <returns>A task that completes once the passages are staged, or immediately when nothing changed.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when any reference argument is <see langword="null" />.</exception>
-    /// <remarks>
-    /// Idempotent by the text rather than by a flag: a message whose text and rules have not moved yields the identical
-    /// passages and this writes nothing, which is what makes it safe for the arrival path, a repair, and a backfill to
-    /// all ask. A folder configured not to embed is cut into no passages whichever of them asks.
-    /// </remarks>
-    Task DeriveChunksAsync(
-        IPersistenceSession session,
-        StoredEmailId emailId,
-        ExtractedEmailText text,
-        CancellationToken cancellationToken);
-
     /// <summary>Stages the removal of every passage cut from one message.</summary>
     /// <param name="session">The explicit persistence session this removal participates in.</param>
     /// <param name="emailId">The message whose passages are removed.</param>

--- a/src/Application/Emails/Chunking/IStoredEmailChunkingStore.cs
+++ b/src/Application/Emails/Chunking/IStoredEmailChunkingStore.cs
@@ -1,0 +1,50 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Emails.Chunking;
+
+/// <summary>Reads the mail whose passages the arrival pipeline still owes, and cuts them from what is already stored.</summary>
+/// <remarks>
+/// The selection is the whole contract. A message leaves it by being cut, so a pass needs no cursor of its own and a
+/// repeat costs one query rather than a second walk of the mailbox; and what puts a message into it is stated by the
+/// implementation rather than by the caller, so the classification gate, the folder's embedding switch, and the record
+/// that the rules have finished with the message are one predicate instead of three the pass could get out of order.
+/// </remarks>
+public interface IStoredEmailChunkingStore
+{
+    /// <summary>Reads one bounded batch of the account's mail that is ready to be cut and has not been.</summary>
+    /// <param name="accountId">The account whose mail is walked.</param>
+    /// <param name="batchSize">How many messages the batch may hold.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The messages, ordered by their identifier, each with the admission that let it through.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="batchSize" /> is below one.</exception>
+    /// <remarks>
+    /// No resume position is taken, because cutting a message is what takes it out of this selection: every message the
+    /// batch names carries extracted text, and text extraction never produces an empty or blank reading, so the cut
+    /// writes at least one passage for each of them and the following batch is the next messages rather than the same
+    /// ones.
+    /// </remarks>
+    Task<IReadOnlyList<StoredEmailAwaitingChunking>> GetEmailsAwaitingChunkingAsync(
+        MailAccountId accountId,
+        int batchSize,
+        CancellationToken cancellationToken);
+
+    /// <summary>Cuts one message's passages from the text an earlier extraction stored, inside the caller's session.</summary>
+    /// <param name="session">The transaction the cut joins.</param>
+    /// <param name="storedEmailId">The message to cut.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>A task that completes when the passages are staged.</returns>
+    /// <remarks>
+    /// The text comes from the stored search document rather than from raw MIME, so the cut is a local write and lands on
+    /// exactly the text every enabled scanner has already redacted.
+    /// </remarks>
+    Task DeriveChunksAsync(
+        IPersistenceSession session,
+        StoredEmailId storedEmailId,
+        CancellationToken cancellationToken);
+}

--- a/src/Application/Emails/Chunking/MailChunkingPass.cs
+++ b/src/Application/Emails/Chunking/MailChunkingPass.cs
@@ -1,0 +1,144 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Spam.Gating;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.Emails.Chunking;
+
+/// <summary>Cuts the passages of the account's mail the earlier stages have finished with, and offers each message for embedding.</summary>
+/// <remarks>
+/// <para>
+/// This is the fourth stage of the arrival pipeline, and it is a stage of its own precisely because of what runs in
+/// front of it. Classification decides whether a message is derived from at all, the owner's rules may move it into a
+/// folder mapped differently from the one it arrived in, and both of those happen after the transaction that stored the
+/// message committed. Cutting inside that transaction would therefore write passages from a message's placement before
+/// the two stages allowed to change it had run — and passages are not undone by the message moving afterwards.
+/// </para>
+/// <para>
+/// A step of the account's synchronization run rather than a schedule of its own, for the reason the classification and
+/// rule passes are: that run already has per-account isolation, a slot count, a jittered backoff, and a failure path
+/// that defers the account instead of the process, and only one pass per account is ever in flight because of it.
+/// </para>
+/// <para>
+/// It needs no cursor. A message leaves the selection by being cut, so an interrupted pass repeats nothing and skips
+/// nothing, and what one pass's batch budget leaves behind is the next run's — or the
+/// <see cref="Embeddings.Backfill.StoredEmailEmbeddingBackfill" /> sweep's, which selects on the same condition and is
+/// what reaches mail the account run never gets to.
+/// </para>
+/// </remarks>
+public sealed class MailChunkingPass
+{
+    /// <summary>How many messages one batch cuts.</summary>
+    /// <remarks>
+    /// A constant rather than a setting, because it bounds this operation's memory and transaction size rather than
+    /// describing a deployment: what an operator tunes about arriving mail is the synchronization interval and the
+    /// embedding bounds, and neither is made better by choosing how many messages one local cut commits together.
+    /// </remarks>
+    private const int BatchSize = 200;
+
+    /// <summary>How many batches one pass may commit before it leaves the rest to the next run.</summary>
+    /// <remarks>
+    /// The bound exists so that an account whose whole mailbox is awaiting the cut — a first synchronization, or a
+    /// mapping switched on over stored mail — does not hold its own run open indefinitely while every other account
+    /// waits for a slot. What it leaves behind is outstanding work in exactly the sense the embedding sweep already
+    /// selects on.
+    /// </remarks>
+    private const int MaxBatchesPerPass = 25;
+
+    private readonly IStoredEmailChunkingStore chunkingStore;
+    private readonly IEmailEmbeddingBacklog embeddingBacklog;
+    private readonly IDerivedWorkGateTelemetry gateTelemetry;
+    private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
+
+    /// <summary>Initializes the pass from the state it walks and the backlog it hands messages to.</summary>
+    /// <param name="chunkingStore">Reads what is awaiting the cut and performs it.</param>
+    /// <param name="embeddingBacklog">Takes each cut message on to the embedding worker.</param>
+    /// <param name="gateTelemetry">Reports which of the classification gate's answers let each message through.</param>
+    /// <param name="commitPolicy">Commits one message's passages, retrying a conflict with a competing writer.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public MailChunkingPass(
+        IStoredEmailChunkingStore chunkingStore,
+        IEmailEmbeddingBacklog embeddingBacklog,
+        IDerivedWorkGateTelemetry gateTelemetry,
+        OptimisticConcurrencyRetryPolicy commitPolicy)
+    {
+        ArgumentNullException.ThrowIfNull(chunkingStore);
+        ArgumentNullException.ThrowIfNull(embeddingBacklog);
+        ArgumentNullException.ThrowIfNull(gateTelemetry);
+        ArgumentNullException.ThrowIfNull(commitPolicy);
+
+        this.chunkingStore = chunkingStore;
+        this.embeddingBacklog = embeddingBacklog;
+        this.gateTelemetry = gateTelemetry;
+        this.commitPolicy = commitPolicy;
+    }
+
+    /// <summary>Takes one bounded pass over the account's mail awaiting the cut.</summary>
+    /// <param name="accountId">The account whose mail is cut.</param>
+    /// <param name="cancellationToken">Cancels the pass between messages and between batches; committed passages stay durable.</param>
+    /// <returns>How many messages this pass cut and offered, and whether more remain.</returns>
+    /// <exception cref="PersistenceConcurrencyConflictException">
+    /// Thrown when a competing writer wins a race the bounded retries could not resolve. Messages already cut stay
+    /// durable and the next run resumes by asking the same question.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels. Committed passages stay durable.</exception>
+    public async Task<MailChunkingPassReport> RunAsync(MailAccountId accountId, CancellationToken cancellationToken)
+    {
+        var chunkedCount = 0;
+        var refusedCount = 0;
+        var emailsRemain = false;
+
+        for (var batchNumber = 1; batchNumber <= MaxBatchesPerPass; batchNumber++)
+        {
+            var batch = await this.chunkingStore.GetEmailsAwaitingChunkingAsync(
+                accountId,
+                BatchSize,
+                cancellationToken);
+
+            if (batch.Count == 0)
+            {
+                emailsRemain = false;
+
+                break;
+            }
+
+            foreach (var email in batch)
+            {
+                // Committed one message at a time rather than one batch at a time, because the offer that follows must
+                // name a message whose passages are already durable: a batch commit would either offer messages before
+                // the transaction they are in has ended, or hold every one of them back until the last of them was cut.
+                await this.commitPolicy.CommitAsync(
+                    (session, attemptCancellationToken) => this.chunkingStore.DeriveChunksAsync(
+                        session,
+                        email.StoredEmailId,
+                        attemptCancellationToken),
+                    cancellationToken);
+
+                // Recorded here because this is where the gate's decision becomes an act. A message the gate was holding
+                // is let through by being cut, and this pass is the one place that release is decidable per message on
+                // the live path.
+                this.gateTelemetry.RecordAdmission(email.Admission);
+
+                chunkedCount++;
+
+                if (!this.embeddingBacklog.TryEnqueue(email.StoredEmailId))
+                {
+                    refusedCount++;
+                }
+            }
+
+            emailsRemain = batch.Count == BatchSize;
+
+            if (!emailsRemain)
+            {
+                break;
+            }
+        }
+
+        return new MailChunkingPassReport(chunkedCount, refusedCount, emailsRemain);
+    }
+}

--- a/src/Application/Emails/Chunking/MailChunkingPass.cs
+++ b/src/Application/Emails/Chunking/MailChunkingPass.cs
@@ -19,6 +19,13 @@ namespace MailFathom.Application.Emails.Chunking;
 /// the two stages allowed to change it had run — and passages are not undone by the message moving afterwards.
 /// </para>
 /// <para>
+/// Running after the rule pass is not the whole of that, and the selection carries the rest: a rule declares a move
+/// rather than performing one, and the account's next run is what carries it to the mail server, so a message this
+/// pass meets may be one still on its way out of the folder it is sitting in. Such a message is passed over and cut
+/// once it has arrived where the rule sent it. <c>StoredEmailChunkingStore.Selecting</c> states which records hold a
+/// cut back and which have stopped mattering.
+/// </para>
+/// <para>
 /// A step of the account's synchronization run rather than a schedule of its own, for the reason the classification and
 /// rule passes are: that run already has per-account isolation, a slot count, a jittered backoff, and a failure path
 /// that defers the account instead of the process, and only one pass per account is ever in flight because of it.

--- a/src/Application/Emails/Chunking/MailChunkingPassReport.cs
+++ b/src/Application/Emails/Chunking/MailChunkingPassReport.cs
@@ -1,0 +1,19 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Emails.Chunking;
+
+/// <summary>Summarizes one bounded pass of the cut that follows the rules.</summary>
+/// <param name="ChunkedEmailCount">How many messages had their passages cut by this pass.</param>
+/// <param name="RefusedOfferCount">How many of those the embedding backlog's bound turned away, which the backfill reaches instead.</param>
+/// <param name="EmailsRemain">Whether messages were still awaiting the cut when the pass spent its batch budget.</param>
+/// <remarks>
+/// Every field is a count. Nothing derived from a message — a subject, an address, a passage — belongs in a result a
+/// worker logs.
+/// </remarks>
+public sealed record MailChunkingPassReport(int ChunkedEmailCount, int RefusedOfferCount, bool EmailsRemain)
+{
+    /// <summary>Gets whether this pass did anything worth an operator's attention.</summary>
+    public bool IsEmpty => this.ChunkedEmailCount == 0 && this.RefusedOfferCount == 0;
+}

--- a/src/Application/Emails/Chunking/MailChunkingPassReport.cs
+++ b/src/Application/Emails/Chunking/MailChunkingPassReport.cs
@@ -14,6 +14,6 @@ namespace MailFathom.Application.Emails.Chunking;
 /// </remarks>
 public sealed record MailChunkingPassReport(int ChunkedEmailCount, int RefusedOfferCount, bool EmailsRemain)
 {
-    /// <summary>Gets whether this pass did anything worth an operator's attention.</summary>
+    /// <summary>Gets whether this pass did nothing worth an operator's attention.</summary>
     public bool IsEmpty => this.ChunkedEmailCount == 0 && this.RefusedOfferCount == 0;
 }

--- a/src/Application/Emails/Chunking/StoredEmailAwaitingChunking.cs
+++ b/src/Application/Emails/Chunking/StoredEmailAwaitingChunking.cs
@@ -1,0 +1,19 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Spam.Gating;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Emails.Chunking;
+
+/// <summary>One stored message the arrival pipeline has carried as far as the cut, and no further.</summary>
+/// <param name="StoredEmailId">The message whose passages are still to be cut.</param>
+/// <param name="Admission">Why the classification gate lets this message be derived from, which is what the pass reports as it cuts.</param>
+/// <remarks>
+/// The admission is carried rather than asked for again, because the query that selected the message already decided it.
+/// Nothing else travels: a subject, a participant, and a body are mail content, and a pass reports counts.
+/// </remarks>
+public sealed record StoredEmailAwaitingChunking(
+    StoredEmailId StoredEmailId,
+    DerivedWorkAdmission Admission = DerivedWorkAdmission.Admitted);

--- a/src/Application/Synchronization/MailboxSynchronizer.cs
+++ b/src/Application/Synchronization/MailboxSynchronizer.cs
@@ -3,8 +3,6 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.EmailContent.Storage;
-using MailFathom.Application.Emails.Chunking;
-using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail;
@@ -40,8 +38,6 @@ public sealed class MailboxSynchronizer
     private readonly IEmailMimeReader mimeReader;
     private readonly IMailboxMutationReconciliationStore mutationStore;
     private readonly MailboxReconciler reconciler;
-    private readonly IEmailEmbeddingBacklog embeddingBacklog;
-    private readonly IEmailChunkStore chunkStore;
     private readonly DerivedWorkGate derivedWorkGate;
     private readonly IDerivedWorkGateTelemetry gateTelemetry;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
@@ -64,8 +60,6 @@ public sealed class MailboxSynchronizer
         IEmailMimeReader mimeReader,
         IMailboxMutationReconciliationStore mutationStore,
         MailboxReconciler reconciler,
-        IEmailEmbeddingBacklog embeddingBacklog,
-        IEmailChunkStore chunkStore,
         DerivedWorkGate derivedWorkGate,
         IDerivedWorkGateTelemetry gateTelemetry,
         OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
@@ -86,8 +80,6 @@ public sealed class MailboxSynchronizer
         this.mimeReader = mimeReader;
         this.mutationStore = mutationStore;
         this.reconciler = reconciler;
-        this.embeddingBacklog = embeddingBacklog;
-        this.chunkStore = chunkStore;
         this.derivedWorkGate = derivedWorkGate;
         this.gateTelemetry = gateTelemetry;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
@@ -583,9 +575,18 @@ public sealed class MailboxSynchronizer
 
     /// <summary>Stores one discovered occurrence, settling the copy that placed it in the same transaction where there was one.</summary>
     /// <remarks>
+    /// <para>
     /// The placement observation belongs in the write that stores the email rather than beside it. A copy whose arrival
     /// was recorded but whose row was rolled back would answer for a change no local state reflects, and the next run
     /// would store the message as an arrival nobody accounted for.
+    /// </para>
+    /// <para>
+    /// What this transaction deliberately does not contain is the cut. Redaction has already happened — it is part of
+    /// the extraction above, so the text committed here is the text every enabled scanner has seen — but classification
+    /// and the owner's rules have not, and both may still decide that this message is not derived from or that it
+    /// belongs in a folder mapped differently. <see cref="Emails.Chunking.MailChunkingPass" /> is where the passages are
+    /// cut, after those two stages, and the same pass is what offers the message for embedding.
+    /// </para>
     /// </remarks>
     private async Task<OccurrenceSynchronizationOutcome> StoreOccurrenceAsync(
         IMailboxSession mailboxSession,
@@ -655,18 +656,16 @@ public sealed class MailboxSynchronizer
         // only what the server's envelope reported, and the folder checkpoint still advances past it.
         var extraction = await this.mimeReader.ReadMetadataAsync(content, cancellationToken);
 
-        // Decided before the commit rather than after it, because it decides what the commit contains. A message this
-        // run is storing for the first time carries no verdict yet, so the answer here is whatever classification's
-        // scope and the account's junk folder say — which is exactly the ordering this exists for: nothing is cut,
-        // nothing is offered to a provider, and nothing is offered to a rule until classification has had its turn.
-        var admission = this.derivedWorkGate.Admit(new DerivedWorkCandidate(
+        // Recorded where the message arrives, although nothing is derived from it here. The gate's answer about a
+        // message nobody has scored yet is the only place the two withholding answers are ever reached — a later stage
+        // sees a message the gate admits or does not see it at all — so a run that recorded nothing until the cut would
+        // report a mailbox held behind classification exactly as it reports a mailbox with no mail in it.
+        this.gateTelemetry.RecordAdmission(this.derivedWorkGate.Admit(new DerivedWorkCandidate(
             metadata.OccurrenceId.AccountId,
             metadata.OccurrenceId.FolderResolutionId.Alias,
             this.timeProvider.GetUtcNow(),
             StoredEmailContentAvailability.Available,
-            Verdict: null));
-
-        this.gateTelemetry.RecordAdmission(admission);
+            Verdict: null)));
 
         var storedEmailId = default(StoredEmailId);
 
@@ -685,34 +684,12 @@ public sealed class MailboxSynchronizer
                     content,
                     attemptCancellationToken);
 
-                // Cut in the same session as the text it derives from, so a message the gate admits is never one whose
-                // passages a later reader has to wait for. A message the gate holds is cut by the embedding backfill
-                // once a verdict admits it, which is the same sweep that reaches whatever else the live path missed.
-                if (admission.PermitsDerivedWork() && extraction.Metadata is { } extracted)
-                {
-                    await this.chunkStore.DeriveChunksAsync(
-                        persistenceSession,
-                        storedEmailId,
-                        extracted.Text,
-                        attemptCancellationToken);
-                }
-
                 await this.ObservePlacementAsync(persistenceSession, placement, attemptCancellationToken);
             },
             cancellationToken);
 
         budget.RecordStored(content.RawMime.Length);
         storageClaim.Settle(content.RawMime.Length);
-
-        // Offered after the commit and never inside it, which is what keeps a provider outage out of this run: the
-        // message and the passages cut beside it are durable by now, so the worker consumes committed state and nothing
-        // it does can extend or fail the transaction that produced it. A refusal by a full backlog is deliberately not
-        // an error here — the message is stored, and the backfill is what reaches mail the live path did not. The
-        // identity is the one the commit resolved, which is the same value this outcome reports.
-        if (admission.PermitsDerivedWork())
-        {
-            this.embeddingBacklog.TryEnqueue(storedEmailId);
-        }
 
         return new OccurrenceSynchronizationOutcome(
             storedEmailId,

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Emails.Chunking;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Persistence;
@@ -258,6 +259,7 @@ internal sealed partial class AccountSynchronizationSupervisor
                 await this.EraseExpiredAuditEntriesAsync(runSettings, workUnitToken);
                 await this.ClassifyRequestedMailAsync(runSettings, workUnitToken);
                 await this.EvaluateMailRulesAsync(runSettings, workUnitToken);
+                await this.CutPassagesOfEvaluatedMailAsync(runSettings, workUnitToken);
             }
         }
         finally
@@ -536,6 +538,55 @@ internal sealed partial class AccountSynchronizationSupervisor
         catch (Exception exception)
         {
             this.LogMailRuleEvaluationFailed(exception, this.accountId.Value);
+        }
+    }
+
+    /// <summary>Cuts the passages of the mail the stages in front of this one have finished with, and offers each message for embedding.</summary>
+    /// <remarks>
+    /// <para>
+    /// Last of the run's local passes, which is the ordering the arrival pipeline is built on rather than an arbitrary
+    /// place to put it. A message may be withheld by the classification pass above and may be moved by the rule pass
+    /// above that, and passages cut before either had its turn are passages of a placement and a verdict that had not
+    /// been settled — so the cut waits for both, and the message is offered to the embedding worker only once its
+    /// passages are durable.
+    /// </para>
+    /// <para>
+    /// A failure never fails the run, for the reason the two passes above it do not: nothing here reaches a mail server,
+    /// what it reads is already stored, and what a pass did not cut stays outstanding for the next run and for the
+    /// embedding sweep, which selects on exactly the same condition.
+    /// </para>
+    /// </remarks>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "A local cut that failed is logged and repeated by the next run rather than putting the account into backoff; the embedding sweep selects on the same outstanding condition.")]
+    private async Task CutPassagesOfEvaluatedMailAsync(
+        MailSynchronizationOptions runSettings,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var scope = this.scopeFactory.CreateScope();
+
+            scope.ServiceProvider.GetRequiredService<ScopedMailSynchronizationSettings>().UseRunSnapshot(runSettings);
+
+            var report = await scope.ServiceProvider
+                .GetRequiredService<MailChunkingPass>()
+                .RunAsync(this.accountId, cancellationToken);
+
+            if (!report.IsEmpty)
+            {
+                this.LogPassagesCut(
+                    this.accountId.Value,
+                    report.ChunkedEmailCount,
+                    report.RefusedOfferCount,
+                    report.EmailsRemain);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            this.LogPassageCutFailed(exception, this.accountId.Value);
         }
     }
 
@@ -1063,6 +1114,21 @@ internal sealed partial class AccountSynchronizationSupervisor
         Level = LogLevel.Warning,
         Message = "Evaluating the rules of account {AccountId} ended unexpectedly; the account is not backed off for it and its next run resumes from the batches this one committed.")]
     private partial void LogMailRuleEvaluationFailed(Exception exception, string accountId);
+
+    /// <summary>Reports one account's cut in counts alone; no subject, address, or passage may reach a log.</summary>
+    [LoggerMessage(
+        Level = LogLevel.Debug,
+        Message = "Cut the passages of {ChunkedEmailCount} messages of account {AccountId}; the embedding backlog refused {RefusedOfferCount} of them, and messages remain: {EmailsRemain}.")]
+    private partial void LogPassagesCut(
+        string accountId,
+        int chunkedEmailCount,
+        int refusedOfferCount,
+        bool emailsRemain);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Cutting the passages of the evaluated mail of account {AccountId} ended unexpectedly; the account is not backed off for it, and what was not cut stays outstanding for the next run and for the embedding sweep.")]
+    private partial void LogPassageCutFailed(Exception exception, string accountId);
 
     /// <summary>Reports one account run's share of a whole-mailbox classification run, in counts and the profile alone.</summary>
     [LoggerMessage(

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -496,7 +496,7 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// <summary>Runs this account's rules over the mail that has arrived, and over its whole mailbox where one was asked for.</summary>
     /// <remarks>
     /// <para>
-    /// Last of the run's local steps, and after the folders rather than beside them, which is what makes "evaluation
+    /// After the folders rather than beside them, and in front of the cut, which is what makes "evaluation
     /// never runs inside the synchronization transaction" true rather than merely intended: every message it can reach
     /// was committed by a folder that has already finished, in a scope and a transaction of its own. Mail a folder the
     /// operator stopped mirroring still holds is out of reach here whichever order the steps ran in, because the pass

--- a/src/Infrastructure/Persistence/Emails/EmailChunkStore.cs
+++ b/src/Infrastructure/Persistence/Emails/EmailChunkStore.cs
@@ -3,7 +3,6 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Emails.Chunking;
-using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Persistence;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Emails;
@@ -12,36 +11,14 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MailFathom.Infrastructure.Persistence.Emails;
 
-/// <summary>EF Core state for the passages a message is cut into and the removal that takes them away again.</summary>
+/// <summary>EF Core state for the removal that takes a message's passages away again.</summary>
 /// <remarks>
-/// The cut itself is <see cref="EmailChunkWriter" />'s, which every path that produces passages goes through, so this
-/// adapter is the port's shape over it rather than a second implementation of the rules. What it adds is the removal,
-/// which no other path performs.
+/// The cut itself is <see cref="EmailChunkWriter" />'s, which every path that produces passages goes through. This
+/// adapter performs the removal, which no other path does.
 /// </remarks>
 [RequiresIntegrationCoverage]
-internal sealed class EmailChunkStore(EmailChunkWriter chunkWriter) : IEmailChunkStore
+internal sealed class EmailChunkStore : IEmailChunkStore
 {
-    /// <inheritdoc />
-    public async Task DeriveChunksAsync(
-        IPersistenceSession session,
-        StoredEmailId emailId,
-        ExtractedEmailText text,
-        CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(text);
-
-        var dbContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
-
-        // Found rather than queried, because the arrival path cuts a message the same session inserted moments ago and
-        // has not committed. FindAsync resolves a staged row from the change tracker, which a set-based read could not
-        // see at all.
-        var storedEmail = await dbContext.StoredEmails.FindAsync([emailId.Value], cancellationToken)
-            ?? throw new InvalidOperationException(
-                $"No stored email carries the identifier {emailId}, so no passages can be cut for it.");
-
-        await chunkWriter.SaveAsync(dbContext, storedEmail, text, cancellationToken);
-    }
-
     /// <inheritdoc />
     public async Task<int> DiscardChunksAsync(
         IPersistenceSession session,

--- a/src/Infrastructure/Persistence/Emails/EmailChunkWriter.cs
+++ b/src/Infrastructure/Persistence/Emails/EmailChunkWriter.cs
@@ -16,11 +16,13 @@ namespace MailFathom.Infrastructure.Persistence.Emails;
 
 /// <summary>Cuts one stored email's extracted text into passages and writes them inside the caller's open session.</summary>
 /// <remarks>
-/// Both writers of extracted text use this, for the reason both use the search-document writer: synchronization has
-/// just read a message it fetched, the backfill re-derives from raw MIME stored before extraction existed, and one
-/// writer is what stops the two paths from storing passages built to different rules. Deriving in the same session as
-/// the metadata is what makes a message and its passages durable together, so nothing downstream has to handle a
-/// message that is committed and has not been cut.
+/// Every path that produces passages arrives here, which is what stops them from storing passages built to different
+/// rules. They arrive by two routes. The extraction backfill has just read a message's raw MIME and cuts what it
+/// derived, in the transaction that writes the extraction. The account run's own cut and the embedding sweep read the
+/// stored reading back through <see cref="SaveFromStoredExtractionAsync" /> and cut it in a transaction of their own,
+/// one step behind the stages that may still redact that text or move the message out of the folder its passages would
+/// describe. So a committed message is one whose passages a later step produces: storing a message no longer derives
+/// them, and the steps that do are what a message committed and not yet cut is waiting for.
 /// </remarks>
 [RequiresIntegrationCoverage]
 internal sealed class EmailChunkWriter(

--- a/src/Infrastructure/Persistence/Emails/EmailChunkWriter.cs
+++ b/src/Infrastructure/Persistence/Emails/EmailChunkWriter.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Folders;
 using MailFathom.CodeCoverage;
+using MailFathom.Domain.Emails;
 using MailFathom.Infrastructure.Observability;
 using MailFathom.Infrastructure.Persistence.Entities;
 using Microsoft.EntityFrameworkCore;
@@ -30,6 +31,46 @@ internal sealed class EmailChunkWriter(
     IMailFolderParticipationReader folderParticipation,
     TimeProvider timeProvider)
 {
+    /// <summary>Saves the passages the extraction already stored for one message yields, reading that message as it goes.</summary>
+    /// <param name="dbContext">The context whose transaction this write joins.</param>
+    /// <param name="storedEmailId">The message to cut.</param>
+    /// <param name="cancellationToken">Propagates caller cancellation.</param>
+    /// <returns>A task that completes when the passages are staged, or immediately when there is no text to cut.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="dbContext" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the message disappeared between its selection and this write.</exception>
+    /// <remarks>
+    /// The text comes from the search document rather than from the raw MIME, which is what keeps this a local write: an
+    /// earlier extraction already read the message and stored both the trimmed and the untrimmed reading, redacted by
+    /// whatever scanners were switched on, and cutting the stored reading again produces exactly the passages that
+    /// message would have been given had it been cut when the reading was taken. A message whose extraction produced no
+    /// text is left as it is, and the caller steps past it.
+    /// </remarks>
+    public async Task SaveFromStoredExtractionAsync(
+        MailFathomDbContext dbContext,
+        StoredEmailId storedEmailId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+
+        var storedEmail = await dbContext.StoredEmails.FindAsync([storedEmailId.Value], cancellationToken)
+            ?? throw new InvalidOperationException("Passages cannot be derived for a stored email that no longer exists.");
+
+        var extraction = await dbContext.EmailSearchDocuments
+            .Where(document => document.StoredEmailId == storedEmailId.Value)
+            .Select(document => new StoredExtractionRow(
+                document.TextSource,
+                document.BodyTextBeforeTrimming,
+                document.BodyText))
+            .SingleOrDefaultAsync(cancellationToken);
+
+        if (extraction is null || RestoreExtractedText(extraction) is not { } text)
+        {
+            return;
+        }
+
+        await this.SaveAsync(dbContext, storedEmail, text, cancellationToken);
+    }
+
     /// <summary>Saves the passages one extraction yields, leaving an unchanged message's rows untouched.</summary>
     /// <param name="dbContext">The context whose transaction this write joins.</param>
     /// <param name="storedEmail">The email the passages belong to, tracked or already persisted.</param>
@@ -199,6 +240,33 @@ internal sealed class EmailChunkWriter(
         }));
     }
 
+    /// <summary>Rebuilds the extraction the chunker reads from the two readings the search document stored.</summary>
+    /// <remarks>
+    /// Only the two sources that produced words can be restored, and both readings have to be there: the chunking rules
+    /// choose between the trimmed and the untrimmed form, so restoring one of them and inventing the other would cut a
+    /// message differently from the same message cut at the moment it was extracted.
+    /// </remarks>
+    private static ExtractedEmailText? RestoreExtractedText(StoredExtractionRow extraction)
+    {
+        if (extraction.BodyTextBeforeTrimming is not { } originalText || extraction.BodyText is not { } trimmedText)
+        {
+            return null;
+        }
+
+        return extraction.TextSource switch
+        {
+            ExtractedEmailTextSource.PlainTextBodyPart => ExtractedEmailText.FromPlainTextBody(originalText, trimmedText),
+            ExtractedEmailTextSource.DerivedFromHtmlBodyPart => ExtractedEmailText.DerivedFromHtmlBody(originalText, trimmedText),
+            _ => null,
+        };
+    }
+
     /// <summary>What a stored passage has to report for re-chunking to decide it is unchanged.</summary>
     private sealed record StoredChunkIdentity(int Ordinal, string ContentHash);
+
+    /// <summary>The stored reading of one message's body, as the chunking projection returns it.</summary>
+    private sealed record StoredExtractionRow(
+        ExtractedEmailTextSource TextSource,
+        string? BodyTextBeforeTrimming,
+        string? BodyText);
 }

--- a/src/Infrastructure/Persistence/Emails/MailAwaitingRelocation.cs
+++ b/src/Infrastructure/Persistence/Emails/MailAwaitingRelocation.cs
@@ -1,0 +1,48 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Linq.Expressions;
+using MailFathom.Domain.Mutations;
+using MailFathom.Infrastructure.Persistence.Entities;
+
+namespace MailFathom.Infrastructure.Persistence.Emails;
+
+/// <summary>Recognizes a message that is on its way out of the folder it is currently in.</summary>
+/// <remarks>
+/// <para>
+/// A rule declares a move rather than performing one: the record is durable when the rule pass ends and the account's
+/// <em>next</em> run carries it to the mail server, so between the two the message sits in a folder it is leaving.
+/// Everything derived from a message is derived under that folder's mapping, and passages are not undone by the message
+/// moving afterwards — so every path that cuts passages waits, and they wait by the same reading rather than by three
+/// copies of it.
+/// </para>
+/// <para>
+/// Only a relocation is read. A copy leaves this message where it is and its second occurrence is discovered in the
+/// destination and derived from there, and a pending delete costs at most one cut whose passages the deletion cascades
+/// away — neither derives anything under a mapping the message is leaving. A relocation that has completed or been
+/// abandoned is not converging either: neither will move the message again, so holding a cut back for one would hold it
+/// back for the life of the deployment.
+/// </para>
+/// </remarks>
+internal static class MailAwaitingRelocation
+{
+    /// <summary>The stored discriminator of the one mutation that can still change which folder a message is in.</summary>
+    /// <remarks>
+    /// Internal rather than private because one caller narrows a single disjunct of a larger predicate and therefore
+    /// writes the clause inline, where an expression of its own cannot be composed. The name is the part that would go
+    /// wrong silently — a discriminator nothing stores matches nothing and withholds nothing — so it is the part shared.
+    /// </remarks>
+    internal static readonly string RelocateMutationName = MailboxMutation.Relocate.Name;
+
+    /// <summary>Gets the predicate that holds for a message no relocation is still converging for.</summary>
+    /// <remarks>
+    /// Published as an expression so it composes into a query the database evaluates in full, and so a path that
+    /// narrows a whole query by it states the rule once rather than restating it.
+    /// </remarks>
+    internal static Expression<Func<StoredEmailEntity, bool>> IsSettledWhereItIs { get; } =
+        email => !email.Mutations.Any(mutation =>
+            mutation.Mutation == RelocateMutationName
+            && mutation.Stage != MailboxMutationStage.Completed
+            && mutation.Stage != MailboxMutationStage.Abandoned);
+}

--- a/src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs
@@ -10,6 +10,7 @@ using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Spam;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
@@ -35,6 +36,9 @@ internal sealed class StoredEmailChunkingStore(
     DerivedWorkGate derivedWorkGate)
     : IStoredEmailChunkingStore
 {
+    /// <summary>The stored discriminator of the one mutation that can still change which folder a message is in.</summary>
+    private static readonly string RelocateMutationName = MailboxMutation.Relocate.Name;
+
     /// <inheritdoc />
     /// <remarks>
     /// Ordering is by the primary key, which is total, stable, and already indexed. No resume position travels with the
@@ -95,11 +99,27 @@ internal sealed class StoredEmailChunkingStore(
     /// <param name="terms">The classification terms the whole batch is decided under.</param>
     /// <returns>The narrowed query, which PostgreSQL evaluates in full.</returns>
     /// <remarks>
+    /// <para>
     /// Written as a composable predicate rather than inline, so what selects a message is one statement that can be
-    /// asserted about directly. The four clauses are the pipeline's own orderings: the message is still part of the
-    /// local mailbox, the rules have finished with it, its folder is one an operator asked to have embedded, and
-    /// classification admits it. The last condition — extracted text present and no passages — is what the cut removes,
-    /// which is why the pass needs no cursor.
+    /// asserted about directly. The clauses are the pipeline's own orderings: the message is still part of the local
+    /// mailbox, the rules have finished with it and are not still moving it, its folder is one an operator asked to
+    /// have embedded, and classification admits it. The last condition — extracted text present and no passages — is
+    /// what the cut removes, which is why the pass needs no cursor.
+    /// </para>
+    /// <para>
+    /// The relocation clause is what makes *the rules ran first* mean anything for a rule that files mail. A rule
+    /// declares a move rather than performing one: the record is durable at once and the account's *next* run carries
+    /// it to the mail server, so a message filed out of an embedded folder is still sitting in that folder when this
+    /// run's cut comes round. Cutting it there would derive passages under the mapping it is leaving and leave them
+    /// behind on the row that is carried to the destination. Waiting costs one interval, after which the message is
+    /// selected under the mapping it actually ended up in. A relocation that has stopped converging — completed, or
+    /// abandoned after its bounded attempts — holds nothing back, since neither will move the message again.
+    /// </para>
+    /// <para>
+    /// Only a relocation is read. A copy leaves this message where it is and its own row is discovered in the
+    /// destination and walks the whole pipeline itself, and a pending delete costs at most one cut whose passages the
+    /// deletion then cascades away — neither derives anything under the wrong mapping.
+    /// </para>
     /// </remarks>
     internal static IQueryable<StoredEmailEntity> Selecting(
         IQueryable<StoredEmailEntity> emails,
@@ -113,7 +133,11 @@ internal sealed class StoredEmailChunkingStore(
                     && email.RulesEvaluatedAt != null
                     && !email.Chunks.Any()
                     && email.SearchDocument != null
-                    && email.SearchDocument.BodyText != null),
+                    && email.SearchDocument.BodyText != null)
+                .Where(email => !email.Mutations.Any(mutation =>
+                    mutation.Mutation == RelocateMutationName
+                    && mutation.Stage != MailboxMutationStage.Completed
+                    && mutation.Stage != MailboxMutationStage.Abandoned)),
             embeddedFolders),
         terms);
 

--- a/src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs
@@ -1,0 +1,143 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Chunking;
+using MailFathom.Application.Folders;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Spam.Gating;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Spam;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Sessions;
+using MailFathom.Infrastructure.Persistence.Spam;
+using Microsoft.EntityFrameworkCore;
+
+namespace MailFathom.Infrastructure.Persistence.Emails;
+
+/// <summary>EF Core state for the cut the account run performs once the stages in front of it have finished.</summary>
+/// <remarks>
+/// The selection carries all four conditions at once, and each of them is one of the arrival pipeline's own orderings.
+/// The message has to have been evaluated by the rules, because a rule may move it into a folder mapped differently
+/// from the one it arrived in. The classification gate has to admit it, because junk is never derived from and a
+/// message still waiting on a verdict is not derived from yet. Its folder has to be one an operator asked to have
+/// embedded, which is the same admission every other path that produces passages applies. And it has to have extracted
+/// text and no passages, which is what makes the cut the thing that removes it from this query.
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed class StoredEmailChunkingStore(
+    MailFathomDbContext dbContext,
+    EmailChunkWriter chunkWriter,
+    IMailFolderParticipationReader folderParticipation,
+    DerivedWorkGate derivedWorkGate)
+    : IStoredEmailChunkingStore
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Ordering is by the primary key, which is total, stable, and already indexed. No resume position travels with the
+    /// batch, because cutting a message is what takes it out of this query: a pass that repeats the read after
+    /// committing a batch sees the next messages rather than the ones it just cut.
+    /// </remarks>
+    public async Task<IReadOnlyList<StoredEmailAwaitingChunking>> GetEmailsAwaitingChunkingAsync(
+        MailAccountId accountId,
+        int batchSize,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(batchSize);
+
+        var mailboxAccountId = accountId.Value;
+        // One snapshot for both halves, exactly as the embedding sweep reads it: the predicate narrows the batch and the
+        // answer below names which of the gate's decisions admitted each row, so a second reading taken microseconds
+        // later could let the query select a row the answer then reported as still waiting.
+        var terms = derivedWorkGate.ReadTerms();
+
+        var candidates = await Selecting(
+                dbContext.StoredEmails.AsNoTracking(),
+                mailboxAccountId,
+                folderParticipation.FoldersGeneratingEmbeddings,
+                terms)
+            .OrderBy(email => email.Id)
+            .Take(batchSize)
+            .Select(email => new OutstandingEmailRow(
+                email.Id,
+                email.MailFolder.MailboxAccountId,
+                email.MailFolder.Alias,
+                email.StoredAt,
+                email.ContentAvailability,
+                email.SpamClassification == null ? null : email.SpamClassification.Verdict))
+            .ToArrayAsync(cancellationToken);
+
+        return
+        [
+            .. candidates.Select(candidate => new StoredEmailAwaitingChunking(
+                StoredEmailId.Create(candidate.Id),
+                AdmissionOf(terms, candidate))),
+        ];
+    }
+
+    /// <inheritdoc />
+    public Task DeriveChunksAsync(
+        IPersistenceSession session,
+        StoredEmailId storedEmailId,
+        CancellationToken cancellationToken) =>
+        chunkWriter.SaveFromStoredExtractionAsync(
+            EfCorePersistenceSessionAccessor.DbContextOf(session),
+            storedEmailId,
+            cancellationToken);
+
+    /// <summary>Narrows stored mail to the messages the arrival pipeline still owes passages for.</summary>
+    /// <param name="emails">The emails to narrow.</param>
+    /// <param name="mailboxAccountId">The configured account this pass belongs to.</param>
+    /// <param name="embeddedFolders">The folders a mapping admits to embedding, which is what decides the cut.</param>
+    /// <param name="terms">The classification terms the whole batch is decided under.</param>
+    /// <returns>The narrowed query, which PostgreSQL evaluates in full.</returns>
+    /// <remarks>
+    /// Written as a composable predicate rather than inline, so what selects a message is one statement that can be
+    /// asserted about directly. The four clauses are the pipeline's own orderings: the message is still part of the
+    /// local mailbox, the rules have finished with it, its folder is one an operator asked to have embedded, and
+    /// classification admits it. The last condition — extracted text present and no passages — is what the cut removes,
+    /// which is why the pass needs no cursor.
+    /// </remarks>
+    internal static IQueryable<StoredEmailEntity> Selecting(
+        IQueryable<StoredEmailEntity> emails,
+        string mailboxAccountId,
+        IReadOnlyList<MailFolderIdentity> embeddedFolders,
+        DerivedWorkAdmissionTerms terms) => DerivedWorkAdmittedEmails.Admitting(
+        AccountScopedMailFolders.Admitting(
+            emails
+                .Where(StoredEmailTombstone.IsNotTombstoned)
+                .Where(email => email.MailboxAccountId == mailboxAccountId
+                    && email.RulesEvaluatedAt != null
+                    && !email.Chunks.Any()
+                    && email.SearchDocument != null
+                    && email.SearchDocument.BodyText != null),
+            embeddedFolders),
+        terms);
+
+    /// <summary>Names the answer the predicate above already reached about one selected row.</summary>
+    /// <remarks>
+    /// The query admits the message; this says which of the gate's answers admitted it, which is the only place a
+    /// release is decidable per message. A withheld one never reaches here, so the answer is always an admitting one.
+    /// </remarks>
+    private static DerivedWorkAdmission AdmissionOf(DerivedWorkAdmissionTerms terms, OutstandingEmailRow candidate) =>
+        DerivedWorkGate.Admit(
+            terms,
+            new DerivedWorkCandidate(
+                MailAccountId.Create(candidate.MailboxAccountId),
+                MailFolderAlias.Create(candidate.Alias),
+                candidate.StoredAt,
+                candidate.ContentAvailability,
+                candidate.Verdict));
+
+    /// <summary>One message awaiting the cut, as the walk's projection returns it.</summary>
+    private sealed record OutstandingEmailRow(
+        Guid Id,
+        string MailboxAccountId,
+        string Alias,
+        DateTimeOffset StoredAt,
+        StoredEmailContentAvailability ContentAvailability,
+        SpamVerdict? Verdict);
+}

--- a/src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs
@@ -10,7 +10,6 @@ using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
-using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Spam;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
@@ -36,9 +35,6 @@ internal sealed class StoredEmailChunkingStore(
     DerivedWorkGate derivedWorkGate)
     : IStoredEmailChunkingStore
 {
-    /// <summary>The stored discriminator of the one mutation that can still change which folder a message is in.</summary>
-    private static readonly string RelocateMutationName = MailboxMutation.Relocate.Name;
-
     /// <inheritdoc />
     /// <remarks>
     /// Ordering is by the primary key, which is total, stable, and already indexed. No resume position travels with the
@@ -116,9 +112,8 @@ internal sealed class StoredEmailChunkingStore(
     /// abandoned after its bounded attempts — holds nothing back, since neither will move the message again.
     /// </para>
     /// <para>
-    /// Only a relocation is read. A copy leaves this message where it is and its own row is discovered in the
-    /// destination and walks the whole pipeline itself, and a pending delete costs at most one cut whose passages the
-    /// deletion then cascades away — neither derives anything under the wrong mapping.
+    /// <see cref="MailAwaitingRelocation" /> holds which records hold a cut back and which have stopped mattering, and
+    /// is read by every path that cuts.
     /// </para>
     /// </remarks>
     internal static IQueryable<StoredEmailEntity> Selecting(
@@ -134,10 +129,7 @@ internal sealed class StoredEmailChunkingStore(
                     && !email.Chunks.Any()
                     && email.SearchDocument != null
                     && email.SearchDocument.BodyText != null)
-                .Where(email => !email.Mutations.Any(mutation =>
-                    mutation.Mutation == RelocateMutationName
-                    && mutation.Stage != MailboxMutationStage.Completed
-                    && mutation.Stage != MailboxMutationStage.Abandoned)),
+                .Where(MailAwaitingRelocation.IsSettledWhereItIs),
             embeddedFolders),
         terms);
 

--- a/src/Infrastructure/Persistence/Emails/StoredEmailExtractionBackfillStore.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailExtractionBackfillStore.cs
@@ -138,12 +138,12 @@ internal sealed class StoredEmailExtractionBackfillStore(
             cancellationToken);
 
         // Cut from the same extraction, so an email this walk reaches arrives at the same state a newly synchronized
-        // one does rather than at a state a second walk would have to complete — including when classification is what
-        // decides it arrives with no passages at all. The gate is read here rather than being folded into the batch
-        // query for the reason it is read at synchronization: an email whose passages this walk withholds still needs
-        // its extraction applied, so what the answer decides is one of the two writes rather than whether the email is
-        // reached.
-        if (await this.IsAdmittedForDerivedWorkAsync(sessionContext, storedEmailId, cancellationToken))
+        // one does rather than at a state a second walk would have to complete — which now means cutting only what the
+        // two stages in front of the cut have finished with, exactly as the account run's own cut does. The question is
+        // asked here rather than folded into the batch query for the reason the gate was: an email whose passages this
+        // walk withholds still needs its extraction applied, so the answer decides one of the two writes rather than
+        // whether the email is reached at all.
+        if (await this.IsReadyForTheCutAsync(sessionContext, storedEmailId, cancellationToken))
         {
             await chunkWriter.SaveAsync(sessionContext, storedEmail, metadata.Text, cancellationToken);
         }
@@ -243,28 +243,35 @@ internal sealed class StoredEmailExtractionBackfillStore(
                 && email.SearchDocument.SensitiveContentStamp != currentStamp));
     }
 
-    /// <summary>Asks the classification gate about one email, through the same predicate every walk is narrowed by.</summary>
+    /// <summary>Asks both stages that stand in front of the cut about one email, through the predicates they own.</summary>
     /// <remarks>
-    /// Expressed as an existence test over the shared predicate rather than as a second reading of the rule, so this
-    /// path and the sweeps can never disagree about one message. It costs one indexed read of the row this write is
-    /// already holding, and none at all on a deployment that classifies nothing.
+    /// <para>
+    /// The classification half is expressed as an existence test over the shared predicate rather than as a second
+    /// reading of the rule, so this path and the sweeps can never disagree about one message.
+    /// </para>
+    /// <para>
+    /// The rule half is the reason this walk cannot cut whatever it extracts. A message the rules skipped for want of
+    /// extracted text is exactly the message this walk supplies text to, so cutting it here would cut it before the
+    /// pass that may still move it has ever read it — and the extracted text this walk just wrote is what lets that
+    /// pass read it on the account's next run, which then cuts it. Withholding costs a run; cutting early costs
+    /// passages of a folder the message was about to leave.
+    /// </para>
+    /// <para>
+    /// It costs one indexed read of the row this write is already holding, whether or not the deployment classifies
+    /// anything.
+    /// </para>
     /// </remarks>
-    private async Task<bool> IsAdmittedForDerivedWorkAsync(
+    private async Task<bool> IsReadyForTheCutAsync(
         MailFathomDbContext sessionContext,
         StoredEmailId storedEmailId,
         CancellationToken cancellationToken)
     {
         var terms = derivedWorkGate.ReadTerms();
+        var email = sessionContext.StoredEmails
+            .AsNoTracking()
+            .Where(candidate => candidate.Id == storedEmailId.Value && candidate.RulesEvaluatedAt != null);
 
-        if (!terms.IsApplied)
-        {
-            return true;
-        }
-
-        return await DerivedWorkAdmittedEmails
-            .Admitting(
-                sessionContext.StoredEmails.AsNoTracking().Where(email => email.Id == storedEmailId.Value),
-                terms)
+        return await (terms.IsApplied ? DerivedWorkAdmittedEmails.Admitting(email, terms) : email)
             .AnyAsync(cancellationToken);
     }
 

--- a/src/Infrastructure/Persistence/Emails/StoredEmailExtractionBackfillStore.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailExtractionBackfillStore.cs
@@ -257,6 +257,11 @@ internal sealed class StoredEmailExtractionBackfillStore(
     /// passages of a folder the message was about to leave.
     /// </para>
     /// <para>
+    /// That last cost is also reachable with the stamp already written, because a rule declares a move rather than
+    /// performing one and the account's next run converges it. So the same walk reaching such a message inside that
+    /// window withholds the cut for it too, by <see cref="MailAwaitingRelocation" />, which every cutting path reads.
+    /// </para>
+    /// <para>
     /// It costs one indexed read of the row this write is already holding, whether or not the deployment classifies
     /// anything.
     /// </para>
@@ -269,7 +274,8 @@ internal sealed class StoredEmailExtractionBackfillStore(
         var terms = derivedWorkGate.ReadTerms();
         var email = sessionContext.StoredEmails
             .AsNoTracking()
-            .Where(candidate => candidate.Id == storedEmailId.Value && candidate.RulesEvaluatedAt != null);
+            .Where(candidate => candidate.Id == storedEmailId.Value && candidate.RulesEvaluatedAt != null)
+            .Where(MailAwaitingRelocation.IsSettledWhereItIs);
 
         return await (terms.IsApplied ? DerivedWorkAdmittedEmails.Admitting(email, terms) : email)
             .AnyAsync(cancellationToken);

--- a/src/Infrastructure/Persistence/Emails/StoredEmailExtractionBackfillStore.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailExtractionBackfillStore.cs
@@ -10,6 +10,7 @@ using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
 using MailFathom.Infrastructure.Persistence.Spam;
@@ -262,6 +263,20 @@ internal sealed class StoredEmailExtractionBackfillStore(
     /// window withholds the cut for it too, by <see cref="MailAwaitingRelocation" />, which every cutting path reads.
     /// </para>
     /// <para>
+    /// Both of those wait for a <em>first</em> cut and nothing else, which is why a message that already carries
+    /// passages is ready whatever they say. This walk is the only path that can replace an existing passage — every
+    /// other one selects on having none — so a rebuild reaching an unstamped or still-moving message would otherwise
+    /// write the new document, take the row out of the walk, and leave the passages and the vectors built from them
+    /// derived under exactly the configuration the rebuild exists to replace, permanently and while the stored text
+    /// reports the new stamp. Cutting them again costs at worst passages of the folder the message is leaving, which is
+    /// the folder they already describe.
+    /// </para>
+    /// <para>
+    /// The classification half takes no such exemption. A verdict of junk is not an ordering to wait for but a decision
+    /// that this message is not derived from at all, and passages it was cut before that verdict are taken away by the
+    /// classifier rather than replaced here.
+    /// </para>
+    /// <para>
     /// It costs one indexed read of the row this write is already holding, whether or not the deployment classifies
     /// anything.
     /// </para>
@@ -272,10 +287,17 @@ internal sealed class StoredEmailExtractionBackfillStore(
         CancellationToken cancellationToken)
     {
         var terms = derivedWorkGate.ReadTerms();
+        // Written inline rather than through MailAwaitingRelocation's expression, because it is one branch of a larger
+        // predicate here: the two orderings hold a first cut back together, and a re-cut answers past both of them.
         var email = sessionContext.StoredEmails
             .AsNoTracking()
-            .Where(candidate => candidate.Id == storedEmailId.Value && candidate.RulesEvaluatedAt != null)
-            .Where(MailAwaitingRelocation.IsSettledWhereItIs);
+            .Where(candidate => candidate.Id == storedEmailId.Value)
+            .Where(candidate => candidate.Chunks.Any()
+                || (candidate.RulesEvaluatedAt != null
+                    && !candidate.Mutations.Any(mutation =>
+                        mutation.Mutation == MailAwaitingRelocation.RelocateMutationName
+                        && mutation.Stage != MailboxMutationStage.Completed
+                        && mutation.Stage != MailboxMutationStage.Abandoned)));
 
         return await (terms.IsApplied ? DerivedWorkAdmittedEmails.Admitting(email, terms) : email)
             .AnyAsync(cancellationToken);

--- a/src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs
+++ b/src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs
@@ -11,6 +11,7 @@ using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Spam;
 using MailFathom.Infrastructure.Persistence.Emails;
 using MailFathom.Infrastructure.Persistence.Entities;
@@ -164,17 +165,20 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
     /// reader.
     /// </remarks>
     /// <remarks>
-    /// The second group carries the rule pass's stamp for the same reason the account run's own cut does, and it is a
+    /// The second group carries both of the conditions the account run's own cut waits for, because cutting is what
+    /// this walk would do to it: the rule pass's stamp, and no relocation still converging.
+    /// <see cref="MailAwaitingRelocation" /> holds the second and why a completed or abandoned one holds nothing
+    /// back. The stamp is a
     /// correctness condition rather than a tidiness one: this sweep runs on its own interval while a run is still
     /// fetching a mailbox, so without it a first synchronization would have its mail cut here, by whichever of the two
     /// got there first, before the rules had read a single message. What the stamp costs is nothing — an unevaluated
     /// message is cut a sweep later, by which time the pass that may still move it has run.
     /// </remarks>
     /// <remarks>
-    /// The classification narrowing is what makes this sweep the place a held message is released. Junk never appears
-    /// here at all, and a message waiting on a verdict appears the moment the verdict admits it or its wait runs out —
-    /// so the sweep both keeps spam away from the provider and stops a wedged scanner from turning the index into one
-    /// that quietly stopped filling.
+    /// The classification narrowing keeps junk out of this walk entirely, and the rule stamp beside it means a message
+    /// still waiting on a verdict cannot appear here at all: the rule pass is narrowed by the same admission, so such a
+    /// message is never stamped. What releases it is therefore the next account run — its rule pass, and the cut one
+    /// step behind that pass — rather than this sweep, which reaches what a run's own batch budget left behind.
     /// </remarks>
     /// <remarks>
     /// The walk is scoped to the folders a mapping admits to embedding, which is the same decision that stops their
@@ -196,7 +200,14 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
                     || (!email.Chunks.Any()
                         && email.RulesEvaluatedAt != null
                         && email.SearchDocument != null
-                        && email.SearchDocument.BodyText != null)),
+                        && email.SearchDocument.BodyText != null
+                        // Composed inline rather than as a second Where, so it narrows the uncut group alone: a message
+                        // whose passages already exist and are missing a vector is embedded wherever it is sitting,
+                        // because the vectors hang on passages this walk is not deciding whether to derive.
+                        && !email.Mutations.Any(mutation =>
+                            mutation.Mutation == MailAwaitingRelocation.RelocateMutationName
+                            && mutation.Stage != MailboxMutationStage.Completed
+                            && mutation.Stage != MailboxMutationStage.Abandoned))),
             folderParticipation.FoldersGeneratingEmbeddings),
         terms);
 

--- a/src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs
+++ b/src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs
@@ -4,7 +4,6 @@
 
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
-using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Spam.Gating;
@@ -101,30 +100,14 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
     /// existed when it arrived. A message whose extraction produced no text is left as it is, and the walk steps past
     /// it.
     /// </remarks>
-    public async Task DeriveChunksAsync(
+    public Task DeriveChunksAsync(
         IPersistenceSession session,
         StoredEmailId storedEmailId,
-        CancellationToken cancellationToken)
-    {
-        var sessionContext = EfCorePersistenceSessionAccessor.DbContextOf(session);
-        var storedEmail = await sessionContext.StoredEmails.FindAsync([storedEmailId.Value], cancellationToken)
-            ?? throw new InvalidOperationException("Passages cannot be derived for a stored email that no longer exists.");
-
-        var extraction = await sessionContext.EmailSearchDocuments
-            .Where(document => document.StoredEmailId == storedEmailId.Value)
-            .Select(document => new StoredExtractionRow(
-                document.TextSource,
-                document.BodyTextBeforeTrimming,
-                document.BodyText))
-            .SingleOrDefaultAsync(cancellationToken);
-
-        if (extraction is null || RestoreExtractedText(extraction) is not { } text)
-        {
-            return;
-        }
-
-        await chunkWriter.SaveAsync(sessionContext, storedEmail, text, cancellationToken);
-    }
+        CancellationToken cancellationToken) =>
+        chunkWriter.SaveFromStoredExtractionAsync(
+            EfCorePersistenceSessionAccessor.DbContextOf(session),
+            storedEmailId,
+            cancellationToken);
 
     /// <inheritdoc />
     public async Task SaveResumePositionAsync(
@@ -209,27 +192,6 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
             folderParticipation.FoldersGeneratingEmbeddings),
         terms);
 
-    /// <summary>Rebuilds the extraction the chunker reads from the two readings the search document stored.</summary>
-    /// <remarks>
-    /// Only the two sources that produced words can be restored, and both readings have to be there: the chunking rules
-    /// choose between the trimmed and the untrimmed form, so restoring one of them and inventing the other would cut a
-    /// backfilled message differently from the same message arriving today.
-    /// </remarks>
-    private static ExtractedEmailText? RestoreExtractedText(StoredExtractionRow extraction)
-    {
-        if (extraction.BodyTextBeforeTrimming is not { } originalText || extraction.BodyText is not { } trimmedText)
-        {
-            return null;
-        }
-
-        return extraction.TextSource switch
-        {
-            ExtractedEmailTextSource.PlainTextBodyPart => ExtractedEmailText.FromPlainTextBody(originalText, trimmedText),
-            ExtractedEmailTextSource.DerivedFromHtmlBodyPart => ExtractedEmailText.DerivedFromHtmlBody(originalText, trimmedText),
-            _ => null,
-        };
-    }
-
     /// <summary>Names the answer the predicate above already reached about one selected row.</summary>
     /// <remarks>
     /// The query admits the message; this says which of the gate's answers admitted it, which is the only place a
@@ -254,10 +216,4 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
         DateTimeOffset StoredAt,
         StoredEmailContentAvailability ContentAvailability,
         SpamVerdict? Verdict);
-
-    /// <summary>The stored reading of one message's body, as the chunking projection returns it.</summary>
-    private sealed record StoredExtractionRow(
-        ExtractedEmailTextSource TextSource,
-        string? BodyTextBeforeTrimming,
-        string? BodyText);
 }

--- a/src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs
+++ b/src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs
@@ -164,6 +164,13 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
     /// reader.
     /// </remarks>
     /// <remarks>
+    /// The second group carries the rule pass's stamp for the same reason the account run's own cut does, and it is a
+    /// correctness condition rather than a tidiness one: this sweep runs on its own interval while a run is still
+    /// fetching a mailbox, so without it a first synchronization would have its mail cut here, by whichever of the two
+    /// got there first, before the rules had read a single message. What the stamp costs is nothing — an unevaluated
+    /// message is cut a sweep later, by which time the pass that may still move it has run.
+    /// </remarks>
+    /// <remarks>
     /// The classification narrowing is what makes this sweep the place a held message is released. Junk never appears
     /// here at all, and a message waiting on a verdict appears the moment the verdict admits it or its wait runs out —
     /// so the sweep both keeps spam away from the provider and stops a wedged scanner from turning the index into one
@@ -187,6 +194,7 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
                 .Where(email => email.Chunks.Any(chunk =>
                         !chunk.Embeddings.Any(vector => vector.EmbeddingProfileId == profileId))
                     || (!email.Chunks.Any()
+                        && email.RulesEvaluatedAt != null
                         && email.SearchDocument != null
                         && email.SearchDocument.BodyText != null)),
             folderParticipation.FoldersGeneratingEmbeddings),

--- a/src/Infrastructure/Persistence/Sessions/PersistenceSessionFactory.cs
+++ b/src/Infrastructure/Persistence/Sessions/PersistenceSessionFactory.cs
@@ -80,9 +80,17 @@ internal sealed class PersistenceSessionFactory(MailFathomDbContext dbContext) :
         /// is that a different reindex is already running.
         /// </para>
         /// <para>
-        /// The last is the mutation identity's case once more, for the account's whole-mailbox rule run: two requests
+        /// The next is the mutation identity's case once more, for the account's whole-mailbox rule run: two requests
         /// for an account that has never had one reach the database together, and the retry reads back the run the
         /// winner asked for instead of the second caller starting a second walk of one mailbox.
+        /// </para>
+        /// <para>
+        /// The last is the passage ordinal, and it is two cutters meeting over one message. The account run's cut and
+        /// the embedding sweep select the same rows and walk them in the same order, and the sweep runs on its own
+        /// interval while a run is still fetching, so on a first synchronization both can reach one message. Each reads
+        /// the stored ordinals inside its own transaction, so the one that commits second read none and writes a second
+        /// ordinal zero. The retry is exactly right there: it re-reads the winner's passages, finds them identical to
+        /// what it would have written, and writes nothing.
         /// </para>
         /// </remarks>
         public bool IsConcurrencyConflict(DbUpdateException exception) =>
@@ -96,7 +104,8 @@ internal sealed class PersistenceSessionFactory(MailFathomDbContext dbContext) :
                     or MailFathomDbContext.MailboxMutationAuditEntryMutationUniqueIndexName
                     or MailFathomDbContext.EmbeddingProfileFingerprintUniqueIndexName
                     or MailFathomDbContext.EmbeddingProfileLifecycleUniqueIndexName
-                    or MailFathomDbContext.MailRuleEvaluationRunPrimaryKeyConstraintName,
+                    or MailFathomDbContext.MailRuleEvaluationRunPrimaryKeyConstraintName
+                    or MailFathomDbContext.EmailChunkOrdinalUniqueIndexName,
             };
 
         public void ClearTrackedState() => dbContext.ChangeTracker.Clear();

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -265,10 +265,14 @@ public static class ServiceCollectionExtensions
         // passage rows a message owns. Its `IEmailTextChunker` comes from the AI boundary, which this project may not
         // reference, so a composition root that registers persistence without the local derivations resolves nothing.
         services.AddScoped<EmailChunkWriter>();
-        // The port over it, which is what the synchronization run and a junk verdict reach it through. Deriving is a
-        // call the run makes rather than something the metadata write does on its way past, because what decides whether
-        // a message is cut is what classification says about it.
+        // The port a verdict that turned out to be junk discards a message's passages through. It carries the discarding
+        // half alone, because nothing outside the arrival pipeline decides when passages are cut.
         services.AddScoped<IEmailChunkStore, EmailChunkStore>();
+        // The port the pipeline's own cut reaches the writer through, and the pass that performs it. Cutting is a call
+        // the account run makes after classification and the rules have finished with a message rather than something
+        // the metadata write does on its way past, because both of those stages may still change what a message is.
+        services.AddScoped<IStoredEmailChunkingStore, StoredEmailChunkingStore>();
+        services.AddScoped<MailChunkingPass>();
         // The backlog is a singleton because the bound it enforces is one process-wide limit on how much embedding work
         // is held in memory; a scoped one would hold that bound per scope, and a synchronization run would be offering
         // into a backlog no worker is reading. Registered whether or not this deployment embeds, because the

--- a/tests/Application.UnitTests/Emails/Chunking/MailChunkingPassTests.cs
+++ b/tests/Application.UnitTests/Emails/Chunking/MailChunkingPassTests.cs
@@ -1,0 +1,198 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Chunking;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Spam.Gating;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Chunking;
+
+/// <summary>Covers the stage that cuts passages once classification and the rules have had their turn.</summary>
+/// <remarks>
+/// Which mail reaches the pass is the store's decision and is asserted where that predicate lives. What is asserted here
+/// is the pass's own contract: every message is committed before it is offered, an offer the backlog refuses loses
+/// nothing, the gate's answer is reported as the release it is, and a walk that is longer than one batch ends rather
+/// than repeating itself.
+/// </remarks>
+public sealed class MailChunkingPassTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+
+    [Fact]
+    public async Task RunAsync_MailAwaitingTheCut_CutsEachMessageAndOffersItForEmbedding()
+    {
+        // Arrange
+        var first = StoredEmailId.Create(Guid.CreateVersion7());
+        var second = StoredEmailId.Create(Guid.CreateVersion7());
+        var store = StoreReturning([Awaiting(first), Awaiting(second)]);
+        var backlog = new RecordingEmailEmbeddingBacklog();
+        var pass = CreatePass(store, backlog);
+
+        // Act
+        var report = await pass.RunAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, report.ChunkedEmailCount);
+        Assert.Equal(0, report.RefusedOfferCount);
+        Assert.False(report.EmailsRemain);
+        Assert.Equal([first, second], backlog.Accepted);
+        await store.Received(1).DeriveChunksAsync(Arg.Any<IPersistenceSession>(), first, CancellationToken.None);
+        await store.Received(1).DeriveChunksAsync(Arg.Any<IPersistenceSession>(), second, CancellationToken.None);
+    }
+
+    /// <summary>The ordering the offer rests on: a message is durable before the worker is told about it.</summary>
+    [Fact]
+    public async Task RunAsync_OneMessage_CommitsItsPassagesBeforeOfferingIt()
+    {
+        // Arrange
+        var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
+        var backlog = new RecordingEmailEmbeddingBacklog();
+        var committed = false;
+        var store = StoreReturning([Awaiting(storedEmailId)]);
+        store
+            .DeriveChunksAsync(Arg.Any<IPersistenceSession>(), storedEmailId, Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                Assert.Empty(backlog.Accepted);
+                committed = true;
+
+                return Task.CompletedTask;
+            });
+
+        // Act
+        await CreatePass(store, backlog).RunAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.True(committed);
+        Assert.Equal([storedEmailId], backlog.Accepted);
+    }
+
+    /// <summary>A full backlog is the expected outcome of a first synchronization rather than a fault.</summary>
+    [Fact]
+    public async Task RunAsync_BacklogRefusesTheOffer_StillCountsTheMessageAsCut()
+    {
+        // Arrange
+        var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
+        var backlog = new RecordingEmailEmbeddingBacklog { Capacity = 0 };
+        var pass = CreatePass(StoreReturning([Awaiting(storedEmailId)]), backlog);
+
+        // Act
+        var report = await pass.RunAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, report.ChunkedEmailCount);
+        Assert.Equal(1, report.RefusedOfferCount);
+        Assert.Empty(backlog.Accepted);
+        Assert.Equal(1, backlog.RefusedCount);
+    }
+
+    /// <summary>Cutting a message the gate was holding is the release, and the release is what an operator reads.</summary>
+    [Fact]
+    public async Task RunAsync_AMessageReleasedAfterWaiting_ReportsThatAdmission()
+    {
+        // Arrange
+        var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
+        var telemetry = new RecordingDerivedWorkGateTelemetry();
+        var pass = CreatePass(
+            StoreReturning([new StoredEmailAwaitingChunking(storedEmailId, DerivedWorkAdmission.ReleasedAfterWaiting)]),
+            new RecordingEmailEmbeddingBacklog(),
+            telemetry);
+
+        // Act
+        await pass.RunAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.Equal([DerivedWorkAdmission.ReleasedAfterWaiting], telemetry.Admissions);
+    }
+
+    [Fact]
+    public async Task RunAsync_NothingAwaitingTheCut_ReportsAnEmptyPass()
+    {
+        // Arrange
+        var store = StoreReturning([]);
+        var pass = CreatePass(store, new RecordingEmailEmbeddingBacklog());
+
+        // Act
+        var report = await pass.RunAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.True(report.IsEmpty);
+        Assert.False(report.EmailsRemain);
+        await store.DidNotReceiveWithAnyArgs().DeriveChunksAsync(
+            Arg.Any<IPersistenceSession>(),
+            Arg.Any<StoredEmailId>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A pass that keeps filling its batch stops at its own bound and says so, rather than holding the account's run
+    /// open for a mailbox whose whole content is awaiting the cut.
+    /// </summary>
+    [Fact]
+    public async Task RunAsync_EveryBatchFull_EndsOnItsBoundAndReportsMailRemaining()
+    {
+        // Arrange
+        var store = Substitute.For<IStoredEmailChunkingStore>();
+        store
+            .GetEmailsAwaitingChunkingAsync(Account, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(call => Task.FromResult<IReadOnlyList<StoredEmailAwaitingChunking>>(
+                [.. Enumerable
+                    .Range(0, call.ArgAt<int>(1))
+                    .Select(_ => Awaiting(StoredEmailId.Create(Guid.CreateVersion7())))]));
+        var pass = CreatePass(store, new RecordingEmailEmbeddingBacklog());
+
+        // Act
+        var report = await pass.RunAsync(Account, CancellationToken.None);
+
+        // Assert
+        Assert.True(report.EmailsRemain);
+        Assert.True(report.ChunkedEmailCount > 0);
+        await store.Received(25).GetEmailsAwaitingChunkingAsync(
+            Account,
+            Arg.Any<int>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private static StoredEmailAwaitingChunking Awaiting(StoredEmailId storedEmailId) => new(storedEmailId);
+
+    private static IStoredEmailChunkingStore StoreReturning(IReadOnlyList<StoredEmailAwaitingChunking> batch)
+    {
+        var store = Substitute.For<IStoredEmailChunkingStore>();
+
+        // The second answer is empty because cutting is what takes a message out of the query the pass re-issues, so a
+        // store that kept returning the same batch would describe a defect rather than the walk.
+        store
+            .GetEmailsAwaitingChunkingAsync(Account, Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(batch, []);
+
+        return store;
+    }
+
+    private static MailChunkingPass CreatePass(
+        IStoredEmailChunkingStore store,
+        RecordingEmailEmbeddingBacklog backlog,
+        RecordingDerivedWorkGateTelemetry? telemetry = null)
+    {
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory
+            .BeginSessionAsync(Arg.Any<CancellationToken>())
+            .Returns(_ => Substitute.For<IPersistenceSession>());
+
+        return new MailChunkingPass(
+            store,
+            backlog,
+            telemetry ?? new RecordingDerivedWorkGateTelemetry(),
+            new OptimisticConcurrencyRetryPolicy(
+                sessionFactory,
+                new PersistenceConcurrencyOptions(),
+                new FakeTimeProvider(new DateTimeOffset(2026, 8, 13, 10, 0, 0, TimeSpan.Zero))));
+    }
+}

--- a/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -1725,7 +1725,6 @@ public sealed class MailboxSynchronizerTests
     }
 
     /// <summary>Settings that put the folder every arrival test synchronizes inside classification's scope.</summary>
-    /// <summary>Settings that put the folder every arrival test synchronizes inside classification's scope.</summary>
     private static SpamClassificationSettings ClassifyingTheInbox() => SpamClassificationSettings.Create(
         isEnabled: true,
         usesScanner: false,

--- a/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -3,8 +3,6 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.EmailContent.Storage;
-using MailFathom.Application.Emails.Chunking;
-using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
@@ -102,6 +100,58 @@ public sealed class MailboxSynchronizerTests
         await metadataRepository.Received(1).UpsertMetadataAsync(persistenceSession, metadata, Arg.Any<ExtractedEmailMetadata?>(), StoredEmailContentAvailability.Available, CancellationToken.None);
         await contentStore.Received(1).SaveContentAsync(persistenceSession, storedEmailId, content, CancellationToken.None);
         await checkpointStore.Received(1).SaveCheckpointAsync(persistenceSession, accountId, folder.Id, Arg.Any<SynchronizationCheckpoint?>(), Arg.Is<SynchronizationCheckpoint>(checkpoint => checkpoint!.LastSeenUid == uid), CancellationToken.None);
+    }
+
+    /// <summary>The run records what the classification gate says about an arriving message, although it derives nothing from it.</summary>
+    /// <remarks>
+    /// The two withholding answers are reached nowhere else: every later stage either sees a message the gate admits or
+    /// does not see it at all, so a mailbox held behind classification would otherwise be indistinguishable from a
+    /// mailbox with nothing in it.
+    /// </remarks>
+    [Fact]
+    public async Task SynchronizeAsync_StoresAMessageAwaitingItsVerdict_RecordsWhatTheGateSaidAboutIt()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var uid = ImapUid.Create(10);
+        var occurrence = EmailOccurrenceId.Create(accountId, InboxFolder.Id, uidValidity, uid);
+        var checkpointStore = CreateCheckpointStoreAt(accountId, uidValidity);
+        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        var session = Substitute.For<IMailboxSession>();
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
+        var gateTelemetry = new RecordingDerivedWorkGateTelemetry();
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128);
+        var synchronizer = CreateSynchronizer(
+            sessionFactory,
+            checkpointStore,
+            sessionScopeFactory,
+            metadataRepository,
+            contentStore: Substitute.For<IEmailContentStore>(),
+            clock,
+            options,
+            classificationSettings: ClassifyingTheInbox(),
+            gateTelemetry: gateTelemetry);
+
+        sessionScopeFactory.BeginSessionAsync(CancellationToken.None).Returns(persistenceSession);
+        sessionFactory.OpenReadOnlyAsync(accountId, InboxFolder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
+        session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        StubRetrievedContent(session, options, occurrence, payloadLength: 3);
+        metadataRepository
+            .UpsertMetadataAsync(persistenceSession, metadata, Arg.Any<ExtractedEmailMetadata?>(), StoredEmailContentAvailability.Available, CancellationToken.None)
+            .Returns(StoredEmailId.Create(Guid.CreateVersion7()));
+
+        // Act
+        var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.StoredEmailCount);
+        Assert.Equal([DerivedWorkAdmission.AwaitingClassification], gateTelemetry.Admissions);
     }
 
     /// <summary>A message MailFathom relocated arrives in its new folder as an ordinary discovery, and is the email it already had.</summary>
@@ -483,156 +533,6 @@ public sealed class MailboxSynchronizerTests
             StoredEmailContentAvailability.Available,
             Arg.Any<CancellationToken>());
         Assert.Null(mutationStore.RecordOf(record.Id).PlacementObservedAt);
-    }
-
-    [Fact]
-    public async Task SynchronizeAsync_NewMessage_OffersTheCommittedMessageForEmbedding()
-    {
-        // Arrange
-        var backlog = new RecordingEmailEmbeddingBacklog();
-        var arrangement = ArrangeOneStoredMessage(backlog);
-
-        // Act
-        var result = await arrangement.Synchronizer.SynchronizeAsync(
-            arrangement.AccountId,
-            InboxMapping,
-            CancellationToken.None);
-
-        // Assert
-        Assert.Equal(1, result.StoredEmailCount);
-        Assert.Equal([arrangement.StoredEmailId], backlog.Accepted);
-        Assert.Equal(0, backlog.RefusedCount);
-    }
-
-    /// <summary>With classification off there is no ordering to obey, so the message is cut and offered exactly as before.</summary>
-    [Fact]
-    public async Task SynchronizeAsync_ClassificationSwitchedOff_CutsThePassagesInTheSameCommit()
-    {
-        // Arrange
-        var backlog = new RecordingEmailEmbeddingBacklog();
-        var arrangement = ArrangeOneStoredMessage(backlog);
-
-        // Act
-        await arrangement.Synchronizer.SynchronizeAsync(
-            arrangement.AccountId,
-            InboxMapping,
-            CancellationToken.None);
-
-        // Assert
-        await arrangement.ChunkStore.Received(1).DeriveChunksAsync(
-            arrangement.PersistenceSession,
-            arrangement.StoredEmailId,
-            Arg.Any<ExtractedEmailText>(),
-            CancellationToken.None);
-        Assert.Equal([DerivedWorkAdmission.Admitted], arrangement.GateTelemetry.Admissions);
-    }
-
-    /// <summary>
-    /// The ordering itself: a message classification is going to score carries no verdict at the moment it is committed,
-    /// so nothing downstream of classification runs for it — it is not cut, and it is not offered to a provider.
-    /// </summary>
-    [Fact]
-    public async Task SynchronizeAsync_AMessageClassificationWillScore_CutsNoPassagesAndOffersNothingForEmbedding()
-    {
-        // Arrange
-        var backlog = new RecordingEmailEmbeddingBacklog();
-        var arrangement = ArrangeOneStoredMessage(backlog, ClassifyingTheInbox());
-
-        // Act
-        var result = await arrangement.Synchronizer.SynchronizeAsync(
-            arrangement.AccountId,
-            InboxMapping,
-            CancellationToken.None);
-
-        // Assert
-        Assert.Equal(1, result.StoredEmailCount);
-        await arrangement.ChunkStore.DidNotReceiveWithAnyArgs().DeriveChunksAsync(
-            Arg.Any<IPersistenceSession>(),
-            Arg.Any<StoredEmailId>(),
-            Arg.Any<ExtractedEmailText>(),
-            Arg.Any<CancellationToken>());
-        Assert.Empty(backlog.Accepted);
-        Assert.Equal([DerivedWorkAdmission.AwaitingClassification], arrangement.GateTelemetry.Admissions);
-    }
-
-    /// <summary>Mail arriving in the junk folder needs no scanner to say so, and never reaches a provider.</summary>
-    [Fact]
-    public async Task SynchronizeAsync_AMessageArrivingInTheJunkFolder_CutsNoPassagesAndOffersNothingForEmbedding()
-    {
-        // Arrange
-        var backlog = new RecordingEmailEmbeddingBacklog();
-        var arrangement = ArrangeOneStoredMessage(
-            backlog,
-            ClassifyingTheInbox(),
-            StubJunkMailFolderCatalog.Naming(new MailFolderIdentity(MailAccountId.Create("primary"), InboxAlias)));
-
-        // Act
-        var result = await arrangement.Synchronizer.SynchronizeAsync(
-            arrangement.AccountId,
-            InboxMapping,
-            CancellationToken.None);
-
-        // Assert
-        Assert.Equal(1, result.StoredEmailCount);
-        await arrangement.ChunkStore.DidNotReceiveWithAnyArgs().DeriveChunksAsync(
-            Arg.Any<IPersistenceSession>(),
-            Arg.Any<StoredEmailId>(),
-            Arg.Any<ExtractedEmailText>(),
-            Arg.Any<CancellationToken>());
-        Assert.Empty(backlog.Accepted);
-        Assert.Equal([DerivedWorkAdmission.WithheldAsJunk], arrangement.GateTelemetry.Admissions);
-    }
-
-    /// <summary>A folder no classification runs over waits on nothing, so its mail is cut and offered as it always was.</summary>
-    [Fact]
-    public async Task SynchronizeAsync_AMessageOutsideTheClassifiedScope_CutsThePassagesInTheSameCommit()
-    {
-        // Arrange
-        var backlog = new RecordingEmailEmbeddingBacklog();
-        var arrangement = ArrangeOneStoredMessage(
-            backlog,
-            SpamClassificationSettings.Create(
-                isEnabled: true,
-                usesScanner: false,
-                [MailFolderAlias.Create("archive")]));
-
-        // Act
-        await arrangement.Synchronizer.SynchronizeAsync(
-            arrangement.AccountId,
-            InboxMapping,
-            CancellationToken.None);
-
-        // Assert
-        await arrangement.ChunkStore.Received(1).DeriveChunksAsync(
-            arrangement.PersistenceSession,
-            arrangement.StoredEmailId,
-            Arg.Any<ExtractedEmailText>(),
-            CancellationToken.None);
-        Assert.Equal([arrangement.StoredEmailId], backlog.Accepted);
-    }
-
-    [Fact]
-    public async Task SynchronizeAsync_EmbeddingBacklogIsFull_StoresTheMessageAndReportsItSynchronized()
-    {
-        // Arrange
-        var backlog = new RecordingEmailEmbeddingBacklog { Capacity = 0 };
-        var arrangement = ArrangeOneStoredMessage(backlog);
-
-        // Act
-        var result = await arrangement.Synchronizer.SynchronizeAsync(
-            arrangement.AccountId,
-            InboxMapping,
-            CancellationToken.None);
-
-        // Assert
-        Assert.Equal(1, result.StoredEmailCount);
-        Assert.Empty(backlog.Accepted);
-        Assert.Equal(1, backlog.RefusedCount);
-        await arrangement.ContentStore.Received(1).SaveContentAsync(
-            arrangement.PersistenceSession,
-            arrangement.StoredEmailId,
-            Arg.Any<RemoteEmailContent>(),
-            CancellationToken.None);
     }
 
     [Fact]
@@ -1825,6 +1725,7 @@ public sealed class MailboxSynchronizerTests
     }
 
     /// <summary>Settings that put the folder every arrival test synchronizes inside classification's scope.</summary>
+    /// <summary>Settings that put the folder every arrival test synchronizes inside classification's scope.</summary>
     private static SpamClassificationSettings ClassifyingTheInbox() => SpamClassificationSettings.Create(
         isEnabled: true,
         usesScanner: false,
@@ -2228,74 +2129,6 @@ public sealed class MailboxSynchronizerTests
         return checkpointStore;
     }
 
-    /// <summary>Composes a run that stores exactly one message, which is the shape both embedding tests assert about.</summary>
-    private static OneStoredMessageArrangement ArrangeOneStoredMessage(
-        IEmailEmbeddingBacklog embeddingBacklog,
-        SpamClassificationSettings? classificationSettings = null,
-        IJunkMailFolderCatalog? junkFolders = null)
-    {
-        var accountId = MailAccountId.Create("primary");
-        var folder = InboxFolder;
-        var uidValidity = ImapUidValidity.Create(5);
-        var uid = ImapUid.Create(10);
-        var occurrence = EmailOccurrenceId.Create(accountId, folder.Id, uidValidity, uid);
-        var checkpointStore = Substitute.For<ISynchronizationCheckpointStore>();
-        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
-        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
-        var persistenceSession = Substitute.For<IPersistenceSession>();
-        sessionScopeFactory.BeginSessionAsync(CancellationToken.None).Returns(persistenceSession);
-        var contentStore = Substitute.For<IEmailContentStore>();
-        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
-        var session = Substitute.For<IMailboxSession>();
-        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
-        var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
-        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128);
-        var content = new RemoteEmailContent(occurrence, new ReadOnlyMemory<byte>([1, 2, 3]));
-        var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
-        var chunkStore = Substitute.For<IEmailChunkStore>();
-        var gateTelemetry = new RecordingDerivedWorkGateTelemetry();
-
-        checkpointStore.GetCheckpointAsync(accountId, folder.Id, CancellationToken.None).Returns(SynchronizationCheckpoint.None(uidValidity));
-        sessionFactory.OpenReadOnlyAsync(accountId, folder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
-        session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
-        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
-        session.FetchEmailContentWithoutSettingSeenAsync(occurrence, 1024, CancellationToken.None).Returns(RemoteEmailContentFetchResult.Retrieved(content));
-        metadataRepository.UpsertMetadataAsync(persistenceSession, metadata, Arg.Any<ExtractedEmailMetadata?>(), StoredEmailContentAvailability.Available, CancellationToken.None).Returns(storedEmailId);
-
-        var synchronizer = CreateSynchronizer(
-            sessionFactory,
-            checkpointStore,
-            sessionScopeFactory,
-            metadataRepository,
-            contentStore,
-            clock,
-            options,
-            embeddingBacklog: embeddingBacklog,
-            chunkStore: chunkStore,
-            classificationSettings: classificationSettings,
-            junkFolders: junkFolders,
-            gateTelemetry: gateTelemetry);
-
-        return new OneStoredMessageArrangement(
-            synchronizer,
-            accountId,
-            storedEmailId,
-            contentStore,
-            persistenceSession,
-            chunkStore,
-            gateTelemetry);
-    }
-
-    /// <summary>The parts of a one-message run the embedding assertions read back.</summary>
-    private sealed record OneStoredMessageArrangement(
-        MailboxSynchronizer Synchronizer,
-        MailAccountId AccountId,
-        StoredEmailId StoredEmailId,
-        IEmailContentStore ContentStore,
-        IPersistenceSession PersistenceSession,
-        IEmailChunkStore ChunkStore,
-        RecordingDerivedWorkGateTelemetry GateTelemetry);
-
     private static MailboxSynchronizer CreateSynchronizer(
         IMailboxSessionFactory mailboxSessionFactory,
         ISynchronizationCheckpointStore checkpointStore,
@@ -2310,11 +2143,9 @@ public sealed class MailboxSynchronizerTests
         MailSynchronizationWindow synchronizationWindow = default,
         IStoredEmailReconciliationStore? reconciliationStore = null,
         InMemoryMailboxMutationReconciliationStore? mutationStore = null,
-        IEmailEmbeddingBacklog? embeddingBacklog = null,
         IStoredEmailContentInventory? contentInventory = null,
         RawMimeMemoryBudget? rawMimeMemoryBudget = null,
         StoredContentCeiling? storedContentCeiling = null,
-        IEmailChunkStore? chunkStore = null,
         SpamClassificationSettings? classificationSettings = null,
         IJunkMailFolderCatalog? junkFolders = null,
         IDerivedWorkGateTelemetry? gateTelemetry = null)
@@ -2346,8 +2177,6 @@ public sealed class MailboxSynchronizerTests
                 concurrencyRetryPolicy,
                 timeProvider,
                 options),
-            embeddingBacklog ?? new RecordingEmailEmbeddingBacklog(),
-            chunkStore ?? Substitute.For<IEmailChunkStore>(),
             new DerivedWorkGate(
                 new StubSpamClassificationSettingsReader(
                     classificationSettings ?? SpamClassificationSettings.Disabled),

--- a/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
@@ -156,14 +156,14 @@ public sealed class AccountSynchronizationSupervisorTests
             new TaskCompletionSource(),
             expectedFolderCount: 1,
             _ => new InvalidOperationException("connect failed"));
-        var localStepsReached = new TaskCompletionSource();
+        var ruleEvaluationReached = new TaskCompletionSource();
         using var harness = CreateHarness(
             CreateOptionsWithArchiveUnmirrored(),
             sessionFactory,
-            ruleEvaluationStore: CreateRuleStoreReporting(localStepsReached));
+            ruleEvaluationStore: CreateRuleStoreReporting(ruleEvaluationReached));
 
-        // Act, waiting on the last local step, which follows every folder the run scheduled.
-        await harness.SuperviseUntilAsync(localStepsReached.Task);
+        // Act, waiting on the rule pass, which follows every folder the run scheduled.
+        await harness.SuperviseUntilAsync(ruleEvaluationReached.Task);
 
         // Assert
         Assert.Equal(["INBOX"], attemptedFolders);
@@ -178,15 +178,15 @@ public sealed class AccountSynchronizationSupervisorTests
     {
         // Arrange
         var mirrorStore = new RecordingMailFolderMirrorStore();
-        var localStepsReached = new TaskCompletionSource();
+        var ruleEvaluationReached = new TaskCompletionSource();
         using var harness = CreateHarness(
             CreateOptionsWithArchiveUnmirrored(),
             Substitute.For<IMailboxSessionFactory>(),
             folderMirrorStore: mirrorStore,
-            ruleEvaluationStore: CreateRuleStoreReporting(localStepsReached));
+            ruleEvaluationStore: CreateRuleStoreReporting(ruleEvaluationReached));
 
-        // Act, waiting on the last of the run's local steps, which is past where an erasure pass would have run.
-        await harness.SuperviseUntilAsync(localStepsReached.Task);
+        // Act, waiting on the rule pass, which is past where an erasure pass would have run.
+        await harness.SuperviseUntilAsync(ruleEvaluationReached.Task);
 
         // Assert
         Assert.Empty(mirrorStore.ErasedFolders);
@@ -212,15 +212,15 @@ public sealed class AccountSynchronizationSupervisorTests
         options.Accounts[0].Folders[1].GenerateEmbeddings = generateEmbeddings;
         options.Accounts[0].Folders[1].VisibleToTools = visibleToTools;
         var mirrorStore = new RecordingMailFolderMirrorStore();
-        var localStepsReached = new TaskCompletionSource();
+        var ruleEvaluationReached = new TaskCompletionSource();
         using var harness = CreateHarness(
             options,
             Substitute.For<IMailboxSessionFactory>(),
             folderMirrorStore: mirrorStore,
-            ruleEvaluationStore: CreateRuleStoreReporting(localStepsReached));
+            ruleEvaluationStore: CreateRuleStoreReporting(ruleEvaluationReached));
 
         // Act
-        await harness.SuperviseUntilAsync(localStepsReached.Task);
+        await harness.SuperviseUntilAsync(ruleEvaluationReached.Task);
 
         // Assert
         Assert.Empty(mirrorStore.ErasedFolders);
@@ -993,10 +993,15 @@ public sealed class AccountSynchronizationSupervisorTests
     }
 
     /// <summary>
-    /// Reports that a run has reached its last local step, which is the signal a test waits on when what it asserts is
-    /// that something did not happen: everything an account run does locally is behind it by then.
+    /// Reports that a run has reached its rule pass, which is the signal a test waits on when what it asserts is that
+    /// something did not happen: every folder the run scheduled is behind it by then.
     /// </summary>
-    private static IMailRuleEvaluationStore CreateRuleStoreReporting(TaskCompletionSource localStepsReached)
+    /// <remarks>
+    /// The cut runs after this signal rather than before it, so the absences a test may assert on it are the ones the
+    /// folders produce — a connection opened, an eraser reached for. An absence the cut could still fill is not one of
+    /// them, and a test wanting that waits on something the pass itself reports.
+    /// </remarks>
+    private static IMailRuleEvaluationStore CreateRuleStoreReporting(TaskCompletionSource ruleEvaluationReached)
     {
         var ruleStore = Substitute.For<IMailRuleEvaluationStore>();
         ruleStore
@@ -1007,7 +1012,7 @@ public sealed class AccountSynchronizationSupervisorTests
                 Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
-                localStepsReached.TrySetResult();
+                ruleEvaluationReached.TrySetResult();
 
                 return Task.FromResult<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>>([]);
             });

--- a/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
@@ -5,10 +5,12 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Emails.Chunking;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules.Evaluation;
+using MailFathom.Application.Spam.Runs;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Common.Observability;
@@ -855,6 +857,103 @@ public sealed class AccountSynchronizationSupervisorTests
         Assert.True(await evaluatedAfterTheFolder.Task);
     }
 
+    /// <summary>
+    /// The arrival pipeline's order, asserted where it is composed. Classification runs first so that every later stage
+    /// reads a verdict instead of deciding without one, the rules run over what it did not settle, and the cut runs last
+    /// because a rule may still move the message into a folder mapped differently from the one it arrived in.
+    /// </summary>
+    /// <remarks>
+    /// Classification is a seam in this release rather than a running job — nothing scores a message because it arrived,
+    /// and what reaches this call site today is an operator asking for a run over a mailbox. What is asserted here is
+    /// that the call site sits where the order requires it and that the run reaches it, which is the half of the stage
+    /// that ships now.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_EveryRun_ClassifiesThenEvaluatesRulesThenCutsPassages()
+    {
+        // Arrange
+        var localSteps = new ConcurrentQueue<string>();
+        var cutReached = new TaskCompletionSource();
+        var classificationRunStore = Substitute.For<ISpamClassificationRunStore>();
+        classificationRunStore
+            .FindOutstandingAsync(Arg.Any<MailAccountId>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                localSteps.Enqueue("classification");
+
+                return Task.FromResult<SpamClassificationRun?>(null);
+            });
+        var ruleStore = Substitute.For<IMailRuleEvaluationStore>();
+        ruleStore
+            .GetEmailsAwaitingFirstEvaluationAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<StoredEmailId?>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                localSteps.Enqueue("rules");
+
+                return Task.FromResult<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>>([]);
+            });
+        var chunkingStore = Substitute.For<IStoredEmailChunkingStore>();
+        chunkingStore
+            .GetEmailsAwaitingChunkingAsync(Arg.Any<MailAccountId>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                localSteps.Enqueue("cut");
+                cutReached.TrySetResult();
+
+                return Task.FromResult<IReadOnlyList<StoredEmailAwaitingChunking>>([]);
+            });
+        using var harness = CreateHarness(
+            SynchronizationTestHost.CreateSingleAccountOptions(enabled: true),
+            Substitute.For<IMailboxSessionFactory>(),
+            ruleEvaluationStore: ruleStore,
+            classificationRunStore: classificationRunStore,
+            chunkingStore: chunkingStore);
+
+        // Act
+        await harness.SuperviseUntilAsync(cutReached.Task);
+
+        // Assert
+        Assert.Equal(["classification", "rules", "cut"], localSteps.Take(3));
+    }
+
+    /// <summary>The cut reaches no mail server either, so failing one must not make the account fetch its mail less often.</summary>
+    [Fact]
+    public async Task RunAsync_CuttingPassagesFails_DoesNotDeferTheAccountsNextRun()
+    {
+        // Arrange
+        var passFailed = new TaskCompletionSource();
+        var chunkingStore = Substitute.For<IStoredEmailChunkingStore>();
+        chunkingStore
+            .GetEmailsAwaitingChunkingAsync(Arg.Any<MailAccountId>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns<Task<IReadOnlyList<StoredEmailAwaitingChunking>>>(_ =>
+            {
+                passFailed.TrySetResult();
+
+                throw new InvalidOperationException("the cut failed");
+            });
+        using var harness = CreateHarness(
+            SynchronizationTestHost.CreateSingleAccountOptions(enabled: true),
+            Substitute.For<IMailboxSessionFactory>(),
+            chunkingStore: chunkingStore);
+
+        // Act
+        await harness.SuperviseUntilAsync(passFailed.Task);
+
+        // Assert
+        Assert.Contains(
+            harness.Logger.Messages,
+            message => message.Contains(
+                "Cutting the passages of the evaluated mail of account primary ended unexpectedly",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            harness.Logger.Messages,
+            message => message.Contains("runs in a row", StringComparison.Ordinal));
+    }
+
     /// <summary>Evaluation reaches no mail server, so failing one must not make the account fetch its mail less often.</summary>
     [Fact]
     public async Task RunAsync_RuleEvaluationFails_DoesNotDeferTheAccountsNextRun()
@@ -1025,6 +1124,8 @@ public sealed class AccountSynchronizationSupervisorTests
         IMailboxMutationRecordStore? mutationRecordStore = null,
         IStoredMailFolderMirrorStore? folderMirrorStore = null,
         IMailRuleEvaluationStore? ruleEvaluationStore = null,
+        ISpamClassificationRunStore? classificationRunStore = null,
+        IStoredEmailChunkingStore? chunkingStore = null,
         params string[] unadvertisedAliases)
     {
         var clock = new FakeTimeProvider();
@@ -1039,6 +1140,8 @@ public sealed class AccountSynchronizationSupervisorTests
             mutationRecordStore,
             folderMirrorStore,
             ruleEvaluationStore,
+            classificationRunStore,
+            chunkingStore,
             unadvertisedAliases);
 
         return new SupervisorHarness(

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -91,6 +91,8 @@ internal static class SynchronizationTestHost
     /// <param name="mutationRecordStore">Replaces the record store that reports nothing outstanding to converge.</param>
     /// <param name="folderMirrorStore">Replaces the store an unmirrored folder's local copy would be erased through, which no run reaches.</param>
     /// <param name="ruleEvaluationStore">Replaces the store a rule pass reads its candidates from; one with nothing to evaluate is the default.</param>
+    /// <param name="classificationRunStore">Replaces the store the classification pass reads its outstanding run from; one with nothing outstanding is the default.</param>
+    /// <param name="chunkingStore">Replaces the store the cut reads its candidates from; one with nothing awaiting passages is the default.</param>
     /// <param name="unadvertisedAliases">Aliases the modelled server does not advertise.</param>
     /// <returns>A provider whose scopes resolve a synchronizer over substituted infrastructure.</returns>
     internal static ServiceProvider BuildServiceProvider(
@@ -103,6 +105,8 @@ internal static class SynchronizationTestHost
         IMailboxMutationRecordStore? mutationRecordStore = null,
         IStoredMailFolderMirrorStore? folderMirrorStore = null,
         IMailRuleEvaluationStore? ruleEvaluationStore = null,
+        ISpamClassificationRunStore? classificationRunStore = null,
+        IStoredEmailChunkingStore? chunkingStore = null,
         params string[] unadvertisedAliases)
     {
         var services = new ServiceCollection();
@@ -124,17 +128,17 @@ internal static class SynchronizationTestHost
         services.AddSingleton(new PersistenceConcurrencyOptions());
         services.AddSingleton(new MailboxSynchronizationOptions());
         services.AddSingleton(timeProvider);
-        // Every committed message is offered for embedding, so a synchronizer cannot be composed without somewhere to
+        // The run's cut offers each message it cuts for embedding, so the pass cannot be composed without somewhere to
         // offer it. Nothing here reads the backlog back; these tests are about the run, not about what embeds afterwards.
         services.AddSingleton<IEmailEmbeddingBacklog>(new ScriptedEmailEmbeddingBacklog());
-        // A committed message is also cut into passages and asked about by the classification gate, so both are composed
-        // for the same reason the backlog is. The gate's own two dependencies are registered with the classification
-        // pass further down rather than again here — the container resolves the last registration of a type, so a second
-        // pair would leave these the ones nothing reads. Classification is off there, which is what every account these
-        // tests configure runs with: the gate then admits everything and the run behaves exactly as it did before it
-        // existed.
-        services.AddSingleton(Substitute.For<IEmailChunkStore>());
         services.AddSingleton<IDerivedWorkGateTelemetry>(new RecordingDerivedWorkGateTelemetry());
+        // The classifier below reaches this to take a junk message's passages away again, which is the one thing the
+        // port does; nothing in these tests scores a message, so it is composed and never called.
+        services.AddSingleton(Substitute.For<IEmailChunkStore>());
+        // The gate's own two dependencies are registered with the classification pass further down rather than again
+        // here — the container resolves the last registration of a type, so a second pair would leave these the ones
+        // nothing reads. Classification is off there, which is what every account these tests configure runs with: the
+        // gate then admits everything and the run behaves exactly as it did before it existed.
         services.AddScoped<DerivedWorkGate>();
 
         var (catalog, resolutionStore) = CreateResolvedFolders(options, unadvertisedAliases);
@@ -212,7 +216,7 @@ internal static class SynchronizationTestHost
         // The classification walk rides the same run, one step before the rules, and a supervisor resolves it from the
         // same scope. These tests ask for no run over any mailbox, so the store below answers that the account has none
         // outstanding and the pass returns without reading a message — which is what an account nobody asked costs.
-        services.AddSingleton(CreateClassificationRunStoreWithNothingOutstanding());
+        services.AddSingleton(classificationRunStore ?? CreateClassificationRunStoreWithNothingOutstanding());
         services.AddSingleton(Substitute.For<IClassifiableEmailReader>());
         services.AddSingleton(Substitute.For<IEmailSpamClassificationStore>());
         services.AddSingleton(Substitute.For<IEmailSpamHeaderReader>());
@@ -227,6 +231,12 @@ internal static class SynchronizationTestHost
         services.AddScoped<EmailSpamClassifier>();
         services.AddScoped<SpamActionRecorder>();
         services.AddScoped<SpamClassificationPass>();
+
+        // The cut is the run's last local step, after the rules for the ordering the arrival pipeline is built on, and a
+        // supervisor resolves it from the same scope. The store answers that no message is awaiting passages, which is
+        // the state a test about folders wants: the pass issues one query and returns.
+        services.AddSingleton(chunkingStore ?? CreateChunkingStoreWithNothingToCut());
+        services.AddScoped<MailChunkingPass>();
 
         // The history's retention pass rides the same run, and a supervisor resolves it from the same scope. These
         // tests configure no mail to evaluate, so it answers that there is nothing to erase.
@@ -263,6 +273,20 @@ internal static class SynchronizationTestHost
                 Arg.Any<int>(),
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<IReadOnlyList<StoredEmailAwaitingRuleEvaluation>>([]));
+
+        return store;
+    }
+
+    /// <summary>Answers that no message is awaiting passages, which is what a run these tests configure produces.</summary>
+    private static IStoredEmailChunkingStore CreateChunkingStoreWithNothingToCut()
+    {
+        var store = Substitute.For<IStoredEmailChunkingStore>();
+
+        store.GetEmailsAwaitingChunkingAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<int>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<StoredEmailAwaitingChunking>>([]));
 
         return store;
     }

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -185,8 +185,9 @@ internal static class SynchronizationTestHost
         services.AddSingleton(folderMirrorStore ?? new RecordingMailFolderMirrorStore());
         services.AddScoped<UnmirroredMailFolderEraser>();
 
-        // The run's last local step. The default rule set declares nothing and the default store holds nothing, so a
-        // test that is not about rules pays for one query that finds no mail and no outstanding run.
+        // The step in front of the cut, which is what a run reaches after every folder it scheduled. The default rule
+        // set declares nothing and the default store holds nothing, so a test that is not about rules pays for one
+        // query that finds no mail and no outstanding run.
         services.AddSingleton(ruleEvaluationStore ?? CreateRuleStoreWithNothingToEvaluate());
         services.AddSingleton(CreateRunStoreWithNothingOutstanding());
         services.AddSingleton(CreateSourceOfAnEmptyRuleSet());

--- a/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailChunkingSelectionTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailChunkingSelectionTests.cs
@@ -1,0 +1,256 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Spam.Gating;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Spam;
+using MailFathom.Infrastructure.Persistence.Emails;
+using MailFathom.Infrastructure.Persistence.Entities;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Emails;
+
+/// <summary>Covers which mail the account run's cut selects, which is where the arrival pipeline's ordering is enforced.</summary>
+/// <remarks>
+/// The predicate is composed here and evaluated by PostgreSQL, so what these tests establish is which rows it selects
+/// rather than what SQL it becomes. Every clause it carries is one of the pipeline's orderings, and each of them fails
+/// silently when it lapses: passages cut from a message the rules were about to move, passages of junk, passages of a
+/// folder an operator asked not to have embedded, or a mailbox re-cut on every run.
+/// </remarks>
+public sealed class StoredEmailChunkingSelectionTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 13, 10, 0, 0, TimeSpan.Zero);
+
+    private static readonly MailFolderIdentity WorkInbox = new(
+        MailAccountId.Create("work"),
+        MailFolderAlias.Create("INBOX"));
+
+    private static readonly MailFolderIdentity WorkArchive = new(
+        MailAccountId.Create("work"),
+        MailFolderAlias.Create("ARCHIVE"));
+
+    /// <summary>The ordinary arrival: extracted, evaluated, admitted, and not cut yet.</summary>
+    [Fact]
+    public void Selecting_MailTheRulesHaveFinishedWith_SelectsIt()
+    {
+        // Arrange
+        var emails = Emails(Email("work", "INBOX"));
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(emails, "work", [WorkInbox], ClassificationOff);
+
+        // Assert
+        Assert.Single(selected.AsEnumerable());
+    }
+
+    /// <summary>
+    /// The ordering this pass exists for. A rule may file the message into a folder mapped differently from the one it
+    /// arrived in, so passages cut before the rules ran would be passages of a placement that had not been settled.
+    /// </summary>
+    [Fact]
+    public void Selecting_MailTheRulesHaveNotReachedYet_LeavesItOut()
+    {
+        // Arrange
+        var email = Email("work", "INBOX");
+        email.RulesEvaluatedAt = null;
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(Emails(email), "work", [WorkInbox], ClassificationOff);
+
+        // Assert
+        Assert.Empty(selected.AsEnumerable());
+    }
+
+    /// <summary>Cutting is what removes a message from this query, which is what lets the pass run without a cursor.</summary>
+    [Fact]
+    public void Selecting_MailThatAlreadyHasPassages_LeavesItOut()
+    {
+        // Arrange
+        var email = Email("work", "INBOX");
+        email.Chunks.Add(new EmailChunkEntity { StoredEmailId = email.Id, StoredEmail = email, Text = "a", ContentHash = "h" });
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(Emails(email), "work", [WorkInbox], ClassificationOff);
+
+        // Assert
+        Assert.Empty(selected.AsEnumerable());
+    }
+
+    /// <summary>A message nobody could extract text from has nothing to cut, and no later run will produce any.</summary>
+    [Fact]
+    public void Selecting_MailWithNoExtractedBody_LeavesItOut()
+    {
+        // Arrange
+        var withoutDocument = Email("work", "INBOX");
+        withoutDocument.SearchDocument = null;
+        var withoutBody = Email("work", "INBOX");
+        withoutBody.SearchDocument!.BodyText = null;
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(
+            Emails(withoutDocument, withoutBody),
+            "work",
+            [WorkInbox],
+            ClassificationOff);
+
+        // Assert
+        Assert.Empty(selected.AsEnumerable());
+    }
+
+    /// <summary>A folder mapped to embed is cut whatever the tool switch says, which is the row the table states explicitly.</summary>
+    [Fact]
+    public void Selecting_AFolderMappedToEmbedButWithheldFromTools_SelectsItsMail()
+    {
+        // Arrange
+        var emails = Emails(Email("work", "INBOX"));
+
+        // Act — the tool switch reaches no admission here, so a folder that generates embeddings is admitted either way.
+        var selected = StoredEmailChunkingStore.Selecting(emails, "work", [WorkInbox], ClassificationOff);
+
+        // Assert
+        Assert.Single(selected.AsEnumerable());
+    }
+
+    /// <summary>A folder an operator asked not to embed cuts no passages, on this path as on every other.</summary>
+    [Fact]
+    public void Selecting_AFolderNotMappedToEmbed_LeavesItsMailOut()
+    {
+        // Arrange
+        var emails = Emails(Email("work", "INBOX"));
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(emails, "work", [WorkArchive], ClassificationOff);
+
+        // Assert
+        Assert.Empty(selected.AsEnumerable());
+    }
+
+    /// <summary>An admitted set that is empty admits nothing, which is what a deployment mapping no folder to embed means.</summary>
+    [Fact]
+    public void Selecting_NoFolderMappedToEmbed_LeavesEverythingOut()
+    {
+        // Arrange
+        var emails = Emails(Email("work", "INBOX"));
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(emails, "work", [], ClassificationOff);
+
+        // Assert
+        Assert.Empty(selected.AsEnumerable());
+    }
+
+    /// <summary>One account's pass never cuts another account's mail, even under a folder alias of the same name.</summary>
+    [Fact]
+    public void Selecting_AnotherAccountsMail_LeavesItOut()
+    {
+        // Arrange
+        var emails = Emails(Email("home", "INBOX"));
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(
+            emails,
+            "work",
+            [WorkInbox, new MailFolderIdentity(MailAccountId.Create("home"), MailFolderAlias.Create("INBOX"))],
+            ClassificationOff);
+
+        // Assert
+        Assert.Empty(selected.AsEnumerable());
+    }
+
+    /// <summary>Nothing expensive happens to a message on its way to the junk folder, and the cut is where that starts.</summary>
+    [Fact]
+    public void Selecting_MailAVerdictCalledJunk_LeavesItOut()
+    {
+        // Arrange
+        var email = Email("work", "INBOX");
+        email.SpamClassification = new EmailSpamClassificationEntity
+        {
+            StoredEmailId = email.Id,
+            Verdict = SpamVerdict.Spam,
+            DecidedBy = SpamClassificationStage.Deterministic,
+            EvaluatedAt = Now,
+        };
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(Emails(email), "work", [WorkInbox], ClassificationOn);
+
+        // Assert
+        Assert.Empty(selected.AsEnumerable());
+    }
+
+    /// <summary>A message still inside the wait a verdict is allowed is held rather than cut.</summary>
+    [Fact]
+    public void Selecting_MailStillWaitingOnAVerdict_LeavesItOut()
+    {
+        // Arrange
+        var emails = Emails(Email("work", "INBOX"));
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(emails, "work", [WorkInbox], ClassificationOn);
+
+        // Assert
+        Assert.Empty(selected.AsEnumerable());
+    }
+
+    /// <summary>A row the local mailbox no longer holds is not worth a passage.</summary>
+    [Fact]
+    public void Selecting_TombstonedMail_LeavesItOut()
+    {
+        // Arrange
+        var email = Email("work", "INBOX");
+        email.RemoteExpungeObservedAt = Now;
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(Emails(email), "work", [WorkInbox], ClassificationOff);
+
+        // Assert
+        Assert.Empty(selected.AsEnumerable());
+    }
+
+    private static DerivedWorkAdmissionTerms ClassificationOff { get; } = new(
+        IsApplied: false,
+        [],
+        [],
+        Now);
+
+    private static DerivedWorkAdmissionTerms ClassificationOn { get; } = new(
+        IsApplied: true,
+        [],
+        [MailFolderAlias.Create("INBOX")],
+        Now - TimeSpan.FromMinutes(15));
+
+    private static IQueryable<StoredEmailEntity> Emails(params StoredEmailEntity[] emails) => emails.AsQueryable();
+
+    /// <summary>Builds the message the pass is meant to cut, which every test then takes one fact away from.</summary>
+    private static StoredEmailEntity Email(string accountId, string alias)
+    {
+        var email = new StoredEmailEntity
+        {
+            MailboxAccountId = accountId,
+            MailFolder = new MailFolderEntity
+            {
+                MailboxAccountId = accountId,
+                Alias = alias,
+                RemotePath = alias,
+                MailboxAccount = new MailboxAccountEntity { Id = accountId },
+            },
+            StoredAt = Now,
+            ContentAvailability = StoredEmailContentAvailability.Available,
+            RulesEvaluatedAt = Now,
+        };
+
+        email.SearchDocument = new EmailSearchDocumentEntity
+        {
+            StoredEmailId = email.Id,
+            StoredEmail = email,
+            BodyText = "a body",
+            BodyTextBeforeTrimming = "a body",
+            ExtractedAt = Now,
+        };
+
+        return email;
+    }
+}

--- a/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailChunkingSelectionTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailChunkingSelectionTests.cs
@@ -6,6 +6,7 @@ using MailFathom.Application.Spam.Gating;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Spam;
 using MailFathom.Infrastructure.Persistence.Emails;
 using MailFathom.Infrastructure.Persistence.Entities;
@@ -15,10 +16,19 @@ namespace MailFathom.Infrastructure.UnitTests.Persistence.Emails;
 
 /// <summary>Covers which mail the account run's cut selects, which is where the arrival pipeline's ordering is enforced.</summary>
 /// <remarks>
+/// <para>
 /// The predicate is composed here and evaluated by PostgreSQL, so what these tests establish is which rows it selects
 /// rather than what SQL it becomes. Every clause it carries is one of the pipeline's orderings, and each of them fails
 /// silently when it lapses: passages cut from a message the rules were about to move, passages of junk, passages of a
 /// folder an operator asked not to have embedded, or a mailbox re-cut on every run.
+/// </para>
+/// <para>
+/// What the predicate reads about a folder is the admitted list, so the tool switch is deliberately absent from these
+/// tests: it decides nothing here. That a mapping withheld from tools still reaches the list — the one row of the
+/// switch table worth stating explicitly — is asserted where the list is built, by
+/// <c>MailFolderParticipationOptionsTests.FoldersVisibleToTools_AFolderWithdrawnFromTools_LeavesItOutAndKeepsItMirrored</c>,
+/// and the two facts compose into the row.
+/// </para>
 /// </remarks>
 public sealed class StoredEmailChunkingSelectionTests
 {
@@ -98,20 +108,6 @@ public sealed class StoredEmailChunkingSelectionTests
 
         // Assert
         Assert.Empty(selected.AsEnumerable());
-    }
-
-    /// <summary>A folder mapped to embed is cut whatever the tool switch says, which is the row the table states explicitly.</summary>
-    [Fact]
-    public void Selecting_AFolderMappedToEmbedButWithheldFromTools_SelectsItsMail()
-    {
-        // Arrange
-        var emails = Emails(Email("work", "INBOX"));
-
-        // Act — the tool switch reaches no admission here, so a folder that generates embeddings is admitted either way.
-        var selected = StoredEmailChunkingStore.Selecting(emails, "work", [WorkInbox], ClassificationOff);
-
-        // Assert
-        Assert.Single(selected.AsEnumerable());
     }
 
     /// <summary>A folder an operator asked not to embed cuts no passages, on this path as on every other.</summary>
@@ -210,6 +206,64 @@ public sealed class StoredEmailChunkingSelectionTests
         Assert.Empty(selected.AsEnumerable());
     }
 
+    /// <summary>
+    /// A rule declares a move rather than performing one, and the account's next run carries it to the mail server. So
+    /// the message is still in the folder it arrived in when this run's cut comes round, and cutting it there would
+    /// derive passages under the mapping it is leaving.
+    /// </summary>
+    [Theory]
+    [InlineData(MailboxMutationStage.Recorded)]
+    [InlineData(MailboxMutationStage.PlacementIssued)]
+    [InlineData(MailboxMutationStage.PlacementConfirmed)]
+    [InlineData(MailboxMutationStage.SourceFlaggedDeleted)]
+    public void Selecting_MailARuleIsStillRelocating_LeavesItOut(MailboxMutationStage stage)
+    {
+        // Arrange
+        var email = Email("work", "INBOX");
+        email.Mutations.Add(Mutation(email, MailboxMutation.Relocate, stage));
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(Emails(email), "work", [WorkInbox], ClassificationOff);
+
+        // Assert
+        Assert.Empty(selected.AsEnumerable());
+    }
+
+    /// <summary>A relocation that has stopped converging moves nothing again, so holding the cut back for it would hold it forever.</summary>
+    [Theory]
+    [InlineData(MailboxMutationStage.Completed)]
+    [InlineData(MailboxMutationStage.Abandoned)]
+    public void Selecting_MailWhoseRelocationHasEnded_SelectsIt(MailboxMutationStage stage)
+    {
+        // Arrange
+        var email = Email("work", "INBOX");
+        email.Mutations.Add(Mutation(email, MailboxMutation.Relocate, stage));
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(Emails(email), "work", [WorkInbox], ClassificationOff);
+
+        // Assert
+        Assert.Single(selected.AsEnumerable());
+    }
+
+    /// <summary>
+    /// A copy leaves this message where it is — the second occurrence is discovered in the destination and walks the
+    /// whole pipeline itself — so the mapping this message is cut under is the one it is already in.
+    /// </summary>
+    [Fact]
+    public void Selecting_MailARuleIsCopyingElsewhere_SelectsIt()
+    {
+        // Arrange
+        var email = Email("work", "INBOX");
+        email.Mutations.Add(Mutation(email, MailboxMutation.Copy, MailboxMutationStage.Recorded));
+
+        // Act
+        var selected = StoredEmailChunkingStore.Selecting(Emails(email), "work", [WorkInbox], ClassificationOff);
+
+        // Assert
+        Assert.Single(selected.AsEnumerable());
+    }
+
     private static DerivedWorkAdmissionTerms ClassificationOff { get; } = new(
         IsApplied: false,
         [],
@@ -253,4 +307,22 @@ public sealed class StoredEmailChunkingSelectionTests
 
         return email;
     }
+
+    /// <summary>Builds the record a rule's declared change is durable as, in the stage the test is about.</summary>
+    private static MailboxMutationEntity Mutation(
+        StoredEmailEntity email,
+        MailboxMutation mutation,
+        MailboxMutationStage stage) => new()
+        {
+            StoredEmailId = email.Id,
+            StoredEmail = email,
+            MailboxAccountId = email.MailboxAccountId,
+            MailFolder = email.MailFolder,
+            Mutation = mutation.Name,
+            RequesterIdentity = "rule:file-the-newsletters",
+            RequesterOrigin = MailboxMutationOrigin.Rule,
+            Stage = stage,
+            RecordedAt = Now,
+            StageChangedAt = Now,
+        };
 }

--- a/tests/IntegrationTests/Orchestration/OrchestratedRuleEvaluationStamp.cs
+++ b/tests/IntegrationTests/Orchestration/OrchestratedRuleEvaluationStamp.cs
@@ -1,0 +1,60 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails;
+using MailFathom.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace MailFathom.IntegrationTests.Orchestration;
+
+/// <summary>Leaves on a stored message what an account run's rule pass leaves on one it has finished with.</summary>
+/// <remarks>
+/// Every path that cuts passages waits for that stamp, because the rules are the stage that may still move a message
+/// out of the folder its passages would describe. A fixture that seeds mail directly never runs a rule pass, so without
+/// this the mail it seeds is mail no cut is meant to reach — and a test asserting that something cut it would be
+/// asserting the ordering is broken. Written as a set-based update rather than through the pass itself, because what a
+/// fixture needs is the state the pass leaves rather than a second run of it.
+/// </remarks>
+internal static class OrchestratedRuleEvaluationStamp
+{
+    /// <summary>Marks one stored message as evaluated, at the instant the caller names.</summary>
+    /// <param name="services">The orchestrated services the update runs through.</param>
+    /// <param name="storedEmailId">The message to stamp.</param>
+    /// <param name="evaluatedAt">When the rules are recorded as having finished with it.</param>
+    /// <param name="cancellationToken">Cancels the update.</param>
+    /// <returns>A task that completes when the row carries the stamp.</returns>
+    internal static Task ApplyAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailId storedEmailId,
+        DateTimeOffset evaluatedAt,
+        CancellationToken cancellationToken) =>
+        StampAsync(services, storedEmailId, evaluatedAt, cancellationToken);
+
+    /// <summary>Takes the stamp off again, leaving a message the rules have not reached.</summary>
+    /// <param name="services">The orchestrated services the update runs through.</param>
+    /// <param name="storedEmailId">The message to leave unevaluated.</param>
+    /// <param name="cancellationToken">Cancels the update.</param>
+    /// <returns>A task that completes when the row carries no stamp.</returns>
+    /// <remarks>
+    /// Cheaper than seeding a second way: a fixture stamps what it stores so its ordinary mail is cuttable, and a test
+    /// about the waiting itself takes the stamp back off one message rather than the helper growing a switch every
+    /// caller then has to answer.
+    /// </remarks>
+    internal static Task ClearAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailId storedEmailId,
+        CancellationToken cancellationToken) =>
+        StampAsync(services, storedEmailId, evaluatedAt: null, cancellationToken);
+
+    private static Task<int> StampAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailId storedEmailId,
+        DateTimeOffset? evaluatedAt,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+        (scope, token) => scope.GetRequiredService<MailFathomDbContext>().StoredEmails
+            .Where(email => email.Id == storedEmailId.Value)
+            .ExecuteUpdateAsync(setters => setters.SetProperty(email => email.RulesEvaluatedAt, evaluatedAt), token),
+        cancellationToken);
+}

--- a/tests/IntegrationTests/Orchestration/SyntheticMailAccount.cs
+++ b/tests/IntegrationTests/Orchestration/SyntheticMailAccount.cs
@@ -115,6 +115,7 @@ internal sealed class SyntheticMailAccount(
         "rule-evaluation",
         "seen-state-provenance",
         "spam-scan",
+        "stale-derived-data",
         "synchronized",
         "timeline-and-search",
         "timeline-read-model",

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailChunkTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailChunkTests.cs
@@ -247,6 +247,13 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
             },
             cancellationToken);
 
+    /// <summary>Stores the message and then cuts it, which is the two-transaction shape the account run performs.</summary>
+    /// <remarks>
+    /// The cut is a second commit rather than part of the first, because that is the ordering the arrival pipeline is
+    /// built on: classification and the owner's rules run between the two, and the store reached here reads the message
+    /// back through the search document the first commit wrote. Cutting through the port the run uses is also what gives
+    /// these tests their subject — a substitute for the database could not show that a re-derivation writes nothing.
+    /// </remarks>
     private static async Task StoreAsync(
         OrchestratedMailFathomServices services,
         EmailOccurrenceId occurrenceId,
@@ -254,7 +261,7 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
         string body,
         CancellationToken cancellationToken)
     {
-        var commitResult = await services.CommitAsync(
+        var storedResult = await services.CommitAsync(
             (scope, session, token) => scope.GetRequiredService<IEmailMetadataRepository>().UpsertMetadataAsync(
                 session,
                 SyntheticEmail.RemoteMetadataOf(occurrenceId, subject),
@@ -263,8 +270,38 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
                 token),
             cancellationToken);
 
-        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+        Assert.Equal(PersistenceCommitResult.Committed, storedResult);
+
+        var storedEmailId = await FindStoredEmailIdAsync(services, occurrenceId, cancellationToken);
+        var cutResult = await services.CommitAsync(
+            (scope, session, token) => scope.GetRequiredService<IStoredEmailChunkingStore>().DeriveChunksAsync(
+                session,
+                storedEmailId,
+                token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, cutResult);
     }
+
+    private static Task<StoredEmailId> FindStoredEmailIdAsync(
+        OrchestratedMailFathomServices services,
+        EmailOccurrenceId occurrenceId,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            async (scope, token) =>
+            {
+                var alias = occurrenceId.FolderResolutionId.Alias.Value;
+
+                return StoredEmailId.Create(
+                    await scope.GetRequiredService<MailFathomDbContext>().StoredEmails
+                        .AsNoTracking()
+                        .Where(email => email.MailFolder.MailboxAccountId == occurrenceId.AccountId.Value
+                            && email.MailFolder.Alias == alias
+                            && email.UidValidity == occurrenceId.UidValidity.Value
+                            && email.Uid == occurrenceId.Uid.Value)
+                        .Select(email => email.Id)
+                        .SingleAsync(token));
+            },
+            cancellationToken);
 
     private static Task<IReadOnlyList<StoredPassage>> ReadPassagesAsync(
         OrchestratedMailFathomServices services,

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailChunkTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailChunkTests.cs
@@ -41,7 +41,7 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
     /// what will later keep a vector attached to the passage it was produced for.
     /// </summary>
     [Fact]
-    public async Task UpsertMetadataAsync_TheSameExtractionTwice_LeavesTheFirstRunsPassagesInPlace()
+    public async Task DeriveChunksAsync_TheSameExtractionTwice_LeavesTheFirstRunsPassagesInPlace()
     {
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -72,7 +72,7 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
     /// no row of the previous cut is left behind to be retrieved as though it were current.
     /// </summary>
     [Fact]
-    public async Task UpsertMetadataAsync_ChangedBodyText_ReplacesEveryPassageAndTheCascadeErasesThemWithTheEmail()
+    public async Task DeriveChunksAsync_ChangedBodyText_ReplacesEveryPassageAndTheCascadeErasesThemWithTheEmail()
     {
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -111,7 +111,7 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
     /// predicate that never matched rather than a message deliberately left uncut.
     /// </remarks>
     [Fact]
-    public async Task UpsertMetadataAsync_AFolderTheAccountLeavesUnembedded_CutsNoPassagesAndLeavesTheRestCut()
+    public async Task DeriveChunksAsync_AFolderTheAccountLeavesUnembedded_CutsNoPassagesAndLeavesTheRestCut()
     {
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -150,7 +150,7 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
     /// all. The mapped folder beside it is the control the absence needs.
     /// </remarks>
     [Fact]
-    public async Task UpsertMetadataAsync_AFolderNoMappingNames_CutsNoPassagesAndLeavesTheRestCut()
+    public async Task DeriveChunksAsync_AFolderNoMappingNames_CutsNoPassagesAndLeavesTheRestCut()
     {
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -183,7 +183,7 @@ public sealed class OrchestratedEmailChunkTests(MailFathomOrchestrationFixture o
     /// session that writes the passages, so a message and the record of what was left out of it are durable together.
     /// </remarks>
     [Fact]
-    public async Task UpsertMetadataAsync_ABodyBeyondThePerMessageCeiling_CutsToItAndRecordsTheLengthItHad()
+    public async Task DeriveChunksAsync_ABodyBeyondThePerMessageCeiling_CutsToItAndRecordsTheLengthItHad()
     {
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingBackfillTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingBackfillTests.cs
@@ -6,10 +6,13 @@ using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Embeddings.Generations;
+using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Spam.Gating;
 using MailFathom.Application.Synchronization;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
 using MailFathom.Infrastructure.Persistence;
 using MailFathom.IntegrationTests.Orchestration;
 using Microsoft.EntityFrameworkCore;
@@ -178,6 +181,73 @@ public sealed class OrchestratedEmailEmbeddingBackfillTests(MailFathomOrchestrat
         Assert.Equal(0, await CountVectorsAsync(services, unevaluated, profileId, cancellationToken));
         Assert.True(await CountPassagesAsync(services, evaluated, cancellationToken) > 0);
         Assert.True(await CountVectorsAsync(services, evaluated, profileId, cancellationToken) > 0);
+    }
+
+    /// <summary>
+    /// A message a rule has filed elsewhere is passed over too, until the move has actually landed: the stamp says the
+    /// rules finished, and the record beside it says where the message is going.
+    /// </summary>
+    /// <remarks>
+    /// A rule declares a move rather than performing one, and the account's next run carries it to the server, so
+    /// between the two the message sits in a folder it is leaving. This sweep runs on its own interval inside that
+    /// window, and passages are not undone by the message moving afterwards — so cutting it here would describe it under
+    /// the mapping it is about to leave, permanently. The settled message beside it is the control: without one, zero
+    /// passages would report a sweep that found nothing rather than one that passed this message over.
+    /// </remarks>
+    [Fact]
+    public async Task Sweeping_MailARuleIsStillMoving_CutsNothingAndEmbedsNothingOfIt()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var relocating = await StoreOneMessageAsync(services, uid: 9341, cancellationToken);
+        var settled = await StoreOneMessageAsync(services, uid: 9342, cancellationToken);
+        await RemovePassagesAsync(services, relocating, cancellationToken);
+        await RemovePassagesAsync(services, settled, cancellationToken);
+        await RecordConvergingRelocationAsync(services, relocating, uid: 9341, cancellationToken);
+        var profileId = await OrchestratedEmbeddingProfile.EnsureActiveDeterministicAsync(services, cancellationToken);
+
+        // Act
+        await SweepAsync(services, cancellationToken);
+
+        // Assert
+        Assert.Equal(0, await CountPassagesAsync(services, relocating, cancellationToken));
+        Assert.Equal(0, await CountVectorsAsync(services, relocating, profileId, cancellationToken));
+        Assert.True(await CountPassagesAsync(services, settled, cancellationToken) > 0);
+        Assert.True(await CountVectorsAsync(services, settled, profileId, cancellationToken) > 0);
+    }
+
+    /// <summary>Writes down a relocation nothing has carried to the mail server yet.</summary>
+    /// <remarks>
+    /// Opened through the port the rule pass writes through rather than by inserting a row, so the record carries the
+    /// stage a freshly authored move actually has — <see cref="MailboxMutationStage.Recorded" />, which is neither
+    /// completed nor abandoned and is therefore exactly what the sweep has to pass over.
+    /// </remarks>
+    private static async Task RecordConvergingRelocationAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailId storedEmailId,
+        uint uid,
+        CancellationToken cancellationToken)
+    {
+        var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
+        var occurrenceId = SyntheticEmail.OccurrenceIn(binding, uid);
+
+        var record = default(MailboxMutationRecord);
+        var commitResult = await services.CommitAsync(
+            async (scope, session, token) => record = await scope
+                .GetRequiredService<IMailboxMutationRecordStore>()
+                .OpenAsync(
+                    session,
+                    MailboxMutationRequest.Relocate(
+                        storedEmailId,
+                        occurrenceId,
+                        MailboxMutationRequester.Rule("file-the-newsletters", "1"),
+                        RemoteFolderPath.Create("Archive")),
+                    token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+        Assert.Equal(MailboxMutationStage.Recorded, record?.Stage);
     }
 
     /// <summary>Runs the backfill until the sweep ends, and answers with the last run that did any work.</summary>

--- a/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingBackfillTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmailEmbeddingBackfillTests.cs
@@ -147,6 +147,39 @@ public sealed class OrchestratedEmailEmbeddingBackfillTests(MailFathomOrchestrat
         Assert.True(await CountVectorsAsync(services, mapped, profileId, cancellationToken) > 0);
     }
 
+    /// <summary>
+    /// The sweep obeys the arrival pipeline's order rather than a version of it: a message the owner's rules have not
+    /// reached is not cut here, however long it has been sitting uncut.
+    /// </summary>
+    /// <remarks>
+    /// This is the ordering that is easiest to lose, because the sweep runs on its own interval while an account run is
+    /// still fetching a mailbox — so without it a first synchronization would have its mail cut by whichever of the two
+    /// got there first, before a rule had read any of it. The stamped message beside it is the control: without one,
+    /// zero passages would report a sweep that found nothing at all rather than one that passed this message over.
+    /// </remarks>
+    [Fact]
+    public async Task Sweeping_MailTheRulesHaveNotReachedYet_CutsNothingAndEmbedsNothingOfIt()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var unevaluated = await StoreOneMessageAsync(services, uid: 9331, cancellationToken);
+        var evaluated = await StoreOneMessageAsync(services, uid: 9332, cancellationToken);
+        await RemovePassagesAsync(services, unevaluated, cancellationToken);
+        await RemovePassagesAsync(services, evaluated, cancellationToken);
+        await OrchestratedRuleEvaluationStamp.ClearAsync(services, unevaluated, cancellationToken);
+        var profileId = await OrchestratedEmbeddingProfile.EnsureActiveDeterministicAsync(services, cancellationToken);
+
+        // Act
+        await SweepAsync(services, cancellationToken);
+
+        // Assert
+        Assert.Equal(0, await CountPassagesAsync(services, unevaluated, cancellationToken));
+        Assert.Equal(0, await CountVectorsAsync(services, unevaluated, profileId, cancellationToken));
+        Assert.True(await CountPassagesAsync(services, evaluated, cancellationToken) > 0);
+        Assert.True(await CountVectorsAsync(services, evaluated, profileId, cancellationToken) > 0);
+    }
+
     /// <summary>Runs the backfill until the sweep ends, and answers with the last run that did any work.</summary>
     private static async Task<StoredEmailEmbeddingBackfillResult> SweepAsync(
         OrchestratedMailFathomServices services,
@@ -215,7 +248,13 @@ public sealed class OrchestratedEmailEmbeddingBackfillTests(MailFathomOrchestrat
                 .FindResumePositionAsync(token),
             cancellationToken);
 
-    /// <summary>Stores one synthetic message, whose passages the chunk writer derives in the same session.</summary>
+    /// <summary>Stores one synthetic message with no passages, as an instance that predates chunking holds it.</summary>
+    /// <remarks>
+    /// The metadata write cuts nothing — the cut is a step of the account run rather than something a store does on its
+    /// way past — so the message is stamped as one the rules have finished with, which is the state every cutting path
+    /// waits for and the state a run would have left it in. What this seeds is therefore exactly the sweep's first
+    /// group: text, no passages, and nothing still to happen to the message before it may be cut.
+    /// </remarks>
     private static async Task<StoredEmailId> StoreOneMessageAsync(
         OrchestratedMailFathomServices services,
         uint uid,
@@ -243,6 +282,8 @@ public sealed class OrchestratedEmailEmbeddingBackfillTests(MailFathomOrchestrat
             cancellationToken);
 
         Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+
+        await OrchestratedRuleEvaluationStamp.ApplyAsync(services, storedEmailId, SyntheticEmail.SentAt, cancellationToken);
 
         return storedEmailId;
     }

--- a/tests/IntegrationTests/Persistence/OrchestratedEmbeddingWorkloadTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedEmbeddingWorkloadTests.cs
@@ -161,7 +161,13 @@ public sealed class OrchestratedEmbeddingWorkloadTests(MailFathomOrchestrationFi
             },
             cancellationToken);
 
-    /// <summary>Stores one synthetic message, whose passages the chunk writer derives in the same session.</summary>
+    /// <summary>Stores one synthetic message with no passages, as an instance that predates chunking holds it.</summary>
+    /// <remarks>
+    /// The metadata write cuts nothing — the cut is a step of the account run rather than something a store does on its
+    /// way past — so the message is stamped as one the rules have finished with, which is the state every cutting path
+    /// waits for and the state a run would have left it in. What this seeds is therefore exactly the sweep's first
+    /// group: text, no passages, and nothing still to happen to the message before it may be cut.
+    /// </remarks>
     private static async Task<StoredEmailId> StoreOneMessageAsync(
         OrchestratedMailFathomServices services,
         uint uid,
@@ -188,6 +194,8 @@ public sealed class OrchestratedEmbeddingWorkloadTests(MailFathomOrchestrationFi
             cancellationToken);
 
         Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+
+        await OrchestratedRuleEvaluationStamp.ApplyAsync(services, storedEmailId, SyntheticEmail.SentAt, cancellationToken);
 
         return storedEmailId;
     }

--- a/tests/IntegrationTests/Persistence/OrchestratedStaleDerivedDataTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedStaleDerivedDataTests.cs
@@ -213,6 +213,120 @@ public sealed class OrchestratedStaleDerivedDataTests(MailFathomOrchestrationFix
         Assert.True(countedWithoutTheExclusion > staleCount);
     }
 
+    /// <summary>A message the rules have not reached gets its extraction and none of its passages.</summary>
+    /// <remarks>
+    /// This walk is the one path that writes derived text for a message no rule pass has read, so it is the one place
+    /// the ordering could be broken silently: writing the document takes the message out of the walk, and cutting it in
+    /// the same transaction would derive passages under a folder mapping the pass that runs next may still change.
+    /// What makes the absence readable is the case below, which cuts through this same store against this same folder.
+    /// </remarks>
+    [Fact]
+    public async Task ApplyExtractionAsync_AMessageTheRulesHaveNotReached_AppliesTheExtractionAndCutsNoPassages()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
+        var stored = await InsertDocumentedEmailsAsync(services, binding, firstUid: 3030, cancellationToken);
+        var unevaluated = stored.WrittenBeforeAnyScannerWasOn;
+
+        // Act
+        await this.ApplyExtractionAsync(services, binding, unevaluated, uid: 3032, "unevaluated", cancellationToken);
+
+        // Assert
+        var document = await ReadDocumentAsync(services, unevaluated, cancellationToken);
+        Assert.Equal(CurrentStamp.Value, document.Stamp);
+        Assert.Contains("unevaluated", document.BodyText, StringComparison.Ordinal);
+
+        Assert.Empty(await ReadPassageHashesAsync(services, unevaluated, cancellationToken));
+    }
+
+    /// <summary>A message that already carries passages has them replaced, whichever stage has not reached it.</summary>
+    /// <remarks>
+    /// The waiting above is for a <em>first</em> cut. A rebuild is the only path that can replace a passage — every
+    /// other one selects on having none — so a message whose text it rewrites and whose passages it then withheld would
+    /// keep passages, and vectors built from them, derived under exactly the configuration the rebuild exists to
+    /// replace, while its stored text reported the new one. The arrangement is the state that makes that reachable: the
+    /// passages are cut while the rules have finished with the message, and the stamp is then taken back off, which is
+    /// what a rule pass rerun for a later configuration leaves behind.
+    /// </remarks>
+    [Fact]
+    public async Task ApplyExtractionAsync_AMessageThatAlreadyCarriesPassages_ReplacesThemBeforeTheRulesReachItAgain()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var binding = await OrchestratedFolderBinding.CommitAsync(services, FolderAlias, cancellationToken);
+        var stored = await InsertDocumentedEmailsAsync(services, binding, firstUid: 3040, cancellationToken);
+        var rebuilt = stored.WrittenUnderAnOlderConfiguration;
+
+        await OrchestratedRuleEvaluationStamp.ApplyAsync(services, rebuilt, SyntheticEmail.SentAt, cancellationToken);
+        await this.ApplyExtractionAsync(services, binding, rebuilt, uid: 3041, "firstcut", cancellationToken);
+        var afterTheFirstCut = await ReadPassageHashesAsync(services, rebuilt, cancellationToken);
+
+        await OrchestratedRuleEvaluationStamp.ClearAsync(services, rebuilt, cancellationToken);
+
+        // Act
+        await this.ApplyExtractionAsync(services, binding, rebuilt, uid: 3041, "secondcut", cancellationToken);
+
+        // Assert
+        var afterTheRebuild = await ReadPassageHashesAsync(services, rebuilt, cancellationToken);
+
+        // The control the case above needs: this store, this folder, and this message do produce passages, so an empty
+        // answer there is the ordering rather than an arrangement nothing could ever have cut.
+        Assert.NotEmpty(afterTheFirstCut);
+        Assert.NotEmpty(afterTheRebuild);
+        Assert.Empty(afterTheRebuild.Intersect(afterTheFirstCut, StringComparer.Ordinal));
+    }
+
+    /// <summary>Applies one extraction through the rebuilding walk's own store, in a session of its own.</summary>
+    private async Task ApplyExtractionAsync(
+        OrchestratedMailFathomServices services,
+        MailFolderResolution binding,
+        StoredEmailId storedEmailId,
+        uint uid,
+        string term,
+        CancellationToken cancellationToken)
+    {
+        var commitResult = await services.CommitAsync(
+            (scope, session, token) => this.StoreIn(scope, rebuildsStaleDerivedData: true).ApplyExtractionAsync(
+                session,
+                storedEmailId,
+                SyntheticEmail.ExtractionOf(
+                    SyntheticEmail.OccurrenceIn(binding, uid),
+                    term,
+                    SyntheticEmail.BodyTextContaining(term, wordCount: 12)),
+                token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+    }
+
+    /// <summary>Reads back what the derived document now holds for one message.</summary>
+    private static Task<DerivedDocument> ReadDocumentAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailId storedEmailId,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+        (scope, token) => scope.GetRequiredService<MailFathomDbContext>().EmailSearchDocuments
+            .AsNoTracking()
+            .Where(document => document.StoredEmailId == storedEmailId.Value)
+            .Select(document => new DerivedDocument(document.SensitiveContentStamp, document.BodyText))
+            .SingleAsync(token),
+        cancellationToken);
+
+    /// <summary>Reads the passages one message carries, as the digests that say which text they were cut from.</summary>
+    private static Task<IReadOnlyList<string>> ReadPassageHashesAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailId storedEmailId,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+        async (scope, token) => (IReadOnlyList<string>)await scope.GetRequiredService<MailFathomDbContext>().EmailChunks
+            .AsNoTracking()
+            .Where(chunk => chunk.StoredEmailId == storedEmailId.Value)
+            .OrderBy(chunk => chunk.Ordinal)
+            .Select(chunk => chunk.ContentHash)
+            .ToArrayAsync(token),
+        cancellationToken);
+
     private async Task<IReadOnlyList<StoredEmailId>> SelectAsync(
         OrchestratedMailFathomServices services,
         bool rebuildsStaleDerivedData,
@@ -397,6 +511,9 @@ public sealed class OrchestratedStaleDerivedDataTests(MailFathomOrchestrationFix
             StoredEmailId.Create(insertedIds[1]),
             StoredEmailId.Create(insertedIds[2]));
     }
+
+    /// <summary>The derived document of one message, as the two values a rebuild is judged by.</summary>
+    private sealed record DerivedDocument(string? Stamp, string? BodyText);
 
     /// <summary>The three emails one arrangement stored, named by the configuration their text was written under.</summary>
     private sealed record StoredDocuments(


### PR DESCRIPTION
Closes #732.

The arrival pipeline's five stages are meant to run in one order. Four of them already did — #688–#691 landed classification, #662–#664 landed redaction inside extraction, and #693 landed the gate — and one ran two stages early: the transaction that stored a message also cut its passages. So chunks existed before classification could withhold the message and before the owner's rules could file it into a folder mapped differently from the one it arrived in, and passages are not undone by a message moving afterwards.

## What changed

**The cut becomes the account run's last local step.** `MailChunkingPass` reads the mail whose passages the pipeline still owes — evaluated by the rules, admitted by the classification gate, in a folder its mapping embeds, carrying extracted text and no passages — cuts each message from the text the search document already holds, and offers it for embedding once its passages are durable. Cutting is what removes a message from that selection, so the pass carries no cursor, an interrupted pass repeats nothing, and a failure defers the account no more than the two passes in front of it do.

**`MailboxSynchronizer` keeps only what belongs to arrival.** The commit writes the metadata, the raw MIME, and the search document, and nothing derived past them. It still records what the gate says about each arriving message, because the two withholding answers are reached nowhere else — every later stage sees a message the gate admits or does not see it at all, so a mailbox held behind classification would otherwise read exactly like a mailbox with no mail in it.

**One reader of a stored extraction instead of two.** `EmailChunkWriter.SaveFromStoredExtractionAsync` is now what both the new pass and the embedding backfill cut through; the duplicated restore of the two stored readings goes. `IEmailChunkStore.DeriveChunksAsync` had no caller left and goes with it, leaving that port the discarding half a junk verdict uses.

**One more constraint counts as a race.** `PersistenceSessionFactory.IsConcurrencyConflict` now recognizes a violation of `ix_email_chunks_email_ordinal` as a retryable optimistic-concurrency conflict rather than as a failure. Two cutters can now meet over one message — the account run's pass and either backfill — and both derive the same passages from the same stored reading, so the loser is a run that read before the winner committed and a fresh read settles it. This reaches every writer that goes through `OptimisticConcurrencyRetryPolicy`, not only the cutters.

**The order is stated once.** `docs/architecture/arrival-pipeline.md` draws it as a Mermaid diagram — what the run waits for and what it hands off, both sidecars and which of them is shown unredacted text, the four classification outcomes and what each permits, the three re-derivation paths, and the two folder switches — and seven feature pages link to it instead of restating their own position in it.

## Verification

- `RunAsync_EveryRun_ClassifiesThenEvaluatesRulesThenCutsPassages` asserts the three local stages in order where they are composed, which is also the seam #730 will hang the classification trigger from: the call site sits where the order requires it and the run reaches it today.
- `StoredEmailChunkingSelectionTests` asserts the selection predicate over seventeen cases: the rule stamp, the two withholding answers of the classification gate — a junk verdict and a message still inside its wait — beside the admission a deployment that classifies nothing gives, the embedded-folder list, a message already cut, one with no extracted text, a tombstone, another account's mail, and — for the relocation clause below — the four converging stages of a move, the two ended ones, and a copy. The gate's two releasing answers are asserted where the gate is, in `DerivedWorkGateTests`; what this class establishes is that the selection asks it at all. The tool switch reaches no admission there, so the row worth stating explicitly rests on two facts: `MailFolderParticipationOptionsTests.FoldersVisibleToTools_AFolderWithdrawnFromTools_LeavesItOutAndKeepsItMirrored` asserts that a mapping withheld from tools still reaches `FoldersGeneratingEmbeddings`, and the selection tests assert that a folder on that list is cut.
- `MailChunkingPassTests` covers the commit-before-offer ordering, a refused offer, a released admission, an empty pass, and the batch budget.
- `OrchestratedEmailChunkTests` now stores and cuts in two transactions, which is the shape the run performs. That test had silently stopped exercising any cut when #693 moved chunking out of `UpsertMetadataAsync`; correcting it is part of this change.

## Divergences found and not corrected here

- **#809** — sensitive-content scanning is not folder-scoped. Redaction hangs on `IEmailMimeReader`, whose signature carries no folder identity, so every synchronized folder is scanned including the mapping that derives and exposes nothing. Narrowing it changes the extraction seam rather than the order the stages run in, which is what this issue is scoped to.
- **#810** — no rule can name what classification concluded. The ordering half of that user story is in place and the gate keeps junk out of the rules, but `MailRuleFact` publishes no verdict, so `spam.verdict == 'junk'` cannot be written. Adding a fact is a change to the rule contract — the name, what it reads on an unscanned message, and what it means with classification off — and none of those is settled by the ordering verified here.

## Review round

`fathom-reviewer` found the order held on the live path and lapsed on two of the three paths that re-derive the same data, and that running after the rule pass is not by itself what the pass promises. All six findings are corrected in e94d350d:

- The embedding sweep selected uncut mail on everything except the rule stamp, and it runs on its own interval while an account run is still fetching a mailbox — so a first synchronization had its mail cut there before a rule had read any of it. It now carries the stamp.
- The extraction backfill cut inside the transaction that wrote the extraction, guarded by classification alone, which cut exactly the message the rules had been skipping for want of that text. It now waits for both stages, and such a message is cut by the account's next run.
- A rule declares a move rather than performing one, and the next run converges it, so a message filed out of an embedded folder was still in that folder when the cut came round. The selection now passes over mail whose relocation is still converging; a completed or abandoned one holds nothing back, and a copy or a pending delete never did.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves; the change is where an existing derivation runs.



