### PR TITLE
Add MCP Registry metadata

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.krzysztof318/mailfathom",
+  "title": "MailFathom",
+  "description": "Security-first, self-hosted email archive with read-only search and cited answers for AI agents.",
+  "repository": {
+    "url": "https://github.com/Krzysztof318/MailFathom",
+    "source": "github",
+    "id": "1309260427"
+  },
+  "version": "0.6.0",
+  "websiteUrl": "https://krzysztof318.github.io/MailFathom/",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://{host}/mcp",
+      "variables": {
+        "host": {
+          "description": "Public HTTPS host of the operator's MailFathom deployment, without a scheme or path.",
+          "isRequired": true,
+          "format": "string",
+          "placeholder": "mail.example.com"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I would like to request that MailFathom be added to this list.

## Summary

- add official MCP Registry metadata for MailFathom `0.6.0`;
- use the ownership-valid `io.github.krzysztof318/mailfathom` namespace;
- represent each operator's HTTPS deployment as a required `{host}` variable ending at `/mcp`;
- avoid claiming a shared hosted endpoint or an OCI package shape the current image does not satisfy.

## Validation

- `mcp-publisher validate` — valid against the production Registry;
- `scripts/verify-fast.sh` — 7133 tests passed;
- `scripts/verify-full.sh` — 7133 tests passed, 95.97% line coverage, 211 workflow contract tests passed.

## Disclosure

I am the MailFathom maintainer. This metadata describes the implemented, documented remote MCP endpoint and current v0.6.0 release.

Closes #856
