### PR TITLE
[#505] Settle sampling and assert the redaction contract over the whole telemetry surface

### DIFF
--- a/docs/features/mail-answering.md
+++ b/docs/features/mail-answering.md
@@ -576,7 +576,8 @@ opening a database. [Telemetry § What a run records](../operations/telemetry.md
 
 The split between the two records is the point rather than an accident. Which messages a run read cannot go on a span:
 a tag per message opens a time series per person, a span store is not MailFathom's to carry an obligation in, exports
-are off by default, spans are sampled, and an erasure request cannot reach somebody else's trace backend. How long a run
+are off by default, [a deployment may sample spans away](../operations/telemetry.md#how-much-of-a-trace-is-recorded),
+and an erasure request cannot reach somebody else's trace backend. How long a run
 took and how much it considered cannot usefully go in a table either, because that is what a dashboard already answers.
 Between them the three questions an operator actually has are answered, each in one place: why did it answer *that* —
 the record; why is it slow — the span; why did it degrade — the span.

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -1295,6 +1295,7 @@ belong to the platform rather than to MailFathom:
 | --- | --- |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Attaches the OTLP exporter for logs, metrics, and traces — startup records included. Unset exports nothing. [Telemetry](telemetry.md) is the page, including the sibling `OTEL_*` variables the exporter reads itself |
 | `OTEL_SERVICE_NAME` | The service identity the startup records and every exported record carry. Unset reports the host assembly's own name |
+| `OTEL_TRACES_SAMPLER` / `OTEL_TRACES_SAMPLER_ARG` | How much of a trace is recorded. Unset records every trace this process starts and honors the decision on one it did not; [telemetry](telemetry.md#how-much-of-a-trace-is-recorded) holds the values and why that is the default |
 | `ASPNETCORE_URLS` / `ASPNETCORE_HTTP_PORTS` / `ASPNETCORE_HTTPS_PORTS` | Nothing — [each surface states where it is served](#where-each-surface-is-served), and setting one of these fails startup with a message naming the key that replaces it |
 | `DOTNET_ENVIRONMENT` / `ASPNETCORE_ENVIRONMENT` | The environment name; `Development` is what admits user secrets and `appsettings.Development.json` |
 | `DOTNET_USE_POLLING_FILE_WATCHER` | Set to `1` where reload must observe a mounted volume's atomic update — Kubernetes ConfigMaps in particular |

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -160,8 +160,9 @@ no disposal on their account.
 
 What publishes to that name is documented with the subsystem that does it.
 
-Every change MailFathom makes to a remote mailbox opens a span named after the mutation, and is counted along with how
-long it took, broken down by the mutation, the account, the folder alias, and whether it succeeded. It is deliberately
+Every change MailFathom makes to a remote mailbox opens a span named after the mutation, and is counted by
+`mailfathom.mailbox.mutations` and timed by `mailfathom.mailbox.mutation.duration`, both broken down by the mutation,
+the account, the folder alias, and whether it succeeded. It is deliberately
 **not** broken down by which IMAP commands carried the change — a relocation is one operation whether the server
 offered RFC 6851 `MOVE` or the copy-flag-expunge sequence was used instead, and a dimension telling the two apart is
 exactly what would make a missing server extension look like a different operation on a dashboard. Which path ran is in
@@ -624,11 +625,72 @@ either keeps up or does not. The refusals are how much of a mailbox is being lef
 is retried on a later run rather than lost. All five read zero on a deployment with both switches off, which constructs
 no detector on this path at all.
 
-What such a signal may carry is bounded by the same rule that governs the log lines, and it is a cardinality rule as
-much as a privacy one. Counts, sizes, durations, outcomes, error codes, and MailFathom's own configured account and
-folder aliases are permitted. Mail content, an address, a subject, a remote folder path, a message identifier, a UID, a
-search term, a credential, and model prompt or completion text are not — every one of them would open a time series per
-message or per person, quite apart from putting personal data in a span store.
+## What no signal carries, and what holds every signal to it
+
+Everything above is one rule, and it is a cardinality rule as much as a privacy one. **Counts, sizes, durations,
+outcomes, error codes, and MailFathom's own configured account, folder, and provider-endpoint aliases are permitted.
+Mail content, an address, a subject, a remote folder path, a message identifier, a UID, a search term, a credential, and
+model prompt or completion text are not** — every one of them would open a time series per message or per person, quite
+apart from putting personal data in a span store. It governs a name as much as a value: a span, an instrument, and a
+dimension are all named after the operation or the quantity they report, never after anything the operation saw.
+
+The rule is the same one that governs the log lines, and the aliases are the one place a value an operator wrote
+reaches an exporter. That is deliberate: an alias is MailFathom's own word for an account, a folder, or an endpoint, it
+is bounded by the size of somebody's configuration, and a dashboard without it cannot say which account is behind.
+
+What makes it a contract rather than a convention is that it is asserted over the emitted surface as a whole rather
+than per feature. A rule checked once per publisher is a rule the next publisher is not covered by, and a telemetry
+surface grows one publisher at a time — so the unit-test suite drives **every** publisher the two boundaries that own
+one hold, through a listener over MailFathom's activity source and meter, and holds what came out against four claims:
+
+- No span name, instrument name, or dimension key is named after a word from the refused list, matched whole segment by
+  whole segment. That is what separates `token`, which names a credential, from `tokens`, which is how many a model
+  consumed.
+- Every instrument name and dimension key sits under the single `mailfathom.` namespace in lower case, which is what
+  keeps a dimension from being minted out of a value at run time.
+- Every span is named as one lower-case phrase, so a span name is an operation rather than anything it read.
+- **Every string the drive hands a publisher is a sentinel**, one per class of input — a configured alias, text a caller
+  sent, text read out of a message — and the assertion is where each was allowed to surface. A caller's text and
+  anything mail-derived may reach nothing at all; an alias may reach the dimensions named for it and no others.
+
+Two things keep that from decaying quietly. Within each of those two boundaries a publisher is found by what it holds —
+an instrument field, or a declared span name — rather than by where it lives, so a publisher nobody added to the drive
+fails the suite instead of going unasserted. And the names every assembly of this deployment *declares*, the host's own
+included, are read and held against the same vocabulary, which reaches what no drive does: the span the extraction
+backfill worker opens, and a dimension only a failure path sets.
+
+## How much of a trace is recorded
+
+Sampling is a decision rather than a default to inherit, and MailFathom's is **parent-based always-on**: every trace
+this process starts is recorded, and a trace it did not start keeps the decision the caller already made.
+
+The always-on half is what a mailbox-sized workload is worth. The volume is bounded by one deployment's accounts and one
+assistant's tool calls rather than by public traffic; a folder run whose duration doubled is attributable only if the
+run before it was recorded too; and export is off unless an endpoint is configured, so the default costs an
+unconfigured deployment nothing at all. The parent-based half keeps a head decision made upstream from being overturned
+here — the MCP surface continues a caller's trace, and a caller that dropped it is not asking for a fragment of it back.
+
+A deployment paying a collector per span is the case that wants the other answer, and it is the operator's to give:
+
+| Variable | What it does |
+| --- | --- |
+| `OTEL_TRACES_SAMPLER` | `always_on`, `always_off`, `traceidratio`, `parentbased_always_on`, `parentbased_always_off`, or `parentbased_traceidratio`. Unset is the default above |
+| `OTEL_TRACES_SAMPLER_ARG` | The ratio the two `traceidratio` samplers use, between `0` and `1` |
+
+Both are read by the OpenTelemetry SDK itself, and MailFathom sets its own sampler **only when the first is unset** —
+the SDK ignores its own configuration when a sampler was set programmatically and reports the fact to an event source
+nobody is listening to, so setting one unconditionally would answer an operator's variable with silence.
+
+Three things follow from the SDK reading these itself. `OTEL_TRACES_SAMPLER_ARG` on its own does nothing, because no
+sampler is a ratio one until the first variable names it. A value the SDK does not recognize — a hyphen where the name
+takes an underscore — is reported to that same event source and falls back to `parentbased_always_on`, which is what
+this host would have set anyway, so a misspelling reads as the variable having been ignored rather than as an error.
+And both have to be **environment variables**, not configuration keys, for the reason the exporter switch below gives —
+a start that writes any `OTEL_*` name into a file or an argument fails naming it.
+
+Health and liveness probes are excluded from tracing before any sampler sees them. A probe arrives every few seconds
+for the life of the process and says the same thing every time, so on a deployment exporting to a collector it pays for,
+the polling would otherwise be most of the bill.
 
 ## The one switch: `OTEL_EXPORTER_OTLP_ENDPOINT`
 

--- a/src/Host/Observability/TraceSamplingExtensions.cs
+++ b/src/Host/Observability/TraceSamplingExtensions.cs
@@ -1,0 +1,78 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using OpenTelemetry.Trace;
+
+namespace MailFathom.Host.Observability;
+
+/// <summary>States which traces this host records, and leaves the decision to the operator where one was made.</summary>
+/// <remarks>
+/// <para>
+/// Sampling is a decision rather than a default to inherit. Recording every span is right for this process and wrong
+/// for a busy one, and a deployment paying a collector per span is the case that needs the other answer — so the answer
+/// is written here, and the standard variable is what changes it.
+/// </para>
+/// <para>
+/// What this host sets when nothing else does is parent-based always-on: every trace it starts is recorded, and a trace
+/// it did not start keeps the decision the caller already made. The always-on half is what a mailbox-sized workload is
+/// worth — the volume is bounded by one deployment's accounts and one assistant's tool calls rather than by public
+/// traffic, a folder run that doubled is attributable only if the run before it was recorded too, and export is off
+/// unless an endpoint is configured, so the default costs an unconfigured deployment nothing. The parent-based half is
+/// what keeps a head decision made upstream from being overturned here: the MCP surface continues a caller's trace, and
+/// a caller that dropped it is not asking this process for a fragment of it.
+/// </para>
+/// <para>
+/// The operator's half is <c>OTEL_TRACES_SAMPLER</c> and <c>OTEL_TRACES_SAMPLER_ARG</c>, which the OpenTelemetry SDK
+/// reads for itself — an environment variable rather than a MailFathom configuration key, for the same reason the
+/// exporter switch is one: the bootstrap pipeline that reports a start failing is built before configuration exists,
+/// and a telemetry decision the two pipelines could disagree about is a decision in the wrong place.
+/// <c>EnvironmentOnlySettings</c> already fails a start that writes any <c>OTEL_*</c> name into a file or an argument,
+/// so the variable is the only way to reach this and no second rule is needed for it.
+/// </para>
+/// <para>
+/// That is why the sampler below is set only when the variable is absent. The SDK ignores its own configuration when a
+/// sampler was set programmatically, and reports the fact to an event source nobody is listening to — so setting one
+/// unconditionally would leave an operator's <c>OTEL_TRACES_SAMPLER=parentbased_traceidratio</c> silently doing
+/// nothing, which is worse than never having offered the variable at all.
+/// </para>
+/// </remarks>
+internal static class TraceSamplingExtensions
+{
+    /// <summary>The standard variable naming the sampler, which the OpenTelemetry SDK reads itself.</summary>
+    internal const string SamplerVariableName = "OTEL_TRACES_SAMPLER";
+
+    /// <summary>Sets the sampler this host records traces with unless the environment already names one.</summary>
+    /// <param name="tracing">The tracing pipeline being composed.</param>
+    /// <param name="configuration">The configuration the standard sampler variable is read from.</param>
+    /// <returns>The same builder instance for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="tracing" /> or <paramref name="configuration" /> is <see langword="null" />.
+    /// </exception>
+    public static TracerProviderBuilder SetDefaultSampler(
+        this TracerProviderBuilder tracing,
+        IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(tracing);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var sampler = SamplerToSet(configuration);
+
+        return sampler is null ? tracing : tracing.SetSampler(sampler);
+    }
+
+    /// <summary>Reads which sampler this host sets, if it sets one at all.</summary>
+    /// <param name="configuration">The configuration the standard sampler variable is read from.</param>
+    /// <returns>
+    /// The sampler to set, or <see langword="null" /> where the environment names one and the SDK is to build it.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
+    internal static Sampler? SamplerToSet(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return string.IsNullOrWhiteSpace(configuration[SamplerVariableName])
+            ? new ParentBasedSampler(new AlwaysOnSampler())
+            : null;
+    }
+}

--- a/src/Host/ServiceDefaultsExtensions.cs
+++ b/src/Host/ServiceDefaultsExtensions.cs
@@ -20,6 +20,9 @@ namespace MailFathom.Host;
 /// </summary>
 internal static class ServiceDefaultsExtensions
 {
+    /// <summary>The standard variable naming the collector every signal is exported to.</summary>
+    internal const string ExporterEndpointVariableName = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
     /// <summary>
     /// Adds observability, service discovery, HTTP resilience, and health-check defaults.
     /// </summary>
@@ -52,7 +55,8 @@ internal static class ServiceDefaultsExtensions
     /// <remarks>
     /// The resource is configured once for all three signals, so a log record, a metric point, and a span all name the
     /// build they came from. <see cref="StampedBuildResourceExtensions" /> holds what that adds and what it leaves to
-    /// the OpenTelemetry SDK.
+    /// the OpenTelemetry SDK, and <see cref="TraceSamplingExtensions" /> holds which traces are recorded and which of
+    /// that decision is the operator's.
     /// </remarks>
     public static TBuilder ConfigureOpenTelemetry<TBuilder>(this TBuilder builder)
         where TBuilder : IHostApplicationBuilder
@@ -71,13 +75,12 @@ internal static class ServiceDefaultsExtensions
             })
             .WithTracing(tracing =>
             {
-                tracing.AddMailFathomActivitySources()
+                tracing.SetDefaultSampler(builder.Configuration)
+                    .AddMailFathomActivitySources()
                     .AddLibraryActivitySources()
-                    // A probe arrives every few seconds for the lifetime of the process and says the same thing every
-                    // time, so tracing it would fill a trace store with the polling rather than with the work.
                     .AddAspNetCoreInstrumentation(tracingOptions =>
                     {
-                        tracingOptions.Filter = context => !HealthProbe.IsProbePath(context.Request.Path);
+                        tracingOptions.Filter = IsWorthTracing;
                         tracingOptions.EnrichWithHttpRequest = RedactAttachmentCapability;
                     })
                     .AddHttpClientInstrumentation();
@@ -91,14 +94,29 @@ internal static class ServiceDefaultsExtensions
     private static TBuilder AddOpenTelemetryExporters<TBuilder>(this TBuilder builder)
         where TBuilder : IHostApplicationBuilder
     {
-        var useOtlpExporter = !string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]);
-
-        if (useOtlpExporter)
+        if (ExportsOverOtlp(builder.Configuration))
         {
             builder.Services.AddOpenTelemetry().UseOtlpExporter();
         }
 
         return builder;
+    }
+
+    /// <summary>Reports whether this deployment named a collector, which is what attaches the exporter.</summary>
+    /// <param name="configuration">The configuration the standard endpoint variable is read from.</param>
+    /// <returns><see langword="true" /> when an endpoint is named, otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuration" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The default is off, and it is a privacy default rather than a gap: the signals describe activity around personal
+    /// mail, so where they flow is a decision an operator takes explicitly. This is a named method rather than a local
+    /// so that the default is asserted rather than read — every sibling change adds a publisher, and none of them may
+    /// turn export on for a deployment that named nowhere to send it.
+    /// </remarks>
+    internal static bool ExportsOverOtlp(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        return !string.IsNullOrWhiteSpace(configuration[ExporterEndpointVariableName]);
     }
 
     /// <summary>States what an exported log record carries beyond its message.</summary>
@@ -129,6 +147,24 @@ internal static class ServiceDefaultsExtensions
 
         logging.IncludeFormattedMessage = true;
         logging.IncludeScopes = false;
+    }
+
+    /// <summary>Reports whether a request is one the trace store is worth filling with.</summary>
+    /// <param name="context">The request the instrumentation is about to span.</param>
+    /// <returns><see langword="false" /> for a health or liveness probe, and <see langword="true" /> for anything else.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A probe arrives every few seconds for the lifetime of the process and says the same thing every time, so tracing
+    /// it would fill a trace store with the polling rather than with the work — and on a deployment exporting to a
+    /// collector it pays for, the polling would be most of the bill. This is a named method rather than a lambda
+    /// because it is a decision an operator relies on, and a decision nothing can assert is one a later change removes
+    /// without anything saying so.
+    /// </remarks>
+    internal static bool IsWorthTracing(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        return !HealthProbe.IsProbePath(context.Request.Path);
     }
 
     /// <summary>Replaces the recorded path of an attachment download with its route template.</summary>

--- a/tests/Host.UnitTests/Host.UnitTests.csproj
+++ b/tests/Host.UnitTests/Host.UnitTests.csproj
@@ -22,6 +22,10 @@
     <!-- Every boundary that publishes instruments asserts them the same way, through a listener over the one
          process-wide meter, so the recorder is built once rather than per suite. -->
     <Compile Include="..\shared\RecordedMailFathomMeasurements.cs" Link="RecordedMailFathomMeasurements.cs" />
+
+    <!-- The redaction contract is stated once and asserted in every project that has a telemetry name to hold against
+         it. This one holds the names every assembly declares, so it needs the rules and not the recorder. -->
+    <Compile Include="..\shared\TelemetryRedactionContract.cs" Link="TelemetryRedactionContract.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Host.UnitTests/Observability/DeclaredTelemetryVocabularyTests.cs
+++ b/tests/Host.UnitTests/Observability/DeclaredTelemetryVocabularyTests.cs
@@ -1,0 +1,84 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Reflection;
+using MailFathom.TestSupport;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Observability;
+
+/// <summary>Holds every telemetry name this deployment declares, in every assembly of it, against the contract.</summary>
+/// <remarks>
+/// <para>
+/// The per-assembly suites assert the contract over what a drive emitted, which is the strongest form of it and also
+/// the one with a reach: a name only a failure path sets, or one a hosted worker opens a span under, is declared and
+/// never seen by a listener a unit test opened. This reads the declarations instead, so a name is covered by being
+/// written rather than by being exercised.
+/// </para>
+/// <para>
+/// It runs here because the composition root is the one project that references every other, so one test covers the
+/// whole deployment rather than one per boundary. The assemblies are read off the host's own references rather than
+/// listed, so a project added later is covered without this file being edited — and the host's own
+/// <c>backfill_email_extraction</c> is the name that made the reach worth having, since nothing else in the repository
+/// publishes a span from a worker.
+/// </para>
+/// </remarks>
+public sealed class DeclaredTelemetryVocabularyTests
+{
+    /// <summary>No span name and no dimension key anywhere is named after mail, a person, or a secret.</summary>
+    [Theory]
+    [MemberData(nameof(ProductionAssemblyNames))]
+    public void EveryDeclaredName_InEveryAssemblyOfThisDeployment_ObeysTheRedactionContract(string assemblyName) =>
+        TelemetryRedactionContract.AssertEveryDeclaredNameObeysTheContract(
+            Assembly.Load(new AssemblyName(assemblyName)));
+
+    /// <summary>The reader finds the names, so the theory above is holding something against the contract.</summary>
+    /// <remarks>
+    /// The control for an assertion that is otherwise an absence. An assembly whose constants this failed to read
+    /// reports no offending name in exactly the way one with nothing wrong in it does, so the two landmarks below are
+    /// read back: the worker's span, which no listener in a unit test reaches and which is the reason this test exists,
+    /// and one dimension, which establishes that the other half of the convention is read too.
+    /// </remarks>
+    [Fact]
+    public void DeclaredTelemetryNames_AcrossThisDeployment_IncludeTheNamesOnlyADeclarationCarries()
+    {
+        // Arrange
+        var declared = MailFathomAssemblyNames()
+            .SelectMany(name => TelemetryRedactionContract.DeclaredTelemetryNamesIn(
+                Assembly.Load(new AssemblyName(name))))
+            .ToArray();
+
+        // Act
+
+        // Assert
+        Assert.Contains(("backfill_email_extraction", true), declared);
+        Assert.Contains(("mailfathom.mail.sync.outcome", false), declared);
+    }
+
+    /// <summary>Names every MailFathom assembly this host is composed of, itself included.</summary>
+    /// <remarks>
+    /// The names are the data rather than the assemblies themselves, because a theory's arguments are what xUnit names
+    /// the case after and an assembly renders as a path nobody reads. It is a theory rather than one test over all of
+    /// them so that a failure says which boundary declared the name.
+    /// </remarks>
+    public static TheoryData<string> ProductionAssemblyNames() => [.. MailFathomAssemblyNames()];
+
+    /// <summary>Reads the host's own references for the assemblies this deployment is built from.</summary>
+    private static IReadOnlyList<string> MailFathomAssemblyNames()
+    {
+        var host = typeof(ServiceDefaultsExtensions).Assembly;
+
+        return
+        [
+            .. host.GetReferencedAssemblies()
+                .Select(reference => reference.Name)
+                .Where(name => name is not null
+                    && name.StartsWith("MailFathom.", StringComparison.Ordinal))
+                .Select(name => name!)
+                .Append(host.GetName().Name!)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal),
+        ];
+    }
+}

--- a/tests/Host.UnitTests/Observability/TraceSamplingExtensionsTests.cs
+++ b/tests/Host.UnitTests/Observability/TraceSamplingExtensionsTests.cs
@@ -1,0 +1,140 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics;
+using MailFathom.Host.Observability;
+using Microsoft.Extensions.Configuration;
+using OpenTelemetry.Trace;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Observability;
+
+/// <summary>Covers which traces this host records and who gets to decide it.</summary>
+/// <remarks>
+/// Two claims are under test and the second is the one that can regress silently. The first is what an unconfigured
+/// deployment records, which is everything it starts. The second is that a deployment that named a sampler is the one
+/// deciding: the SDK discards its own configuration when a sampler was set programmatically and says so only to an
+/// event source, so a host setting one unconditionally would answer <c>OTEL_TRACES_SAMPLER</c> with silence.
+/// </remarks>
+public sealed class TraceSamplingExtensionsTests
+{
+    /// <summary>A deployment that named no sampler gets the one this host chose, stated rather than inherited.</summary>
+    [Fact]
+    public void SamplerToSet_SamplerVariableAbsent_IsParentBasedAlwaysOn()
+    {
+        // Arrange
+        var configuration = ConfigurationWith([]);
+
+        // Act
+        var sampler = TraceSamplingExtensions.SamplerToSet(configuration);
+
+        // Assert
+        Assert.IsType<ParentBasedSampler>(sampler);
+        Assert.Contains("AlwaysOn", sampler.Description, StringComparison.Ordinal);
+    }
+
+    /// <summary>An empty value names no sampler, so it is the absent case rather than a sampler that drops nothing.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SamplerToSet_SamplerVariableBlank_IsStillTheDefault(string configuredValue)
+    {
+        // Arrange
+        var configuration = ConfigurationWith(
+            [new KeyValuePair<string, string?>(TraceSamplingExtensions.SamplerVariableName, configuredValue)]);
+
+        // Act
+        var sampler = TraceSamplingExtensions.SamplerToSet(configuration);
+
+        // Assert
+        Assert.IsType<ParentBasedSampler>(sampler);
+    }
+
+    /// <summary>A deployment that named a sampler has this host set none, so the SDK builds the one it asked for.</summary>
+    /// <remarks>
+    /// Every value the specification defines is covered rather than one of them, because what is under test is that the
+    /// variable is deferred to at all — this host does not parse it, and a value it does not recognize is the SDK's to
+    /// reject.
+    /// </remarks>
+    [Theory]
+    [InlineData("always_on")]
+    [InlineData("always_off")]
+    [InlineData("traceidratio")]
+    [InlineData("parentbased_always_on")]
+    [InlineData("parentbased_always_off")]
+    [InlineData("parentbased_traceidratio")]
+    [InlineData("something_the_sdk_will_reject")]
+    public void SamplerToSet_SamplerVariableSet_LeavesTheSamplerToTheSdk(string configuredValue)
+    {
+        // Arrange
+        var configuration = ConfigurationWith(
+            [new KeyValuePair<string, string?>(TraceSamplingExtensions.SamplerVariableName, configuredValue)]);
+
+        // Act
+        var sampler = TraceSamplingExtensions.SamplerToSet(configuration);
+
+        // Assert
+        Assert.Null(sampler);
+    }
+
+    /// <summary>A trace this process starts is recorded, which is what makes a worker's own cycle diagnosable.</summary>
+    [Fact]
+    public void SamplerToSet_RootSpan_RecordsIt()
+    {
+        // Arrange
+        var sampler = TraceSamplingExtensions.SamplerToSet(ConfigurationWith([]));
+        var parameters = SamplingParametersFor(parentContext: null);
+
+        // Act
+        var result = sampler!.ShouldSample(in parameters);
+
+        // Assert
+        Assert.Equal(SamplingDecision.RecordAndSample, result.Decision);
+    }
+
+    /// <summary>A caller that recorded its trace has this process record the part of it that happens here.</summary>
+    [Fact]
+    public void SamplerToSet_ChildOfARecordedTrace_RecordsIt()
+    {
+        // Arrange
+        var sampler = TraceSamplingExtensions.SamplerToSet(ConfigurationWith([]));
+        var parameters = SamplingParametersFor(ContextWith(ActivityTraceFlags.Recorded));
+
+        // Act
+        var result = sampler!.ShouldSample(in parameters);
+
+        // Assert
+        Assert.Equal(SamplingDecision.RecordAndSample, result.Decision);
+    }
+
+    /// <summary>A caller that dropped its trace is not overruled here, which is what parent-based buys.</summary>
+    [Fact]
+    public void SamplerToSet_ChildOfADroppedTrace_DropsIt()
+    {
+        // Arrange
+        var sampler = TraceSamplingExtensions.SamplerToSet(ConfigurationWith([]));
+        var parameters = SamplingParametersFor(ContextWith(ActivityTraceFlags.None));
+
+        // Act
+        var result = sampler!.ShouldSample(in parameters);
+
+        // Assert
+        Assert.Equal(SamplingDecision.Drop, result.Decision);
+    }
+
+    private static IConfiguration ConfigurationWith(IReadOnlyList<KeyValuePair<string, string?>> values) =>
+        new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    /// <summary>Builds a parent a caller already decided about, recorded or not.</summary>
+    private static ActivityContext ContextWith(ActivityTraceFlags traceFlags) =>
+        new(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), traceFlags);
+
+    /// <summary>Builds the question a sampler is asked, with no parent where the trace starts here.</summary>
+    private static SamplingParameters SamplingParametersFor(ActivityContext? parentContext) =>
+        new(
+            parentContext: parentContext ?? default,
+            traceId: ActivityTraceId.CreateRandom(),
+            name: "probe",
+            kind: ActivityKind.Internal);
+}

--- a/tests/Host.UnitTests/ServiceDefaultsTelemetryRedactionTests.cs
+++ b/tests/Host.UnitTests/ServiceDefaultsTelemetryRedactionTests.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics;
 using MailFathom.Host.Api;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using OpenTelemetry.Logs;
 using Xunit;
 
@@ -39,6 +40,86 @@ public sealed class ServiceDefaultsTelemetryRedactionTests
         // Assert
         Assert.False(logging.IncludeScopes);
         Assert.True(logging.IncludeFormattedMessage);
+    }
+
+    /// <summary>A deployment that named no collector exports nothing, however many publishers have been added.</summary>
+    /// <remarks>
+    /// The default this asserts is a privacy one rather than a convenience: every signal describes activity around
+    /// personal mail, so a deployment sends it somewhere only by saying where. A blank value counts as unset on both
+    /// sides, because templating a manifest routinely emits an empty string for a setting nobody chose.
+    /// </remarks>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ExportsOverOtlp_NoEndpointNamed_KeepsEverySignalInTheProcess(string? configuredEndpoint)
+    {
+        // Arrange
+        var configuration = ConfigurationWith(configuredEndpoint);
+
+        // Act
+        var exports = ServiceDefaultsExtensions.ExportsOverOtlp(configuration);
+
+        // Assert
+        Assert.False(exports);
+    }
+
+    /// <summary>Naming a collector is what attaches the exporter, which is the control for the absence above.</summary>
+    [Fact]
+    public void ExportsOverOtlp_AnEndpointNamed_ExportsToIt()
+    {
+        // Arrange
+        var configuration = ConfigurationWith("http://localhost:4317");
+
+        // Act
+        var exports = ServiceDefaultsExtensions.ExportsOverOtlp(configuration);
+
+        // Assert
+        Assert.True(exports);
+    }
+
+    /// <summary>A probe is never traced, however many sibling changes have been made to the pipeline since.</summary>
+    /// <remarks>
+    /// Every probe path is driven rather than one, and the trailing-slash form with them, because routing serves
+    /// <c>/health/</c> as readiness and a filter written for exact equality would trace the polling it was added to
+    /// keep out.
+    /// </remarks>
+    [Theory]
+    [InlineData("/started")]
+    [InlineData("/health")]
+    [InlineData("/health/")]
+    [InlineData("/alive")]
+    [InlineData("/ALIVE")]
+    public void IsWorthTracing_AProbePath_KeepsThePollingOutOfTheTraceStore(string path)
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+
+        // Act
+        var traced = ServiceDefaultsExtensions.IsWorthTracing(context);
+
+        // Assert
+        Assert.False(traced);
+    }
+
+    /// <summary>Everything a client actually calls is still traced, which is what makes the absence above readable.</summary>
+    [Theory]
+    [InlineData("/mcp")]
+    [InlineData("/api/admin/embeddings/profiles")]
+    [InlineData("/health/details")]
+    [InlineData("/aliveness")]
+    public void IsWorthTracing_AnyOtherPath_IsTraced(string path)
+    {
+        // Arrange
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+
+        // Act
+        var traced = ServiceDefaultsExtensions.IsWorthTracing(context);
+
+        // Assert
+        Assert.True(traced);
     }
 
     /// <summary>The capability is replaced by the route it was served under, so the span still says what was fetched.</summary>
@@ -79,4 +160,14 @@ public sealed class ServiceDefaultsTelemetryRedactionTests
         var recordedPath = Assert.Single(activity.TagObjects, tag => tag.Key == "url.path");
         Assert.Equal(path, recordedPath.Value);
     }
+
+    private static IConfiguration ConfigurationWith(string? configuredEndpoint) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(
+            [
+                new KeyValuePair<string, string?>(
+                    ServiceDefaultsExtensions.ExporterEndpointVariableName,
+                    configuredEndpoint),
+            ])
+            .Build();
 }

--- a/tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj
+++ b/tests/Infrastructure.UnitTests/Infrastructure.UnitTests.csproj
@@ -32,5 +32,11 @@
     <!-- Every boundary that publishes instruments asserts them the same way, through a listener over the one
          process-wide meter, so the recorder is built once rather than per suite. -->
     <Compile Include="..\shared\RecordedMailFathomMeasurements.cs" Link="RecordedMailFathomMeasurements.cs" />
+
+    <!-- The redaction contract is asserted in every assembly that publishes a signal, so the recorder that reads the
+         whole surface and the rules it is held against are shared rather than restated. The recorder reuses the
+         measurement record the file above declares, so the two are included together. -->
+    <Compile Include="..\shared\EmittedTelemetrySurface.cs" Link="EmittedTelemetrySurface.cs" />
+    <Compile Include="..\shared\TelemetryRedactionContract.cs" Link="TelemetryRedactionContract.cs" />
   </ItemGroup>
 </Project>

--- a/tests/Infrastructure.UnitTests/Observability/TelemetrySurfaceCollectionDefinition.cs
+++ b/tests/Infrastructure.UnitTests/Observability/TelemetrySurfaceCollectionDefinition.cs
@@ -1,0 +1,30 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Observability;
+
+/// <summary>Runs the surface-wide telemetry contract on its own, because it drives every publisher in the assembly.</summary>
+/// <remarks>
+/// <para>
+/// Every other class here drives the one publisher it is about, which is what makes a listener over the process-wide
+/// meter usable at all: two classes never publish to the same instrument at the same moment, so a read filtered by
+/// instrument and by account sees only its own. A contract over the whole surface breaks that arrangement by
+/// construction — it drives all of them — and an assertion elsewhere that a counter recorded nothing would then fail
+/// on this suite's traffic rather than on a defect.
+/// </para>
+/// <para>
+/// Turning parallelization off for this collection is what restores it: xUnit runs a non-parallelizable collection by
+/// itself, after the ones that run together, so nothing else is publishing while this drives. It also settles what the
+/// drive leaves behind — an observable gauge stays registered on the process-wide meter for the life of the run, and
+/// running last is what means nobody observes one of this suite's afterwards.
+/// </para>
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class TelemetrySurfaceCollectionDefinition
+{
+    /// <summary>The name a test class joins this collection by.</summary>
+    public const string Name = "Telemetry surface";
+}

--- a/tests/Infrastructure.UnitTests/Observability/TelemetrySurfaceContractTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/TelemetrySurfaceContractTests.cs
@@ -1,0 +1,509 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.AiProviders;
+using MailFathom.Application.Chat;
+using MailFathom.Application.Emails.Embeddings;
+using MailFathom.Application.Emails.Embeddings.Backfill;
+using MailFathom.Application.Emails.Embeddings.Generation;
+using MailFathom.Application.Emails.Embeddings.Generations;
+using MailFathom.Application.Emails.Extraction;
+using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Jobs;
+using MailFathom.Application.Jobs.Execution;
+using MailFathom.Application.Jobs.Scheduling;
+using MailFathom.Application.Mail.Mutations.Convergence;
+using MailFathom.Application.Observability;
+using MailFathom.Application.Retrieval.AskMail;
+using MailFathom.Application.SensitiveContent;
+using MailFathom.Application.SensitiveContent.Egress;
+using MailFathom.Application.SensitiveContent.Redaction;
+using MailFathom.Application.Spam.Gating;
+using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Answering.Audit;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Domain.Mutations.Audit;
+using MailFathom.Infrastructure.Embeddings;
+using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Observability;
+
+/// <summary>Asserts the redaction contract over everything this assembly publishes, rather than per publisher.</summary>
+/// <remarks>
+/// <para>
+/// Each publisher's own tests assert what it measured and what it tagged, and that is the right level for a feature.
+/// It is the wrong level for the privacy rule, which is a property of the surface as a whole: a rule checked once per
+/// publisher is a rule the next publisher is not covered by, and the whole reason the surface is worth a contract is
+/// that a signal added in a year is the one nobody will remember to check.
+/// </para>
+/// <para>
+/// So this drives every publisher the assembly has, with every string a caller or a message could supply replaced by a
+/// sentinel, and asserts over what came out. A publisher that put a subject, a remote folder path, an IMAP command, or
+/// a caller's text into a name or a dimension fails here whatever its own tests say about it, and a publisher nobody
+/// added to the drive fails the last test in the class rather than going unasserted.
+/// </para>
+/// <para>
+/// The publishers are static and built once. Their instruments live on the process-wide meter and an observable gauge
+/// registered there answers for the rest of the run, so an instance per test would leave one gauge per test reporting
+/// this suite's numbers into whatever observes the meter next. Building them once, in a collection that runs by itself
+/// after everything else, is what bounds that to one instance nobody observes afterwards.
+/// </para>
+/// </remarks>
+[Collection(TelemetrySurfaceCollectionDefinition.Name)]
+public sealed class TelemetrySurfaceContractTests
+{
+    /// <summary>An account alias with nothing real in it, which the contract permits a dimension to carry.</summary>
+    private static readonly MailAccountId Account =
+        MailAccountId.Create(TelemetryRedactionContract.ConfiguredAliasSentinel);
+
+    /// <summary>A folder alias, which is the operator's own word and therefore also permitted.</summary>
+    private static readonly MailFolderAlias FolderAlias =
+        MailFolderAlias.Create(TelemetryRedactionContract.ConfiguredAliasSentinel);
+
+    private static readonly DateTimeOffset Moment = new(2026, 8, 13, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly FakeTimeProvider Clock = new(Moment);
+
+    private static readonly AiProviderHealthTracker ProviderHealth =
+        new(Clock, NullLogger<AiProviderHealthTracker>.Instance);
+
+    private static readonly DerivedWorkGateTelemetry DerivedWorkGate = new();
+    private static readonly EmailEmbeddingBackfillTelemetry EmbeddingBackfill = new();
+    private static readonly EmailEmbeddingTelemetry Embedding = new();
+    private static readonly JobQueueTelemetry JobQueue = new();
+
+    private static readonly MailAnsweringAuditTelemetry AnsweringAudit =
+        new(NullLogger<MailAnsweringAuditTelemetry>.Instance);
+
+    private static readonly MailAnsweringRunTelemetry AnsweringRun = new();
+
+    private static readonly MailAnsweringSpendTracker AnsweringSpend = new(
+        MailAnsweringPeriodBounds.Create(TimeSpan.FromHours(1), maximumRuns: 30, maximumTokens: 300_000),
+        Clock,
+        NullLogger<MailAnsweringSpendTracker>.Instance);
+
+    private static readonly MailboxContentVolumeTelemetry ContentVolume =
+        new(NullLogger<MailboxContentVolumeTelemetry>.Instance);
+
+    private static readonly MailboxConvergenceTelemetry Convergence =
+        new(NullLogger<MailboxConvergenceTelemetry>.Instance, Clock);
+
+    private static readonly MailboxMutationAuditTelemetry MutationAudit =
+        new(NullLogger<MailboxMutationAuditTelemetry>.Instance);
+
+    private static readonly MailboxMutationTelemetry Mutation =
+        new(NullLogger<MailboxMutationTelemetry>.Instance, Clock);
+
+    private static readonly MailboxReadTelemetry MailboxRead = new();
+    private static readonly MailExtractionBackfillTelemetry ExtractionBackfill = new();
+    private static readonly MailSynchronizationTelemetry Synchronization = new(Clock);
+    private static readonly PersistenceCommitTelemetry PersistenceCommits = new();
+    private static readonly SensitiveContentDerivationTelemetry Derivation = new();
+    private static readonly SensitiveContentEgressTelemetry Egress = new();
+    private static readonly StoredEmailContentTelemetry StoredContent = new(Clock);
+
+    private static readonly BoundedEmailEmbeddingBacklog EmbeddingBacklog =
+        new(new EmailEmbeddingBacklogOptions { Capacity = 4 });
+
+    /// <summary>Every publisher this suite drives, which the discovery test holds the assembly against.</summary>
+    private static readonly Type[] DrivenPublishers =
+    [
+        typeof(AiProviderHealthTracker),
+        typeof(BoundedEmailEmbeddingBacklog),
+        typeof(DerivedWorkGateTelemetry),
+        typeof(EmailEmbeddingBackfillTelemetry),
+        typeof(EmailEmbeddingTelemetry),
+        typeof(JobQueueTelemetry),
+        typeof(MailAnsweringAuditTelemetry),
+        typeof(MailAnsweringRunTelemetry),
+        typeof(MailAnsweringSpendTracker),
+        typeof(MailboxContentVolumeTelemetry),
+        typeof(MailboxConvergenceTelemetry),
+        typeof(MailboxMutationAuditTelemetry),
+        typeof(MailboxMutationTelemetry),
+        typeof(MailboxReadTelemetry),
+        typeof(MailExtractionBackfillTelemetry),
+        typeof(MailSynchronizationTelemetry),
+        typeof(PersistenceCommitTelemetry),
+        typeof(SensitiveContentDerivationTelemetry),
+        typeof(SensitiveContentEgressTelemetry),
+        typeof(StoredEmailContentTelemetry),
+    ];
+
+    /// <summary>The drive really emits the surface, and the poison really travels through it.</summary>
+    /// <remarks>
+    /// Every other assertion in this class is that something is <b>absent</b>, and an absence proves nothing unless
+    /// the same observation would report it present. This is that control. It establishes both halves the others rest
+    /// on: that the drive produced a surface at all rather than a listener over nothing, and that a poisoned string
+    /// does reach a dimension when the contract permits it — so the four sentinels the others look for are sentinels
+    /// that would have been seen.
+    /// </remarks>
+    [Fact]
+    public void EmittedSurface_EveryPublisherDriven_ReportsASurfaceWithThePoisonedInputInIt()
+    {
+        // Arrange
+        using var surface = DriveEveryPublisher();
+
+        // Act
+
+        // Assert
+        Assert.Contains(MailSynchronizationTelemetry.AccountRunSpanName, surface.Spans.Select(span => span.Name));
+        Assert.Contains("mailfathom.mail.sync.run.duration", surface.InstrumentNames);
+        Assert.Contains(surface.EmittedTags, tag => CarriesTheAlias(tag, MailSynchronizationTelemetry.AccountTagName));
+        Assert.Contains(surface.EmittedTags, tag => CarriesTheAlias(tag, MailSynchronizationTelemetry.FolderTagName));
+    }
+
+    /// <summary>Nothing this process publishes is named after a message, a person, or a secret.</summary>
+    [Fact]
+    public void EmittedSurface_EveryPublisherDriven_IsNamedAfterNothingInAMailbox()
+    {
+        // Arrange
+        using var surface = DriveEveryPublisher();
+
+        // Act — the drive is the act; what is asserted is everything it emitted.
+
+        // Assert
+        TelemetryRedactionContract.AssertNothingIsNamedAfterMailOrASecret(surface.EmittedNames);
+    }
+
+    /// <summary>Every instrument and every dimension sits under the one name an operator filters this process by.</summary>
+    [Fact]
+    public void EmittedSurface_EveryPublisherDriven_IsNamespacedUnderMailFathom()
+    {
+        // Arrange
+        using var surface = DriveEveryPublisher();
+
+        // Act
+
+        // Assert
+        TelemetryRedactionContract.AssertEveryDimensionIsNamespacedUnderMailFathom(surface.InstrumentNames, surface.EmittedTags);
+    }
+
+    /// <summary>Every span is named after the operation it reports rather than after anything that operation saw.</summary>
+    [Fact]
+    public void EmittedSurface_EveryPublisherDriven_NamesEverySpanAfterItsOperation()
+    {
+        // Arrange
+        using var surface = DriveEveryPublisher();
+
+        // Act
+
+        // Assert
+        TelemetryRedactionContract.AssertEverySpanIsNamedAfterItsOperation(surface.SpanNames);
+    }
+
+    /// <summary>No caller's text and nothing read out of a message reached a name, a key, or a value.</summary>
+    /// <remarks>
+    /// This is the assertion the others cannot make. Every string handed to a publisher above is a sentinel, so where
+    /// one surfaces is exactly where that class of input reaches an exporter — and an alias is the only class allowed
+    /// to, on the dimensions named for it.
+    /// </remarks>
+    [Fact]
+    public void EmittedSurface_EveryPublisherDrivenWithPoisonedInput_LetsNoneOfItReachAnExporter()
+    {
+        // Arrange
+        using var surface = DriveEveryPublisher();
+
+        // Act
+
+        // Assert
+        TelemetryRedactionContract.AssertNoPoisonedInputEscaped(surface.EmittedNames, surface.EmittedTags);
+    }
+
+    /// <summary>A publisher nobody added to the drive fails here rather than going unasserted.</summary>
+    [Fact]
+    public void EveryPublisherInTheAssembly_WhateverItIsCalled_IsDrivenByThisSuite() =>
+        TelemetryRedactionContract.AssertEveryPublisherInTheAssemblyIsDriven(
+            typeof(MailSynchronizationTelemetry).Assembly,
+            DrivenPublishers);
+
+    /// <summary>Reports whether one dimension came out carrying the alias the drive supplied.</summary>
+    /// <remarks>
+    /// Case-insensitively, because a folder alias is upper-cased on its way into the domain value: the sentinel that
+    /// went in as one word comes out as the same word in the canonical casing, which is the alias arriving rather than
+    /// a different string.
+    /// </remarks>
+    private static bool CarriesTheAlias(KeyValuePair<string, object?> tag, string dimension) =>
+        StringComparer.Ordinal.Equals(tag.Key, dimension)
+        && StringComparer.OrdinalIgnoreCase.Equals(
+            tag.Value?.ToString(),
+            TelemetryRedactionContract.ConfiguredAliasSentinel);
+
+    /// <summary>Puts every publisher through the work it reports, with every string it accepts poisoned.</summary>
+    private static EmittedTelemetrySurface DriveEveryPublisher()
+    {
+        var surface = new EmittedTelemetrySurface();
+
+        DriveProviderHealth();
+        DriveDerivedWorkGate();
+        DriveEmbedding();
+        DriveJobQueue();
+        DriveAnswering();
+        DriveMailbox();
+        DriveMutations();
+        DriveSynchronization();
+        DriveContentStore();
+        DriveSensitiveContent();
+
+        PersistenceCommits.RecordCommitted();
+        PersistenceCommits.RecordConcurrencyConflict();
+        EmbeddingBacklog.TryEnqueue(StoredEmailId.Create(Guid.CreateVersion7()));
+
+        surface.ObserveGauges();
+
+        return surface;
+    }
+
+    private static void DriveProviderHealth()
+    {
+        ProviderHealth.RecordServed(AiProviderRole.Embedding);
+        ProviderHealth.RecordUnavailable(AiProviderRole.Chat);
+        ProviderHealth.RecordMisconfigured(AiProviderRole.Chat);
+    }
+
+    private static void DriveDerivedWorkGate()
+    {
+        foreach (var admission in Enum.GetValues<DerivedWorkAdmission>())
+        {
+            DerivedWorkGate.RecordAdmission(admission);
+        }
+
+        DerivedWorkGate.RecordDiscardedPassages(61_003);
+    }
+
+    private static void DriveEmbedding()
+    {
+        Embedding.RecordEmbeddedMessage(StoredEmailEmbeddingRun.Embedded(3), TimeSpan.FromSeconds(2));
+        Embedding.RecordEmbeddedMessage(
+            StoredEmailEmbeddingRun.SpendCeilingReached(2, inputCharacterCount: 61_007, Moment),
+            TimeSpan.FromSeconds(1));
+
+        foreach (var failure in Enum.GetValues<EmbeddingGenerationFailure>())
+        {
+            Embedding.RecordEmbeddedMessage(StoredEmailEmbeddingRun.ProviderFailed(1, failure), TimeSpan.FromSeconds(1));
+        }
+
+        Embedding.RecordTruncatedEmbeddingInput(61_009);
+
+        EmbeddingBackfill.RecordPass(new EmbeddingGenerationUpkeepResult(
+            new StoredEmailEmbeddingBackfillResult(
+                StoredEmailEmbeddingBackfillOutcome.SweepCompleted,
+                ChunkedEmailCount: 2,
+                EmbeddedEmailCount: 2,
+                EmbeddedChunkCount: 5,
+                CallBudgetExhaustedEmailCount: 0,
+                OutstandingEmailCountAtSweepStart: 61_011,
+                Failure: null,
+                SpendPeriodEndsAt: null),
+            EmbeddingGenerationTransition.None,
+            RemovedSupersededVectorCount: 0));
+    }
+
+    private static void DriveJobQueue()
+    {
+        foreach (var outcome in Enum.GetValues<JobExecutionOutcome>())
+        {
+            JobQueue.RecordAttempt(new JobExecutionResult(
+                JobId.Create(Guid.CreateVersion7()),
+                JobType.ClassifyEmailSpam,
+                AttemptCount: 1,
+                outcome,
+                TimeSpan.FromSeconds(1)));
+        }
+
+        foreach (var outcome in Enum.GetValues<JobScheduleDispatchOutcome>())
+        {
+            JobQueue.RecordScheduleDispatch(new JobScheduleDispatch(
+                JobScheduleId.Create($"mail-rules:{TelemetryRedactionContract.ConfiguredAliasSentinel}:housekeeping"),
+                JobType.RunScheduledMailRules,
+                outcome,
+                Moment,
+                SkippedOccurrenceCount: 1));
+        }
+
+        JobQueue.RecordQueueDepth([new JobQueueDepthReading(JobType.ClassifyEmailSpam, 61_013)]);
+    }
+
+    private static void DriveAnswering()
+    {
+        AnsweringSpend.TryAdmitRun();
+        AnsweringSpend.RecordSpend(new ChatTokenUsage(InputTokens: 61_017, OutputTokens: 61_019));
+
+        var observation = PoisonedAnsweringRun();
+
+        using (AnsweringRun.BeginRun(observation))
+        {
+            // The span is published when the scope ends, which is what the contract reads.
+        }
+
+        AnsweringAudit.RecordRefusedAppend(observation, owedEntryCount: 1, new InvalidOperationException("refused"));
+    }
+
+    private static MailAnsweringRunObservation PoisonedAnsweringRun()
+    {
+        var observation = new MailAnsweringRunObservation(
+            MailAnsweringRunId.Create(Guid.CreateVersion7(Moment)),
+            MailboxScope.Create([Account], []),
+            Moment);
+
+        observation.RecordComposition(TelemetryRedactionContract.ConfiguredAliasSentinel, "0a1b2c3d4e5f");
+        observation.RecordRetrieval(new MailAnsweringRetrievalReport(
+            Passages: [],
+            CandidateCount: 4,
+            RelevantCandidateCount: 3,
+            MailAnsweringRunDegradation.None));
+        observation.RecordOutcome(MailAnsweringRunOutcome.Answered, [], Moment.AddSeconds(9));
+
+        return observation;
+    }
+
+    private static void DriveMailbox()
+    {
+        foreach (var operation in Enum.GetValues<MailboxReadOperation>())
+        {
+            using var read = MailboxRead.BeginRead(operation, CancellationToken.None);
+            read.Completed(3);
+        }
+
+        ContentVolume.Report(
+            Account,
+            FolderAlias.Value,
+            new MailboxContentVolume(
+                FetchedBytes: 61_023,
+                StoredBytes: 61_027,
+                StoredContentBytes: 61_029,
+                DeferredForStorageEmailCount: 1,
+                RefilledEmailCount: 1,
+                StoppedForContentBudget: true));
+
+        Convergence.Report(
+            Account,
+            new MailboxConvergenceReport(
+                CompletedCount: 1,
+                DeadLetteredCount: 1,
+                DeferredCount: 1,
+                FailedCount: 1,
+                Outstanding:
+                [
+                    new MailboxMutationLifecycleCount(
+                        MailboxMutation.Relocate,
+                        MailboxMutationLifecycle.Pending,
+                        Count: 1,
+                        OldestRecordedAt: Moment.AddMinutes(-5)),
+                ]));
+    }
+
+    private static void DriveMutations()
+    {
+        using (var scope = Mutation.Begin(MailboxMutation.Relocate, Account, FolderAlias))
+        {
+            scope.ProtocolPathChosen(TelemetryRedactionContract.CallerSuppliedSentinel);
+            scope.CommandIssued(TelemetryRedactionContract.CallerSuppliedSentinel);
+            scope.Completed();
+        }
+
+        MutationAudit.RecordRefusedAppend(PoisonedAuditEntry(), new InvalidOperationException("refused"));
+    }
+
+    /// <summary>Builds an entry whose every mail-derived field is a sentinel, above all the remote folder path.</summary>
+    private static MailboxMutationAuditEntry PoisonedAuditEntry() => new()
+    {
+        Id = MailboxMutationAuditEntryId.Create(Guid.CreateVersion7()),
+        MutationRecordId = MailboxMutationRecordId.Create(Guid.CreateVersion7()),
+        AccountId = Account,
+        StoredEmailId = StoredEmailId.Create(Guid.CreateVersion7()),
+        Mutation = MailboxMutation.Relocate,
+        SourceFolderPath = RemoteFolderPath.Create(TelemetryRedactionContract.MailDerivedSentinel),
+        SourceUidValidity = ImapUidValidity.Create(1),
+        SourceUid = ImapUid.Create(2),
+        DestinationFolderPath = RemoteFolderPath.Create(TelemetryRedactionContract.MailDerivedSentinel),
+        Placement = RemoteEmailPlacement.NotReported(),
+        DesiredSeenState = null,
+        Requester = MailboxMutationRequester.Command(TelemetryRedactionContract.CallerSuppliedSentinel),
+        RequestedAt = Moment,
+        CompletedAt = Moment.AddSeconds(1),
+        Outcome = MailboxMutationAuditOutcome.Performed,
+        Failure = null,
+    };
+
+    private static void DriveSynchronization()
+    {
+        using (Synchronization.EnterRunQueue())
+        {
+            // The queue depth is a level rather than an event, so it is observed while something is in it.
+        }
+
+        using (var cycle = Synchronization.BeginAccountRun(Account))
+        {
+            using (var folder = Synchronization.BeginFolderRun(Account))
+            {
+                folder.Synchronized(FolderAlias.Value, storedEmailCount: 2, skippedEmailCount: 1);
+            }
+
+            using (var failed = Synchronization.BeginFolderRun(Account))
+            {
+                failed.MailServerUnavailable(FolderAlias.Value);
+            }
+
+            using (var unresolved = Synchronization.BeginFolderRun(Account))
+            {
+                unresolved.AliasUnresolved(FolderAlias.Value);
+            }
+
+            cycle.Completed(scheduledFolderCount: 3, failedFolderCount: 1, convergenceFailed: false);
+        }
+
+        Synchronization.RecordScheduledDelay(Account, TimeSpan.FromSeconds(61_031), consecutiveFailureCount: 3);
+        Synchronization.RecordSupervisionEnded(Account);
+
+        ExtractionBackfill.RecordCompleted(
+            new StoredEmailExtractionBackfillResult(
+                ExtractedEmailCount: 2,
+                UnreadableEmailCount: 1,
+                MissingContentEmailCount: 1,
+                OutstandingEmailCount: 61_037,
+                EmailsRemain: true),
+            TimeSpan.FromSeconds(2));
+        ExtractionBackfill.RecordDeferred(TimeSpan.FromSeconds(1));
+        ExtractionBackfill.RecordFailed(TimeSpan.FromSeconds(1));
+        ExtractionBackfill.RecordInterrupted(TimeSpan.FromSeconds(1));
+    }
+
+    private static void DriveContentStore()
+    {
+        using (var found = StoredContent.BeginRead())
+        {
+            found.Found(61_039);
+        }
+
+        using (var absent = StoredContent.BeginRead())
+        {
+            absent.Absent();
+        }
+
+        using var write = StoredContent.BeginWrite();
+        write.Stored(61_043);
+    }
+
+    private static void DriveSensitiveContent()
+    {
+        var redacted = RedactedText.Create(TelemetryRedactionContract.MailDerivedSentinel, [], omittedCharacterCount: 3);
+
+        Derivation.RecordDerived(redacted, TimeSpan.FromMilliseconds(4));
+        Derivation.RecordRefused(SensitiveContentScannerKind.Secrets);
+
+        foreach (var egressPoint in Enum.GetValues<SensitiveContentEgressPoint>())
+        {
+            Egress.RecordGuarded(egressPoint, redacted, TimeSpan.FromMilliseconds(4));
+            Egress.RecordRefused(egressPoint, SensitiveContentScannerKind.Pii);
+        }
+    }
+}

--- a/tests/Mcp.UnitTests/Mcp.UnitTests.csproj
+++ b/tests/Mcp.UnitTests/Mcp.UnitTests.csproj
@@ -24,6 +24,12 @@
     <!-- Every boundary that publishes instruments asserts them the same way, through a listener over the one
          process-wide meter, so the recorder is built once rather than per suite. -->
     <Compile Include="..\shared\RecordedMailFathomMeasurements.cs" Link="RecordedMailFathomMeasurements.cs" />
+
+    <!-- The redaction contract is asserted in every assembly that publishes a signal, so the recorder that reads the
+         whole surface and the rules it is held against are shared rather than restated. The recorder reuses the
+         measurement record the file above declares, so the two are included together. -->
+    <Compile Include="..\shared\EmittedTelemetrySurface.cs" Link="EmittedTelemetrySurface.cs" />
+    <Compile Include="..\shared\TelemetryRedactionContract.cs" Link="TelemetryRedactionContract.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Mcp.UnitTests/Observability/TelemetrySurfaceCollectionDefinition.cs
+++ b/tests/Mcp.UnitTests/Observability/TelemetrySurfaceCollectionDefinition.cs
@@ -1,0 +1,29 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Xunit;
+
+namespace MailFathom.Mcp.UnitTests.Observability;
+
+/// <summary>Runs the surface-wide telemetry contract on its own, because it drives every publisher in the assembly.</summary>
+/// <remarks>
+/// <para>
+/// Every other class here drives the one publisher it is about, which is what makes a listener over the process-wide
+/// meter usable at all: an assertion that a counter recorded one call, or none, holds only while nothing else is
+/// recording on it. A contract over the whole surface breaks that by construction, since driving everything is the
+/// point of it.
+/// </para>
+/// <para>
+/// Turning parallelization off for this collection restores it: xUnit runs a non-parallelizable collection by itself,
+/// after the ones that run together, so nothing else is publishing while this drives. The definition is declared per
+/// assembly because a collection is an assembly-level thing in xUnit, not because the reasoning differs from the one
+/// the Infrastructure suite states.
+/// </para>
+/// </remarks>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class TelemetrySurfaceCollectionDefinition
+{
+    /// <summary>The name a test class joins this collection by.</summary>
+    public const string Name = "Telemetry surface";
+}

--- a/tests/Mcp.UnitTests/Observability/TelemetrySurfaceContractTests.cs
+++ b/tests/Mcp.UnitTests/Observability/TelemetrySurfaceContractTests.cs
@@ -1,0 +1,118 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Mcp.Observability;
+using MailFathom.TestSupport;
+using Xunit;
+
+namespace MailFathom.Mcp.UnitTests.Observability;
+
+/// <summary>Asserts the redaction contract over what this boundary publishes, which is where a caller's text arrives.</summary>
+/// <remarks>
+/// <para>
+/// The same contract runs over every assembly that publishes a signal, and this is the one where the poison is real
+/// rather than representative. A tool call is the only place in this process where text a stranger wrote reaches a
+/// publisher directly: the name a caller sends is a string of their choosing, and a dimension taking it would let a
+/// client minting names in a loop mint a time series apiece that never goes away.
+/// </para>
+/// <para>
+/// So the drive calls every recording method with a tool name that is a sentinel and asserts that none of it survived.
+/// What should come out instead is the one fixed placeholder this surface measures an unpublished name under, and the
+/// control below reads it back so the absence above is an absence that would have been visible.
+/// </para>
+/// </remarks>
+[Collection(TelemetrySurfaceCollectionDefinition.Name)]
+public sealed class TelemetrySurfaceContractTests
+{
+    private static readonly McpToolCallTelemetry ToolCalls = new();
+
+    /// <summary>Every publisher this suite drives, which the discovery test holds the assembly against.</summary>
+    private static readonly Type[] DrivenPublishers = [typeof(McpToolCallTelemetry)];
+
+    /// <summary>The drive really emits the surface, and the caller's name really reaches the publisher.</summary>
+    /// <remarks>
+    /// The control for every absence below. It reads back the placeholder the name was reduced to, which is what says
+    /// the name arrived and was refused rather than that the drive published nothing.
+    /// </remarks>
+    [Fact]
+    public void EmittedSurface_EveryPublisherDriven_MeasuresTheCallUnderThePlaceholderInstead()
+    {
+        // Arrange
+        using var surface = DriveEveryPublisher();
+
+        // Act
+
+        // Assert
+        Assert.Contains("mailfathom.mcp.tool.calls", surface.InstrumentNames);
+        Assert.Contains(
+            surface.EmittedTags,
+            tag => tag.Key == McpToolCallTelemetry.ToolTagName
+                && Equals(tag.Value, McpToolCallTelemetry.UnpublishedToolName));
+    }
+
+    /// <summary>Nothing this boundary publishes is named after a message, a person, or a secret.</summary>
+    [Fact]
+    public void EmittedSurface_EveryPublisherDriven_IsNamedAfterNothingInAMailbox()
+    {
+        // Arrange
+        using var surface = DriveEveryPublisher();
+
+        // Act
+
+        // Assert
+        TelemetryRedactionContract.AssertNothingIsNamedAfterMailOrASecret(surface.EmittedNames);
+    }
+
+    /// <summary>Every instrument and every dimension sits under the one name an operator filters this process by.</summary>
+    [Fact]
+    public void EmittedSurface_EveryPublisherDriven_IsNamespacedUnderMailFathom()
+    {
+        // Arrange
+        using var surface = DriveEveryPublisher();
+
+        // Act
+
+        // Assert
+        TelemetryRedactionContract.AssertEveryDimensionIsNamespacedUnderMailFathom(surface.InstrumentNames, surface.EmittedTags);
+    }
+
+    /// <summary>The tool name a caller sent reached no name, no key, and no dimension value.</summary>
+    [Fact]
+    public void EmittedSurface_EveryCallMadeUnderACallersOwnName_LetsNoneOfItReachAnExporter()
+    {
+        // Arrange
+        using var surface = DriveEveryPublisher();
+
+        // Act
+
+        // Assert
+        TelemetryRedactionContract.AssertNoPoisonedInputEscaped(surface.EmittedNames, surface.EmittedTags);
+    }
+
+    /// <summary>A publisher nobody added to the drive fails here rather than going unasserted.</summary>
+    [Fact]
+    public void EveryPublisherInTheAssembly_WhateverItIsCalled_IsDrivenByThisSuite() =>
+        TelemetryRedactionContract.AssertEveryPublisherInTheAssemblyIsDriven(
+            typeof(McpToolCallTelemetry).Assembly,
+            DrivenPublishers);
+
+    /// <summary>Records every ending a tool call has, each under a name the caller invented.</summary>
+    private static EmittedTelemetrySurface DriveEveryPublisher()
+    {
+        var surface = new EmittedTelemetrySurface();
+        var callersOwnName = TelemetryRedactionContract.CallerSuppliedSentinel;
+        var duration = TimeSpan.FromMilliseconds(37);
+
+        ToolCalls.RecordCompleted(callersOwnName, isError: false, duration);
+        ToolCalls.RecordCompleted(callersOwnName, isError: true, duration);
+        ToolCalls.RecordCancelled(callersOwnName, duration);
+        ToolCalls.RecordProtocolFailure(callersOwnName, duration);
+        ToolCalls.RecordRefused(callersOwnName, duration);
+        ToolCalls.RecordUnexpectedFailure(callersOwnName, duration);
+
+        surface.ObserveGauges();
+
+        return surface;
+    }
+}

--- a/tests/SharedSources.UnitTests/EmittedTelemetrySurfaceTests.cs
+++ b/tests/SharedSources.UnitTests/EmittedTelemetrySurfaceTests.cs
@@ -1,0 +1,125 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using MailFathom.Common.Observability;
+using MailFathom.TestSupport;
+using Xunit;
+
+namespace MailFathom.SharedSources.UnitTests;
+
+/// <summary>Covers the recorder the surface-wide telemetry contract is asserted over.</summary>
+/// <remarks>
+/// A fault here reports a false verdict in every suite that uses it, and the false verdict is the dangerous direction:
+/// a recorder that quietly saw nothing makes a contract over an absence pass. So both halves are proved — that what
+/// MailFathom publishes is recorded with its names and its dimensions, and that what another registry publishes is not
+/// mistaken for it.
+/// </remarks>
+public sealed class EmittedTelemetrySurfaceTests
+{
+    /// <summary>The span this drives, named so it is not read as a publisher's own declaration.</summary>
+    /// <remarks>
+    /// A constant ending in <c>SpanName</c> is how the contract finds a publisher, and this class is a test
+    /// rather than one — so the name here deliberately stops short of the convention.
+    /// </remarks>
+    private const string ProbeSpan = "shared_sources_probe_span";
+    private const string CounterName = "mailfathom.shared_sources.probe.counter";
+    private const string GaugeName = "mailfathom.shared_sources.probe.gauge";
+    private const string DimensionName = "mailfathom.shared_sources.probe.outcome";
+
+    /// <summary>A span MailFathom started is recorded with the name it opened under and the tags it carried.</summary>
+    [Fact]
+    public void Spans_AnActivityOnMailFathomsSource_AreRecordedWithTheirTags()
+    {
+        // Arrange
+        using var surface = new EmittedTelemetrySurface();
+
+        // Act
+        using (var activity = Telemetry.ActivitySource.StartActivity(ProbeSpan))
+        {
+            activity?.SetTag(DimensionName, "succeeded");
+        }
+
+        // Assert
+        var span = Assert.Single(surface.Spans, recorded => recorded.Name == ProbeSpan);
+
+        Assert.Equal("succeeded", span.Tags[DimensionName]);
+        Assert.Contains(ProbeSpan, surface.SpanNames);
+        Assert.Contains(DimensionName, surface.EmittedNames);
+    }
+
+    /// <summary>A span another library started is not recorded, so a contract judges MailFathom's own surface.</summary>
+    [Fact]
+    public void Spans_AnActivityOnAnotherSource_AreNotRecorded()
+    {
+        // Arrange
+        using var somebodyElse = new ActivitySource("SharedSources.NotMailFathom");
+        using var surface = new EmittedTelemetrySurface();
+
+        // Act
+        using (somebodyElse.StartActivity(ProbeSpan))
+        {
+            // The span is recorded when it ends, which is where the source is judged.
+        }
+
+        // Assert
+        Assert.DoesNotContain(ProbeSpan, surface.SpanNames);
+    }
+
+    /// <summary>An instrument is recorded by name, and its measurements by value and by dimension.</summary>
+    [Fact]
+    public void Measurements_ACounterOnMailFathomsMeter_AreRecordedWithTheirDimensions()
+    {
+        // Arrange
+        using var surface = new EmittedTelemetrySurface();
+        var counter = Telemetry.Meter.CreateCounter<long>(CounterName);
+
+        // Act
+        counter.Add(3, new KeyValuePair<string, object?>(DimensionName, "refused"));
+
+        // Assert
+        var measurement = Assert.Single(surface.Measurements, recorded => recorded.InstrumentName == CounterName);
+
+        Assert.Equal(3, measurement.Value);
+        Assert.Equal("refused", measurement.Tags[DimensionName]);
+        Assert.Contains(CounterName, surface.InstrumentNames);
+        Assert.Contains(surface.EmittedTags, tag => tag.Key == DimensionName && Equals(tag.Value, "refused"));
+    }
+
+    /// <summary>An observable instrument reports nothing until it is asked, which is what the gauge read is for.</summary>
+    [Fact]
+    public void ObserveGauges_AnObservableInstrument_ReportsOnlyOnceItIsAsked()
+    {
+        // Arrange
+        using var surface = new EmittedTelemetrySurface();
+        Telemetry.Meter.CreateObservableGauge(GaugeName, static () => new Measurement<long>(7));
+
+        // Act
+        var beforeAsking = surface.Measurements.Any(recorded => recorded.InstrumentName == GaugeName);
+        surface.ObserveGauges();
+
+        // Assert
+        Assert.False(beforeAsking);
+        Assert.Contains(surface.Measurements, recorded => recorded.InstrumentName == GaugeName && recorded.Value == 7);
+    }
+
+    /// <summary>An instrument on another meter is not recorded, however MailFathom-shaped its name is.</summary>
+    [Fact]
+    public void Measurements_ACounterOnAnotherMeter_AreNotRecorded()
+    {
+        // Arrange
+        using var somebodyElse = new Meter("SharedSources.NotMailFathom");
+        using var surface = new EmittedTelemetrySurface();
+        var counter = somebodyElse.CreateCounter<long>(CounterName);
+
+        // Act
+        counter.Add(5);
+
+        // Assert
+        Assert.DoesNotContain(
+            surface.Measurements,
+            recorded => recorded.InstrumentName == CounterName && recorded.Value == 5);
+    }
+}

--- a/tests/SharedSources.UnitTests/TelemetryRedactionContractTests.cs
+++ b/tests/SharedSources.UnitTests/TelemetryRedactionContractTests.cs
@@ -1,0 +1,188 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.Metrics;
+using MailFathom.TestSupport;
+using Xunit;
+using Xunit.Sdk;
+
+namespace MailFathom.SharedSources.UnitTests;
+
+/// <summary>Covers the rules the whole telemetry surface is held against, in both directions.</summary>
+/// <remarks>
+/// Every assertion this file is about reports a defect as an empty collection being non-empty, which is a shape that
+/// passes just as quietly when the rule matches nothing at all. So each rule is driven twice: once over a surface that
+/// obeys it, and once over one that breaks it in the way the rule exists to catch. The sample types the discovery
+/// checks read are declared here rather than taken from a production boundary, so what they prove is the rule rather
+/// than today's arrangement of somebody else's assembly.
+/// </remarks>
+public sealed class TelemetryRedactionContractTests
+{
+    /// <summary>A name that says nothing about a mailbox passes, whichever of the three forms it takes.</summary>
+    [Fact]
+    public void AssertNothingIsNamedAfterMailOrASecret_OrdinaryNames_Passes() =>
+        TelemetryRedactionContract.AssertNothingIsNamedAfterMailOrASecret(
+            ["synchronize_account", "mailfathom.mail.sync.run.duration", "mailfathom.answering.period.tokens"]);
+
+    /// <summary>A name that is about a message, a person, or a secret fails, whole segment by whole segment.</summary>
+    [Theory]
+    [InlineData("mailfathom.mail.subject")]
+    [InlineData("mailfathom.mail.sender.address")]
+    [InlineData("read_email_body")]
+    [InlineData("mailfathom.mcp.tool.query")]
+    [InlineData("mailfathom.answering.prompt")]
+    [InlineData("mailfathom.mail.occurrence.uid")]
+    [InlineData("mailfathom.provider.token")]
+    [InlineData("mailfathom.mail.folder.path")]
+    public void AssertNothingIsNamedAfterMailOrASecret_ANameAboutAMailbox_Fails(string name) =>
+        Assert.Throws<EmptyException>(() =>
+            TelemetryRedactionContract.AssertNothingIsNamedAfterMailOrASecret([name]));
+
+    /// <summary>A word inside another word is not that word, which is what keeps two legitimate names legitimate.</summary>
+    [Theory]
+    [InlineData("mailfathom.answering.tokens")]
+    [InlineData("mailfathom.mail.content.stored_total")]
+    public void AssertNothingIsNamedAfterMailOrASecret_AForbiddenWordInsideAnotherWord_Passes(string name) =>
+        TelemetryRedactionContract.AssertNothingIsNamedAfterMailOrASecret([name]);
+
+    /// <summary>A dimension minted from a value, or written outside the one namespace, fails.</summary>
+    [Theory]
+    [InlineData("mailfathom.mail.Account")]
+    [InlineData("mail.sync.outcome")]
+    [InlineData("mailfathom.mail.folder-alias")]
+    public void AssertEveryDimensionIsNamespacedUnderMailFathom_ANameOutsideTheShape_Fails(string name) =>
+        Assert.Throws<EmptyException>(() =>
+            TelemetryRedactionContract.AssertEveryDimensionIsNamespacedUnderMailFathom([name], []));
+
+    /// <summary>A dimension in the one namespace passes, whether it arrives as an instrument or as a tag key.</summary>
+    [Fact]
+    public void AssertEveryDimensionIsNamespacedUnderMailFathom_TheNamesInUse_Passes() =>
+        TelemetryRedactionContract.AssertEveryDimensionIsNamespacedUnderMailFathom(
+            ["mailfathom.jobs.queue.depth"],
+            [new KeyValuePair<string, object?>("mailfathom.job.type", "classify_email_spam")]);
+
+    /// <summary>A span named after what it saw rather than after what it did fails.</summary>
+    [Theory]
+    [InlineData("Synchronize Account")]
+    [InlineData("synchronize/INBOX")]
+    public void AssertEverySpanIsNamedAfterItsOperation_ANameOutsideTheShape_Fails(string name) =>
+        Assert.Throws<EmptyException>(() =>
+            TelemetryRedactionContract.AssertEverySpanIsNamedAfterItsOperation([name]));
+
+    /// <summary>The hyphenated form a mutation span takes passes, because it is the published name of the mutation.</summary>
+    [Fact]
+    public void AssertEverySpanIsNamedAfterItsOperation_AMutationsOwnName_Passes() =>
+        TelemetryRedactionContract.AssertEverySpanIsNamedAfterItsOperation(["set-seen", "synchronize_account"]);
+
+    /// <summary>An alias reaching a dimension named for one is the case the contract allows.</summary>
+    [Fact]
+    public void AssertNoPoisonedInputEscaped_AnAliasOnADimensionNamedForOne_Passes() =>
+        TelemetryRedactionContract.AssertNoPoisonedInputEscaped(
+            ["mailfathom.mail.account"],
+            [
+                new KeyValuePair<string, object?>(
+                    "mailfathom.mail.account",
+                    TelemetryRedactionContract.ConfiguredAliasSentinel),
+            ]);
+
+    /// <summary>An alias reaching any other dimension fails, because only the ones named for it may carry one.</summary>
+    [Fact]
+    public void AssertNoPoisonedInputEscaped_AnAliasOnAnyOtherDimension_Fails() =>
+        Assert.Throws<EmptyException>(() =>
+            TelemetryRedactionContract.AssertNoPoisonedInputEscaped(
+                ["mailfathom.jobs.attempts"],
+                [
+                    new KeyValuePair<string, object?>(
+                        "mailfathom.job.type",
+                        TelemetryRedactionContract.ConfiguredAliasSentinel),
+                ]));
+
+    /// <summary>A caller's text and anything read out of a message reach no dimension at all.</summary>
+    [Theory]
+    [InlineData(TelemetryRedactionContract.CallerSuppliedSentinel)]
+    [InlineData(TelemetryRedactionContract.MailDerivedSentinel)]
+    public void AssertNoPoisonedInputEscaped_ForbiddenTextOnAPermittedDimension_Fails(string poison) =>
+        Assert.Throws<EmptyException>(() =>
+            TelemetryRedactionContract.AssertNoPoisonedInputEscaped(
+                ["mailfathom.mail.account"],
+                [new KeyValuePair<string, object?>("mailfathom.mail.account", poison)]));
+
+    /// <summary>A poisoned string that became part of a name fails wherever the name came from.</summary>
+    [Fact]
+    public void AssertNoPoisonedInputEscaped_APoisonedName_Fails() =>
+        Assert.Throws<EmptyException>(() =>
+            TelemetryRedactionContract.AssertNoPoisonedInputEscaped(
+                [$"mailfathom.{TelemetryRedactionContract.MailDerivedSentinel}"],
+                []));
+
+    /// <summary>A type holding an instrument is a publisher, and a suite that did not drive it is told so.</summary>
+    [Fact]
+    public void AssertEveryPublisherInTheAssemblyIsDriven_APublisherNobodyDrove_Fails() =>
+        Assert.Throws<EmptyException>(() =>
+            TelemetryRedactionContract.AssertEveryPublisherInTheAssemblyIsDriven(
+                typeof(SamplePublisher).Assembly,
+                []));
+
+    /// <summary>A suite naming every publisher in the assembly passes.</summary>
+    [Fact]
+    public void AssertEveryPublisherInTheAssemblyIsDriven_EveryPublisherNamed_Passes()
+    {
+        // Arrange — the sample is a publisher by holding an instrument, so it is built and driven like one.
+        new SamplePublisher().Record();
+
+        // Act
+
+        // Assert
+        TelemetryRedactionContract.AssertEveryPublisherInTheAssemblyIsDriven(
+            typeof(SamplePublisher).Assembly,
+            [typeof(SamplePublisher), typeof(SampleSpanPublisher)]);
+    }
+
+    /// <summary>The declared names are read off the two field-name conventions and nothing else.</summary>
+    [Fact]
+    public void DeclaredTelemetryNamesIn_ThisAssembly_ReadsTheTagAndSpanConstantsAlone()
+    {
+        // Arrange
+        var declared = TelemetryRedactionContract.DeclaredTelemetryNamesIn(typeof(SamplePublisher).Assembly);
+
+        // Act
+
+        // Assert
+        Assert.Contains(("mailfathom.sample.outcome", false), declared);
+        Assert.Contains(("run_sample", true), declared);
+        Assert.DoesNotContain(declared, name => name.Value == SampleSpanPublisher.NotATelemetryName);
+    }
+
+    /// <summary>A declaration that breaks the contract is caught without anything having to run.</summary>
+    [Fact]
+    public void AssertEveryDeclaredNameObeysTheContract_ThisAssembly_FailsOnTheDeliberatelyWrongOne() =>
+        Assert.Throws<EmptyException>(() =>
+            TelemetryRedactionContract.AssertEveryDeclaredNameObeysTheContract(typeof(SamplePublisher).Assembly));
+
+    /// <summary>A publisher found by the instrument it holds rather than by where it lives.</summary>
+    private sealed class SamplePublisher
+    {
+        internal const string OutcomeTagName = "mailfathom.sample.outcome";
+
+        private readonly Counter<long> samples =
+            new Meter("SharedSources.SamplePublisher").CreateCounter<long>("mailfathom.sample.count");
+
+        internal void Record() => this.samples.Add(1);
+    }
+
+    /// <summary>A publisher found by the span constant it declares, and the one wrong name this assembly carries.</summary>
+    /// <remarks>
+    /// <see cref="SubjectTagName" /> is deliberately named after a message so the declared-name assertion has something
+    /// to fail on. It is a constant in a test double and reaches no meter and no activity source, so nothing publishes
+    /// it — which is the point: the check reads declarations, and this proves it reads them.
+    /// </remarks>
+    private static class SampleSpanPublisher
+    {
+        internal const string RunSpanName = "run_sample";
+
+        internal const string SubjectTagName = "mailfathom.sample.subject";
+
+        internal const string NotATelemetryName = "mailfathom.sample-hash.v1";
+    }
+}

--- a/tests/shared/EmittedTelemetrySurface.cs
+++ b/tests/shared/EmittedTelemetrySurface.cs
@@ -1,0 +1,145 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using MailFathom.Common.Observability;
+
+namespace MailFathom.TestSupport;
+
+/// <summary>Records the whole of what MailFathom's own registries emitted, rather than one instrument of it.</summary>
+/// <remarks>
+/// <para>
+/// <see cref="RecordedMailFathomMeasurements" /> answers what one named instrument measured, which is what a test about
+/// a feature asks. This answers what the process publishes at all — every instrument that appeared on the meter, every
+/// span that was started on the activity source, and every name, key, and value on either — which is the only level a
+/// contract over the emitted surface can be asserted at. A rule checked per publisher is a rule the next publisher is
+/// not covered by.
+/// </para>
+/// <para>
+/// Both listeners are process-wide, and xUnit runs test classes in parallel, so what this records includes whatever
+/// another class published while it was open. That is deliberate rather than tolerated: a name is either permitted for
+/// every publisher or for none, so a name arriving from elsewhere is judged by the same rule and can only fail the
+/// contract earlier. What must not depend on the timing is a *value*, which is why the values this asserts on are
+/// sentinels the driving test supplied itself — no other class can produce one, so no other class can make an
+/// assertion about one pass or fail.
+/// </para>
+/// <para>
+/// Construct it before the publishers under test. An instrument is announced when it is created, so a listener opened
+/// afterwards sees the instrument only once something measures on it, and never sees one that only ever reports through
+/// an observable callback.
+/// </para>
+/// </remarks>
+internal sealed class EmittedTelemetrySurface : IDisposable
+{
+    private readonly ActivityListener activityListener;
+    private readonly MeterListener meterListener;
+    private readonly ConcurrentQueue<RecordedSpan> spans = new();
+    private readonly ConcurrentQueue<RecordedMeasurement> measurements = new();
+    private readonly ConcurrentDictionary<string, byte> instrumentNames = new(StringComparer.Ordinal);
+
+    /// <summary>Subscribes to MailFathom's activity source and meter and records everything either publishes.</summary>
+    internal EmittedTelemetrySurface()
+    {
+        this.activityListener = new ActivityListener
+        {
+            ShouldListenTo = source => StringComparer.Ordinal.Equals(source.Name, Telemetry.Name),
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            SampleUsingParentId = static (ref ActivityCreationOptions<string> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = this.RecordSpan,
+        };
+
+        ActivitySource.AddActivityListener(this.activityListener);
+
+        this.meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, subscription) =>
+            {
+                if (!StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
+                {
+                    return;
+                }
+
+                this.instrumentNames.TryAdd(instrument.Name, 0);
+                subscription.EnableMeasurementEvents(instrument);
+            },
+        };
+
+        this.meterListener.SetMeasurementEventCallback<long>(this.RecordMeasurement);
+        this.meterListener.SetMeasurementEventCallback<int>(this.RecordMeasurement);
+        this.meterListener.SetMeasurementEventCallback<double>(this.RecordMeasurement);
+        this.meterListener.Start();
+    }
+
+    /// <summary>Gets every span recorded so far, in the order they ended.</summary>
+    internal IReadOnlyList<RecordedSpan> Spans => [.. this.spans];
+
+    /// <summary>Gets every measurement recorded so far, in the order the instruments took them.</summary>
+    internal IReadOnlyList<RecordedMeasurement> Measurements => [.. this.measurements];
+
+    /// <summary>Gets the name of every instrument that appeared on MailFathom's meter.</summary>
+    internal IReadOnlyCollection<string> InstrumentNames => [.. this.instrumentNames.Keys];
+
+    /// <summary>Gets the name every span was started under, one entry per span rather than per distinct name.</summary>
+    internal IReadOnlyCollection<string> SpanNames => [.. this.Spans.Select(span => span.Name)];
+
+    /// <summary>Gets every span name, tag key, instrument name, and dimension key emitted.</summary>
+    /// <remarks>
+    /// The names and the keys are one list because the contract over them is one rule: a reader of a dashboard meets
+    /// them in the same place, and neither may say anything about a message or a person.
+    /// </remarks>
+    internal IReadOnlyCollection<string> EmittedNames =>
+    [
+        .. this.InstrumentNames,
+        .. this.Spans.Select(span => span.Name),
+        .. this.Spans.SelectMany(span => span.Tags.Keys),
+        .. this.Measurements.SelectMany(measurement => measurement.Tags.Keys),
+    ];
+
+    /// <summary>Gets every tag the surface carries, whether it came from a span or from a measurement.</summary>
+    internal IReadOnlyList<KeyValuePair<string, object?>> EmittedTags =>
+    [
+        .. this.Spans.SelectMany(span => span.Tags),
+        .. this.Measurements.SelectMany(measurement => measurement.Tags),
+    ];
+
+    /// <summary>Asks every observable instrument being watched for its current value.</summary>
+    /// <remarks>An observable instrument publishes nothing until something asks, so its dimensions are invisible until then.</remarks>
+    internal void ObserveGauges() => this.meterListener.RecordObservableInstruments();
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        this.activityListener.Dispose();
+        this.meterListener.Dispose();
+    }
+
+    private void RecordSpan(Activity activity) =>
+        this.spans.Enqueue(new RecordedSpan(
+            activity.OperationName,
+            activity.TagObjects.ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
+
+    private void RecordMeasurement<TMeasurement>(
+        Instrument instrument,
+        TMeasurement measurement,
+        ReadOnlySpan<KeyValuePair<string, object?>> tags,
+        object? state)
+        where TMeasurement : struct
+    {
+        this.instrumentNames.TryAdd(instrument.Name, 0);
+        this.measurements.Enqueue(new RecordedMeasurement(
+            instrument.Name,
+            Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
+            tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
+    }
+}
+
+/// <summary>One span MailFathom published, as a listener saw it when it ended.</summary>
+/// <param name="Name">The operation name it was started under.</param>
+/// <param name="Tags">The attributes it carried when it stopped.</param>
+internal sealed record RecordedSpan(string Name, IReadOnlyDictionary<string, object?> Tags);

--- a/tests/shared/TelemetryRedactionContract.cs
+++ b/tests/shared/TelemetryRedactionContract.cs
@@ -1,0 +1,341 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.Metrics;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MailFathom.TestSupport;
+
+/// <summary>Holds the contract every MailFathom span and instrument obeys, and asserts it over an emitted surface.</summary>
+/// <remarks>
+/// <para>
+/// The rule itself is one sentence: a signal carries counts, sizes, durations, outcomes, error codes, and MailFathom's
+/// own configured account, folder, and endpoint aliases, and nothing else. Mail content, an address, a subject, a
+/// remote folder path, a message identifier, a UID, a search term, a credential, and model prompt or completion text
+/// are refused — which is a cardinality rule as much as a privacy one, because every one of them would open a time
+/// series per message or per person.
+/// </para>
+/// <para>
+/// Asserting it needs two different mechanisms, because names and values fail differently. A <b>name</b> — a span's, an
+/// instrument's, a dimension's — is a literal somebody wrote, so it is judged by reading it: the vocabulary below names
+/// what a name may never be about, and the shapes name what one may look like. A <b>value</b> is whatever ran, so no
+/// list decides it; the driving test poisons every string a caller or a message could supply and this asserts where
+/// each poison was allowed to surface. Between them they say what the acceptance asks: nothing about mail or a person
+/// is in a name, and no dimension takes its value from one.
+/// </para>
+/// <para>
+/// This file holds no inventory of the names that exist today. An approved list would fail on every addition rather
+/// than on every wrong one, which trains a reader to extend it without reading it — and the surface it would mirror is
+/// documented in <c>docs/operations/telemetry.md</c>, where a person reads it. What is asserted here is the property,
+/// so a signal nobody has written yet is covered by it.
+/// </para>
+/// </remarks>
+internal static class TelemetryRedactionContract
+{
+    /// <summary>Stands in for an alias an operator configured, which is the one caller string a dimension may carry.</summary>
+    internal const string ConfiguredAliasSentinel = "sentinel-configured-alias";
+
+    /// <summary>Stands in for text a caller sent — a tool name, a protocol argument — which no dimension may carry.</summary>
+    internal const string CallerSuppliedSentinel = "sentinel-caller-supplied";
+
+    /// <summary>Stands in for anything read out of a message, which reaches no name, key, or value anywhere.</summary>
+    internal const string MailDerivedSentinel = "sentinel-mail-derived";
+
+    /// <summary>The dimensions permitted to carry a name an operator configured, and the only ones.</summary>
+    /// <remarks>
+    /// An alias is MailFathom's own word for an account, a folder, or a provider endpoint: the operator wrote it, it is
+    /// bounded by the size of their configuration, and a dashboard is unreadable without it. Every other dimension is
+    /// one of this process's own closed words, so a caller string arriving on one is the defect this catches.
+    /// </remarks>
+    internal static readonly string[] DimensionsCarryingAConfiguredAlias =
+    [
+        "mailfathom.mail.account",
+        "mailfathom.mail.folder",
+        "mailfathom.mail.folder_alias",
+        "mailfathom.answering.endpoint",
+    ];
+
+    /// <summary>The words a span, an instrument, or a dimension may never be named after.</summary>
+    /// <remarks>
+    /// <para>
+    /// Each one names either a piece of a message or a secret, so a signal named after it is already wrong whatever it
+    /// happens to carry at run time. The match is over whole segments — a name is split on <c>.</c> and <c>_</c> — so
+    /// that a word only fails where it is the thing being named. That is what separates <c>token</c>, which names a
+    /// credential, from <c>tokens</c>, which is how many a model consumed and is a legitimate count; and it is what
+    /// keeps <c>stored_total</c> from tripping over a two-letter word inside it.
+    /// </para>
+    /// <para>
+    /// <c>content</c> is deliberately absent. It is the name of a subsystem here — the content store, the byte volume it
+    /// moves — rather than of a message's text, and forbidding it would forbid the instruments that report how much
+    /// storage a mailbox costs.
+    /// </para>
+    /// </remarks>
+    internal static readonly string[] WordsNoSignalIsNamedAfter =
+    [
+        "subject",
+        "sender",
+        "recipient",
+        "address",
+        "uid",
+        "uidvalidity",
+        "body",
+        "snippet",
+        "text",
+        "query",
+        "prompt",
+        "completion",
+        "password",
+        "secret",
+        "credential",
+        "token",
+        "capability",
+        "path",
+        "filename",
+        "id",
+        "identifier",
+    ];
+
+    /// <summary>The shape an instrument name or a dimension key takes, which is one namespace under one root.</summary>
+    private static readonly Regex DimensionShape = new(
+        @"^mailfathom(\.[a-z0-9]+(_[a-z0-9]+)*)+$",
+        RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
+
+    /// <summary>The shape a span name takes, which is the operation it reports written as one lower-case phrase.</summary>
+    /// <remarks>
+    /// A hyphen is allowed beside an underscore because one family of spans is named after the mutation it performs,
+    /// and a mutation's published name is hyphenated — <c>set-seen</c> is the word an operator already reads in the
+    /// audit trail and in the configuration, so the span agreeing with it is worth more than one spelling rule.
+    /// </remarks>
+    private static readonly Regex SpanNameShape = new(
+        @"^[a-z][a-z0-9]*([_-][a-z0-9]+)*$",
+        RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
+
+    private static readonly char[] NameSeparators = ['.', '_', '-'];
+
+    /// <summary>Asserts that nothing on the emitted surface is named after mail, a person, or a secret.</summary>
+    /// <param name="emittedNames">Every span name, instrument name, and dimension key the publishers emitted.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="emittedNames" /> is <see langword="null" />.</exception>
+    internal static void AssertNothingIsNamedAfterMailOrASecret(IReadOnlyCollection<string> emittedNames)
+    {
+        ArgumentNullException.ThrowIfNull(emittedNames);
+
+        string[] offending =
+        [
+            .. emittedNames
+                .Where(name => SegmentsOf(name).Intersect(WordsNoSignalIsNamedAfter, StringComparer.Ordinal).Any())
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal),
+        ];
+
+        Assert.Empty(offending);
+    }
+
+    /// <summary>Asserts that every instrument name and dimension key is one namespaced lower-case word list.</summary>
+    /// <param name="instrumentNames">Every instrument that appeared on MailFathom's meter.</param>
+    /// <param name="emittedTags">Every tag a span or a measurement carried.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The shape is what keeps a dimension from being minted out of a value. A key assembled at run time — from an
+    /// account, a header name, a rule — would not survive it, and a key written by hand in the wrong namespace would
+    /// leave the one filter an operator has for everything this process owns.
+    /// </remarks>
+    internal static void AssertEveryDimensionIsNamespacedUnderMailFathom(
+        IReadOnlyCollection<string> instrumentNames,
+        IReadOnlyCollection<KeyValuePair<string, object?>> emittedTags)
+    {
+        ArgumentNullException.ThrowIfNull(instrumentNames);
+        ArgumentNullException.ThrowIfNull(emittedTags);
+
+        string[] offending =
+        [
+            .. instrumentNames
+                .Concat(emittedTags.Select(tag => tag.Key))
+                .Distinct(StringComparer.Ordinal)
+                .Where(name => !DimensionShape.IsMatch(name))
+                .Order(StringComparer.Ordinal),
+        ];
+
+        Assert.Empty(offending);
+    }
+
+    /// <summary>Asserts that every span is named after the operation it reports rather than after anything it saw.</summary>
+    /// <param name="spanNames">The name of every span the publishers started.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="spanNames" /> is <see langword="null" />.</exception>
+    internal static void AssertEverySpanIsNamedAfterItsOperation(IReadOnlyCollection<string> spanNames)
+    {
+        ArgumentNullException.ThrowIfNull(spanNames);
+
+        string[] offending =
+        [
+            .. spanNames
+                .Distinct(StringComparer.Ordinal)
+                .Where(name => !SpanNameShape.IsMatch(name))
+                .Order(StringComparer.Ordinal),
+        ];
+
+        Assert.Empty(offending);
+    }
+
+    /// <summary>Asserts that the poisoned strings the drive supplied surfaced only where the contract allows.</summary>
+    /// <param name="emittedNames">Every span name, instrument name, and dimension key the publishers emitted.</param>
+    /// <param name="emittedTags">Every tag a span or a measurement carried.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// This is the half no list of names can do. Every string the drive handed a publisher is one of the three
+    /// sentinels, so wherever one comes out is exactly where that class of input reaches an exporter: a caller's text
+    /// and anything read out of a message may reach nowhere at all, and a configured alias may reach the dimensions
+    /// named for it and no others.
+    /// </remarks>
+    internal static void AssertNoPoisonedInputEscaped(
+        IReadOnlyCollection<string> emittedNames,
+        IReadOnlyCollection<KeyValuePair<string, object?>> emittedTags)
+    {
+        ArgumentNullException.ThrowIfNull(emittedNames);
+        ArgumentNullException.ThrowIfNull(emittedTags);
+
+        string[] namesCarryingAPoisonedInput =
+        [
+            .. emittedNames
+                .Where(CarriesAnySentinel)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal),
+        ];
+
+        string[] dimensionsCarryingSomethingTheyMayNot =
+        [
+            .. emittedTags
+                .Where(tag => CarriesAForbiddenSentinel(tag.Value)
+                    || (CarriesSentinel(tag.Value, ConfiguredAliasSentinel)
+                        && !DimensionsCarryingAConfiguredAlias.Contains(tag.Key, StringComparer.Ordinal)))
+                .Select(tag => $"{tag.Key}={tag.Value}")
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal),
+        ];
+
+        Assert.Empty(namesCarryingAPoisonedInput);
+        Assert.Empty(dimensionsCarryingSomethingTheyMayNot);
+    }
+
+    /// <summary>Asserts that every span name and dimension key an assembly declares obeys the contract.</summary>
+    /// <param name="publishingAssembly">The production assembly to inspect.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="publishingAssembly" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// The emitted surface proves what ran; this proves what is written down, and the two catch different things. A
+    /// name declared for a signal nothing in a unit test reaches — a worker's span, a dimension only a failure path
+    /// sets — is invisible to a listener and perfectly visible here, which is why both halves exist rather than the
+    /// cheaper one.
+    /// </para>
+    /// <para>
+    /// It reads the constants by their field names rather than by their values, because that is the distinction a value
+    /// cannot carry: <c>mailfathom.email-chunk.v1</c> is a hash domain and <c>mailfathom.admin</c> is a certificate
+    /// store key, and neither is a dimension however much it looks like one. A field ending in <c>TagName</c> is a
+    /// dimension and one ending in <c>SpanName</c> is a span, which is the convention every publisher in this
+    /// repository already writes and the one the discovery check above also depends on.
+    /// </para>
+    /// </remarks>
+    internal static void AssertEveryDeclaredNameObeysTheContract(Assembly publishingAssembly)
+    {
+        ArgumentNullException.ThrowIfNull(publishingAssembly);
+
+        var declared = DeclaredTelemetryNamesIn(publishingAssembly);
+
+        string[] offending =
+        [
+            .. declared
+                .Where(name => !(name.IsSpan ? SpanNameShape : DimensionShape).IsMatch(name.Value)
+                    || SegmentsOf(name.Value).Intersect(WordsNoSignalIsNamedAfter, StringComparer.Ordinal).Any())
+                .Select(name => name.Value)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal),
+        ];
+
+        Assert.Empty(offending);
+    }
+
+    /// <summary>Reads every span name and dimension key an assembly declares as a constant.</summary>
+    /// <param name="publishingAssembly">The production assembly to inspect.</param>
+    /// <returns>Each declared name, and whether it names a span rather than a dimension.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="publishingAssembly" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Published beside the assertion so a suite can establish that the reader found anything at all. An assertion that
+    /// no declared name is wrong passes just as quietly over an assembly whose names this failed to read.
+    /// </remarks>
+    internal static IReadOnlyList<(string Value, bool IsSpan)> DeclaredTelemetryNamesIn(Assembly publishingAssembly)
+    {
+        ArgumentNullException.ThrowIfNull(publishingAssembly);
+
+        return
+        [
+            .. publishingAssembly.GetTypes()
+                .SelectMany(type => type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+                .Where(field => field.IsLiteral
+                    && field.FieldType == typeof(string)
+                    && (field.Name.EndsWith("SpanName", StringComparison.Ordinal)
+                        || field.Name.EndsWith("TagName", StringComparison.Ordinal)))
+                .Select(field => (
+                    Value: field.GetRawConstantValue() as string,
+                    IsSpan: field.Name.EndsWith("SpanName", StringComparison.Ordinal)))
+                .Where(name => name.Value is not null)
+                .Select(name => (name.Value!, name.IsSpan)),
+        ];
+    }
+
+    /// <summary>Asserts that every type in the assembly that publishes a signal was driven by the suite.</summary>
+    /// <param name="publishingAssembly">The production assembly to inspect.</param>
+    /// <param name="drivenTypes">The publishers the suite constructed and exercised.</param>
+    /// <exception cref="ArgumentNullException">Thrown when either argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Without this the contract holds over whatever the suite remembered to drive, which is the failure the whole
+    /// exercise exists to prevent: a publisher added next year is exactly the one nobody thought to add here.
+    /// </para>
+    /// <para>
+    /// A publisher is found by what it holds rather than by where it lives, because a namespace is a convention a new
+    /// type can be outside of without anybody noticing. Holding an <see cref="Instrument" /> is what it is to own a
+    /// metric, and declaring a constant whose name ends in <c>SpanName</c> is what it is to own a span — the second is
+    /// a convention too, but it is one the suite fails on rather than one it silently depends on, because a span whose
+    /// name is not declared that way is a span this reports as undriven.
+    /// </para>
+    /// </remarks>
+    internal static void AssertEveryPublisherInTheAssemblyIsDriven(
+        Assembly publishingAssembly,
+        IReadOnlyCollection<Type> drivenTypes)
+    {
+        ArgumentNullException.ThrowIfNull(publishingAssembly);
+        ArgumentNullException.ThrowIfNull(drivenTypes);
+
+        string[] undriven =
+        [
+            .. publishingAssembly.GetTypes()
+                .Where(PublishesASignal)
+                .Where(type => !drivenTypes.Contains(type))
+                .Select(type => type.FullName ?? type.Name)
+                .Order(StringComparer.Ordinal),
+        ];
+
+        Assert.Empty(undriven);
+    }
+
+    private static bool PublishesASignal(Type type) =>
+        type.GetFields(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+            .Any(field => typeof(Instrument).IsAssignableFrom(field.FieldType)
+                || (field.IsLiteral && field.Name.EndsWith("SpanName", StringComparison.Ordinal)));
+
+    private static string[] SegmentsOf(string name) =>
+        name.Split(NameSeparators, StringSplitOptions.RemoveEmptyEntries);
+
+    private static bool CarriesAnySentinel(string name) =>
+        CarriesSentinel(name, ConfiguredAliasSentinel) || CarriesAForbiddenSentinel(name);
+
+    private static bool CarriesAForbiddenSentinel(object? value) =>
+        CarriesSentinel(value, CallerSuppliedSentinel) || CarriesSentinel(value, MailDerivedSentinel);
+
+    private static bool CarriesSentinel(object? value, string sentinel) =>
+        value?.ToString()?.Contains(sentinel, StringComparison.OrdinalIgnoreCase) == true;
+}


### PR DESCRIPTION
Settles how much of a trace this host records, and turns the redaction rule that governed telemetry by convention into a contract asserted over the whole emitted surface.

## Sampling

`TraceSamplingExtensions` sets **parent-based always-on**: every trace this process starts is recorded, and a trace it did not start keeps the decision the caller already made. A mailbox-sized workload is bounded by one deployment's accounts rather than by public traffic, a folder run whose duration doubled is attributable only if the run before it was recorded too, and export stays off unless an endpoint is configured — so the default costs an unconfigured deployment nothing.

The sampler is set **only when `OTEL_TRACES_SAMPLER` is absent**. The OpenTelemetry SDK ignores its own configuration once a sampler has been set programmatically and reports the fact to an event source nobody listens to, so setting one unconditionally would answer an operator's variable with silence. `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` therefore work exactly as the specification defines them.

Health and liveness probes stay excluded from tracing, and that exclusion is now a named method with tests rather than a lambda nothing could assert.

## The redaction contract

A rule checked once per publisher is a rule the next publisher is not covered by, so the suite drives **every** publisher in `Infrastructure` and `Mcp` through a listener over MailFathom's activity source and meter, and holds what came out against four claims:

- no span name, instrument name, or dimension key is named after a word from the refused list, matched whole segment by whole segment — which is what separates `token`, a credential, from `tokens`, a count;
- every instrument name and dimension key sits under the single `mailfathom.` namespace in lower case, which is what keeps a dimension from being minted out of a value at run time;
- every span is named as one lower-case phrase;
- **every string the drive hands a publisher is a sentinel** — one for a configured alias, one for text a caller sent, one for text read out of a message — and the assertion is where each was allowed to surface. A caller's text and anything mail-derived may reach nothing at all; an alias may reach the four dimensions named for it and no others.

Two guards keep that from decaying. A publisher is discovered by what it holds — an instrument field, or a declared span name — rather than by where it lives, so one nobody added to the drive fails the suite instead of going unasserted. And the names every assembly of this deployment *declares* are read and held against the same vocabulary, which reaches what no drive does: the span the extraction backfill worker opens, and a dimension only a failure path sets.

The suite was mutation-tested before it was committed — a publisher removed from the driven list and a poisoned span injected both failed the tests they were meant to fail.

## Public surfaces

No break. `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` are additions to what an operator may set, and unset behaviour is unchanged in every existing deployment. No configuration key, database schema, MCP tool contract, or deployment contract moved.

## Documentation

`docs/operations/telemetry.md` gains the emitted-surface contract and a section on how much of a trace is recorded, including the two traps this cost an afternoon each: a programmatic sampler silences the standard variable, and `OTEL_TRACES_SAMPLER_ARG` on its own does nothing. `docs/operations/configuration-reference.md` carries the row, and `docs/features/mail-answering.md` now links the section instead of asserting that spans are sampled.

## Verification

`scripts/verify-full.sh` — 6952 tests passed, 0 failed; aggregate line coverage 95.91% against the 85% gate; formatting clean.

Closes #505
