### PR TITLE
[#520] Observe every call to a model, and record nothing of what was asked

### DIFF
--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry and the Aspire dashboard
 
-<!-- describes: src/Application/Observability/**, src/Common/Observability/**, src/Host/Observability/**, src/Host/ServiceDefaultsExtensions.cs, src/Host/Hosting/Workers/MailExtractionBackfillWorker.cs, src/Infrastructure/Observability/**, src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, src/Infrastructure/HostApplicationBuilderExtensions.cs, src/Mcp/Observability/**, src/AppHost/** -->
+<!-- describes: src/Application/Observability/**, src/Common/Observability/**, src/Host/Observability/**, src/Host/ServiceDefaultsExtensions.cs, src/Host/Hosting/Workers/MailExtractionBackfillWorker.cs, src/Infrastructure/Observability/**, src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, src/Infrastructure/HostApplicationBuilderExtensions.cs, src/Mcp/Observability/**, src/AppHost/**, src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs -->
 
 The host instruments itself with OpenTelemetry throughout — logs, metrics, and traces — and exports none of it unless
 the environment names a destination. Today exactly one environment does that out of the box: a local run under the
@@ -20,7 +20,7 @@ and a duration, never as what was searched for. [What the endpoint records](mcp-
 states that boundary precisely.
 
 **Metrics** cover the request pipeline (ASP.NET Core), outbound HTTP (`HttpClient`), and the .NET runtime through their
-instrumentation packages, and four meters that the libraries publishing them name themselves:
+instrumentation packages, and five meters that the libraries publishing them name themselves:
 
 | Meter | What it reports | Subscribed by |
 | --- | --- | --- |
@@ -28,16 +28,18 @@ instrumentation packages, and four meters that the libraries publishing them nam
 | `Microsoft.EntityFrameworkCore` | Active contexts, queries, save operations, compiled-query cache hits and misses, execution-strategy failures, and optimistic-concurrency failures | The host |
 | `Experimental.ModelContextProtocol` | MCP session duration, and per-operation duration broken down by protocol method and — for a tool call — tool name | The host |
 | `Polly` | Every outbound-resilience pipeline's attempts, outcomes, timeouts, and circuit-breaker state transitions | The host |
+| `Experimental.Microsoft.Extensions.AI` | One provider call's duration and the tokens it consumed, broken down by operation, provider, model, and token type | The host |
 
 The split in the last column is where a meter is registered, not how important it is: the Aspire enrichment that gives
 the EF Core context its health check and its database tracing subscribes `Npgsql` as part of the same call, and the
-host subscribes the three it leaves out. Nothing is subscribed twice.
+host subscribes the four it leaves out. Nothing is subscribed twice.
 [Outbound resilience](../architecture/outbound-resilience.md#telemetry-and-privacy) records which tags the `Polly`
 events carry and which they never do; the optimistic-concurrency counter is the aggregate view of the same conflicts
 that surface individually as a persistence conflict failure.
 
-**Traces** cover incoming requests, outbound HTTP, database commands, and MCP protocol operations, correlated end to
-end: the trace a request arrives with is the trace its log records and its failure diagnostics carry. The MCP spans
+**Traces** cover incoming requests, outbound HTTP, database commands, MCP protocol operations, and calls to an AI
+provider, correlated end to end: the trace a request arrives with is the trace its log records and its failure
+diagnostics carry, and a model call appears inside the MCP request that caused it rather than beside it. The MCP spans
 come from the SDK's own `Experimental.ModelContextProtocol` activity source and carry the protocol method, the
 negotiated protocol version, the transport, the session identifier, the JSON-RPC request identifier, and the tool name
 for a tool call — which is what makes a slow call attributable to a tool before anything inside the tool is
@@ -61,9 +63,40 @@ turns scopes on for the console output rather than for the exporter — and
 [the MCP endpoint](mcp-endpoint.md#the-one-route-on-this-surface-that-admits-no-credential) states what each one costs.
 
 Every tag on the metrics above is a bounded set — a protocol method, a transport kind, a negotiated version, one of the
-three tool names, an outcome — so none of them opens a time series per message or per person. The MCP SDK does tag a
-metric with a resource URI, but only for the protocol's resource methods, and MailFathom's server publishes tools
-alone: no resources and no prompts, so the tag never arises.
+three tool names, an outcome, and on the AI instruments the operation, the provider, the requested and answered model
+names, the configured endpoint's address and port, and the token type — so none of them opens a time series per message
+or per person. The MCP SDK does tag a metric with a resource URI, but only for the protocol's resource methods, and
+MailFathom's server publishes tools alone: no resources and no prompts, so the tag never arises.
+
+### What a call to a model emits, and what it never does
+
+A chat model and an embedding model are reached through one client construction, and every client it builds is wrapped
+in the telemetry decorators `Microsoft.Extensions.AI` publishes. That is a property of the construction rather than of
+any call site: an adapter added later reaches a provider the same way and is spanned without anything else being
+written. The decorator sits innermost, beneath the resilience pipeline and the spend ceiling, so a span measures one
+attempt against the provider — a call retried three times is three spans rather than one slow one, which is what makes
+a provider's own latency separable from the retrying around it. Spans and instruments both arrive under
+`Experimental.Microsoft.Extensions.AI`, which is the library's name for them and follows OpenTelemetry's semantic
+conventions for generative AI, still marked experimental upstream.
+
+**The spans are complete; the instruments are not, under sustained load.** A client is built per provider call, so each
+call constructs the decorator anew — and the decorator creates a meter of its own with it. Every construction therefore
+allocates two fresh metric streams, and the OpenTelemetry SDK caps a provider at 1000 of them; the cap is reached after
+roughly 250 provider calls within one export interval, and the streams are reclaimed at the next export. Measured
+against the pinned SDK: 400 calls in one interval produce 400 spans and 250 measured calls. An ordinary interval's worth
+of questions is far below that and is measured in full, and an embedding backfill running at full concurrency is the
+shape that exceeds it — which shows up as an undercounted call rate and an undercounted token total for that interval,
+never as a missing span or a wrong duration on the calls that were recorded. Reading a backfill's cost from the provider's
+own accounting rather than from this meter is the remedy while that holds.
+
+**A prompt and a completion are never recorded.** The library will capture both — the question somebody asked of their
+mailbox, the answer a model gave, the passages an embedding request carried — and it turns that capture on from the
+environment variable `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. MailFathom sets the switch explicitly where
+it builds the client, and an explicit value takes precedence, so **that variable has no effect on this process**. There
+is no configuration key for it either: a collector holding every question and answer would be a second copy of the mail,
+under a retention nobody chose and an access rule the mail store never granted, and this is not a trade an operator is
+offered. What remains is metadata — which operation ran, against which model and endpoint, how long it took, how many
+tokens it consumed, and whether it failed.
 
 ## The build every record names
 

--- a/src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs
+++ b/src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs
@@ -74,7 +74,7 @@ internal sealed class OpenAiCompatibleClientFactory
                 options);
 #pragma warning restore OPENAI001
 
-        return client.AsIEmbeddingGenerator();
+        return ObservedThroughTelemetry(client.AsIEmbeddingGenerator());
     }
 
     /// <summary>Opens a chat client over the declared endpoint for the duration of one request.</summary>
@@ -100,7 +100,7 @@ internal sealed class OpenAiCompatibleClientFactory
         ArgumentNullException.ThrowIfNull(credential);
         ArgumentNullException.ThrowIfNull(transport);
 
-        return endpoint.Api switch
+        return ObservedThroughTelemetry(endpoint.Api switch
         {
             ChatProviderApi.ChatCompletions => this.OpenChatCompletionsClient(endpoint, credential, transport),
             ChatProviderApi.Responses => this.OpenResponsesClient(endpoint, credential, transport),
@@ -108,7 +108,7 @@ internal sealed class OpenAiCompatibleClientFactory
                 nameof(endpoint),
                 endpoint.Api,
                 "The endpoint names no API this factory can reach."),
-        };
+        });
     }
 
     private IChatClient OpenChatCompletionsClient(
@@ -154,6 +154,60 @@ internal sealed class OpenAiCompatibleClientFactory
         return client.AsIChatClient(endpoint.RoutedModelName);
 #pragma warning restore OPENAI001
     }
+
+    /// <summary>Wraps one chat client in the decorator every provider call is observed through.</summary>
+    /// <remarks>
+    /// <para>
+    /// Applied where the client is built rather than at a call site, because a call site is what a later feature adds:
+    /// the single-request adapter and the answering run each open a client here, and an adapter written after this one
+    /// is spanned by construction instead of by somebody remembering to wrap it.
+    /// </para>
+    /// <para>
+    /// It sits innermost, beneath the resilience and budget decorators an answering run composes, so a span measures
+    /// one attempt against the provider. A decorator placed outside the resilience pipeline would report a call that
+    /// was retried three times as a single slow one, which is the opposite of what the span is read for.
+    /// </para>
+    /// <para>
+    /// Prompt and completion capture is switched off explicitly rather than left at its default, and that is what the
+    /// callback exists for. The library turns it on when <c>OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT</c> says
+    /// so, and a deployment whose collector then held every question asked of a mailbox and every answer given would
+    /// have made a second copy of the mail out of its trace store — under a retention nobody chose and an access rule
+    /// the mail store never granted. An explicit value takes precedence over that variable, so the setting is not
+    /// reachable from the environment at all. What is left is metadata: the operation, the model, the endpoint address,
+    /// the token counts, and the outcome, none of which opens a dimension per message, per address, or per prompt.
+    /// </para>
+    /// <para>
+    /// No source name is passed, so the spans and instruments arrive under the library's own default. The host
+    /// subscribes that name beside the other library names it collects, and its unit tests assert the string against
+    /// the library's own declaration, which is what makes a rename arriving with a package bump a failing build rather
+    /// than a quietly empty dashboard.
+    /// </para>
+    /// <para>
+    /// What this position costs is the instruments rather than the spans, and it is measured rather than suspected: the
+    /// decorator creates a meter of its own, a client is built per call, and the OpenTelemetry SDK caps a provider at
+    /// 1000 metric streams — so beyond roughly 250 calls inside one export interval a measurement is dropped, while
+    /// every span is still recorded. Ordinary use stays well under that; a backfill running at full concurrency does
+    /// not. Lifting the decorator above the per-call construction is what removes the cap, and it is a change to how a
+    /// provider client is held rather than to where the decorator is applied.
+    /// </para>
+    /// </remarks>
+    private static IChatClient ObservedThroughTelemetry(IChatClient client) =>
+        client
+            .AsBuilder()
+            .UseOpenTelemetry(configure: static observed => observed.EnableSensitiveData = false)
+            .Build();
+
+    /// <summary>Wraps one embedding generator in the same decorator, for the same reasons.</summary>
+    /// <remarks>
+    /// The passages an embedding request carries are mail, so the capture switch matters here exactly as it does for a
+    /// chat client: what a span records is how many passages were embedded and how long it took, never what they said.
+    /// </remarks>
+    private static IEmbeddingGenerator<string, Embedding<float>> ObservedThroughTelemetry(
+        IEmbeddingGenerator<string, Embedding<float>> generator) =>
+        generator
+            .AsBuilder()
+            .UseOpenTelemetry(configure: static observed => observed.EnableSensitiveData = false)
+            .Build();
 
     /// <summary>Builds the options a chat completions or embedding client is constructed with.</summary>
     private static OpenAIClientOptions BuildClientOptions(Uri? address, HttpClient transport)

--- a/src/Host/Observability/TelemetrySubscriptionExtensions.cs
+++ b/src/Host/Observability/TelemetrySubscriptionExtensions.cs
@@ -41,6 +41,14 @@ internal static class TelemetrySubscriptionExtensions
     /// <summary>The meter EF Core publishes its context, query, and concurrency instruments to.</summary>
     private const string EntityFrameworkCoreMeterName = "Microsoft.EntityFrameworkCore";
 
+    /// <summary>The one name the AI telemetry decorators publish both their spans and their instruments under.</summary>
+    /// <remarks>
+    /// The decorators the AI boundary applies to every chat client and embedding generator it builds pass no source
+    /// name, so this is the library's own default rather than a name MailFathom chose. The unit tests read it from the
+    /// library's declaration and assert it against this string.
+    /// </remarks>
+    private const string MicrosoftExtensionsAiTelemetryName = "Experimental.Microsoft.Extensions.AI";
+
     /// <summary>Subscribes the activity source MailFathom publishes spans to.</summary>
     /// <param name="tracing">The tracing pipeline being composed.</param>
     /// <returns>The same builder instance for chaining.</returns>
@@ -76,6 +84,12 @@ internal static class TelemetrySubscriptionExtensions
     /// that did not happen rather than as a span nobody collected.
     /// </para>
     /// <para>
+    /// The AI decorators span one call against a chat model or an embedding model, from the position the AI boundary
+    /// applies them: innermost, beneath the resilience and budget decorators, so a span is one attempt rather than a
+    /// retried sequence. Without this subscription a slow answer is attributable to the code around the model call and
+    /// not to the call, which is the one distinction the whole span exists to draw.
+    /// </para>
+    /// <para>
     /// EF Core is deliberately absent. It reports through <c>DiagnosticSource</c> rather than an
     /// <c>ActivitySource</c>, so no name subscribes it; reaching it means adding a bridging instrumentation package,
     /// which would then span the same database commands the <c>Npgsql</c> source already spans.
@@ -85,7 +99,7 @@ internal static class TelemetrySubscriptionExtensions
     {
         ArgumentNullException.ThrowIfNull(tracing);
 
-        return tracing.AddSource(ModelContextProtocolTelemetryName);
+        return tracing.AddSource(ModelContextProtocolTelemetryName, MicrosoftExtensionsAiTelemetryName);
     }
 
     /// <summary>Subscribes the meters the pinned libraries publish instruments to under their own names.</summary>
@@ -101,11 +115,18 @@ internal static class TelemetrySubscriptionExtensions
     /// <c>PersistenceConcurrencyConflictException</c> and is visible nowhere else.
     /// </para>
     /// <para>
+    /// The AI decorators report the duration of one provider call and the tokens it consumed, which is what makes a
+    /// model's latency and a model's consumption readable per operation and per model rather than only in an invoice.
+    /// </para>
+    /// <para>
     /// Every tag on those instruments is a bounded set: a protocol method, a transport kind, a negotiated version, one
-    /// of MailFathom's three tool names, an outcome. The MCP SDK does tag a metric with a resource URI, which would be
-    /// neither bounded nor free of personal data, but only for the resource methods — and MailFathom publishes tools
-    /// alone, no resources and no prompts, so the tag cannot arise. A resource capability added later brings that
-    /// question with it.
+    /// of MailFathom's three tool names, an outcome, and — on the AI instruments — the operation, the provider, the
+    /// requested and answered model names, the configured endpoint's address and port, and the token type. The MCP SDK
+    /// does tag a metric with a resource URI, which would be neither bounded nor free of personal data, but only for
+    /// the resource methods — and MailFathom publishes tools alone, no resources and no prompts, so the tag cannot
+    /// arise. A resource capability added later brings that question with it. Nothing here opens a dimension per
+    /// message, per address, or per prompt, and the one thing that could — the AI decorators capturing prompts and
+    /// completions — is switched off where those decorators are applied rather than left to this subscription.
     /// </para>
     /// </remarks>
     public static MeterProviderBuilder AddLibraryMeters(this MeterProviderBuilder metrics)
@@ -115,6 +136,7 @@ internal static class TelemetrySubscriptionExtensions
         return metrics.AddMeter(
             PollyMeterName,
             ModelContextProtocolTelemetryName,
-            EntityFrameworkCoreMeterName);
+            EntityFrameworkCoreMeterName,
+            MicrosoftExtensionsAiTelemetryName);
     }
 }

--- a/tests/AI.UnitTests/ProviderAdapters/OpenAiCompatibleClientFactoryTests.cs
+++ b/tests/AI.UnitTests/ProviderAdapters/OpenAiCompatibleClientFactoryTests.cs
@@ -10,6 +10,7 @@ using MailFathom.AI.ProviderAdapters;
 using MailFathom.AI.Providers;
 using MailFathom.AI.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
+using Microsoft.Extensions.AI;
 using Xunit;
 
 namespace MailFathom.AI.UnitTests.ProviderAdapters;
@@ -22,6 +23,9 @@ namespace MailFathom.AI.UnitTests.ProviderAdapters;
 /// </remarks>
 public sealed class OpenAiCompatibleClientFactoryTests
 {
+    /// <summary>The variable the telemetry decorators read prompt and completion capture from when nothing sets it.</summary>
+    private const string MessageCaptureVariable = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT";
+
     private readonly OpenAiCompatibleClientFactory factory = new();
 
     [Fact]
@@ -289,6 +293,120 @@ public sealed class OpenAiCompatibleClientFactoryTests
             ChatDeclarations.Endpoint(api: (ChatProviderApi)7),
             credential,
             transport));
+    }
+
+    /// <summary>
+    /// Every client this factory builds is observed, whichever role and whichever API it was opened for. Asserted
+    /// against the construction rather than against a call site, because a call site is what a later feature adds: an
+    /// adapter written tomorrow reaches a provider through this factory and is spanned without anybody wrapping it.
+    /// </summary>
+    [Theory]
+    [InlineData(ChatProviderApi.ChatCompletions)]
+    [InlineData(ChatProviderApi.Responses)]
+    public void OpenChatClient_AnyDeclaredApi_OpensAClientObservedThroughTheTelemetryDecorator(ChatProviderApi api)
+    {
+        // Arrange
+        using var handler = new FakeHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)));
+        using var transport = new HttpClient(handler, disposeHandler: false);
+        using var credential = ProviderEndpointCredential.FromApiKey("a-resolved-key", resolvedMaterial: null);
+
+        // Act
+        using var client = this.factory.OpenChatClient(ChatDeclarations.Endpoint(api: api), credential, transport);
+
+        // Assert
+        Assert.NotNull(client.GetService<OpenTelemetryChatClient>());
+    }
+
+    [Fact]
+    public void OpenEmbeddingGenerator_AnyEndpoint_OpensAGeneratorObservedThroughTheTelemetryDecorator()
+    {
+        // Arrange
+        using var handler = new FakeHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)));
+        using var transport = new HttpClient(handler, disposeHandler: false);
+        using var credential = ProviderEndpointCredential.FromApiKey("a-resolved-key", resolvedMaterial: null);
+
+        // Act
+        using var generator = this.factory.OpenEmbeddingGenerator(
+            EmbeddingDeclarations.Endpoint(),
+            credential,
+            transport);
+
+        // Assert
+        Assert.NotNull(generator.GetService<OpenTelemetryEmbeddingGenerator<string, Embedding<float>>>());
+    }
+
+    /// <summary>
+    /// What the decorator must never be allowed to record. The question a person asked of their mailbox and the answer
+    /// a model gave are the mail itself, so a trace store holding them would be a second copy of it — and the library
+    /// turns that capture on from an environment variable unless the value is set explicitly. These two tests are why
+    /// the variable is set here rather than only asserted absent: a run that read the environment would pass with the
+    /// variable unset and export message content the moment an operator set it.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("true")]
+    public void OpenChatClient_WhateverTheEnvironmentAsksFor_CapturesNoPromptOrCompletion(string? messageCapture)
+    {
+        // Arrange
+        using var handler = new FakeHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)));
+        using var transport = new HttpClient(handler, disposeHandler: false);
+        using var credential = ProviderEndpointCredential.FromApiKey("a-resolved-key", resolvedMaterial: null);
+
+        var restored = Environment.GetEnvironmentVariable(MessageCaptureVariable);
+        Environment.SetEnvironmentVariable(MessageCaptureVariable, messageCapture);
+
+        try
+        {
+            // Act
+            using var client = this.factory.OpenChatClient(ChatDeclarations.Endpoint(), credential, transport);
+
+            // Assert
+            var observed = client.GetService<OpenTelemetryChatClient>();
+
+            Assert.NotNull(observed);
+            Assert.False(observed.EnableSensitiveData);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MessageCaptureVariable, restored);
+        }
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("true")]
+    public void OpenEmbeddingGenerator_WhateverTheEnvironmentAsksFor_CapturesNoPassageText(string? messageCapture)
+    {
+        // Arrange
+        using var handler = new FakeHttpMessageHandler(
+            (_, _) => Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK)));
+        using var transport = new HttpClient(handler, disposeHandler: false);
+        using var credential = ProviderEndpointCredential.FromApiKey("a-resolved-key", resolvedMaterial: null);
+
+        var restored = Environment.GetEnvironmentVariable(MessageCaptureVariable);
+        Environment.SetEnvironmentVariable(MessageCaptureVariable, messageCapture);
+
+        try
+        {
+            // Act
+            using var generator = this.factory.OpenEmbeddingGenerator(
+                EmbeddingDeclarations.Endpoint(),
+                credential,
+                transport);
+
+            // Assert
+            var observed = generator.GetService<OpenTelemetryEmbeddingGenerator<string, Embedding<float>>>();
+
+            Assert.NotNull(observed);
+            Assert.False(observed.EnableSensitiveData);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(MessageCaptureVariable, restored);
+        }
     }
 
     /// <summary>The narrowest embeddings answer a client will read, so a request can be sent and its headers inspected.</summary>

--- a/tests/Host.UnitTests/Observability/TelemetrySubscriptionExtensionsTests.cs
+++ b/tests/Host.UnitTests/Observability/TelemetrySubscriptionExtensionsTests.cs
@@ -9,6 +9,7 @@ using MailFathom.Common.Observability;
 using MailFathom.Host.Observability;
 using MailFathom.Host.UnitTests.TestDoubles;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.Extensions.AI;
 using ModelContextProtocol.Server;
 using OpenTelemetry.Metrics;
 using Xunit;
@@ -34,6 +35,29 @@ public sealed class TelemetrySubscriptionExtensionsTests
     /// </remarks>
     private static Type ModelContextProtocolDiagnostics =>
         typeof(McpServerTool).Assembly.GetType("ModelContextProtocol.Diagnostics", throwOnError: true)!;
+
+    /// <summary>The name the AI telemetry decorators publish under when a client is built without one of its own.</summary>
+    /// <remarks>
+    /// Read from the library for the same reason the MCP SDK's is, and with more at stake: the AI boundary passes no
+    /// source name to <c>UseOpenTelemetry</c>, so what its spans and instruments arrive under is entirely the library's
+    /// default. A rename under a package bump would leave every provider call uncollected while the code went on
+    /// looking instrumented, and the declaration is internal, so reflection is what turns that into a failing test
+    /// here. One name serves both registries because the decorators construct their activity source and their meter
+    /// from the same string; a release that split them would fail the meter assertion rather than pass it silently.
+    /// </remarks>
+    private static string DeclaredExtensionsAiTelemetryName
+    {
+        get
+        {
+            var declaration = typeof(OpenTelemetryChatClient).Assembly
+                .GetType("Microsoft.Extensions.AI.OpenTelemetryConsts", throwOnError: true)!
+                .GetField("DefaultSourceName", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+            Assert.NotNull(declaration);
+
+            return Assert.IsType<string>(declaration.GetValue(null));
+        }
+    }
 
     [Fact]
     public void AddMailFathomActivitySources_SubscribesTheDeclaredName()
@@ -71,7 +95,9 @@ public sealed class TelemetrySubscriptionExtensionsTests
         tracing.AddLibraryActivitySources();
 
         // Assert
-        Assert.Equal(["Experimental.ModelContextProtocol"], tracing.SubscribedSources);
+        Assert.Equal(
+            ["Experimental.ModelContextProtocol", "Experimental.Microsoft.Extensions.AI"],
+            tracing.SubscribedSources);
     }
 
     [Fact]
@@ -85,7 +111,12 @@ public sealed class TelemetrySubscriptionExtensionsTests
 
         // Assert
         Assert.Equal(
-            ["Polly", "Experimental.ModelContextProtocol", "Microsoft.EntityFrameworkCore"],
+            [
+                "Polly",
+                "Experimental.ModelContextProtocol",
+                "Microsoft.EntityFrameworkCore",
+                "Experimental.Microsoft.Extensions.AI",
+            ],
             metrics.SubscribedMeters);
     }
 
@@ -168,6 +199,32 @@ public sealed class TelemetrySubscriptionExtensionsTests
 #pragma warning disable EF1001
         Assert.Contains(EntityFrameworkMetrics.MeterName, metrics.SubscribedMeters);
 #pragma warning restore EF1001
+    }
+
+    [Fact]
+    public void AddLibraryActivitySources_SubscribesTheNameTheAiDecoratorsStartTheirSpansFrom()
+    {
+        // Arrange
+        var tracing = new RecordingTracerProviderBuilder();
+
+        // Act
+        tracing.AddLibraryActivitySources();
+
+        // Assert
+        Assert.Contains(DeclaredExtensionsAiTelemetryName, tracing.SubscribedSources);
+    }
+
+    [Fact]
+    public void AddLibraryMeters_SubscribesTheNameTheAiDecoratorsCreateTheirInstrumentsOn()
+    {
+        // Arrange
+        var metrics = new RecordingMeterProviderBuilder();
+
+        // Act
+        metrics.AddLibraryMeters();
+
+        // Assert
+        Assert.Contains(DeclaredExtensionsAiTelemetryName, metrics.SubscribedMeters);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #520.

`Microsoft.Extensions.AI` publishes no telemetry a host can subscribe by name alone — its spans and instruments exist
only where a client is decorated. When #520 was split out of #501 nothing under `src/AI` composed a client, so there was
nothing to decorate. There is now: `OpenAiCompatibleClientFactory` builds every chat client and every embedding
generator this system reaches a provider through, for both supported APIs and all three credential shapes.

## What this does

- **The decorator goes where the client is built**, not at a call site. The single-request chat adapter, the embedding
  adapter, and the answering run each open a client through that one factory, so an adapter written later is spanned by
  construction rather than by somebody remembering to wrap it.
- **It sits innermost**, beneath the resilience and budget decorators an answering run composes. A span therefore
  measures one attempt against the provider: a call the pipeline retried three times is three spans rather than one slow
  one, which is the distinction the span exists to draw.
- **Prompt and completion capture is off explicitly.** The library turns it on from
  `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`, and a collector then holding every question asked of a mailbox
  and every answer given would be a second copy of the mail — under a retention nobody chose and an access rule the mail
  store never granted. An explicit value takes precedence over the variable, so the setting is not reachable from the
  environment at all. Four unit tests set the variable to `"true"` and assert the capture stays off, which is what makes
  *explicitly off* a failing test rather than a reading of the source.
- **The host subscribes the name the decorators publish under**, for the activity source and the meter alike. The Host
  tests read that name from the library's own internal declaration, the same arrangement the MCP SDK's name already has,
  so a rename arriving with a package bump fails the build instead of quietly emptying a dashboard.
- **Tag cardinality checked** against the rule the rest of the emitted surface follows. The tags observed on a real span
  are `gen_ai.operation.name`, `gen_ai.request.model`, `gen_ai.provider.name`, `server.address`, `server.port`,
  `gen_ai.response.finish_reasons`, `gen_ai.response.model`, and the two token counts — every one of them bounded by
  configuration or by the provider's own vocabulary. Nothing per message, per address, or per prompt.

## One thing measured while writing this, and documented rather than left to be found

A provider client is opened per call, deliberately, and the decorator therefore creates a `Meter` with it. Every
construction allocates two fresh metric streams and the OpenTelemetry SDK caps a provider at 1000 of them, reclaiming
them at export. Measured against the pinned SDK, one call at a time with no export in between:

| Calls in one export interval | Spans recorded | Calls measured |
| --- | --- | --- |
| 400 | 400 | 250 |

Ordinary use of the answering feature stays well under that and is measured in full; an embedding backfill at full
concurrency is the shape that exceeds it, and it reads as an undercounted call rate and token total for that interval
rather than as a missing span or a wrong duration. `docs/operations/telemetry.md` states this as it stands today, and
the code says the same where the decorator is applied. Removing the cap means holding the decorator above the per-call
construction, which is a change to how a provider client is held rather than to where the decorator is applied — so it
is #827 rather than a correction folded into this pull request.

## Contract surfaces

No break. Nothing changes in the MCP tool contract, the configuration schema, the database schema, or the deployment
contract. Two names are added to what the process collects, which is additive: `Experimental.Microsoft.Extensions.AI` as
an activity source and as a meter.

## Verification

`scripts/verify-full.sh` — exit 0, 6875 tests passed, 0 failed, 0 skipped, aggregate line coverage 95.84% against the 85% gate.

- https://github.com/Krzysztof318/MailFathom/issues/520
- https://github.com/Krzysztof318/MailFathom/issues/827
