### PR TITLE
[#816] Advertise the scopes a client should ask for, separately from the ones a token must carry

### DIFF
--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -800,6 +800,19 @@ the scopes to ask for all come from the deployment: it publishes an [RFC 9728](h
 metadata document at `/.well-known/oauth-protected-resource/api/admin`, and the server it names publishes where to
 authorize. Nothing is transcribed, so nothing is transcribed wrongly.
 
+**The scope list is taken verbatim, and that includes `offline_access`.** A refresh token is what makes the sign-in
+outlive its first access token, and a client is issued one by naming that scope — so the entry serving this endpoint has
+to advertise it, in
+[`AdvertisedScopes`](mcp-endpoint.md#scopes-you-advertise-but-do-not-require) rather than in `RequiredScopes`. Without
+it the sign-in is refused where the token is issued rather than an hour later, naming what to do:
+
+```console
+$ mfctl login --endpoint https://mail.example.test:8443 --mode interactive --client-id mfctl
+The authorization server issued no refresh token, so the sign-in would end within the hour. Grant the client offline
+access at the authorization server and have the deployment advertise 'offline_access', or sign in with an API key
+instead.
+```
+
 Register the command as a **public client** with an authorization-code grant, PKCE required, and the redirect address
 `http://127.0.0.1:8765/`. It ships as a binary anyone can download, so it holds no client secret and presents none.
 Pass `--redirect-uri` if you registered a different loopback port, and `--issuer` if the deployment accepts tokens from
@@ -929,6 +942,11 @@ clear-text protection off globally. These are the client's decisions about one d
 An access token is typically minted for an hour, and you should never notice. Every command checks the stored token
 before it sends anything and exchanges the refresh token for a new one when it is within a minute of expiring, which is
 what keeps that hour from being an hourly interruption.
+
+**Whether there is a refresh token at all is the deployment's decision**, taken by advertising `offline_access` on the
+OAuth entry serving this endpoint — see [with OAuth](#with-oauth) above. The command asks for exactly the scopes the
+metadata document lists and adds nothing of its own, so a deployment that advertises the scope gives every client a
+renewable session and one that does not gives none of them one.
 
 **The refresh token itself is never renewed, and a rotated one is not adopted.** When the authorization server answers a
 renewal with a new refresh token, the command keeps the one issued at sign-in and discards the new one. That is
@@ -1077,7 +1095,7 @@ encryption answers the copy. Holding the credential in the platform's own secret
 | `not a usable web address` | The authorization server published a `verification_uri` that is not an absolute `http` or `https` address, so there is nothing to put in front of the person signing in. This is a fault at the authorization server rather than in its configuration here. |
 | `publishes no OAuth metadata` | The endpoint accepts API keys only. Sign in with one, or ask the operator to add an `OAuth` entry to `AdminEndpoint:Authentication`. |
 | `accepts tokens from several authorization servers` | More than one is configured and only you know which population you belong to. Name it with `--issuer`. |
-| `issued no refresh token` | The client was not granted offline access, so the session would end within the hour. Grant it at the authorization server. |
+| `issued no refresh token` | Nothing asked for offline access, so the session would end within the hour. Two settings can be missing: the deployment advertising `offline_access` in [`AdvertisedScopes`](mcp-endpoint.md#scopes-you-advertise-but-do-not-require), and the client being granted the scope at the authorization server. Check the metadata document first — if `scopes_supported` does not list it, nothing asked. |
 | `no device authorization endpoint` | That authorization server offers no device grant. Sign in from a machine with a browser. |
 
 ## Related

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -1046,13 +1046,16 @@ same entries; the administrative one adds a single rule, stated with it below.
 | `…:<n>:PublicKey` | secret block | — | One [named secret](secret-provisioning.md#the-secret-block) with its own `Lifetime`, resolving to one client's PEM public key. Startup refuses material that is not one, an RSA key below 2048 bits, and — explicitly — material carrying a private key | restart; material per request |
 | `…:<n>:OAuth:Resource` | string | — | Required; the canonical `https` URL clients reach this endpoint at — behind a proxy, the proxy's public URL. Every OAuth entry names the same one, because the endpoint publishes one metadata document at an address derived from it | restart |
 | `…:<n>:OAuth:RequiredScopes` | string list | empty | Scopes a token from *this entry's* servers must carry; empty accepts any token they issued for this resource | restart |
+| `…:<n>:OAuth:AdvertisedScopes` | string list | empty | Scopes published in `scopes_supported` for a client to ask for and checked on no token — `offline_access` is what a client needs to be issued a refresh token. Every required scope is published regardless, so a value repeating one is refused, as is one that is not a scope token | restart |
 | `…:<n>:OAuth:AuthorizationServers:<m>:Name` | string | — | Required; the identity diagnostics use, and unique across every entry because it composes the scheme its validator registers under | restart |
 | `…:<n>:OAuth:AuthorizationServers:<m>:Issuer` | string | — | Required; a well-formed `https` issuer, compared against `iss` exactly, and unique across every entry | restart |
 | `…:<n>:OAuth:AuthorizationServers:<m>:MetadataAddress` | string | unset | An absolute `https` URL on the issuer's own host; overrides issuer-derived discovery | restart |
 | `…:<n>:OAuth:AuthorizationServers:<m>:AuthorizedSubjects` | string list | — | At least one; a token whose `sub` is not listed is refused, so every user the server can sign in does not automatically read this mailbox | restart |
 
 MailFathom is a protected resource only; an external authorization server signs users in.
-[`OAuth`](mcp-endpoint.md#oauth) records what a token must prove,
+[`OAuth`](mcp-endpoint.md#oauth) records what a token must prove and
+[scopes you advertise but do not require](mcp-endpoint.md#scopes-you-advertise-but-do-not-require) why the published list
+is longer than the checked one,
 [API keys](mcp-endpoint.md#api-keys) what a key is compared against, and
 [Key pairs](mcp-endpoint.md#key-pairs) what a client signs and what the deployment verifies — including the audience,
 expiry, and replay identifier an assertion carries, none of which is a setting.

--- a/docs/operations/mcp-client-oauth.md
+++ b/docs/operations/mcp-client-oauth.md
@@ -123,6 +123,15 @@ scope, from its own name.
 If you require no scope, create the client scope anyway and call it something descriptive. It exists to carry the
 mapper.
 
+**Decide here whether clients should hold a refresh token.** A client asks for one by naming `offline_access`, and it
+learns to ask by reading that scope in MailFathom's metadata document — so if you do not advertise it, a client asks
+only for the scope above and its user signs in again whenever the access token expires, typically hourly. It goes in
+[step 7](#7-write-the-mailfathom-entry) as `AdvertisedScopes` rather than `RequiredScopes`, because it describes the
+client's session rather than anything MailFathom protects and is checked on nothing;
+[the reference](mcp-endpoint.md#scopes-you-advertise-but-do-not-require) has the whole rule. **In Keycloak** the scope
+exists already, as the built-in `offline_access` client scope, and what remains is assigning it to the client in
+[step 4](#4-register-an-application-for-the-client) — nothing new is created here.
+
 ### 3. Make the token's audience agree
 
 **This is the step that is not guessable, and the one most first connections fail on.** An MCP client asks for a token
@@ -225,6 +234,7 @@ Now the part that is MailFathom's, and it is one block:
         "OAuth": {
           "Resource": "https://mail.example.com/mcp",
           "RequiredScopes": [ "mailfathom.read" ],
+          "AdvertisedScopes": [ "offline_access" ],
           "AuthorizationServers": [
             {
               "Name": "workforce",
@@ -239,8 +249,10 @@ Now the part that is MailFathom's, and it is one block:
 }
 ```
 
-`Resource` came from step 1, `RequiredScopes` from step 2, and `AuthorizedSubjects` from step 6; `Name` is a label of
-your own that diagnostics report. `Issuer` is the one new value and the one to be careful with: **copy it verbatim from
+`Resource` came from step 1, `RequiredScopes` and `AdvertisedScopes` from step 2, and `AuthorizedSubjects` from step 6;
+`Name` is a label of your own that diagnostics report. Drop `AdvertisedScopes` if you decided against offline access —
+it publishes a scope for clients to ask for and is checked on nothing, so leaving it out narrows no boundary and only
+shortens how long a client goes between sign-ins. `Issuer` is the one new value and the one to be careful with: **copy it verbatim from
 the provider, trailing slash included**, because it is compared to a token's `iss` by exact string equality and is the
 one identifier MailFathom deliberately never rewrites. Several widely deployed servers publish an issuer whose entire
 path is one trailing slash, and tidying it by hand produces a deployment that starts cleanly and then refuses every token
@@ -252,9 +264,10 @@ from the issuer, and takes the key set address out of it.
 
 The section is read once while the host is composed, so this takes effect on restart.
 
-[The reference](mcp-endpoint.md#oauth) is where the rules on these four live: what happens with several entries, why
-every entry must agree on `Resource`, why `Name` and `Issuer` are unique across the whole list, and what leaving
-`RequiredScopes` empty means. Two more things it records are worth knowing before the next step. A deployment behind a
+[The reference](mcp-endpoint.md#oauth) is where the rules on these five live: what happens with several entries, why
+every entry must agree on `Resource`, why `Name` and `Issuer` are unique across the whole list, what leaving
+`RequiredScopes` empty means, and why
+[a scope you advertise](mcp-endpoint.md#scopes-you-advertise-but-do-not-require) can never turn a caller away. Two more things it records are worth knowing before the next step. A deployment behind a
 TLS-terminating proxy must name that proxy in
 [`ReverseProxy:TrustedProxies`](mcp-endpoint.md#behind-a-tls-terminating-reverse-proxy) — an access token is refused
 outright when the request did not arrive over TLS, and with no proxy named that refusal stops working rather than
@@ -273,7 +286,7 @@ $ curl -sS https://mail.example.com/.well-known/oauth-protected-resource/mcp | j
 {
   "resource": "https://mail.example.com/mcp",
   "authorization_servers": [ "https://sso.example.test/realms/mailfathom" ],
-  "scopes_supported": [ "mailfathom.read" ],
+  "scopes_supported": [ "mailfathom.read", "offline_access" ],
   "bearer_methods_supported": [ "header" ],
   "resource_name": "MailFathom"
 }
@@ -281,7 +294,8 @@ $ curl -sS https://mail.example.com/.well-known/oauth-protected-resource/mcp | j
 
 Check `resource` against what you will type into the client, and `authorization_servers` against your issuer. A
 deployment configuring several authorization servers publishes them all here, and a client may use only the first —
-order them accordingly.
+order them accordingly. `scopes_supported` is what a client will ask for, which is why `offline_access` appears in it
+without being required: an absence here is a client that never asks for a refresh token.
 
 **An unauthenticated request is refused, and says where to authorize:**
 
@@ -372,6 +386,7 @@ second:
 | The client reports it cannot reach the server, and the provider logs no traffic at all | Discovery never completed, so the client never learned where to authorize. Run the first two commands of [step 8](#8-verify-before-you-touch-the-client) |
 | The sign-in page never appears, or the redirect is rejected | The callback URL is not allowed, or not matched ignoring the port for a loopback client — [step 5](#5-take-the-callback-url-from-the-client) |
 | The sign-in fails at the token exchange | The token-endpoint authentication method disagrees. A public client sending nothing to a confidential registration, or the reverse — [step 4](#4-register-an-application-for-the-client) |
+| Everything works, and the person is asked to sign in again every hour | The client was issued no refresh token, because nothing told it to ask for one. Advertise `offline_access` — [step 2](#2-register-mailfathom-as-a-resource-in-the-provider) — and assign the scope to the client at the provider |
 | `429` where you expected `401` | The [rate limiter](mcp-endpoint.md#rate-limiting) ran out of capacity before authorization was reached. A flood of bad credentials is meant to cost the sender something |
 | A startup failure naming `McpEndpoint:Authentication:0` | The entry itself. The [reference](mcp-endpoint.md#authentication) lists what is refused before anything binds |
 

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -41,6 +41,7 @@ endpoint exposes synchronized mailboxes to whoever can reach it and satisfy what
 | `Authentication[].ApiKey` | — | One key a client may present, a named secret with its own lifetime |
 | `Authentication[].OAuth.Resource` | — | The canonical public URL this deployment is known by in OAuth terms |
 | `Authentication[].OAuth.RequiredScopes` | empty | The scopes an access token from *this entry's* servers must carry |
+| `Authentication[].OAuth.AdvertisedScopes` | empty | Scopes published for a client to ask for and checked on no token — `offline_access` above all |
 | `Authentication[].OAuth.AuthorizationServers` | — | The external authorization servers whose tokens this entry accepts |
 | `Cors.AllowedOrigins` | `["*"]` | The browser origins served: `*` for every one, a list for exactly those, an empty list for none |
 | `ClientCertificateProfiles` | empty | The client applications whose certificates are accepted, each with its own authorities and expected names |
@@ -347,6 +348,7 @@ the identity provider — read that first if this is a deployment's first OAuth 
         "OAuth": {
           "Resource": "https://mail.example.test/mcp",
           "RequiredScopes": [ "mailfathom.read" ],
+          "AdvertisedScopes": [ "offline_access" ],
           "AuthorizationServers": [
             {
               "Name": "workforce",
@@ -361,9 +363,11 @@ the identity provider — read that first if this is a deployment's first OAuth 
 }
 ```
 
-**Several OAuth entries are supported, and each states its own terms.** `RequiredScopes` and `AuthorizationServers` belong
-to the entry that carries them, so a token is judged against what *its own* issuer's entry asks for — one tenant may be
-required to carry a scope while another is not, without either being weakened to match the other. What every entry must
+**Several OAuth entries are supported, and each states its own terms.** `RequiredScopes`, `AdvertisedScopes`, and
+`AuthorizationServers` belong to the entry that carries them, so a token is judged against what *its own* issuer's entry
+asks for — one tenant may be required to carry a scope while another is not, without either being weakened to match the
+other. The published document is the one place they are read together, because there is one of it: it lists every scope
+any entry requires or advertises, so a client cannot tell from it which entry asked for what. What every entry must
 agree on is `Resource`, and startup refuses two that disagree: the endpoint publishes one protected resource metadata
 document, at an address derived from that identifier, so a second resource would leave one entry's clients reading a
 document that describes somebody else and asking their authorization server for the wrong audience.
@@ -428,7 +432,8 @@ Every token is checked, before any MCP protocol handling and before any tool run
 - an `aud` equal to `Resource`. A valid signature from a trusted issuer is not by itself a reason to serve a mailbox;
 - `exp` and `nbf`, with 60 seconds of clock skew tolerated;
 - a `sub` among that profile's `AuthorizedSubjects`;
-- every scope in `RequiredScopes`.
+- every scope in `RequiredScopes`. `AdvertisedScopes` is checked on nothing — it is published for clients and takes no
+  part in any of this.
 
 A subject and a scope are both required and neither stands in for the other: a scope says what a token was issued for, and
 a subject says whose it is. A token from an authorized subject that is missing a scope is answered `403` naming the scopes;
@@ -452,6 +457,38 @@ boundary rather than a broken one, and it is the right setting where the authori
 token for MailFathom. A required scope constrains tokens only: an API key cannot carry one, and its authorization is the
 operator's decision to configure it.
 
+#### Scopes you advertise but do not require
+
+**`AdvertisedScopes` publishes a scope for clients to ask for, and checks it on nothing.** The metadata document's
+`scopes_supported` is what a client should request — that is what
+[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) defines the field as — and it is not the same list as what a
+token is refused for lacking. Both lists reach the document; only `RequiredScopes` reaches the check.
+
+**`offline_access` is what the setting exists for.** A client asks for a refresh token by naming that scope, and the
+widely deployed authorization servers issue none without it. A client that reads your metadata document and asks for
+exactly what it lists therefore holds no refresh token, and sends the person back through a sign-in page whenever the
+access token expires — every hour on most servers. Advertising it fixes that for every client at once:
+
+```json
+{
+  "AdvertisedScopes": [ "offline_access" ]
+}
+```
+
+**Requiring it instead would be wrong, and there is deliberately no way to arrive at that by accident.** The value
+describes the client's own session rather than anything MailFathom protects, and an authorization server need not put it
+in the access token's `scope` claim at all — so requiring it would refuse perfectly good tokens from a server that
+grants offline access and does not name it in the token. A scope listed here can never turn a caller away.
+
+Every value is a scope token, refused at startup with the same message a malformed required scope gets, naming the
+setting and the index. A value that is already in `RequiredScopes` is refused as well: every required scope is published
+regardless, so writing it twice would say nothing and would leave the setting reading as the whole advertised list
+rather than as what is advertised beyond what is checked.
+
+`mfctl` asks for exactly what the document lists and adds nothing to it, so this is the setting that decides whether an
+`mfctl` sign-in survives its first hour — see
+[how long an OAuth sign-in lasts](admin-endpoint.md#how-long-an-oauth-sign-in-lasts).
+
 **Tokens are never passed on.** A token presented here is used to identify the caller and nothing else. It is not forwarded to
 a mail provider, to a downstream service, or to another MCP server.
 
@@ -465,7 +502,7 @@ derived from `Resource` — for `https://mail.example.test/mcp`, that is
 {
   "resource": "https://mail.example.test/mcp",
   "authorization_servers": [ "https://sso.example.test/realms/mailfathom" ],
-  "scopes_supported": [ "mailfathom.read" ],
+  "scopes_supported": [ "mailfathom.read", "offline_access" ],
   "bearer_methods_supported": [ "header" ],
   "resource_name": "MailFathom"
 }

--- a/src/Cli/Authorization/DeploymentAuthorizationDiscovery.cs
+++ b/src/Cli/Authorization/DeploymentAuthorizationDiscovery.cs
@@ -88,8 +88,18 @@ internal sealed class DeploymentAuthorizationDiscovery
             tokenEndpoint,
             ReadEndpoint(serverMetadata.DeviceAuthorizationEndpoint),
             resource,
-            string.Join(' ', resourceMetadata.ScopesSupported ?? []));
+            ReadPublishedScopes(resourceMetadata.ScopesSupported));
     }
+
+    /// <summary>Reads the scope list the deployment published, in the space-separated form RFC 6749 sends it in.</summary>
+    /// <remarks>
+    /// Blank entries are dropped rather than joined, because this document comes from a machine the process does not own
+    /// and a list of them would compose into a scope parameter made of spaces — which is the empty parameter an absent
+    /// one is deliberately not, and which several authorization servers refuse. What survives is sent verbatim: a value
+    /// this command does not recognize is still the operator's to publish.
+    /// </remarks>
+    private static string ReadPublishedScopes(IReadOnlyList<string>? publishedScopes) =>
+        string.Join(' ', (publishedScopes ?? []).Where(scope => !string.IsNullOrWhiteSpace(scope)));
 
     /// <summary>Names the one authorization server this sign-in will use.</summary>
     /// <remarks>

--- a/src/Cli/Authorization/DeploymentAuthorizationDiscovery.cs
+++ b/src/Cli/Authorization/DeploymentAuthorizationDiscovery.cs
@@ -15,9 +15,14 @@ namespace MailFathom.Cli.Authorization;
 /// <remarks>
 /// <para>
 /// Two documents and no configuration. The deployment publishes which authorization servers it accepts, the resource
-/// identifier a token must be issued for, and the scopes it requires; the server publishes where a person approves a
-/// sign-in and where a grant is exchanged. Everything the sign-in needs comes from one of the two, which is what keeps
-/// <c>login</c> from being a command an operator has to prepare four values for, each wrong in its own way.
+/// identifier a token must be issued for, and the scopes a client should ask for; the server publishes where a person
+/// approves a sign-in and where a grant is exchanged. Everything the sign-in needs comes from one of the two, which is
+/// what keeps <c>login</c> from being a command an operator has to prepare four values for, each wrong in its own way.
+/// </para>
+/// <para>
+/// The scope list is taken verbatim, including <c>offline_access</c> where the deployment advertises one. Nothing is
+/// added to it: a client that appends a scope of its own asks an authorization server for something the operator never
+/// published, and whether this session may outlive its first access token is the deployment's decision to state.
 /// </para>
 /// <para>
 /// The issuer the deployment names is the anchor. A discovery document is accepted only when the <c>issuer</c> it

--- a/src/Cli/Authorization/DeploymentAuthorizationMetadata.cs
+++ b/src/Cli/Authorization/DeploymentAuthorizationMetadata.cs
@@ -10,7 +10,7 @@ namespace MailFathom.Cli.Authorization;
 /// <summary>The subset of an RFC 9728 protected resource metadata document the command reads.</summary>
 /// <param name="Resource">The identifier a token must be issued for, sent back as RFC 8707's <c>resource</c> parameter.</param>
 /// <param name="AuthorizationServers">The issuers whose tokens the deployment accepts.</param>
-/// <param name="ScopesSupported">The scopes the deployment requires, which the command asks for rather than guessing.</param>
+/// <param name="ScopesSupported">The scopes the deployment tells a client to ask for, which the command asks for verbatim rather than adding to.</param>
 /// <remarks>
 /// Every member is optional because the document comes from a machine this process does not own — a proxy, a captive
 /// portal, and a deployment that serves no administrative surface all answer this address with something. What makes a

--- a/src/Cli/Authorization/DeploymentAuthorizer.cs
+++ b/src/Cli/Authorization/DeploymentAuthorizer.cs
@@ -109,7 +109,7 @@ internal sealed class DeploymentAuthorizer
         // scope the document never named would ask an authorization server for something the operator did not intend,
         // and a session that outlives the first hour is the deployment's decision to publish rather than this client's
         // to assume.
-        if (authorization.Scope is { Length: > 0 })
+        if (!string.IsNullOrWhiteSpace(authorization.Scope))
         {
             query["scope"] = authorization.Scope;
         }
@@ -252,10 +252,10 @@ internal sealed class DeploymentAuthorizer
     }
 
     /// <summary>Asks for the scopes the deployment published, and asks for nothing where it published none.</summary>
-    /// <remarks>An empty <c>scope</c> parameter is not the same thing as an absent one, and a deployment that requires and advertises no scope publishes an empty list — so the parameter is left out rather than sent empty to a server that may well refuse it.</remarks>
+    /// <remarks>An empty <c>scope</c> parameter is not the same thing as an absent one, and a deployment that requires and advertises no scope publishes an empty list — so the parameter is left out rather than sent empty to a server that may well refuse it. Blank is read as absent as well, because a stored session predating this reading may carry one.</remarks>
     private static void AddPublishedScopes(Dictionary<string, string> form, DeploymentAuthorization authorization)
     {
-        if (authorization.Scope is { Length: > 0 })
+        if (!string.IsNullOrWhiteSpace(authorization.Scope))
         {
             form["scope"] = authorization.Scope;
         }

--- a/src/Cli/Authorization/DeploymentAuthorizer.cs
+++ b/src/Cli/Authorization/DeploymentAuthorizer.cs
@@ -105,9 +105,14 @@ internal sealed class DeploymentAuthorizer
         // and the deployment refuses it — correctly, and for a reason nothing in the refusal explains.
         query["resource"] = authorization.Resource;
 
-        // A refresh token is what makes the session outlive the first hour, and both of the widely deployed servers ask
-        // for it by name in the scope list rather than inferring it from the grant.
-        query["scope"] = ScopeWithOfflineAccess(authorization.Scope);
+        // Verbatim from the deployment's metadata document, including 'offline_access' where it advertises one. Adding a
+        // scope the document never named would ask an authorization server for something the operator did not intend,
+        // and a session that outlives the first hour is the deployment's decision to publish rather than this client's
+        // to assume.
+        if (authorization.Scope is { Length: > 0 })
+        {
+            query["scope"] = authorization.Scope;
+        }
 
         return new PendingSignIn(
             new UriBuilder(authorizationEndpoint) { Query = query.ToString() }.Uri,
@@ -227,33 +232,33 @@ internal sealed class DeploymentAuthorizer
         ArgumentNullException.ThrowIfNull(clientId);
         ArgumentNullException.ThrowIfNull(refreshToken);
 
+        var form = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["grant_type"] = "refresh_token",
+            ["refresh_token"] = refreshToken,
+            ["client_id"] = clientId,
+            ["resource"] = authorization.Resource,
+        };
+
+        AddPublishedScopes(form, authorization);
+
         var renewed = await this.ExchangeAsync(
             authorization,
-            new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["grant_type"] = "refresh_token",
-                ["refresh_token"] = refreshToken,
-                ["client_id"] = clientId,
-                ["resource"] = authorization.Resource,
-                ["scope"] = authorization.Scope,
-            },
+            form,
             GrantAttempt.StoredRefreshToken,
             cancellationToken);
 
         return renewed with { RefreshToken = refreshToken };
     }
 
-    /// <summary>Asks for offline access by name, so a refresh token is issued rather than hoped for.</summary>
-    /// <remarks>Appended rather than assumed present, because the scopes come from what the deployment requires and a deployment has no reason to list a scope about the client's own session.</remarks>
-    private static string ScopeWithOfflineAccess(string scope)
+    /// <summary>Asks for the scopes the deployment published, and asks for nothing where it published none.</summary>
+    /// <remarks>An empty <c>scope</c> parameter is not the same thing as an absent one, and a deployment that requires and advertises no scope publishes an empty list — so the parameter is left out rather than sent empty to a server that may well refuse it.</remarks>
+    private static void AddPublishedScopes(Dictionary<string, string> form, DeploymentAuthorization authorization)
     {
-        const string OfflineAccess = "offline_access";
-
-        var requested = scope.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-        return requested.Contains(OfflineAccess, StringComparer.Ordinal)
-            ? scope
-            : string.Join(' ', [.. requested, OfflineAccess]);
+        if (authorization.Scope is { Length: > 0 })
+        {
+            form["scope"] = authorization.Scope;
+        }
     }
 
     /// <summary>Creates the opaque value the redirect must echo, which is what binds a returned code to this request.</summary>
@@ -330,14 +335,17 @@ internal sealed class DeploymentAuthorizer
         string clientId,
         CancellationToken cancellationToken)
     {
+        var form = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["client_id"] = clientId,
+            ["resource"] = authorization.Resource,
+        };
+
+        AddPublishedScopes(form, authorization);
+
         var response = await this.PostFormAsync(
             deviceAuthorizationEndpoint,
-            new Dictionary<string, string>(StringComparer.Ordinal)
-            {
-                ["client_id"] = clientId,
-                ["scope"] = ScopeWithOfflineAccess(authorization.Scope),
-                ["resource"] = authorization.Resource,
-            },
+            form,
             CliJsonContext.Default.OAuthDeviceAuthorizationResponse,
             cancellationToken);
 
@@ -437,7 +445,7 @@ internal sealed class DeploymentAuthorizer
         if (attempt is not GrantAttempt.StoredRefreshToken && response.RefreshToken is not { Length: > 0 })
         {
             throw new CliFailure(
-                "The authorization server issued no refresh token, so the sign-in would end within the hour. Grant the client offline access, or sign in with an API key instead.");
+                "The authorization server issued no refresh token, so the sign-in would end within the hour. Grant the client offline access at the authorization server and have the deployment advertise 'offline_access', or sign in with an API key instead.");
         }
 
         return new DeploymentGrant(

--- a/src/Host/Api/AdminProtectedResourceMetadataEndpoint.cs
+++ b/src/Host/Api/AdminProtectedResourceMetadataEndpoint.cs
@@ -53,7 +53,7 @@ internal static class AdminProtectedResourceMetadataEndpoint
 /// <summary>What a client learns about this resource before it has a credential for it.</summary>
 /// <param name="Resource">The identifier a token must be issued for, which the client sends as RFC 8707's <c>resource</c> parameter.</param>
 /// <param name="AuthorizationServers">The issuers whose tokens this endpoint accepts, each of which publishes its own discovery document.</param>
-/// <param name="ScopesSupported">The scopes a token must carry, so a client asks for what it will need rather than for everything.</param>
+/// <param name="ScopesSupported">The scopes a client should ask for, which is what RFC 9728 defines the field as rather than what a token is checked against — so a scope this endpoint advertises without requiring is in it too.</param>
 /// <param name="BearerMethodsSupported">How a token may be presented; the header alone, because a credential in a query reaches every access log on the path.</param>
 /// <param name="ResourceName">The product's own name, which is what a consent screen shows the person approving.</param>
 /// <remarks>

--- a/src/Host/Configuration/Access/OAuthValidationOptions.cs
+++ b/src/Host/Configuration/Access/OAuthValidationOptions.cs
@@ -59,12 +59,31 @@ internal sealed class OAuthValidationOptions
 
     /// <summary>Gets the scopes a token must carry before any tool runs.</summary>
     /// <remarks>
-    /// Published as the minimal set in the protected resource metadata and named in the challenge that answers a token
-    /// lacking them, so a client learns what to ask for from the refusal itself. Leaving it empty accepts any token this
-    /// resource's authorization servers issued, which is a coarser boundary rather than a broken one; it is the right
-    /// setting only where the authorization server already restricts who receives a token for this resource.
+    /// Published in the protected resource metadata alongside <see cref="AdvertisedScopes" /> and named in the challenge
+    /// that answers a token lacking them, so a client learns what to ask for from the refusal itself. Leaving it empty
+    /// accepts any token this resource's authorization servers issued, which is a coarser boundary rather than a broken
+    /// one; it is the right setting only where the authorization server already restricts who receives a token for this
+    /// resource.
     /// </remarks>
     public IList<string> RequiredScopes { get; } = [];
+
+    /// <summary>Gets the scopes published for a client to ask for on top of the required ones, and checked on no token.</summary>
+    /// <remarks>
+    /// <para>
+    /// What a client should ask for and what a token is refused for lacking are two lists, and RFC 9728's
+    /// <c>scopes_supported</c> is the first of them. <c>offline_access</c> is what makes the difference visible: a client
+    /// that never asks for it is issued no refresh token and sends its user back through the authorization server every
+    /// time the access token expires, while requiring it here would refuse every token from a server that leaves it out
+    /// of the <c>scope</c> claim — which such a server may do, because the value describes the client's own session
+    /// rather than anything this resource protects.
+    /// </para>
+    /// <para>
+    /// Published beside <see cref="RequiredScopes" /> rather than instead of it: a required scope is advertised whether
+    /// it appears here or not, and a scope named here is never enforced. A value repeating a required one is refused
+    /// rather than folded away, so this list goes on saying exactly what the required list does not.
+    /// </para>
+    /// </remarks>
+    public IList<string> AdvertisedScopes { get; } = [];
 
     /// <summary>Gets the external authorization servers whose access tokens are accepted.</summary>
     public IList<AuthorizationServerOptions> AuthorizationServers { get; } = [];
@@ -73,6 +92,7 @@ internal sealed class OAuthValidationOptions
     public bool IsConfigured =>
         !string.IsNullOrWhiteSpace(this.Resource)
         || this.RequiredScopes.Count > 0
+        || this.AdvertisedScopes.Count > 0
         || this.AuthorizationServers.Any(authorizationServer => authorizationServer.IsConfigured);
 
     /// <summary>Finds everything an operator must fix before OAuth tokens can be validated.</summary>
@@ -92,6 +112,7 @@ internal sealed class OAuthValidationOptions
         }
 
         errors.AddRange(this.FindRequiredScopeErrors());
+        errors.AddRange(this.FindAdvertisedScopeErrors());
         errors.AddRange(this.FindAuthorizationServerErrors());
 
         return errors;
@@ -130,6 +151,38 @@ internal sealed class OAuthValidationOptions
             else if (!claimedScopes.Add(configuredScope))
             {
                 yield return $"{settingPath} — '{configuredScope}' repeats a scope the list already carries.";
+            }
+        }
+    }
+
+    /// <summary>Finds what an operator must fix in the scopes this entry advertises without checking.</summary>
+    /// <remarks>
+    /// A malformed value is refused exactly as a malformed required one is, because both are published in the metadata
+    /// document and named in a challenge, where a space or a quotation mark would split one scope into two or end the
+    /// header parameter early. A value that is already required is refused as well: every required scope is published
+    /// regardless, so repeating one here states nothing and would leave the list reading as the whole advertised set
+    /// rather than as what is advertised beyond what is checked.
+    /// </remarks>
+    private IEnumerable<string> FindAdvertisedScopeErrors()
+    {
+        var requiredScopes = new HashSet<string>(this.RequiredScopes, StringComparer.Ordinal);
+        var claimedScopes = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (index, configuredScope) in this.AdvertisedScopes.Index())
+        {
+            var settingPath = $"{nameof(this.AdvertisedScopes)}:{index}";
+
+            if (!IsScopeToken(configuredScope))
+            {
+                yield return $"{settingPath} — '{configuredScope}' is not a scope; write the value the authorization server issues, with no space, quotation mark, or backslash in it.";
+            }
+            else if (!claimedScopes.Add(configuredScope))
+            {
+                yield return $"{settingPath} — '{configuredScope}' repeats a scope the list already carries.";
+            }
+            else if (requiredScopes.Contains(configuredScope))
+            {
+                yield return $"{settingPath} — '{configuredScope}' is already required and is published for that reason; list here only a scope this endpoint advertises without checking it.";
             }
         }
     }

--- a/src/Host/Configuration/Access/OAuthValidationOptions.cs
+++ b/src/Host/Configuration/Access/OAuthValidationOptions.cs
@@ -157,11 +157,13 @@ internal sealed class OAuthValidationOptions
 
     /// <summary>Finds what an operator must fix in the scopes this entry advertises without checking.</summary>
     /// <remarks>
-    /// A malformed value is refused exactly as a malformed required one is, because both are published in the metadata
-    /// document and named in a challenge, where a space or a quotation mark would split one scope into two or end the
-    /// header parameter early. A value that is already required is refused as well: every required scope is published
-    /// regardless, so repeating one here states nothing and would leave the list reading as the whole advertised set
-    /// rather than as what is advertised beyond what is checked.
+    /// A malformed value is refused exactly as a malformed required one is, and for the metadata document alone: a
+    /// client composes the space-separated <c>scope</c> parameter of its own authorization request out of what it reads
+    /// there, so a space or a quotation mark splits one scope into two. No challenge carries one — only a required scope
+    /// reaches a <c>WWW-Authenticate</c> header, because that is the only kind a token is turned away for lacking. A
+    /// value that is already required is refused as well: every required scope is published regardless, so repeating one
+    /// here states nothing and would leave the list reading as the whole advertised set rather than as what is
+    /// advertised beyond what is checked.
     /// </remarks>
     private IEnumerable<string> FindAdvertisedScopeErrors()
     {

--- a/src/Host/Configuration/Access/PublishedOAuthMetadata.cs
+++ b/src/Host/Configuration/Access/PublishedOAuthMetadata.cs
@@ -7,7 +7,7 @@ namespace MailFathom.Host.Configuration.Access;
 /// <summary>What a protected surface's configured OAuth entries publish about themselves to a client holding nothing yet.</summary>
 /// <param name="Resource">The identifier a token must be issued for, which every entry names identically.</param>
 /// <param name="AuthorizationServers">Every issuer a token may come from, across every entry.</param>
-/// <param name="ScopesSupported">Every scope any entry asks for, listed once however many ask for it.</param>
+/// <param name="ScopesSupported">Every scope a client should ask for, listed once however many entries name it.</param>
 /// <remarks>
 /// <para>
 /// Two surfaces publish an RFC 9728 document and neither may publish a different one: the MCP endpoint through the
@@ -21,6 +21,14 @@ namespace MailFathom.Host.Configuration.Access;
 /// address derived from that resource's identifier. Every entry names the same resource, which configuration validation
 /// is what guarantees, so the resource comes from the first; the two lists carry what all of them accept, because a
 /// client reads this to find out where to authorize and what to ask for.
+/// </para>
+/// <para>
+/// <see cref="ScopesSupported" /> is what a client should ask for rather than what a token is checked against, which is
+/// what RFC 9728 defines the field as. It therefore composes an entry's required scopes together with the ones it
+/// advertises without checking — <c>offline_access</c> being the case that needs the distinction, since a client has to
+/// ask for it to be issued a refresh token while a token proves nothing by carrying it. Enforcement reads
+/// <see cref="OAuthValidationOptions.RequiredScopes" /> directly and never this list, so advertising a scope can widen
+/// what a client requests and can never narrow who is served.
 /// </para>
 /// </remarks>
 internal sealed record PublishedOAuthMetadata(
@@ -52,6 +60,11 @@ internal sealed record PublishedOAuthMetadata(
                     .SelectMany(oauthMethod => oauthMethod.AuthorizationServers)
                     .Select(authorizationServer => authorizationServer.ValidatedIssuer()),
             ],
-            [.. oauthMethods.SelectMany(oauthMethod => oauthMethod.RequiredScopes).Distinct(StringComparer.Ordinal)]);
+            [
+                .. oauthMethods
+                    .SelectMany(oauthMethod => oauthMethod.RequiredScopes)
+                    .Concat(oauthMethods.SelectMany(oauthMethod => oauthMethod.AdvertisedScopes))
+                    .Distinct(StringComparer.Ordinal),
+            ]);
     }
 }

--- a/tests/Cli.UnitTests/FakeOAuthDeployment.cs
+++ b/tests/Cli.UnitTests/FakeOAuthDeployment.cs
@@ -72,6 +72,11 @@ internal sealed class FakeOAuthDeployment
     internal IReadOnlyDictionary<string, string> LastTokenRequest { get; private set; } =
         new Dictionary<string, string>(StringComparer.Ordinal);
 
+    /// <summary>Gets the form the device authorization endpoint was last posted.</summary>
+    /// <remarks>Recorded separately from the token endpoint's because a device sign-in asks for its scopes here, before any code exists to exchange — so a request that asked for the wrong ones would otherwise reach no assertion at all.</remarks>
+    internal IReadOnlyDictionary<string, string> LastDeviceAuthorizationRequest { get; private set; } =
+        new Dictionary<string, string>(StringComparer.Ordinal);
+
     /// <summary>Builds a deployment that publishes OAuth metadata and an authorization server that answers.</summary>
     /// <returns>The scenario, whose <see cref="Handler" /> the context is built over.</returns>
     internal static FakeOAuthDeployment Answering() => new();
@@ -114,14 +119,25 @@ internal sealed class FakeOAuthDeployment
             OpenIdConnectDiscoveryPath => Json(HttpStatusCode.OK, this.AuthorizationServerMetadata()),
             "/realms/mailfathom/protocol/openid-connect/token" =>
                 await this.AnswerTokenEndpointAsync(request, cancellationToken),
-            "/realms/mailfathom/protocol/openid-connect/auth/device" => Json(
-                HttpStatusCode.OK,
-                $$"""{"device_code":"a-device-code","user_code":"WDJB-MJHT","verification_uri":"{{this.VerificationUri}}","expires_in":600,"interval":1}"""),
+            "/realms/mailfathom/protocol/openid-connect/auth/device" =>
+                await this.AnswerDeviceAuthorizationEndpointAsync(request, cancellationToken),
             "/api/admin/session" => Json(
                 HttpStatusCode.OK,
                 FakeAdminEndpoint.SessionBody("kasia", FakeAdminEndpoint.CommandVersion)),
             _ => new HttpResponseMessage(HttpStatusCode.NotFound),
         };
+    }
+
+    [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The response is handed to the HttpClient that asked for it, which disposes it.")]
+    private async Task<HttpResponseMessage> AnswerDeviceAuthorizationEndpointAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        this.LastDeviceAuthorizationRequest = await ReadFormAsync(request, cancellationToken);
+
+        return Json(
+            HttpStatusCode.OK,
+            $$"""{"device_code":"a-device-code","user_code":"WDJB-MJHT","verification_uri":"{{this.VerificationUri}}","expires_in":600,"interval":1}""");
     }
 
     [SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "The response is handed to the HttpClient that asked for it, which disposes it.")]

--- a/tests/Cli.UnitTests/FakeOAuthDeployment.cs
+++ b/tests/Cli.UnitTests/FakeOAuthDeployment.cs
@@ -46,8 +46,9 @@ internal sealed class FakeOAuthDeployment
     /// <remarks>What proves whether a rotated token was adopted: the second renewal presents either the original or the one the first renewal returned.</remarks>
     internal IReadOnlyList<string> PresentedRefreshTokens => this.issuedRefreshTokens;
 
-    /// <summary>Gets or sets the scopes the deployment publishes as required.</summary>
-    internal IReadOnlyList<string> RequiredScopes { get; set; } = ["mailfathom.admin"];
+    /// <summary>Gets or sets the scopes the deployment publishes for a client to ask for.</summary>
+    /// <remarks>This is the document's <c>scopes_supported</c> rather than what a token is checked against, so a deployment advertising offline access states it here and one that does not simply leaves it out.</remarks>
+    internal IReadOnlyList<string> PublishedScopes { get; set; } = ["mailfathom.admin"];
 
     /// <summary>Gets or sets the issuers the deployment publishes, which is more than one where several are accepted.</summary>
     internal IReadOnlyList<string> Issuers { get; set; } = [Issuer];
@@ -161,7 +162,7 @@ internal sealed class FakeOAuthDeployment
         {
           "resource": "{{Resource}}",
           "authorization_servers": [{{string.Join(", ", this.Issuers.Select(issuer => $"\"{issuer}\""))}}],
-          "scopes_supported": [{{string.Join(", ", this.RequiredScopes.Select(scope => $"\"{scope}\""))}}],
+          "scopes_supported": [{{string.Join(", ", this.PublishedScopes.Select(scope => $"\"{scope}\""))}}],
           "bearer_methods_supported": ["header"],
           "resource_name": "MailFathom"
         }

--- a/tests/Cli.UnitTests/OAuthSignInTests.cs
+++ b/tests/Cli.UnitTests/OAuthSignInTests.cs
@@ -94,20 +94,57 @@ public sealed class OAuthSignInTests : IDisposable
     {
         // Arrange
         var deployment = FakeOAuthDeployment.Answering();
-        deployment.RequiredScopes = ["mailfathom.admin", "mailfathom.read"];
+        deployment.PublishedScopes = ["mailfathom.admin", "mailfathom.read", "offline_access"];
         using var handler = deployment.Handler();
 
         // Act
         await this.RunInteractiveAsync(this.CreateStore(), handler);
 
         // Assert
-        var requested = HttpUtility.ParseQueryString(new Uri(this.AuthorizationAddress()).Query)["scope"]?.Split(' ');
-        Assert.Contains("mailfathom.admin", requested!);
-        Assert.Contains("mailfathom.read", requested!);
+        var requested = HttpUtility.ParseQueryString(new Uri(this.AuthorizationAddress()).Query)["scope"]!.Split(' ');
+        Assert.Equal(["mailfathom.admin", "mailfathom.read", "offline_access"], requested);
+    }
 
-        // Without offline access asked for by name, neither of the widely deployed servers issues a refresh token, and
-        // the session would end within the hour.
-        Assert.Contains("offline_access", requested!);
+    /// <summary>
+    /// The document states what to ask for, and this command asks for that and nothing more. It used to append
+    /// <c>offline_access</c> itself, which meant a deployment could not decide whether its clients hold a refresh token;
+    /// now the deployment advertises the scope and every client reading the same document asks for it, rather than only
+    /// the one client that hard-coded the value.
+    /// </summary>
+    [Fact]
+    public async Task Login_ADeploymentAdvertisingNoOfflineAccess_AsksForNothingItDidNotPublish()
+    {
+        // Arrange
+        var deployment = FakeOAuthDeployment.Answering();
+        deployment.PublishedScopes = ["mailfathom.admin"];
+        using var handler = deployment.Handler();
+
+        // Act
+        await this.RunInteractiveAsync(this.CreateStore(), handler);
+
+        // Assert
+        var requested = HttpUtility.ParseQueryString(new Uri(this.AuthorizationAddress()).Query)["scope"]!.Split(' ');
+        Assert.Equal(["mailfathom.admin"], requested);
+    }
+
+    /// <summary>
+    /// A deployment requiring and advertising nothing publishes an empty list, and an empty <c>scope</c> parameter is
+    /// not the same request as one carrying none — several authorization servers refuse the first outright. Nothing is
+    /// substituted for the absence either: the sign-in then ends within the hour, which is the deployment's own choice.
+    /// </summary>
+    [Fact]
+    public async Task Login_ADeploymentPublishingNoScopeAtAll_AsksWithNoScopeParameter()
+    {
+        // Arrange
+        var deployment = FakeOAuthDeployment.Answering();
+        deployment.PublishedScopes = [];
+        using var handler = deployment.Handler();
+
+        // Act
+        await this.RunInteractiveAsync(this.CreateStore(), handler);
+
+        // Assert
+        Assert.Null(HttpUtility.ParseQueryString(new Uri(this.AuthorizationAddress()).Query)["scope"]);
     }
 
     /// <summary>A redirect echoing a value this run never issued belongs to a different request, so nothing may be redeemed against it.</summary>

--- a/tests/Cli.UnitTests/OAuthSignInTests.cs
+++ b/tests/Cli.UnitTests/OAuthSignInTests.cs
@@ -352,6 +352,82 @@ public sealed class OAuthSignInTests : IDisposable
         Assert.Equal("urn:ietf:params:oauth:grant-type:device_code", deployment.LastTokenRequest["grant_type"]);
     }
 
+    /// <summary>
+    /// A device sign-in asks for its scopes at the device authorization endpoint, before any code exists to exchange,
+    /// so that request is the only place a wrong scope list would appear. Dropping a scope the deployment advertises
+    /// costs the person a refresh token they were meant to have and shows up as nothing else.
+    /// </summary>
+    [Fact]
+    public async Task Login_ADeviceSignIn_AsksTheDeviceEndpointForTheScopesTheDeploymentPublishes()
+    {
+        // Arrange
+        var deployment = FakeOAuthDeployment.Answering();
+        deployment.PublishedScopes = ["mailfathom.admin", "offline_access"];
+        using var handler = deployment.Handler();
+
+        // The device grant polls, and the poll waits on the injected clock rather than on a real delay.
+        var signIn = RunAsync(
+            this.Context(this.CreateStore(), handler, FakeMailboxRedirect.Silent()),
+            "login",
+            "--endpoint",
+            FakeOAuthDeployment.DeploymentAddress,
+            "--mode",
+            "device",
+            "--client-id",
+            ClientId);
+
+        // Act
+        await this.AdvanceUntilCompleteAsync(signIn);
+
+        // Assert
+        Assert.Equal(0, await signIn);
+        Assert.Equal("mailfathom.admin offline_access", deployment.LastDeviceAuthorizationRequest["scope"]);
+    }
+
+    /// <summary>The same guard as the interactive request, on the request that carries it: an empty <c>scope</c> parameter is not an absent one.</summary>
+    [Fact]
+    public async Task Login_ADeviceSignInAgainstADeploymentPublishingNoScope_AsksWithNoScopeParameter()
+    {
+        // Arrange
+        var deployment = FakeOAuthDeployment.Answering();
+        deployment.PublishedScopes = [];
+        using var handler = deployment.Handler();
+
+        // The device grant polls, and the poll waits on the injected clock rather than on a real delay.
+        var signIn = RunAsync(
+            this.Context(this.CreateStore(), handler, FakeMailboxRedirect.Silent()),
+            "login",
+            "--endpoint",
+            FakeOAuthDeployment.DeploymentAddress,
+            "--mode",
+            "device",
+            "--client-id",
+            ClientId);
+
+        // Act
+        await this.AdvanceUntilCompleteAsync(signIn);
+
+        // Assert
+        Assert.Equal(0, await signIn);
+        Assert.DoesNotContain("scope", deployment.LastDeviceAuthorizationRequest.Keys);
+    }
+
+    /// <summary>A document answering with blanks composes into a scope parameter made of spaces, which is the empty one the guard exists to avoid — and it comes from a machine this process does not own.</summary>
+    [Fact]
+    public async Task Login_ADeploymentPublishingBlankScopes_AsksWithNoScopeParameter()
+    {
+        // Arrange
+        var deployment = FakeOAuthDeployment.Answering();
+        deployment.PublishedScopes = [" ", string.Empty];
+        using var handler = deployment.Handler();
+
+        // Act
+        await this.RunInteractiveAsync(this.CreateStore(), handler);
+
+        // Assert
+        Assert.Null(HttpUtility.ParseQueryString(new Uri(this.AuthorizationAddress()).Query)["scope"]);
+    }
+
     /// <summary>A server publishing no device endpoint is reported as that, rather than as a sign-in that hangs on a grant it will never answer.</summary>
     [Fact]
     public async Task Login_ADeviceSignInAtAServerOfferingNone_SaysSoRatherThanPolling()
@@ -479,6 +555,9 @@ public sealed class OAuthSignInTests : IDisposable
         Assert.Equal(0, exitCode);
         Assert.Equal("refresh_token", deployment.LastTokenRequest["grant_type"]);
         Assert.Equal("a-renewed-access-token", store.Resolve(requestedDeployment: null).Token);
+
+        // The renewal asks for the same scopes the sign-in did, so a session does not quietly narrow as it is renewed.
+        Assert.Equal("mailfathom.admin", deployment.LastTokenRequest["scope"]);
     }
 
     /// <summary>

--- a/tests/Host.UnitTests/Api/AdminProtectedResourceMetadataEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/AdminProtectedResourceMetadataEndpointTests.cs
@@ -71,6 +71,25 @@ public sealed class AdminProtectedResourceMetadataEndpointTests
         Assert.Equal(["mailfathom.admin", "mailfathom.read", "partners.read"], document.ScopesSupported);
     }
 
+    /// <summary>
+    /// <c>mfctl</c> asks for exactly what this document lists and adds nothing to it, so a deployment that wants the
+    /// sign-in to outlive its first access token says so here. The field is what a client should ask for rather than
+    /// what a token is checked against, which is what RFC 9728 defines it as.
+    /// </summary>
+    [Fact]
+    public void For_AnEntryAdvertisingOfflineAccess_PublishesItForTheClientToAskFor()
+    {
+        // Arrange
+        var oauthSettings = Configured();
+        oauthSettings.AdvertisedScopes.Add("offline_access");
+
+        // Act
+        var document = ProtectedResourceMetadataDocument.For([oauthSettings]);
+
+        // Assert
+        Assert.Equal(["mailfathom.admin", "mailfathom.read", "offline_access"], document.ScopesSupported);
+    }
+
     /// <summary>A credential in a query string reaches every access log on the path, so the header is the only method offered.</summary>
     [Fact]
     public void For_AnySettings_OffersTheHeaderAsTheOnlyWayToPresentAToken()

--- a/tests/Host.UnitTests/Configuration/Access/OAuthValidationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Access/OAuthValidationOptionsTests.cs
@@ -72,6 +72,83 @@ public sealed class OAuthValidationOptionsTests
         Assert.StartsWith("RequiredScopes:1", error, StringComparison.Ordinal);
     }
 
+    /// <summary>An advertised scope reaches the metadata document and a challenge exactly as a required one does, so a value that is not a scope token is refused there too.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AnAdvertisedScopeThatIsNotAScopeToken_IsRefusedNamingItsIndex()
+    {
+        // Arrange
+        var oauth = ConfiguredEntry();
+        oauth.AdvertisedScopes.Add("offline_access");
+        oauth.AdvertisedScopes.Add("two scopes");
+
+        // Act
+        var error = Assert.Single(oauth.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith("AdvertisedScopes:1", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_ARepeatedAdvertisedScope_IsRefused()
+    {
+        // Arrange
+        var oauth = ConfiguredEntry();
+        oauth.AdvertisedScopes.Add("offline_access");
+        oauth.AdvertisedScopes.Add("offline_access");
+
+        // Act
+        var error = Assert.Single(oauth.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith("AdvertisedScopes:1", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Every required scope is published regardless, so repeating one here would state nothing and would leave the
+    /// setting reading as the whole advertised set rather than as what is advertised beyond what is checked.
+    /// </summary>
+    [Fact]
+    public void FindConfigurationErrors_AnAdvertisedScopeThatIsAlreadyRequired_IsRefused()
+    {
+        // Arrange
+        var oauth = ConfiguredEntry();
+        oauth.RequiredScopes.Add("mailfathom.read");
+        oauth.AdvertisedScopes.Add("mailfathom.read");
+
+        // Act
+        var error = Assert.Single(oauth.FindConfigurationErrors());
+
+        // Assert
+        Assert.StartsWith("AdvertisedScopes:0", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>An entry advertising a scope beside the ones it requires is what the separation is for, and is accepted.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AnAdvertisedScopeBesideARequiredOne_IsAccepted()
+    {
+        // Arrange
+        var oauth = ConfiguredEntry();
+        oauth.RequiredScopes.Add("mailfathom.read");
+        oauth.AdvertisedScopes.Add("offline_access");
+
+        // Act, Assert
+        Assert.Empty(oauth.FindConfigurationErrors());
+    }
+
+    /// <summary>A section carrying nothing but an advertised scope was still written, so it is reported rather than treated as an OAuth block nobody meant to configure.</summary>
+    [Fact]
+    public void IsConfigured_AnAdvertisedScopeAlone_ReportsThatSomethingWasWritten()
+    {
+        // Arrange
+        var oauth = new OAuthValidationOptions();
+
+        // Act
+        oauth.AdvertisedScopes.Add("offline_access");
+
+        // Assert
+        Assert.True(oauth.IsConfigured);
+    }
+
     /// <summary>Two profiles sharing a name would leave a diagnostic unable to say which of them it meant.</summary>
     [Fact]
     public void FindConfigurationErrors_TwoAuthorizationServersSharingAName_IsRefused()
@@ -96,5 +173,20 @@ public sealed class OAuthValidationOptionsTests
 
         // Assert
         Assert.StartsWith("AuthorizationServers:1:Name", error, StringComparison.Ordinal);
+    }
+
+    /// <summary>An entry with nothing wrong with it, so a test asserting one refusal reads that refusal rather than the section's other omissions.</summary>
+    private static OAuthValidationOptions ConfiguredEntry()
+    {
+        var oauth = new OAuthValidationOptions { Resource = "https://mail.example.test/mcp" };
+
+        oauth.AuthorizationServers.Add(new AuthorizationServerOptions
+        {
+            Name = "workforce",
+            Issuer = "https://sso.example.test/realms/mailfathom",
+            AuthorizedSubjects = { "9f2c" },
+        });
+
+        return oauth;
     }
 }

--- a/tests/Host.UnitTests/Configuration/Access/PublishedOAuthMetadataTests.cs
+++ b/tests/Host.UnitTests/Configuration/Access/PublishedOAuthMetadataTests.cs
@@ -91,6 +91,96 @@ public sealed class PublishedOAuthMetadataTests
     public void For_NoEntryAtAll_IsRefusedRatherThanPublishingAnEmptyDocument() =>
         Assert.Throws<ArgumentException>(() => PublishedOAuthMetadata.For([]));
 
+    /// <summary>
+    /// The document states what a client should ask for, so a scope the deployment advertises without checking is in it
+    /// beside the ones it does check. <c>offline_access</c> is the value the whole separation exists for: a client that
+    /// never asks for it holds no refresh token, and sends its user back through the authorization server every time the
+    /// access token expires.
+    /// </summary>
+    [Fact]
+    public void For_AnEntryAdvertisingOfflineAccess_PublishesItBesideTheRequiredScopes()
+    {
+        // Arrange
+        var workforce = EntryFor(WorkforceIssuer, "workforce", "mailfathom.read");
+        workforce.AdvertisedScopes.Add("offline_access");
+
+        // Act
+        var published = PublishedOAuthMetadata.For([workforce]);
+
+        // Assert
+        Assert.Equal(["mailfathom.read", "offline_access"], published.ScopesSupported);
+    }
+
+    /// <summary>A deployment that advertises nothing extra publishes exactly what it requires, which is what it published before the two lists were separated.</summary>
+    [Fact]
+    public void For_AnEntryAdvertisingNothingExtra_PublishesOnlyWhatItRequires()
+    {
+        // Arrange
+        var workforce = EntryFor(WorkforceIssuer, "workforce", "mailfathom.read");
+
+        // Act
+        var published = PublishedOAuthMetadata.For([workforce]);
+
+        // Assert
+        Assert.Equal(["mailfathom.read"], published.ScopesSupported);
+    }
+
+    /// <summary>One document over several entries, so a scope one of them advertises reaches every client reading it, once.</summary>
+    [Fact]
+    public void For_SeveralEntriesAdvertisingScopes_PublishesEveryRequiredScopeThenEveryAdvertisedOneOnce()
+    {
+        // Arrange
+        var workforce = EntryFor(WorkforceIssuer, "workforce", "mailfathom.read");
+        workforce.AdvertisedScopes.Add("offline_access");
+
+        var partners = EntryFor(PartnerIssuer, "partners", "partners.read");
+        partners.AdvertisedScopes.Add("offline_access");
+        partners.AdvertisedScopes.Add("openid");
+
+        // Act
+        var published = PublishedOAuthMetadata.For([workforce, partners]);
+
+        // Assert
+        Assert.Equal(
+            ["mailfathom.read", "partners.read", "offline_access", "openid"],
+            published.ScopesSupported);
+    }
+
+    /// <summary>
+    /// Advertising is not requiring. What turns an authenticated caller away is the required list alone, so a scope
+    /// reaching the document must leave that list exactly where it was — otherwise publishing a hint for clients would
+    /// start refusing every token an authorization server issues without it.
+    /// </summary>
+    [Fact]
+    public void For_AnAdvertisedScope_LeavesWhatATokenIsCheckedAgainstUntouched()
+    {
+        // Arrange
+        var workforce = EntryFor(WorkforceIssuer, "workforce", "mailfathom.read");
+        workforce.AdvertisedScopes.Add("offline_access");
+
+        // Act
+        var published = PublishedOAuthMetadata.For([workforce]);
+
+        // Assert
+        Assert.Contains("offline_access", published.ScopesSupported);
+        Assert.Equal(["mailfathom.read"], workforce.RequiredScopes);
+    }
+
+    /// <summary>An entry that requires nothing and advertises a scope publishes it, which is the deployment accepting any token while still telling clients what to ask for.</summary>
+    [Fact]
+    public void For_AnEntryRequiringNothingButAdvertisingAScope_PublishesThatScope()
+    {
+        // Arrange
+        var workforce = EntryFor(WorkforceIssuer, "workforce");
+        workforce.AdvertisedScopes.Add("offline_access");
+
+        // Act
+        var published = PublishedOAuthMetadata.For([workforce]);
+
+        // Assert
+        Assert.Equal(["offline_access"], published.ScopesSupported);
+    }
+
     private static OAuthValidationOptions EntryFor(string issuer, string name, params string[] requiredScopes)
     {
         var oauth = new OAuthValidationOptions { Resource = Resource };

--- a/tests/Host.UnitTests/Security/Mcp/McpTransportSecurityExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Mcp/McpTransportSecurityExtensionsTests.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers.Text;
 using System.Text;
+using MailFathom.Host.Api;
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Mcp;
@@ -15,6 +16,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
+using ModelContextProtocol.AspNetCore.Authentication;
 using Xunit;
 
 namespace MailFathom.Host.UnitTests.Security.Mcp;
@@ -159,24 +161,68 @@ public sealed class McpTransportSecurityExtensionsTests
             .GetSchemeAsync(selectedScheme!));
     }
 
+    /// <summary>
+    /// Two surfaces publish this deployment's RFC 9728 document — the MCP endpoint through the protocol SDK's type, the
+    /// administrative endpoint through a record of this repository's own — and a client reads whichever one it reached.
+    /// Composing the scope list twice is what would let them disagree, so the two are asserted against each other over
+    /// settings where the answer is not simply the required list: a scope advertised without being checked has to reach
+    /// both documents or the same deployment tells two clients to ask for different things.
+    /// </summary>
+    [Fact]
+    public void AddMcpTransportSecurity_AnEndpointAdvertisingAScope_PublishesWhatTheAdministrativeDocumentPublishes()
+    {
+        // Arrange
+        var oauthSettings = OAuthEntryFor("workforce", "https://sso.example.test");
+        oauthSettings.RequiredScopes.Add("mailfathom.read");
+        oauthSettings.AdvertisedScopes.Add("offline_access");
+
+        var endpointSettings = new McpEndpointOptions { Enabled = true };
+        endpointSettings.Authentication.Add(new TransportAuthenticationOptions { OAuth = oauthSettings });
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        // Act
+        services.AddMcpTransportSecurity(endpointSettings);
+
+        // Assert
+        using var composed = services.BuildServiceProvider();
+        var published = composed
+            .GetRequiredService<IOptionsMonitor<McpAuthenticationOptions>>()
+            .Get(McpAuthenticationDefaults.AuthenticationScheme)
+            .ResourceMetadata;
+
+        Assert.NotNull(published);
+        Assert.Equal(["mailfathom.read", "offline_access"], published.ScopesSupported);
+        Assert.Equal(
+            ProtectedResourceMetadataDocument.For([oauthSettings]).ScopesSupported,
+            published.ScopesSupported);
+    }
+
     private static ServiceProvider ComposeOAuthOnlyEndpoint()
     {
         var services = new ServiceCollection();
         services.AddLogging();
 
         var endpointSettings = new McpEndpointOptions { Enabled = true };
-        var oauthSettings = new OAuthValidationOptions { Resource = McpResource };
-        oauthSettings.AuthorizationServers.Add(new AuthorizationServerOptions
-        {
-            Name = "workforce",
-            Issuer = "https://sso.example.test",
-        });
 
-        endpointSettings.Authentication.Add(new TransportAuthenticationOptions { OAuth = oauthSettings });
+        endpointSettings.Authentication.Add(new TransportAuthenticationOptions
+        {
+            OAuth = OAuthEntryFor("workforce", "https://sso.example.test"),
+        });
 
         services.AddMcpTransportSecurity(endpointSettings);
 
         return services.BuildServiceProvider();
+    }
+
+    private static OAuthValidationOptions OAuthEntryFor(string name, string issuer)
+    {
+        var oauthSettings = new OAuthValidationOptions { Resource = McpResource };
+
+        oauthSettings.AuthorizationServers.Add(new AuthorizationServerOptions { Name = name, Issuer = issuer });
+
+        return oauthSettings;
     }
 
     private static DefaultHttpContext RequestTo(IServiceProvider composed, string? authorizationHeaderValue)


### PR DESCRIPTION
Closes #816

## What this changes

`PublishedOAuthMetadata.For` composed `scopes_supported` from `RequiredScopes` alone, so a deployment could publish exactly the scopes it would refuse a token for lacking and nothing else. `offline_access` had no way through that: requiring it would refuse every token from an authorization server that grants offline access and leaves the value out of the access token's `scope` claim, which such a server may do because the value describes the client's own session rather than anything this resource protects. `mfctl` compensated by appending the scope to whatever the document published, which fixed the one client that hard-coded it and no other — every client that takes the document at its word asked for the published scopes, was issued no refresh token, and sent its user back through `/authorize` whenever the access token expired.

The two lists are now two lists.

- **`OAuthValidationOptions.AdvertisedScopes`** carries the scopes an entry publishes without checking. `PublishedOAuthMetadata` composes the required scopes of every entry followed by the advertised ones, distinct; enforcement reads `RequiredScopes` directly and never the published list, so advertising can widen what a client asks for and can never narrow who is served. `InsufficientScopeResultHandler` and the `WWW-Authenticate` challenge are untouched — they still name required scopes only.
- **Both published documents move together.** They are two serializations of one `PublishedOAuthMetadata`, and a new test in `McpTransportSecurityExtensionsTests` asserts the SDK-shaped document the MCP scheme publishes against the administrative endpoint's own record over settings where the answer is not simply the required list.
- **Validation** refuses an advertised value that is not a scope token exactly as it refuses a malformed required one, naming `AdvertisedScopes:<index>`; it also refuses a repeat within the list, and one that is already in `RequiredScopes` — every required scope is published regardless, so repeating one would say nothing and would leave the setting reading as the whole advertised set.
- **`mfctl` stops compensating.** `DeploymentAuthorizer.ScopeWithOfflineAccess` is removed rather than left as a second answer to the same question; the authorization request, the device authorization request, and the refresh all ask for what the document lists and nothing more.

One thing beyond the issue's list, found while reviewing the diff: with the compensation gone, a deployment publishing an empty `scopes_supported` would have made `mfctl` send an empty `scope` parameter, which is not the same request as one carrying none and which several authorization servers refuse outright. The parameter is now omitted where the published list is empty, on all three requests, and a test pins it.

## Break, and the operator's action

No configuration key changes shape and no key is removed, so a deployment upgrades without editing anything — but **`mfctl` sign-in behavior changes against a deployment that does not advertise `offline_access`.** Before this change the command appended the scope itself and obtained a refresh token; now it asks for what the document lists, so on such a deployment the sign-in is refused where the token is issued:

```
The authorization server issued no refresh token, so the sign-in would end within the hour. Grant the client offline
access at the authorization server and have the deployment advertise 'offline_access', or sign in with an API key
instead.
```

**Operator action:** add `"AdvertisedScopes": [ "offline_access" ]` to the `OAuth` entry serving the endpoint `mfctl` signs in to, and keep the scope granted to the client at the authorization server. The refusal is loud and names both halves, and it arrives at sign-in rather than an hour later. The same setting is what finally gives an MCP client a refresh token, which is the capability the issue opened for.

Recorded here per ADR 0004: the surface is the deployment contract, the release is `0.6.0`, and no deprecation window applies below `1.0.0`.

## Verification

- `scripts/verify-full.sh` — passed. 6647 unit tests green; aggregate line coverage 95.78% (19879/20755), gate 85%; `dotnet format` verified 2175 files with nothing to rewrite; 167 workflow-contract assertions passed.
- `scripts/review-obligations.sh` — every row answered. The `Cli/Authorization` pages it named (`docs/operations/mailbox-oauth.md`, `docs/users/administering.md`) describe `mfctl mailbox authorize`, a different flow that this change does not reach.
- Documentation: `docs/operations/mcp-endpoint.md` gains the setting, its own section, and the note that an advertised scope takes no part in what a token must prove; `docs/operations/configuration-reference.md` gains the row; `docs/operations/mcp-client-oauth.md` puts the decision in step 2 where the client scope is created and carries it through the entry, the verification output, and the failure table; `docs/operations/admin-endpoint.md` says which setting decides whether an `mfctl` session survives its first hour.
- No dependency, register, or changelog change.

---

- Issue: https://github.com/Krzysztof318/MailFathom/issues/816
