### PR TITLE
[#503] Trace the local request path from the MCP call to the content store

### DIFF
--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry and the Aspire dashboard
 
-<!-- describes: src/Common/Observability/**, src/Host/Observability/**, src/Host/ServiceDefaultsExtensions.cs, src/Infrastructure/Observability/**, src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, src/Infrastructure/HostApplicationBuilderExtensions.cs, src/AppHost/** -->
+<!-- describes: src/Application/Observability/**, src/Common/Observability/**, src/Host/Observability/**, src/Host/ServiceDefaultsExtensions.cs, src/Host/Hosting/Workers/MailExtractionBackfillWorker.cs, src/Infrastructure/Observability/**, src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, src/Infrastructure/HostApplicationBuilderExtensions.cs, src/AppHost/** -->
 
 The host instruments itself with OpenTelemetry throughout — logs, metrics, and traces — and exports none of it unless
 the environment names a destination. Today exactly one environment does that out of the box: a local run under the
@@ -42,7 +42,9 @@ come from the SDK's own `Experimental.ModelContextProtocol` activity source and 
 negotiated protocol version, the transport, the session identifier, the JSON-RPC request identifier, and the tool name
 for a tool call — which is what makes a slow call attributable to a tool before anything inside the tool is
 instrumented. Database commands are spanned by the `Npgsql` source rather than by EF Core, which reports through
-`DiagnosticSource` and would need a bridging package to span the same commands a second time.
+`DiagnosticSource` and would need a bridging package to span the same commands a second time. Between those two ends
+sit MailFathom's own spans, which say which use case ran; [what a request-path trace contains](#what-a-request-path-trace-contains)
+is where they are named.
 
 One filter is deliberate: requests to the health-probe paths are not traced at all, because a probe arrives every few
 seconds for the life of the process and says the same thing every time — tracing it would fill a trace store with
@@ -226,6 +228,60 @@ now and the record says when it stopped being true, which is the question the st
 carries no age. Only a change is written: every provider call records a state, so a record per call would scale the log
 with the mailbox instead of with what an operator would act on. A first call that succeeded is the one change that is
 not written, because it restored nothing; a first call that failed is.
+
+### What a request-path trace contains
+
+A tool call arrives with a span from the request pipeline and leaves a set of database spans behind it, and neither of
+those says which use case ran in between. Every read the MCP surface serves therefore opens a span of its own, named
+after the use case rather than after the tool — the tool's own name is already on the SDK's span above it, and a second
+entrypoint over the same use case is work of the same kind:
+
+| Span | The read it reports |
+| --- | --- |
+| `read_account_directory` | Which accounts this deployment serves, and how current the local copy of each is |
+| `list_mailbox_timeline` | One bounded page of the stored email timeline |
+| `search_mailbox` | One window of a ranking over the stored emails |
+| `read_email_content` | The stored content of the emails one call named |
+| `answer_mail_question` | One answering run, described in full [below](#what-a-run-records) |
+
+The nesting is what they are for. Each is started inside the protocol span, so it is that span's child, and the database
+commands and content-store reads it issues are its children — which is what separates a tool call that was slow in the
+use case from one that was slow in a query, and both from one that spent its time waiting on a scanner. A search made
+inside an answering run is reported by that run's span instead of opening a second `search_mailbox` beside it, so the
+same work is never counted twice.
+
+| Tag | What it carries |
+| --- | --- |
+| `mailfathom.mailbox.read.results` | How many accounts, summaries, matches, or emails the read returned |
+| `mailfathom.mailbox.read.outcome` | How it ended: `succeeded`, `cancelled`, or `failed` |
+
+`cancelled` is deliberately not `failed`. A client that disconnects mid-read is ordinary traffic on this surface, and
+counting it as a failure would make an impatient assistant read as a broken deployment. A read that returned nothing is
+`succeeded` with a count of zero: matching nothing is a normal answer everywhere here, and the outcome describes the
+read rather than what the mailbox held.
+
+For `read_email_content` the count is the emails that were **served** rather than the emails that were named. The gap
+between the two is the whole of what that number can say — a call naming ten identifiers and answering for one is a
+caller working from a listing that has moved on.
+
+Beneath a read, one span answers a question the database span cannot. **`read_stored_email_content`** is opened
+wherever raw MIME is read out of local storage, and carries `mailfathom.mail.content.bytes` with the size of what came
+back and `mailfathom.mail.content.found` with whether anything was there. Every other query this deployment issues
+returns columns sized like a row; this one returns a whole message, so a command duration on its own cannot tell a
+forty-megabyte message from a two-kilobyte one. An email whose content was never stored reports `found` as false and no
+size, which is an answer rather than a failure.
+
+One more span belongs to no request at all. The extraction backfill opens **`backfill_email_extraction`** once per
+bounded pass, which is what tells work an interval caused apart from work a caller caused — without it the pass appears
+as parentless database commands competing with the requests around them. It carries
+`mailfathom.mail.extraction.backfill.extracted`, `…unreadable`, and `…missing_content` as the counts the pass reached,
+`…remaining` as whether any stored email still awaits extraction, and `…outcome` as one of `succeeded`, `deferred`,
+`failed`, or `interrupted`. `deferred` is a competing writer the pass could not resolve against and `interrupted` is
+shutdown; neither is a failure, and the next interval resumes from the committed position in both cases.
+
+Nothing on any of these spans is derived from a message. There is nowhere on them to put a query text, a filter value, a
+cursor, a subject, an address, or a stored identity — the values are counts, sizes, and closed sets of MailFathom's own
+words, which is a cardinality rule as much as a privacy one.
 
 ### Durable background work
 

--- a/src/Application/Accounts/MailAccountDirectoryReader.cs
+++ b/src/Application/Accounts/MailAccountDirectoryReader.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Observability;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Accounts;
 
@@ -30,24 +31,29 @@ public sealed class MailAccountDirectoryReader
     private readonly IMailAccountCatalog accountCatalog;
     private readonly ISynchronizationFreshnessReader freshnessReader;
     private readonly MailboxScopeResolver scopeResolver;
+    private readonly IMailboxReadTelemetry readTelemetry;
 
     /// <summary>Initializes the use case.</summary>
     /// <param name="accountCatalog">Describes the accounts this deployment serves.</param>
     /// <param name="freshnessReader">Reads how current the local copy of each folder is.</param>
     /// <param name="scopeResolver">Answers which folders of those accounts a tool may see.</param>
+    /// <param name="readTelemetry">Publishes the read as the operation it is, beside the call it happened inside.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public MailAccountDirectoryReader(
         IMailAccountCatalog accountCatalog,
         ISynchronizationFreshnessReader freshnessReader,
-        MailboxScopeResolver scopeResolver)
+        MailboxScopeResolver scopeResolver,
+        IMailboxReadTelemetry readTelemetry)
     {
         ArgumentNullException.ThrowIfNull(accountCatalog);
         ArgumentNullException.ThrowIfNull(freshnessReader);
         ArgumentNullException.ThrowIfNull(scopeResolver);
+        ArgumentNullException.ThrowIfNull(readTelemetry);
 
         this.accountCatalog = accountCatalog;
         this.freshnessReader = freshnessReader;
         this.scopeResolver = scopeResolver;
+        this.readTelemetry = readTelemetry;
     }
 
     /// <summary>Reads the served accounts and their synchronization freshness.</summary>
@@ -59,10 +65,16 @@ public sealed class MailAccountDirectoryReader
     /// </remarks>
     public async Task<MailAccountDirectory> ReadAsync(CancellationToken cancellationToken)
     {
+        using var read = this.readTelemetry.BeginRead(
+            MailboxReadOperation.ReadAccountDirectory,
+            cancellationToken);
+
         var servedAccounts = this.accountCatalog.ServedAccounts;
 
         if (servedAccounts.Count is 0)
         {
+            read.Completed(0);
+
             return new MailAccountDirectory(this.accountCatalog.SynchronizationEnabled, []);
         }
 
@@ -77,6 +89,8 @@ public sealed class MailAccountDirectoryReader
         var foldersByAccount = folderFreshness
             .GroupBy(static freshness => freshness.AccountId)
             .ToDictionary(static group => group.Key, FoldersOrderedByAlias);
+
+        read.Completed(servedAccounts.Count);
 
         return new MailAccountDirectory(
             this.accountCatalog.SynchronizationEnabled,

--- a/src/Application/Emails/GetEmailContent/EmailContentReader.cs
+++ b/src/Application/Emails/GetEmailContent/EmailContentReader.cs
@@ -11,6 +11,7 @@ using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Observability;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Domain.Emails;
@@ -75,6 +76,7 @@ public sealed class EmailContentReader
     private readonly IAttachmentDownloadLinkIssuer linkIssuer;
     private readonly SensitiveContentEgressGuard egressGuard;
     private readonly EmailContentReadOptions readOptions;
+    private readonly IMailboxReadTelemetry readTelemetry;
 
     /// <summary>Initializes the use case.</summary>
     /// <param name="summaryReader">Reads one stored email's summary by its identity.</param>
@@ -85,6 +87,7 @@ public sealed class EmailContentReader
     /// <param name="linkIssuer">Mints the short-lived capability a caller fetches an attachment with.</param>
     /// <param name="egressGuard">Scans what the message's author wrote before a read publishes it.</param>
     /// <param name="readOptions">The bounds on how much body text one call returns.</param>
+    /// <param name="readTelemetry">Publishes the read as the operation it is, beside the call it happened inside.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public EmailContentReader(
         IStoredEmailSummaryReader summaryReader,
@@ -94,7 +97,8 @@ public sealed class EmailContentReader
         MailboxScopeResolver scopeResolver,
         IAttachmentDownloadLinkIssuer linkIssuer,
         SensitiveContentEgressGuard egressGuard,
-        EmailContentReadOptions readOptions)
+        EmailContentReadOptions readOptions,
+        IMailboxReadTelemetry readTelemetry)
     {
         ArgumentNullException.ThrowIfNull(summaryReader);
         ArgumentNullException.ThrowIfNull(contentStore);
@@ -104,6 +108,7 @@ public sealed class EmailContentReader
         ArgumentNullException.ThrowIfNull(linkIssuer);
         ArgumentNullException.ThrowIfNull(egressGuard);
         ArgumentNullException.ThrowIfNull(readOptions);
+        ArgumentNullException.ThrowIfNull(readTelemetry);
 
         this.summaryReader = summaryReader;
         this.contentStore = contentStore;
@@ -113,6 +118,7 @@ public sealed class EmailContentReader
         this.linkIssuer = linkIssuer;
         this.egressGuard = egressGuard;
         this.readOptions = readOptions;
+        this.readTelemetry = readTelemetry;
     }
 
     /// <summary>Reads every email the request names.</summary>
@@ -138,6 +144,8 @@ public sealed class EmailContentReader
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        using var read = this.readTelemetry.BeginRead(MailboxReadOperation.ReadEmailContent, cancellationToken);
+
         var outcomes = new List<EmailContentReadOutcome>(request.StoredEmailIds.Count);
         var remainingCharacters = this.readOptions.MaxCharactersPerRead;
 
@@ -152,6 +160,11 @@ public sealed class EmailContentReader
             remainingCharacters -= CharactersReturnedBy(outcome);
             outcomes.Add(outcome);
         }
+
+        // The emails that were served rather than the emails that were named, because the gap between the two is the
+        // whole of what this read can report: a call naming ten identifiers and answering for one is a caller working
+        // from a stale listing, and the count of what it asked for would say nothing about that.
+        read.Completed(outcomes.Count(outcome => outcome.Content is not null));
 
         return new GetEmailContentResult(new ReadOnlyCollection<EmailContentReadOutcome>(outcomes));
     }

--- a/src/Application/Emails/ListEmails/MailboxTimelineReader.cs
+++ b/src/Application/Emails/ListEmails/MailboxTimelineReader.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Observability;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
@@ -36,28 +37,33 @@ public sealed class MailboxTimelineReader
     private readonly ISynchronizationFreshnessReader freshnessReader;
     private readonly MailboxScopeResolver scopeResolver;
     private readonly SensitiveContentEgressGuard egressGuard;
+    private readonly IMailboxReadTelemetry readTelemetry;
 
     /// <summary>Initializes the use case.</summary>
     /// <param name="timelineReader">Reads bounded pages of stored email summaries.</param>
     /// <param name="freshnessReader">Reads how current the local copy of each folder is.</param>
     /// <param name="scopeResolver">Decides which accounts and folders the listing runs against.</param>
     /// <param name="egressGuard">Scans what the page is about to publish, where this deployment scans anything.</param>
+    /// <param name="readTelemetry">Publishes the read as the operation it is, beside the call it happened inside.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public MailboxTimelineReader(
         IStoredEmailTimelineReader timelineReader,
         ISynchronizationFreshnessReader freshnessReader,
         MailboxScopeResolver scopeResolver,
-        SensitiveContentEgressGuard egressGuard)
+        SensitiveContentEgressGuard egressGuard,
+        IMailboxReadTelemetry readTelemetry)
     {
         ArgumentNullException.ThrowIfNull(timelineReader);
         ArgumentNullException.ThrowIfNull(freshnessReader);
         ArgumentNullException.ThrowIfNull(scopeResolver);
         ArgumentNullException.ThrowIfNull(egressGuard);
+        ArgumentNullException.ThrowIfNull(readTelemetry);
 
         this.timelineReader = timelineReader;
         this.freshnessReader = freshnessReader;
         this.scopeResolver = scopeResolver;
         this.egressGuard = egressGuard;
+        this.readTelemetry = readTelemetry;
     }
 
     /// <summary>Lists one page of emails.</summary>
@@ -79,6 +85,8 @@ public sealed class MailboxTimelineReader
     {
         ArgumentNullException.ThrowIfNull(request);
 
+        using var read = this.readTelemetry.BeginRead(MailboxReadOperation.ListMailboxTimeline, cancellationToken);
+
         var filter = this.ReadableFilter(request);
         var pageSize = MailboxQueryPageSize.FromRequested(request.PageSize);
         var continueAfter = ContinuationPosition(request.Cursor, filter);
@@ -87,6 +95,8 @@ public sealed class MailboxTimelineReader
         // refusals a deployment that serves several does, and only then reports that it holds nothing to read.
         if (filter.Selection.Scope.AccountIds.Count is 0)
         {
+            read.Completed(0);
+
             return new ListEmailsResult([], NextCursor: null, [], filter.Selection.Scope.IncludesJunkMail);
         }
 
@@ -110,8 +120,12 @@ public sealed class MailboxTimelineReader
         // Guarded after the cursor is issued rather than before it. The cursor names a position in the timeline, which
         // is the received instant and the stored identity, and redaction touches neither — issuing it from the guarded
         // page would be the same value arrived at through more work.
+        var guardedPage = await this.GuardedAsync(page, cancellationToken);
+
+        read.Completed(guardedPage.Count);
+
         return new ListEmailsResult(
-            await this.GuardedAsync(page, cancellationToken),
+            guardedPage,
             nextCursor,
             folderFreshness,
             filter.Selection.Scope.IncludesJunkMail);

--- a/src/Application/Emails/SearchEmails/MailboxSearchReader.cs
+++ b/src/Application/Emails/SearchEmails/MailboxSearchReader.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
+using MailFathom.Application.Observability;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
@@ -71,6 +72,7 @@ public sealed class MailboxSearchReader
     private readonly MailboxScopeResolver scopeResolver;
     private readonly EmailSearchSnippetBounds snippetBounds;
     private readonly SensitiveContentEgressGuard egressGuard;
+    private readonly IMailboxReadTelemetry readTelemetry;
 
     /// <summary>Initializes the use case.</summary>
     /// <param name="searchIndexReader">Ranks mail against the query text and reads the window a ranking selected.</param>
@@ -79,6 +81,7 @@ public sealed class MailboxSearchReader
     /// <param name="scopeResolver">Decides which accounts and folders the search runs against.</param>
     /// <param name="snippetBounds">How much of a message's body one result may show.</param>
     /// <param name="egressGuard">Scans what the window is about to publish, where this deployment scans anything.</param>
+    /// <param name="readTelemetry">Publishes the search as the operation it is, beside the call it happened inside.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public MailboxSearchReader(
         IEmailSearchIndexReader searchIndexReader,
@@ -86,7 +89,8 @@ public sealed class MailboxSearchReader
         ISynchronizationFreshnessReader freshnessReader,
         MailboxScopeResolver scopeResolver,
         EmailSearchSnippetBounds snippetBounds,
-        SensitiveContentEgressGuard egressGuard)
+        SensitiveContentEgressGuard egressGuard,
+        IMailboxReadTelemetry readTelemetry)
     {
         ArgumentNullException.ThrowIfNull(searchIndexReader);
         ArgumentNullException.ThrowIfNull(semanticSearch);
@@ -94,6 +98,7 @@ public sealed class MailboxSearchReader
         ArgumentNullException.ThrowIfNull(scopeResolver);
         ArgumentNullException.ThrowIfNull(snippetBounds);
         ArgumentNullException.ThrowIfNull(egressGuard);
+        ArgumentNullException.ThrowIfNull(readTelemetry);
 
         this.searchIndexReader = searchIndexReader;
         this.semanticSearch = semanticSearch;
@@ -101,6 +106,7 @@ public sealed class MailboxSearchReader
         this.scopeResolver = scopeResolver;
         this.snippetBounds = snippetBounds;
         this.egressGuard = egressGuard;
+        this.readTelemetry = readTelemetry;
     }
 
     /// <summary>Searches for one window of ranked emails and publishes it to a caller outside this process.</summary>
@@ -113,17 +119,30 @@ public sealed class MailboxSearchReader
     /// <exception cref="EmailSearchResultLimitOutOfRangeException">Thrown when the request names a result count outside the accepted range.</exception>
     /// <exception cref="SensitiveContentScannerUnavailableException">Thrown when a switched-on scanner could not establish what the window carries, which refuses the search rather than serving it unscanned.</exception>
     /// <remarks>
+    /// <para>
     /// The guard belongs to publishing rather than to searching, which is why it is here and not in
     /// <see cref="SearchWindowAsync" />: this window becomes an MCP tool's answer, while the one that method returns is
     /// read inside the process by something that guards it at its own egress point.
+    /// </para>
+    /// <para>
+    /// The span is reported around the same boundary and for the same reason. What it has to measure is what an MCP
+    /// caller waited for, which includes the scan of everything the window publishes; a span around the ranking alone
+    /// would report a fast search on a deployment whose reads are slow because they are being scanned. The retrieval an
+    /// answering run makes is reported by that run's own span instead, so the two do not report the same work twice.
+    /// </para>
     /// </remarks>
     public async Task<SearchEmailsResult> SearchEmailsAsync(
         SearchEmailsRequest request,
         CancellationToken cancellationToken)
     {
-        var window = await this.SearchWindowAsync(request, cancellationToken);
+        using var read = this.readTelemetry.BeginRead(MailboxReadOperation.SearchMailbox, cancellationToken);
 
-        return window with { Matches = await this.GuardedAsync(window.Matches, cancellationToken) };
+        var window = await this.SearchWindowAsync(request, cancellationToken);
+        var matches = await this.GuardedAsync(window.Matches, cancellationToken);
+
+        read.Completed(matches.Count);
+
+        return window with { Matches = matches };
     }
 
     /// <summary>Searches for one window of ranked emails, for a reader inside this process.</summary>

--- a/src/Application/Observability/IMailboxReadScope.cs
+++ b/src/Application/Observability/IMailboxReadScope.cs
@@ -1,0 +1,22 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Observability;
+
+/// <summary>Holds one local read's report open for as long as the read is running.</summary>
+/// <remarks>
+/// The report is open <em>around</em> the read rather than written after it, so the persistence and content-store work
+/// the read causes is reported beneath it. A read that never reports what it returned is reported as one that did not
+/// finish, which is what makes a refusal, a cancellation, and a fault visible without the use case catching anything.
+/// </remarks>
+public interface IMailboxReadScope : IDisposable
+{
+    /// <summary>Records that the read produced an answer, and how much of one.</summary>
+    /// <param name="resultCount">How many accounts, summaries, matches, or emails the read is returning.</param>
+    /// <remarks>
+    /// Called once, with what the caller actually receives. An empty answer is a completed read rather than an
+    /// unfinished one: matching nothing is a normal result everywhere on this surface.
+    /// </remarks>
+    void Completed(int resultCount);
+}

--- a/src/Application/Observability/IMailboxReadTelemetry.cs
+++ b/src/Application/Observability/IMailboxReadTelemetry.cs
@@ -1,0 +1,29 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Observability;
+
+/// <summary>Publishes one read of the local mailbox copy as the operation somebody asked for.</summary>
+/// <remarks>
+/// <para>
+/// A protocol call and the database commands it issues are both instrumented by libraries, and neither says which use
+/// case ran between them. That is the gap this port closes: a read reported here sits inside the span the protocol
+/// boundary already produces and parents the persistence and content-store work it causes, so a slow tool call is
+/// attributable to a use case, and the use case's own cost is separable from the queries beneath it.
+/// </para>
+/// <para>
+/// A port rather than a call into a tracing API, because starting a span is infrastructure: the application states that
+/// a read began, what it returned, and that it is over, and an adapter decides which registry that reaches. It is also
+/// what keeps the signal's privacy rule in one place, since nothing above the adapter can attach a tag to it — a read
+/// reports counts and nothing about what was asked for or found.
+/// </para>
+/// </remarks>
+public interface IMailboxReadTelemetry
+{
+    /// <summary>Opens the report of one read, and publishes it when the returned scope is disposed.</summary>
+    /// <param name="operation">Which read is beginning.</param>
+    /// <param name="cancellationToken">The caller's token, read as the scope is disposed to tell a caller that walked away from a read that broke.</param>
+    /// <returns>The scope, which the caller must dispose exactly once and which the read must be conducted inside.</returns>
+    IMailboxReadScope BeginRead(MailboxReadOperation operation, CancellationToken cancellationToken);
+}

--- a/src/Application/Observability/MailboxReadOperation.cs
+++ b/src/Application/Observability/MailboxReadOperation.cs
@@ -1,0 +1,27 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Observability;
+
+/// <summary>Names the local read a report is being opened for.</summary>
+/// <remarks>
+/// Each member names the operation the use case performs rather than the tool that reached it, because a second
+/// entrypoint over the same use case is work of the same kind and the protocol span above already carries the tool's
+/// own name. What each member is published as is the adapter's to decide, which is what keeps a span name out of
+/// <c>Application</c> along with every other tracing detail.
+/// </remarks>
+public enum MailboxReadOperation
+{
+    /// <summary>Reading which accounts this deployment serves and how current each one's local copy is.</summary>
+    ReadAccountDirectory = 0,
+
+    /// <summary>Reading one bounded page of the stored email timeline.</summary>
+    ListMailboxTimeline = 1,
+
+    /// <summary>Ranking the stored emails against a query and reading one window of the ranking.</summary>
+    SearchMailbox = 2,
+
+    /// <summary>Reading the stored content of the emails one call names.</summary>
+    ReadEmailContent = 3,
+}

--- a/src/Host/Hosting/Workers/MailExtractionBackfillWorker.cs
+++ b/src/Host/Hosting/Workers/MailExtractionBackfillWorker.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Persistence;
+using MailFathom.Common.Observability;
 using MailFathom.Host.Configuration.Mail;
 using Microsoft.Extensions.Options;
 
@@ -19,6 +21,31 @@ namespace MailFathom.Host.Hosting.Workers;
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this hosted service.")]
 internal sealed partial class MailExtractionBackfillWorker : BackgroundService
 {
+    /// <summary>The name one bounded backfill pass opens its span under.</summary>
+    /// <remarks>
+    /// A run of this worker is the one piece of extraction nothing else in a trace explains: it is caused by an
+    /// interval rather than by a request, so without a span of its own its database commands appear as parentless work
+    /// beside the requests they compete with. Named after what the pass does rather than after the worker, so it reads
+    /// as the work that was done if the pass is ever scheduled from somewhere else.
+    /// </remarks>
+    internal const string RunSpanName = "backfill_email_extraction";
+
+    internal const string ExtractedTagName = "mailfathom.mail.extraction.backfill.extracted";
+    internal const string UnreadableTagName = "mailfathom.mail.extraction.backfill.unreadable";
+    internal const string MissingContentTagName = "mailfathom.mail.extraction.backfill.missing_content";
+    internal const string RemainingTagName = "mailfathom.mail.extraction.backfill.remaining";
+    internal const string OutcomeTagName = "mailfathom.mail.extraction.backfill.outcome";
+
+    internal const string SucceededOutcomeName = "succeeded";
+
+    /// <summary>Names a pass a competing writer deferred, which the next interval resumes from.</summary>
+    internal const string DeferredOutcomeName = "deferred";
+
+    internal const string FailedOutcomeName = "failed";
+
+    /// <summary>Names a pass the host stopped, which is shutdown rather than a failure.</summary>
+    internal const string InterruptedOutcomeName = "interrupted";
+
     private readonly IServiceScopeFactory scopeFactory;
     private readonly MailExtractionBackfillOptions settings;
     private readonly ILogger<MailExtractionBackfillWorker> logger;
@@ -70,12 +97,21 @@ internal sealed partial class MailExtractionBackfillWorker : BackgroundService
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "The hosted worker isolates an unexpected failure so a later interval can resume from the committed position.")]
     private async Task<bool> RunOnceAsync(CancellationToken cancellationToken)
     {
+        using var run = Telemetry.ActivitySource.StartActivity(RunSpanName);
+
         try
         {
             using var scope = this.scopeFactory.CreateScope();
 
             var backfill = scope.ServiceProvider.GetRequiredService<StoredEmailExtractionBackfill>();
             var result = await backfill.RunAsync(cancellationToken);
+
+            run?.SetTag(ExtractedTagName, result.ExtractedEmailCount);
+            run?.SetTag(UnreadableTagName, result.UnreadableEmailCount);
+            run?.SetTag(MissingContentTagName, result.MissingContentEmailCount);
+            run?.SetTag(RemainingTagName, result.EmailsRemain);
+            run?.SetTag(OutcomeTagName, SucceededOutcomeName);
+            run?.SetStatus(ActivityStatusCode.Ok);
 
             this.LogBackfillProgressed(
                 result.ExtractedEmailCount,
@@ -92,16 +128,25 @@ internal sealed partial class MailExtractionBackfillWorker : BackgroundService
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            // Shutdown rather than a failure, exactly as an interrupted synchronization cycle is, so a rolling restart
+            // does not read as a backfill that broke.
+            run?.SetTag(OutcomeTagName, InterruptedOutcomeName);
+
             throw;
         }
         catch (PersistenceConcurrencyConflictException exception)
         {
+            run?.SetTag(OutcomeTagName, DeferredOutcomeName);
+
             this.LogBackfillDeferredAfterConcurrencyConflict(exception);
 
             return true;
         }
         catch (Exception exception)
         {
+            run?.SetTag(OutcomeTagName, FailedOutcomeName);
+            run?.SetStatus(ActivityStatusCode.Error);
+
             this.LogBackfillFailed(exception);
 
             return true;

--- a/src/Infrastructure/Observability/MailboxReadTelemetry.cs
+++ b/src/Infrastructure/Observability/MailboxReadTelemetry.cs
@@ -1,0 +1,106 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics;
+using MailFathom.Application.Observability;
+using MailFathom.Common.Observability;
+
+namespace MailFathom.Infrastructure.Observability;
+
+/// <summary>Publishes one read of the local mailbox copy as a span between the protocol call and the queries it issued.</summary>
+/// <remarks>
+/// <para>
+/// The span is named after the use case, so a trace reads as the work that was done rather than as the tool that asked
+/// for it — the tool's own name is already on the MCP SDK's span above. Nesting is what the span is for: it becomes a
+/// child of that protocol span because it is started inside it, and the database and content-store spans the read
+/// causes become children of this, which is what attributes a slow tool call to a use case, to a query, or to neither.
+/// </para>
+/// <para>
+/// A read publishes a count and an ending and nothing else. Not the query text, not a filter value, not a cursor, not a
+/// subject, an address, or a stored identity — every one of those is either mail or a value per message, and a span
+/// store is the last place either belongs.
+/// </para>
+/// </remarks>
+internal sealed class MailboxReadTelemetry : IMailboxReadTelemetry
+{
+    internal const string AccountDirectorySpanName = "read_account_directory";
+    internal const string MailboxTimelineSpanName = "list_mailbox_timeline";
+    internal const string MailboxSearchSpanName = "search_mailbox";
+    internal const string EmailContentSpanName = "read_email_content";
+
+    internal const string ResultCountTagName = "mailfathom.mailbox.read.results";
+    internal const string OutcomeTagName = "mailfathom.mailbox.read.outcome";
+
+    internal const string SucceededOutcomeName = "succeeded";
+
+    /// <summary>Names a read the caller stopped waiting for, which is a disconnect rather than a defect.</summary>
+    internal const string CancelledOutcomeName = "cancelled";
+
+    internal const string FailedOutcomeName = "failed";
+
+    /// <inheritdoc />
+    public IMailboxReadScope BeginRead(MailboxReadOperation operation, CancellationToken cancellationToken) =>
+        new ReadSpan(Telemetry.ActivitySource.StartActivity(SpanNameOf(operation)), cancellationToken);
+
+    /// <summary>Reads the name one operation is published under.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the operation is not one this adapter publishes.</exception>
+    private static string SpanNameOf(MailboxReadOperation operation) => operation switch
+    {
+        MailboxReadOperation.ReadAccountDirectory => AccountDirectorySpanName,
+        MailboxReadOperation.ListMailboxTimeline => MailboxTimelineSpanName,
+        MailboxReadOperation.SearchMailbox => MailboxSearchSpanName,
+        MailboxReadOperation.ReadEmailContent => EmailContentSpanName,
+        _ => throw new ArgumentOutOfRangeException(nameof(operation), operation, "The read operation has no published span name."),
+    };
+
+    /// <summary>Carries one read from the span that opens it to the ending that closes it.</summary>
+    /// <remarks>
+    /// A read that reported no result is published as cancelled where the caller's token was cancelled and as failed
+    /// otherwise. Telling the two apart matters here more than it does for background work: a client disconnecting
+    /// mid-read is ordinary traffic, and counting it as a failure would make an impatient assistant look like a broken
+    /// deployment. The activity is null on an instance nothing is listening to, which is the ordinary case for a
+    /// deployment exporting nothing, and the scope then costs one allocation and no work.
+    /// </remarks>
+    private sealed class ReadSpan(Activity? activity, CancellationToken cancellationToken) : IMailboxReadScope
+    {
+        private int? returnedResults;
+        private bool reported;
+
+        public void Completed(int resultCount) => this.returnedResults = resultCount;
+
+        public void Dispose()
+        {
+            if (this.reported)
+            {
+                return;
+            }
+
+            this.reported = true;
+
+            if (activity is null)
+            {
+                return;
+            }
+
+            if (this.returnedResults is { } returned)
+            {
+                activity.SetTag(ResultCountTagName, returned);
+                activity.SetTag(OutcomeTagName, SucceededOutcomeName);
+                activity.SetStatus(ActivityStatusCode.Ok);
+            }
+            else if (cancellationToken.IsCancellationRequested)
+            {
+                activity.SetTag(OutcomeTagName, CancelledOutcomeName);
+                activity.SetStatus(ActivityStatusCode.Unset);
+            }
+            else
+            {
+                activity.SetTag(OutcomeTagName, FailedOutcomeName);
+                activity.SetStatus(ActivityStatusCode.Error);
+            }
+
+            activity.Dispose();
+        }
+    }
+}

--- a/src/Infrastructure/Observability/StoredEmailContentTelemetry.cs
+++ b/src/Infrastructure/Observability/StoredEmailContentTelemetry.cs
@@ -1,0 +1,75 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics;
+using MailFathom.Common.Observability;
+
+namespace MailFathom.Infrastructure.Observability;
+
+/// <summary>Publishes a read of stored raw MIME as a span of its own, with what it cost in bytes.</summary>
+/// <remarks>
+/// <para>
+/// Every other query this deployment issues returns columns sized like a row. This one returns a whole message, so it
+/// is the one place a read's duration is explained by how much it moved rather than by how much it searched — and the
+/// database span beneath it reports a command duration without ever saying how large the payload was. A read of a
+/// forty-megabyte message and a read of a two-kilobyte one are otherwise the same line in a trace.
+/// </para>
+/// <para>
+/// The span carries a size and whether anything was there, and never the stored identity, the account, the folder, or
+/// any part of the message. The identity alone would open a series per message, and the payload is mail.
+/// </para>
+/// </remarks>
+internal sealed class StoredEmailContentTelemetry
+{
+    /// <summary>The name a read of one email's stored raw MIME opens its span under.</summary>
+    internal const string ReadSpanName = "read_stored_email_content";
+
+    internal const string ByteLengthTagName = "mailfathom.mail.content.bytes";
+    internal const string FoundTagName = "mailfathom.mail.content.found";
+
+    /// <summary>Opens the span one content read is reported as, and returns the scope that ends it.</summary>
+    /// <returns>The scope, which the caller must dispose after recording what the read found.</returns>
+    public ContentReadScope BeginRead() => new(Telemetry.ActivitySource.StartActivity(ReadSpanName));
+
+    /// <summary>Carries one read of stored raw MIME from the span that opens it to what it turned out to hold.</summary>
+    /// <remarks>
+    /// A read that reported neither outcome is one that threw, and the span says so rather than publishing a size
+    /// nobody measured.
+    /// </remarks>
+    internal sealed class ContentReadScope(Activity? activity) : IDisposable
+    {
+        private bool reported;
+
+        /// <summary>Records the content that was read, and how many bytes of it there were.</summary>
+        /// <param name="byteLength">The length of the raw MIME the read returned.</param>
+        public void Found(long byteLength)
+        {
+            this.reported = true;
+
+            activity?.SetTag(FoundTagName, true);
+            activity?.SetTag(ByteLengthTagName, byteLength);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+        }
+
+        /// <summary>Records an email whose content this deployment holds none of, which is not a failure.</summary>
+        public void Absent()
+        {
+            this.reported = true;
+
+            activity?.SetTag(FoundTagName, false);
+            activity?.SetStatus(ActivityStatusCode.Ok);
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (!this.reported)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error);
+            }
+
+            activity?.Dispose();
+        }
+    }
+}

--- a/src/Infrastructure/Persistence/Emails/EmailContentStore.cs
+++ b/src/Infrastructure/Persistence/Emails/EmailContentStore.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Persistence;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Emails;
+using MailFathom.Infrastructure.Observability;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
 using Microsoft.EntityFrameworkCore;
@@ -17,7 +18,10 @@ namespace MailFathom.Infrastructure.Persistence.Emails;
 
 /// <summary>EF Core raw MIME content store.</summary>
 [RequiresIntegrationCoverage]
-internal sealed class EmailContentStore(MailFathomDbContext dbContext, TimeProvider timeProvider) : IEmailContentStore
+internal sealed class EmailContentStore(
+    MailFathomDbContext dbContext,
+    TimeProvider timeProvider,
+    StoredEmailContentTelemetry telemetry) : IEmailContentStore
 {
     /// <inheritdoc />
     /// <remarks>
@@ -25,23 +29,36 @@ internal sealed class EmailContentStore(MailFathomDbContext dbContext, TimeProvi
     /// kept alive by the change tracker after the caller is done with it. The recorded length and digest are read in
     /// the same round trip as the payload they describe, because a second query could read them from a row a
     /// re-synchronization had rewritten in between and report a mismatch nothing is wrong with.
+    /// <para>
+    /// The read is spanned because this is where a request meets a whole message: the command's own span reports how
+    /// long it took and never how much it moved, and those are the same question here.
+    /// </para>
     /// </remarks>
     public async Task<StoredEmailContent?> FindStoredContentAsync(
         StoredEmailId storedEmailId,
         CancellationToken cancellationToken)
     {
+        using var read = telemetry.BeginRead();
+
         var storedContent = await dbContext.EmailMessageContents
             .AsNoTracking()
             .Where(content => content.StoredEmailId == storedEmailId.Value)
             .Select(content => new StoredEmailContentRow(content.RawMime, content.MimeByteLength, content.Sha256Hash))
             .SingleOrDefaultAsync(cancellationToken);
 
-        return storedContent is null
-            ? null
-            : new StoredEmailContent(
-                storedContent.RawMime.AsMemory(),
-                storedContent.MimeByteLength,
-                storedContent.Sha256Hash.AsMemory());
+        if (storedContent is null)
+        {
+            read.Absent();
+
+            return null;
+        }
+
+        read.Found(storedContent.RawMime.LongLength);
+
+        return new StoredEmailContent(
+            storedContent.RawMime.AsMemory(),
+            storedContent.MimeByteLength,
+            storedContent.Sha256Hash.AsMemory());
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Mail.Mutations.Convergence;
 using MailFathom.Application.Mail.Mutations.Destinations;
+using MailFathom.Application.Observability;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Resilience;
 using MailFathom.Application.Retrieval;
@@ -424,6 +425,10 @@ public static class ServiceCollectionExtensions
         services.AddScoped<MailboxReconciler>();
         services.AddScoped<StoredEmailExtractionBackfill>();
         services.AddScoped<MailboxScopeResolver>();
+        // Singletons for the reason every other publisher here is one: a span source is a fact about the process, and a
+        // scoped instance would build one per request for no gain.
+        services.AddSingleton<IMailboxReadTelemetry, MailboxReadTelemetry>();
+        services.AddSingleton<StoredEmailContentTelemetry>();
         services.AddScoped<MailAccountDirectoryReader>();
         // The guard every egress point calls, registered for every deployment rather than only where a scanner is
         // switched on. What is conditional is the redaction behind it: with both switches off the provider hands over

--- a/tests/Application.UnitTests/Accounts/MailAccountDirectoryReaderTests.cs
+++ b/tests/Application.UnitTests/Accounts/MailAccountDirectoryReaderTests.cs
@@ -4,7 +4,9 @@
 
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Observability;
 using MailFathom.Application.Synchronization.Checkpoints;
+using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Synchronization;
@@ -132,12 +134,56 @@ public sealed class MailAccountDirectoryReaderTests
         Assert.Single(directory.Accounts);
     }
 
+    /// <summary>
+    /// The read is reported as the operation it is, so the queries it issues have a use case above them in a trace
+    /// rather than only the protocol call that reached it.
+    /// </summary>
+    [Fact]
+    public async Task ReadAsync_AnyRead_ReportsTheDirectoryReadAndHowManyAccountsItPublished()
+    {
+        // Arrange
+        var readTelemetry = new RecordingMailboxReadTelemetry();
+        var reader = ReaderOver(readTelemetry, Freshness(), synchronizationEnabled: true, Work, Private);
+
+        // Act
+        await reader.ReadAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var read = Assert.Single(readTelemetry.Reads);
+
+        Assert.Equal(MailboxReadOperation.ReadAccountDirectory, read.Operation);
+        Assert.Equal(2, read.ResultCount);
+        Assert.True(read.WasClosed);
+    }
+
+    /// <summary>A deployment serving nothing still reports the read, because a read that happened is not a read that did nothing.</summary>
+    [Fact]
+    public async Task ReadAsync_ADeploymentServingNoAccount_ReportsTheReadAsAnEmptyOne()
+    {
+        // Arrange
+        var readTelemetry = new RecordingMailboxReadTelemetry();
+        var reader = ReaderOver(readTelemetry, Freshness(), synchronizationEnabled: true);
+
+        // Act
+        await reader.ReadAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, Assert.Single(readTelemetry.Reads).ResultCount);
+    }
+
     private static MailAccountDirectoryReader ReaderOver(
         ISynchronizationFreshnessReader freshnessReader,
         params ServedMailAccount[] servedAccounts) =>
         ReaderOver(freshnessReader, synchronizationEnabled: true, servedAccounts);
 
     private static MailAccountDirectoryReader ReaderOver(
+        ISynchronizationFreshnessReader freshnessReader,
+        bool synchronizationEnabled,
+        params ServedMailAccount[] servedAccounts) =>
+        ReaderOver(new RecordingMailboxReadTelemetry(), freshnessReader, synchronizationEnabled, servedAccounts);
+
+    private static MailAccountDirectoryReader ReaderOver(
+        IMailboxReadTelemetry readTelemetry,
         ISynchronizationFreshnessReader freshnessReader,
         bool synchronizationEnabled,
         params ServedMailAccount[] servedAccounts)
@@ -153,7 +199,8 @@ public sealed class MailAccountDirectoryReaderTests
                 catalog,
                 StubMailFolderParticipation.Nothing,
                 StubJunkMailFolderCatalog.None,
-                StubMailFolderMappings.ResolvingNothing));
+                StubMailFolderMappings.ResolvingNothing),
+            readTelemetry);
     }
 
     /// <summary>Answers the folders local state knows of, in an order the reader is expected to correct.</summary>

--- a/tests/Application.UnitTests/Emails/GetEmailContent/EmailContentReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/GetEmailContent/EmailContentReaderTests.cs
@@ -16,6 +16,7 @@ using MailFathom.Application.Emails.GetEmailContent;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
+using MailFathom.Application.Observability;
 using MailFathom.Application.SensitiveContent;
 using MailFathom.Application.SensitiveContent.Derivation;
 using MailFathom.Application.SensitiveContent.Detection;
@@ -1337,6 +1338,58 @@ public sealed class EmailContentReaderTests
         Assert.Equal($"{Marker} bot", Assert.Single(content.Headers.Participants).Address.DisplayName);
     }
 
+    /// <summary>
+    /// The read is reported as the operation it is, so the content-store reads it causes have a use case above them in
+    /// a trace rather than only the protocol call that reached it.
+    /// </summary>
+    [Fact]
+    public async Task ReadContentAsync_EmailsThatWereServed_ReportsTheReadAndHowManyItServed()
+    {
+        // Arrange
+        var readTelemetry = new RecordingMailboxReadTelemetry();
+        var summaries = SummariesOf(2);
+        var reader = ReaderOver(
+            summaries,
+            RendererReturning(RenderingOf()),
+            readTelemetry: readTelemetry);
+
+        // Act
+        await reader.ReadContentAsync(
+            RequestFor(IdentitiesOf(summaries)),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var read = Assert.Single(readTelemetry.Reads);
+
+        Assert.Equal(MailboxReadOperation.ReadEmailContent, read.Operation);
+        Assert.Equal(2, read.ResultCount);
+        Assert.True(read.WasClosed);
+    }
+
+    /// <summary>
+    /// What is counted is what was served rather than what was named, because the gap between the two is a caller
+    /// working from a listing that has moved on.
+    /// </summary>
+    [Fact]
+    public async Task ReadContentAsync_AnIdentifierThisDeploymentDoesNotServe_CountsOnlyTheEmailsItServed()
+    {
+        // Arrange
+        var readTelemetry = new RecordingMailboxReadTelemetry();
+        var summaries = SummariesOf(1);
+        var reader = ReaderOver(
+            summaries,
+            RendererReturning(RenderingOf()),
+            readTelemetry: readTelemetry);
+
+        // Act
+        await reader.ReadContentAsync(
+            RequestFor([.. IdentitiesOf(summaries), StoredEmailId.Create(Guid.CreateVersion7())]),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, Assert.Single(readTelemetry.Reads).ResultCount);
+    }
+
     private static GetEmailContentRequest RequestFor(
         IReadOnlyList<StoredEmailId> storedEmailIds,
         bool includeSanitizedHtml = false,
@@ -1365,7 +1418,8 @@ public sealed class EmailContentReaderTests
         IAttachmentDownloadLinkIssuer? linkIssuer = null,
         EmailContentReadOptions? readOptions = null,
         IMailFolderParticipationReader? folderParticipation = null,
-        SensitiveContentEgressGuard? egressGuard = null) => new(
+        SensitiveContentEgressGuard? egressGuard = null,
+        IMailboxReadTelemetry? readTelemetry = null) => new(
         SummaryReaderReturning(summary),
         contentStore ?? ContentStoreReturning(IntactContent()),
         renderer,
@@ -1377,7 +1431,8 @@ public sealed class EmailContentReaderTests
             StubMailFolderMappings.ResolvingNothing),
         linkIssuer ?? new RecordingAttachmentDownloadLinkIssuer(),
         egressGuard ?? SensitiveContentEgressGuards.Inactive(),
-        readOptions ?? new EmailContentReadOptions());
+        readOptions ?? new EmailContentReadOptions(),
+        readTelemetry ?? new RecordingMailboxReadTelemetry());
 
     private static EmailContentReader ReaderOver(
         IReadOnlyList<EmailSummary> summaries,
@@ -1387,7 +1442,8 @@ public sealed class EmailContentReaderTests
         IMailAccountCatalog? accountCatalog = null,
         IAttachmentDownloadLinkIssuer? linkIssuer = null,
         EmailContentReadOptions? readOptions = null,
-        SensitiveContentEgressGuard? egressGuard = null) => new(
+        SensitiveContentEgressGuard? egressGuard = null,
+        IMailboxReadTelemetry? readTelemetry = null) => new(
         SummaryReaderOver(summaries),
         contentStore ?? ContentStoreReturning(IntactContent()),
         renderer,
@@ -1399,7 +1455,8 @@ public sealed class EmailContentReaderTests
             StubMailFolderMappings.ResolvingNothing),
         linkIssuer ?? new RecordingAttachmentDownloadLinkIssuer(),
         egressGuard ?? SensitiveContentEgressGuards.Inactive(),
-        readOptions ?? new EmailContentReadOptions());
+        readOptions ?? new EmailContentReadOptions(),
+        readTelemetry ?? new RecordingMailboxReadTelemetry());
 
     /// <summary>Maps the folders these emails were stored from, which is what a deployment holding them has configured.</summary>
     /// <remarks>

--- a/tests/Application.UnitTests/Emails/ListEmails/MailboxTimelineReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/ListEmails/MailboxTimelineReaderTests.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.ListEmails;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Observability;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
@@ -797,11 +798,57 @@ public sealed class MailboxTimelineReaderTests
         Assert.Equal($"the key is {Marker}", Assert.Single(result.Emails).Subject);
     }
 
+    /// <summary>
+    /// The listing is reported as the operation it is, so a page a caller waited on has a use case above its queries in
+    /// a trace rather than only the protocol call that reached it.
+    /// </summary>
+    [Fact]
+    public async Task ListEmailsAsync_APageThatWasServed_ReportsTheListingAndWhatItReturned()
+    {
+        // Arrange
+        var readTelemetry = new RecordingMailboxReadTelemetry();
+        var timeline = new InMemoryStoredEmailTimeline().WithAll(
+            SyntheticEmailSummaries.CreateDailyRun(3, FirstJuly));
+        var reader = ReaderOver(timeline, readTelemetry: readTelemetry);
+
+        // Act
+        await reader.ListEmailsAsync(new ListEmailsRequest(), TestContext.Current.CancellationToken);
+
+        // Assert
+        var read = Assert.Single(readTelemetry.Reads);
+
+        Assert.Equal(MailboxReadOperation.ListMailboxTimeline, read.Operation);
+        Assert.Equal(3, read.ResultCount);
+        Assert.True(read.WasClosed);
+    }
+
+    /// <summary>A refused listing reports no result, which is what makes the span say the read did not finish.</summary>
+    [Fact]
+    public async Task ListEmailsAsync_ARefusedRequest_ReportsAReadThatReturnedNothing()
+    {
+        // Arrange
+        var readTelemetry = new RecordingMailboxReadTelemetry();
+        var reader = ReaderOver(new InMemoryStoredEmailTimeline(), readTelemetry: readTelemetry);
+
+        // Act
+        await Assert.ThrowsAsync<MailboxQueryCursorMalformedException>(
+            () => reader.ListEmailsAsync(
+                new ListEmailsRequest { Cursor = "not a cursor at all" },
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        var read = Assert.Single(readTelemetry.Reads);
+
+        Assert.Null(read.ResultCount);
+        Assert.True(read.WasClosed);
+    }
+
     private static MailboxTimelineReader ReaderOver(
         InMemoryStoredEmailTimeline timeline,
         IMailAccountCatalog? accountCatalog = null,
         ISynchronizationFreshnessReader? freshnessReader = null,
-        SensitiveContentEgressGuard? egressGuard = null) => new(
+        SensitiveContentEgressGuard? egressGuard = null,
+        IMailboxReadTelemetry? readTelemetry = null) => new(
         timeline,
         freshnessReader ?? FreshnessReaderReturning(InboxFreshness),
         new MailboxScopeResolver(
@@ -809,7 +856,8 @@ public sealed class MailboxTimelineReaderTests
             StubMailFolderParticipation.Nothing,
             StubJunkMailFolderCatalog.None,
             StubMailFolderMappings.ResolvingNothing),
-        egressGuard ?? SensitiveContentEgressGuards.Inactive());
+        egressGuard ?? SensitiveContentEgressGuards.Inactive(),
+        readTelemetry ?? new RecordingMailboxReadTelemetry());
 
     /// <summary>Builds a catalog that serves exactly the accounts named, in the order the port promises.</summary>
     private static IMailAccountCatalog CatalogServing(params MailAccountId[] servedAccountIds)

--- a/tests/Application.UnitTests/Emails/SearchEmails/MailboxSearchReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/SearchEmails/MailboxSearchReaderTests.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Emails.SearchEmails;
+using MailFathom.Application.Observability;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
@@ -600,6 +601,50 @@ public sealed class MailboxSearchReaderTests
         Assert.Equal([$"use {Marker} to sign in"], match.Snippets);
     }
 
+    /// <summary>
+    /// The search is reported as the operation it is, so a slow query has a use case above its index reads in a trace
+    /// rather than only the protocol call that reached it.
+    /// </summary>
+    [Fact]
+    public async Task SearchEmailsAsync_AWindowThatWasServed_ReportsTheSearchAndWhatItReturned()
+    {
+        // Arrange
+        var readTelemetry = new RecordingMailboxReadTelemetry();
+        var index = new InMemoryEmailSearchIndex()
+            .With(SyntheticEmailSummaries.Create(FirstJuly), relevanceRank: 0.9f, matchedText: "invoice")
+            .With(SyntheticEmailSummaries.Create(FirstJuly.AddDays(1)), relevanceRank: 0.2f, matchedText: "invoice");
+        var reader = ReaderOver(index, readTelemetry: readTelemetry);
+
+        // Act
+        await reader.SearchEmailsAsync(RequestFor("invoice"), TestContext.Current.CancellationToken);
+
+        // Assert
+        var read = Assert.Single(readTelemetry.Reads);
+
+        Assert.Equal(MailboxReadOperation.SearchMailbox, read.Operation);
+        Assert.Equal(2, read.ResultCount);
+        Assert.True(read.WasClosed);
+    }
+
+    /// <summary>A refused search reports no result, which is what makes the span say the read did not finish.</summary>
+    [Fact]
+    public async Task SearchEmailsAsync_ARefusedQuery_ReportsAReadThatReturnedNothing()
+    {
+        // Arrange
+        var readTelemetry = new RecordingMailboxReadTelemetry();
+        var reader = ReaderOver(new InMemoryEmailSearchIndex(), readTelemetry: readTelemetry);
+
+        // Act
+        await Assert.ThrowsAsync<MailboxQueryFilterInvalidException>(
+            () => reader.SearchEmailsAsync(RequestFor("   "), TestContext.Current.CancellationToken));
+
+        // Assert
+        var read = Assert.Single(readTelemetry.Reads);
+
+        Assert.Null(read.ResultCount);
+        Assert.True(read.WasClosed);
+    }
+
     private static SearchEmailsRequest RequestFor(string? queryText) => new() { QueryText = queryText };
 
     private static MailboxSearchReader ReaderOver(
@@ -607,7 +652,8 @@ public sealed class MailboxSearchReaderTests
         IMailAccountCatalog? accountCatalog = null,
         EmailSearchSnippetBounds? snippetBounds = null,
         SemanticEmailSearch? semanticSearch = null,
-        SensitiveContentEgressGuard? egressGuard = null) => new(
+        SensitiveContentEgressGuard? egressGuard = null,
+        IMailboxReadTelemetry? readTelemetry = null) => new(
         index,
         semanticSearch ?? LexicalOnlySemanticSearch(),
         FreshnessReaderReturning(InboxFreshness),
@@ -617,7 +663,8 @@ public sealed class MailboxSearchReaderTests
             StubJunkMailFolderCatalog.None,
             StubMailFolderMappings.ResolvingNothing),
         snippetBounds ?? EmailSearchSnippetBounds.Default,
-        egressGuard ?? SensitiveContentEgressGuards.Inactive());
+        egressGuard ?? SensitiveContentEgressGuards.Inactive(),
+        readTelemetry ?? new RecordingMailboxReadTelemetry());
 
     /// <summary>Builds the semantic half of a deployment that configured no embedding provider and activated nothing.</summary>
     private static SemanticEmailSearch LexicalOnlySemanticSearch() => new(

--- a/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
+++ b/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
@@ -450,7 +450,8 @@ public sealed class MailboxKnowledgeSearchTests
                 StubJunkMailFolderCatalog.None,
                 StubMailFolderMappings.ResolvingNothing),
             EmailSearchSnippetBounds.Default,
-            egressGuard ?? SensitiveContentEgressGuards.Inactive()),
+            egressGuard ?? SensitiveContentEgressGuards.Inactive(),
+            new RecordingMailboxReadTelemetry()),
         bounds ?? EmailKnowledgeBounds.Default);
 
     /// <summary>Builds the semantic half of a deployment that configured no embedding provider and activated nothing.</summary>

--- a/tests/Application.UnitTests/TestDoubles/RecordingMailboxReadTelemetry.cs
+++ b/tests/Application.UnitTests/TestDoubles/RecordingMailboxReadTelemetry.cs
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Observability;
+
+namespace MailFathom.Application.UnitTests.TestDoubles;
+
+/// <summary>Stands in for the span a local read is published as, keeping what each read reported.</summary>
+/// <remarks>
+/// It records the operation, what the read said it returned, and that the scope was closed, which is the whole of what a
+/// use case decides. What those become — a span name, a tag, an ending — is the adapter's contract and is proved against
+/// a real listener where that adapter lives.
+/// </remarks>
+internal sealed class RecordingMailboxReadTelemetry : IMailboxReadTelemetry
+{
+    private readonly List<PublishedRead> reads = [];
+
+    /// <summary>Gets the reads that were opened, in the order they began.</summary>
+    public IReadOnlyList<PublishedRead> Reads => this.reads;
+
+    /// <inheritdoc />
+    public IMailboxReadScope BeginRead(MailboxReadOperation operation, CancellationToken cancellationToken)
+    {
+        var read = new PublishedRead(operation);
+        this.reads.Add(read);
+
+        return read;
+    }
+
+    /// <summary>One opened read and what it reported before its scope was closed.</summary>
+    internal sealed class PublishedRead(MailboxReadOperation operation) : IMailboxReadScope
+    {
+        /// <summary>Gets the read that was opened.</summary>
+        public MailboxReadOperation Operation => operation;
+
+        /// <summary>Gets what the read said it returned, or <see langword="null" /> while it has reported nothing.</summary>
+        public int? ResultCount { get; private set; }
+
+        /// <summary>Gets whether the scope was closed, which a read conducted inside it always is.</summary>
+        public bool WasClosed { get; private set; }
+
+        /// <inheritdoc />
+        public void Completed(int resultCount) => this.ResultCount = resultCount;
+
+        /// <inheritdoc />
+        public void Dispose() => this.WasClosed = true;
+    }
+}

--- a/tests/Host.UnitTests/Hosting/Workers/MailExtractionBackfillWorkerTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/MailExtractionBackfillWorkerTests.cs
@@ -142,6 +142,56 @@ public sealed class MailExtractionBackfillWorkerTests : IDisposable
         Assert.Contains(
             logger.Messages,
             message => message.Contains("optimistic concurrency conflict", StringComparison.Ordinal));
+        Assert.Equal(
+            "deferred",
+            Assert.Single(this.publishedRuns).GetTagItem("mailfathom.mail.extraction.backfill.outcome"));
+    }
+
+    /// <summary>
+    /// Shutdown is not a failure, and the span says which it was: a rolling deployment would otherwise read as a
+    /// backfill that broke on every replica it stopped.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_APassTheHostStopped_PublishesItAsInterruptedRatherThanFailed()
+    {
+        // Arrange
+        var firstRunStarted = new TaskCompletionSource();
+        var backfillStore = Substitute.For<IStoredEmailExtractionBackfillStore>();
+        backfillStore
+            .FindResumePositionAsync(Arg.Any<CancellationToken>())
+            .Returns(call =>
+            {
+                firstRunStarted.TrySetResult();
+
+                return BlockedUntilStopped(call.Arg<CancellationToken>());
+            });
+        using var worker = CreateWorker(new MailExtractionBackfillOptions(), backfillStore, out _);
+
+        // Act
+        await worker.StartAsync(CancellationToken.None);
+        await firstRunStarted.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+        await worker.StopAsync(CancellationToken.None);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => worker.ExecuteTask!);
+
+        // Assert
+        var span = Assert.Single(this.publishedRuns);
+
+        Assert.Equal("interrupted", span.GetTagItem("mailfathom.mail.extraction.backfill.outcome"));
+        Assert.NotEqual(ActivityStatusCode.Error, span.Status);
+    }
+
+    /// <summary>A run that reaches the host's shutdown instead of finishing, which is what the interrupted outcome names.</summary>
+    /// <remarks>
+    /// It waits on the stopping token rather than on a clock, so nothing here depends on how long the test host takes
+    /// to get to <c>StopAsync</c>.
+    /// </remarks>
+    private static Task<StoredEmailId?> BlockedUntilStopped(CancellationToken stoppingToken)
+    {
+        var blocked = new TaskCompletionSource<StoredEmailId?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        stoppingToken.Register(() => blocked.TrySetCanceled(stoppingToken));
+
+        return blocked.Task;
     }
 
     /// <summary>

--- a/tests/Host.UnitTests/Hosting/Workers/MailExtractionBackfillWorkerTests.cs
+++ b/tests/Host.UnitTests/Hosting/Workers/MailExtractionBackfillWorkerTests.cs
@@ -2,9 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Persistence;
+using MailFathom.Common.Observability;
 using MailFathom.Domain.Emails;
 using MailFathom.Host.Configuration.Mail;
 using MailFathom.Host.Hosting.Workers;
@@ -17,10 +20,39 @@ using Xunit;
 
 namespace MailFathom.Host.UnitTests.Hosting.Workers;
 
-public sealed class MailExtractionBackfillWorkerTests
+public sealed class MailExtractionBackfillWorkerTests : IDisposable
 {
     /// <summary>Guards against a hung worker. No assertion depends on how long the run actually takes.</summary>
     private static readonly TimeSpan DeadlockGuard = TimeSpan.FromSeconds(30);
+
+    private readonly ConcurrentBag<Activity> publishedRuns = [];
+    private readonly ActivityListener listener;
+
+    /// <summary>Listens to the real activity source, narrowed to this worker's own span name.</summary>
+    /// <remarks>
+    /// The source is the process's and is shared by everything MailFathom publishes, so the name is what keeps a span
+    /// another test class produced at the same moment out of these assertions.
+    /// </remarks>
+    public MailExtractionBackfillWorkerTests()
+    {
+        this.listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.Name,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                if (activity.OperationName == MailExtractionBackfillWorker.RunSpanName)
+                {
+                    this.publishedRuns.Add(activity);
+                }
+            },
+        };
+
+        ActivitySource.AddActivityListener(this.listener);
+    }
+
+    public void Dispose() => this.listener.Dispose();
 
     [Fact]
     public async Task ExecuteAsync_BackfillDisabled_NeverReadsAStoredEmail()
@@ -110,6 +142,69 @@ public sealed class MailExtractionBackfillWorkerTests
         Assert.Contains(
             logger.Messages,
             message => message.Contains("optimistic concurrency conflict", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Work an interval caused rather than a request is otherwise a set of parentless database spans competing with the
+    /// requests around them, so a pass is published as a span of its own with what it turned out to have done.
+    /// </summary>
+    [Fact]
+    public async Task ExecuteAsync_APassThatFinished_PublishesItAsASpanOfCountsAndAnEnding()
+    {
+        // Arrange
+        var backfillStore = Substitute.For<IStoredEmailExtractionBackfillStore>();
+        backfillStore
+            .GetEmailsAwaitingExtractionAsync(Arg.Any<StoredEmailId?>(), Arg.Any<int>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<StoredEmailAwaitingExtraction>>([]));
+        using var worker = CreateWorker(new MailExtractionBackfillOptions(), backfillStore, out _);
+
+        // Act
+        await worker.StartAsync(CancellationToken.None);
+        await worker.ExecuteTask!.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+
+        // Assert
+        var span = Assert.Single(this.publishedRuns);
+
+        Assert.Equal("backfill_email_extraction", span.OperationName);
+        Assert.Equal(
+            [
+                ("mailfathom.mail.extraction.backfill.extracted", "0"),
+                ("mailfathom.mail.extraction.backfill.unreadable", "0"),
+                ("mailfathom.mail.extraction.backfill.missing_content", "0"),
+                ("mailfathom.mail.extraction.backfill.remaining", "False"),
+                ("mailfathom.mail.extraction.backfill.outcome", "succeeded"),
+            ],
+            span.TagObjects.Select(tag => (tag.Key, tag.Value?.ToString())));
+    }
+
+    /// <summary>A pass that broke is the one worth attributing, so it publishes the ending it reached rather than none.</summary>
+    [Fact]
+    public async Task ExecuteAsync_APassThatFailed_PublishesTheEndingItReached()
+    {
+        // Arrange
+        var firstRunFailed = new TaskCompletionSource();
+        var backfillStore = Substitute.For<IStoredEmailExtractionBackfillStore>();
+        backfillStore
+            .FindResumePositionAsync(Arg.Any<CancellationToken>())
+            .Returns<StoredEmailId?>(_ =>
+            {
+                firstRunFailed.TrySetResult();
+
+                throw new InvalidOperationException("the database is unavailable");
+            });
+        using var worker = CreateWorker(new MailExtractionBackfillOptions(), backfillStore, out _);
+
+        // Act
+        await worker.StartAsync(CancellationToken.None);
+        await firstRunFailed.Task.WaitAsync(DeadlockGuard, TestContext.Current.CancellationToken);
+        await worker.StopAsync(CancellationToken.None);
+
+        // Assert
+        var span = Assert.Single(
+            this.publishedRuns,
+            run => run.GetTagItem("mailfathom.mail.extraction.backfill.outcome") is "failed");
+
+        Assert.Equal(ActivityStatusCode.Error, span.Status);
     }
 
     private static MailExtractionBackfillWorker CreateWorker(

--- a/tests/Infrastructure.UnitTests/Observability/MailboxReadTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/MailboxReadTelemetryTests.cs
@@ -1,0 +1,210 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using MailFathom.Application.Observability;
+using MailFathom.Common.Observability;
+using MailFathom.Infrastructure.Observability;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Observability;
+
+/// <summary>Covers the span a local read publishes: what it is called, where it sits, and what it carries.</summary>
+/// <remarks>
+/// It listens to the real activity source, because the rule under test is about what an exporter would receive. The
+/// listener is narrowed to the four read span names, so a span published by another test class at the same moment is not
+/// mistaken for one of these — the source is the process's and is shared by everything MailFathom publishes.
+/// </remarks>
+public sealed class MailboxReadTelemetryTests : IDisposable
+{
+    /// <summary>Stands in for a source somebody else owns, which is what the MCP SDK's own span arrives from.</summary>
+    private static readonly ActivitySource ProtocolBoundary = new("MailboxReadTelemetryTests.ProtocolBoundary");
+
+    private static readonly string[] ReadSpanNames =
+    [
+        MailboxReadTelemetry.AccountDirectorySpanName,
+        MailboxReadTelemetry.MailboxTimelineSpanName,
+        MailboxReadTelemetry.MailboxSearchSpanName,
+        MailboxReadTelemetry.EmailContentSpanName,
+    ];
+
+    private readonly ConcurrentBag<Activity> published = [];
+    private readonly ActivityListener listener;
+
+    public MailboxReadTelemetryTests()
+    {
+        this.listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.Name || source == ProtocolBoundary,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                if (ReadSpanNames.Contains(activity.OperationName))
+                {
+                    this.published.Add(activity);
+                }
+            },
+        };
+
+        ActivitySource.AddActivityListener(this.listener);
+    }
+
+    public void Dispose() => this.listener.Dispose();
+
+    /// <summary>The span names an operator writes a filter against, one per use case the MCP surface reaches.</summary>
+    [Theory]
+    [InlineData(MailboxReadOperation.ReadAccountDirectory, "read_account_directory")]
+    [InlineData(MailboxReadOperation.ListMailboxTimeline, "list_mailbox_timeline")]
+    [InlineData(MailboxReadOperation.SearchMailbox, "search_mailbox")]
+    [InlineData(MailboxReadOperation.ReadEmailContent, "read_email_content")]
+    public void BeginRead_EachOperation_PublishesItUnderTheNameOfTheUseCase(
+        MailboxReadOperation operation,
+        string expectedSpanName)
+    {
+        // Arrange
+        var telemetry = new MailboxReadTelemetry();
+
+        // Act
+        using (var read = telemetry.BeginRead(operation, TestContext.Current.CancellationToken))
+        {
+            read.Completed(0);
+        }
+
+        // Assert
+        Assert.Equal(expectedSpanName, Assert.Single(this.published).OperationName);
+    }
+
+    /// <summary>What a completed read says: how much it returned, and that it returned it.</summary>
+    [Fact]
+    public void BeginRead_AReadThatReturnedResults_PublishesTheCountAndThatItSucceeded()
+    {
+        // Arrange
+        var telemetry = new MailboxReadTelemetry();
+
+        // Act
+        using (var read = telemetry.BeginRead(
+            MailboxReadOperation.SearchMailbox,
+            TestContext.Current.CancellationToken))
+        {
+            read.Completed(7);
+        }
+
+        // Assert
+        var span = Assert.Single(this.published);
+
+        Assert.Equal(
+            [
+                ("mailfathom.mailbox.read.results", "7"),
+                ("mailfathom.mailbox.read.outcome", "succeeded"),
+            ],
+            span.TagObjects.Select(tag => (tag.Key, tag.Value?.ToString())));
+        Assert.Equal(ActivityStatusCode.Ok, span.Status);
+    }
+
+    /// <summary>
+    /// The nesting is the whole point of the span: it is started inside the protocol boundary's own span, so a trace
+    /// leads from a tool call to the use case that served it rather than from a tool call to a set of database commands.
+    /// </summary>
+    [Fact]
+    public void BeginRead_AReadInsideAProtocolSpan_PublishesBeneathIt()
+    {
+        // Arrange
+        var telemetry = new MailboxReadTelemetry();
+
+        // Act
+        using var protocolCall = ProtocolBoundary.StartActivity("tools/call");
+        using (var read = telemetry.BeginRead(
+            MailboxReadOperation.ListMailboxTimeline,
+            TestContext.Current.CancellationToken))
+        {
+            read.Completed(1);
+        }
+
+        // Assert
+        Assert.NotNull(protocolCall);
+        Assert.Equal(protocolCall.Id, Assert.Single(this.published).ParentId);
+    }
+
+    /// <summary>A caller that walked away is ordinary traffic, so it is told apart from a read that broke.</summary>
+    [Fact]
+    public void BeginRead_AReadTheCallerCancelled_PublishesItAsCancelledRatherThanFailed()
+    {
+        // Arrange
+        var telemetry = new MailboxReadTelemetry();
+        using var caller = new CancellationTokenSource();
+
+        // Act
+        using (telemetry.BeginRead(MailboxReadOperation.ReadEmailContent, caller.Token))
+        {
+            caller.Cancel();
+        }
+
+        // Assert
+        var span = Assert.Single(this.published);
+
+        Assert.Equal("cancelled", span.GetTagItem("mailfathom.mailbox.read.outcome"));
+        Assert.Null(span.GetTagItem("mailfathom.mailbox.read.results"));
+    }
+
+    /// <summary>A read that reported nothing and was not cancelled is a read that threw, and the span says so.</summary>
+    [Fact]
+    public void BeginRead_AReadThatReportedNothing_PublishesItAsFailed()
+    {
+        // Arrange
+        var telemetry = new MailboxReadTelemetry();
+
+        // Act
+        using (telemetry.BeginRead(MailboxReadOperation.SearchMailbox, TestContext.Current.CancellationToken))
+        {
+        }
+
+        // Assert
+        var span = Assert.Single(this.published);
+
+        Assert.Equal("failed", span.GetTagItem("mailfathom.mailbox.read.outcome"));
+        Assert.Equal(ActivityStatusCode.Error, span.Status);
+    }
+
+    /// <summary>
+    /// The rule the telemetry page states as a cardinality rule as much as a privacy one: a read publishes a count and
+    /// an ending, so no query text, filter value, cursor, subject, address, or stored identity can reach a span store
+    /// through it — there is nowhere on the span to put one.
+    /// </summary>
+    [Fact]
+    public void BeginRead_AnyRead_PublishesNothingBeyondACountAndAnEnding()
+    {
+        // Arrange
+        var telemetry = new MailboxReadTelemetry();
+
+        // Act
+        using (var read = telemetry.BeginRead(
+            MailboxReadOperation.SearchMailbox,
+            TestContext.Current.CancellationToken))
+        {
+            read.Completed(3);
+        }
+
+        // Assert
+        Assert.Equal(
+            ["mailfathom.mailbox.read.results", "mailfathom.mailbox.read.outcome"],
+            Assert.Single(this.published).TagObjects.Select(tag => tag.Key));
+    }
+
+    /// <summary>An operation this adapter publishes no name for is a member added without a span, never an unnamed span.</summary>
+    [Fact]
+    public void BeginRead_AnOperationOutsideTheDeclaredSet_IsRefused()
+    {
+        // Arrange
+        var telemetry = new MailboxReadTelemetry();
+
+        // Act
+        void BeginUnknownRead() =>
+            telemetry.BeginRead((MailboxReadOperation)(-1), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Throws<ArgumentOutOfRangeException>(BeginUnknownRead);
+    }
+}

--- a/tests/Infrastructure.UnitTests/Observability/StoredEmailContentTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/StoredEmailContentTelemetryTests.cs
@@ -1,0 +1,131 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using MailFathom.Common.Observability;
+using MailFathom.Infrastructure.Observability;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Observability;
+
+/// <summary>Covers the span a read of stored raw MIME publishes, which is the one place a read's size is visible.</summary>
+/// <remarks>
+/// It listens to the real activity source and narrows to this span's own name, so a span published by another test class
+/// at the same moment is not mistaken for one of these.
+/// </remarks>
+public sealed class StoredEmailContentTelemetryTests : IDisposable
+{
+    private readonly ConcurrentBag<Activity> published = [];
+    private readonly ActivityListener listener;
+
+    public StoredEmailContentTelemetryTests()
+    {
+        this.listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.Name,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity =>
+            {
+                if (activity.OperationName == StoredEmailContentTelemetry.ReadSpanName)
+                {
+                    this.published.Add(activity);
+                }
+            },
+        };
+
+        ActivitySource.AddActivityListener(this.listener);
+    }
+
+    public void Dispose() => this.listener.Dispose();
+
+    /// <summary>What a read that found content says: that it found some, and how many bytes of it there were.</summary>
+    [Fact]
+    public void BeginRead_ContentThatWasFound_PublishesItsSize()
+    {
+        // Arrange
+        var telemetry = new StoredEmailContentTelemetry();
+
+        // Act
+        using (var read = telemetry.BeginRead())
+        {
+            read.Found(42_000);
+        }
+
+        // Assert
+        var span = Assert.Single(this.published);
+
+        Assert.Equal("read_stored_email_content", span.OperationName);
+        Assert.Equal(
+            [
+                ("mailfathom.mail.content.found", "True"),
+                ("mailfathom.mail.content.bytes", "42000"),
+            ],
+            span.TagObjects.Select(tag => (tag.Key, tag.Value?.ToString())));
+        Assert.Equal(ActivityStatusCode.Ok, span.Status);
+    }
+
+    /// <summary>An email this deployment holds no content for is an answer rather than a failure.</summary>
+    [Fact]
+    public void BeginRead_ContentThatIsNotStored_PublishesTheAbsenceWithoutASize()
+    {
+        // Arrange
+        var telemetry = new StoredEmailContentTelemetry();
+
+        // Act
+        using (var read = telemetry.BeginRead())
+        {
+            read.Absent();
+        }
+
+        // Assert
+        var span = Assert.Single(this.published);
+
+        Assert.Equal(false, span.GetTagItem("mailfathom.mail.content.found"));
+        Assert.Null(span.GetTagItem("mailfathom.mail.content.bytes"));
+        Assert.Equal(ActivityStatusCode.Ok, span.Status);
+    }
+
+    /// <summary>A read that reported neither outcome is one that threw, and the span says so rather than staying silent.</summary>
+    [Fact]
+    public void BeginRead_AReadThatReportedNothing_PublishesItAsAnError()
+    {
+        // Arrange
+        var telemetry = new StoredEmailContentTelemetry();
+
+        // Act
+        using (telemetry.BeginRead())
+        {
+        }
+
+        // Assert
+        var span = Assert.Single(this.published);
+
+        Assert.Equal(ActivityStatusCode.Error, span.Status);
+        Assert.Empty(span.TagObjects);
+    }
+
+    /// <summary>
+    /// The payload this span describes is a whole message, so what it may say about it is a size and nothing else: no
+    /// stored identity, no account, no folder, and no part of the mail itself.
+    /// </summary>
+    [Fact]
+    public void BeginRead_AnyRead_PublishesNothingBeyondASizeAndWhetherAnythingWasThere()
+    {
+        // Arrange
+        var telemetry = new StoredEmailContentTelemetry();
+
+        // Act
+        using (var read = telemetry.BeginRead())
+        {
+            read.Found(1_024);
+        }
+
+        // Assert
+        Assert.Equal(
+            ["mailfathom.mail.content.found", "mailfathom.mail.content.bytes"],
+            Assert.Single(this.published).TagObjects.Select(tag => tag.Key));
+    }
+}

--- a/tests/Mcp.UnitTests/TestDoubles/RegisteredMcpToolSurface.cs
+++ b/tests/Mcp.UnitTests/TestDoubles/RegisteredMcpToolSurface.cs
@@ -14,6 +14,7 @@ using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Emails.SearchEmails;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Observability;
 using MailFathom.Application.Retrieval.AskMail;
 using MailFathom.Application.Synchronization.Checkpoints;
 using Microsoft.Extensions.DependencyInjection;
@@ -82,6 +83,7 @@ internal static class RegisteredMcpToolSurface
         services.AddSingleton(Substitute.For<IEmailContentRepairRequestStore>());
         services.AddSingleton<IMailAccountCatalog>(new StubMailAccountCatalog("personal"));
         services.AddSingleton<MailboxScopeResolver>();
+        services.AddSingleton(Substitute.For<IMailboxReadTelemetry>());
         services.AddSingleton<MailAccountDirectoryReader>();
         services.AddSingleton<MailboxTimelineReader>();
         services.AddSingleton<EmailContentReader>();

--- a/tests/Mcp.UnitTests/Tools/GetEmailContentToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/GetEmailContentToolTests.cs
@@ -14,6 +14,7 @@ using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.GetEmailContent;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Observability;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
@@ -940,7 +941,8 @@ public sealed class GetEmailContentToolTests
                 StubMailFolderMappings.ResolvingNothing),
             linkIssuer ?? new StubAttachmentDownloadLinkIssuer(),
             SensitiveContentEgressGuards.Inactive(),
-            new EmailContentReadOptions()));
+            new EmailContentReadOptions(),
+            Substitute.For<IMailboxReadTelemetry>()));
 
     /// <summary>The one folder this deployment maps, which is what makes the mail these tests store readable at all.</summary>
     /// <remarks>

--- a/tests/Mcp.UnitTests/Tools/ListAccountsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/ListAccountsToolTests.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Observability;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
@@ -12,6 +13,7 @@ using MailFathom.Mcp.Tools;
 using MailFathom.Mcp.Tools.Results;
 using MailFathom.Mcp.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
+using NSubstitute;
 using Xunit;
 
 namespace MailFathom.Mcp.UnitTests.Tools;
@@ -177,6 +179,7 @@ public sealed class ListAccountsToolTests
                     catalog,
                     StubMailFolderParticipation.Nothing,
                     StubJunkMailFolderCatalog.None,
-                    StubMailFolderMappings.ResolvingNothing)),
+                    StubMailFolderMappings.ResolvingNothing),
+                Substitute.For<IMailboxReadTelemetry>()),
             catalog);
 }

--- a/tests/Mcp.UnitTests/Tools/ListEmailsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/ListEmailsToolTests.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Emails.ListEmails;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
+using MailFathom.Application.Observability;
 using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Accounts;
@@ -18,6 +19,7 @@ using MailFathom.Mcp.Tools.Results;
 using MailFathom.Mcp.Tools.Summaries;
 using MailFathom.Mcp.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
+using NSubstitute;
 using Xunit;
 
 namespace MailFathom.Mcp.UnitTests.Tools;
@@ -648,6 +650,7 @@ public sealed class ListEmailsToolTests
                 StubMailFolderParticipation.Nothing,
                 junkFolders ?? StubJunkMailFolderCatalog.None,
                 folderMappings.Resolver),
-            egressGuard ?? SensitiveContentEgressGuards.Inactive()),
+            egressGuard ?? SensitiveContentEgressGuards.Inactive(),
+            Substitute.For<IMailboxReadTelemetry>()),
         new StubMailAccountCatalog(ServedAccountId));
 }

--- a/tests/Mcp.UnitTests/Tools/SearchEmailsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/SearchEmailsToolTests.cs
@@ -9,6 +9,7 @@ using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Emails.SearchEmails;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Observability;
 using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Accounts;
@@ -588,7 +589,8 @@ public sealed class SearchEmailsToolTests
                     junkFolders ?? StubJunkMailFolderCatalog.None,
                     StubMailFolderMappings.ResolvingNothing),
                 bounds,
-                egressGuard ?? SensitiveContentEgressGuards.Inactive()),
+                egressGuard ?? SensitiveContentEgressGuards.Inactive(),
+                Substitute.For<IMailboxReadTelemetry>()),
             bounds,
             new StubMailAccountCatalog(ServedAccountId));
     }


### PR DESCRIPTION
Closes #503

A trace reached the transport boundary at one end and the database command at the other and said nothing about what happened between them. This closes that gap for the local read path; synchronization is its own child of #85 and is untouched here.

## What changed

- **`IMailboxReadTelemetry`**, a new application port under `src/Application/Observability/`, with `MailboxReadOperation` naming the four reads the MCP surface serves. Every one of them now opens a span named after the use case rather than after the tool — `read_account_directory`, `list_mailbox_timeline`, `search_mailbox`, `read_email_content` — nested inside the MCP SDK's own span and parenting the database and content-store spans it causes. A port rather than a call into a tracing API, for the same reason `IMailAnsweringRunTelemetry` is one: starting a span is infrastructure, and the privacy rule then lives in one adapter.
- **`MailboxReadTelemetry`** implements it in `Infrastructure`, on the existing `MailFathom` activity source, so nothing new has to be subscribed. A read carries `mailfathom.mailbox.read.results` and `mailfathom.mailbox.read.outcome` as `succeeded`, `cancelled`, or `failed`. `cancelled` is deliberately not `failed`: a client disconnecting mid-read is ordinary traffic on this surface.
- **`read_stored_email_content`** spans the content-store read with `mailfathom.mail.content.bytes` and `mailfathom.mail.content.found`. It is the one place a request meets a whole message, and a command duration alone cannot tell a forty-megabyte one from a two-kilobyte one.
- **`backfill_email_extraction`** spans each bounded pass of `MailExtractionBackfillWorker` with its counts, whether work remains, and an outcome of `succeeded`, `deferred`, `failed`, or `interrupted` — which is what tells work an interval caused apart from work a caller caused.
- `search_mailbox` is opened by `SearchEmailsAsync` and not by the internal `SearchWindowAsync`, so the retrieval an answering run makes stays reported by `answer_mail_question` and the same work is never counted twice. For `read_email_content` the count is the emails **served** rather than the emails named, because the gap between the two is the whole of what that number can say.

## Privacy

There is nowhere on any of these spans to put a query text, a filter value, a cursor, a subject, an address, or a stored identity. The values are counts, sizes, and closed sets of MailFathom's own words, which is a cardinality rule as much as a privacy one; unit tests assert the exact tag set on each span rather than only the presence of the right ones.

## Contract surfaces

None broken. No configuration key, database column, MCP tool argument, or deployment contract moves. The four use-case constructors take one more dependency, which is internal to the process and resolved by the container.

## Verification

- `scripts/verify-full.sh` — pass, working tree clean afterwards.
- 6693 unit tests pass; aggregate line coverage 95.77% against the 85% gate.
- `docs/operations/telemetry.md` gains *What a request-path trace contains* and its `describes:` marker now covers the new port and the worker.