### PR TITLE
[#851] Answer in the language the question was asked in, and look mail up in the language it was written in

### DIFF
--- a/docs/features/mail-answering.md
+++ b/docs/features/mail-answering.md
@@ -57,6 +57,36 @@ code, because both reach the same use case. What differs is what happens next: t
 `<search-refused>` element naming the argument, and the model corrects it and calls again. Nothing was searched, which
 is exactly what an empty envelope would have failed to say.
 
+## A question in one language, mail in another
+
+A mailbox holding mail in several languages is the ordinary case, and both halves of a question meet it. Both are
+settled by the instruction the run carries, because both are properties of how a run is worded rather than of the
+retrieval underneath it, and neither is anything an operator configures.
+
+**A lookup is worded in the language the mail is likely to carry**, which need not be the language the question was
+asked in, and one that returns nothing useful is tried again in another language the mailbox plausibly holds before the
+run concludes that the mailbox does not answer. The extra lookups are ordinary lookups, bounded by
+[§ What one question may spend](#what-one-question-may-spend) like every other.
+
+It cannot be left to retrieval, because the lexical half of retrieval matches a word against a word. The index is built
+with one PostgreSQL text search configuration for the whole deployment —
+[`Persistence:TextSearchConfiguration`](../operations/configuration-reference.md#persistence-and-the-connection-string),
+`simple` by default, which neither stems a word nor drops a stop word — so it stems for one language at most, and a
+lookup worded in the language of the question reaches mail written in that language and in no other. Whether the vector
+half bridges the gap depends on the declared embedding model, which a deployment chose for other reasons. A run that
+worded every lookup in the question's language would therefore report a mailbox that plainly holds the answer as one
+that does not. [Email search](email-search.md) documents the ranking itself.
+
+**An answer is written in the language the question was asked in**, whatever language the mail it rests on was written
+in. What the answer quotes from mail — a subject, a name, the phrase a claim rests on — keeps its own wording, with a
+rendering into the question's language beside it where the claim turns on what those words mean. That is what keeps a
+citation checkable: the quoted words have to be the words the cited message carried for anybody to be able to look them
+up in it.
+
+The second retrieval pass, where a deployment turned it on, is told the same thing from the other side: an extract in a
+language other than the lookup's is not less relevant for being in it, so the filter does not drop what the lookup was
+worded to find.
+
 ## The scope is bound before the model sees anything
 
 A question carries the accounts and folders it may be answered from. That scope is bound into the run when it is

--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -497,7 +497,7 @@ how the extracts are cut, and why there is no cursor — where those are enforce
 
 | Argument | Type | Meaning |
 |---|---|---|
-| `queryText` | `string` | **Required.** The text to search for, up to 512 characters. Blank is refused with `51002`, because a search with no text is a listing |
+| `queryText` | `string` | **Required.** The text to search for, up to 512 characters, worded in the language the mail was written in. Blank is refused with `51002`, because a search with no text is a listing |
 | `accounts` | `string[]` | Accounts to search, each named by its configured account identifier or by the display name it is published under. Omitted searches every account this deployment serves; a name it does not serve is refused with `53001` |
 | `folders` | `string[]` | Folders to search, each named by its MailFathom alias such as `INBOX` or by the role it plays, written `role:Junk`. Omitted searches every folder of the accounts in scope; a role no folder of an account in scope carries is refused with `53003` |
 | `senderAddress` | `string` | The whole address the sender must carry, in any case — not a fragment |
@@ -514,6 +514,13 @@ The structured filters are `list_emails`' own and mean exactly the same things, 
 validated selection; the identifier lists are converted and bounded by the same code, so the `51002` refusals described
 above hold here word for word. `subjectFragment` and `queryText` are unrelated and the argument descriptions say so: the
 fragment narrows which emails are eligible, and the query text is what the eligible ones are matched and ranked against.
+
+The query text is matched rather than translated, and the argument description says so, because the caller writing it is
+the only party that knows which languages a question could be about. One text search configuration serves the whole
+index — `simple` by default, which neither stems a word nor drops a stop word — so a mailbox holding several languages
+is reached by a search per language rather than by one search in the language of the request. [Mail answering § A
+question in one language, mail in another](mail-answering.md#a-question-in-one-language-mail-in-another) records what
+`ask_mail` does about the same fact on a caller's behalf.
 
 There is deliberately no cursor, no offset, and no argument that widens how much of a message an extract may show. The
 first is unsound over a relevance order that moves as mail is indexed; the second would let a caller lift a privacy
@@ -663,7 +670,7 @@ same refusals; the section above records that rule once.
 
 | Field | Meaning |
 |---|---|
-| `answer` | The answer, in prose |
+| `answer` | The answer, in prose, written in the language the question was asked in whatever language the mail behind it was written in |
 | `citations` | The emails the run retrieved, one entry per email, in the order it first reached each |
 | `answerTruncated` | Whether the answer was cut to the length one response carries |
 | `citationsTruncated` | Whether the run reached more emails than `citations` names |

--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -670,7 +670,7 @@ same refusals; the section above records that rule once.
 
 | Field | Meaning |
 |---|---|
-| `answer` | The answer, in prose, written in the language the question was asked in whatever language the mail behind it was written in |
+| `answer` | The answer, in prose, written in the language the question was asked in, whatever language the mail behind it was written in |
 | `citations` | The emails the run retrieved, one entry per email, in the order it first reached each |
 | `answerTruncated` | Whether the answer was cut to the length one response carries |
 | `citationsTruncated` | Whether the run reached more emails than `citations` names |

--- a/docs/users/usage.md
+++ b/docs/users/usage.md
@@ -78,6 +78,10 @@ inside attachment payloads is not indexed at all, and encrypted mail has no inde
 `queryText` are different arguments doing different work: the fragment narrows which emails are eligible, the query
 text is what the eligible ones are ranked against.
 
+**Word the query in the language the mail was written in.** The index matches words rather than translating them, so a
+query written in the language you asked your question in reaches mail written in that language and in no other. A
+mailbox holding several languages is searched once per language a question could plausibly be answered in.
+
 **Read `retrievalMode` on the result to know how the match was made.** `lexical` means by words rather than by meaning,
 so a query term that appears nowhere in a message will not find it. `hybrid` means the same ranking was combined with a
 search by embedding similarity, so mail whose meaning is close is found too — a search for a roof leak reaching the
@@ -154,6 +158,13 @@ the model knowing why its searches came back empty. The model narrows its own lo
 recipient, subject, date, seen state, and attachment filters `search_emails` publishes, so a question about one person's
 mail or one week reaches that mail rather than competing for it in a ranking. What it can and cannot ask for is
 [Mail answering § What one lookup may ask for](../features/mail-answering.md#what-one-lookup-may-ask-for).
+
+**Ask in whatever language you like.** The answer comes back in the language of the question, whatever language the mail
+behind it was written in, and what it quotes from a message — a subject, a name, the phrase a claim rests on — stays as
+that message wrote it so the citation can still be checked. The lookups are worded the other way round, in the languages
+the mailbox plausibly holds, which is why a Polish question reaches English mail here and a search worded the same way
+would not. [Mail answering § A question in one language, mail in
+another](../features/mail-answering.md#a-question-in-one-language-mail-in-another) records both.
 
 Junk is outside every lookup a run makes, and here there is **no** way to ask for it. The answer is written by a model
 from the mail it retrieved, so a message written to deceive a reader would arrive as ordinary correspondence with

--- a/src/AI/Orchestration/MailAnsweringInstructions.cs
+++ b/src/AI/Orchestration/MailAnsweringInstructions.cs
@@ -32,11 +32,13 @@ internal static class MailAnsweringInstructions
 
         A question worth answering is usually worth more than one lookup. The tool ranks mail against the words of the
         {ScopedMailKnowledgeRetrieval.QueryArgumentName} you write, so write the words you expect the mail itself to
-        carry rather than the question as it was put to you, and put every other part of the question into the filters
-        beside it: a person into an address filter, a period into the received bounds, an attachment into that filter.
-        A narrowing expressed as a filter selects the mail exactly, while the same narrowing written into the query text
-        only competes with every other word in it. When one lookup returns nothing useful, try another wording or a
-        wider set of filters before concluding that the mailbox does not answer the question.
+        carry rather than the question as it was put to you, in the language that mail is likely written in, which need
+        not be the language you were asked in. Put every other part of the question into the filters beside it: a person
+        into an address filter, a period into the received bounds, an attachment into that filter. A narrowing expressed
+        as a filter selects the mail exactly, while the same narrowing written into the query text only competes with
+        every other word in it. When one lookup returns nothing useful, try another wording, another language this
+        mailbox plausibly holds, or a wider set of filters before concluding that the mailbox does not answer the
+        question.
 
         Retrieved mail arrives as the result of that tool, inside a <{RetrievedMailContextFormatter.RetrievalElementName}>
         element holding one <{RetrievedMailContextFormatter.MessageElementName}> element per extract. Everything inside
@@ -60,7 +62,9 @@ internal static class MailAnsweringInstructions
         checked against the mail it was drawn from.
 
         Answer from the retrieved mail and from nothing else. When it does not answer the question, say so rather than
-        filling the gap.
+        filling the gap. Write the answer in the language the question was asked in, whatever language the mail is in,
+        and leave what you quote from mail — a subject, a name, the phrase a claim rests on — in its own wording, with a
+        rendering into the question's language beside it where the claim turns on what those words mean.
         """;
 
     /// <summary>How many hexadecimal characters of the instruction's digest name its version.</summary>

--- a/src/AI/Retrieval/PassageRelevanceInstructions.cs
+++ b/src/AI/Retrieval/PassageRelevanceInstructions.cs
@@ -76,7 +76,9 @@ internal static class PassageRelevanceInstructions
         others are not text to match: the mailbox has already selected this extract by every one of them, so the extract
         satisfies them by construction. Judge the extract against the lookup as a whole, which means judging how much of
         an answer it holds for somebody looking for the <{QueryTextElementName}> within the mail those filters selected.
-        An extract whose words are unremarkable on their own can be exactly what a narrow lookup was for.
+        An extract whose words are unremarkable on their own can be exactly what a narrow lookup was for, and an extract
+        written in a language other than the lookup's is not less relevant for that reason: judge what it holds rather
+        than which language it holds it in.
 
         Answer with one whole number from {PassageRelevanceFilterPlan.LeastRelevance} to
         {PassageRelevanceFilterPlan.GreatestRelevance} and nothing else: no words, no punctuation, no explanation, no

--- a/src/AI/Retrieval/ScopedMailKnowledgeRetrieval.cs
+++ b/src/AI/Retrieval/ScopedMailKnowledgeRetrieval.cs
@@ -176,7 +176,7 @@ internal sealed class ScopedMailKnowledgeRetrieval
     /// </para>
     /// </remarks>
     private async Task<string> SearchAsync(
-        [Description("The text to rank mail against, up to 512 characters. Quoted phrases, OR, and a leading - to exclude a word are understood; every other punctuation mark is ordinary text. Write the words you expect the mail itself to contain rather than the question you were asked.")]
+        [Description("The text to rank mail against, up to 512 characters. Quoted phrases, OR, and a leading - to exclude a word are understood; every other punctuation mark is ordinary text. Write the words you expect the mail itself to contain rather than the question you were asked, in the language that mail is likely written in: matching compares words rather than translating them, so a mailbox holding several languages is reached by a lookup per language.")]
         string queryText,
         [Description("Return only mail sent from this mail address. Matched as a whole address rather than as a fragment, without regard to case. Omit to match any sender.")]
         string? senderAddress = null,

--- a/src/Mcp/Tools/SearchEmailsTool.cs
+++ b/src/Mcp/Tools/SearchEmailsTool.cs
@@ -95,7 +95,7 @@ internal sealed class SearchEmailsTool(
         + "Returns one window of at most 50 results that nothing continues, so narrow the filters or write a different "
         + "query to reach other mail. Matching nothing is a normal empty result rather than an error.")]
     public async Task<SearchEmailsToolResult> SearchEmailsAsync(
-        [Description("The text to search for, up to 512 characters. Quoted phrases, OR, and a leading - to exclude a word are understood; every other punctuation mark is ordinary text. Required: a search with no text is a listing, which list_emails answers in a stable order and with a cursor.")]
+        [Description("The text to search for, up to 512 characters. Quoted phrases, OR, and a leading - to exclude a word are understood; every other punctuation mark is ordinary text. Write the words the mail itself is likely to contain, in the language it was written in rather than the language of your request: matching compares words rather than translating them, so a mailbox holding several languages is reached by a search per language. Required: a search with no text is a listing, which list_emails answers in a stable order and with a cursor.")]
         string queryText,
         [Description("MailFathom accounts to search, each named by its configured account identifier or by the display name it is published under. Omit to search every account this deployment serves; call list_accounts to see what they are. At most 64 may be named, and a name this deployment does not serve is refused rather than answered with an empty window.")]
         string[]? accounts = null,

--- a/tests/AI.UnitTests/Orchestration/MailAnsweringAgentCompositionTests.cs
+++ b/tests/AI.UnitTests/Orchestration/MailAnsweringAgentCompositionTests.cs
@@ -190,6 +190,37 @@ public sealed class MailAnsweringAgentCompositionTests
     }
 
     /// <summary>
+    /// The run's instruction states which language a lookup is worded in, and the argument's own description states it
+    /// again where the model reads what the argument is for — the two are one rule and a model that read only the
+    /// schema would otherwise word every lookup in the language of the question.
+    /// </summary>
+    [Fact]
+    public async Task Compose_TheSearchTool_TellsTheModelWhichLanguageALookupIsWordedIn()
+    {
+        // Arrange
+        var knowledgeSearch = new RecordingEmailKnowledgeSearch();
+        using var chatClient = ScriptedChatClient.Answering("nothing to look up");
+        var agent = AgentOver(chatClient, knowledgeSearch, OnePrimaryAccount, out _);
+
+        // Act
+        await agent.RunAsync("what arrived", session: null, options: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        var queryText = Assert.Single(OfferedTools(chatClient))
+            .JsonSchema
+            .GetProperty("properties")
+            .GetProperty(ScopedMailKnowledgeRetrieval.QueryArgumentName)
+            .GetProperty("description")
+            .GetString();
+
+        Assert.NotNull(queryText);
+        Assert.Contains(
+            "in the language that mail is likely written in",
+            queryText,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// A run that cannot send, delete, move, or mark mail is one composed with no such tool, which is a property of the
     /// composition rather than a rule written down beside it.
     /// </summary>

--- a/tests/AI.UnitTests/Orchestration/MailAnsweringInstructionsTests.cs
+++ b/tests/AI.UnitTests/Orchestration/MailAnsweringInstructionsTests.cs
@@ -1,0 +1,65 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.AI.Orchestration;
+using MailFathom.AI.Retrieval;
+using Xunit;
+
+namespace MailFathom.AI.UnitTests.Orchestration;
+
+/// <summary>Covers the rules the run's own instruction has to carry, which are the whole of what decides them.</summary>
+/// <remarks>
+/// A rule stated only in the instruction text is a rule nothing else in the process implements, so the text is where it
+/// is asserted. What each assertion protects is a behavior an operator would meet as a wrong answer rather than as a
+/// failure: an answer written in the language of the mail instead of the language of the question, or a mailbox
+/// reported as holding nothing because every lookup was worded in a language it does not carry.
+/// </remarks>
+public sealed class MailAnsweringInstructionsTests
+{
+    /// <summary>The instruction as one line, so an assertion is about what it says rather than about where it wraps.</summary>
+    private static readonly string Instruction = MailAnsweringInstructions.Text.ReplaceLineEndings(" ");
+
+    /// <summary>The language of an answer follows the question, because that is the one thing the caller did ask for.</summary>
+    [Fact]
+    public void Text_TheInstruction_StatesThatAnAnswerIsWrittenInTheLanguageOfTheQuestion()
+    {
+        // Assert
+        Assert.Contains(
+            "in the language the question was asked in, whatever language the mail is in",
+            Instruction,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>A quotation checked against the mail it came from has to be the words the mail carried.</summary>
+    [Fact]
+    public void Text_TheInstruction_StatesThatQuotedMailKeepsItsOwnWording()
+    {
+        // Assert
+        Assert.Contains("in its own wording", Instruction, StringComparison.Ordinal);
+        Assert.Contains("rendering into the question's language", Instruction, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The lexical half of retrieval matches a word against a word, so a lookup worded in the language of the question
+    /// reaches mail written in another language only as far as the vector half happens to carry it.
+    /// </summary>
+    [Fact]
+    public void Text_TheInstruction_StatesThatALookupIsWordedInTheLanguageTheMailIsLikelyWrittenIn()
+    {
+        // Assert
+        Assert.Contains(ScopedMailKnowledgeRetrieval.QueryArgumentName, Instruction, StringComparison.Ordinal);
+        Assert.Contains(
+            "in the language that mail is likely written in, which need not be the language you were asked in",
+            Instruction,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>One empty lookup is not a mailbox without an answer, and another language is one of the things to try before saying it is.</summary>
+    [Fact]
+    public void Text_TheInstruction_StatesThatAnEmptyLookupIsRetriedInAnotherLanguage()
+    {
+        // Assert
+        Assert.Contains("another language this mailbox plausibly holds", Instruction, StringComparison.Ordinal);
+    }
+}

--- a/tests/AI.UnitTests/Retrieval/PassageRelevanceInstructionsTests.cs
+++ b/tests/AI.UnitTests/Retrieval/PassageRelevanceInstructionsTests.cs
@@ -153,6 +153,20 @@ public sealed class PassageRelevanceInstructionsTests
             StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// A run that words its lookups in the language the mail is likely to carry retrieves extracts in a language other
+    /// than the question's, so a filter that read the difference as distance would undo what the lookup found.
+    /// </summary>
+    [Fact]
+    public void Text_TheInstruction_StatesThatAnExtractInAnotherLanguageIsNotLessRelevant()
+    {
+        // Assert
+        Assert.Contains(
+            "written in a language other than the lookup's is not less relevant for that reason",
+            PassageRelevanceInstructions.Text.ReplaceLineEndings(" "),
+            StringComparison.Ordinal);
+    }
+
     /// <summary>Reads one element of the query back out of the turn, through a parser rather than by searching the text for it.</summary>
     private static string ElementIn(string turn, string elementName) =>
         QueryElementIn(turn).Element(elementName)?.Value

--- a/tests/Mcp.UnitTests/Tools/AskMailToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/AskMailToolTests.cs
@@ -108,6 +108,36 @@ public sealed class AskMailToolTests
             });
     }
 
+    /// <summary>
+    /// A question asked in one language about mail written in another is the ordinary case for a multilingual mailbox,
+    /// and nothing this boundary owns reads either language: the question travels as it was asked, the citations are
+    /// read from the passages the run retrieved, and the bounds are counted in characters and messages.
+    /// </summary>
+    [Fact]
+    public async Task AskMailAsync_AnAnswerWrittenInTheQuestionsLanguageFromMailInAnother_PublishesTheSameCitationsAndBounds()
+    {
+        // Arrange
+        const string PolishQuestion = "ile ubezpieczyciel zgodził się zapłacić";
+        const string PolishAnswer = "Ubezpieczyciel zgodził się zapłacić 400, według faktury \"Quarterly invoice\".";
+        var answerer = new StubMailQuestionAnswerer().Answering(PolishAnswer, PassageOf(1), PassageOf(2));
+        var tool = ToolOver(answerer);
+
+        // Act
+        var result = await tool.AskMailAsync(PolishQuestion, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(answerer.LastQuestion);
+        Assert.Equal(PolishQuestion, answerer.LastQuestion.Text.Value);
+        Assert.Equal(PolishAnswer, result.Answer);
+        Assert.Equal(
+            [EmailIdentityAt(1).ToString(), EmailIdentityAt(2).ToString()],
+            result.Citations.Select(static citation => citation.StoredEmailId));
+        Assert.All(result.Citations, static citation => Assert.Equal("Quarterly invoice", citation.Subject));
+        Assert.False(result.AnswerTruncated);
+        Assert.False(result.CitationsTruncated);
+        Assert.False(result.RetrievalTruncated);
+    }
+
     /// <summary>An empty citation list is an ordinary answer: the mailbox was searched and held nothing about the question.</summary>
     [Fact]
     public async Task AskMailAsync_ARunThatRetrievedNothing_PublishesTheAnswerWithNoCitations()

--- a/tests/Mcp.UnitTests/Tools/SearchEmailsToolMetadataTests.cs
+++ b/tests/Mcp.UnitTests/Tools/SearchEmailsToolMetadataTests.cs
@@ -124,6 +124,30 @@ public sealed class SearchEmailsToolMetadataTests
         Assert.Equal(["queryText"], required);
     }
 
+    /// <summary>
+    /// Matching compares words rather than translating them, so a caller that words every search in the language it was
+    /// asked in reads a multilingual mailbox as one that holds nothing. The schema is where that is said, because the
+    /// caller writing the query is the only party that knows which languages the question could be about.
+    /// </summary>
+    [Fact]
+    public void AddMailFathomServer_DescribesTheQueryTextAsWordedInTheLanguageTheMailWasWrittenIn()
+    {
+        // Arrange, Act
+        var queryText = AdvertisedSearchEmailsTool()
+            .InputSchema
+            .GetProperty("properties")
+            .GetProperty("queryText")
+            .GetProperty("description")
+            .GetString();
+
+        // Assert
+        Assert.NotNull(queryText);
+        Assert.Contains(
+            "in the language it was written in rather than the language of your request",
+            queryText,
+            StringComparison.Ordinal);
+    }
+
     /// <summary>An argument nobody can interpret is an argument a model guesses at, so every one carries its own description.</summary>
     [Fact]
     public void AddMailFathomServer_DescribesEveryInputSchemaProperty()


### PR DESCRIPTION
A question asked in one language about mail written in another was answered badly in two places, and both were
properties of the instruction text rather than of the retrieval machinery — so both are fixed where they are stated.

## The answer

`MailAnsweringInstructions` now states that the answer is written in the language the question was asked in, whatever
language the retrieved mail is in, and that what the answer quotes from mail — a subject, a name, the phrase a claim
rests on — keeps its own wording, with a rendering into the question's language beside it where the claim turns on what
those words mean. That is what keeps a citation checkable: the quoted words have to be the words the cited message
carried.

## The lookup

The same instruction states that `queryText` is worded in the language the mail is likely to carry, which need not be
the language of the question, and that a lookup returning nothing useful is retried in another language the mailbox
plausibly holds before the run concludes that the mailbox does not answer. The extra lookups are ordinary lookups, under
the run ceilings every other question has, and nothing here is configurable.

`PassageRelevanceInstructions` says it from the other side: an extract in a language other than the lookup's is not less
relevant for that reason, so the second pass does not undo what the first one found.

## Both search surfaces

The rule is carried where the caller writing a query reads it — the `search_mail` argument the model writes, and the
`search_emails` argument an MCP client writes. The lexical index is built with one PostgreSQL text search configuration
for the whole deployment (`simple` by default, neither stemming nor dropping stop words), so matching compares words
rather than translating them and a mailbox holding several languages is reached by a lookup per language.

## What moves

`MailAnsweringInstructions.Version` is derived from the text, so an audited run records which revision answered it
without anything further being done. No configuration key, database column, tool argument, or result field changes, so
this breaks no published surface; what changes is the wording of two tool-argument descriptions and the answers a run
produces.

## Tests

- `MailAnsweringInstructionsTests` asserts the instruction carries both rules.
- `PassageRelevanceInstructionsTests` asserts the relevance filter is told a language difference is not distance.
- `MailAnsweringAgentCompositionTests` asserts the `search_mail` schema tells the model which language to word a lookup in.
- `SearchEmailsToolMetadataTests` asserts the advertised `queryText` description says the same to an MCP client.
- `AskMailToolTests` covers a run answering a Polish question from English extracts at the `ask_mail` boundary: the
  citations and every truncation flag are unchanged by any of this.

## Documentation

`docs/features/mail-answering.md` gains § *A question in one language, mail in another*, which records what the run does
and why the lexical half of retrieval cannot bridge the gap on its own. `docs/features/mcp-tools.md` and
`docs/users/usage.md` state the caller's half for `search_emails` and `ask_mail`.

Verification: `scripts/verify-full.sh` passed over exactly this content; 7141 unit tests, coverage collected.

Closes #851
