### PR TITLE
[#502] Span a synchronization cycle, meter what it moves, and keep the mailbox out of both

### DIFF
--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -1,6 +1,6 @@
 # IMAP synchronization
 
-<!-- describes: src/Application/Synchronization/**, src/Domain/Synchronization/**, src/Domain/Folders/**, src/Application/Folders/**, src/Infrastructure/Mail/**, src/Application/Mail/Mutations/**, src/Domain/Mutations/** -->
+<!-- describes: src/Application/Synchronization/**, src/Domain/Synchronization/**, src/Domain/Folders/**, src/Application/Folders/**, src/Infrastructure/Mail/**, src/Application/Mail/Mutations/**, src/Domain/Mutations/**, src/Host/Hosting/Workers/MailSynchronizationCoordinator.cs, src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs, src/Host/Hosting/Workers/AccountPushNotificationWatch.cs -->
 
 MailFathom synchronizes mailboxes read-only, on a bounded schedule, and — for an account that asks for it — the moment the mail server says something changed. Both mechanisms run the same synchronization pass over the same read-only session; what differs is only what starts one.
 
@@ -129,8 +129,11 @@ readable as well as stopping being synchronized. Turning `Enabled` off stops the
 readable; removing the account does both.
 
 Supervisor logs and run records carry the account identifier, the folder alias, counts, the run duration, the
-consecutive failure count, and the current backoff, and never message-level data. They are structured log records;
-first-party metering instruments for the same values are still [pending](#pending-work).
+consecutive failure count, and the current backoff, and never message-level data. The same facts are also spanned and
+metered under MailFathom's own name: a cycle is one span with a span per folder beneath it, so a cycle that stalled is
+attributable to the folder it stalled in, and the wait before an account's next run is a gauge, so a backing-off account
+is visible without a log line being read at all. [What a synchronization cycle
+emits](../operations/telemetry.md#what-a-synchronization-cycle-emits) names each signal and what it answers.
 
 ## Bounding how much mail a run brings in
 
@@ -1748,10 +1751,6 @@ A rejected reload is logged with the configuration path and the failure identity
 - Per-account discovery. Every folder currently resolves on its own short-lived connection, so a run costs one extra
   IMAP login per configured folder on top of its synchronization session. The listing is the same for every folder of
   an account, and the per-account supervisor a run now belongs to is where one listing can serve them all.
-- Metering instruments for the rest of a supervised run. The byte volume a run moves is published through MailFathom's
-  own meter, as [Bounding how much mail a run brings in](#bounding-how-much-mail-a-run-brings-in) lists; run duration,
-  the stored and skipped counts, the consecutive failure count, and the current backoff are still structured log
-  properties alone.
 - Watching a folder the account does not synchronize. A subscription names the folders a run resolved, so a change in a
   folder nothing is configured for is not reported and would not start a pass if it were.
 - A durable audit store for mapping changes. The log-backed sink cannot join the transaction that commits a binding,

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry and the Aspire dashboard
 
-<!-- describes: src/Common/Observability/**, src/Host/Observability/**, src/Host/ServiceDefaultsExtensions.cs, src/Infrastructure/Observability/**, src/Infrastructure/HostApplicationBuilderExtensions.cs, src/AppHost/** -->
+<!-- describes: src/Common/Observability/**, src/Host/Observability/**, src/Host/ServiceDefaultsExtensions.cs, src/Infrastructure/Observability/**, src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, src/Infrastructure/HostApplicationBuilderExtensions.cs, src/AppHost/** -->
 
 The host instruments itself with OpenTelemetry throughout — logs, metrics, and traces — and exports none of it unless
 the environment names a destination. Today exactly one environment does that out of the box: a local run under the
@@ -270,6 +270,65 @@ and empty.
 An instance with `Jobs:Enabled` switched off, or one with no registered handler, publishes none of the four: its worker
 does not start, so it neither runs work nor measures the queue. The depth of a queue that instance is not draining is
 somebody else's replica to report.
+
+### What a synchronization cycle emits
+
+No instrumentation package exists for the mail library, so without what follows the part of MailFathom that spends the
+most wall-clock time would publish nothing of its own at all. Two spans and eight instruments answer the two questions
+an operator opens a dashboard with: is this account still synchronizing, and if it is slow, which part of it is.
+
+One account's cycle opens **`synchronize_account`**, and each folder it works opens **`synchronize_folder`** beneath it.
+That nesting is the whole point of the pair — a cycle whose duration doubled is attributable to the folder it doubled
+in rather than to the account as a whole — and the records the same cycle already logs carry the trace and span
+identifiers of whichever of the two they were written inside, so a count in a log line and the span it belongs to are
+one thing.
+
+| Tag | Where | What it carries |
+| --- | --- | --- |
+| `mailfathom.mail.account` | Both | MailFathom's own configured alias for the account |
+| `mailfathom.mail.folder` | Folder | MailFathom's own configured alias for the folder |
+| `mailfathom.mail.sync.outcome` | Both | How it ended: `succeeded`, `failed`, `interrupted`, and for a folder also `alias_unresolved` or `alias_ambiguous` |
+| `mailfathom.mail.sync.failure` | Folder | What stopped it: `concurrency_conflict`, `mail_server_unavailable`, or `unexpected` |
+| `mailfathom.mail.sync.folders`, `…folders.failed` | Cycle | How many folders the cycle scheduled, and how many did not complete |
+| `mailfathom.mail.sync.stored`, `…skipped` | Folder | What the folder stored with its content, and what it recorded from the envelope alone |
+
+`interrupted` is deliberately not `failed`. Shutdown is what produces it, and an account backed off for every restart
+would be an account approached less often for having been stopped. An alias that named no single advertised folder is
+kept apart for the same reason: it is a configuration mistake an edit remedies, so it is an outcome rather than a
+failure, and it counts against nothing.
+
+| Instrument | What it answers |
+| --- | --- |
+| `mailfathom.mail.sync.run.duration` | How long one account's cycle took, by account and outcome |
+| `mailfathom.mail.sync.emails.stored` | Messages a folder run stored with their content, by account and folder |
+| `mailfathom.mail.sync.emails.skipped` | Messages it recorded from their envelope alone because they exceeded the size limit |
+| `mailfathom.mail.sync.failures` | Folder runs that did not complete, by what stopped them |
+| `mailfathom.mail.sync.backoff` | How long each account waits before its next run, which is its configured interval until a run fails |
+| `mailfathom.mail.sync.consecutive_failures` | How many of that account's runs failed in a row |
+| `mailfathom.mail.sync.runs.queued` | Account cycles waiting for one of the slots that bound how many accounts run at once |
+| `mailfathom.mail.sync.runs.active` | Account cycles holding one of those slots |
+
+The counts are separate from the byte volume above rather than a second view of it: one message is anywhere between a
+kilobyte and the size limit, so how much a mailbox costs and how much of it has arrived are different questions.
+
+The wait and the failure count are published together because neither is readable alone — a wait says nothing about
+health without the interval it is being compared against, and a failure count says nothing about when the server will
+next be approached. Both are republished on every pass rather than only while an account is backing off, so an account
+that recovered stops reporting the wait it was deferred by instead of holding it, and an account nothing supervises any
+more stops reporting altogether. A rising `consecutive_failures` against a flat `runs.active` is the reading worth
+alerting on: an account being deferred rather than run.
+
+The queue depth is the wait for a slot, which is why the cycle's span opens only once the account holds one — a
+duration that included the wait would report the accounts in front of it as this account's own work.
+`runs.queued` standing at the account count while `runs.active` sits at the configured bound is a pipeline saturated by
+that bound rather than an idle one, which is a distinction nothing else here makes.
+
+Nothing published by any of this is derived from a message. The dimensions are the two configured aliases and closed
+sets of MailFathom's own words, and the values are counts and durations — no UID, no message identifier, no address, no
+subject, and no remote folder path, each of which would open a time series per message or per person. The mail library
+itself reaches none of it either: every IMAP client this deployment opens is constructed without a protocol logger, so
+the commands, responses, and payloads of a session are written nowhere for a log level or a setting to expose, and no
+configuration key exists that could attach one.
 
 ### Answering spend
 

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -265,6 +265,16 @@ internal sealed partial class AccountSynchronizationSupervisor
             this.accountRunSlots.Release();
         }
 
+        // A cycle the host stopped scheduling did not finish, and its failure count says nothing about that: a folder
+        // still queued behind the folder bound returns without being started, so it raises no count and would leave
+        // a cycle that skipped most of its work reporting a clean run. Leaving the scope unreported publishes it as
+        // interrupted, which is what a folder cut off by the same shutdown already reports, and the line is withheld
+        // for the same reason — the supervisor logs the stop itself, and there is no finished run to announce.
+        if (schedulingToken.IsCancellationRequested)
+        {
+            return new AccountRunOutcome(failedFolderCount > 0 || convergenceFailed, [.. resolvedFolders]);
+        }
+
         run.Completed(scheduledFolders.Length, failedFolderCount, convergenceFailed);
 
         this.LogAccountRunFinished(

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -43,8 +43,8 @@ internal sealed partial class AccountSynchronizationSupervisor
     private readonly ISettingsSnapshot<MailSynchronizationOptions> settings;
     private readonly SemaphoreSlim accountRunSlots;
     private readonly AccountPushNotificationWatch pushNotifications;
+    private readonly MailSynchronizationTelemetry telemetry;
     private readonly ILogger<AccountSynchronizationSupervisor> logger;
-    private readonly TimeProvider timeProvider;
 
     /// <summary>Initializes a supervisor for one configured account.</summary>
     /// <param name="accountId">The account this supervisor synchronizes and names in every line it logs.</param>
@@ -52,24 +52,24 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// <param name="settings">Supplies the snapshot every run is scheduled from.</param>
     /// <param name="accountRunSlots">Bounds how many accounts run at once; owned by the coordinator and never released beyond what this supervisor took.</param>
     /// <param name="pushNotifications">Ends the wait between runs early when a watched folder changes; owned by this supervisor and disposed with it.</param>
+    /// <param name="telemetry">Publishes the run as a span with its folders beneath it, and the counts and waits an operator reads without opening a log; it also measures how long a run took.</param>
     /// <param name="logger">Records run outcomes, which carry account and folder aliases and no message-level data.</param>
-    /// <param name="timeProvider">Measures run duration and the wait between runs.</param>
     public AccountSynchronizationSupervisor(
         MailAccountId accountId,
         IServiceScopeFactory scopeFactory,
         ISettingsSnapshot<MailSynchronizationOptions> settings,
         SemaphoreSlim accountRunSlots,
         AccountPushNotificationWatch pushNotifications,
-        ILogger<AccountSynchronizationSupervisor> logger,
-        TimeProvider timeProvider)
+        MailSynchronizationTelemetry telemetry,
+        ILogger<AccountSynchronizationSupervisor> logger)
     {
         this.accountId = accountId;
         this.scopeFactory = scopeFactory;
         this.settings = settings;
         this.accountRunSlots = accountRunSlots;
         this.pushNotifications = pushNotifications;
+        this.telemetry = telemetry;
         this.logger = logger;
-        this.timeProvider = timeProvider;
     }
 
     /// <summary>Supervises the account until scheduling stops or the account leaves configuration.</summary>
@@ -109,6 +109,10 @@ internal sealed partial class AccountSynchronizationSupervisor
             // ended by starting a new one, and a connection left open by the previous one would be a connection nothing
             // is left to close.
             await this.pushNotifications.DisposeAsync();
+
+            // The schedule goes with them, for the same reason: an account nothing is scheduling any more would
+            // otherwise publish the wait it was last scheduled behind for the life of the process.
+            this.telemetry.RecordSupervisionEnded(this.accountId);
         }
     }
 
@@ -142,6 +146,10 @@ internal sealed partial class AccountSynchronizationSupervisor
                 runSettings.Interval,
                 runSettings.MaxFailureBackoff,
                 consecutiveFailureCount);
+
+            // Published on every pass rather than only on a backed-off one, because a gauge that stops being written
+            // holds its last value: an account that recovered would go on reporting the wait it was backing off by.
+            this.telemetry.RecordScheduledDelay(this.accountId, delayBeforeNextRun, consecutiveFailureCount);
 
             if (consecutiveFailureCount > 0)
             {
@@ -194,9 +202,14 @@ internal sealed partial class AccountSynchronizationSupervisor
         var failedFolderCount = 0;
         var convergenceFailed = false;
 
-        await this.accountRunSlots.WaitAsync(schedulingToken);
+        // The wait for a slot is counted and the run itself is spanned, which is the split that keeps a cycle's
+        // duration the cycle rather than the cycle plus however long the accounts in front of it took.
+        using (this.telemetry.EnterRunQueue())
+        {
+            await this.accountRunSlots.WaitAsync(schedulingToken);
+        }
 
-        var startedAt = this.timeProvider.GetTimestamp();
+        using var run = this.telemetry.BeginAccountRun(this.accountId);
 
         try
         {
@@ -252,13 +265,13 @@ internal sealed partial class AccountSynchronizationSupervisor
             this.accountRunSlots.Release();
         }
 
-        var runDuration = this.timeProvider.GetElapsedTime(startedAt);
+        run.Completed(scheduledFolders.Length, failedFolderCount, convergenceFailed);
 
         this.LogAccountRunFinished(
             this.accountId.Value,
             scheduledFolders.Length,
             failedFolderCount,
-            runDuration);
+            run.Elapsed);
 
         return new AccountRunOutcome(failedFolderCount > 0 || convergenceFailed, [.. resolvedFolders]);
     }
@@ -633,6 +646,11 @@ internal sealed partial class AccountSynchronizationSupervisor
     {
         var folderAlias = configuredFolder.Alias;
 
+        // Opened before the mapping is built, so a folder whose configuration reached the run unusable is a span with
+        // a failure on it rather than a gap under the cycle. The alias is carried by the outcome for the same reason:
+        // until the mapping exists there is only the configured spelling of it.
+        using var folderRun = this.telemetry.BeginFolderRun(this.accountId);
+
         try
         {
             var folderMapping = configuredFolder.CreateMapping();
@@ -652,29 +670,37 @@ internal sealed partial class AccountSynchronizationSupervisor
                 folderAlias,
                 remotelyDeletedEmailDisposition,
                 result,
-                scope.ServiceProvider.GetRequiredService<MailboxContentVolumeTelemetry>());
+                scope.ServiceProvider.GetRequiredService<MailboxContentVolumeTelemetry>(),
+                folderRun);
 
             return new FolderRunOutcome(Succeeded: true, result.Folder);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Shutdown rather than a defect, so the folder is recorded as interrupted and counted under no failure:
+            // an account backed off for every restart would be an account approached less often for being stopped.
+            folderRun.Interrupted(folderAlias);
+
             throw;
         }
         catch (PersistenceConcurrencyConflictException exception)
         {
             this.LogFolderSynchronizationDeferredAfterConcurrencyConflict(exception, this.accountId.Value, folderAlias);
+            folderRun.ConcurrencyConflict(folderAlias);
 
             return FolderRunOutcome.Failed;
         }
         catch (MailboxUnavailableException exception)
         {
             this.LogFolderSynchronizationDeferredAfterMailServerUnavailable(exception, this.accountId.Value, folderAlias);
+            folderRun.MailServerUnavailable(folderAlias);
 
             return FolderRunOutcome.Failed;
         }
         catch (Exception exception)
         {
             this.LogFolderSynchronizationFailed(exception, this.accountId.Value, folderAlias);
+            folderRun.UnexpectedFailure(folderAlias);
 
             return FolderRunOutcome.Failed;
         }
@@ -685,11 +711,13 @@ internal sealed partial class AccountSynchronizationSupervisor
         string folderAlias,
         RemotelyDeletedEmailDisposition remotelyDeletedEmailDisposition,
         MailboxSynchronizationResult result,
-        MailboxContentVolumeTelemetry contentVolumeTelemetry)
+        MailboxContentVolumeTelemetry contentVolumeTelemetry,
+        MailSynchronizationTelemetry.FolderRunScope folderRun)
     {
         if (result.Outcome == MailboxSynchronizationOutcome.FolderAliasUnresolved)
         {
             this.LogFolderAliasUnresolved(this.accountId.Value, folderAlias);
+            folderRun.AliasUnresolved(folderAlias);
 
             return;
         }
@@ -697,6 +725,7 @@ internal sealed partial class AccountSynchronizationSupervisor
         if (result.Outcome == MailboxSynchronizationOutcome.FolderAliasAmbiguous)
         {
             this.LogFolderAliasAmbiguous(this.accountId.Value, folderAlias);
+            folderRun.AliasAmbiguous(folderAlias);
 
             return;
         }
@@ -717,6 +746,8 @@ internal sealed partial class AccountSynchronizationSupervisor
                 result.RelocatedEmailCount,
                 result.Reconciliation.OwnMutationCompletedEmailCount);
         }
+
+        folderRun.Synchronized(folderAlias, result.StoredEmailCount, result.SkippedOversizedEmailCount);
 
         // Published only for a folder the run actually reached, because the level it carries is a measurement rather
         // than a count: an alias that resolved to nothing measured nothing, and publishing its empty volume would move

--- a/src/Host/Hosting/Workers/MailSynchronizationCoordinator.cs
+++ b/src/Host/Hosting/Workers/MailSynchronizationCoordinator.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using MailFathom.Domain.Accounts;
 using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Mail;
+using MailFathom.Infrastructure.Observability;
 
 namespace MailFathom.Host.Hosting.Workers;
 
@@ -29,6 +30,7 @@ internal sealed partial class MailSynchronizationCoordinator : BackgroundService
     private readonly Dictionary<string, Task> supervisedAccounts = new(StringComparer.Ordinal);
     private readonly IServiceScopeFactory scopeFactory;
     private readonly ISettingsSnapshot<MailSynchronizationOptions> settings;
+    private readonly MailSynchronizationTelemetry telemetry;
     private readonly ILoggerFactory loggerFactory;
     private readonly ILogger<MailSynchronizationCoordinator> logger;
     private readonly TimeProvider timeProvider;
@@ -36,11 +38,13 @@ internal sealed partial class MailSynchronizationCoordinator : BackgroundService
     /// <summary>Initializes a new mail synchronization coordinator.</summary>
     /// <param name="scopeFactory">Creates the scope each folder work unit runs in.</param>
     /// <param name="settings">Supplies the snapshot the supervised account set is read from.</param>
+    /// <param name="telemetry">Published to by every supervisor this coordinator starts, which is why one instance is handed to all of them.</param>
     /// <param name="loggerFactory">Supplies this coordinator's logger and the logger of every supervisor it starts, so a supervisor logs under its own category.</param>
     /// <param name="timeProvider">Drives the supervision interval and bounds the shutdown drain.</param>
     public MailSynchronizationCoordinator(
         IServiceScopeFactory scopeFactory,
         ISettingsSnapshot<MailSynchronizationOptions> settings,
+        MailSynchronizationTelemetry telemetry,
         ILoggerFactory loggerFactory,
         TimeProvider timeProvider)
     {
@@ -48,6 +52,7 @@ internal sealed partial class MailSynchronizationCoordinator : BackgroundService
 
         this.scopeFactory = scopeFactory;
         this.settings = settings;
+        this.telemetry = telemetry;
         this.loggerFactory = loggerFactory;
         this.logger = loggerFactory.CreateLogger<MailSynchronizationCoordinator>();
         this.timeProvider = timeProvider;
@@ -143,8 +148,8 @@ internal sealed partial class MailSynchronizationCoordinator : BackgroundService
             this.settings,
             accountRunSlots,
             pushNotifications,
-            this.loggerFactory.CreateLogger<AccountSynchronizationSupervisor>(),
-            this.timeProvider);
+            this.telemetry,
+            this.loggerFactory.CreateLogger<AccountSynchronizationSupervisor>());
 
         return supervisor.RunAsync(schedulingToken, workUnitToken);
     }

--- a/src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs
+++ b/src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs
@@ -1,0 +1,29 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailKit.Net.Imap;
+
+namespace MailFathom.Infrastructure.Mail.MailKit;
+
+/// <summary>Creates every IMAP client this deployment opens, and is the one place a protocol logger could be attached.</summary>
+/// <remarks>
+/// <para>
+/// MailKit writes the bytes of a session — every command, every response, and the envelopes and payloads inside them —
+/// to the protocol logger it was constructed with, and to nothing else. A client built with none writes them nowhere,
+/// which is what makes "no mail reaches a log or an exporter through the mail library" a property of construction
+/// rather than of a level, a category filter, or a configuration key somebody could set. There is no such key, and this
+/// type is why one could not be honoured without passing through the test that asserts the opposite.
+/// </para>
+/// <para>
+/// It exists for that invariant alone. A client needs no other arrangement at construction — its timeouts, its
+/// transport security, and its authentication are settled by the connection that opens it — so a second reason to route
+/// construction through here would be a reason to question this one.
+/// </para>
+/// </remarks>
+internal static class MailKitImapClientFactory
+{
+    /// <summary>Creates an IMAP client that writes no protocol traffic anywhere.</summary>
+    /// <returns>A disconnected client, owned by the caller.</returns>
+    internal static ImapClient CreateWithoutProtocolLogging() => new();
+}

--- a/src/Infrastructure/Observability/MailSynchronizationTelemetry.cs
+++ b/src/Infrastructure/Observability/MailSynchronizationTelemetry.cs
@@ -1,0 +1,436 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using MailFathom.Common.Observability;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Infrastructure.Observability;
+
+/// <summary>Makes a synchronization cycle readable as work rather than as a sequence of log lines.</summary>
+/// <remarks>
+/// <para>
+/// No instrumentation package exists for the library this subsystem talks to, so the part of MailFathom that spends the
+/// most wall-clock time would otherwise publish nothing at all. What is published here answers the two questions an
+/// operator opens a dashboard with: is this account still synchronizing, and if it is slow, which part of it is. The
+/// first is the account's schedule, which the gauges carry; the second is the cycle span with one child per folder,
+/// which is what attributes a stalled cycle to the folder it stalled in instead of to the account as a whole.
+/// </para>
+/// <para>
+/// A cycle's span opens once the account holds one of the slots that bound how many accounts run at once, so its
+/// duration is the run rather than the run plus its wait. The wait is not lost: it is the queue depth beside it, which
+/// is what separates a pipeline that is idle from one whose accounts are all queued behind a bound an operator could
+/// raise.
+/// </para>
+/// <para>
+/// The dimensions are MailFathom's own configured account and folder aliases and closed sets of its own words. Nothing
+/// per email, per UID, per address, or per subject appears, and no remote folder path does — every one of those would
+/// open a time series per message or per person quite apart from putting mail in a span store. Nothing MailKit reports
+/// reaches any of this either: MailFathom attaches no protocol logger to any client it opens, so protocol traffic is
+/// written nowhere for a level or a setting to expose.
+/// </para>
+/// </remarks>
+public sealed class MailSynchronizationTelemetry
+{
+    /// <summary>The name one account's synchronization cycle opens its span under.</summary>
+    /// <remarks>
+    /// Named after the operation rather than after the worker that drives it, so the span reads as the work that was
+    /// done and stays right if the cycle is ever scheduled from somewhere else.
+    /// </remarks>
+    internal const string AccountRunSpanName = "synchronize_account";
+
+    /// <summary>The name one folder's turn through a cycle opens its span under, always beneath the span above.</summary>
+    internal const string FolderRunSpanName = "synchronize_folder";
+
+    internal const string AccountTagName = "mailfathom.mail.account";
+    internal const string FolderTagName = "mailfathom.mail.folder";
+    internal const string OutcomeTagName = "mailfathom.mail.sync.outcome";
+    internal const string FailureTagName = "mailfathom.mail.sync.failure";
+    internal const string ScheduledFolderCountTagName = "mailfathom.mail.sync.folders";
+    internal const string FailedFolderCountTagName = "mailfathom.mail.sync.folders.failed";
+    internal const string StoredEmailCountTagName = "mailfathom.mail.sync.stored";
+    internal const string SkippedEmailCountTagName = "mailfathom.mail.sync.skipped";
+
+    internal const string SucceededOutcomeName = "succeeded";
+    internal const string FailedOutcomeName = "failed";
+
+    /// <summary>Names a cycle or a folder that ended without reporting how, which is what shutdown produces.</summary>
+    internal const string InterruptedOutcomeName = "interrupted";
+
+    internal const string AliasUnresolvedOutcomeName = "alias_unresolved";
+    internal const string AliasAmbiguousOutcomeName = "alias_ambiguous";
+
+    internal const string ConcurrencyConflictFailureName = "concurrency_conflict";
+    internal const string MailServerUnavailableFailureName = "mail_server_unavailable";
+    internal const string UnexpectedFailureName = "unexpected";
+
+    private readonly ConcurrentDictionary<string, AccountSchedule> scheduleByAccount = new(StringComparer.Ordinal);
+    private readonly TimeProvider timeProvider;
+    private readonly Histogram<double> runDuration;
+    private readonly Counter<long> storedEmails;
+    private readonly Counter<long> skippedEmails;
+    private readonly Counter<long> failures;
+
+    private long queuedRunCount;
+    private long activeRunCount;
+
+    /// <summary>Initializes the instruments a synchronization cycle is published through.</summary>
+    /// <param name="timeProvider">Measures how long a cycle took.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeProvider" /> is <see langword="null" />.</exception>
+    public MailSynchronizationTelemetry(TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        this.timeProvider = timeProvider;
+
+        this.runDuration = Telemetry.Meter.CreateHistogram<double>(
+            "mailfathom.mail.sync.run.duration",
+            unit: "s",
+            description: "How long one account's synchronization cycle took, by account and outcome.");
+        this.storedEmails = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.mail.sync.emails.stored",
+            unit: "{email}",
+            description: "Messages a folder run stored with their content, by account and folder alias.");
+        this.skippedEmails = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.mail.sync.emails.skipped",
+            unit: "{email}",
+            description: "Messages a folder run recorded from their envelope alone because they exceeded the size limit, by account and folder alias.");
+        this.failures = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.mail.sync.failures",
+            unit: "{failure}",
+            description: "Folder runs that did not complete, by account, folder alias, and what stopped them.");
+
+        Telemetry.Meter.CreateObservableGauge(
+            "mailfathom.mail.sync.backoff",
+            this.ObserveBackoff,
+            unit: "s",
+            description: "How long each account waits before its next synchronization run, which is its configured interval until a run fails.");
+        Telemetry.Meter.CreateObservableGauge(
+            "mailfathom.mail.sync.consecutive_failures",
+            this.ObserveConsecutiveFailures,
+            unit: "{run}",
+            description: "How many synchronization runs of each account failed in a row, which is what the wait beside it is derived from.");
+        Telemetry.Meter.CreateObservableGauge(
+            "mailfathom.mail.sync.runs.queued",
+            this.ObserveQueuedRuns,
+            unit: "{run}",
+            description: "Account synchronization runs waiting for one of the slots that bound how many accounts run at once.");
+        Telemetry.Meter.CreateObservableGauge(
+            "mailfathom.mail.sync.runs.active",
+            this.ObserveActiveRuns,
+            unit: "{run}",
+            description: "Account synchronization runs holding one of those slots.");
+    }
+
+    /// <summary>Counts one account run as waiting for a slot until the returned scope is disposed.</summary>
+    /// <returns>The scope, which the caller disposes as soon as the wait ends however it ended.</returns>
+    /// <remarks>
+    /// The wait is counted rather than spanned, because a run that has not started is not work a trace can attribute
+    /// anything to. What an operator needs from it is a level: how many accounts are queued behind the bound right now.
+    /// </remarks>
+    public IDisposable EnterRunQueue()
+    {
+        Interlocked.Increment(ref this.queuedRunCount);
+
+        return new QueuedRun(this);
+    }
+
+    /// <summary>Opens the span one account's synchronization cycle is reported as, and returns the scope that ends it.</summary>
+    /// <param name="accountId">The account whose cycle is beginning.</param>
+    /// <returns>The scope, which the caller must dispose; a scope disposed without <see cref="AccountRunScope.Completed" /> reports an interrupted cycle.</returns>
+    public AccountRunScope BeginAccountRun(MailAccountId accountId)
+    {
+        var activity = Telemetry.ActivitySource.StartActivity(AccountRunSpanName);
+        activity?.SetTag(AccountTagName, accountId.Value);
+
+        Interlocked.Increment(ref this.activeRunCount);
+
+        return new AccountRunScope(this, accountId, activity, this.timeProvider.GetTimestamp());
+    }
+
+    /// <summary>Opens the span one folder's turn through a cycle is reported as, beneath the cycle's own span.</summary>
+    /// <param name="accountId">The account the folder belongs to.</param>
+    /// <returns>The scope, which the caller must dispose after recording how the folder ended.</returns>
+    /// <remarks>
+    /// The folder alias is carried by the outcome rather than by this call, because a mapping that reached the run
+    /// unusable has only the configured alias to name until it has been turned into one.
+    /// </remarks>
+    public FolderRunScope BeginFolderRun(MailAccountId accountId)
+    {
+        var activity = Telemetry.ActivitySource.StartActivity(FolderRunSpanName, ActivityKind.Client);
+        activity?.SetTag(AccountTagName, accountId.Value);
+
+        return new FolderRunScope(this, accountId, activity);
+    }
+
+    /// <summary>Publishes the wait an account's next run is scheduled behind, and the failure count that produced it.</summary>
+    /// <param name="accountId">The account the wait belongs to.</param>
+    /// <param name="delayBeforeNextRun">What the run backoff decided, which is the configured interval while nothing is failing.</param>
+    /// <param name="consecutiveFailureCount">How many of the account's runs have failed in a row.</param>
+    /// <remarks>
+    /// Both are published because neither is readable alone: a wait says nothing about health without the interval it
+    /// is being compared against, and a failure count says nothing about when the server will next be approached.
+    /// </remarks>
+    public void RecordScheduledDelay(
+        MailAccountId accountId,
+        TimeSpan delayBeforeNextRun,
+        int consecutiveFailureCount) =>
+        this.scheduleByAccount[accountId.Value] =
+            new AccountSchedule(delayBeforeNextRun, consecutiveFailureCount);
+
+    /// <summary>Stops publishing an account's schedule, because nothing is scheduling it any more.</summary>
+    /// <param name="accountId">The account whose supervision has ended.</param>
+    /// <remarks>
+    /// An account the operator removed, or one whose supervisor ended, would otherwise report the wait it was last
+    /// scheduled behind for the life of the process — a flat line that reads as an account waiting rather than as one
+    /// nobody is running.
+    /// </remarks>
+    public void RecordSupervisionEnded(MailAccountId accountId) =>
+        this.scheduleByAccount.TryRemove(accountId.Value, out _);
+
+    private void LeaveRunQueue() => Interlocked.Decrement(ref this.queuedRunCount);
+
+    private void EndAccountRun(MailAccountId accountId, string outcome, TimeSpan elapsed)
+    {
+        Interlocked.Decrement(ref this.activeRunCount);
+
+        this.runDuration.Record(
+            elapsed.TotalSeconds,
+            new TagList
+            {
+                { AccountTagName, accountId.Value },
+                { OutcomeTagName, outcome },
+            });
+    }
+
+    private void RecordFolderSynchronized(
+        MailAccountId accountId,
+        string folderAlias,
+        int storedEmailCount,
+        int skippedEmailCount)
+    {
+        var tags = new TagList
+        {
+            { AccountTagName, accountId.Value },
+            { FolderTagName, folderAlias },
+        };
+
+        this.storedEmails.Add(storedEmailCount, tags);
+        this.skippedEmails.Add(skippedEmailCount, tags);
+    }
+
+    private void RecordFolderFailure(MailAccountId accountId, string folderAlias, string failure) =>
+        this.failures.Add(
+            1,
+            new TagList
+            {
+                { AccountTagName, accountId.Value },
+                { FolderTagName, folderAlias },
+                { FailureTagName, failure },
+            });
+
+    private TimeSpan ElapsedSince(long startingTimestamp) => this.timeProvider.GetElapsedTime(startingTimestamp);
+
+    private IEnumerable<Measurement<double>> ObserveBackoff() =>
+    [
+        .. this.scheduleByAccount.Select(account => new Measurement<double>(
+            account.Value.DelayBeforeNextRun.TotalSeconds,
+            new TagList { { AccountTagName, account.Key } })),
+    ];
+
+    private IEnumerable<Measurement<long>> ObserveConsecutiveFailures() =>
+    [
+        .. this.scheduleByAccount.Select(account => new Measurement<long>(
+            account.Value.ConsecutiveFailureCount,
+            new TagList { { AccountTagName, account.Key } })),
+    ];
+
+    private Measurement<long> ObserveQueuedRuns() => new(Interlocked.Read(ref this.queuedRunCount));
+
+    private Measurement<long> ObserveActiveRuns() => new(Interlocked.Read(ref this.activeRunCount));
+
+    /// <summary>What an account's supervisor last decided about when it runs again.</summary>
+    /// <param name="DelayBeforeNextRun">The wait the run backoff produced, which is the configured interval while nothing is failing.</param>
+    /// <param name="ConsecutiveFailureCount">How many of the account's runs failed in a row.</param>
+    private readonly record struct AccountSchedule(TimeSpan DelayBeforeNextRun, int ConsecutiveFailureCount);
+
+    /// <summary>Holds one account run's place in the queue for a slot until the wait ends.</summary>
+    private sealed class QueuedRun(MailSynchronizationTelemetry telemetry) : IDisposable
+    {
+        private bool left;
+
+        public void Dispose()
+        {
+            if (this.left)
+            {
+                return;
+            }
+
+            this.left = true;
+            telemetry.LeaveRunQueue();
+        }
+    }
+
+    /// <summary>Carries one account's cycle from the moment it takes a slot to the outcome that ends it.</summary>
+    /// <remarks>
+    /// A cycle that never reported an outcome is published as interrupted rather than as failed. Shutdown is what
+    /// produces one, and counting it as a failure would make every restart look like an account that stopped working.
+    /// </remarks>
+    public sealed class AccountRunScope : IDisposable
+    {
+        private readonly MailSynchronizationTelemetry telemetry;
+        private readonly MailAccountId accountId;
+        private readonly Activity? activity;
+        private readonly long startingTimestamp;
+
+        private string outcome = InterruptedOutcomeName;
+        private bool reported;
+
+        internal AccountRunScope(
+            MailSynchronizationTelemetry telemetry,
+            MailAccountId accountId,
+            Activity? activity,
+            long startingTimestamp)
+        {
+            this.telemetry = telemetry;
+            this.accountId = accountId;
+            this.activity = activity;
+            this.startingTimestamp = startingTimestamp;
+        }
+
+        /// <summary>Gets how long the cycle has been running, which is its duration once the work is done.</summary>
+        public TimeSpan Elapsed => this.telemetry.ElapsedSince(this.startingTimestamp);
+
+        /// <summary>Records what the cycle turned out to have done.</summary>
+        /// <param name="scheduledFolderCount">How many folders the cycle was scheduled to synchronize.</param>
+        /// <param name="failedFolderCount">How many of them did not complete.</param>
+        /// <param name="convergenceFailed">Whether the pass that carries outstanding mailbox changes failed.</param>
+        public void Completed(int scheduledFolderCount, int failedFolderCount, bool convergenceFailed)
+        {
+            this.outcome = failedFolderCount > 0 || convergenceFailed ? FailedOutcomeName : SucceededOutcomeName;
+
+            this.activity?.SetTag(ScheduledFolderCountTagName, scheduledFolderCount);
+            this.activity?.SetTag(FailedFolderCountTagName, failedFolderCount);
+            this.activity?.SetStatus(
+                failedFolderCount > 0 || convergenceFailed ? ActivityStatusCode.Error : ActivityStatusCode.Ok);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (this.reported)
+            {
+                return;
+            }
+
+            this.reported = true;
+
+            this.activity?.SetTag(OutcomeTagName, this.outcome);
+            this.telemetry.EndAccountRun(this.accountId, this.outcome, this.Elapsed);
+            this.activity?.Dispose();
+        }
+    }
+
+    /// <summary>Carries one folder's turn through a cycle from the span that opens it to the outcome that ends it.</summary>
+    /// <remarks>
+    /// An alias the mail server advertises no single folder for is an outcome of its own rather than a failure, which
+    /// is the same distinction the supervisor draws when it decides whether to back the account off: a configuration
+    /// mistake is remedied by an edit, and counting it as a failure would put a working account into backoff.
+    /// </remarks>
+    public sealed class FolderRunScope : IDisposable
+    {
+        private readonly MailSynchronizationTelemetry telemetry;
+        private readonly MailAccountId accountId;
+        private readonly Activity? activity;
+
+        private bool reported;
+
+        internal FolderRunScope(
+            MailSynchronizationTelemetry telemetry,
+            MailAccountId accountId,
+            Activity? activity)
+        {
+            this.telemetry = telemetry;
+            this.accountId = accountId;
+            this.activity = activity;
+        }
+
+        /// <summary>Records a folder that was synchronized, and what it brought in.</summary>
+        /// <param name="folderAlias">MailFathom's own name for the folder.</param>
+        /// <param name="storedEmailCount">How many messages were stored with their content.</param>
+        /// <param name="skippedEmailCount">How many were recorded from their envelope alone.</param>
+        public void Synchronized(string folderAlias, int storedEmailCount, int skippedEmailCount)
+        {
+            this.Report(folderAlias, SucceededOutcomeName, ActivityStatusCode.Ok);
+
+            this.activity?.SetTag(StoredEmailCountTagName, storedEmailCount);
+            this.activity?.SetTag(SkippedEmailCountTagName, skippedEmailCount);
+            this.telemetry.RecordFolderSynchronized(
+                this.accountId,
+                folderAlias,
+                storedEmailCount,
+                skippedEmailCount);
+        }
+
+        /// <summary>Records an alias the mail server advertises no folder for.</summary>
+        /// <param name="folderAlias">The configured alias that matched nothing.</param>
+        public void AliasUnresolved(string folderAlias) =>
+            this.Report(folderAlias, AliasUnresolvedOutcomeName, ActivityStatusCode.Unset);
+
+        /// <summary>Records an alias several advertised folders matched.</summary>
+        /// <param name="folderAlias">The configured alias that matched more than one folder.</param>
+        public void AliasAmbiguous(string folderAlias) =>
+            this.Report(folderAlias, AliasAmbiguousOutcomeName, ActivityStatusCode.Unset);
+
+        /// <summary>Records a folder deferred by a competing writer this run could not resolve against.</summary>
+        /// <param name="folderAlias">MailFathom's own name for the folder.</param>
+        public void ConcurrencyConflict(string folderAlias) => this.Failed(folderAlias, ConcurrencyConflictFailureName);
+
+        /// <summary>Records a folder deferred because the mail server did not serve it within its resilience budget.</summary>
+        /// <param name="folderAlias">MailFathom's own name for the folder.</param>
+        public void MailServerUnavailable(string folderAlias) =>
+            this.Failed(folderAlias, MailServerUnavailableFailureName);
+
+        /// <summary>Records a folder that ended in a way nothing above it anticipated.</summary>
+        /// <param name="folderAlias">MailFathom's own name for the folder, or the configured alias where no mapping was built.</param>
+        public void UnexpectedFailure(string folderAlias) => this.Failed(folderAlias, UnexpectedFailureName);
+
+        /// <summary>Records a folder the host stopped before it finished, which is shutdown rather than a failure.</summary>
+        /// <param name="folderAlias">MailFathom's own name for the folder.</param>
+        public void Interrupted(string folderAlias) =>
+            this.Report(folderAlias, InterruptedOutcomeName, ActivityStatusCode.Unset);
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            // A folder that reported nothing is a path added above without an outcome beside it. The span says so
+            // rather than the counter, because no alias is known here to count it under.
+            if (!this.reported)
+            {
+                this.activity?.SetStatus(ActivityStatusCode.Error);
+            }
+
+            this.activity?.Dispose();
+        }
+
+        private void Failed(string folderAlias, string failure)
+        {
+            this.Report(folderAlias, FailedOutcomeName, ActivityStatusCode.Error);
+
+            this.activity?.SetTag(FailureTagName, failure);
+            this.telemetry.RecordFolderFailure(this.accountId, folderAlias, failure);
+        }
+
+        private void Report(string folderAlias, string outcome, ActivityStatusCode status)
+        {
+            this.reported = true;
+
+            this.activity?.SetTag(FolderTagName, folderAlias);
+            this.activity?.SetTag(OutcomeTagName, outcome);
+            this.activity?.SetStatus(status);
+        }
+    }
+}

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -87,7 +87,6 @@ using MailFathom.Infrastructure.Security.OAuth;
 using MailFathom.Infrastructure.SensitiveContent.PersonalData;
 using MailFathom.Infrastructure.SensitiveContent.Secrets;
 using MailFathom.Infrastructure.Spam;
-using MailKit.Net.Imap;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
@@ -536,14 +535,14 @@ public static class ServiceCollectionExtensions
             provider.GetRequiredService<TimeProvider>(),
             provider.GetRequiredService<ILogger<MailOAuthAccessTokenSource>>()));
         services.AddScoped<IMailboxSessionFactory>(provider => new MailKitImapMailboxSessionFactory(
-            static () => new ImapClient(),
+            MailKitImapClientFactory.CreateWithoutProtocolLogging,
             provider.GetRequiredService<IImapAccountSettingsProvider>(),
             provider.GetRequiredService<IMailAccessTokenSource>(),
             provider.GetRequiredService<OutboundOperationExecutor>(),
             provider.GetRequiredService<ITransientFailureClassifier>(),
             provider.GetRequiredService<TimeProvider>()));
         services.AddScoped<IMailboxNotificationSessionFactory>(provider => new MailKitImapNotificationSessionFactory(
-            static () => new ImapClient(),
+            MailKitImapClientFactory.CreateWithoutProtocolLogging,
             provider.GetRequiredService<IImapAccountSettingsProvider>(),
             provider.GetRequiredService<IMailAccessTokenSource>(),
             provider.GetRequiredService<OutboundOperationExecutor>(),
@@ -555,7 +554,7 @@ public static class ServiceCollectionExtensions
         // front of it stays scoped like every other mail adapter, and carries no state of its own.
         services.AddSingleton<MailboxMutationTelemetry>();
         services.AddSingleton(provider => new MailboxWriteConnectionPool(
-            static () => new ImapClient(),
+            MailKitImapClientFactory.CreateWithoutProtocolLogging,
             provider.GetRequiredService<IServiceScopeFactory>(),
             provider.GetRequiredService<OutboundOperationExecutor>(),
             provider.GetRequiredService<ITransientFailureClassifier>(),
@@ -591,10 +590,14 @@ public static class ServiceCollectionExtensions
         // A singleton for the same reason: the level it publishes belongs to the deployment's one content store rather
         // than to any run, and the counters beside it accumulate across every account.
         services.AddSingleton<MailboxContentVolumeTelemetry>();
+        // A singleton for the third time, and for the strongest form of the reason: the levels it publishes — how many
+        // account runs are queued behind the concurrency bound, and how long each account waits before its next run —
+        // describe the process rather than any run, and a second instance would publish a second set of them.
+        services.AddSingleton<MailSynchronizationTelemetry>();
         services.AddScoped<MailboxMutationConverger>();
         services.AddScoped<MailboxDestinationResolver>();
         services.AddScoped<IRemoteFolderCatalog>(provider => new MailKitRemoteFolderCatalog(
-            static () => new ImapClient(),
+            MailKitImapClientFactory.CreateWithoutProtocolLogging,
             provider.GetRequiredService<IImapAccountSettingsProvider>(),
             provider.GetRequiredService<IMailAccessTokenSource>(),
             provider.GetRequiredService<OutboundOperationExecutor>(),

--- a/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
@@ -612,6 +612,57 @@ public sealed class AccountSynchronizationSupervisorTests
         Assert.Equal(["INBOX"], attemptedFolders);
     }
 
+    /// <summary>A cycle the host stopped mid-way skipped folders that raised no failure count, so it must not read as a clean run.</summary>
+    /// <remarks>
+    /// The folders still queued behind the folder bound return without being started, so nothing about them reaches
+    /// the failure count the cycle would otherwise be judged by. Reporting that as a run that succeeded would put a
+    /// spurious healthy point on the duration histogram at every shutdown that lands inside a cycle.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_SchedulingStopsMidRun_PublishesTheCycleAsInterruptedRatherThanSucceeded()
+    {
+        // Arrange
+        var firstFolderEntered = new TaskCompletionSource();
+        var releaseFirstFolder = new TaskCompletionSource();
+
+        await using var emptyMailbox = CreateEmptyMailbox();
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        sessionFactory
+            .OpenReadOnlyAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailFolderResolution>(),
+                Arg.Any<MailTransportSecurityPolicy>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                firstFolderEntered.TrySetResult();
+
+                return HoldUntilReleasedAsync(releaseFirstFolder, emptyMailbox);
+            });
+
+        using var spans = new SynchronizationSpanCollector("interrupted-mid-cycle");
+        using var harness = CreateHarness(
+            SynchronizationTestHost.CreateOptions(
+                enabled: true,
+                SynchronizationTestHost.CreateAccount("interrupted-mid-cycle", "INBOX", "Archive", "Sent")),
+            sessionFactory);
+        var supervision = harness.StartSupervision();
+
+        // Act
+        await firstFolderEntered.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+        await harness.StopSchedulingAsync();
+        releaseFirstFolder.SetResult();
+        await supervision.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+
+        // Assert
+        var cycle = Assert.Single(spans.Named("synchronize_account"));
+
+        Assert.Equal("interrupted", cycle.GetTagItem("mailfathom.mail.sync.outcome"));
+        Assert.DoesNotContain(
+            harness.Logger.Messages,
+            message => message.Contains("finished in", StringComparison.Ordinal));
+    }
+
     /// <summary>An account a reload removes is withdrawn work, not a failure, so its supervisor ends instead of connecting again.</summary>
     [Fact]
     public async Task RunAsync_AccountLeavesConfiguration_EndsSupervisionOfIt()
@@ -938,6 +989,16 @@ public sealed class AccountSynchronizationSupervisorTests
         await release.Task;
 
         throw new InvalidOperationException("connect failed");
+    }
+
+    /// <summary>Models the same work unit ending in a folder the server serves, for a test about what a held run finishes as.</summary>
+    private static async Task<IMailboxSession> HoldUntilReleasedAsync(
+        TaskCompletionSource release,
+        IMailboxSession mailbox)
+    {
+        await release.Task;
+
+        return mailbox;
     }
 
     /// <summary>Models a folder the server serves and that holds no email, which is the cheapest successful run there is.</summary>

--- a/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/AccountSynchronizationSupervisorTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Mail.Mutations;
@@ -9,6 +11,7 @@ using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Synchronization;
 using MailFathom.Application.Synchronization.Sessions;
+using MailFathom.Common.Observability;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
@@ -17,6 +20,7 @@ using MailFathom.Domain.Transport;
 using MailFathom.Host.Configuration.Mail;
 using MailFathom.Host.Hosting.Workers;
 using MailFathom.Host.UnitTests.TestDoubles;
+using MailFathom.Infrastructure.Observability;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
@@ -301,6 +305,57 @@ public sealed class AccountSynchronizationSupervisorTests
         var logged = string.Join(' ', harness.Logger.Messages);
         Assert.DoesNotContain("mailfathom@example.test", logged, StringComparison.Ordinal);
         Assert.DoesNotContain("imap-primary-password", logged, StringComparison.Ordinal);
+    }
+
+    /// <summary>A cycle is one span with its folders beneath it, which is what attributes a stall to the step it stalled in.</summary>
+    /// <remarks>
+    /// Asserted here rather than only against the telemetry itself, because the shape depends on where the supervisor
+    /// opens each scope: a folder span started outside the cycle's own would be a root span per folder, and a trace
+    /// that no longer says which cycle a slow folder belonged to.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_ACycleOverTwoFolders_PublishesEachFolderBeneathTheCyclesOwnSpan()
+    {
+        // Arrange
+        var secondFolderReached = new TaskCompletionSource();
+        var openedFolderCount = 0;
+
+        await using var emptyMailbox = CreateEmptyMailbox();
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        sessionFactory
+            .OpenReadOnlyAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailFolderResolution>(),
+                Arg.Any<MailTransportSecurityPolicy>(),
+                Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                if (Interlocked.Increment(ref openedFolderCount) == 2)
+                {
+                    secondFolderReached.TrySetResult();
+                }
+
+                return Task.FromResult(emptyMailbox);
+            });
+
+        using var spans = new SynchronizationSpanCollector("spans-its-folders");
+        using var harness = CreateHarness(
+            SynchronizationTestHost.CreateOptions(
+                enabled: true,
+                SynchronizationTestHost.CreateAccount("spans-its-folders", "INBOX", "Archive")),
+            sessionFactory);
+
+        // Act
+        await harness.SuperviseUntilAsync(secondFolderReached.Task);
+
+        // Assert
+        var cycle = Assert.Single(spans.Named("synchronize_account"));
+        var folders = spans.Named("synchronize_folder");
+
+        Assert.Equal(
+            ["INBOX", "ARCHIVE"],
+            folders.Select(folder => (string?)folder.GetTagItem("mailfathom.mail.folder")));
+        Assert.All(folders, folder => Assert.Equal(cycle.SpanId, folder.ParentSpanId));
     }
 
     /// <summary>One IMAP connection per account is the default, so two folders of one account never open at once.</summary>
@@ -841,6 +896,42 @@ public sealed class AccountSynchronizationSupervisorTests
         return sessionFactory;
     }
 
+    /// <summary>Collects the synchronization spans one account published while a test ran.</summary>
+    /// <remarks>
+    /// Narrowed to one account, because the activity source is the application's own and every other class of this
+    /// suite supervises an account of its own at the same moment. The spans are kept in the order they stopped, which
+    /// is the order a run with one folder connection works its folders in.
+    /// </remarks>
+    private sealed class SynchronizationSpanCollector : IDisposable
+    {
+        private readonly ConcurrentQueue<Activity> stopped = new();
+        private readonly ActivityListener listener;
+
+        internal SynchronizationSpanCollector(string accountId)
+        {
+            this.listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == Telemetry.Name,
+                Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                    ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity =>
+                {
+                    if (Equals(activity.GetTagItem("mailfathom.mail.account"), accountId))
+                    {
+                        this.stopped.Enqueue(activity);
+                    }
+                },
+            };
+
+            ActivitySource.AddActivityListener(this.listener);
+        }
+
+        public void Dispose() => this.listener.Dispose();
+
+        internal IReadOnlyList<Activity> Named(string operationName) =>
+            [.. this.stopped.Where(activity => activity.OperationName == operationName)];
+    }
+
     /// <summary>Models a folder work unit that is under way and stays there until the test lets it end.</summary>
     private static async Task<IMailboxSession> HoldUntilReleasedAsync(TaskCompletionSource release)
     {
@@ -927,8 +1018,8 @@ public sealed class AccountSynchronizationSupervisorTests
                     services.GetRequiredService<IServiceScopeFactory>(),
                     this.PushLogger,
                     clock),
-                this.Logger,
-                clock);
+                services.GetRequiredService<MailSynchronizationTelemetry>(),
+                this.Logger);
         }
 
         internal StubSettingsSnapshot<MailSynchronizationOptions> Settings { get; }

--- a/tests/Host.UnitTests/Hosting/Workers/MailSynchronizationCoordinatorTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/MailSynchronizationCoordinatorTests.cs
@@ -9,6 +9,7 @@ using MailFathom.Domain.Transport;
 using MailFathom.Host.Configuration.Mail;
 using MailFathom.Host.Hosting.Workers;
 using MailFathom.Host.UnitTests.TestDoubles;
+using MailFathom.Infrastructure.Observability;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
@@ -289,6 +290,7 @@ public sealed class MailSynchronizationCoordinatorTests
             this.Coordinator = new MailSynchronizationCoordinator(
                 services.GetRequiredService<IServiceScopeFactory>(),
                 settings,
+                services.GetRequiredService<MailSynchronizationTelemetry>(),
                 this.loggerFactory,
                 clock);
         }

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -159,6 +159,10 @@ internal static class SynchronizationTestHost
         services.AddSingleton(Substitute.For<IMailboxWriteSessionFactory>());
         services.AddSingleton<MailboxConvergenceTelemetry>();
         services.AddSingleton<MailboxContentVolumeTelemetry>();
+        // Resolved by the coordinator and handed to every supervisor it starts, so it is composed here rather than
+        // constructed per harness: a supervisor built with one instance and a coordinator with another would publish
+        // two sets of the levels that describe the process.
+        services.AddSingleton<MailSynchronizationTelemetry>();
         services.AddScoped<IMailboxMutationPerformer, MailboxMutationPerformer>();
         services.AddScoped<MailboxMutationConverger>();
 

--- a/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitImapClientFactoryTests.cs
+++ b/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitImapClientFactoryTests.cs
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Infrastructure.Mail.MailKit;
+using MailKit;
+using MailKit.Net.Imap;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Mail.MailKit;
+
+/// <summary>Covers the one invariant every IMAP client this deployment opens is constructed under.</summary>
+/// <remarks>
+/// MailKit writes a session's commands, responses, envelopes, and payloads to the protocol logger it was constructed
+/// with and to nothing else, so a client holding the null logger writes them nowhere. That is what makes the rule a
+/// property of construction rather than of a log level or a category filter: no setting can turn protocol traffic back
+/// on, because there is nothing for it to be turned on towards.
+/// </remarks>
+public sealed class MailKitImapClientFactoryTests
+{
+    [Fact]
+    public void CreateWithoutProtocolLogging_AnyClient_WritesProtocolTrafficNowhere()
+    {
+        // Act
+        using var client = MailKitImapClientFactory.CreateWithoutProtocolLogging();
+
+        // Assert
+        Assert.IsType<NullProtocolLogger>(client.ProtocolLogger);
+    }
+
+    /// <summary>
+    /// The control the assertion above needs: a client built with a writing logger reports that logger, so the absence
+    /// asserted there is a property being read rather than one MailKit could have stopped reporting.
+    /// </summary>
+    [Fact]
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Ownership of the logger passes to the client, which disposes it along with the stream it writes to.")]
+    public void CreateWithoutProtocolLogging_ComparedWithAClientThatLogs_ReadsWhatTheClientWasBuiltWith()
+    {
+        // Arrange
+        var written = new MemoryStream();
+
+        // Act
+        using var logging = new ImapClient(new ProtocolLogger(written));
+
+        // Assert
+        Assert.IsNotType<NullProtocolLogger>(logging.ProtocolLogger);
+    }
+}

--- a/tests/Infrastructure.UnitTests/Observability/MailSynchronizationTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/MailSynchronizationTelemetryTests.cs
@@ -1,0 +1,468 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using MailFathom.Common.Observability;
+using MailFathom.Domain.Accounts;
+using MailFathom.Infrastructure.Observability;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Observability;
+
+/// <summary>Covers what a synchronization cycle publishes: the spans, the instruments, and the dimensions they carry.</summary>
+/// <remarks>
+/// Each test names an account of its own, which is what keeps the measurements it asserts on apart from its
+/// neighbours': the meter and the activity source are the application's own and are shared by everything MailFathom
+/// publishes, including whatever another test class publishes at the same moment. The four gauges need more than that,
+/// because xUnit builds a fresh instance of this class per test and every telemetry it constructs goes on observing the
+/// process-wide meter for the rest of the run — so a gauge is read by value rather than as the only one published.
+/// </remarks>
+public sealed class MailSynchronizationTelemetryTests : IDisposable
+{
+    private const string RunDurationInstrumentName = "mailfathom.mail.sync.run.duration";
+
+    private const string StoredEmailsInstrumentName = "mailfathom.mail.sync.emails.stored";
+
+    private const string SkippedEmailsInstrumentName = "mailfathom.mail.sync.emails.skipped";
+
+    private const string FailuresInstrumentName = "mailfathom.mail.sync.failures";
+
+    private const string BackoffInstrumentName = "mailfathom.mail.sync.backoff";
+
+    private const string ConsecutiveFailuresInstrumentName = "mailfathom.mail.sync.consecutive_failures";
+
+    private const string QueuedRunsInstrumentName = "mailfathom.mail.sync.runs.queued";
+
+    private const string ActiveRunsInstrumentName = "mailfathom.mail.sync.runs.active";
+
+    private const string AccountTagName = "mailfathom.mail.account";
+
+    private const string FolderTagName = "mailfathom.mail.folder";
+
+    private const string OutcomeTagName = "mailfathom.mail.sync.outcome";
+
+    private const string FailureTagName = "mailfathom.mail.sync.failure";
+
+    private readonly FakeTimeProvider clock = new();
+    private readonly MailSynchronizationTelemetry telemetry;
+    private readonly ConcurrentBag<Activity> published = [];
+    private readonly ActivityListener listener;
+
+    public MailSynchronizationTelemetryTests()
+    {
+        this.telemetry = new MailSynchronizationTelemetry(this.clock);
+        this.listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.Name,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = this.published.Add,
+        };
+
+        ActivitySource.AddActivityListener(this.listener);
+    }
+
+    public void Dispose() => this.listener.Dispose();
+
+    /// <summary>The cycle is one span and each folder is a span beneath it, which is what attributes a stall to a step.</summary>
+    [Fact]
+    public void BeginAccountRun_ACycleThatSynchronizedItsFolders_PublishesEachFolderBeneathTheCycle()
+    {
+        // Arrange
+        var account = MailAccountId.Create("publishes-its-folders");
+
+        // Act
+        using (var run = this.telemetry.BeginAccountRun(account))
+        {
+            using (var folder = this.telemetry.BeginFolderRun(account))
+            {
+                folder.Synchronized("INBOX", storedEmailCount: 4, skippedEmailCount: 1);
+            }
+
+            run.Completed(scheduledFolderCount: 1, failedFolderCount: 0, convergenceFailed: false);
+        }
+
+        // Assert
+        var cycle = this.PublishedSpan(account, "synchronize_account");
+        var folderSpan = this.PublishedSpan(account, "synchronize_folder");
+
+        Assert.Equal(cycle.SpanId, folderSpan.ParentSpanId);
+        Assert.Equal("succeeded", cycle.GetTagItem(OutcomeTagName));
+        Assert.Equal(1, cycle.GetTagItem("mailfathom.mail.sync.folders"));
+        Assert.Equal(0, cycle.GetTagItem("mailfathom.mail.sync.folders.failed"));
+        Assert.Equal("INBOX", folderSpan.GetTagItem(FolderTagName));
+    }
+
+    /// <summary>The cycle's duration is what an operator alerts a stalled account on, tagged by how it ended.</summary>
+    [Fact]
+    public void BeginAccountRun_ACycleWithAFailedFolder_RecordsItsDurationAsAFailedCycle()
+    {
+        // Arrange
+        var account = MailAccountId.Create("records-a-failed-cycle");
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (var run = this.telemetry.BeginAccountRun(account))
+        {
+            this.clock.Advance(TimeSpan.FromSeconds(30));
+            run.Completed(scheduledFolderCount: 2, failedFolderCount: 1, convergenceFailed: false);
+        }
+
+        // Assert
+        var duration = Assert.Single(collector.Read(RunDurationInstrumentName, account));
+
+        Assert.Equal(30, duration.Value);
+        Assert.Equal("failed", duration.Tags[OutcomeTagName]);
+    }
+
+    /// <summary>A convergence pass that failed fails the cycle, exactly as a folder that failed does.</summary>
+    [Fact]
+    public void BeginAccountRun_ACycleWhoseConvergenceFailed_RecordsItAsAFailedCycle()
+    {
+        // Arrange
+        var account = MailAccountId.Create("records-failed-convergence");
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (var run = this.telemetry.BeginAccountRun(account))
+        {
+            run.Completed(scheduledFolderCount: 1, failedFolderCount: 0, convergenceFailed: true);
+        }
+
+        // Assert
+        Assert.Equal("failed", Assert.Single(collector.Read(RunDurationInstrumentName, account)).Tags[OutcomeTagName]);
+    }
+
+    /// <summary>Shutdown ends a cycle without an outcome, and an account stopped is not an account that failed.</summary>
+    [Fact]
+    public void BeginAccountRun_ACycleThatReportedNoOutcome_RecordsItAsInterruptedRatherThanFailed()
+    {
+        // Arrange
+        var account = MailAccountId.Create("records-an-interruption");
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (this.telemetry.BeginAccountRun(account))
+        {
+        }
+
+        // Assert
+        Assert.Equal(
+            "interrupted",
+            Assert.Single(collector.Read(RunDurationInstrumentName, account)).Tags[OutcomeTagName]);
+    }
+
+    /// <summary>Counting messages is what says a mailbox is being brought in, and the two counts narrow for different reasons.</summary>
+    [Fact]
+    public void Synchronized_AFolderRun_CountsWhatItStoredAndWhatItRecordedWithoutContent()
+    {
+        // Arrange
+        var account = MailAccountId.Create("counts-its-messages");
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (var folder = this.telemetry.BeginFolderRun(account))
+        {
+            folder.Synchronized("ARCHIVE", storedEmailCount: 12, skippedEmailCount: 3);
+        }
+
+        // Assert
+        var stored = Assert.Single(collector.Read(StoredEmailsInstrumentName, account));
+        var skipped = Assert.Single(collector.Read(SkippedEmailsInstrumentName, account));
+
+        Assert.Equal(12, stored.Value);
+        Assert.Equal("ARCHIVE", stored.Tags[FolderTagName]);
+        Assert.Equal(3, skipped.Value);
+        Assert.Equal("ARCHIVE", skipped.Tags[FolderTagName]);
+    }
+
+    /// <summary>The three ways a folder is stopped ask an operator for different things, so each is its own dimension.</summary>
+    [Theory]
+    [InlineData("concurrency-conflict", "concurrency_conflict")]
+    [InlineData("mail-server-unavailable", "mail_server_unavailable")]
+    [InlineData("unexpected-failure", "unexpected")]
+    public void Failed_AFolderRunThatDidNotComplete_CountsItUnderWhatStoppedIt(string accountId, string expected)
+    {
+        // Arrange
+        var account = MailAccountId.Create(accountId);
+        Action<MailSynchronizationTelemetry.FolderRunScope> record = expected switch
+        {
+            "concurrency_conflict" => folder => folder.ConcurrencyConflict("INBOX"),
+            "mail_server_unavailable" => folder => folder.MailServerUnavailable("INBOX"),
+            _ => folder => folder.UnexpectedFailure("INBOX"),
+        };
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (var folder = this.telemetry.BeginFolderRun(account))
+        {
+            record(folder);
+        }
+
+        // Assert
+        var failure = Assert.Single(collector.Read(FailuresInstrumentName, account));
+
+        Assert.Equal(1, failure.Value);
+        Assert.Equal(expected, failure.Tags[FailureTagName]);
+        Assert.Equal("INBOX", failure.Tags[FolderTagName]);
+    }
+
+    /// <summary>An alias naming no single folder is a configuration mistake, and counting it as a failure would back a working account off.</summary>
+    [Theory]
+    [InlineData("alias-unresolved", "alias_unresolved")]
+    [InlineData("alias-ambiguous", "alias_ambiguous")]
+    public void AliasOutcome_AnAliasThatNamedNoSingleFolder_CountsNoFailureAndSaysWhichItWas(
+        string accountId,
+        string expected)
+    {
+        // Arrange
+        var account = MailAccountId.Create(accountId);
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (var folder = this.telemetry.BeginFolderRun(account))
+        {
+            if (expected == "alias_unresolved")
+            {
+                folder.AliasUnresolved("SENT");
+            }
+            else
+            {
+                folder.AliasAmbiguous("SENT");
+            }
+        }
+
+        // Assert
+        Assert.Empty(collector.Read(FailuresInstrumentName, account));
+        Assert.Equal(expected, this.PublishedSpan(account, "synchronize_folder").GetTagItem(OutcomeTagName));
+    }
+
+    /// <summary>Shutdown reaching a folder is not a folder that failed, so nothing is counted against the account.</summary>
+    [Fact]
+    public void Interrupted_AFolderRunTheHostStopped_CountsNoFailure()
+    {
+        // Arrange
+        var account = MailAccountId.Create("interrupted-folder");
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (var folder = this.telemetry.BeginFolderRun(account))
+        {
+            folder.Interrupted("INBOX");
+        }
+
+        // Assert
+        Assert.Empty(collector.Read(FailuresInstrumentName, account));
+        Assert.Equal("interrupted", this.PublishedSpan(account, "synchronize_folder").GetTagItem(OutcomeTagName));
+    }
+
+    /// <summary>The wait and the failure count are published together, because neither is readable without the other.</summary>
+    [Fact]
+    public void RecordScheduledDelay_AnAccountThatIsBackingOff_PublishesTheWaitAndTheFailuresBehindIt()
+    {
+        // Arrange
+        var account = MailAccountId.Create("is-backing-off");
+        using var collector = new MeasurementCollector();
+
+        // Act
+        this.telemetry.RecordScheduledDelay(account, TimeSpan.FromMinutes(8), consecutiveFailureCount: 3);
+
+        // Assert
+        Assert.Equal(480, Assert.Single(collector.ReadGauge(BackoffInstrumentName, account)).Value);
+        Assert.Equal(3, Assert.Single(collector.ReadGauge(ConsecutiveFailuresInstrumentName, account)).Value);
+    }
+
+    /// <summary>An account nobody supervises any more must stop reporting, or its last wait reads as an account still waiting.</summary>
+    [Fact]
+    public void RecordSupervisionEnded_AnAccountNoLongerSupervised_StopsPublishingItsSchedule()
+    {
+        // Arrange
+        var account = MailAccountId.Create("left-configuration");
+        using var collector = new MeasurementCollector();
+
+        this.telemetry.RecordScheduledDelay(account, TimeSpan.FromMinutes(5), consecutiveFailureCount: 0);
+
+        // Act
+        this.telemetry.RecordSupervisionEnded(account);
+
+        // Assert
+        Assert.Empty(collector.ReadGauge(BackoffInstrumentName, account));
+        Assert.Empty(collector.ReadGauge(ConsecutiveFailuresInstrumentName, account));
+    }
+
+    /// <summary>The depth is what separates a pipeline that is idle from one whose accounts are all queued behind the bound.</summary>
+    /// <remarks>
+    /// The two levels are read by value rather than as the only measurements published, for the reason the class remark
+    /// gives: every instance this suite has built so far still observes the process-wide meter, and each of those
+    /// reports the zero it has always held. Only the reading this test produced says anything about it, and the fall
+    /// back to zero is asserted over all of them because that is the state every instance is then in.
+    /// </remarks>
+    [Fact]
+    public void EnterRunQueue_RunsWaitingForASlot_PublishesTheDepthAndReleasesItWhenTheWaitEnds()
+    {
+        // Arrange
+        var account = MailAccountId.Create("waits-for-a-slot");
+        using var collector = new MeasurementCollector();
+
+        // Act and assert
+        using (this.telemetry.EnterRunQueue())
+        using (this.telemetry.EnterRunQueue())
+        using (this.telemetry.BeginAccountRun(account))
+        {
+            Assert.Contains(collector.ReadUntaggedGauge(QueuedRunsInstrumentName), gauge => gauge.Value == 2);
+            Assert.Contains(collector.ReadUntaggedGauge(ActiveRunsInstrumentName), gauge => gauge.Value == 1);
+        }
+
+        Assert.All(collector.ReadUntaggedGauge(QueuedRunsInstrumentName), gauge => Assert.Equal(0, gauge.Value));
+        Assert.All(collector.ReadUntaggedGauge(ActiveRunsInstrumentName), gauge => Assert.Equal(0, gauge.Value));
+    }
+
+    /// <summary>
+    /// The rule the telemetry page states as a cardinality rule as much as a privacy one: the work is per mailbox, per
+    /// folder, and per message, and the dimensions are none of those beyond MailFathom's own two aliases.
+    /// </summary>
+    [Fact]
+    public void BeginFolderRun_AFolderRunOverMail_CarriesOnlyMailFathomsOwnNamesAndCounts()
+    {
+        // Arrange
+        var account = MailAccountId.Create("carries-no-mail");
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (var run = this.telemetry.BeginAccountRun(account))
+        {
+            using (var folder = this.telemetry.BeginFolderRun(account))
+            {
+                folder.Synchronized("INBOX", storedEmailCount: 2, skippedEmailCount: 0);
+            }
+
+            run.Completed(scheduledFolderCount: 1, failedFolderCount: 0, convergenceFailed: false);
+        }
+
+        // Assert
+        var spanTagNames = this.published
+            .Where(activity => Equals(activity.GetTagItem(AccountTagName), account.Value))
+            .SelectMany(activity => activity.TagObjects)
+            .Select(tag => tag.Key)
+            .Distinct(StringComparer.Ordinal);
+        var measurementTagNames = collector.ReadEverythingFor(account)
+            .SelectMany(measurement => measurement.Tags.Keys)
+            .Distinct(StringComparer.Ordinal);
+
+        Assert.All(spanTagNames, name => Assert.Contains(name, PermittedDimensions));
+        Assert.All(measurementTagNames, name => Assert.Contains(name, PermittedDimensions));
+    }
+
+    /// <summary>Every dimension a synchronization signal is allowed to carry, which is what the assertion above is read against.</summary>
+    private static IReadOnlyList<string> PermittedDimensions =>
+    [
+        AccountTagName,
+        FolderTagName,
+        OutcomeTagName,
+        FailureTagName,
+        "mailfathom.mail.sync.folders",
+        "mailfathom.mail.sync.folders.failed",
+        "mailfathom.mail.sync.stored",
+        "mailfathom.mail.sync.skipped",
+    ];
+
+    /// <summary>Selects one span this test produced out of whatever the shared source published while it ran.</summary>
+    private Activity PublishedSpan(MailAccountId accountId, string operationName) => Assert.Single(
+        this.published,
+        activity => activity.OperationName == operationName
+            && Equals(activity.GetTagItem(AccountTagName), accountId.Value));
+
+    /// <summary>Collects what the application's meter publishes while one test runs.</summary>
+    /// <remarks>
+    /// The collection is concurrent because the writer and the reader are not the same thread: this listener enables
+    /// every instrument of the process-wide meter, and xUnit runs test classes in parallel, so a class publishing its
+    /// own telemetry records here from whichever thread it runs on. Every read filters by instrument and by account for
+    /// the same reason.
+    /// </remarks>
+    private sealed class MeasurementCollector : IDisposable
+    {
+        private readonly MeterListener listener = new();
+        private readonly ConcurrentQueue<PublishedMeasurement> measurements = new();
+
+        internal MeasurementCollector()
+        {
+            this.listener.InstrumentPublished = (instrument, activeListener) =>
+            {
+                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
+                {
+                    activeListener.EnableMeasurementEvents(instrument);
+                }
+            };
+            this.listener.SetMeasurementEventCallback<long>(this.Record);
+            this.listener.SetMeasurementEventCallback<double>(this.Record);
+            this.listener.Start();
+        }
+
+        public void Dispose() => this.listener.Dispose();
+
+        /// <summary>Returns what one instrument published for one account since this collector started.</summary>
+        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName, MailAccountId accountId) =>
+        [
+            .. this.measurements.Where(measurement =>
+                StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)
+                && measurement.Tags.TryGetValue(AccountTagName, out var account)
+                && Equals(account, accountId.Value)),
+        ];
+
+        /// <summary>Returns everything published for one account, whichever instrument published it.</summary>
+        internal IReadOnlyList<PublishedMeasurement> ReadEverythingFor(MailAccountId accountId) =>
+        [
+            .. this.measurements.Where(measurement =>
+                measurement.Tags.TryGetValue(AccountTagName, out var account)
+                && Equals(account, accountId.Value)),
+        ];
+
+        /// <summary>Collects the gauges once and returns what one of them published for one account.</summary>
+        internal IReadOnlyList<PublishedMeasurement> ReadGauge(string instrumentName, MailAccountId accountId)
+        {
+            this.CollectGauges();
+
+            return this.Read(instrumentName, accountId);
+        }
+
+        /// <summary>Collects the gauges once and returns what one instrument published for the process.</summary>
+        internal IReadOnlyList<PublishedMeasurement> ReadUntaggedGauge(string instrumentName)
+        {
+            this.CollectGauges();
+
+            return
+            [
+                .. this.measurements.Where(measurement =>
+                    StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)),
+            ];
+        }
+
+        private void CollectGauges()
+        {
+            this.measurements.Clear();
+            this.listener.RecordObservableInstruments();
+        }
+
+        private void Record<TMeasurement>(
+            Instrument instrument,
+            TMeasurement measurement,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags,
+            object? state)
+            where TMeasurement : struct =>
+            this.measurements.Enqueue(new PublishedMeasurement(
+                instrument.Name,
+                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
+                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
+    }
+
+    /// <summary>One measurement an instrument published, with the dimensions it carried.</summary>
+    private sealed record PublishedMeasurement(
+        string InstrumentName,
+        double Value,
+        IReadOnlyDictionary<string, object?> Tags);
+}


### PR DESCRIPTION
Closes #502

No OpenTelemetry instrumentation package exists for MailKit, so the part of MailFathom that spends the most wall-clock
time published nothing of its own: a synchronization cycle left structured log lines and nothing an operator could put
on a dashboard or alert on. *Is account X still synchronizing, and how far behind is it* could only be answered by
reading logs.

## What a cycle now emits

One account's cycle opens **`synchronize_account`**, and each folder it works opens **`synchronize_folder`** beneath it.
That nesting is the point of the pair — a cycle whose duration doubled is attributable to the folder it doubled in
rather than to the account as a whole — and the log records the same cycle already writes are emitted inside those
spans, so a count in a line and the span it belongs to are one thing.

Eight instruments answer the rest, all on the `MailFathom` meter the foundation issue established:

| Instrument | What it answers |
| --- | --- |
| `mailfathom.mail.sync.run.duration` | How long one account's cycle took, by account and outcome |
| `mailfathom.mail.sync.emails.stored` | Messages a folder run stored with their content |
| `mailfathom.mail.sync.emails.skipped` | Messages it recorded from their envelope alone |
| `mailfathom.mail.sync.failures` | Folder runs that did not complete, by what stopped them |
| `mailfathom.mail.sync.backoff` | How long each account waits before its next run |
| `mailfathom.mail.sync.consecutive_failures` | How many of that account's runs failed in a row |
| `mailfathom.mail.sync.runs.queued` | Cycles waiting for one of the slots that bound how many accounts run at once |
| `mailfathom.mail.sync.runs.active` | Cycles holding one of those slots |

The wait and the failure count are published together because neither is readable alone, and both are republished on
every pass rather than only while an account is backing off — a gauge that stops being written holds its last value, so
an account that recovered would go on reporting the wait it was deferred by. An account nothing supervises any more
stops reporting altogether.

The wait for a slot is counted rather than spanned, which keeps a cycle's duration the cycle rather than the cycle plus
however long the accounts in front of it took. `runs.queued` at the account count while `runs.active` sits at the
configured bound is a pipeline saturated by that bound rather than an idle one, which is a distinction nothing else
here makes.

## Two outcomes that are deliberately not failures

**Shutdown** ends a cycle and a folder as `interrupted`. An account backed off for every restart would be an account
approached less often for having been stopped. **An alias that named no single advertised folder** stays an outcome
rather than a failure, which is the same distinction the supervisor already draws when it decides whether to defer the
account: a configuration mistake is remedied by an edit, and counting it would put a working account into backoff.

## Keeping the mailbox out of it

Every IMAP client is now constructed through one factory that attaches no protocol logger, so a session's commands,
responses, envelopes, and payloads are written nowhere for a log level or a setting to expose — and no configuration
key exists that could attach one. That makes the rule a property of construction rather than of a filter, and
`MailKitImapClientFactoryTests` asserts it against the control that would report a logger present.

Nothing else published here is derived from a message either: the dimensions are MailFathom's own configured account and
folder aliases plus closed sets of its own words, and the values are counts and durations. No UID, message identifier,
address, subject, or remote folder path appears.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves. The one signature change
is internal: `AccountSynchronizationSupervisor` takes the telemetry and no longer takes a `TimeProvider`, because the
cycle's duration is now measured once, by the scope that publishes it, instead of twice.

## Verification

`scripts/verify-full.sh` — exit 0: workflow contract suite 167 passed, Release build 0 errors, 6599 unit tests passed,
aggregate line coverage 95.81% against the 85% gate, `dotnet format` reformatted nothing. Rebased onto `origin/main`
at `e30ff23b` and re-run after the rebase.

Issue: https://github.com/Krzysztof318/MailFathom/issues/502
