### PR TITLE
[#854] Name the right probe in the chart's comments, its schema, and the container image page

### DIFF
--- a/deploy/helm/mailfathom/values.schema.json
+++ b/deploy/helm/mailfathom/values.schema.json
@@ -883,7 +883,7 @@
       "properties": {
         "path": {
           "const": "/health",
-          "description": "Readiness consults the dependencies a request needs, the database included, so a pod that cannot serve leaves the Service's endpoints. /alive would report a process that is running but cannot answer, which is the opposite of what readiness decides."
+          "description": "Readiness consults the dependencies a request needs \u2014 the database, and only with personalDataScanning.enabled the analyzer answering for every configured category \u2014 so a pod that cannot serve leaves the Service's endpoints. /alive would report a process that is running but cannot answer, which is the opposite of what readiness decides."
         },
         "initialDelaySeconds": {
           "$ref": "#/definitions/probeTiming/initialDelaySeconds"
@@ -908,7 +908,7 @@
       "properties": {
         "path": {
           "const": "/started",
-          "description": "Startup reports whether the host's own startup gates have completed \u2014 every secret reference resolved, the database schema verified, only with personalDataScanning.enabled the analyzer answering for every configured category, and only with spamScanning.enabled the spam daemon answering. Every other path is refused: /alive answers before those gates have run and would end the startup grace period while the pod is still coming up, and /health consults the database."
+          "description": "Startup reports whether the host's own startup gates have completed \u2014 every secret reference resolved, the database schema verified, and only with spamScanning.enabled the spam daemon answering. Every other path is refused: /alive answers before those gates have run and would end the startup grace period while the pod is still coming up, and /health consults the database."
         },
         "initialDelaySeconds": {
           "$ref": "#/definitions/probeTiming/initialDelaySeconds"

--- a/deploy/helm/mailfathom/values.yaml
+++ b/deploy/helm/mailfathom/values.yaml
@@ -440,16 +440,17 @@ probes:
   # reporting dependency state is exposed by which network its port is on, and by nothing else.
   port: 8081
   # Startup reports whether MailFathom has finished coming up — every secret reference resolved, the database schema
-  # verified, only with personalDataScanning.enabled the analyzer answering for every configured category, and only with
-  # spamScanning.enabled the spam daemon answering. Its budget is what a slow first start is allowed, and it holds the
-  # liveness probe off until it succeeds.
+  # verified, and only with spamScanning.enabled the spam daemon answering. Its budget is what a slow first start is
+  # allowed, and it holds the liveness probe off until it succeeds. The personal-data analyzer is deliberately not among
+  # them: it is a sidecar that may become ready after this pod, so it is a readiness question and is asked below.
   startup:
     path: /started
     periodSeconds: 5
     timeoutSeconds: 5
     failureThreshold: 30
-  # Readiness consults the dependencies a request needs, the database included, so a pod that cannot serve leaves the
-  # Service's endpoints instead of answering requests it cannot fulfil.
+  # Readiness consults the dependencies a request needs — the database, and only with personalDataScanning.enabled the
+  # analyzer answering for every configured category — so a pod that cannot serve leaves the Service's endpoints instead
+  # of answering requests it cannot fulfil. The pod is not restarted for either: it rejoins when the dependency answers.
   readiness:
     path: /health
     initialDelaySeconds: 10

--- a/docs/operations/container-image.md
+++ b/docs/operations/container-image.md
@@ -92,11 +92,11 @@ port is asked from the host instead.
 The three answer different questions and are wired to different probes on purpose:
 
 - **`/started`** reports whether the host's startup gates have completed: every secret reference resolved, the database
-  schema verified, and — each only where its own switch is on — the analyzer answering for every category it was
-  configured with and the spam scanner naming the corpus it scores under. It is what an orchestrator's startup probe
-  reads, so a slow first start extends the grace period rather than counting as a failure.
-- **`/health`** consults the dependencies a request needs, the database among them. It is readiness: a process that
-  cannot reach its database stops receiving requests it cannot fulfil.
+  schema verified, and — only where its own switch is on — the spam scanner naming the corpus it scores under. It is what
+  an orchestrator's startup probe reads, so a slow first start extends the grace period rather than counting as a failure.
+- **`/health`** consults the dependencies a request needs: the database, and — only where its switch is on — the
+  personal-data analyzer answering for every configured category. It is readiness: a process that cannot reach either
+  stops receiving requests it cannot fulfil, and is not restarted for it.
 - **`/alive`** consults only process-local state. It is liveness: a database outage must never become a restart loop
   that cannot fix what is actually broken.
 


### PR DESCRIPTION
Closes #854

#853 moved the personal-data analyzer from a startup gate to a readiness health check and corrected the pages that described the old arrangement. Three descriptions of the probes were missed, and each still tells an operator that `/started` waits for the analyzer:

- `deploy/helm/mailfathom/values.yaml` — the `probes.startup` comment now names only the secret references, the schema, and the spam daemon, and says why the analyzer is not among them; the `probes.readiness` comment gains it and states that the pod is not restarted for either dependency, it rejoins when the dependency answers.
- `deploy/helm/mailfathom/values.schema.json` — the `description` on `probes.startup.path` and on `probes.readiness.path` now say the same thing. That is the form an operator's editor renders while they are writing a values file, so it is where the claim is read most often.
- `docs/operations/container-image.md` — the analyzer moves from the `/started` bullet to the `/health` bullet.

`fathom-reviewer` found the first of these while approving #853, could not anchor it to a diff line, and raised it in the review body as a follow-up. The other two are the same sentence in two more places, found by searching for it. The correction was written and verified before #853 merged; the merge landed a minute after the approval, so it needs a pull request of its own.

## Not a behaviour change

Nothing here changes what any probe consults — #853 did that. Every claim about the spam scanner in these files is untouched, because that gate did not move: `/started` still waits for the daemon to name its corpus, and the startup refusal for a scanner switched on with classification off is configuration validation that still holds.

## Verification

- `scripts/verify-full.sh` — pass over exactly this tree. 7133 unit tests and 211 workflow-contract assertions, none failing.
- `helm lint deploy/helm/mailfathom` against both `ci/nightly-values.yaml` and `ci/release-values.yaml` — 0 charts failed. `values.schema.json` re-parsed as JSON after the edit.
- `$check-docs-licenses` — Docs `pass` (this change is the documentation correction), Changelog `n/a`, Licenses `n/a`: no package, image, model, service, or copied source is added, removed, or upgraded.
