### PR TITLE
[#867] Document the rootless-Podman teardown error and what it leaves running

### DIFF
--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -324,6 +324,41 @@ docker compose down --remove-orphans                # keeps the mail
 docker compose down --volumes --remove-orphans      # destroys it
 ```
 
+## The error a rootless-Podman teardown reports
+
+Taking the deployment down under Podman can end on this, and everything it reports on has already happened:
+
+```text
+Error: removing container <id> network: 1 error occurred:
+        * rootless netns: kill network process: permission denied
+```
+
+The containers are gone, the networks are gone, and the volume survives exactly as it does on any other `down`. What
+failed is the last step of the teardown rather than the teardown. Rootless Podman holds the network namespace its
+containers share open with a `pasta` process, and finishes by sending that process `SIGTERM` — and here the kernel
+refused the signal. No file mode is involved in that refusal. `pasta` runs confined by an AppArmor profile, that profile
+accepts a signal from an *unconfined* sender and from nobody else, and on a distribution that also ships an AppArmor
+profile for `podman` the sender is no longer unconfined, so no rule matches and the signal is denied. Podman reads that
+as the distribution's policy rather than as a defect of its own, and
+[closed the report on those terms](https://github.com/containers/podman/issues/27372).
+
+What it costs is one `pasta` process per teardown, left running with nothing to serve. `pgrep --list-full pasta` finds
+them: the ones Podman started carry `rootless-netns` in their arguments. Killing them by hand works, because your own
+shell is not what the policy refuses.
+
+Making the error stop is a change to the host's AppArmor policy, and the one thing there not to guess at is which
+profile refused whom. The denial says both:
+
+```bash
+journalctl --dmesg --grep 'apparmor="DENIED".*operation="signal"'   # /var/log/audit/audit.log where auditd runs
+```
+
+`profile=` names the process that was signalled and `peer=` the one that signalled it. What allows that pair is a rule
+in the profile `profile=` names — `signal (receive) set=("term") peer=<peer>,` added inside the `pasta` profile, which
+the `passt` package installs as `/etc/apparmor.d/usr.bin.pasta`, and applied with
+`apparmor_parser --replace /etc/apparmor.d/usr.bin.pasta`. That file belongs to the package, so a later upgrade of it
+asks what to do with the edit.
+
 ## The image
 
 `MAILFATHOM_IMAGE` defaults to `mailfathom:local`, a name no registry can serve, so `docker compose up --build` builds this

--- a/docs/operations/deployment-quadlet.md
+++ b/docs/operations/deployment-quadlet.md
@@ -345,6 +345,12 @@ Stopping the units leaves the volume. Removing it is `podman volume rm mailfatho
 because rebuilding it costs a full IMAP resynchronization — and everything that is not in the mailbox, the answering
 audit trail and the embeddings, is regenerated rather than refetched.
 
+Stopping them can also report `rootless netns: kill network process: permission denied`, which is the host's AppArmor
+policy refusing a signal rather than a unit that failed to stop. These containers are torn down through the same
+rootless network namespace as the Compose deployment's and end on the same step, so
+[the error a rootless-Podman teardown reports](deployment-compose.md#the-error-a-rootless-podman-teardown-reports)
+holds here unchanged.
+
 ## Uninstalling
 
 ```bash


### PR DESCRIPTION
Closes #867

Taking the Compose deployment down under rootless Podman can end on an error that reads as a failed teardown and is not one:

```
Error: removing container <id> network: 1 error occurred:
        * rootless netns: kill network process: permission denied
```

Podman removes the containers, removes the networks, and leaves the volume alone. What fails is the last step: the `SIGTERM` it sends to the `pasta` process holding the rootless network namespace comes back `EPERM`, because the host's AppArmor policy refuses the signal — `pasta` is confined and its profile accepts a signal from an unconfined sender only, which podman stops being on a distribution that ships an AppArmor profile for it. The podman maintainer closed [containers/podman#27372](https://github.com/containers/podman/issues/27372) on those terms, and Debian settled its own copy of it in [#1100135](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1100135) by dropping the `podman` profile.

## What this changes

- `docs/operations/deployment-compose.md` gains a section under *Uninstalling* stating what the error is, what survived it, that the leak is one `pasta` process per teardown, how to read the denied `profile=`/`peer=` pair out of the kernel log, and what rule allows the pair. It names no distribution version and no package version, because those age silently and the audit line answers the question on the host itself.
- `docs/operations/deployment-quadlet.md` reaches the same fact through a link rather than restating it: those containers are torn down through the same rootless network namespace and end on the same step.

Nothing in `deploy/` changes, and no MailFathom behavior is involved — the message comes from `containers/common`, `libnetwork/internal/rootlessnetns`, where `cleanupRootlessNetns()` collects the failed kill and `cleanup()` carries on with the rest of the teardown, which is why everything except that process is already gone when the operator reads the error.

## Verification

- `scripts/verify-full.sh` — passed.
- `scripts/test-agent-workflow.sh` — 212 passed, 0 failed.
- `scripts/build-docs-site.sh` — built with 0 errors, which is what validates the new cross-page anchor.
- `scripts/review-obligations.sh` — no production file changed, no `describes:` marker covers a changed path, no register triggered.
