### PR TITLE
[#730] Classify a message because it arrived, as a leased job the queue retries per message

### DIFF
--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -1,6 +1,6 @@
 # The arrival pipeline
 
-<!-- describes: src/Application/Synchronization/MailboxSynchronizer.cs, src/Application/Emails/Chunking/MailChunkingPass.cs, src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs, src/Application/Emails/Extraction/RedactingEmailMimeReader.cs, src/Application/Spam/Gating/**, src/Application/Spam/Runs/SpamClassificationPass.cs, src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs, src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs, src/Host/Hosting/Workers/MailEmbeddingWorker.cs -->
+<!-- describes: src/Application/Synchronization/MailboxSynchronizer.cs, src/Application/Emails/Chunking/MailChunkingPass.cs, src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs, src/Application/Emails/Extraction/RedactingEmailMimeReader.cs, src/Application/Spam/Gating/**, src/Application/Spam/Runs/SpamClassificationPass.cs, src/Application/Spam/SpamClassificationArrivals.cs, src/Application/Spam/EmailSpamClassificationHandler.cs, src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs, src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs, src/Host/Hosting/Workers/MailEmbeddingWorker.cs -->
 
 Six features decide what happens to a message between the moment synchronization commits it and the moment everything
 derived from it exists. Each of them documents its own half, and none of them can state the order, because the order is
@@ -21,7 +21,8 @@ flowchart TD
         fetch["Fetch raw MIME, without setting the remote Seen flag"]
         extract["Extract the body text"]
         commit[("Commit: metadata, raw MIME, search document")]
-        classify["Classification pass — only when somebody asked for a run"]
+        ask(["Ask for the message to be classified"])
+        classify["Classification pass — only when somebody asked for a run over the whole mailbox"]
         rules["Rule evaluation pass"]
         cut["Cut the passages"]
         offer(["Offer the message to the embedding backlog"])
@@ -34,6 +35,7 @@ flowchart TD
     end
 
     subgraph elsewhere["Executions outside the run"]
+        job["Classification job — one message, leased, retried, dead-lettered"]
         worker["Embedding worker — one message at a time"]
         sweeps["Extraction and embedding backfills"]
     end
@@ -42,29 +44,41 @@ flowchart TD
     extract -. "redaction, fails closed" .-> presidio
     presidio -. "placeholders replace every finding" .-> extract
     extract --> commit
-    commit --> classify
+    commit --> ask
+    ask -. "one job per occurrence; a full queue refuses rather than waits" .-> job
+    ask --> classify
+    job -. "one scan per message" .-> spamd
     classify -. "one scan per message" .-> spamd
+    job -. "records the verdict" .-> gate
     classify --> gate{"What does classification say?"}
     gate -- "junk" --> withheld["Nothing further runs, and passages already cut are removed"]
     gate -- "not junk, or no classification covers the folder" --> rules
-    gate -- "still waiting for a verdict" --> held["Held; the next run or a sweep asks again"]
+    gate -- "no verdict yet: queued, running, or the job ran out of attempts" --> held["Held; the next run or a sweep asks again"]
     gate -- "released: unclassifiable, or waited longer than allowed" --> rules
     rules --> cut
     cut --> offer
     offer -.-> worker
     sweeps --> cut
     sweeps --> worker
-
-    classDef seam stroke-dasharray: 5 3;
-    class classify seam;
 ```
 
-The dashed border on the classification pass is the one stage that is a seam rather than a running job in this release:
-the call site sits where the order requires it, and what reaches it today is an operator asking for a run over a
-mailbox. Nothing classifies a message because it arrived. The trigger that will is
-[issue 730](https://github.com/Krzysztof318/MailFathom/issues/730), and until it ships the gate below releases mail that
-has waited longer than a verdict is allowed to take, so an unclassified deployment indexes exactly as it did before
-classification existed.
+Classification happens in two places and the drawing separates them deliberately. **A message is classified because it
+arrived**: the run asks for one as soon as it has committed the message and its content, and the work runs as an
+execution of the durable queue — leased to one worker, retried per message with a jittered backoff, and dead-lettered
+when it cannot succeed. That per-message backoff is the whole reason it is a job rather than another pass of the run: a
+scan reaches a sidecar that can be unreachable, saturated, or restarting, and a run whose only recovery is deferring the
+whole account cannot express one message out of three hundred deserving another attempt.
+
+The pass inside the run is the second place, and it is the operator's:
+[classifying the mail you already have](../features/spam-classification.md#classifying-the-mail-you-already-have) walks
+a mailbox that was stored before any of this, or stored while the feature was off. Both reach the same use case, record
+the same record, and consult the same sidecar; what differs is which mail they cover.
+
+Four things can become of one classification, and the gate below reads what was recorded rather than what happened to
+the job. A verdict of junk withholds the message; a verdict of anything else admits it; a scan that could not answer
+still records the verdict the headers reached, so the message is admitted or withheld on that; and a job that failed
+every attempt records nothing at all, which leaves the message waiting until the bound below releases it. **No outcome
+of the queue stops a mailbox being indexed** — that is what the bound is for.
 
 ## What the run waits for, and what it hands off
 
@@ -74,11 +88,19 @@ the folders between them are walked by `MaxConcurrentFoldersPerAccount` at a tim
 a deployment that raises it has several folders fetching, extracting, and committing side by side.
 [Synchronizing a mailbox](../features/imap-synchronization.md) states that bound and what else it costs.
 
-The one hand-off is the last arrow: offering a message to the embedding backlog is a non-blocking enqueue into a
-bounded in-process queue, and **a full backlog is not an error**. An initial synchronization of a large mailbox produces
-work faster than any provider accepts it, so the bound refuses rather than waits; the message is stored with its
-passages, and the
+There are two hand-offs, both drawn as dashed arrows out of the run, and **neither of them is allowed to fail the pass
+that produced it**. Offering a message to the embedding backlog is a non-blocking enqueue into a bounded in-process
+queue, and a full backlog is not an error: an initial synchronization of a large mailbox produces work faster than any
+provider accepts it, so the bound refuses rather than waits; the message is stored with its passages, and the
 [embedding backfill](../features/embedding-backfill.md) is what reaches mail the live path did not.
+
+Asking for a classification is the same shape against a durable queue rather than an in-process one. It is one insert
+per stored message, made after the transaction that stored the message has committed — the queue takes no persistence
+session by design, so there is no way to enqueue work whose subject may still roll back. A queue already holding as much
+of that type as the deployment accepts refuses the row rather than growing, and the run does not read the answer: a
+message nobody classifies is released by the wait a verdict is allowed, which is the property that keeps a classification
+backlog a degraded signal instead of a stalled mailbox. A message stored without its content is not asked for at all,
+because a message whose payload is not stored is reported unclassifiable rather than fetched.
 
 Nothing else about the pipeline crosses a process boundary while a transaction is open. The two sidecar calls happen
 outside the commit that follows them, and the embedding provider is reached only by the worker, which consumes committed
@@ -92,7 +114,7 @@ pipeline unchanged.
 | Sidecar | What it is shown | What its silence does |
 | --- | --- | --- |
 | Personal-data analyzer | The extracted body text of one message | **Fails closed.** The derivation is refused, nothing derived is written, and the run retries the message later |
-| Spam scanner | The raw MIME of one message | **Fails open.** No verdict is recorded, the message keeps waiting, and the wait's own bound eventually releases it |
+| Spam scanner | The raw MIME of one message | **Fails open.** The classification keeps the verdict the message's own headers reached, which may be that nothing was found either way, and the message is admitted or withheld on that |
 
 The asymmetry is deliberate and it is the single most important thing on this page. Redaction is an egress guard: text
 that reached a derived store unscanned is text a retrieval hit can hand back months later, and putting it back costs a
@@ -114,7 +136,7 @@ mail an owner drags out of the junk folder ordinary mail from that moment.
 | --- | --- | --- | --- |
 | Junk — a verdict, or the message is in the account's junk folder | No | No, and any already cut are removed | No |
 | Not junk, or the folder is outside the configured scope | Yes | Yes | Yes |
-| Still waiting for a verdict | No, held | No, held | No, held |
+| No verdict yet — the job is queued, running, or ran out of attempts without recording one | No, held | No, held | No, held |
 | Released — the message carries nothing classifiable, or it waited longer than allowed | Yes | Yes | Yes |
 
 A held message is held rather than dropped. The same four facts are read again by the next account run and by both

--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -1178,8 +1178,10 @@ passages exactly as one it accepted, and an instance that has activated no embed
 nothing drains. [Automatic embedding](automatic-embedding.md) is what happens on the other side of it.
 
 Where spam classification is switched on over the folder, both halves of that are decided one step earlier: the message
-is neither cut nor offered while no verdict exists for it, and junk is neither cut nor offered at all. What releases a
-held message is the account's own next run — its rule pass and the cut behind it ask the gate again — rather than the
+is neither cut nor offered while no verdict exists for it, and junk is neither cut nor offered at all. The verdict is
+usually already there, because the run asks for one as soon as it has committed the message and the work runs on the
+durable queue rather than in the run. What releases a message the verdict was not there for is the account's own next
+run — its rule pass and the cut behind it ask the gate again — rather than the
 [embedding backfill](embedding-backfill.md) sweep, which is narrowed by the same admission and therefore never sees a
 message no rule pass has stamped.
 [Junk is kept out of what a deployment derives from mail](spam-classification.md#junk-is-kept-out-of-what-a-deployment-derives-from-mail)

--- a/docs/features/spam-classification.md
+++ b/docs/features/spam-classification.md
@@ -8,10 +8,10 @@ decided what it thought of it — in an `Authentication-Results` header, in a pr
 the message in the junk folder. Spam classification is what keeps that decision rather than discarding it, and records
 it as derived data beside the message.
 
-Four things ship here and are independent of each other: the classification record with the stage that fills it, the two
-switches that let a verdict reach the mail server, the junk folder becoming a fact that mailbox reads act on, and junk
-being kept out of everything this deployment derives from mail. The third is true of a mailbox with no classification at
-all.
+Five things ship here and are independent of each other: the classification record with the stage that fills it, mail
+being classified as it arrives, the two switches that let a verdict reach the mail server, the junk folder becoming a
+fact that mailbox reads act on, and junk being kept out of everything this deployment derives from mail. The fourth is
+true of a mailbox with no classification at all.
 
 ## The junk folder is left out of listing and search
 
@@ -277,9 +277,10 @@ of its own for it to be withheld — the same fact the deterministic stage reads
 
 ### Waiting is bounded, and running out of patience is not a failure
 
-A verdict that never arrives is the case this bound exists for: a run nobody asked for, a scanner nobody noticed was
-wedged, a pass that keeps failing. Without a bound each of those would hold mail out of the index indefinitely, and an
-instance withholding everything publishes the same silence as one with nothing to do.
+A verdict that never arrives is the case this bound exists for: a scanner nobody noticed was wedged, a queue deep enough
+that a message waits hours for a worker, a job that spent every attempt and was dead-lettered, a run nobody asked for.
+Without a bound each of those would hold mail out of the index indefinitely, and an instance withholding everything
+publishes the same silence as one with nothing to do.
 
 `SpamClassification:ClassificationWait` is how long a message may wait, measured from when it was stored, and it is
 fifteen minutes unless a deployment says otherwise. Past it the message is released and derived from, verdict or no
@@ -347,11 +348,54 @@ Content comes from the local content store, which already holds it, so no classi
 none can affect a remote `\Seen` flag. A message stored without content — one that exceeded the size limit — is
 reported as unclassifiable rather than fetched.
 
+## Mail is classified as it arrives
+
+A message is classified because it arrived, without an operator asking for anything. Synchronization asks for one as
+soon as it has committed the message and its content, and the work then runs as an execution of the same durable queue
+that carries every other background job: leased to one worker, bounded by a timeout, retried with a jittered backoff,
+and dead-lettered once it has spent its attempts. A job that stopped is read and acted on through
+[administering a deployment](../operations/admin-endpoint.md#reading-the-background-work-that-stopped-and-deciding-what-becomes-of-it),
+under the job type `classify-email-spam`.
+
+**Why a job rather than another step of the synchronization run.** Rule evaluation is a step of that run and needs
+nothing else, because evaluating a rule over committed local state has no transient failure and therefore nothing to
+retry. A scan does: it reaches a sidecar that can be unreachable, saturated, or restarting, so one message can fail for
+a reason the next attempt would not meet. The account run's only recovery is to defer the whole account, which cannot
+express one message out of three hundred deserving another attempt — and per-message backoff is the whole of what the
+queue is here for. Nothing about it is written onto the classification record: the attempt count, the next attempt, and
+the terminal failure all belong to the queue's own row.
+
+**What it costs a synchronization run is one insert per stored message.** The run does not wait for the verdict and does
+not read what the queue answered. A queue already holding as much of this type as `Jobs:MaxQueueDepthPerType` allows
+refuses the row rather than growing, and that refusal changes nothing about the message: it is stored, and the wait a
+verdict is allowed releases it to derived work without one. A classification backlog therefore degrades a secondary
+signal instead of stalling the pass that produced it, and it is watched where every other backlog is: the queue's depth
+per job type saturates at exactly the bound enqueuing is refused at, which
+[telemetry](../operations/telemetry.md#durable-background-work) states in full.
+
+**Two messages are deliberately not asked for.** One whose folder the configured scope does not cover, and one stored
+without its content — a message above the fetch size limit, or one waiting for storage headroom — because a message
+whose payload is not stored is reported unclassifiable rather than fetched. The second becomes classifiable the moment a
+later run stores its content, without the message being fetched a second time for classification's sake. With
+classification switched off, nothing is asked for at all: the switch and the scope are read before the queue is touched,
+which is the same shape every other path here has when it is off.
+
+Asking twice for one message is asking once. The queue compares the job type together with the message's own stored
+identity — the identifier `mfctl spam classifications --email` takes — so a folder walked again, or a run resumed after
+a crash, finds the classification already asked for rather than adding a second one. Where the message is stays readable
+beside it, in the job's own payload, which names the account, the folder, and the remote numbers and nothing else.
+
+The changes an operator's switches ask of the mailbox are applied to a verdict reached this way exactly as they are to
+one a run reached; [what an operator can let a verdict do](#what-an-operator-can-let-a-verdict-do) is the whole of that
+decision, and both switches are still off by default.
+[The arrival pipeline](../architecture/arrival-pipeline.md) draws where this sits among the stages it orders.
+
 ## Classifying the mail you already have
 
-Nothing classifies a message on its own yet — see [what is not here](#what-is-not-here) — so a **classification run** is
-what reaches the mail a deployment holds, and it is what switching classification on, moving a threshold, or switching
-filing on is applied to the mailbox with. `mfctl spam run --account <id>` asks for one, and
+The trigger above reaches mail as it arrives, so a **classification run** is what reaches the mail a deployment already
+holds: everything stored before this existed, everything stored while the feature was off, and everything a wedged
+sidecar or a full queue left without a verdict. It is also what switching classification on, moving a threshold, or
+switching filing on is applied to an existing mailbox with. `mfctl spam run --account <id>` asks for one, and
 [administering a deployment](../operations/admin-endpoint.md#classifying-the-mail-you-already-have-and-reading-what-was-concluded)
 is the command reference.
 
@@ -454,19 +498,6 @@ own answer, with its own retention.
 **The signals appear by name and never by value.** A name is an authentication method, a header field, a folder alias,
 or a scanner rule; the observation beside it is text a mail server wrote and can carry a sending domain, which is
 exactly the second copy of the mailbox a record read back over an administrative endpoint must not become.
-
-## What is not here
-
-Nothing classifies a message as it arrives. The trigger that would do it is not built, so every verdict this deployment
-holds was reached by a run somebody asked for, and mail stored since the last one carries none until the next one is
-asked for.
-
-That is what the wait above currently absorbs, and it is worth stating plainly rather than leaving to be inferred: with
-no arrival trigger, a newly stored message of a classified folder waits out `SpamClassification:ClassificationWait` and
-is then released, unless a run scores it first. So what the gate withholds today without anybody asking for a run is
-mail the receiving server already filed in the junk folder, and mail a run already decided is spam — both of which are
-facts that exist before this deployment does anything. Every other message is delayed rather than withheld, and it is
-delayed into the sweep that would have reached it anyway.
 
 ## Privacy
 

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -260,9 +260,10 @@ reference for all five, including what the history records and what it deliberat
 
 ## Classifying the mail you already have
 
-[Spam classification](../features/spam-classification.md) reaches a message when a run somebody asked for reaches it,
-so switching it on — or switching filing on, or moving a threshold — does nothing about the mail already in the mailbox
-until you ask:
+[Spam classification](../features/spam-classification.md) reaches arriving mail on its own: a message is classified
+because it arrived, and you ask for nothing. What it does not reach is the mail that was already there — everything
+stored before you switched it on, and everything stored while it was off — so switching it on, switching filing on, or
+moving a threshold does nothing about the existing mailbox until you ask:
 
 | What you want | Command |
 | --- | --- |

--- a/src/Application/Spam/EmailSpamClassificationHandler.cs
+++ b/src/Application/Spam/EmailSpamClassificationHandler.cs
@@ -1,0 +1,127 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Jobs;
+using MailFathom.Application.Jobs.Execution;
+using MailFathom.Application.Spam.Actions;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Spam;
+
+namespace MailFathom.Application.Spam;
+
+/// <summary>Runs the classification of one message occurrence as a leased execution of the durable queue.</summary>
+/// <remarks>
+/// <para>
+/// The work is the use case that already exists, reached once per occurrence: the queue supplies the lease, the bounded
+/// attempts, the jittered backoff between them, and the dead letter that ends a job nothing can finish. That is the
+/// whole reason classification is a job rather than a step of the account's synchronization run — a scan reaches a
+/// sidecar that can be unreachable, saturated, or restarting, and a run that deferred the whole account could not
+/// express one message out of three hundred deserving another attempt.
+/// </para>
+/// <para>
+/// Nothing here is a scheduler, a retry policy, or an idempotency identity of its own. The classification record carries
+/// no attempt count and no next-attempt time, because those are the queue row's and putting them on the record would be
+/// a job written in the wrong place.
+/// </para>
+/// <para>
+/// Running it twice with one payload is the same as running it once, which is what the queue asks of every handler. The
+/// use case is keyed to the occurrence and asked to leave an existing record alone, and the changes a verdict asks of
+/// the mailbox are written under an identity of their own, so an attempt that crashed after committing its verdict
+/// leaves the next one with the same verdict to act on rather than with a second one to reach.
+/// </para>
+/// <para>
+/// It reaches no mail server for the message it reads. Content comes from the local content store, so no classification
+/// path opens an IMAP session and none can affect a remote <c>\Seen</c> flag; the one thing that does reach the mailbox
+/// is a change an operator switched on, and that is written down as a durable mutation record for the account's own
+/// convergence pass to carry.
+/// </para>
+/// </remarks>
+public sealed class EmailSpamClassificationHandler : IJobHandler
+{
+    private readonly IClassifiableEmailReader emails;
+    private readonly IEmailSpamClassificationStore classifications;
+    private readonly EmailSpamClassifier classifier;
+    private readonly SpamActionRecorder actionRecorder;
+
+    /// <summary>Initializes the handler over the work one job describes.</summary>
+    /// <param name="emails">Turns the occurrence the payload names into the local email it was stored as.</param>
+    /// <param name="classifications">Reads the verdict an earlier attempt recorded, so a repeated attempt still acts on it.</param>
+    /// <param name="classifier">Reaches a verdict about the occurrence and records it.</param>
+    /// <param name="actionRecorder">Writes down whatever the operator's switches ask a verdict to do to the mailbox.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public EmailSpamClassificationHandler(
+        IClassifiableEmailReader emails,
+        IEmailSpamClassificationStore classifications,
+        EmailSpamClassifier classifier,
+        SpamActionRecorder actionRecorder)
+    {
+        ArgumentNullException.ThrowIfNull(emails);
+        ArgumentNullException.ThrowIfNull(classifications);
+        ArgumentNullException.ThrowIfNull(classifier);
+        ArgumentNullException.ThrowIfNull(actionRecorder);
+
+        this.emails = emails;
+        this.classifications = classifications;
+        this.classifier = classifier;
+        this.actionRecorder = actionRecorder;
+    }
+
+    /// <inheritdoc />
+    public JobType JobType => JobType.ClassifyEmailSpam;
+
+    /// <inheritdoc />
+    /// <exception cref="ArgumentException">Thrown when the payload is not the contract this job type names.</exception>
+    /// <remarks>
+    /// An occurrence nothing is stored at ends the job as done rather than as a failure. Mail can be expunged between
+    /// the moment a classification was asked for and the moment it runs, and that is the message leaving rather than
+    /// work to attempt again.
+    /// </remarks>
+    public async Task RunAsync(IJobPayload payload, CancellationToken cancellationToken)
+    {
+        if (payload is not EmailOccurrenceJobPayload occurrence)
+        {
+            throw new ArgumentException(
+                $"A '{JobType.ClassifyEmailSpam}' job carries a payload naming one message occurrence.",
+                nameof(payload));
+        }
+
+        var storedEmailId = await this.emails.FindStoredEmailIdAsync(
+            occurrence.ToOccurrenceId(),
+            cancellationToken);
+
+        if (storedEmailId is not { } emailId)
+        {
+            return;
+        }
+
+        var classification = await this.ClassifyAsync(emailId, cancellationToken);
+
+        if (classification is not null)
+        {
+            await this.actionRecorder.RecordAsync(classification, SpamActionPosture.Acting, cancellationToken);
+        }
+    }
+
+    /// <summary>Reaches a verdict about the occurrence, or recovers the one an earlier attempt already recorded.</summary>
+    /// <remarks>
+    /// The re-read is what makes a repeated attempt whole rather than merely harmless. An attempt that committed its
+    /// verdict and then lost its lease left the message classified and its filing unasked for, and a second attempt that
+    /// read only its own result would see an occurrence already classified and end having done neither. Every other
+    /// outcome is a reason no verdict exists — classification switched off, a folder outside the scope, content that is
+    /// not stored — and none of them has anything for the mailbox to be asked about.
+    /// </remarks>
+    private async Task<SpamClassification?> ClassifyAsync(
+        StoredEmailId emailId,
+        CancellationToken cancellationToken)
+    {
+        var result = await this.classifier.ClassifyAsync(
+            emailId,
+            SpamClassificationMode.FirstTimeOnly,
+            cancellationToken);
+
+        return result.Outcome is SpamClassificationOutcome.AlreadyClassified
+            ? await this.classifications.FindAsync(emailId, cancellationToken)
+            : result.Classification;
+    }
+}

--- a/src/Application/Spam/IClassifiableEmailReader.cs
+++ b/src/Application/Spam/IClassifiableEmailReader.cs
@@ -33,6 +33,18 @@ public interface IClassifiableEmailReader
     /// </remarks>
     Task<ClassifiableEmail?> FindAsync(StoredEmailId emailId, CancellationToken cancellationToken);
 
+    /// <summary>Resolves the stable remote occurrence identity into the local email it was stored as.</summary>
+    /// <param name="occurrenceId">The account, folder binding, UIDVALIDITY, and UID the message was discovered under.</param>
+    /// <param name="cancellationToken">Cancels the lookup.</param>
+    /// <returns>The local identity, or <see langword="null" /> when nothing is stored at that occurrence.</returns>
+    /// <remarks>
+    /// A durable execution names the occurrence rather than the local key, because the local key is a value this system
+    /// generated and the occurrence is what the mail server and the enqueuer both know. This is where the one is turned
+    /// into the other, and an absent answer is the ordinary case of a message expunged between the moment the work was
+    /// enqueued and the moment it ran.
+    /// </remarks>
+    Task<StoredEmailId?> FindStoredEmailIdAsync(EmailOccurrenceId occurrenceId, CancellationToken cancellationToken);
+
     /// <summary>Reads one account's stored occurrences in identity order, narrowed to a set of folders.</summary>
     /// <param name="accountId">The account whose mailbox is walked.</param>
     /// <param name="folderAliases">MailFathom's own names for the folders the walk covers.</param>

--- a/src/Application/Spam/SpamClassificationArrivals.cs
+++ b/src/Application/Spam/SpamClassificationArrivals.cs
@@ -1,0 +1,106 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using MailFathom.Application.Jobs;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Spam;
+
+/// <summary>Asks for a classification of each message synchronization has just committed.</summary>
+/// <remarks>
+/// <para>
+/// This is the whole arrival trigger. It is reached once per stored message, after the transaction that stored the
+/// message and its content has committed, and it writes one row into the durable queue — where the work is leased,
+/// retried per message, and made idempotent by the queue's own model rather than by anything here.
+/// </para>
+/// <para>
+/// A message stored without its content is deliberately not asked for. Classification reads the local content store and
+/// reports a message it cannot read as unclassifiable rather than fetching it, so enqueuing one would spend a lease to
+/// reach an answer that is already known — and the gate over derived work already releases such a message rather than
+/// holding it.
+/// </para>
+/// <para>
+/// The two cheap questions are asked before the row is written, in the order they cost: whether classification runs at
+/// all, and whether the configured scope covers the folder the message arrived in. A deployment with classification off
+/// therefore performs one property read per stored message and reaches no queue, which is the same shape every other
+/// path through this feature has when it is switched off.
+/// </para>
+/// <para>
+/// <strong>What the queue answers is not acted on, and that is the bound the synchronization run needs.</strong> A row
+/// this call wrote, a row an earlier attempt already wrote, and a refusal because the queue holds as much of this type
+/// as the deployment accepts are all the same thing here: the message is stored, and a classification either happens or
+/// the wait a verdict is allowed releases the message to derived work without one. A refusal is visible as the queue
+/// depth standing at its configured bound, which is where backpressure is read from rather than from anything this type
+/// records.
+/// </para>
+/// <para>
+/// Nothing from the message reaches the queue. The payload names the occurrence and the idempotency key is the message's
+/// own stored identity, so an operator reading a stuck job sees where the message is and can ask what was concluded
+/// about it, and neither carries a subject, an address, or anything else out of the mail.
+/// </para>
+/// </remarks>
+public sealed class SpamClassificationArrivals
+{
+    private readonly IJobStore jobs;
+    private readonly ISpamClassificationSettingsReader settingsReader;
+
+    /// <summary>Initializes the trigger over the queue it writes to and the settings that decide whether it does.</summary>
+    /// <param name="jobs">The durable queue one classification is enqueued into.</param>
+    /// <param name="settingsReader">Answers whether classification runs and which folders it covers.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public SpamClassificationArrivals(IJobStore jobs, ISpamClassificationSettingsReader settingsReader)
+    {
+        ArgumentNullException.ThrowIfNull(jobs);
+        ArgumentNullException.ThrowIfNull(settingsReader);
+
+        this.jobs = jobs;
+        this.settingsReader = settingsReader;
+    }
+
+    /// <summary>Asks for one committed message to be classified.</summary>
+    /// <param name="emailId">The local identity the occurrence was stored as, which the execution is keyed by.</param>
+    /// <param name="occurrenceId">The occurrence synchronization has just stored, with its content.</param>
+    /// <param name="cancellationToken">Cancels the enqueue.</param>
+    /// <returns>A task that completes once the queue has answered, or at once where no classification is wanted.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="occurrenceId" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Asking twice for one message is asking once. Both identities name the same message — the local row is keyed by
+    /// the occurrence — so a run that stored it again, whether a folder walked afresh or a run resumed after a crash, is
+    /// answered with the job that is already there rather than adding a second one.
+    /// </remarks>
+    public async Task ScheduleAsync(
+        StoredEmailId emailId,
+        EmailOccurrenceId occurrenceId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(occurrenceId);
+
+        var settings = this.settingsReader.Settings;
+
+        if (!settings.IsEnabled || !settings.Covers(occurrenceId.FolderResolutionId.Alias))
+        {
+            return;
+        }
+
+        var request = JobEnqueueRequest.Create(
+            KeyOf(emailId),
+            EmailOccurrenceJobPayload.For(occurrenceId),
+            occurrenceId.AccountId);
+
+        await this.jobs.EnqueueAsync(request, cancellationToken);
+    }
+
+    /// <summary>Composes the identity two enqueues of one message's classification are compared by.</summary>
+    /// <remarks>
+    /// The stored identity rather than the occurrence written out, and the reason is a bound rather than a preference: a
+    /// key may be 256 characters, while an account identifier and a folder alias may each be 128, so a composition of
+    /// the two plus the remote numbers can exceed it — and a key that cannot be composed would raise out of the
+    /// synchronization run that asked, which is exactly what this trigger may never do. What is lost is nothing an
+    /// operator needs: the occurrence is in the payload beside the key, and this is the identifier
+    /// <c>mfctl spam classifications --email</c> already takes, so a stuck job leads straight to what was concluded.
+    /// </remarks>
+    private static JobIdempotencyKey KeyOf(StoredEmailId emailId) => JobIdempotencyKey.Create(
+        emailId.Value.ToString("d", CultureInfo.InvariantCulture));
+}

--- a/src/Application/Synchronization/MailboxSynchronizer.cs
+++ b/src/Application/Synchronization/MailboxSynchronizer.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Folders;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Persistence;
+using MailFathom.Application.Spam;
 using MailFathom.Application.Spam.Gating;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.Synchronization.Reconciliation;
@@ -40,6 +41,7 @@ public sealed class MailboxSynchronizer
     private readonly MailboxReconciler reconciler;
     private readonly DerivedWorkGate derivedWorkGate;
     private readonly IDerivedWorkGateTelemetry gateTelemetry;
+    private readonly SpamClassificationArrivals classificationArrivals;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
     private readonly TimeProvider timeProvider;
     private readonly MailboxSynchronizationOptions options;
@@ -62,6 +64,7 @@ public sealed class MailboxSynchronizer
         MailboxReconciler reconciler,
         DerivedWorkGate derivedWorkGate,
         IDerivedWorkGateTelemetry gateTelemetry,
+        SpamClassificationArrivals classificationArrivals,
         OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
         TimeProvider timeProvider,
         MailboxSynchronizationOptions options)
@@ -82,6 +85,7 @@ public sealed class MailboxSynchronizer
         this.reconciler = reconciler;
         this.derivedWorkGate = derivedWorkGate;
         this.gateTelemetry = gateTelemetry;
+        this.classificationArrivals = classificationArrivals;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
         this.timeProvider = timeProvider;
         this.options = options;
@@ -587,6 +591,12 @@ public sealed class MailboxSynchronizer
     /// belongs in a folder mapped differently. <see cref="Emails.Chunking.MailChunkingPass" /> is where the passages are
     /// cut, after those two stages, and the same pass is what offers the message for embedding.
     /// </para>
+    /// <para>
+    /// What follows the commit is the one hand-off this method makes: the message is asked to be classified, as a job
+    /// the durable queue leases and retries per message. It is asked for only where the content was stored, because a
+    /// message without content is reported unclassifiable rather than fetched, and only after the commit, because the
+    /// queue enqueues against state that cannot roll back underneath it.
+    /// </para>
     /// </remarks>
     private async Task<OccurrenceSynchronizationOutcome> StoreOccurrenceAsync(
         IMailboxSession mailboxSession,
@@ -690,6 +700,15 @@ public sealed class MailboxSynchronizer
 
         budget.RecordStored(content.RawMime.Length);
         storageClaim.Settle(content.RawMime.Length);
+
+        // Asked for after the commit rather than inside it, because the queue takes no persistence session by design:
+        // work enqueued against a transaction that then rolled back would name a message no local state holds. It is one
+        // insert per stored message, it is refused rather than queued once the deployment's backlog bound is reached,
+        // and it is skipped outright where classification is off or does not cover this folder.
+        await this.classificationArrivals.ScheduleAsync(
+            storedEmailId,
+            metadata.OccurrenceId,
+            cancellationToken);
 
         return new OccurrenceSynchronizationOutcome(
             storedEmailId,

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -582,9 +582,11 @@ try
     // a loop of its own, so a schedule reaches the same worker and the same capacity bounds as an event-driven enqueue.
     builder.Services.AddScoped<IScheduledJobSource, MailRuleScheduleSource>();
     builder.Services.AddScoped<JobSchedulePass>();
-    // The one handler this build registers, which is also what makes the worker claim at all. A rule's scheduled run is
-    // recorded here and walked by the account's own synchronization run, so the job itself is short.
+    // The handlers this build registers, which are also what makes the worker claim at all. A rule's scheduled run is
+    // recorded here and walked by the account's own synchronization run, so that job is short; a classification runs the
+    // whole of one message's work, which is what the per-message lease and backoff exist for.
     builder.Services.AddScoped<IJobHandler, ScheduledMailRuleRunHandler>();
+    builder.Services.AddScoped<IJobHandler, EmailSpamClassificationHandler>();
     // A singleton rather than a scoped value: the bound is a deployment-wide privacy control, so every search in the
     // process applies the one an operator configured rather than whichever snapshot a scope happened to open under.
     builder.Services.AddSingleton(provider =>

--- a/src/Infrastructure/Persistence/Spam/ClassifiableEmailReader.cs
+++ b/src/Infrastructure/Persistence/Spam/ClassifiableEmailReader.cs
@@ -45,6 +45,38 @@ internal sealed class ClassifiableEmailReader(MailFathomDbContext dbContext) : I
 
     /// <inheritdoc />
     /// <remarks>
+    /// The folder is matched on the alias and the generation it was bound under rather than on the remote path, for the
+    /// reason the occurrence identity carries both: an alias repointed at another folder names a different message from
+    /// the one the work was enqueued for. A tombstoned occurrence is readable here on the same terms as everywhere else
+    /// in this reader.
+    /// </remarks>
+    public async Task<StoredEmailId?> FindStoredEmailIdAsync(
+        EmailOccurrenceId occurrenceId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(occurrenceId);
+
+        var mailboxAccountId = occurrenceId.AccountId.Value;
+        var alias = occurrenceId.FolderResolutionId.Alias.Value;
+        var generation = occurrenceId.FolderResolutionId.Generation.Value;
+        var uidValidity = occurrenceId.UidValidity.Value;
+        var uid = occurrenceId.Uid.Value;
+
+        var row = await dbContext.StoredEmails
+            .AsNoTracking()
+            .Where(email => email.MailboxAccountId == mailboxAccountId
+                && email.MailFolder.Alias == alias
+                && email.MailFolder.ResolutionGeneration == generation
+                && email.UidValidity == uidValidity
+                && email.Uid == uid)
+            .Select(email => new { email.Id })
+            .SingleOrDefaultAsync(cancellationToken);
+
+        return row is null ? null : StoredEmailId.Create(row.Id);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
     /// The folder is matched on the alias the mapping gave it rather than on the remote path, because the alias is what
     /// the run's scope was written in and what an operator typed. A tombstoned occurrence is walked for the reason it is
     /// readable one at a time: the local copy is mail somebody can still reach, so leaving it out would put exactly the

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -490,6 +490,10 @@ public static class ServiceCollectionExtensions
         // every deployment because the paths that obey it are unconditional: with classification off the gate admits
         // everything and every one of them behaves exactly as it did before the gate existed.
         services.AddScoped<DerivedWorkGate>();
+        // The arrival trigger, scoped beside the synchronization run that reaches it and beside the job store it writes
+        // through. It is registered whatever the switches say, for the reason the gate is: with classification off it
+        // reads one property per stored message and enqueues nothing.
+        services.AddScoped<SpamClassificationArrivals>();
         // Registered beside the classifier and independent of it: what a verdict causes is a decision of its own, and the
         // classifier resolves nothing from here, which is what keeps a deployment that records verdicts and touches
         // nothing genuinely unable to reach a mailbox through classification.

--- a/tests/Application.UnitTests/Spam/EmailSpamClassificationHandlerTests.cs
+++ b/tests/Application.UnitTests/Spam/EmailSpamClassificationHandlerTests.cs
@@ -1,0 +1,308 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Cryptography;
+using System.Text;
+using MailFathom.Application.EmailContent.Storage;
+using MailFathom.Application.Emails.Chunking;
+using MailFathom.Application.Folders;
+using MailFathom.Application.Jobs;
+using MailFathom.Application.Mail;
+using MailFathom.Application.Mail.Mutations;
+using MailFathom.Application.Mail.Mutations.Destinations;
+using MailFathom.Application.Persistence;
+using MailFathom.Application.Spam;
+using MailFathom.Application.Spam.Actions;
+using MailFathom.Application.Spam.Signals;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Spam;
+using MailFathom.Domain.Transport;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Spam;
+
+/// <summary>Covers what one leased classification does, and what makes running it twice the same as running it once.</summary>
+public sealed class EmailSpamClassificationHandlerTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("acct-1");
+
+    private static readonly MailFolderAlias Inbox = MailFolderAlias.Create("INBOX");
+
+    private static readonly DateTimeOffset EvaluatedAt = new(2026, 8, 13, 9, 0, 0, TimeSpan.Zero);
+
+    private static readonly EmailOccurrenceId Occurrence = EmailOccurrenceId.Create(
+        Account,
+        new MailFolderResolutionId(Inbox, MailFolderResolutionGeneration.First),
+        ImapUidValidity.Create(9),
+        ImapUid.Create(4401));
+
+    private static readonly MailTransportSecurityPolicy TlsOnConnect = MailTransportSecurityPolicy.Create(
+        MailConnectionSecurity.TlsOnConnect,
+        MailAuthenticationPolicy.Create(
+            [MailAuthenticationMechanism.Plain],
+            allowInsecureConnection: false,
+            allowClearTextAuthenticationOverUnencryptedConnection: false),
+        MailServerCertificateTrust.SystemTrustStore,
+        trustedCertificateAuthorityReference: null);
+
+    private readonly InMemoryClassifiableEmailReader emails = new();
+
+    private readonly InMemoryEmailSpamClassificationStore classifications = new();
+
+    private readonly InMemoryMailboxMutationRecordStore mutations = new();
+
+    private readonly InMemoryMailFolderResolutionStore bindings = new();
+
+    private readonly IEmailContentStore contentStore = Substitute.For<IEmailContentStore>();
+
+    private readonly FakeTimeProvider timeProvider = new(EvaluatedAt);
+
+    public EmailSpamClassificationHandlerTests() => this.contentStore
+        .FindStoredContentAsync(Arg.Any<StoredEmailId>(), Arg.Any<CancellationToken>())
+        .Returns(_ => SomeContent());
+
+    [Fact]
+    public void JobType_Always_IsTheClassificationOfOneOccurrence() =>
+        Assert.Equal(JobType.ClassifyEmailSpam, this.CreateHandler().JobType);
+
+    [Fact]
+    public async Task RunAsync_AnOccurrenceNobodyHasScored_RecordsTheVerdictAndActsOnIt()
+    {
+        // Arrange
+        var emailId = this.StoreEmailAtTheOccurrence();
+
+        // Act
+        await this.CreateHandler(MarksJunkRead).RunAsync(
+            EmailOccurrenceJobPayload.For(Occurrence),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal([emailId], this.classifications.Saved.Select(classification => classification.EmailId));
+        Assert.Equal(SpamVerdict.Spam, this.classifications.Saved.Single().Verdict);
+        Assert.Equal(1, this.mutations.OpenedRecordCount);
+    }
+
+    /// <summary>An attempt that committed its verdict and lost its lease leaves the next one the filing to finish.</summary>
+    [Fact]
+    public async Task RunAsync_AnOccurrenceAnEarlierAttemptAlreadyScored_ScoresNothingAgainAndStillActsOnTheVerdict()
+    {
+        // Arrange
+        var emailId = this.StoreEmailAtTheOccurrence();
+        this.classifications.Hold(ClassificationOf(emailId));
+
+        // Act
+        await this.CreateHandler(MarksJunkRead).RunAsync(
+            EmailOccurrenceJobPayload.For(Occurrence),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(this.classifications.Saved);
+        Assert.Equal(1, this.mutations.OpenedRecordCount);
+    }
+
+    /// <summary>Mail expunged between the enqueue and the lease is the message leaving, not work to attempt again.</summary>
+    [Fact]
+    public async Task RunAsync_AnOccurrenceNothingIsStoredAt_EndsTheJobWithoutClassifyingOrActing()
+    {
+        // Act
+        await this.CreateHandler(MarksJunkRead).RunAsync(
+            EmailOccurrenceJobPayload.For(Occurrence),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(this.classifications.Saved);
+        Assert.Equal(0, this.mutations.OpenedRecordCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_ClassificationSwitchedOff_RecordsNoVerdictAndAsksTheMailboxForNothing()
+    {
+        // Arrange
+        this.StoreEmailAtTheOccurrence();
+
+        // Act
+        await this.CreateHandler(MarksJunkRead, SpamClassificationSettings.Disabled).RunAsync(
+            EmailOccurrenceJobPayload.For(Occurrence),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(this.classifications.Saved);
+        Assert.Equal(0, this.mutations.OpenedRecordCount);
+    }
+
+    [Fact]
+    public async Task RunAsync_APayloadOfAnotherContract_IsRefusedAsTheWrongWork()
+    {
+        // Act
+        var refusal = await Assert.ThrowsAsync<ArgumentException>(() => this.CreateHandler().RunAsync(
+            MailAccountJobPayload.For(Account),
+            TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal("payload", refusal.ParamName);
+    }
+
+    private static SpamActionSettings MarksJunkRead =>
+        SpamActionSettings.Create(filesJunk: false, marksJunkRead: true, threshold: null);
+
+    private static SpamClassificationSettings SettingsCovering(params MailFolderAlias[] aliases) =>
+        SpamClassificationSettings.Create(isEnabled: true, usesScanner: false, aliases);
+
+    /// <summary>A record an earlier attempt would have left, under the terms this test's settings name.</summary>
+    private static SpamClassification ClassificationOf(StoredEmailId emailId) => SpamClassification.Create(
+        emailId,
+        SpamVerdict.Spam,
+        SpamClassificationStage.Deterministic,
+        assessment: null,
+        corpusRevision: null,
+        SettingsCovering(Inbox).Profile,
+        [],
+        EvaluatedAt.AddMinutes(-1));
+
+    /// <summary>Builds content the handler only hands to its collaborators, so the bytes themselves say nothing.</summary>
+    private static StoredEmailContent SomeContent()
+    {
+        var rawMime = Encoding.ASCII.GetBytes("Subject: synthetic\r\n\r\nA body nothing here reads.\r\n");
+
+        return new StoredEmailContent(rawMime, rawMime.Length, SHA256.HashData(rawMime));
+    }
+
+    /// <summary>Answers with the classified occurrence for whichever message the recorder asks about.</summary>
+    private static ISpamActionOccurrenceReader OccurrenceReader()
+    {
+        var reader = Substitute.For<ISpamActionOccurrenceReader>();
+        reader
+            .FindAsync(Arg.Any<StoredEmailId>(), Arg.Any<CancellationToken>())
+            .Returns(call => new SpamActionOccurrence(
+                call.Arg<StoredEmailId>(),
+                Occurrence,
+                Inbox,
+                IsRemotelySeen: false));
+
+        return reader;
+    }
+
+    private StoredEmailId StoreEmailAtTheOccurrence()
+    {
+        var emailId = this.emails.Add(new ClassifiableEmail(
+            StoredEmailId.Create(Guid.Parse("0199a0c0-0000-7000-8000-000000000001")),
+            Account,
+            Inbox));
+
+        this.emails.AddOccurrence(Occurrence, emailId);
+
+        return emailId;
+    }
+
+    private EmailSpamClassificationHandler CreateHandler(
+        SpamActionSettings? actions = null,
+        SpamClassificationSettings? settings = null)
+    {
+        var settingsReader = Substitute.For<ISpamClassificationSettingsReader>();
+        settingsReader.Settings.Returns(settings ?? SettingsCovering(Inbox));
+
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
+
+        var commitPolicy = new OptimisticConcurrencyRetryPolicy(
+            sessionFactory,
+            new PersistenceConcurrencyOptions(),
+            this.timeProvider);
+
+        return new EmailSpamClassificationHandler(
+            this.emails,
+            this.classifications,
+            this.CreateClassifier(settingsReader, commitPolicy),
+            this.CreateActionRecorder(actions ?? SpamActionSettings.None, sessionFactory, commitPolicy));
+    }
+
+    /// <summary>Builds the real use case the handler scores through, over a header that says the mail is junk.</summary>
+    private EmailSpamClassifier CreateClassifier(
+        ISpamClassificationSettingsReader settingsReader,
+        OptimisticConcurrencyRetryPolicy commitPolicy)
+    {
+        var headerReader = Substitute.For<IEmailSpamHeaderReader>();
+        headerReader
+            .ReadAsync(Arg.Any<StoredEmailContent>(), Arg.Any<CancellationToken>())
+            .Returns(SpamHeaderFacts.Create(
+                [],
+                [new ProviderSpamHeaderValue("X-Spam-Status", "Yes, score=15.2 required=5.0")]));
+
+        return new EmailSpamClassifier(
+            this.emails,
+            this.contentStore,
+            headerReader,
+            StubJunkMailFolderCatalog.None,
+            new DeterministicSpamClassifier(),
+            settingsReader,
+            this.classifications,
+            Substitute.For<IEmailChunkStore>(),
+            new RecordingDerivedWorkGateTelemetry(),
+            commitPolicy,
+            this.timeProvider);
+    }
+
+    private SpamActionRecorder CreateActionRecorder(
+        SpamActionSettings actions,
+        IPersistenceSessionFactory sessionFactory,
+        OptimisticConcurrencyRetryPolicy commitPolicy)
+    {
+        var settingsReader = Substitute.For<ISpamActionSettingsReader>();
+        settingsReader.Actions.Returns(actions);
+
+        var dispositions = Substitute.For<IAuthoredDeleteEmailDispositionReader>();
+        dispositions
+            .GetAuthoredDeleteDisposition(Arg.Any<MailAccountId>())
+            .Returns(AuthoredDeleteEmailDisposition.RetainLocalCopy);
+
+        return new SpamActionRecorder(
+            settingsReader,
+            OccurrenceReader(),
+            this.mutations,
+            this.CreateDestinationResolver(sessionFactory),
+            dispositions,
+            commitPolicy);
+    }
+
+    /// <summary>Resolves destinations over a server advertising nothing, because no test here files anything.</summary>
+    private MailboxDestinationResolver CreateDestinationResolver(IPersistenceSessionFactory sessionFactory)
+    {
+        var remoteFolderCatalog = Substitute.For<IRemoteFolderCatalog>();
+        remoteFolderCatalog
+            .ListFoldersAsync(
+                Arg.Any<MailAccountId>(),
+                Arg.Any<MailTransportSecurityPolicy>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<RemoteFolder>>([]));
+
+        var transportSecurityPolicies = Substitute.For<IMailTransportSecurityPolicyReader>();
+        transportSecurityPolicies.GetPolicy(Arg.Any<MailAccountId>()).Returns(TlsOnConnect);
+
+        return new MailboxDestinationResolver(
+            StubMailFolderMappings.Nothing.Resolver,
+            this.bindings,
+            new MailFolderResolver(
+                remoteFolderCatalog,
+                Substitute.For<IRemoteFolderCreator>(),
+                this.bindings,
+                Substitute.For<IMailFolderMappingChangeAuditor>(),
+                sessionFactory,
+                this.timeProvider),
+            transportSecurityPolicies);
+    }
+
+    private sealed class CommittingSession : IPersistenceSession
+    {
+        public Task<PersistenceCommitResult> CommitAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(PersistenceCommitResult.Committed);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Application.UnitTests/Spam/SpamClassificationArrivalsTests.cs
+++ b/tests/Application.UnitTests/Spam/SpamClassificationArrivalsTests.cs
@@ -1,0 +1,165 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Jobs;
+using MailFathom.Application.Spam;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Spam;
+
+/// <summary>Covers what a stored message asks of the queue, and what it deliberately asks of nothing.</summary>
+public sealed class SpamClassificationArrivalsTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("acct-1");
+
+    private static readonly MailFolderAlias Inbox = MailFolderAlias.Create("INBOX");
+
+    private static readonly MailFolderAlias Archive = MailFolderAlias.Create("ARCHIVE");
+
+    private static readonly StoredEmailId StoredEmail =
+        StoredEmailId.Create(Guid.Parse("0199a0c0-0000-7000-8000-00000000000a"));
+
+    private readonly IJobStore jobs = Substitute.For<IJobStore>();
+
+    public SpamClassificationArrivalsTests() => this.jobs
+        .EnqueueAsync(Arg.Any<JobEnqueueRequest>(), Arg.Any<CancellationToken>())
+        .Returns(JobEnqueueResult.Created(JobId.Create(Guid.Parse("0199a0c0-0000-7000-8000-000000000001"))));
+
+    [Fact]
+    public async Task ScheduleAsync_AMessageInAClassifiedFolder_EnqueuesOneClassificationNamingTheOccurrence()
+    {
+        // Arrange
+        var occurrence = OccurrenceIn(Inbox, uid: 4401);
+
+        // Act
+        await this.CreateArrivals(SettingsCovering(Inbox))
+            .ScheduleAsync(StoredEmail, occurrence, TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = this.EnqueuedRequests().Single();
+
+        Assert.Equal(JobType.ClassifyEmailSpam, request.JobType);
+        Assert.Equal(Account, request.AccountId);
+        Assert.Equal(occurrence, Assert.IsType<EmailOccurrenceJobPayload>(request.Payload).ToOccurrenceId());
+        Assert.Null(request.AvailableAt);
+    }
+
+    /// <summary>The key is the message's own stored identity, which fits the bound whatever an operator named their account and folders.</summary>
+    [Fact]
+    public async Task ScheduleAsync_AnAccountAndFolderNamedAtTheirGreatestLength_ComposesAKeyInsideTheBound()
+    {
+        // Arrange
+        var longestName = new string('a', 128);
+        var occurrence = EmailOccurrenceId.Create(
+            MailAccountId.Create(longestName),
+            new MailFolderResolutionId(
+                MailFolderAlias.Create(longestName),
+                MailFolderResolutionGeneration.Create(int.MaxValue)),
+            ImapUidValidity.Create(uint.MaxValue),
+            ImapUid.Create(uint.MaxValue));
+
+        // Act
+        await this.CreateArrivals(SettingsCovering(occurrence.FolderResolutionId.Alias))
+            .ScheduleAsync(StoredEmail, occurrence, TestContext.Current.CancellationToken);
+
+        // Assert
+        var key = this.EnqueuedRequests().Single().Key.Value;
+
+        Assert.Equal("0199a0c0-0000-7000-8000-00000000000a", key);
+        Assert.True(key.Length <= JobIdempotencyKey.MaximumLength);
+    }
+
+    /// <summary>Two arrivals of one message carry one identity, so the queue answers the second with the first.</summary>
+    [Fact]
+    public async Task ScheduleAsync_TheSameMessageTwice_AsksUnderOneIdentity()
+    {
+        // Arrange
+        var arrivals = this.CreateArrivals(SettingsCovering(Inbox));
+        var occurrence = OccurrenceIn(Inbox, uid: 4401);
+
+        // Act
+        await arrivals.ScheduleAsync(StoredEmail, occurrence, TestContext.Current.CancellationToken);
+        await arrivals.ScheduleAsync(StoredEmail, occurrence, TestContext.Current.CancellationToken);
+
+        // Assert
+        var requests = this.EnqueuedRequests();
+
+        Assert.Equal(2, requests.Count);
+        Assert.Single(requests.Select(request => request.Key.Value).Distinct(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public async Task ScheduleAsync_ClassificationSwitchedOff_AsksTheQueueForNothing()
+    {
+        // Act
+        await this.CreateArrivals(SpamClassificationSettings.Disabled).ScheduleAsync(
+            StoredEmail,
+            OccurrenceIn(Inbox, uid: 4401),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(this.EnqueuedRequests());
+    }
+
+    [Fact]
+    public async Task ScheduleAsync_AFolderOutsideTheConfiguredScope_AsksTheQueueForNothing()
+    {
+        // Act
+        await this.CreateArrivals(SettingsCovering(Inbox)).ScheduleAsync(
+            StoredEmail,
+            OccurrenceIn(Archive, uid: 4401),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(this.EnqueuedRequests());
+    }
+
+    /// <summary>A full queue is backpressure the arrival path absorbs: the wait a verdict is allowed releases the message instead.</summary>
+    [Fact]
+    public async Task ScheduleAsync_AQueueAlreadyAtItsDepthBound_ReportsNothingToTheCaller()
+    {
+        // Arrange
+        this.jobs
+            .EnqueueAsync(Arg.Any<JobEnqueueRequest>(), Arg.Any<CancellationToken>())
+            .Returns(JobEnqueueResult.RefusedAtCapacity());
+
+        // Act
+        await this.CreateArrivals(SettingsCovering(Inbox)).ScheduleAsync(
+            StoredEmail,
+            OccurrenceIn(Inbox, uid: 4401),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(this.EnqueuedRequests());
+    }
+
+    private static SpamClassificationSettings SettingsCovering(params MailFolderAlias[] aliases) =>
+        SpamClassificationSettings.Create(isEnabled: true, usesScanner: false, aliases);
+
+    private static EmailOccurrenceId OccurrenceIn(MailFolderAlias alias, uint uid) => EmailOccurrenceId.Create(
+        Account,
+        new MailFolderResolutionId(alias, MailFolderResolutionGeneration.First),
+        ImapUidValidity.Create(9),
+        ImapUid.Create(uid));
+
+    private SpamClassificationArrivals CreateArrivals(SpamClassificationSettings settings)
+    {
+        var settingsReader = Substitute.For<ISpamClassificationSettingsReader>();
+        settingsReader.Settings.Returns(settings);
+
+        return new SpamClassificationArrivals(this.jobs, settingsReader);
+    }
+
+    private IReadOnlyList<JobEnqueueRequest> EnqueuedRequests() =>
+    [
+        .. this.jobs
+            .ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == nameof(IJobStore.EnqueueAsync))
+            .Select(call => (JobEnqueueRequest)call.GetArguments()[0]!),
+    ];
+}

--- a/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
+++ b/tests/Application.UnitTests/Synchronization/MailboxSynchronizerTests.cs
@@ -6,6 +6,7 @@ using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
+using MailFathom.Application.Jobs;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Spam;
@@ -152,6 +153,107 @@ public sealed class MailboxSynchronizerTests
         // Assert
         Assert.Equal(1, result.StoredEmailCount);
         Assert.Equal([DerivedWorkAdmission.AwaitingClassification], gateTelemetry.Admissions);
+    }
+
+    /// <summary>A message committed with its content is asked to be classified, once the transaction that stored it has ended.</summary>
+    /// <remarks>
+    /// The trigger is the whole of what makes classification continuous rather than something an operator asks for. It
+    /// is one enqueue against committed state: the run neither waits for the verdict nor learns anything from the
+    /// queue's answer, so a classification backlog degrades a secondary signal instead of stalling the pass.
+    /// </remarks>
+    [Fact]
+    public async Task SynchronizeAsync_StoresAMessageWithItsContent_AsksForOneClassificationOfThatOccurrence()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var uid = ImapUid.Create(10);
+        var occurrence = EmailOccurrenceId.Create(accountId, InboxFolder.Id, uidValidity, uid);
+        var checkpointStore = CreateCheckpointStoreAt(accountId, uidValidity);
+        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        var session = Substitute.For<IMailboxSession>();
+        var jobStore = Substitute.For<IJobStore>();
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 128);
+        var synchronizer = CreateSynchronizer(
+            sessionFactory,
+            checkpointStore,
+            sessionScopeFactory,
+            metadataRepository,
+            contentStore: Substitute.For<IEmailContentStore>(),
+            clock,
+            options,
+            classificationSettings: ClassifyingTheInbox(),
+            jobStore: jobStore);
+
+        sessionScopeFactory.BeginSessionAsync(CancellationToken.None).Returns(persistenceSession);
+        sessionFactory.OpenReadOnlyAsync(accountId, InboxFolder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
+        session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        StubRetrievedContent(session, options, occurrence, payloadLength: 3);
+        metadataRepository
+            .UpsertMetadataAsync(persistenceSession, metadata, Arg.Any<ExtractedEmailMetadata?>(), StoredEmailContentAvailability.Available, CancellationToken.None)
+            .Returns(StoredEmailId.Create(Guid.CreateVersion7()));
+
+        // Act
+        var result = await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(1, result.StoredEmailCount);
+
+        var request = Assert.Single(EnqueuedJobs(jobStore));
+
+        Assert.Equal(JobType.ClassifyEmailSpam, request.JobType);
+        Assert.Equal(occurrence, Assert.IsType<EmailOccurrenceJobPayload>(request.Payload).ToOccurrenceId());
+    }
+
+    /// <summary>A message stored from its envelope alone is asked of nothing: no content means no verdict is coming.</summary>
+    [Fact]
+    public async Task SynchronizeAsync_RecordsAMessageAboveTheSizeLimit_AsksForNoClassificationOfIt()
+    {
+        // Arrange
+        var accountId = MailAccountId.Create("primary");
+        var uidValidity = ImapUidValidity.Create(5);
+        var uid = ImapUid.Create(10);
+        var occurrence = EmailOccurrenceId.Create(accountId, InboxFolder.Id, uidValidity, uid);
+        var checkpointStore = CreateCheckpointStoreAt(accountId, uidValidity);
+        var metadataRepository = Substitute.For<IEmailMetadataRepository>();
+        var sessionScopeFactory = Substitute.For<IPersistenceSessionFactory>();
+        var persistenceSession = Substitute.For<IPersistenceSession>();
+        var sessionFactory = Substitute.For<IMailboxSessionFactory>();
+        var session = Substitute.For<IMailboxSession>();
+        var jobStore = Substitute.For<IJobStore>();
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 7, 24, 12, 0, 0, TimeSpan.Zero));
+        var options = new MailboxSynchronizationOptions { MaxMetadataBatchSize = 25, MaxRawMimeBytes = 1024 };
+        var metadata = new RemoteEmailMetadata(occurrence, "message-1@example.test", "Subject", new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), 4096);
+        var synchronizer = CreateSynchronizer(
+            sessionFactory,
+            checkpointStore,
+            sessionScopeFactory,
+            metadataRepository,
+            contentStore: Substitute.For<IEmailContentStore>(),
+            clock,
+            options,
+            classificationSettings: ClassifyingTheInbox(),
+            jobStore: jobStore);
+
+        sessionScopeFactory.BeginSessionAsync(CancellationToken.None).Returns(persistenceSession);
+        sessionFactory.OpenReadOnlyAsync(accountId, InboxFolder, Arg.Any<MailTransportSecurityPolicy>(), CancellationToken.None).Returns(session);
+        session.GetUidValidityAsync(CancellationToken.None).Returns(uidValidity);
+        session.GetEmailBatchAfterAsync(null, 25, MailSynchronizationWindow.Unbounded, CancellationToken.None).Returns(new RemoteEmailMetadataBatch([metadata], uid, HasMore: false));
+        metadataRepository
+            .UpsertMetadataAsync(persistenceSession, metadata, Arg.Any<ExtractedEmailMetadata?>(), StoredEmailContentAvailability.ExceededSizeLimit, CancellationToken.None)
+            .Returns(StoredEmailId.Create(Guid.CreateVersion7()));
+
+        // Act
+        await synchronizer.SynchronizeAsync(accountId, InboxMapping, CancellationToken.None);
+
+        // Assert
+        Assert.Empty(EnqueuedJobs(jobStore));
     }
 
     /// <summary>A message MailFathom relocated arrives in its new folder as an ordinary discovery, and is the email it already had.</summary>
@@ -1725,6 +1827,15 @@ public sealed class MailboxSynchronizerTests
     }
 
     /// <summary>Settings that put the folder every arrival test synchronizes inside classification's scope.</summary>
+    /// <summary>Reads back what the run asked the durable queue for, which is the whole of the arrival trigger's effect.</summary>
+    private static IReadOnlyList<JobEnqueueRequest> EnqueuedJobs(IJobStore jobStore) =>
+    [
+        .. jobStore
+            .ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == nameof(IJobStore.EnqueueAsync))
+            .Select(call => (JobEnqueueRequest)call.GetArguments()[0]!),
+    ];
+
     private static SpamClassificationSettings ClassifyingTheInbox() => SpamClassificationSettings.Create(
         isEnabled: true,
         usesScanner: false,
@@ -2147,7 +2258,8 @@ public sealed class MailboxSynchronizerTests
         StoredContentCeiling? storedContentCeiling = null,
         SpamClassificationSettings? classificationSettings = null,
         IJunkMailFolderCatalog? junkFolders = null,
-        IDerivedWorkGateTelemetry? gateTelemetry = null)
+        IDerivedWorkGateTelemetry? gateTelemetry = null,
+        IJobStore? jobStore = null)
     {
         var concurrencyRetryPolicy = new OptimisticConcurrencyRetryPolicy(
             persistenceSessionFactory,
@@ -2182,6 +2294,10 @@ public sealed class MailboxSynchronizerTests
                 junkFolders ?? StubJunkMailFolderCatalog.None,
                 timeProvider),
             gateTelemetry ?? new RecordingDerivedWorkGateTelemetry(),
+            new SpamClassificationArrivals(
+                jobStore ?? Substitute.For<IJobStore>(),
+                new StubSpamClassificationSettingsReader(
+                    classificationSettings ?? SpamClassificationSettings.Disabled)),
             concurrencyRetryPolicy,
             timeProvider,
             options);

--- a/tests/Application.UnitTests/TestDoubles/InMemoryClassifiableEmailReader.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryClassifiableEmailReader.cs
@@ -17,6 +17,7 @@ namespace MailFathom.Application.UnitTests.TestDoubles;
 internal sealed class InMemoryClassifiableEmailReader : IClassifiableEmailReader
 {
     private readonly List<ClassifiableEmail> emails = [];
+    private readonly Dictionary<EmailOccurrenceId, StoredEmailId> emailIdsByOccurrence = [];
 
     /// <summary>Gets the batch sizes the reads asked for, oldest first.</summary>
     internal List<int> RequestedBatchSizes { get; } = [];
@@ -31,9 +32,21 @@ internal sealed class InMemoryClassifiableEmailReader : IClassifiableEmailReader
         return email.Id;
     }
 
+    /// <summary>Stores the occurrence one held email was discovered at, so a job payload naming it resolves.</summary>
+    /// <param name="occurrenceId">The stable remote occurrence identity.</param>
+    /// <param name="emailId">The local identity it was stored as.</param>
+    internal void AddOccurrence(EmailOccurrenceId occurrenceId, StoredEmailId emailId) =>
+        this.emailIdsByOccurrence[occurrenceId] = emailId;
+
     /// <inheritdoc />
     public Task<ClassifiableEmail?> FindAsync(StoredEmailId emailId, CancellationToken cancellationToken) =>
         Task.FromResult(this.emails.FirstOrDefault(email => email.Id == emailId));
+
+    /// <inheritdoc />
+    public Task<StoredEmailId?> FindStoredEmailIdAsync(
+        EmailOccurrenceId occurrenceId,
+        CancellationToken cancellationToken) => Task.FromResult(
+        this.emailIdsByOccurrence.TryGetValue(occurrenceId, out var emailId) ? emailId : (StoredEmailId?)null);
 
     /// <inheritdoc />
     public Task<IReadOnlyList<ClassifiableEmail>> GetStoredEmailsAsync(

--- a/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
+++ b/tests/Host.UnitTests/TestDoubles/SynchronizationTestHost.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
+using MailFathom.Application.Jobs;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Mutations;
 using MailFathom.Application.Mail.Mutations.Audit;
@@ -232,6 +233,11 @@ internal static class SynchronizationTestHost
         services.AddScoped<EmailSpamClassifier>();
         services.AddScoped<SpamActionRecorder>();
         services.AddScoped<SpamClassificationPass>();
+        // The arrival trigger the run reaches after each message it commits, and the queue it writes through. Every
+        // account these tests configure runs with classification off, so the trigger reads one property per stored
+        // message and the substituted queue is never asked for anything.
+        services.AddSingleton(Substitute.For<IJobStore>());
+        services.AddScoped<SpamClassificationArrivals>();
 
         // The cut is the run's last local step, after the rules for the ordering the arrival pipeline is built on, and a
         // supervisor resolves it from the same scope. The store answers that no message is awaiting passages, which is


### PR DESCRIPTION
Closes #730

Classification stops being a seam and becomes a running execution. `#688` shipped the record, the deterministic stage, the scanner port, and the gate; nothing invoked `EmailSpamClassifier` unless an operator asked for a run over a whole mailbox. This is the trigger, built on the job model `#405` and its children delivered.

## What runs now

**The arrival trigger.** `SpamClassificationArrivals` is reached once per stored message, from `MailboxSynchronizer.StoreOccurrenceAsync`, after the transaction that committed the message and its content. It writes one row into the durable queue.

**The execution.** `EmailSpamClassificationHandler` runs `JobType.ClassifyEmailSpam`: it resolves the occurrence the payload names into the local email, classifies it in `FirstTimeOnly` mode, and puts the verdict to `SpamActionRecorder` under the acting posture, so the switches an operator turned on reach arriving mail exactly as they reach mail a run walks. Both switches remain off by default.

## Why the job model rather than the account run

Per-message backoff, and nothing else. A scan reaches a sidecar that can be unreachable, saturated, or restarting; the account run's only recovery is deferring the whole account, which cannot express one message out of three hundred deserving another attempt. Nothing here adds an attempt counter, a next-attempt time, or a terminal failure state to the classification record — those are the queue row's.

## What keeps it off the synchronization run's critical path

- The switch and the folder scope are read before the queue is touched, so a deployment with classification off performs one property read per stored message.
- The enqueue happens after the commit, because `IJobStore` takes no persistence session by design.
- A message stored without its content is not asked for: it is reported unclassifiable rather than fetched, and the gate already releases it.
- The queue's answer is not acted on. A refusal at `Jobs:MaxQueueDepthPerType` leaves the message to `SpamClassification:ClassificationWait`, which `#693` already counts as a release. A backlog degrades a secondary signal instead of stalling the pass, and it is read from the queue-depth gauge, which saturates at exactly the bound enqueuing is refused at.

## Idempotency

The execution is keyed by the message's own stored identity rather than by the occurrence written out. That is a bound rather than a preference: a key may be 256 characters while an account identifier and a folder alias may each be 128, so the composed form could exceed it and raise out of the synchronization run — precisely what this trigger may never do. The occurrence stays fully readable in the payload beside the key.

A repeated attempt re-reads the verdict an earlier one committed, so an attempt that lost its lease after recording a verdict leaves the filing to be finished rather than silently dropped.

## Breaking changes

None. No configuration key, database column, MCP tool argument, or deployment contract moves; the migration set is untouched.

## Documentation

`docs/architecture/arrival-pipeline.md` is corrected rather than duplicated: the diagram now shows the hand-off, the classification job with its sidecar call, and what each outcome permits downstream, and the seam styling is gone. Its spam-scanner row said no verdict is recorded when a scan fails, which was never true of `EmailSpamClassifier` — corrected in the same pass. `docs/features/spam-classification.md` gains *Mail is classified as it arrives* and loses *What is not here*; `docs/features/imap-synchronization.md` and `docs/users/administering.md` follow.

## Verification

`scripts/verify-full.sh` green on the rebased branch: 6821 tests, 0 failed, aggregate line coverage 95.81%.