### PR TITLE
[#852] Document the analyzer's language boundary, and what a second language actually requires

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -116,9 +116,12 @@
 # hands the mail to a third party in order to establish whether it may be handed to one.
 # MAILFATHOM_PERSONAL_DATA_ANALYZER=http://presidio-analyzer:3000
 #
-# The two-letter code of the language every request states. The pinned image carries an English model and nothing else,
-# so changing this means supplying an analyzer configured for that language in the same edit; MailFathom reports unready
-# for as long as the analyzer has no model for what is named here.
+# The two-letter code of the language every request states — one per deployment, with no per-account or per-message
+# language and no detection. The pinned image carries an English model and an English recognizer registry, so changing
+# this means supplying an analyzer built for that language in the same edit: MailFathom reports unready for as long as
+# the analyzer recognises nothing for what is named here, rather than falling back to English. Which identifiers each
+# language reaches, and what building such an image takes, is in
+# docs/operations/personal-data-analyzer-languages.md.
 # MAILFATHOM_PERSONAL_DATA_LANGUAGE=en
 #
 # How sure the analyzer must be before a finding is redacted, from 0 to 1. Redaction acts on every finding whatever its
@@ -129,7 +132,8 @@
 # MAILFATHOM_PERSONAL_DATA_MINIMUM_CONFIDENCE=0.4
 #
 # The analyzer image. An immutable tag, and the same pin the Helm chart and the integration suite use, so an analyzer
-# reviewed against one is the analyzer running in the others.
+# reviewed against one is the analyzer running in the others. It is also where an image built for another language is
+# named, since a model is installed while an analyzer image is built rather than while it starts.
 # MAILFATHOM_PRESIDIO_IMAGE=ghcr.io/data-privacy-stack/presidio-analyzer:2.2.364
 
 ### Spam classification with a scanner

--- a/deploy/compose/compose.yaml
+++ b/deploy/compose/compose.yaml
@@ -195,7 +195,9 @@ services:
     # An immutable tag, like the database image and unlike MailFathom's own: this is a dependency the deployment operates
     # rather than a version it chooses. It is the same pin the Helm chart and the integration suite use, so an analyzer
     # reviewed against one is the analyzer running in the others. MIT-licensed, and it loads an MIT-licensed spaCy model —
-    # both are recorded in THIRD_PARTY_LICENSES.md.
+    # both are recorded in THIRD_PARTY_LICENSES.md. It is built for English alone, and a model is installed while the
+    # image is built rather than while it starts, so an override here is how a deployment runs the analyzer in another
+    # language — docs/operations/personal-data-analyzer-languages.md states what that takes.
     image: ${MAILFATHOM_PRESIDIO_IMAGE:-ghcr.io/data-privacy-stack/presidio-analyzer:2.2.364}
     restart: unless-stopped
     healthcheck:

--- a/deploy/helm/mailfathom/values.schema.json
+++ b/deploy/helm/mailfathom/values.schema.json
@@ -347,7 +347,7 @@
             "language": {
               "type": "string",
               "pattern": "^[a-z]{2}$",
-              "description": "The two-letter code of the language every request states. The pinned image carries an English model and nothing else, so changing this means supplying an analyzer configured for that language in the same edit."
+              "description": "The two-letter code of the language every request states, one per release. The pinned image carries an English model and an English recognizer registry, so changing this means supplying an analyzer built for that language in the same edit; the pod reports unready rather than falling back to English."
             },
             "minimumConfidence": {
               "type": "number",

--- a/deploy/helm/mailfathom/values.yaml
+++ b/deploy/helm/mailfathom/values.yaml
@@ -204,9 +204,12 @@ personalDataScanning:
     # docs/features/sensitive-content-scanning.md states what is given up.
     endpoint: ""
 
-    # The two-letter code of the language every request states. The image below carries an English model and nothing
-    # else, so changing this means supplying an analyzer configured for the language in the same edit; the pod reports
-    # unready for as long as the analyzer has no model for what is named here.
+    # The two-letter code of the language every request states — one per release, with no per-account or per-message
+    # language and no detection. The image below carries an English model and an English recognizer registry, so
+    # changing this means supplying an analyzer built for that language in the same edit: the pod reports unready for as
+    # long as the analyzer recognises nothing for what is named here, rather than falling back to English. Which
+    # identifiers each language reaches, and what building such an image takes, is in
+    # docs/operations/personal-data-analyzer-languages.md.
     language: en
 
     # How sure the analyzer must be before a finding is redacted, from 0 to 1. Redaction acts on every finding whatever
@@ -220,6 +223,8 @@ personalDataScanning:
     # An immutable tag naming the analyzer release, like the database image above and unlike the application image: this
     # is a dependency the chart operates rather than a version a deployment chooses. It is the same pin the Compose
     # deployment and the integration suite use, so an analyzer reviewed against one is the analyzer running in the others.
+    # It is also where an image built for another language is named, since a model is installed while an analyzer image
+    # is built rather than while it starts, and this Deployment mounts no analyzer configuration.
     image:
       registry: ghcr.io
       repository: data-privacy-stack/presidio-analyzer

--- a/deploy/quadlet/mailfathom-presidio.container
+++ b/deploy/quadlet/mailfathom-presidio.container
@@ -21,6 +21,11 @@ After=network-online.target
 # rather than a version it chooses. It is the same pin the Compose deployment, the Helm chart, and the integration suite
 # use, so an analyzer reviewed against one is the analyzer running in all of them. The image is MIT-licensed and loads an
 # MIT-licensed spaCy model; THIRD_PARTY_LICENSES.md records both.
+#
+# It is built for English and nothing else: one spaCy model, and a recognizer registry declaring English alone. A model
+# is installed while that image is built rather than while it starts, so running the analyzer in another language means
+# an image of your own named here — docs/operations/personal-data-analyzer-languages.md states what building one takes
+# and which identifiers each language reaches.
 Image=ghcr.io/data-privacy-stack/presidio-analyzer:2.2.364
 ContainerName=mailfathom-presidio
 

--- a/deploy/quadlet/mailfathom.container
+++ b/deploy/quadlet/mailfathom.container
@@ -114,6 +114,10 @@ Environment=Persistence__Password__SecretReference=systemd-credential:mailfathom
 # operate one, keeping it inside your own network, and then install no analyzer unit at all.
 # docs/features/sensitive-content-scanning.md states what each category hides and what pointing the endpoint outside the
 # deployment gives up.
+# The language is one per deployment and the analyzer image below has to have been built for it: the pinned image carries
+# an English model and an English recognizer registry, so naming another code here leaves the unit unready rather than
+# scanning in that language. docs/operations/personal-data-analyzer-languages.md states what a second language takes and
+# which identifiers each language reaches.
 #Environment=SensitiveContent__Pii__Enabled=true
 #Environment=SensitiveContent__PersonalDataAnalyzer__Endpoint=http://mailfathom-presidio:3000
 #Environment=SensitiveContent__PersonalDataAnalyzer__Language=en

--- a/docs/features/sensitive-content-scanning.md
+++ b/docs/features/sensitive-content-scanning.md
@@ -480,6 +480,37 @@ every switched-on category has **at least one** entity the analyzer knows, which
 scanned for and never found; it deliberately does not require all of them, because a narrower registry costs recall
 inside a category that still works.
 
+That rule is right and it has a consequence worth stating plainly: a category can be half unreachable while the
+deployment reads healthy. `NationalIdentifier` covers 27 analyzer entities, of which the shipped image knows `US_SSN`
+and `US_ITIN`; the category passes the probe on those two while `PL_PESEL` — also one of its entities — is not looked
+for at all. Nothing is logged, because nothing went wrong: the analyzer was asked what it knows and answered.
+
+### One language, chosen once for the deployment
+
+`SensitiveContent:PersonalDataAnalyzer:Language` is a single two-letter code. It is stated on every request, there is no
+per-account, per-folder, or per-message language and no detection, and it is part of the detector revision a finding
+carries — so the same text asked in two languages is two results, and changing it marks derived text stale.
+
+**A recognizer exists only for the languages it is registered for.** This is the mechanism behind the paragraph above:
+the analyzer's registry declares each recognizer against a language, and one not declared for the configured language is
+absent rather than weaker. The shipped image's registry names a recognizer for eleven languages and ships most of the
+locale-specific ones switched off, so what a category can find is decided by the language before it is decided by
+anything MailFathom configures. `en` and `it` are the two languages under which all five default categories have
+something behind them; `es` and `pl` leave `IdentityDocument` with nothing, and the remaining seven leave
+`PaymentCard`, `NationalIdentifier`, and `IdentityDocument` empty — which the readiness probe refuses on, naming the
+category.
+
+**Polish is the case worth naming**, because it is where the two rules meet. Its only entry in the registry is
+`PL_PESEL`; there is no Polish passport recognizer and no Polish identity-card one, while several other locales carry
+both. So the two identifiers Polish correspondence carries most are the two with nothing to switch on, and a Polish
+deployment either adds a recognizer for them or drops `IdentityDocument` and accepts that those numbers stay in the
+text.
+
+Asking in a language the analyzer's own image was not built for is a refusal rather than a downgrade: the entity probe
+answers nothing, the deployment reports itself unready, and no scan runs against a fallback. What it takes to make a
+second language work — the model, the image, the registry, and the MailFathom-side entry a new entity needs — is
+[the analyzer's language](../operations/personal-data-analyzer-languages.md).
+
 ### The confidence floor
 
 The analyzer scores every finding, and redaction acts on a finding without weighing it. The floor is therefore the only

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -339,7 +339,7 @@ nowhere to ask **fails startup** rather than running unprotected.
 | `SensitiveContent:Pii:Suppressions:<n>:Category` | string | — | As above | restart |
 | `SensitiveContent:Pii:Suppressions:<n>:Rule` | string | — | As above | restart |
 | `SensitiveContent:PersonalDataAnalyzer:Endpoint` | string | unset | Required once `Pii` is on, and an absolute `http` or `https` address; read by nothing while that switch is off | restart |
-| `SensitiveContent:PersonalDataAnalyzer:Language` | string | `en` | Two lowercase letters, naming a language the analyzer loads a model for | restart |
+| `SensitiveContent:PersonalDataAnalyzer:Language` | string | `en` | Two lowercase letters, naming a language the analyzer loads a model for and registers recognizers in. One per deployment, stated on every request, and part of the derivation stamp | restart |
 | `SensitiveContent:PersonalDataAnalyzer:MinimumConfidence` | double | `0.4` | 0 – 1 inclusive, compared inclusively by the analyzer. It decides which regions are replaced, so it is part of the derivation stamp and changing it marks earlier-derived rows stale | restart |
 | `SensitiveContent:MaximumAnalyzedCharacters` | int | `200000` | 1 – 10000000; text beyond it is dropped from the result rather than handed on unscanned. On the derived path that is what is *stored*, so lowering it truncates every message indexed afterwards and the value is part of the derivation stamp | restart |
 | `SensitiveContent:ScanTimeout` | TimeSpan | `00:00:05` | One second to two minutes, per call to one scanner | restart |
@@ -411,6 +411,13 @@ The analyzer block is read only while `Pii` is on. An address left behind under 
 inert, for the reason a category list under one is: it describes no protection, so refusing to start over it would be
 refusing over a comment. The reverse — the scanner on with no address, a relative or non-HTTP address, a language that is
 not two lowercase letters, or a floor outside 0 to 1 — fails startup naming the key.
+
+**`Language` is a code the analyzer has to have been built for**, and setting it is only the last of the steps that make
+a second language work: the model, the image, the analyzer's recognizer registry, its engine, and then this key. A code the analyzer registers
+nothing for leaves the deployment unready rather than falling back to English, and even a code it does register decides
+which of the eleven categories above can find anything — under `pl` the shipped registry knows one national identifier
+and no identity document at all. [The analyzer's language](personal-data-analyzer-languages.md) records what each
+language reaches and what changing it takes.
 
 The analyzed ceiling defaults to the same number as `EmailContent:MaxCharactersPerRead`, so an ordinary content read is
 analyzed whole and only something pathological reaches it.

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -394,6 +394,13 @@ outside gives up.
 The analyzer is attached to the `backend` network alone and publishes no port. It receives mail content in the clear and
 answers where the identifiers in it are, so nothing outside the host can reach it and MailFathom asks it over plain HTTP.
 
+**`MAILFATHOM_PERSONAL_DATA_LANGUAGE` is not a language switch on its own.** It states the one language every request
+is made in, and the pinned image is built for English alone — one model, and a recognizer registry declaring English.
+Naming another code leaves MailFathom unready rather than scanning in that language, because the analyzer answers that
+it recognises nothing for it. A second language means an image built for it, named in `MAILFATHOM_PRESIDIO_IMAGE`;
+[the analyzer's language](personal-data-analyzer-languages.md) records what that takes and which identifiers each
+language reaches.
+
 ## Spam scanning
 
 The stack has a fourth service, `spamassassin`, and it is not started either. It sits behind its own Compose profile, so

--- a/docs/operations/deployment-kubernetes.md
+++ b/docs/operations/deployment-kubernetes.md
@@ -396,6 +396,15 @@ boundary, and the feature page states what pointing it outside gives up.
 The analyzer's Service is ClusterIP with no value to change it, no ingress rule is rendered for it, and its pod mounts no
 service-account token. It is the pod in the release that reads mail content in the clear.
 
+**The language is a property of the image, not of the chart.** `personalDataScanning.analyzer.language` states the one
+language every request is made in, and the pinned image is built for English alone — one model, and a recognizer
+registry declaring English. Naming another code leaves the pod unready rather than scanning in that language. The
+analyzer Deployment mounts no configuration and takes no analyzer environment of its own, deliberately: a value per
+Presidio setting would be this chart publishing a partial copy of a third party's configuration schema. A second
+language is therefore an image of your own in `analyzer.image`, or `analyzer.deploy: false` and an analyzer you operate
+— [the analyzer's language](personal-data-analyzer-languages.md) records what building one takes and which identifiers
+each language reaches.
+
 **Resources and readiness.** The analyzer requests a gigabyte of memory and is limited to two, because it loads a language
 model before it serves anything and holds it for the life of the pod; below roughly a gigabyte it is killed while loading.
 Its startup probe allows five minutes of that. MailFathom itself comes up regardless and reports **unready** until the

--- a/docs/operations/deployment-quadlet.md
+++ b/docs/operations/deployment-quadlet.md
@@ -392,6 +392,13 @@ volumes, no configuration, and no `PublishPort=`. It receives request bodies and
 `mailfathom-backend.network` alone and reachable from MailFathom and nothing else. It needs no `UserNS=keep-id` either,
 because nothing in it reads a file you own.
 
+**The language line is the one that needs the image behind it.** The commented `SensitiveContent__PersonalDataAnalyzer__Language`
+line names `en`, and the pinned image is built with an English model and an English recognizer registry. Naming another
+code there leaves MailFathom permanently unready rather than scanning in that language: the analyzer answers that it
+recognises nothing for it. Running the analyzer in a second language means an image of your own, named on the `Image=`
+line of the copied unit — [the analyzer's language](personal-data-analyzer-languages.md) records what that takes and
+which identifiers each language reaches.
+
 ## Spam scanning
 
 The same shape, and the same default: `mailfathom-spamassassin.container` is a file you either copy or do not, and not

--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -425,7 +425,7 @@ equally often. They cover each category the two scanners look for unless a deplo
 | A JSON Web Token | `Secrets` / `JsonWebToken` | the secret rule corpus |
 | A database connection string carrying its password | `Secrets` / `ConnectionString` | the secret rule corpus |
 | A download link whose query string is the credential | `Secrets` / `CredentialUrl` | the secret rule corpus |
-| A payment card number | `Pii` / `PaymentCard` | the analyzer, in any language |
+| A payment card number | `Pii` / `PaymentCard` | the analyzer, asked in English, Spanish, Italian, or Polish |
 | An IBAN | `Pii` / `BankAccount` | the analyzer, in any language |
 | A medical licence number | `Pii` / `HealthIdentifier` | the analyzer, in any language |
 | A PESEL | `Pii` / `NationalIdentifier` | the analyzer, asked in Polish |
@@ -435,8 +435,11 @@ equally often. They cover each category the two scanners look for unless a deplo
 **Which of the personal identifiers a deployment finds follows the language it asks the analyzer in**, because a
 recogniser for a country's identification number is registered for one language and is not loaded for the others. A
 deployment on the default `en` finds the social security and passport numbers and never the PESEL; one configured for
-`pl` finds the PESEL and neither of the other two. The three global ones are found either way. A decoy nothing reports
-is therefore worth checking against `SensitiveContent:PersonalDataAnalyzer:Language` before it is read as a defect.
+`pl` finds the PESEL and neither of the other two. The IBAN and the medical licence number are found either way,
+because the recognisers behind them are registered for no particular language, and the payment card in the four its
+recogniser names. A decoy nothing reports is therefore worth checking against
+`SensitiveContent:PersonalDataAnalyzer:Language` before it is read as a defect —
+[the analyzer's language](personal-data-analyzer-languages.md) has the whole table.
 
 **Every value is fabricated at run time and is structurally valid.** A payment card passes Luhn, an IBAN its
 remainder, a PESEL its weighted sum, a medical licence its own check digit — an identifier that failed its validator

--- a/docs/operations/personal-data-analyzer-languages.md
+++ b/docs/operations/personal-data-analyzer-languages.md
@@ -1,0 +1,230 @@
+# The analyzer's language, and what a second one requires
+
+<!-- describes: src/Infrastructure/SensitiveContent/PersonalData/**, src/Host/Configuration/SensitiveContent/PersonalDataAnalyzerOptions.cs, deploy/compose/compose.yaml, deploy/quadlet/mailfathom-presidio.container, deploy/helm/mailfathom/values.yaml -->
+
+> [!WARNING]
+> Some of the steps on this page are performed in a product this project does not control. Any screen, menu, or field
+> named here can be renamed or moved there at any time. Where this page and that product's own documentation disagree,
+> the product's documentation is right.
+
+The personal-data scanner asks its analyzer in exactly one language, named once for the whole deployment by
+[`SensitiveContent:PersonalDataAnalyzer:Language`](configuration-reference.md#sensitivecontent). A mailbox is not
+single-language — a Polish deployment receives English mail and an English one receives Polish mail — so this page
+states what that one language buys, what it leaves unreachable, and what it actually takes to change it.
+[The personal-data scanner](../features/sensitive-content-scanning.md#the-personal-data-scanner) records what the
+feature does with what it finds; this page is about what it is able to find at all.
+
+## What the shipped analyzer is configured with
+
+The analyzer image the three deployment shapes pin reads **three** configuration files, each named by an environment
+variable of its own and each baked into the image at build time:
+
+| Variable | Default file in the image | What it decides |
+| --- | --- | --- |
+| `NLP_CONF_FILE` | `presidio_analyzer/conf/default.yaml` | Which NLP framework runs and which model is loaded per language |
+| `RECOGNIZER_REGISTRY_CONF_FILE` | `presidio_analyzer/conf/default_recognizers.yaml` | Which recognizers exist, which are switched on, and which languages each serves |
+| `ANALYZER_CONF_FILE` | `presidio_analyzer/conf/default_analyzer.yaml` | Which languages the engine answers for at all |
+
+As shipped, all three say English and only English: the NLP configuration loads one spaCy model, and both the registry
+and the engine declare `supported_languages: [en]`. Nineteen entities are reachable that way, which is what a deployment
+that never touches this page is scanning with.
+
+**A model is installed while the image is built, not while it starts.** The image's build step reads the NLP
+configuration and downloads the models it names, so a configuration file mounted over the running container names a
+model that is not on disk and the analyzer fails to load rather than fetching it. That single fact is what makes every
+route below either a derived image or a mount *plus* an install step, and it is why no environment variable on the
+analyzer container enables a language.
+
+## One language per deployment, and what the probe does about it
+
+`Language` is a scalar validated to two lowercase letters. It is written into the `language` argument of every
+`/analyze` call and of the entity probe MailFathom's readiness check makes, and there is no per-account, per-folder, or
+per-message language and no detection. It is also part of the detector revision every finding carries, so changing it
+marks derived text written under the old one stale — [derived
+data](../features/sensitive-content-scanning.md#derived-data-is-written-redacted-and-stamped) records what that costs.
+
+The readiness probe asks the analyzer which entities it recognises **in that language** and requires each switched-on
+category to have **at least one** of them. That rule is right — a narrower registry costing recall inside a category
+that still works should not refuse a start — but it means a category can be half unreachable while the deployment reads
+healthy. `NationalIdentifier` is the worked example: it covers 27 analyzer entities, of which the shipped image
+registers `US_SSN` and `US_ITIN` under `en`. `PL_PESEL` is not among them, so a PESEL in Polish correspondence is not
+found, no log line says so, and the probe passes on the strength of the two it does know.
+
+What the probe does catch is a category with *nothing* behind it, and that is the ordinary result of naming a language
+the image was not built for. Two failures, in the order an operator meets them:
+
+- **The language is not in the analyzer's registry at all.** The entity probe answers an empty list, and MailFathom
+  reports `81002` naming `SensitiveContent:PersonalDataAnalyzer:Endpoint` on its readiness log. This is what setting
+  `Language: pl` against the unmodified image does — not a degraded scan, and not a fall back to English.
+- **The language is registered, but a switched-on category has no entity in it.** The probe names that category in the
+  `81002`. Under `pl` with the default category set, `IdentityDocument` is that category, for the reason the next
+  section gives.
+
+Either way the host comes up, reports itself unready, and stays out of traffic until the analyzer answers — it is not a
+startup failure. [Health endpoints](health-endpoints.md#the-three-probes) records what each probe consults.
+
+## What each language can actually find
+
+The registry the image ships names a recognizer for eleven languages, and most of the locale-specific entries in it are
+`enabled: false` — every German, Korean, Australian, Indian, Nigerian, Philippine, Canadian, Singaporean, South
+African, Swedish, Thai, and Turkish one, and the British ones other than the NHS number. Nine recognizers declare no
+language at all, so they are instantiated for whatever language list the registry is given: the ones behind
+`IBAN_CODE`, `EMAIL_ADDRESS`, `PHONE_NUMBER`, `DATE_TIME`, `IP_ADDRESS`, `MAC_ADDRESS`, and `MEDICAL_LICENSE`, plus two
+MailFathom maps to nothing.
+
+The table is what remains once both filters have been applied, assuming a model for the language has been installed and
+nothing in the registry has been switched on by hand. **Empty** names a default category with no entity behind it,
+which is the category the readiness probe refuses on.
+
+| Language | Beyond the language-agnostic entities | Default categories left empty |
+| --- | --- | --- |
+| `en` | `CREDIT_CARD`, `US_SSN`, `US_ITIN`, `US_BANK_NUMBER`, `US_PASSPORT`, `US_DRIVER_LICENSE`, `UK_NHS` | none |
+| `it` | `CREDIT_CARD`, `IT_FISCAL_CODE`, `IT_VAT_CODE`, `IT_PASSPORT`, `IT_IDENTITY_CARD`, `IT_DRIVER_LICENSE` | none |
+| `es` | `CREDIT_CARD`, `ES_NIF`, `ES_NIE` | `IdentityDocument` |
+| `pl` | `CREDIT_CARD`, `PL_PESEL` | `IdentityDocument` |
+| `de`, `fr`, `ko`, `kr`, `sv`, `th`, `tr` | nothing | `PaymentCard`, `NationalIdentifier`, `IdentityDocument` |
+
+**Polish gets one recognizer, and it is not the one most mail carries.** `PL_PESEL` is the only Polish entry the
+registry declares; there is no Polish passport recognizer and no Polish identity-card one, while Germany, Spain, India,
+Italy, Korea, the United Kingdom, and the United States each have a passport recognizer somewhere in the registry, and
+Germany and Italy an identity-card one. So the two identifiers
+Polish correspondence carries most are exactly the two with nothing to switch on, and `IdentityDocument` — a category on
+by default — has nothing behind it in that language. A Polish deployment either adds a recognizer for one of them, by
+the route below, or drops `IdentityDocument` from `SensitiveContent:Pii:Categories` and accepts that those numbers are
+not redacted.
+
+The other direction holds too, and it is not a defect: MailFathom's corpus names entities no shipped registry produces
+in any language, `FI_PERSONAL_IDENTITY_CODE` among them. The corpus is written against what the analyzer's recognizer
+set can be configured to report, not against one image's defaults — [the
+mapping](../features/sensitive-content-scanning.md#the-categories-and-which-are-on-by-default) is what an operator
+configures categories against, and an entity nothing reports simply never arrives.
+
+## Running the analyzer in another language
+
+Five steps, and only the last of them is on MailFathom's side.
+
+1. **Name the model.** Add a `lang_code` / `model_name` pair to the `models:` list in the NLP configuration. It is a
+   list rather than a scalar, so a second language is declared *beside* English rather than in place of it — which is
+   what a mixed mailbox wants, even though MailFathom asks in one of them at a time.
+
+   ```yaml
+   nlp_engine_name: spacy
+   models:
+     - lang_code: en
+       model_name: en_core_web_lg
+     - lang_code: pl
+       model_name: pl_core_news_md
+   ```
+
+2. **Get the model into the image.** Build a derived image from the pinned one with the file above supplied as the
+   build's NLP configuration, which is what installs the model. Mounting the file over a running container instead is a
+   half of that step rather than an alternative to it: the container then names a model nothing put on its disk, and it
+   fails to load. A mount is useful only on an image that already carries every model the mounted file names.
+
+3. **Widen the registry.** Add the language to `supported_languages:` in the recognizer-registry configuration and set
+   `enabled: true` on the entries you want, since most locale-specific ones ship off. A recognizer whose own
+   `supported_languages` does not list the language is dropped whatever else is configured, which is why widening the
+   list is not by itself enough for a locale-specific entry.
+
+4. **Widen the engine.** The analyzer configuration's own `supported_languages:` has to carry the same list as the
+   registry's; upstream states that requirement outright, and an engine narrower than its registry answers for a
+   language whose recognizers it will never reach.
+
+5. **Then tell MailFathom.** `SensitiveContent:PersonalDataAnalyzer:Language` names the new code last, once an analyzer
+   that answers for it is running. Setting the key first produces the unready deployment the previous section
+   describes.
+
+Where the image is named differs per deployment shape, and nothing else about them changes:
+
+| Shape | What names the analyzer image |
+| --- | --- |
+| Compose | `MAILFATHOM_PRESIDIO_IMAGE` in `.env`, which the analyzer service reads — see [Docker Compose](deployment-compose.md#personal-data-scanning) |
+| Quadlet | The `Image=` line in the copy of [`mailfathom-presidio.container`](https://github.com/Krzysztof318/MailFathom/blob/main/deploy/quadlet/mailfathom-presidio.container) that was installed |
+| Kubernetes | `personalDataScanning.analyzer.image`, or `analyzer.deploy: false` with an `endpoint` naming an analyzer you operate — see [Kubernetes](deployment-kubernetes.md#personal-data-scanning) |
+
+The chart's analyzer Deployment mounts no configuration and takes no analyzer environment of its own, deliberately: a
+chart value per Presidio setting would be this repository publishing a second, partial copy of a third party's
+configuration schema. A derived image carries its own configuration, and an analyzer that needs more than that is one
+the deployment operates itself.
+
+Whichever route is taken, **the image is no longer the pinned one every other MailFathom deployment runs**. Findings
+carry the analyzer profile they were produced under rather than the image tag, so nothing detects the substitution for
+you; treat the derived image as a dependency of your own, rebuild it when the pin here moves, and record it wherever
+your deployment records the images it runs. A derived image is also yours to distribute rather than MailFathom's, so
+its notices are yours to preserve — the analyzer and the models it loads are permissively licensed and
+[the third-party register](https://github.com/Krzysztof318/MailFathom/blob/main/THIRD_PARTY_LICENSES.md) names the terms
+this project reviewed them under.
+
+## Adding a recognizer MailFathom can use
+
+A recognizer the analyzer gains is not a recognizer MailFathom asks about. Every `/analyze` request names the entities
+it wants, computed from the switched-on categories and their suppressions, and an entity absent from that list is
+neither requested nor mapped when it arrives. So the analyzer-side half below is necessary and never sufficient: the
+last two steps are a code change in this repository.
+
+The Polish identity card is the worked case, because it exercises every step.
+
+**On the analyzer.** Declare a custom entry in the recognizer-registry configuration. A pattern recognizer needs a
+name, the entity it reports, one or more patterns with a base score, and the language it serves; context words lift the
+score of a match found near one of them, and they are per language, so they are translated rather than reused.
+
+```yaml
+  - name: PlIdCardRecognizer
+    type: custom
+    supported_entity: PL_ID_CARD
+    patterns:
+      - name: "Polish identity card"
+        regex: "\\b[A-Z]{3} ?\\d{6}\\b"
+        score: 0.5
+    supported_languages:
+      - language: pl
+        context: [dowód, osobisty, dowodu, tożsamości]
+```
+
+**Clear the floor.** The confidence floor travels on the request and the analyzer applies it, so a finding scored below
+`SensitiveContent:PersonalDataAnalyzer:MinimumConfidence` never crosses the process boundary. A base score under the
+floor — `0.4` by default — means the recognizer reports nothing unless a context word lifts it, which is a recognizer
+that works on some sentences and not others. Choose the base score against the floor the deployment runs, and remember
+that lowering the floor to accommodate one recognizer lowers it for every other one too.
+
+**In this repository.** Add the entity to
+[`PresidioEntityCorpus`](https://github.com/Krzysztof318/MailFathom/blob/main/src/Infrastructure/SensitiveContent/PersonalData/PresidioEntityCorpus.cs),
+spelled exactly as the analyzer spells it, inside the category it belongs to — `IdentityDocument` here. That is what
+puts it in the request, what makes it a rule an operator can suppress by name, and what maps the offsets back onto the
+text. Then move `MappingRevision` in the same file, because a changed mapping is a changed detector.
+
+**Then pay for the revision.** Moving it changes the detector revision every finding carries, and the derivation stamp
+computed from it, so every message already indexed reads as derived under a different configuration. The startup report
+counts them and
+[`SensitiveContent:RebuildStaleDerivedData`](configuration-reference.md#sensitivecontent) is what re-derives them — one
+full re-extraction, re-chunking, and re-embedding of the affected messages, billed again on a hosted embedding
+endpoint. That is the honest price of a new recognizer, and it is the reason to add the ones a deployment needs in one
+change rather than one at a time.
+
+## Verifying it took
+
+Ask the analyzer directly, from somewhere inside the deployment's own network, before restarting MailFathom against it:
+
+```bash
+curl --silent 'http://presidio-analyzer:3000/supportedentities?language=pl'
+curl --silent 'http://presidio-analyzer:3000/recognizers?language=pl'
+```
+
+An empty array from the first is the analyzer saying it has nothing for that language, which is exactly what MailFathom
+reports as unready. A list that omits an entity you configured is a recognizer that loaded for a different language or
+did not load at all, and the second call names the recognizers rather than their entities, which is what separates the
+two. Once the entities are there, the readiness probe is the last check: `/health` answers `Healthy` when every
+switched-on category has at least one of them, and the log names the category when one does not.
+
+## What this page does not cover
+
+**Asking in more than one language at a time.** `Language` is a scalar, one request states one language, and nothing
+detects a message's own. A deployment whose mail is genuinely mixed chooses the language its regulated identifiers are
+written in and accepts that the other language's locale-specific entities are not found. What survives the choice is
+the row of entities registered against no language — IBANs, email addresses, phone numbers, dates, network addresses,
+and medical licence numbers — and the named-entity ones, which are found as well as a model for the configured
+language reads the other language's text.
+
+**Recognizers MailFathom ships for a language.** The corpus above is the analyzer's vocabulary as this build maps it,
+and MailFathom neither carries recognizer definitions nor installs them. What a deployment adds, it adds to its own
+analyzer image by the route on this page.

--- a/docs/operations/toc.yml
+++ b/docs/operations/toc.yml
@@ -45,6 +45,9 @@
     - name: Changing the embedding model
       href: embedding-profiles.md
       description: Activating a new embedding profile without invalidating the vectors already stored, and what the change costs while it runs.
+    - name: The analyzer's language
+      href: personal-data-analyzer-languages.md
+      description: Which personal identifiers the personal-data analyzer can find in each language, and what running it in a second one takes.
 - name: Endpoints
   items:
     - name: The MCP endpoint

--- a/src/Host/Configuration/SensitiveContent/PersonalDataAnalyzerOptions.cs
+++ b/src/Host/Configuration/SensitiveContent/PersonalDataAnalyzerOptions.cs
@@ -43,9 +43,11 @@ internal sealed class PersonalDataAnalyzerOptions
 
     /// <summary>Gets or sets the two-letter code of the language every request states.</summary>
     /// <remarks>
-    /// The analyzer selects a model by it and refuses a language it loaded none for, which is what the readiness probe finds
-    /// out. The default is the language the shipped analyzer image carries a model for; changing it means changing the
-    /// analyzer's own configuration in the same edit.
+    /// One per deployment, with no per-account, per-folder, or per-message language and no detection. The analyzer selects
+    /// a model by it and registers a recognizer against it, so a language it was not built for is one it recognises nothing
+    /// in — which the readiness probe reports rather than falling back. The default is what the shipped analyzer image
+    /// carries; naming another code means an analyzer image built for that language in the same edit, because a model is
+    /// installed while such an image is built rather than while it starts.
     /// </remarks>
     public string Language { get; set; } = "en";
 

--- a/tools/SyntheticMail/Generation/SensitiveDecoys/SensitiveDecoyCatalog.cs
+++ b/tools/SyntheticMail/Generation/SensitiveDecoys/SensitiveDecoyCatalog.cs
@@ -16,9 +16,9 @@ namespace MailFathom.SyntheticMail.Generation.SensitiveDecoys;
 /// <para>
 /// <b>Two entries share a category on purpose.</b> A national identification number is found by a recogniser
 /// registered for one language, so the same category is reached through a Polish number and an American one and a
-/// deployment finds whichever its analyzer was asked in. Everything else is either language-agnostic — a payment card,
-/// an account number, a medical licence — or reached through the English-language recogniser that a default
-/// deployment loads.
+/// deployment finds whichever its analyzer was asked in. Everything else is either registered for no particular
+/// language — an account number, a medical licence — or reached through a recogniser the default English deployment
+/// loads; the payment card's own recogniser names four languages, English among them.
 /// </para>
 /// <para>
 /// Nothing in a message says a decoy is one. A corpus whose planted lines were marked would test a scanner against


### PR DESCRIPTION
The personal-data scanner asks its analyzer in exactly one language and nothing in the product said what that costs. The gap was found in a live mailbox: a PESEL stood unredacted while the deployment reported healthy, because the readiness probe passes a category that has *one* recognisable entity and `NationalIdentifier` had two under English.

Documentation is the whole deliverable. Every claim below was verified against the pinned analyzer release rather than taken from the issue body, and two of the issue's own figures turned out to be wrong: the registry names **eleven** languages rather than twelve, and Finnish is not among them — `FiPersonalIdentityCodeRecognizer` exists as a class but no registry entry lists it.

## What was added

`docs/operations/personal-data-analyzer-languages.md`, in the Deployment group of the operations navigation:

- the **three** configuration files the shipped image reads — the NLP engine, the recognizer registry, and the engine's own language list — and that all three say English only;
- that a model is installed while the image is *built*, which is why no environment variable on the analyzer container enables a language and why every route is a derived image;
- the two shapes a wrong language takes: an entity probe answering an empty list, and a switched-on category with nothing behind it, both reported as `81002` on readiness rather than as a startup failure or a fall back to English;
- a table of what each of the eleven languages can actually find and which default category it leaves empty — `en` and `it` leave none, `es` and `pl` leave `IdentityDocument`, and the other seven leave three of the five;
- the five steps a second language takes, per deployment shape;
- the custom-recogniser path worked end to end on the Polish identity document: the YAML entry, the confidence floor its base score has to clear, the `PresidioEntityCorpus` entry without which MailFathom never asks for the entity, the `MappingRevision` move, and the full re-derivation that revision move bills.

## What was corrected elsewhere

- `docs/features/sensitive-content-scanning.md` states the language boundary beside the at-least-one rule it follows from, with the `PL_PESEL` / `US_SSN` case as the worked example of a category that is half unreachable while the deployment reads healthy.
- `docs/operations/configuration-reference.md` says `Language` is one per deployment and the last of several steps rather than the only one.
- The three deployment pages and the Compose, Quadlet, and Helm assets now agree wherever they name the language or the analyzer image; the Helm values schema description agrees with them.
- Two claims read a payment card as language-agnostic when its recogniser names four languages — `docs/operations/local-development.md` and `SensitiveDecoyCatalog`'s remarks. Both corrected.

The two source-file edits are XML documentation comments. **No behaviour, configuration key, tool contract, database column, or deployment contract changes, so nothing here breaks a public surface.**

## Deliberately not done

The issue's own **Boundary** section names two findings as product limits rather than gaps in prose, and this change documents them instead of lifting them: asking in more than one language at a time would make the scalar a set and change the configuration surface, the probe, and the detector revision; and whether MailFathom ships Polish identity-document recognisers out of the box is a decision about what the product detects. Each needs its own issue if wanted.

## Verification

- `scripts/verify-full.sh` — passed, recorded `2026-08-15T16:32:33Z`.
- `scripts/test-agent-workflow.sh` — 212 passed, 0 failed.
- `scripts/build-docs-site.sh` — build succeeded; the only warnings are the four the script exempts, so every relative link and anchor on the new page resolves.
- `scripts/review-obligations.sh` — every row confirmed in the file it points at. `docs/users/installation.md`, `docs/users/getting-started.md`, and `docs/operations/configuration-sources.md` mention neither the analyzer nor the language key, so nothing there stopped being true; the doc-comment edit owes no test.
- `$check-docs-licenses` — Docs pass, Changelog n/a, Licenses n/a. No component is added: the analyzer image and the spaCy model it loads are already registered, and the register's existing line about preserving notices in a derived image is what the new page points at.

Closes #852
