### PR TITLE
[#823] Prove span nesting whatever order the class runs in

### DIFF
--- a/tests/Infrastructure.UnitTests/Observability/MailboxReadTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/MailboxReadTelemetryTests.cs
@@ -19,9 +19,6 @@ namespace MailFathom.Infrastructure.UnitTests.Observability;
 /// </remarks>
 public sealed class MailboxReadTelemetryTests : IDisposable
 {
-    /// <summary>Stands in for a source somebody else owns, which is what the MCP SDK's own span arrives from.</summary>
-    private static readonly ActivitySource ProtocolBoundary = new("MailboxReadTelemetryTests.ProtocolBoundary");
-
     private static readonly string[] ReadSpanNames =
     [
         MailboxReadTelemetry.AccountDirectorySpanName,
@@ -31,13 +28,29 @@ public sealed class MailboxReadTelemetryTests : IDisposable
     ];
 
     private readonly ConcurrentBag<Activity> published = [];
+
+    /// <summary>
+    /// Stands in for a source somebody else owns, which is what the MCP SDK's own span arrives from.
+    /// </summary>
+    /// <remarks>
+    /// It is an instance field so that it is constructed before the listener below, which is what makes the nesting
+    /// test deterministic. As a static field it was initialized lazily, and the first thing to touch it was the
+    /// delegate this listener registers with: the source was then constructed *during*
+    /// <see cref="ActivitySource.AddActivityListener"/>, found no listener to attach to because this one was still
+    /// being added, and was missed by the walk already in flight over the sources that existed before it. Nothing
+    /// listened to it, <see cref="ActivitySource.StartActivity(string, ActivityKind)"/> returned <c>null</c>, and the
+    /// test failed — but only when it was the first of this class to run, because every later instance found the
+    /// source already there.
+    /// </remarks>
+    private readonly ActivitySource protocolBoundary = new("MailboxReadTelemetryTests.ProtocolBoundary");
+
     private readonly ActivityListener listener;
 
     public MailboxReadTelemetryTests()
     {
         this.listener = new ActivityListener
         {
-            ShouldListenTo = source => source.Name == Telemetry.Name || source == ProtocolBoundary,
+            ShouldListenTo = source => source.Name == Telemetry.Name || source == this.protocolBoundary,
             Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
                 ActivitySamplingResult.AllDataAndRecorded,
             ActivityStopped = activity =>
@@ -52,7 +65,11 @@ public sealed class MailboxReadTelemetryTests : IDisposable
         ActivitySource.AddActivityListener(this.listener);
     }
 
-    public void Dispose() => this.listener.Dispose();
+    public void Dispose()
+    {
+        this.listener.Dispose();
+        this.protocolBoundary.Dispose();
+    }
 
     /// <summary>The span names an operator writes a filter against, one per use case the MCP surface reaches.</summary>
     [Theory]
@@ -115,7 +132,7 @@ public sealed class MailboxReadTelemetryTests : IDisposable
         var telemetry = new MailboxReadTelemetry();
 
         // Act
-        using var protocolCall = ProtocolBoundary.StartActivity("tools/call");
+        using var protocolCall = this.protocolBoundary.StartActivity("tools/call");
         using (var read = telemetry.BeginRead(
             MailboxReadOperation.ListMailboxTimeline,
             TestContext.Current.CancellationToken))


### PR DESCRIPTION
`MailboxReadTelemetryTests.BeginRead_AReadInsideAProtocolSpan_PublishesBeneathIt` failed on `main` whenever it was the first test of its class to run, which is every local `scripts/verify-fast.sh` and `scripts/verify-full.sh` on this machine and every run under `--filter-method`. The pipeline was green on the commit that added it because the order there reached another test of the class first.

## What was wrong

The stand-in `ActivitySource` was a `static readonly` field, and nothing touched it before the constructor registered the listener. So the type initializer ran inside `ActivitySource.AddActivityListener`, at the moment the `ShouldListenTo` delegate first dereferenced the field:

- `AddActivityListener` walks the sources that exist and calls `ShouldListenTo` on each;
- the first such call initialized the class, constructing the source;
- that constructor walked the listeners looking for its own, while the listener registering was still mid-walk, and attached nothing;
- `AddActivityListener` then finished its walk over the snapshot taken before the source existed, and never saw it either.

Nothing listened to the source, `StartActivity` returned `null`, and `Assert.NotNull(protocolCall)` failed. A second instance of the class found the source already constructed and passed, which is what made the failure order-dependent rather than random.

Reproduced outside xUnit in about twenty lines, and fixed there the same way it is fixed here.

## What changed

The source becomes an instance field, constructed by its initializer before the constructor body registers the listener, and disposed with it. No production code changes: `MailboxReadTelemetry` was behaving correctly and the defect was in how the test observed it. The remark on the field records the failure mode, because the next reader would otherwise have no reason not to make it static again.

## Verification

- `dotnet test --filter-method "*BeginRead_AReadInsideAProtocolSpan_PublishesBeneathIt*"` — passes in isolation, which is the case that failed.
- `scripts/verify-fast.sh` — 6807 passed, 0 failed.
- `scripts/verify-full.sh` — exit 0, aggregate line coverage 95.84%.

Closes #823