### PR TITLE
[#867] Accept passt as a project word in the typo check

### DIFF
--- a/.config/typos.toml
+++ b/.config/typos.toml
@@ -96,5 +96,9 @@ extend-ignore-re = [
 HashiCorp = "HashiCorp"
 
 [default.extend-words]
+# `passt`, the project whose `pasta` binary rootless Podman starts to hold a network namespace open.
+# The Compose and Quadlet deployment pages name the package because that is what owns the AppArmor
+# profile an operator has to edit, and a dictionary reads the name as a misspelling of `passed`.
+passt = "passt"
 requeueing = "requeueing"
 unparseable = "unparseable"


### PR DESCRIPTION
Follow-up to #867, merged as #872.

`Typo check` failed on that pull request and the finding was real in the sense that only a dictionary can be: `passt` is the project whose `pasta` binary rootless Podman starts to hold a network namespace open, and both deployment pages name the package because it owns `/etc/apparmor.d/usr.bin.pasta`, which is the file an operator edits to stop the teardown error. The dictionary reads the name as a misspelling of `passed`.

This adds it to the vocabulary table in `.config/typos.toml`, which is the kind of entry that file's own header describes first: a spelling MailFathom uses on purpose and would go on using if a dictionary disagreed.

Verified with the same binary the workflow downloads, `typos v1.48.0`, over the two pages and the config itself — exit `0`. No other gate was run, at the owner's instruction.
