### PR TITLE
[#865] Raise the default sensitive-content scan timeout to 15 seconds

### DIFF
--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -342,7 +342,7 @@ nowhere to ask **fails startup** rather than running unprotected.
 | `SensitiveContent:PersonalDataAnalyzer:Language` | string | `en` | Two lowercase letters, naming a language the analyzer loads a model for | restart |
 | `SensitiveContent:PersonalDataAnalyzer:MinimumConfidence` | double | `0.4` | 0 – 1 inclusive, compared inclusively by the analyzer. It decides which regions are replaced, so it is part of the derivation stamp and changing it marks earlier-derived rows stale | restart |
 | `SensitiveContent:MaximumAnalyzedCharacters` | int | `200000` | 1 – 10000000; text beyond it is dropped from the result rather than handed on unscanned. On the derived path that is what is *stored*, so lowering it truncates every message indexed afterwards and the value is part of the derivation stamp | restart |
-| `SensitiveContent:ScanTimeout` | TimeSpan | `00:00:05` | One second to two minutes, per call to one scanner | restart |
+| `SensitiveContent:ScanTimeout` | TimeSpan | `00:00:15` | One second to two minutes, per call to one scanner. A scan that misses it is refused rather than served unscanned, and on the derivation path that refusal ends the synchronization run carrying it, so a budget below what the analyzer spends on a large body leaves a folder repeating the same batch | restart |
 | `SensitiveContent:MaximumConcurrentScans` | int | `4` | 1 – 256, across the process | restart |
 | `SensitiveContent:RebuildStaleDerivedData` | bool | `false` | Read only while a scanner is on; re-derives every message whose derived text predates the current configuration | restart |
 

--- a/src/Application/SensitiveContent/SensitiveContentScanBounds.cs
+++ b/src/Application/SensitiveContent/SensitiveContentScanBounds.cs
@@ -28,9 +28,12 @@ public sealed record SensitiveContentScanBounds
     /// <summary>Gets the bounds a deployment that states none receives.</summary>
     /// <remarks>
     /// The analyzed ceiling matches what one content read may return in total, so an ordinary mail body is analyzed
-    /// whole and only something pathological reaches the ceiling at all.
+    /// whole and only something pathological reaches the ceiling at all. The timeout is set above what an analyzer
+    /// spends on a body of that size rather than at the shortest budget an ordinary scan fits in: a scan that misses it
+    /// is refused rather than served unscanned, and on the derivation path that refusal ends the synchronization run
+    /// carrying it, which leaves a folder repeating the same batch instead of advancing past it.
     /// </remarks>
-    public static SensitiveContentScanBounds Default { get; } = new(200_000, TimeSpan.FromSeconds(5), 4);
+    public static SensitiveContentScanBounds Default { get; } = new(200_000, TimeSpan.FromSeconds(15), 4);
 
     /// <summary>Gets the greatest number of characters one scan analyzes.</summary>
     /// <remarks>

--- a/tests/Application.UnitTests/SensitiveContent/SensitiveContentScanBoundsTests.cs
+++ b/tests/Application.UnitTests/SensitiveContent/SensitiveContentScanBoundsTests.cs
@@ -19,7 +19,7 @@ public sealed class SensitiveContentScanBoundsTests
 
         // Assert
         Assert.Equal(200_000, bounds.MaximumAnalyzedCharacters);
-        Assert.Equal(TimeSpan.FromSeconds(5), bounds.ScanTimeout);
+        Assert.Equal(TimeSpan.FromSeconds(15), bounds.ScanTimeout);
         Assert.Equal(4, bounds.MaximumConcurrentScans);
     }
 


### PR DESCRIPTION
Closes #865.

## What changed

`SensitiveContentScanBounds.Default.ScanTimeout` moves from 5 to 15 seconds, with the test that states
the documented defaults and the configuration reference following it.

Five seconds leaves no headroom above what the personal-data analyzer spends on a large body. A scan
that misses the budget is refused rather than served unscanned — which is the guard behaving as
designed — but on the derivation path that refusal propagates out of
`MailboxSynchronizer.StoreOccurrenceAsync` and ends the folder's synchronization run before it commits
its checkpoint. The next run reads the same batch, meets the same message, and fails again, so the
account backs off further while the folder makes no progress and a mailbox still being backfilled never
reaches its older mail.

The remarks on `Default` and the reference row now say what the budget is set against, so the next
reader does not have to rediscover why it is not the shortest value an ordinary scan fits in.

## Surface

The configuration schema's **default** moves. The key, its type, and its accepted range — one second to
two minutes — are unchanged, and no operator action is required: a deployment that sets `ScanTimeout`
explicitly is unaffected, and one that does not receives the wider budget on its next restart. Nothing
is re-derived, because `ScanTimeout` is not part of the derivation stamp.

## Verification

Left to the pipeline for this one; the change is three lines and the only assertion over the old value
is updated with it.
