### PR TITLE
[#846] Keep the obligations index out of what a later pass is narrowed to

### DIFF
--- a/.github/fathom-review/reviewer-prompt.md
+++ b/.github/fathom-review/reviewer-prompt.md
@@ -149,6 +149,14 @@ What that changes:
 - Everything else is context, and reading it is still required: the coverage ledger is
   unchanged and a file you did not open is a file you cannot judge the changed ones
   against. What the list bounds is the verdict, never the reading.
+- **`obligations.json` is outside this bound.** Work through every row of it on this pass
+  exactly as on the first, and raise what it turns out to owe whether or not the path it
+  names moved since your last review. The reason the bound does not apply is that this
+  list cannot widen: a step derives it from the whole of `files.json` and the declared
+  markers, so it is the same list on the sixth pass as on the first, and a row of it is a
+  gap in what the change owes the rest of the repository rather than something you noticed
+  by looking further afield. It is also the one rubric where the defect is what the change
+  is *missing*, which no later push can put in front of you.
 - A defect you can see on a path nothing has moved is one the earlier passes read and let
   through. Leaving it is deliberate. A change that has been reviewed three times and is
   still collecting first findings on untouched files is a review that never converges,

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -1177,7 +1177,18 @@ finding belongs on a path that file names, or on something that stopped being tr
 whose subject moved — and the second kind names the changed path that made it
 wrong, so the connection is on the record. Everything else stays context: the
 ledger is unchanged, and a file the reviewer did not open is one it cannot judge
-the changed files against. The file is absent on a first pass, on a review
+the changed files against.
+
+`obligations.json` is outside that bound, and the exception is what keeps the
+narrowing from contradicting the rubric beside it. That index is derived from the
+whole of `files.json` and the declared `describes:` markers, so it is the same
+list on the sixth pass as on the first — it cannot widen, which is the only thing
+the narrowing exists to stop. Without the exception a fourth pass would be shown a
+row saying a page describing a changed file is not in the change, and told in the
+same prompt not to raise it because that file had not moved since the last push.
+It is also the one rubric where the defect is what the change is *missing*, and
+nothing a later push contains can put a missing page or a missing test in front of
+the reviewer. The file is absent on a first pass, on a review
 somebody asked for, and where the comparison failed, and each of those puts the
 whole change back in scope — a bound derived from an API error would silence
 findings on files that did move.


### PR DESCRIPTION
## What this changes

#844 bounded a later pass to the paths that moved since the reviewer's previous review, and the bound reached one rubric it should not have.

`obligations.json` is derived from the whole of `files.json` and the declared `describes:` markers. The prompt calls it "the only rubric where what is *absent* from the change is the defect" and tells the reviewer to work through every row in this pass rather than the next one. Its rows are about paths the pull request changed at any point, not about what the last push touched — so on a fourth pass the reviewer would be shown a row saying a page describing a changed file is not in the change, and told a paragraph earlier not to raise it because that file had not moved since the previous review. Two instructions in one prompt, decided differently run to run, which is worse than either of them alone.

The exception is safe because this index is the one list in the review that cannot widen: a step computes it before the model runs, from the whole change, so it is identical on the sixth pass and the first. What the narrowing exists to stop is a reviewer that keeps opening more of the change as it goes, and that is not a thing an index of fixed length does.

Nothing else about the narrowing moves. A finding on the *content* of a file nothing has touched since the last push is still out of scope, which is exactly what #839's fourth, fifth, and sixth rounds produced.

## Verification

Prompt and documentation only — no workflow logic changed, and the reviewer prompt carries no contracts to extend. Run at the owner's request without the full gate.

Closes #846
