### PR TITLE
[#859] Select the reviewer's Claude credential by profile

### DIFF
--- a/.github/workflows/fathom-review.yml
+++ b/.github/workflows/fathom-review.yml
@@ -111,9 +111,27 @@ permissions:
 #
 # It renders as nothing. A Markdown comment is invisible in the review GitHub displays and survives
 # the round trip through the API, which an invisible character or a trailing convention would not.
+#
+# Which Claude subscription pays for a review is the second thing declared here, and for a related
+# reason: three steps name the credential and they have to name the same one. `CLAUDE_CODE_PROFILE`
+# is a repository variable rather than a secret, because the name of a profile is not one — keeping
+# it out of the secret store is what lets a run say which subscription it selected instead of `***`.
+# Set it to `secondary` to spend the second profile's subscription; unset, or set to anything else,
+# means the first and `CLAUDE_CODE_OAUTH_TOKEN`. Both tokens live in the secret store at once, so
+# switching back is a variable change rather than a token regenerated over one that was overwritten.
+#
+# What is declared here is the secret's *name*, which the annotations that report a missing
+# credential print. The value is read per step, by the same condition, because a secret in a
+# workflow-level `env` is in the environment of every step of every job — including the two that
+# never touch a Claude credential and the one that runs the model — and this file's whole posture is
+# that the credential is held by the fewest steps that can do the work. `scripts/test-agent-workflow.sh`
+# fails when the four spellings of the condition stop agreeing, which is the one failure this split
+# can produce and the one nothing else would report: a leak check comparing findings against a token
+# no run spends passes every review it is given.
 env:
   AUTOMATIC_REVIEW_MARKER: '<!-- fathom-review: automatic -->'
   REQUESTED_REVIEW_MARKER: '<!-- fathom-review: requested -->'
+  CLAUDE_CREDENTIAL_SECRET: ${{ vars.CLAUDE_CODE_PROFILE == 'secondary' && 'CLAUDE_CODE_OAUTH_TOKEN_SECONDARY' || 'CLAUDE_CODE_OAUTH_TOKEN' }}
 
 jobs:
   decide:
@@ -1194,9 +1212,17 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           # A Claude Code OAuth token rather than an API key: the review runs on the owner's Claude
-          # subscription. Generate it with `claude setup-token` and store it as the
-          # `CLAUDE_CODE_OAUTH_TOKEN` repository secret.
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # subscription. Generate it with `claude setup-token` and store it as the repository
+          # secret the profile declared at the top of this file selects — `CLAUDE_CODE_OAUTH_TOKEN`,
+          # or `CLAUDE_CODE_OAUTH_TOKEN_SECONDARY` where `CLAUDE_CODE_PROFILE` is `secondary`.
+          #
+          # A `&&`/`||` expression yields its right operand whenever the middle one is empty, so a
+          # `secondary` profile whose secret was never stored falls back to the first profile's
+          # token rather than authenticating with nothing. That is the better of the two outcomes —
+          # a review that runs on the other subscription beats one that cannot run at all — and it
+          # is the reason the two steps below still refuse an unset credential outright: both
+          # secrets missing is the case no fallback covers.
+          claude_code_oauth_token: ${{ vars.CLAUDE_CODE_PROFILE == 'secondary' && secrets.CLAUDE_CODE_OAUTH_TOKEN_SECONDARY || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Explicit, so the action uses the workflow token with the permissions declared above
           # rather than exchanging an OIDC token for a GitHub App installation token whose scopes
           # this workflow does not state.
@@ -1308,7 +1334,12 @@ jobs:
         env:
           EXECUTION_FILE: ${{ runner.temp }}/claude-execution-output.json
           WORKFLOW_TOKEN: ${{ github.token }}
-          CLAUDE_CREDENTIAL: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The credential the step above actually authenticated with, selected by the same
+          # condition rather than by a second reading of the profile: this compares printed text
+          # against it, so a comparison against the token the run did not spend would be no
+          # comparison at all. `CLAUDE_CREDENTIAL_SECRET` names it and arrives from the
+          # workflow-level `env`, which every step already carries.
+          CLAUDE_CREDENTIAL: ${{ vars.CLAUDE_CODE_PROFILE == 'secondary' && secrets.CLAUDE_CODE_OAUTH_TOKEN_SECONDARY || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -1338,7 +1369,7 @@ jobs:
           # secret is reported rather than compared: `grep -F ''` matches everything, which would
           # turn a missing secret into a permanent false positive.
           if [[ -z "$CLAUDE_CREDENTIAL" ]]; then
-            echo '::error::CLAUDE_CODE_OAUTH_TOKEN is not set, which is why the reviewer could not run.'
+            printf '::error::%s is not set, which is why the reviewer could not run.\n' "$CLAUDE_CREDENTIAL_SECRET"
             exit 0
           fi
 
@@ -1477,8 +1508,10 @@ jobs:
           REVIEWER_TOKEN: ${{ steps.reviewer.outputs.token }}
           # Held only by this step, which runs no model output and makes one API call, so that a
           # credential the reviewer was never able to read still cannot be published if it somehow
-          # reaches the findings.
-          CLAUDE_CREDENTIAL: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # reaches the findings. It is the credential the reviewer authenticated with, selected by
+          # the same condition the action input above uses: what this refuses to publish has to be
+          # the token the run spent rather than the one the other profile would have.
+          CLAUDE_CREDENTIAL: ${{ vars.CLAUDE_CODE_PROFILE == 'secondary' && secrets.CLAUDE_CODE_OAUTH_TOKEN_SECONDARY || secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Whether the reviewer got as far as an answer. Two branches consult it: an empty answer
           # is a failure already reported when the step failed and this workflow's own defect when
           # it did not, and an empty findings array means one thing from a run that finished and
@@ -1539,7 +1572,7 @@ jobs:
           # An unset secret is refused rather than compared: `grep -F ''` matches every file, so
           # comparing against it would reject every review this workflow ever produced.
           if [[ -z "$CLAUDE_CREDENTIAL" ]]; then
-            echo '::error::CLAUDE_CODE_OAUTH_TOKEN is not set, so the findings cannot be checked against it.'
+            printf '::error::%s is not set, so the findings cannot be checked against it.\n' "$CLAUDE_CREDENTIAL_SECRET"
             exit 1
           fi
 

--- a/docs/operations/agent-workflow.md
+++ b/docs/operations/agent-workflow.md
@@ -1014,10 +1014,12 @@ does not inherit this reasoning; it argues its own case or uses `pull_request`.
 
 ### What bounds the cost
 
-The run spends the repository owner's personal Claude subscription through
-`CLAUDE_CODE_OAUTH_TOKEN`, so what limits how often it runs is a design concern
-rather than an operational one. Nine things do, and they are listed together
-because each closes a different way the bill could grow:
+The run spends the repository owner's personal Claude subscription — whichever of
+the two the `CLAUDE_CODE_PROFILE` variable selects, as
+[Provisioning the App](#provisioning-the-app) describes — so what limits how
+often it runs is a design concern rather than an operational one. Nine things do,
+and they are listed together because each closes a different way the bill could
+grow:
 
 - a draft is never reviewed automatically, so a branch still being written is
   pushed to freely and spends nothing;
@@ -1369,9 +1371,11 @@ depending on a promise it does not own, because a later action version that rena
 output or stopped failing on it would otherwise leave every review posting nothing under a
 green job — a pipeline that has silently stopped reviewing.
 
-Both steps refuse to compare against an unset `CLAUDE_CODE_OAUTH_TOKEN` and report the
-missing secret instead, because `grep -F ''` matches every file and an empty pattern
-would otherwise turn every review into a refusal that reads like a credential leak.
+Both steps refuse to compare against an unset Claude credential and report the missing
+secret by name instead, because `grep -F ''` matches every file and an empty pattern
+would otherwise turn every review into a refusal that reads like a credential leak. The
+name they report is the one the profile selected, so a run missing a credential says
+which of the two subscriptions it looked for.
 
 ### What the submission step guarantees
 
@@ -1585,13 +1589,41 @@ Rotating the key is generating a new one, replacing `REVIEWER_APP_PRIVATE_KEY`,
 and then deleting the old key from the App — in that order, so no run falls
 between a revoked key and its replacement.
 
-The reviewer authenticates with the `CLAUDE_CODE_OAUTH_TOKEN` repository secret,
-produced by `claude setup-token` against the owner's Claude subscription. Without
-it the run fails at the action step. That secret buys model time and nothing
-else; publishing is the App's, and the two credentials are never held by the same
-step. `THIRD_PARTY_LICENSES.md` records exactly what the run sends and under
-whose terms, including the consumer-plan data-training setting that decides
-whether what is submitted this way trains future models.
+The reviewer authenticates with a Claude Code OAuth token, produced by
+`claude setup-token` against a Claude subscription. Without it the run fails at
+the action step. That secret buys model time and nothing else; publishing is the
+App's, and the two credentials are never held by the same step.
+`THIRD_PARTY_LICENSES.md` records exactly what the run sends and under whose
+terms, including the consumer-plan data-training setting that decides whether
+what is submitted this way trains future models.
+
+**Which subscription pays for a review is a repository variable.** The owner runs
+Claude Code under more than one profile, and each profile's subscription has its
+own token, so both live in the secret store at once and one variable selects
+between them: `CLAUDE_CODE_PROFILE` set to `secondary` makes every run
+authenticate with `CLAUDE_CODE_OAUTH_TOKEN_SECONDARY`, and unset — or set to
+anything else — means `CLAUDE_CODE_OAUTH_TOKEN`. It is a variable rather than a
+secret because the name of a profile is not one, and keeping it out of the secret
+store is what lets a run's log say which subscription it selected instead of
+`***`. Switching back is that variable changing rather than a token regenerated
+over one somebody overwrote.
+
+A `secondary` profile whose secret was never stored falls back to the first
+profile's token rather than authenticating with nothing, because a GitHub
+expression yields its right operand whenever the middle one is empty. That is the
+better of the two outcomes — a review running on the other subscription beats one
+that cannot run — and it is why the two steps that compare findings against the
+credential still refuse an unset one outright: both secrets missing is the case
+no fallback covers, and each of those steps names the secret the run actually
+looked for.
+
+Three places in the workflow name that credential and a fourth names the secret,
+so `scripts/test-agent-workflow.sh` fails when they stop agreeing. Handing the
+secret to one place and letting every step read it would be the alternative, and
+it would put the credential in the environment of the two jobs that never touch
+one and of the step that runs the model. What the contract guards against is the
+failure that is otherwise silent: a leak check comparing a review against the
+token the run never spent matches nothing, passes every review, and is green.
 
 The board write is a third credential, `BOARD_PROJECT_TOKEN`, and it is optional:
 without it the review is published exactly as before and only the `Status` write

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -924,6 +924,7 @@ again locally in `scripts/verify-full.sh`, from `scripts/test-agent-workflow.sh`
 | `every_write_scope_is_one_the_policy_records` | A write scope appearing anywhere the list in that contract does not already name |
 | `every_checkout_refuses_to_persist_credentials` | An `actions/checkout` step that leaves the workflow token in `.git/config` for the steps after it |
 | `only_the_reviewer_workflow_uses_pull_request_target` | A second `pull_request_target` trigger beside the one `fathom-review.yml` holds |
+| `the_reviewer_resolves_one_claude_credential_everywhere` | A step in `fathom-review.yml` reaching a Claude credential without the `CLAUDE_CODE_PROFILE` selector, or a fourth step holding one, either of which leaves a leak check comparing a review against a token no run spent |
 
 Every write scope in the repository but one belongs to publishing something: `packages: write` with
 `id-token: write` and `attestations: write` in `nightly.yml`, `publish-container-image.yml`, and

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -5827,6 +5827,53 @@ a_comment_never_cancels_a_review_in_flight() {
   done
 }
 
+# The reviewer's subscription credential is named in four places: the workflow-level `env` that
+# carries the secret's *name* into the annotation reporting a missing one, the action input that
+# spends it, and the two leak checks that refuse to publish findings containing it. Declaring the
+# secret once would also hand it to every step that has no business holding it, so the four
+# spellings are separate by design and this is what keeps them agreeing.
+#
+# The failure they can otherwise produce is silent in the worst way. A leak check comparing a review
+# against the token the run never spent matches nothing, passes every review it is given, and is
+# green while doing it — so the one step that stands between a credential and a published review
+# stops standing there with nothing to say so.
+the_reviewer_resolves_one_claude_credential_everywhere() {
+  local reviewer_workflow="$source_repository_root/.github/workflows/fathom-review.yml"
+  local selector="vars.CLAUDE_CODE_PROFILE == 'secondary'"
+  local value_expression="\${{ ${selector} && secrets.CLAUDE_CODE_OAUTH_TOKEN_SECONDARY || secrets.CLAUDE_CODE_OAUTH_TOKEN }}"
+  local name_expression="\${{ ${selector} && 'CLAUDE_CODE_OAUTH_TOKEN_SECONDARY' || 'CLAUDE_CODE_OAUTH_TOKEN' }}"
+  local selecting_reads
+  local unselected_reads
+
+  selecting_reads="$(grep -cF "$value_expression" "$reviewer_workflow" || true)"
+
+  if [[ "$selecting_reads" != '3' ]]; then
+    printf 'fathom-review.yml resolves the Claude credential through the profile in %s place(s), expected 3: the action input and both leak checks\n' \
+      "$selecting_reads" >&2
+    return 1
+  fi
+
+  # Every other read of a Claude secret, whatever it is spelled as. A step reaching one without the
+  # selector is either the profile being ignored or a fourth holder of the credential, and both are
+  # this contract's subject. A comment naming the secrets context is not: the file argues this
+  # arrangement at length, and a contract that failed on the argument would be one nobody could
+  # explain in the file it guards.
+  unselected_reads="$(grep -nF 'secrets.CLAUDE_CODE_OAUTH_TOKEN' "$reviewer_workflow" |
+    grep -vE '^[0-9]+:[[:space:]]*#' |
+    grep -vF "$value_expression" || true)"
+
+  if [[ -n "$unselected_reads" ]]; then
+    printf 'fathom-review.yml reads a Claude credential without selecting it by profile:\n%s\n' \
+      "$unselected_reads" >&2
+    return 1
+  fi
+
+  if ! grep -qF "CLAUDE_CREDENTIAL_SECRET: ${name_expression}" "$reviewer_workflow"; then
+    printf 'fathom-review.yml does not name the selected secret in CLAUDE_CREDENTIAL_SECRET, so a run missing one reports the other\n' >&2
+    return 1
+  fi
+}
+
 # `tools/` holds development tooling that must never ship. `tools/SyntheticMail` fabricates mail and
 # submits it under a stored credential, which is not an operator capability and has no business in
 # `mfctl`, in the container image, or in a release asset. Being outside `src/` is what makes that true
@@ -6245,6 +6292,7 @@ run_test no_channel_builds_an_artifact_before_the_commit_has_verified
 run_test a_paid_provider_run_is_never_the_default
 run_test only_the_reviewer_workflow_uses_pull_request_target
 run_test a_comment_never_cancels_a_review_in_flight
+run_test the_reviewer_resolves_one_claude_credential_everywhere
 run_test the_development_tooling_never_reaches_a_published_artifact
 run_test workflow_scripts_use_flat_manual_layout
 run_test every_yaml_file_carries_the_license_header


### PR DESCRIPTION
`Fathom review` authenticated with one repository secret, `CLAUDE_CODE_OAUTH_TOKEN`, so spending a
second Claude subscription meant overwriting the token every run reads. Both tokens now live in the
secret store at once, and one repository variable selects between them.

## What changed

- `CLAUDE_CODE_PROFILE` set to `secondary` makes every run authenticate with
  `CLAUDE_CODE_OAUTH_TOKEN_SECONDARY`; unset, or set to anything else, keeps `CLAUDE_CODE_OAUTH_TOKEN`.
  It is a variable rather than a secret because the name of a profile is not one — which is what lets
  a run's log say which subscription it selected instead of `***`.
- The same condition resolves the credential in all three places the workflow holds one: the action
  input that spends it, and the two leak checks that refuse to publish findings containing it. A leak
  check comparing a review against the token the run never spent would match nothing, pass every
  review, and be green while doing it.
- The credential stays scoped to those three steps. Declaring it once in a workflow-level `env` was
  the alternative and would have put it in the environment of the two jobs that never touch one and of
  the step that runs the model, which is the opposite of what this file argues everywhere else. The
  workflow-level `env` carries the secret's *name* instead, so the two `is not set` annotations report
  the one the run actually looked for.
- `the_reviewer_resolves_one_claude_credential_everywhere` in `scripts/test-agent-workflow.sh` fails
  when the four spellings of the condition stop agreeing, and when a fourth step starts holding a
  Claude credential.

A `secondary` profile whose secret was never stored falls back to the first profile's token, because a
GitHub expression yields its right operand whenever the middle one is empty. A review running on the
other subscription beats one that cannot run, and both steps still refuse an unset credential outright
— both secrets missing is the case no fallback covers.

## Operator action

None until the second subscription is wanted. To switch: store `CLAUDE_CODE_OAUTH_TOKEN_SECONDARY`
from `claude setup-token`, then set the repository variable `CLAUDE_CODE_PROFILE` to `secondary`.
Switching back is deleting or changing that variable. No configuration key, database column, MCP tool
argument, or deployment contract moves, so nothing an operator runs is affected.

## Verification

`scripts/verify-full.sh` — passed, 7133 unit tests and 212 workflow contracts.

Closes #859
