### PR TITLE
[#584] Grant permissions to a credential in configuration, and refuse an unknown one at startup

### DIFF
--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1,6 +1,6 @@
 # Administering a deployment
 
-<!-- describes: src/Host/Configuration/Endpoints/AdminEndpointOptions.cs, src/Host/Api/Admin*.cs, src/Host/Api/Embedding*.cs, src/Host/Api/Job*.cs, src/Host/Api/Mail*.cs, src/Host/Api/Spam*.cs, src/Host/Hosting/Startup/SurfaceIsolation.cs, src/Host/Hosting/Warnings/AdminTransportSecurityWarning.cs, src/Host/Security/Endpoints/TransportListenerBinder.cs, src/Host/Security/Transport/TransportRateLimiting.cs, src/Cli/**, scripts/install-mfctl.sh -->
+<!-- describes: src/Host/Configuration/Endpoints/AdminEndpointOptions.cs, src/Host/Api/Admin*.cs, src/Host/Api/Embedding*.cs, src/Host/Api/Job*.cs, src/Host/Api/Mail*.cs, src/Host/Api/Spam*.cs, src/Host/Hosting/Startup/SurfaceIsolation.cs, src/Host/Hosting/Warnings/AdminTransportSecurityWarning.cs, src/Host/Hosting/Warnings/TransportGrantStartupReport.cs, src/Host/Security/Endpoints/TransportListenerBinder.cs, src/Host/Security/Transport/TransportRateLimiting.cs, src/Cli/**, scripts/install-mfctl.sh -->
 
 How the `mfctl` command reaches a running deployment, and what that deployment has to have enabled before it will
 answer.

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -57,8 +57,9 @@ location exactly when the resource names the same one. A deployment whose resour
 document nothing could find, and OAuth sign-in would be unreachable for a reason no refusal would explain. Behind a
 reverse proxy, write the public URL and keep the path: `https://mail.example.test/api/admin`.
 
-> **Every authenticated caller may perform every administrative operation.** There is no permission model. The
-> credential is what bounds access, so provision one per client and rotate it like any other secret.
+> **Every authenticated caller may still perform every administrative operation.** A grant can now be written on an
+> entry — see below — and nothing on this surface varies by it yet, so the credential remains what bounds access.
+> Provision one per client and rotate it like any other secret.
 >
 > Weigh that against what the operations are. The endpoint serves reads — who a credential makes the caller, two
 > records of what a mailbox has had done to it and what has been read from it, where semantic search stands, and what
@@ -66,6 +67,49 @@ reverse proxy, write the public URL and keep the path: `https://mail.example.tes
 > writes that store a mailbox refresh token, start a provider bill, and erase what a folder has stored. Any credential
 > that can do the first can therefore do all of them, so an administrative key is as sensitive as the mailbox
 > credentials it can place, the histories it can read, the spend it can begin, and the mail it can dispose of.
+
+## What a credential may do
+
+Each entry states what the credentials it admits may do, as `Permissions`. This surface's half of the published set is
+six names, allocated so that the separations an operator would plausibly want to make are the ones they can:
+
+| Permission | What it covers |
+| --- | --- |
+| `mailfathom.admin.read` | The reads reporting the deployment's own state and no mail: embedding status and the activation preview, the loaded rules, a run's progress, the stopped-job list |
+| `mailfathom.admin.audit.read` | The per-account records derived from mail: the mailbox-mutation audit, the answering audit, the rules history, the spam classifications |
+| `mailfathom.admin.operate` | Asking the deployment to do work it can already do: running rules over an account, classifying an account, retrying or dropping a stopped job, cancelling a reindex |
+| `mailfathom.admin.credentials.write` | Storing a mailbox refresh token |
+| `mailfathom.admin.spend` | Activating the declared embedding model, which is the one operation that starts a provider bill |
+| `mailfathom.admin.erase` | Erasing the mail stored for a folder an account no longer mirrors |
+
+No permission implies another, so a credential that needs to read state and to run rules is granted both names. A
+`mailfathom.mail.*` name written here fails startup, naming the entry's index: it belongs to the MCP surface and would
+grant nothing on this one.
+
+`GET /api/admin/session` sits outside the model and needs no permission. It reports the credential the caller already
+presented and the version this deployment already publishes, so it discloses nothing a caller did not bring — and it is
+what every command reads first, `mfctl login` included. Requiring a permission for it would make that permission a
+component of every administrative grant.
+
+The rest of the reading is the same on both surfaces and is written once, under
+[what a credential may do](mcp-endpoint.md#what-a-credential-may-do): the grant belongs to the entry rather than to the
+block inside it, an absent `Permissions` key leaves the entry holding everything this surface publishes while
+`Permissions: []` grants nothing, an endpoint with no entry at all grants everything to every caller it serves, and
+`PermissionsFromTokenScopes` turns the list into a ceiling a token's own scopes narrow.
+
+Startup records what every entry resolved to, one line per entry, and names the ones that wrote no grant:
+
+```text
+info: MailFathom.Host.Hosting.Warnings.TransportGrantStartupReport
+      The administrative endpoint entry AdminEndpoint:Authentication:0 grants mailfathom.admin.read,
+      mailfathom.admin.operate to every credential it admits.
+```
+
+Nothing in those lines names a key, a public key, a token, an authorization server, or a subject: a grant is what the
+deployment wrote, never who presented something.
+
+**Nothing on this surface varies by the grant today.** The permissions are read, validated, carried on the authenticated
+caller, and reported at startup; every route still serves any authenticated caller, which is what the note above says.
 
 ## What the endpoint serves
 

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1,6 +1,6 @@
 # Administering a deployment
 
-<!-- describes: src/Host/Configuration/Endpoints/AdminEndpointOptions.cs, src/Host/Api/Admin*.cs, src/Host/Api/Embedding*.cs, src/Host/Api/Job*.cs, src/Host/Api/Mail*.cs, src/Host/Api/Spam*.cs, src/Host/Hosting/Startup/SurfaceIsolation.cs, src/Host/Hosting/Warnings/AdminTransportSecurityWarning.cs, src/Host/Hosting/Warnings/TransportGrantStartupReport.cs, src/Host/Security/Endpoints/TransportListenerBinder.cs, src/Host/Security/Transport/TransportRateLimiting.cs, src/Cli/**, scripts/install-mfctl.sh -->
+<!-- describes: src/Host/Configuration/Endpoints/AdminEndpointOptions.cs, src/Host/Api/Admin*.cs, src/Host/Api/Embedding*.cs, src/Host/Api/Job*.cs, src/Host/Api/Mail*.cs, src/Host/Api/Spam*.cs, src/Host/Hosting/Startup/SurfaceIsolation.cs, src/Host/Hosting/Warnings/AdminTransportSecurityWarning.cs, src/Host/Hosting/Warnings/TransportGrantStartupReport.cs, src/Domain/Access/MailFathomPermission.cs, src/Host/Security/Endpoints/TransportListenerBinder.cs, src/Host/Security/Transport/TransportRateLimiting.cs, src/Cli/**, scripts/install-mfctl.sh -->
 
 How the `mfctl` command reaches a running deployment, and what that deployment has to have enabled before it will
 answer.
@@ -75,16 +75,17 @@ six names, allocated so that the separations an operator would plausibly want to
 
 | Permission | What it covers |
 | --- | --- |
-| `mailfathom.admin.read` | The reads reporting the deployment's own state and no mail: embedding status and the activation preview, the loaded rules, a run's progress, the stopped-job list |
+| `mailfathom.admin.read` | The reads reporting the deployment's own state and no mail: what synchronization is doing per account and per folder, embedding status and the activation preview, the loaded rules, a run's progress, the stopped-job list |
 | `mailfathom.admin.audit.read` | The per-account records derived from mail: the mailbox-mutation audit, the answering audit, the rules history, the spam classifications |
 | `mailfathom.admin.operate` | Asking the deployment to do work it can already do: running rules over an account, classifying an account, retrying or dropping a stopped job, cancelling a reindex |
 | `mailfathom.admin.credentials.write` | Storing a mailbox refresh token |
 | `mailfathom.admin.spend` | Activating the declared embedding model, which is the one operation that starts a provider bill |
 | `mailfathom.admin.erase` | Erasing the mail stored for a folder an account no longer mirrors |
 
-No permission implies another, so a credential that needs to read state and to run rules is granted both names. A
-`mailfathom.mail.*` name written here fails startup, naming the entry's index: it belongs to the MCP surface and would
-grant nothing on this one.
+No permission implies another, so a credential that needs to read state and to run rules is granted both names. A name
+nothing publishes fails startup, naming the entry and the position in the list, so a misspelling is refused rather than
+read as a narrower grant than you meant; so is a name the same grant already carries. A `mailfathom.mail.*` name is
+refused for a second reason as well — it belongs to the MCP surface and would grant nothing on this one.
 
 `GET /api/admin/session` sits outside the model and needs no permission. It reports the credential the caller already
 presented and the version this deployment already publishes, so it discloses nothing a caller did not bring — and it is

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -1148,11 +1148,17 @@ No permission implies another, so a credential that needs two is granted two.
 block at once, and `Permissions` on it applies to every credential it admits. Two credentials to be granted differently
 are therefore two entries — which is what turns grouping, until now only a matter of tidiness, into a decision.
 
+**Nothing enforces a grant yet.** The permissions are read, validated, carried on the authenticated caller, and reported
+at startup; no tool and no route consults them, so every admitted caller still reaches everything its surface serves.
+Writing a grant states what a credential is meant to reach and starts refusing when the enforcement it describes ships.
+Read every sentence below as what the setting says rather than as what it currently stops.
+
 **An absent `Permissions` key and an empty list are opposites.** Writing no key at all leaves the entry holding
 everything its surface publishes, which is what makes a first deployment work before it is governed and what leaves an
-existing deployment unchanged on upgrade. Writing `Permissions: []` grants nothing, which is how a credential is retired
-without deleting its entry: it still authenticates, and on the administrative surface it can still read
-`GET /api/admin/session`, which needs no permission because it reports only what the caller already presented.
+existing deployment unchanged on upgrade. Writing `Permissions: []` grants nothing, which is how a credential will be
+retired without deleting its entry: it still authenticates, and on the administrative surface it will still read
+`GET /api/admin/session`, which needs no permission because it reports only what the caller already presented. Until
+enforcement ships, an emptied grant retires nothing — the credential goes on reaching every tool and every route.
 
 **A surface with no `Authentication` entry at all grants that surface's whole half**, because there is no entry for a
 grant to be written on. That is the unauthenticated posture the startup warning already reports.

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -1107,9 +1107,11 @@ same entries; the administrative one adds a single rule, stated with it below.
 | --- | --- | --- | --- | --- |
 | `…:<n>:ApiKey` | secret block | — | One [named secret](secret-provisioning.md#the-secret-block) with its own `Lifetime`; a second key is a second entry | restart; material per request |
 | `…:<n>:PublicKey` | secret block | — | One [named secret](secret-provisioning.md#the-secret-block) with its own `Lifetime`, resolving to one client's PEM public key. Startup refuses material that is not one, an RSA key below 2048 bits, and — explicitly — material carrying a private key | restart; material per request |
+| `…:<n>:Permissions` | string list | absent = everything this surface publishes | The [permissions](#what-a-credential-may-do--permissions) every credential this entry admits may hold; an empty list grants nothing. A name nothing publishes, a name belonging to the other surface, and a repeated name each fail startup naming the entry's index | restart |
+| `…:<n>:PermissionsFromTokenScopes` | bool | `false` | Narrows the list above by each token's own scopes instead of granting all of it. Refused on an entry that also carries `ApiKey` or `PublicKey`, neither of which can carry a scope | restart |
 | `…:<n>:OAuth:Resource` | string | — | Required; the canonical `https` URL clients reach this endpoint at — behind a proxy, the proxy's public URL. Every OAuth entry names the same one, because the endpoint publishes one metadata document at an address derived from it | restart |
-| `…:<n>:OAuth:RequiredScopes` | string list | empty | Scopes a token from *this entry's* servers must carry; empty accepts any token they issued for this resource | restart |
-| `…:<n>:OAuth:AdvertisedScopes` | string list | empty | Scopes published in `scopes_supported` for a client to ask for and checked on no token — `offline_access` is what a client needs to be issued a refresh token. Every required scope is published regardless, so a value repeating one is refused, as is one that is not a scope token | restart |
+| `…:<n>:OAuth:RequiredScopes` | string list | empty | Scopes a token from *this entry's* servers must carry; empty accepts any token they issued for this resource. A permission name is refused here, because requiring one would close the door on a caller the deployment meant to serve less | restart |
+| `…:<n>:OAuth:AdvertisedScopes` | string list | empty | Scopes published in `scopes_supported` for a client to ask for and checked on no token — `offline_access` is what a client needs to be issued a refresh token. Every required scope is published regardless, so a value repeating one is refused, as is one that is not a scope token, as is a permission name — the grant that reads one advertises it already | restart |
 | `…:<n>:OAuth:AuthorizationServers:<m>:Name` | string | — | Required; the identity diagnostics use, and unique across every entry because it composes the scheme its validator registers under | restart |
 | `…:<n>:OAuth:AuthorizationServers:<m>:Issuer` | string | — | Required; a well-formed `https` issuer, compared against `iss` exactly, and unique across every entry | restart |
 | `…:<n>:OAuth:AuthorizationServers:<m>:MetadataAddress` | string | unset | An absolute `https` URL on the issuer's own host; overrides issuer-derived discovery | restart |
@@ -1122,6 +1124,51 @@ is longer than the checked one,
 [API keys](mcp-endpoint.md#api-keys) what a key is compared against, and
 [Key pairs](mcp-endpoint.md#key-pairs) what a client signs and what the deployment verifies — including the audience,
 expiry, and replay identifier an assertion carries, none of which is a setting.
+
+### What a credential may do — `Permissions`
+
+A permission is a named capability MailFathom publishes. The set is closed, so every name a grant can carry has a check
+behind it and a misspelling fails startup instead of reading as a narrower grant than it is. The two endpoints draw from
+disjoint halves, and the name says which half it belongs to.
+
+| Permission | Surface | What it covers |
+| --- | --- | --- |
+| `mailfathom.mail.read` | MCP | The tools that read the local mailbox copy: `list_accounts`, `list_emails`, `get_email_content`, `search_emails`. Where semantic retrieval is configured, searching places the caller's own query text with the embedding provider, so this is not an egress-free grant |
+| `mailfathom.mail.ask` | MCP | `ask_mail`, which answers from mail content by sending it to a model provider. It does not imply `mailfathom.mail.read`, and granting it is granting access to mail |
+| `mailfathom.admin.read` | administrative | The reads reporting the deployment's own state and no mail: embedding status and the activation preview, the loaded rules, a run's progress, the stopped-job list |
+| `mailfathom.admin.audit.read` | administrative | The per-account records derived from mail: the mailbox-mutation audit, the answering audit, the rules history, the spam classifications |
+| `mailfathom.admin.operate` | administrative | Asking the deployment to do work it can already do: running rules, classifying an account, retrying or dropping a stopped job, cancelling a reindex |
+| `mailfathom.admin.credentials.write` | administrative | Storing a mailbox refresh token |
+| `mailfathom.admin.spend` | administrative | Activating the declared embedding model, which is the one operation that starts a provider bill |
+| `mailfathom.admin.erase` | administrative | Erasing the mail stored for a folder an account no longer mirrors |
+
+No permission implies another, so a credential that needs two is granted two.
+
+**The grant belongs to the entry, not to the block.** An entry may carry an `ApiKey`, a `PublicKey`, and an `OAuth`
+block at once, and `Permissions` on it applies to every credential it admits. Two credentials to be granted differently
+are therefore two entries — which is what turns grouping, until now only a matter of tidiness, into a decision.
+
+**An absent `Permissions` key and an empty list are opposites.** Writing no key at all leaves the entry holding
+everything its surface publishes, which is what makes a first deployment work before it is governed and what leaves an
+existing deployment unchanged on upgrade. Writing `Permissions: []` grants nothing, which is how a credential is retired
+without deleting its entry: it still authenticates, and on the administrative surface it can still read
+`GET /api/admin/session`, which needs no permission because it reports only what the caller already presented.
+
+**A surface with no `Authentication` entry at all grants that surface's whole half**, because there is no entry for a
+grant to be written on. That is the unauthenticated posture the startup warning already reports.
+
+**`PermissionsFromTokenScopes` makes the list a ceiling rather than a grant.** With it, a token holds the published
+names its scopes carry *and* the entry lists, so the authorization server decides per subject within a bound the
+deployment fixed; a scope naming anything else — `openid`, `offline_access`, another resource's scope — is ignored, and
+a scope naming a permission the entry never listed grants nothing. It is available only where the entry's sole block is
+`OAuth`: neither a key nor a public key can carry a scope, so startup refuses the combination rather than asking a
+credential a question it cannot answer. Every such entry's ceiling is published in `scopes_supported`, which is what an
+operator creates in their authorization server; an entry granting from configuration publishes none of its permissions,
+because a client cannot ask for one.
+
+Startup records what every entry resolved to, one line per entry, so the posture is read on the first run rather than
+inferred later. [The MCP endpoint](mcp-endpoint.md#what-a-credential-may-do) and
+[the administrative endpoint](admin-endpoint.md#what-a-credential-may-do) each carry the lines their surface produces.
 
 ### Browser origins — `McpEndpoint:Cors`
 
@@ -1247,7 +1294,7 @@ request or per handshake. [Administering a deployment](admin-endpoint.md) is the
 | `AdminEndpoint:BindAddress` | string | `0.0.0.0` | An IP address; binds the clear-text socket, which `HttpsOnly` does not open | restart |
 | `AdminEndpoint:Port` | int | `8080` | 1–65535. The MCP endpoint's default as well, so enabling both without stating a port publishes one shared socket — see [sharing a socket](#sharing-a-socket) | restart |
 | `AdminEndpoint:Transport` | enum | `Http` | `Http`, `HttpAndHttps`, `HttpsOnly` — the same setting the MCP endpoint carries, read the same way | restart |
-| `AdminEndpoint:Authentication` | list of credentials | empty | Same shape and rules as [`McpEndpoint:Authentication:<n>`](#the-accepted-credentials--mcpendpointauthenticationn), with two additions: every `OAuth` block's `Resource` must end in `/api/admin`, because that is where these routes answer and what `mfctl` appends to find the metadata document; and a client assertion presented here names the audience `urn:mailfathom:admin` rather than `urn:mailfathom:mcp` | restart; material per request |
+| `AdminEndpoint:Authentication` | list of credentials | empty | Same shape and rules as [`McpEndpoint:Authentication:<n>`](#the-accepted-credentials--mcpendpointauthenticationn), with three additions: every `OAuth` block's `Resource` must end in `/api/admin`, because that is where these routes answer and what `mfctl` appends to find the metadata document; a client assertion presented here names the audience `urn:mailfathom:admin` rather than `urn:mailfathom:mcp`; and `Permissions` draws from the `mailfathom.admin.*` half of [the published set](#what-a-credential-may-do--permissions), so a `mailfathom.mail.*` name written here fails startup | restart; material per request |
 | `AdminEndpoint:Https:Endpoints:<n>` | list of profiles | empty | Same shape and rules as `McpEndpoint:Https:Endpoints:<n>`, read under the two `Transport` modes that terminate TLS | restart; material per handshake |
 | `AdminEndpoint:Https:Redirect` | block | on | Same shape and rules as `McpEndpoint:Https:Redirect`; its socket is this surface's own `BindAddress` and `Port`, so terminating TLS on both surfaces opens two clear-text ports that do not collide | restart |
 | `AdminEndpoint:RateLimiting` | block | bounded | Same shape, defaults, and rules as `McpEndpoint:RateLimiting` above; applied whether or not it is written | restart |

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -1100,7 +1100,7 @@ routing and listeners — while key and certificate material is read per request
 
 Each entry carries the block of whichever method judges it, and the block's presence is what selects that method — there
 is no separate setting naming it. As many entries may state any method as a deployment needs, and one entry may carry
-several blocks; an entry carrying none fails startup, named by its position. A grant written on an entry adds four more
+several blocks; an entry carrying none fails startup, named by its position. A grant written on an entry adds five more
 refusals and makes one combination of blocks impossible —
 [what a credential may do](#what-a-credential-may-do--permissions) is where they are stated. Both endpoints take the
 same entries; the administrative one adds a single rule, stated with it below.

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -1,6 +1,6 @@
 # Configuration reference
 
-<!-- describes: src/**/*Options.cs, src/Host/Configuration/** -->
+<!-- describes: src/**/*Options.cs, src/Host/Configuration/**, src/Domain/Access/MailFathomPermission.cs -->
 
 Every user-settable option, in one place, checked against the options classes that bind it. Each section's table
 states the key, its type, the value a deployment gets by writing nothing, the constraint startup enforces, and what a
@@ -1137,7 +1137,7 @@ disjoint halves, and the name says which half it belongs to.
 | --- | --- | --- |
 | `mailfathom.mail.read` | MCP | The tools that read the local mailbox copy: `list_accounts`, `list_emails`, `get_email_content`, `search_emails`. Where semantic retrieval is configured, searching places the caller's own query text with the embedding provider, so this is not an egress-free grant |
 | `mailfathom.mail.ask` | MCP | `ask_mail`, which answers from mail content by sending it to a model provider. It does not imply `mailfathom.mail.read`, and granting it is granting access to mail |
-| `mailfathom.admin.read` | administrative | The reads reporting the deployment's own state and no mail: embedding status and the activation preview, the loaded rules, a run's progress, the stopped-job list |
+| `mailfathom.admin.read` | administrative | The reads reporting the deployment's own state and no mail: what synchronization is doing, embedding status and the activation preview, the loaded rules, a run's progress, the stopped-job list |
 | `mailfathom.admin.audit.read` | administrative | The per-account records derived from mail: the mailbox-mutation audit, the answering audit, the rules history, the spam classifications |
 | `mailfathom.admin.operate` | administrative | Asking the deployment to do work it can already do: running rules, classifying an account, retrying or dropping a stopped job, cancelling a reindex |
 | `mailfathom.admin.credentials.write` | administrative | Storing a mailbox refresh token |

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -1100,7 +1100,9 @@ routing and listeners — while key and certificate material is read per request
 
 Each entry carries the block of whichever method judges it, and the block's presence is what selects that method — there
 is no separate setting naming it. As many entries may state any method as a deployment needs, and one entry may carry
-several blocks; the only entry that fails startup is one carrying none, named by its position. Both endpoints take the
+several blocks; an entry carrying none fails startup, named by its position. A grant written on an entry adds four more
+refusals and makes one combination of blocks impossible —
+[what a credential may do](#what-a-credential-may-do--permissions) is where they are stated. Both endpoints take the
 same entries; the administrative one adds a single rule, stated with it below.
 
 | Key | Type | Default | Constraint | Change |

--- a/docs/operations/mcp-client-oauth.md
+++ b/docs/operations/mcp-client-oauth.md
@@ -123,6 +123,19 @@ scope, from its own name.
 If you require no scope, create the client scope anyway and call it something descriptive. It exists to carry the
 mapper.
 
+**Decide here whether a token should also carry MailFathom permissions.** It has to when the entry you write in
+[step 7](#7-write-the-mailfathom-entry) sets `PermissionsFromTokenScopes`, which is what lets your authorization server
+decide per subject what an admitted caller may do rather than the deployment granting every token the same thing. Create
+one further client scope per permission you intend a token to bring, named exactly as MailFathom publishes it —
+`mailfathom.mail.read`, `mailfathom.mail.ask`, or on the administrative endpoint one of the `mailfathom.admin.*` names
+[the reference](configuration-reference.md#what-a-credential-may-do--permissions) lists. The spelling is compared byte
+for byte, so a differently cased or padded name is a different scope and grants nothing. Leave **Include in token scope**
+on, as above, and assign each to the client in [step 4](#4-register-an-application-for-the-client) — a scope the client
+never receives is a permission the caller never holds. Step 8's metadata document lists exactly the ones to create: an
+entry that narrows by token scopes publishes its whole ceiling in `scopes_supported`, and one that grants from
+configuration publishes none of its permissions, because no client can ask for one. Skip this whole paragraph if you
+write the grant in configuration instead, which is the only form available where your server cannot mint custom scopes.
+
 **Decide here whether clients should hold a refresh token.** A client asks for one by naming `offline_access`, and it
 learns to ask by reading that scope in MailFathom's metadata document — so if you do not advertise it, a client asks
 only for the scope above and its user signs in again whenever the access token expires, typically hourly. It goes in
@@ -261,6 +274,22 @@ opens the discovery document, and its `issuer` field is the value to copy.
 
 Nothing else about the server is configured here: MailFathom finds the discovery document itself, at addresses it derives
 from the issuer, and takes the key set address out of it.
+
+The entry writes down no grant, so every token it admits reaches everything the MCP surface publishes. To bound them,
+add `Permissions` beside `OAuth` — and add `"PermissionsFromTokenScopes": true` as well where the scopes you created in
+step 2 should narrow the list per subject:
+
+```json
+{
+  "OAuth": { "…": "as above" },
+  "Permissions": [ "mailfathom.mail.read" ],
+  "PermissionsFromTokenScopes": true
+}
+```
+
+Both settings sit on the entry rather than inside the `OAuth` block, because the grant belongs to the credential entry
+and applies to every block in it; [what a credential may do](mcp-endpoint.md#what-a-credential-may-do) has the whole
+reading, including what an empty list means and why the setting is refused beside a key.
 
 The section is read once while the host is composed, so this takes effect on restart.
 

--- a/docs/operations/mcp-client-oauth.md
+++ b/docs/operations/mcp-client-oauth.md
@@ -332,7 +332,10 @@ $ curl -sS https://mail.example.com/.well-known/oauth-protected-resource/mcp | j
 Check `resource` against what you will type into the client, and `authorization_servers` against your issuer. A
 deployment configuring several authorization servers publishes them all here, and a client may use only the first —
 order them accordingly. `scopes_supported` is what a client will ask for, which is why `offline_access` appears in it
-without being required: an absence here is a client that never asks for a refresh token.
+without being required: an absence here is a client that never asks for a refresh token. An entry setting
+`PermissionsFromTokenScopes` publishes its whole ceiling here as well, so the permission names in this field are exactly
+the client scopes to create in your authorization server — the document above is from a deployment that sets none. An
+entry granting from configuration publishes none of its permissions, because no client can ask for one.
 
 **An unauthenticated request is refused, and says where to authorize:**
 

--- a/docs/operations/mcp-client-oauth.md
+++ b/docs/operations/mcp-client-oauth.md
@@ -136,6 +136,12 @@ entry that narrows by token scopes publishes its whole ceiling in `scopes_suppor
 configuration publishes none of its permissions, because no client can ask for one. Skip this whole paragraph if you
 write the grant in configuration instead, which is the only form available where your server cannot mint custom scopes.
 
+**Nothing enforces a grant yet**, on either surface. What a token's scopes narrow is read, validated, carried on the
+authenticated caller and reported at startup, and no tool and no route consults it — so a scope you create here bounds
+what a credential is *meant* to reach rather than what it currently reaches, and starts refusing when the enforcement it
+describes ships. The scopes are worth creating now: an entry that narrows by them publishes them in `scopes_supported`,
+and a client that never receives one holds nothing under it the moment enforcement arrives.
+
 **Decide here whether clients should hold a refresh token.** A client asks for one by naming `offline_access`, and it
 learns to ask by reading that scope in MailFathom's metadata document — so if you do not advertise it, a client asks
 only for the scope above and its user signs in again whenever the access token expires, typically hourly. It goes in
@@ -275,9 +281,11 @@ opens the discovery document, and its `issuer` field is the value to copy.
 Nothing else about the server is configured here: MailFathom finds the discovery document itself, at addresses it derives
 from the issuer, and takes the key set address out of it.
 
-The entry writes down no grant, so every token it admits reaches everything the MCP surface publishes. To bound them,
+The entry writes down no grant, so every token it admits reaches everything the MCP surface publishes. To state a bound,
 add `Permissions` beside `OAuth` — and add `"PermissionsFromTokenScopes": true` as well where the scopes you created in
-step 2 should narrow the list per subject:
+step 2 should narrow the list per subject. It is a statement rather than a bound today, for the reason
+[step 2](#2-register-mailfathom-as-a-resource-in-the-provider) gives: nothing consults a grant yet, so every token this
+entry admits goes on reaching every tool whatever you write here.
 
 ```json
 {

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -1,6 +1,6 @@
 # The MCP endpoint and what protects it
 
-<!-- describes: src/Mcp/**, src/Host/Security/**, src/Infrastructure/Security/**, src/Common/OAuth/**, src/Common/ClientAssertions/**, src/Host/Hosting/Warnings/McpTransportAuthenticationWarning.cs, src/Host/Configuration/Endpoints/TransportClearTextRedirectOptions.cs, src/Host/Configuration/Endpoints/TransportListenerConfiguration.cs, src/Host/Configuration/Endpoints/ExternalListenerConfiguration.cs, src/Host/Configuration/Endpoints/ReverseProxyOptions.cs, src/Host/Hosting/Startup/ClearTextRedirectToHttps.cs, src/Host/Hosting/Warnings/TransportClearTextRedirectReport.cs, src/Host/Hosting/Warnings/ReverseProxyTrustWarning.cs, src/Host/Hosting/Warnings/McpTransportEncryptionWarning.cs -->
+<!-- describes: src/Mcp/**, src/Host/Security/**, src/Infrastructure/Security/**, src/Common/OAuth/**, src/Common/ClientAssertions/**, src/Host/Hosting/Warnings/McpTransportAuthenticationWarning.cs, src/Host/Hosting/Warnings/TransportGrantStartupReport.cs, src/Host/Configuration/Endpoints/TransportClearTextRedirectOptions.cs, src/Host/Configuration/Endpoints/TransportListenerConfiguration.cs, src/Host/Configuration/Endpoints/ExternalListenerConfiguration.cs, src/Host/Configuration/Endpoints/ReverseProxyOptions.cs, src/Host/Hosting/Startup/ClearTextRedirectToHttps.cs, src/Host/Hosting/Warnings/TransportClearTextRedirectReport.cs, src/Host/Hosting/Warnings/ReverseProxyTrustWarning.cs, src/Host/Hosting/Warnings/McpTransportEncryptionWarning.cs -->
 
 The MCP endpoint is how an agent reaches MailFathom. This page records what enabling it means operationally, what a client
 has to present to reach it, which browser origins it answers, which client applications it accepts a certificate from,
@@ -151,9 +151,11 @@ for each:
 makes a method impossible to select without configuring it, or to configure without selecting it: a key is the entry that
 turns keys on. There is no limit on how many entries state any method — a second key is a second entry, and a second
 authorization server may be either — and an entry may carry several blocks at once, which is a matter of how you group
-what you wrote rather than a distinction the endpoint draws. Exactly one shape of entry fails startup, named by its
-position: one carrying no block. So does a value written where the list belongs, because a value contributes no entries
-and would otherwise leave the endpoint served with no credential at all.
+what you wrote rather than a distinction the endpoint draws, until you write a grant on one:
+[what a credential may do](#what-a-credential-may-do) is where grouping acquires a consequence, and it names the one
+combination of blocks that is refused. Otherwise one shape of entry fails startup, named by its position: one carrying
+no block. So does a value written where the list belongs, because a value contributes no entries and would otherwise
+leave the endpoint served with no credential at all.
 
 A request is served when it satisfies **any one** of the entries. The credentials are told apart by shape: a client
 assertion is a JSON Web Token declaring MailFathom's own media type in its header, an access token is a JSON Web Token

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -462,7 +462,9 @@ operator's decision to configure it.
 **`AdvertisedScopes` publishes a scope for clients to ask for, and checks it on nothing.** The metadata document's
 `scopes_supported` is what a client should request — that is what
 [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) defines the field as — and it is not the same list as what a
-token is refused for lacking. Both lists reach the document; only `RequiredScopes` reaches the check.
+token is refused for lacking. Both lists reach the document; only `RequiredScopes` reaches the check. An entry that
+narrows by token scopes publishes its whole ceiling there too, for the reason
+[what a credential may do](#what-a-credential-may-do) gives: a client cannot ask for a permission nothing advertises.
 
 **`offline_access` is what the setting exists for.** A client asks for a refresh token by naming that scope, and the
 widely deployed authorization servers issue none without it. A client that reads your metadata document and asks for
@@ -611,14 +613,71 @@ The operational consequences are the ones that always applied to an unauthentica
 - **Treat the whole surface as read-only but not harmless.** The tools cannot send, delete, move, or mark mail as read, so
   the exposure is disclosure rather than modification. Disclosure of a mailbox is enough.
 
+### What a credential may do
+
+Every entry in `McpEndpoint:Authentication` states what the credentials it admits may do, as `Permissions` — a list of
+names MailFathom publishes. This surface's half is two:
+
+| Permission | What it covers |
+| --- | --- |
+| `mailfathom.mail.read` | The tools that read the local mailbox copy: `list_accounts`, `list_emails`, `get_email_content`, `search_emails` |
+| `mailfathom.mail.ask` | `ask_mail`, which answers from mail content by sending it to a model provider |
+
+Neither implies the other. `mailfathom.mail.ask` is not the weaker of the two — a cited answer returns mail content — and
+`mailfathom.mail.read` is not egress-free either: where semantic retrieval is configured, `search_emails` places the
+caller's own query text with the embedding provider before anything is read back. What withholding
+`mailfathom.mail.ask` stops is mail content going to a *chat* provider on a caller's behalf.
+
+An `mailfathom.admin.*` name written here fails startup, naming the entry's index: the two surfaces draw from disjoint
+halves, so a permission on the wrong one would sit in the file granting nothing.
+
+**The grant belongs to the entry.** An entry may carry an `ApiKey`, a `PublicKey`, and an `OAuth` block at once, and
+`Permissions` applies to every credential it admits — so two credentials to be granted differently are two entries.
+
+**Writing no `Permissions` key leaves the entry holding both.** That is the default a deployment gets for configuring
+nothing, and it is why nothing about this has to be configured before the endpoint works. Writing `Permissions: []`
+grants nothing instead: the credential still authenticates and holds no capability, which is how one is retired without
+its entry being deleted. An endpoint with no `Authentication` entry at all grants both to every caller it serves, for the
+same reason — there is no entry for a grant to be written on.
+
+**`PermissionsFromTokenScopes` turns the list into a ceiling.** On an entry whose sole block is `OAuth`, a token then
+holds the published names its scopes carry *and* the entry lists, so the authorization server decides per subject within
+a bound this deployment fixed. A scope naming anything else is ignored, and one naming a permission the entry never
+listed grants nothing. Startup refuses the setting beside an `ApiKey` or a `PublicKey`, because neither credential can
+carry a scope. A permission name written into `RequiredScopes` or `AdvertisedScopes` is refused too: the first would
+refuse at the door a caller meant to be served less, and the second is already published by the grant that reads it.
+
+Startup states what every entry resolved to, one line per entry, so the posture is one an operator reads on the first
+run rather than infers later. An entry that wrote no grant says so rather than being reported as though somebody had
+chosen what it holds:
+
+```text
+info: MailFathom.Host.Hosting.Warnings.TransportGrantStartupReport
+      The MCP endpoint entry McpEndpoint:Authentication:0 writes down no grant, so every credential it admits holds
+      mailfathom.mail.read, mailfathom.mail.ask — everything this surface publishes. Write a 'Permissions' list on the
+      entry to narrow it, or an empty one to grant nothing.
+```
+
+An entry that narrowed its grant is reported as what it grants, an entry with `PermissionsFromTokenScopes` as what it
+grants *at most*, and an entry granted nothing as `nothing` rather than as a line that lost its argument. An endpoint
+with no entry at all gets one line naming the section a grant would be written under. Nothing in the report names a key,
+a public key, a token, an authorization server, or a subject: a grant is what the deployment wrote, never who presented
+something.
+
+**What varies by the grant today is nothing.** The permissions are resolved from configuration, carried on the
+authenticated caller, and recorded at startup; the tool listing and the tool calls this endpoint serves do not yet
+consult them. Writing a narrower grant is therefore a statement about what a credential is meant to reach, and it starts
+being enforced when the enforcement it describes ships.
+
 ### What a credential decides, and what it does not
 
 **The endpoint asks whether this is a caller the deployment serves, and of a token also which person it names.** Beyond
 that, every tool call resolves the accounts the configured owner controls and refuses anything outside them, whichever
 credential got the caller in. Two admitted callers therefore see the same mailboxes — which is exactly why a token has to
 name an authorized subject: admitting a colleague of the same tenant would admit them to the owner's mail rather than to
-their own. Per-user permissions are future work; `RequiredScopes` is the seam they will be built on, which is why it
-exists before anything varies by it.
+their own. `Permissions` above says what a caller may do; which of the configured mail accounts it may do it to is not
+something a credential decides, and no setting narrows it. Every admitted caller reaches every account this deployment
+configures.
 
 A key identifies a *client*, a public key identifies a *client that can prove it holds the other half*, a token
 identifies a *person*, and the difference matters operationally. A shared bearer credential has the properties every

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -631,7 +631,7 @@ caller's own query text with the embedding provider before anything is read back
 `mailfathom.mail.ask` stops is mail content going to a *chat* provider on a caller's behalf.
 
 **A name nothing publishes fails startup, naming the entry and the position in the list.** That is what the closed
-vocabulary buys: `mailfathom.mail.raed` is refused rather than read as a grant narrower than the one you meant. A
+vocabulary buys: `mailfathom.mail.reads` is refused rather than read as a grant narrower than the one you meant. A
 `mailfathom.admin.*` name is refused the same way and for a second reason — the two surfaces draw from disjoint halves,
 so a permission on the wrong one would sit in the file granting nothing. So is a name the same grant already carries.
 

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -1,6 +1,6 @@
 # The MCP endpoint and what protects it
 
-<!-- describes: src/Mcp/**, src/Host/Security/**, src/Infrastructure/Security/**, src/Common/OAuth/**, src/Common/ClientAssertions/**, src/Host/Hosting/Warnings/McpTransportAuthenticationWarning.cs, src/Host/Hosting/Warnings/TransportGrantStartupReport.cs, src/Host/Configuration/Endpoints/TransportClearTextRedirectOptions.cs, src/Host/Configuration/Endpoints/TransportListenerConfiguration.cs, src/Host/Configuration/Endpoints/ExternalListenerConfiguration.cs, src/Host/Configuration/Endpoints/ReverseProxyOptions.cs, src/Host/Hosting/Startup/ClearTextRedirectToHttps.cs, src/Host/Hosting/Warnings/TransportClearTextRedirectReport.cs, src/Host/Hosting/Warnings/ReverseProxyTrustWarning.cs, src/Host/Hosting/Warnings/McpTransportEncryptionWarning.cs -->
+<!-- describes: src/Mcp/**, src/Host/Security/**, src/Infrastructure/Security/**, src/Common/OAuth/**, src/Common/ClientAssertions/**, src/Host/Hosting/Warnings/McpTransportAuthenticationWarning.cs, src/Host/Hosting/Warnings/TransportGrantStartupReport.cs, src/Domain/Access/MailFathomPermission.cs, src/Host/Configuration/Endpoints/TransportClearTextRedirectOptions.cs, src/Host/Configuration/Endpoints/TransportListenerConfiguration.cs, src/Host/Configuration/Endpoints/ExternalListenerConfiguration.cs, src/Host/Configuration/Endpoints/ReverseProxyOptions.cs, src/Host/Hosting/Startup/ClearTextRedirectToHttps.cs, src/Host/Hosting/Warnings/TransportClearTextRedirectReport.cs, src/Host/Hosting/Warnings/ReverseProxyTrustWarning.cs, src/Host/Hosting/Warnings/McpTransportEncryptionWarning.cs -->
 
 The MCP endpoint is how an agent reaches MailFathom. This page records what enabling it means operationally, what a client
 has to present to reach it, which browser origins it answers, which client applications it accepts a certificate from,
@@ -630,8 +630,10 @@ Neither implies the other. `mailfathom.mail.ask` is not the weaker of the two �
 caller's own query text with the embedding provider before anything is read back. What withholding
 `mailfathom.mail.ask` stops is mail content going to a *chat* provider on a caller's behalf.
 
-An `mailfathom.admin.*` name written here fails startup, naming the entry's index: the two surfaces draw from disjoint
-halves, so a permission on the wrong one would sit in the file granting nothing.
+**A name nothing publishes fails startup, naming the entry and the position in the list.** That is what the closed
+vocabulary buys: `mailfathom.mail.raed` is refused rather than read as a grant narrower than the one you meant. A
+`mailfathom.admin.*` name is refused the same way and for a second reason — the two surfaces draw from disjoint halves,
+so a permission on the wrong one would sit in the file granting nothing. So is a name the same grant already carries.
 
 **The grant belongs to the entry.** An entry may carry an `ApiKey`, a `PublicKey`, and an `OAuth` block at once, and
 `Permissions` applies to every credential it admits — so two credentials to be granted differently are two entries.

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -255,8 +255,12 @@ origins, serving your own domain over TLS, client certificates, and the rate lim
 **A credential reaches the whole surface until its entry narrows it.** The entry above writes no `Permissions` list, so
 the key it configures may do everything the MCP surface publishes — read the local mailbox copy and ask questions of it.
 That is deliberate: nothing has to be granted before a first deployment works. Writing a `Permissions` list on the entry
-narrows it, and startup reports what every entry resolved to either way —
+states a narrower grant, and startup reports what every entry resolved to either way —
 [what a credential may do](../operations/mcp-endpoint.md#what-a-credential-may-do) has the names and the rules.
+
+Nothing enforces that grant yet: the permissions are read, validated, carried on the authenticated caller and reported at
+startup, and no tool consults them, so a narrowed entry still reaches every tool the endpoint serves. Write one to say
+what a credential is meant to reach; it starts refusing when the enforcement it describes ships.
 
 MailFathom itself serves plain HTTP unless its own TLS termination is configured, so keep the application port on
 loopback or behind a TLS-terminating proxy — the Compose deployment's default — and give the proxy the certificate. If

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -252,6 +252,12 @@ announced with a startup warning, because an unauthenticated endpoint serves you
 [the MCP endpoint](../operations/mcp-endpoint.md) before widening anything: it records the OAuth alternative, browser
 origins, serving your own domain over TLS, client certificates, and the rate limits that apply out of the box.
 
+**A credential reaches the whole surface until its entry narrows it.** The entry above writes no `Permissions` list, so
+the key it configures may do everything the MCP surface publishes — read the local mailbox copy and ask questions of it.
+That is deliberate: nothing has to be granted before a first deployment works. Writing a `Permissions` list on the entry
+narrows it, and startup reports what every entry resolved to either way —
+[what a credential may do](../operations/mcp-endpoint.md#what-a-credential-may-do) has the names and the rules.
+
 MailFathom itself serves plain HTTP unless its own TLS termination is configured, so keep the application port on
 loopback or behind a TLS-terminating proxy — the Compose deployment's default — and give the proxy the certificate. If
 you put a proxy in front, name it in `ReverseProxy:TrustedProxies` as well. The public scheme and host survive the hop

--- a/docs/users/mcp-clients.md
+++ b/docs/users/mcp-clients.md
@@ -269,9 +269,12 @@ absence is the deployment saying it cannot answer questions yet rather than a co
 changes it.
 
 **A credential reaches the whole surface until its entry narrows it.** Every configuration above writes a credential and
-no `Permissions` list, so the client connects holding everything the MCP surface publishes. Narrowing that is a change to
-the entry in `McpEndpoint:Authentication` rather than anything the client sets:
-[what a credential may do](../operations/mcp-endpoint.md#what-a-credential-may-do).
+no `Permissions` list, so the client connects holding everything the MCP surface publishes. Narrowing that will be a
+change to the entry in `McpEndpoint:Authentication` rather than anything the client sets:
+[what a credential may do](../operations/mcp-endpoint.md#what-a-credential-may-do). Nothing enforces a grant yet — the
+permissions are read, validated, carried on the authenticated caller and reported at startup, and no tool consults them —
+so a client whose entry you narrow goes on listing and calling every tool. That is the deployment, not the client
+configuration on this page.
 
 Then ask the assistant to list recent mail, and read `folderFreshness` in the result before reading the emails:
 [getting started § make the first call](getting-started.md#8-make-the-first-call-and-read-it-correctly) is what that

--- a/docs/users/mcp-clients.md
+++ b/docs/users/mcp-clients.md
@@ -268,6 +268,11 @@ A fifth tool, `ask_mail`, appears only once a chat model and an embedding model 
 absence is the deployment saying it cannot answer questions yet rather than a connection fault, and no client setting
 changes it.
 
+**A credential reaches the whole surface until its entry narrows it.** Every configuration above writes a credential and
+no `Permissions` list, so the client connects holding everything the MCP surface publishes. Narrowing that is a change to
+the entry in `McpEndpoint:Authentication` rather than anything the client sets:
+[what a credential may do](../operations/mcp-endpoint.md#what-a-credential-may-do).
+
 Then ask the assistant to list recent mail, and read `folderFreshness` in the result before reading the emails:
 [getting started § make the first call](getting-started.md#8-make-the-first-call-and-read-it-correctly) is what that
 field means, and [using the tools](usage.md) is the day-to-day surface.

--- a/src/Domain/Access/MailFathomPermission.cs
+++ b/src/Domain/Access/MailFathomPermission.cs
@@ -1,0 +1,209 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Domain.Access;
+
+/// <summary>One named capability MailFathom publishes, which a grant lists and a caller either holds or does not.</summary>
+/// <remarks>
+/// <para>
+/// The type is a closed enumeration of values rather than a C# <see langword="enum" />, because the name is the
+/// identity and it travels outside this process: an operator writes it in configuration, a deployment advertises it in
+/// its protected resource metadata document, and an authorization server mints it as a scope so a token can carry it.
+/// A member's ordinal would mean nothing to any of the three, and its C# name has to be free to change without moving
+/// what an operator already wrote.
+/// </para>
+/// <para>
+/// The set is closed so that every name a grant can carry corresponds to a check that exists. A name nothing publishes
+/// is unknown rather than new, which is what lets startup refuse a misspelling instead of accepting a grant nobody
+/// enforces. Adding a member is a configuration-schema change and is made when the capability it names exists, never
+/// ahead of it.
+/// </para>
+/// <para>
+/// A name is <c>mailfathom.&lt;surface&gt;[.&lt;subject&gt;].&lt;verb&gt;</c>, lowercase and dot-separated, and is
+/// always a valid OAuth scope token so the same string can travel in a <c>scope</c> claim. The prefix after
+/// <c>mailfathom.</c> names the <see cref="Surface" /> the permission belongs to, and the two halves are disjoint: no
+/// permission implies another, and holding one says nothing about holding the next.
+/// </para>
+/// <para>
+/// Being a struct, <see langword="default" /> is reachable and is not a permission. It reports itself through
+/// <see cref="IsSpecified" />, refuses to answer for a name, and is rejected by the JSON converter below; a grant is
+/// composed from <see cref="TryParse" /> or from the members themselves, so no undeclared value can reach one.
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(MailFathomPermissionJsonConverter))]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "The suffix is reserved for code access security, which .NET removed; permission is the word ADR 0012 fixed for this unit and the word an operator writes in configuration.")]
+public readonly record struct MailFathomPermission
+{
+    private readonly string? name;
+
+    private MailFathomPermission(string name, ProtectedSurface surface)
+    {
+        this.name = name;
+        this.Surface = surface;
+    }
+
+    #region Mail
+
+    /// <summary>Gets the permission covering the tools that read the local mailbox copy.</summary>
+    /// <remarks>
+    /// It is not an egress-free grant. Where semantic retrieval is configured, searching places the caller's own query
+    /// text with the embedding provider, which is why the pages describing the grant say so where an operator writes
+    /// it. What it does not permit is sending mail content to a chat provider, which is <see cref="MailAsk" />.
+    /// </remarks>
+    public static MailFathomPermission MailRead { get; } = new("mailfathom.mail.read", ProtectedSurface.Mail);
+
+    /// <summary>Gets the permission covering the tool that answers from mail content by sending it to a model provider.</summary>
+    /// <remarks>It does not imply <see cref="MailRead" /> and is not the weaker of the two: a cited answer returns mail content, so granting it is granting access to mail.</remarks>
+    public static MailFathomPermission MailAsk { get; } = new("mailfathom.mail.ask", ProtectedSurface.Mail);
+
+    #endregion
+
+    #region Administration
+
+    /// <summary>Gets the permission covering the administrative reads that report the deployment's own state and no mail.</summary>
+    public static MailFathomPermission AdminRead { get; } = new("mailfathom.admin.read", ProtectedSurface.Administration);
+
+    /// <summary>Gets the permission covering the per-account records derived from mail: the audits, the rules history, and the spam classifications.</summary>
+    public static MailFathomPermission AdminAuditRead { get; } = new("mailfathom.admin.audit.read", ProtectedSurface.Administration);
+
+    /// <summary>Gets the permission covering asking the deployment to do work it can already do.</summary>
+    public static MailFathomPermission AdminOperate { get; } = new("mailfathom.admin.operate", ProtectedSurface.Administration);
+
+    /// <summary>Gets the permission covering storing a mailbox refresh token.</summary>
+    public static MailFathomPermission AdminCredentialsWrite { get; } = new("mailfathom.admin.credentials.write", ProtectedSurface.Administration);
+
+    /// <summary>Gets the permission covering the one operation that starts a provider bill, which is activating the declared embedding model.</summary>
+    public static MailFathomPermission AdminSpend { get; } = new("mailfathom.admin.spend", ProtectedSurface.Administration);
+
+    /// <summary>Gets the permission covering erasing the mail stored for a folder an account no longer mirrors.</summary>
+    public static MailFathomPermission AdminErase { get; } = new("mailfathom.admin.erase", ProtectedSurface.Administration);
+
+    #endregion
+
+    /// <summary>Gets every published permission.</summary>
+    /// <remarks>Declared last so the members it lists are already initialized when this initializer runs.</remarks>
+    public static IReadOnlyList<MailFathomPermission> All { get; } =
+    [
+        MailRead,
+        MailAsk,
+        AdminRead,
+        AdminAuditRead,
+        AdminOperate,
+        AdminCredentialsWrite,
+        AdminSpend,
+        AdminErase,
+    ];
+
+    /// <summary>Gets whether this value names a published permission rather than the unusable struct default.</summary>
+    public bool IsSpecified => this.name is not null;
+
+    /// <summary>Gets the surface this permission belongs to.</summary>
+    /// <remarks>The struct default reports <see cref="ProtectedSurface.Mail" /> like any other unset enum field, so ask <see cref="IsSpecified" /> before reading it.</remarks>
+    public ProtectedSurface Surface { get; }
+
+    /// <summary>Gets the published name, which is what an operator writes and what a token carries as a scope.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a permission.</exception>
+    public string Name => this.name
+        ?? throw new InvalidOperationException("The value is the default of the struct and does not name a permission.");
+
+    /// <summary>Reports every permission one surface publishes, which is what a grant nobody narrowed reaches.</summary>
+    /// <param name="surface">The surface whose half is being asked for.</param>
+    /// <returns>The permissions belonging to that surface, in declaration order.</returns>
+    public static IReadOnlyList<MailFathomPermission> PublishedFor(ProtectedSurface surface) =>
+        [.. All.Where(permission => permission.Surface == surface)];
+
+    /// <summary>Parses an operator-supplied or token-supplied permission name.</summary>
+    /// <param name="name">The written name.</param>
+    /// <param name="permission">The parsed permission when the name is published; otherwise the unspecified default.</param>
+    /// <returns><see langword="true" /> when the name is one this repository publishes; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// The comparison is exact and neither trimmed nor case-folded, because the same string has to travel as an OAuth
+    /// scope token, where a scope is compared byte for byte. Accepting a spelling here that an authorization server
+    /// would treat as a different scope is how a grant comes to mean one thing in configuration and another in a token.
+    /// </remarks>
+    public static bool TryParse(string? name, out MailFathomPermission permission)
+    {
+        // No published permission is the struct default, so an unmatched name yields the unspecified value the caller
+        // already receives when parsing fails.
+        permission = name is null
+            ? default
+            : All.FirstOrDefault(candidate => string.Equals(candidate.Name, name, StringComparison.Ordinal));
+
+        return permission.IsSpecified;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => this.name ?? "(unspecified)";
+}
+
+/// <summary>Serializes <see cref="MailFathomPermission" /> as its published name.</summary>
+/// <remarks>
+/// The type carries this converter through <see cref="JsonConverterAttribute" />, so every serializer that meets the
+/// value uses it without per-call registration. The JSON form is the published name for the same reason the value
+/// object exists: it is the identity an operator, a metadata document, and an authorization server already agree on,
+/// while an ordinal would silently change meaning the first time the set gained a member.
+/// </remarks>
+public sealed class MailFathomPermissionJsonConverter : JsonConverter<MailFathomPermission>
+{
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the token is not a string or does not name a published permission.</exception>
+    public override MailFathomPermission Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException($"A permission must be a JSON string, but the token was {reader.TokenType}.");
+        }
+
+        return ParseOrThrow(reader.GetString());
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the value is the unspecified struct default.</exception>
+    public override void Write(Utf8JsonWriter writer, MailFathomPermission value, JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WriteStringValue(NameOrThrow(value));
+    }
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the property name does not name a published permission.</exception>
+    public override MailFathomPermission ReadAsPropertyName(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options) => ParseOrThrow(reader.GetString());
+
+    /// <inheritdoc />
+    /// <exception cref="JsonException">Thrown when the value is the unspecified struct default.</exception>
+    public override void WriteAsPropertyName(
+        Utf8JsonWriter writer,
+        MailFathomPermission value,
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        writer.WritePropertyName(NameOrThrow(value));
+    }
+
+    private static MailFathomPermission ParseOrThrow(string? name)
+    {
+        if (!MailFathomPermission.TryParse(name, out var permission))
+        {
+            throw new JsonException($"'{name}' is not a permission MailFathom publishes.");
+        }
+
+        return permission;
+    }
+
+    private static string NameOrThrow(MailFathomPermission permission) => permission.IsSpecified
+        ? permission.Name
+        : throw new JsonException("An unspecified permission cannot be serialized.");
+}

--- a/src/Domain/Access/ProtectedSurface.cs
+++ b/src/Domain/Access/ProtectedSurface.cs
@@ -1,0 +1,27 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Access;
+
+/// <summary>One of the two halves the published permission vocabulary is divided into.</summary>
+/// <remarks>
+/// <para>
+/// A permission belongs to exactly one surface and says so in its own name, which is what lets a grant written on the
+/// wrong surface be refused at startup instead of sitting there granting nothing. The two halves are disjoint: no
+/// permission covers an operation on both.
+/// </para>
+/// <para>
+/// It is a plain enum because a member is nothing but a name the process reads. What a caller may do is carried by
+/// <see cref="MailFathomPermission" />, and where a surface is served — which listener, which routes, which
+/// authentication schemes — is the host's own question and is answered there.
+/// </para>
+/// </remarks>
+public enum ProtectedSurface
+{
+    /// <summary>The surface serving the mailbox: the MCP tools that read the local copy and the one that answers from it.</summary>
+    Mail = 0,
+
+    /// <summary>The surface serving the deployment's own administration.</summary>
+    Administration = 1,
+}

--- a/src/Host/Api/AdminProtectedResourceMetadataEndpoint.cs
+++ b/src/Host/Api/AdminProtectedResourceMetadataEndpoint.cs
@@ -4,6 +4,7 @@
 
 using System.Text.Json.Serialization;
 using MailFathom.Host.Configuration.Access;
+using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Transport;
 
 namespace MailFathom.Host.Api;
@@ -32,17 +33,17 @@ internal static class AdminProtectedResourceMetadataEndpoint
 {
     /// <summary>Maps the document at the address its resource identifier places it.</summary>
     /// <param name="endpoints">The route builder.</param>
-    /// <param name="oauthMethods">The endpoint's authorization servers and token requirements, one entry per configured OAuth block.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpoints" /> or <paramref name="oauthMethods" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="oauthMethods" /> is empty, which is a surface accepting no token at all.</exception>
+    /// <param name="methods">The endpoint's configured credential entries, in configuration order.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpoints" /> or <paramref name="methods" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when no entry states OAuth, which is a surface accepting no token at all.</exception>
     internal static void MapAdminProtectedResourceMetadata(
         this IEndpointRouteBuilder endpoints,
-        IReadOnlyList<OAuthValidationOptions> oauthMethods)
+        IReadOnlyList<TransportAuthenticationOptions> methods)
     {
         ArgumentNullException.ThrowIfNull(endpoints);
-        ArgumentNullException.ThrowIfNull(oauthMethods);
+        ArgumentNullException.ThrowIfNull(methods);
 
-        var document = ProtectedResourceMetadataDocument.For(oauthMethods);
+        var document = ProtectedResourceMetadataDocument.For(methods);
 
         endpoints.MapGet(
             ProtectedResourceMetadataAddress.PathFor(document.Resource),
@@ -70,18 +71,18 @@ internal sealed record ProtectedResourceMetadataDocument(
     [property: JsonPropertyName("resource_name")] string ResourceName)
 {
     /// <summary>Describes what one endpoint's OAuth settings publish.</summary>
-    /// <param name="oauthMethods">The endpoint's authorization servers and token requirements, one entry per configured OAuth block.</param>
+    /// <param name="methods">The endpoint's configured credential entries, in configuration order.</param>
     /// <returns>The document.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="oauthMethods" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="methods" /> is <see langword="null" />.</exception>
     /// <remarks>
     /// What the entries publish between them is <see cref="PublishedOAuthMetadata" />'s to decide, because the MCP
     /// endpoint publishes the same document through the protocol SDK's own type and the two must not answer differently
     /// from one configuration. What is this record's own is the wire shape: the JSON names RFC 9728 fixes, and the
     /// bearer method and resource name that are constants rather than settings.
     /// </remarks>
-    internal static ProtectedResourceMetadataDocument For(IReadOnlyList<OAuthValidationOptions> oauthMethods)
+    internal static ProtectedResourceMetadataDocument For(IReadOnlyList<TransportAuthenticationOptions> methods)
     {
-        var published = PublishedOAuthMetadata.For(oauthMethods);
+        var published = PublishedOAuthMetadata.For(methods, AdminEndpointOptions.GrantedSurface);
 
         return new ProtectedResourceMetadataDocument(
             published.Resource,

--- a/src/Host/Configuration/Access/OAuthValidationOptions.cs
+++ b/src/Host/Configuration/Access/OAuthValidationOptions.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Common.OAuth;
+using MailFathom.Domain.Access;
 
 namespace MailFathom.Host.Configuration.Access;
 
@@ -64,6 +65,12 @@ internal sealed class OAuthValidationOptions
     /// accepts any token this resource's authorization servers issued, which is a coarser boundary rather than a broken
     /// one; it is the right setting only where the authorization server already restricts who receives a token for this
     /// resource.
+    /// <para>
+    /// It decides admission and never what an admitted caller may do, so a <see cref="MailFathomPermission" /> name
+    /// written here is refused at startup: it would close the door on a caller the deployment meant to serve less
+    /// rather than granting them less. The grant lives in
+    /// <see cref="TransportAuthenticationOptions.Permissions" /> on the entry this block sits in.
+    /// </para>
     /// </remarks>
     public IList<string> RequiredScopes { get; } = [];
 
@@ -81,6 +88,11 @@ internal sealed class OAuthValidationOptions
     /// Published beside <see cref="RequiredScopes" /> rather than instead of it: a required scope is advertised whether
     /// it appears here or not, and a scope named here is never enforced. A value repeating a required one is refused
     /// rather than folded away, so this list goes on saying exactly what the required list does not.
+    /// </para>
+    /// <para>
+    /// A <see cref="MailFathomPermission" /> name is refused here too, and for the opposite reason: an entry whose
+    /// grant a token narrows already advertises its own ceiling, and an entry whose grant it does not narrow would be
+    /// telling a client to ask its authorization server for a scope nothing here reads.
     /// </para>
     /// </remarks>
     public IList<string> AdvertisedScopes { get; } = [];
@@ -148,6 +160,10 @@ internal sealed class OAuthValidationOptions
             {
                 yield return $"{settingPath} — '{configuredScope}' is not a scope; write the value the authorization server issues, with no space, quotation mark, or backslash in it.";
             }
+            else if (MailFathomPermission.TryParse(configuredScope, out _))
+            {
+                yield return $"{settingPath} — '{configuredScope}' is a MailFathom permission, and requiring one would turn a smaller grant into a closed door: a caller the deployment meant to serve less would be refused at the entrance instead. Write it in '{nameof(TransportAuthenticationOptions.Permissions)}' on this entry, which is what decides what an admitted caller may do.";
+            }
             else if (!claimedScopes.Add(configuredScope))
             {
                 yield return $"{settingPath} — '{configuredScope}' repeats a scope the list already carries.";
@@ -177,6 +193,10 @@ internal sealed class OAuthValidationOptions
             if (!IsScopeToken(configuredScope))
             {
                 yield return $"{settingPath} — '{configuredScope}' is not a scope; write the value the authorization server issues, with no space, quotation mark, or backslash in it.";
+            }
+            else if (MailFathomPermission.TryParse(configuredScope, out _))
+            {
+                yield return $"{settingPath} — '{configuredScope}' is a MailFathom permission, and the grant that reads one already advertises it; an entry granting none would be telling a client to ask for something nothing here grants. Write it in '{nameof(TransportAuthenticationOptions.Permissions)}' on this entry and set '{nameof(TransportAuthenticationOptions.PermissionsFromTokenScopes)}'.";
             }
             else if (!claimedScopes.Add(configuredScope))
             {

--- a/src/Host/Configuration/Access/PublishedOAuthMetadata.cs
+++ b/src/Host/Configuration/Access/PublishedOAuthMetadata.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Access;
+
 namespace MailFathom.Host.Configuration.Access;
 
 /// <summary>What a protected surface's configured OAuth entries publish about themselves to a client holding nothing yet.</summary>
@@ -30,6 +32,13 @@ namespace MailFathom.Host.Configuration.Access;
 /// <see cref="OAuthValidationOptions.RequiredScopes" /> directly and never this list, so advertising a scope can widen
 /// what a client requests and can never narrow who is served.
 /// </para>
+/// <para>
+/// A permission joins that list from every entry whose grant a token's own scopes narrow, and from no other, which
+/// follows from the same reading of the field: a permission the deployment grants from configuration is not something
+/// any client can ask for. The union of those entries' ceilings is therefore also exactly what an operator has to
+/// create as scopes in their authorization server, read from the document rather than transcribed out of their own
+/// configuration file.
+/// </para>
 /// </remarks>
 internal sealed record PublishedOAuthMetadata(
     string Resource,
@@ -37,21 +46,36 @@ internal sealed record PublishedOAuthMetadata(
     IReadOnlyList<string> ScopesSupported)
 {
     /// <summary>Composes what the configured entries publish between them.</summary>
-    /// <param name="oauthMethods">The configured OAuth blocks, in configuration order.</param>
+    /// <param name="methods">The configured credential entries, in configuration order.</param>
+    /// <param name="surface">The surface these entries guard, which decides what an entry that wrote no grant advertises.</param>
     /// <returns>The published metadata.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="oauthMethods" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="oauthMethods" /> is empty, which is a surface accepting no token at all.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="methods" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when no entry states OAuth, which is a surface accepting no token at all.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the settings have not passed their configuration errors.</exception>
-    internal static PublishedOAuthMetadata For(IReadOnlyList<OAuthValidationOptions> oauthMethods)
+    /// <remarks>
+    /// The whole entry rather than its OAuth block, because the grant belongs to the entry and the document has to
+    /// carry it. Reading the blocks alone would leave the two halves of one entry consulted in two places, which is how
+    /// a document comes to advertise a ceiling the entry beside it never granted.
+    /// </remarks>
+    internal static PublishedOAuthMetadata For(
+        IReadOnlyList<TransportAuthenticationOptions> methods,
+        ProtectedSurface surface)
     {
-        ArgumentNullException.ThrowIfNull(oauthMethods);
+        ArgumentNullException.ThrowIfNull(methods);
+
+        var oauthMethods = TransportAuthenticationConfiguration.OAuthMethodsIn(methods);
 
         if (oauthMethods.Count == 0)
         {
             throw new ArgumentException(
                 "A protected resource metadata document describes the configured OAuth methods, and none was configured.",
-                nameof(oauthMethods));
+                nameof(methods));
         }
+
+        var advertisedPermissions = methods
+            .Where(method => method.PermissionsFromTokenScopes && method.OAuth is not null)
+            .SelectMany(method => method.GrantedPermissions(surface))
+            .Select(permission => permission.Name);
 
         return new PublishedOAuthMetadata(
             oauthMethods[0].CanonicalResource(),
@@ -64,6 +88,7 @@ internal sealed record PublishedOAuthMetadata(
                 .. oauthMethods
                     .SelectMany(oauthMethod => oauthMethod.RequiredScopes)
                     .Concat(oauthMethods.SelectMany(oauthMethod => oauthMethod.AdvertisedScopes))
+                    .Concat(advertisedPermissions)
                     .Distinct(StringComparer.Ordinal),
             ]);
     }

--- a/src/Host/Configuration/Access/TransportAuthenticationConfiguration.cs
+++ b/src/Host/Configuration/Access/TransportAuthenticationConfiguration.cs
@@ -62,30 +62,37 @@ internal static class TransportAuthenticationConfiguration
         ProtectedSurface surface) =>
         GrantsByCredentialName(methods, method => method.PublicKey, surface);
 
-    /// <summary>Records which entries wrote a grant, which the binder cannot say and only the section can.</summary>
+    /// <summary>Applies the permissive default to every entry that stated no grant, which the binder cannot say and only the section can.</summary>
     /// <param name="endpointSection">The endpoint section the entries were bound from.</param>
     /// <param name="methods">The bound entries, in configuration order.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpointSection" /> or <paramref name="methods" /> is <see langword="null" />.</exception>
     /// <remarks>
+    /// <para>
     /// An absent list and an emptied one bind identically and mean opposite things — the whole surface against nothing
     /// — so the two are told apart by asking configuration whether the key exists at all. Both endpoints call this
     /// rather than each asking the question in its own words, because a reading that differed between them would grant
     /// one surface what it refused the other from the same configuration.
+    /// </para>
+    /// <para>
+    /// Each entry is paired with the configuration child it was bound from rather than with its position in the bound
+    /// list, because the two come apart the moment a source numbers its entries with a gap: the binder appends a child
+    /// per key it finds and keeps no record of which key that was, so an environment-variable configuration writing
+    /// <c>…__0__…</c> and <c>…__2__…</c> binds two entries at positions 0 and 1. Reading a grant by position there
+    /// would hand the second entry the whole surface it had narrowed away from.
+    /// </para>
     /// </remarks>
-    internal static void MarkWrittenGrants(
+    internal static void GrantTheWholeSurfaceWhereNoneIsStated(
         IConfigurationSection endpointSection,
         IReadOnlyList<TransportAuthenticationOptions> methods)
     {
         ArgumentNullException.ThrowIfNull(endpointSection);
         ArgumentNullException.ThrowIfNull(methods);
 
-        foreach (var (index, method) in methods.Index())
+        foreach (var (entrySection, method) in endpointSection.GetSection(SettingName).GetChildren().Zip(methods))
         {
-            if (endpointSection
-                .GetSection($"{SettingName}:{index}:{nameof(TransportAuthenticationOptions.Permissions)}")
-                .Exists())
+            if (!entrySection.GetSection(nameof(TransportAuthenticationOptions.Permissions)).Exists())
             {
-                method.MarkGrantWritten();
+                method.GrantTheWholeSurface();
             }
         }
     }

--- a/src/Host/Configuration/Access/TransportAuthenticationConfiguration.cs
+++ b/src/Host/Configuration/Access/TransportAuthenticationConfiguration.cs
@@ -265,7 +265,7 @@ internal static class TransportAuthenticationConfiguration
 
             if (!string.Equals(resource, firstResource, StringComparison.Ordinal))
             {
-                yield return $"{sectionName}:{SettingName}:{index}:{nameof(TransportAuthenticationOptions.OAuth)}:{nameof(OAuthValidationOptions.Resource)} — every OAuth entry names the same resource, because the endpoint publishes one protected resource metadata document and publishes it at an address derived from that identifier. An earlier entry names '{firstResource}'; write that, or move this entry to an endpoint of its own.";
+                yield return $"{SettingPathOf(sectionName, method, index)}:{nameof(TransportAuthenticationOptions.OAuth)}:{nameof(OAuthValidationOptions.Resource)} — every OAuth entry names the same resource, because the endpoint publishes one protected resource metadata document and publishes it at an address derived from that identifier. An earlier entry names '{firstResource}'; write that, or move this entry to an endpoint of its own.";
             }
         }
     }
@@ -294,7 +294,7 @@ internal static class TransportAuthenticationConfiguration
             foreach (var (serverIndex, authorizationServer) in oauth.AuthorizationServers.Index())
             {
                 var settingPath =
-                    $"{sectionName}:{SettingName}:{index}:{nameof(TransportAuthenticationOptions.OAuth)}:{nameof(OAuthValidationOptions.AuthorizationServers)}:{serverIndex}";
+                    $"{SettingPathOf(sectionName, method, index)}:{nameof(TransportAuthenticationOptions.OAuth)}:{nameof(OAuthValidationOptions.AuthorizationServers)}:{serverIndex}";
 
                 if (!claimedNames.Add(authorizationServer.Name!))
                 {

--- a/src/Host/Configuration/Access/TransportAuthenticationConfiguration.cs
+++ b/src/Host/Configuration/Access/TransportAuthenticationConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Access;
 using MailFathom.Infrastructure.Secrets.Discovery;
 
 namespace MailFathom.Host.Configuration.Access;
@@ -37,6 +38,56 @@ internal static class TransportAuthenticationConfiguration
         ArgumentNullException.ThrowIfNull(methods);
 
         return [.. methods.Select(method => method.PublicKey).OfType<ConfiguredSecret>()];
+    }
+
+    /// <summary>Maps each configured API key onto the permissions the entry that carries it grants.</summary>
+    /// <param name="methods">The configured entries, in configuration order.</param>
+    /// <param name="surface">The surface these entries guard, which decides what an entry that wrote no grant reaches.</param>
+    /// <returns>The granted permissions, keyed by the key's configured name.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="methods" /> is <see langword="null" />.</exception>
+    /// <remarks>Keyed by the name because that is the identity a successful authentication reports, and it is unique within the section a duplicate would be refused in.</remarks>
+    internal static IReadOnlyDictionary<string, IReadOnlyList<MailFathomPermission>> GrantsByApiKeyName(
+        IEnumerable<TransportAuthenticationOptions> methods,
+        ProtectedSurface surface) =>
+        GrantsByCredentialName(methods, method => method.ApiKey, surface);
+
+    /// <summary>Maps each configured client public key onto the permissions the entry that carries it grants.</summary>
+    /// <param name="methods">The configured entries, in configuration order.</param>
+    /// <param name="surface">The surface these entries guard, which decides what an entry that wrote no grant reaches.</param>
+    /// <returns>The granted permissions, keyed by the public key's configured name.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="methods" /> is <see langword="null" />.</exception>
+    /// <remarks>Keyed by the name for the reason <see cref="GrantsByApiKeyName" /> is.</remarks>
+    internal static IReadOnlyDictionary<string, IReadOnlyList<MailFathomPermission>> GrantsByPublicKeyName(
+        IEnumerable<TransportAuthenticationOptions> methods,
+        ProtectedSurface surface) =>
+        GrantsByCredentialName(methods, method => method.PublicKey, surface);
+
+    /// <summary>Records which entries wrote a grant, which the binder cannot say and only the section can.</summary>
+    /// <param name="endpointSection">The endpoint section the entries were bound from.</param>
+    /// <param name="methods">The bound entries, in configuration order.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpointSection" /> or <paramref name="methods" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// An absent list and an emptied one bind identically and mean opposite things — the whole surface against nothing
+    /// — so the two are told apart by asking configuration whether the key exists at all. Both endpoints call this
+    /// rather than each asking the question in its own words, because a reading that differed between them would grant
+    /// one surface what it refused the other from the same configuration.
+    /// </remarks>
+    internal static void MarkWrittenGrants(
+        IConfigurationSection endpointSection,
+        IReadOnlyList<TransportAuthenticationOptions> methods)
+    {
+        ArgumentNullException.ThrowIfNull(endpointSection);
+        ArgumentNullException.ThrowIfNull(methods);
+
+        foreach (var (index, method) in methods.Index())
+        {
+            if (endpointSection
+                .GetSection($"{SettingName}:{index}:{nameof(TransportAuthenticationOptions.Permissions)}")
+                .Exists())
+            {
+                method.MarkGrantWritten();
+            }
+        }
     }
 
     /// <summary>Reports what a token must prove, once per entry that states OAuth.</summary>
@@ -78,6 +129,7 @@ internal static class TransportAuthenticationConfiguration
     /// <summary>Finds everything an operator must fix before the configured credentials can guard an endpoint.</summary>
     /// <param name="sectionName">The endpoint section the list was bound from, which every message is written against.</param>
     /// <param name="methods">The configured entries, in configuration order.</param>
+    /// <param name="surface">The surface this list guards, which decides which half of the published vocabulary a grant may name.</param>
     /// <returns>One message per faulty setting, each naming its configuration path, empty when the settings are usable.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sectionName" /> or <paramref name="methods" /> is <see langword="null" />.</exception>
     /// <remarks>
@@ -93,7 +145,8 @@ internal static class TransportAuthenticationConfiguration
     /// </remarks>
     internal static IReadOnlyList<string> FindConfigurationErrors(
         string sectionName,
-        IReadOnlyList<TransportAuthenticationOptions> methods)
+        IReadOnlyList<TransportAuthenticationOptions> methods,
+        ProtectedSurface surface)
     {
         ArgumentNullException.ThrowIfNull(sectionName);
         ArgumentNullException.ThrowIfNull(methods);
@@ -102,7 +155,7 @@ internal static class TransportAuthenticationConfiguration
 
         foreach (var (index, method) in methods.Index())
         {
-            errors.AddRange(method.FindConfigurationErrors($"{sectionName}:{SettingName}:{index}"));
+            errors.AddRange(method.FindConfigurationErrors($"{sectionName}:{SettingName}:{index}", surface));
         }
 
         // The rules below read validated values, so they run only once every entry is usable on its own. Asking a
@@ -116,6 +169,30 @@ internal static class TransportAuthenticationConfiguration
         errors.AddRange(FindAuthorizationServerCollisionErrors(sectionName, methods));
 
         return errors;
+    }
+
+    /// <summary>Maps one kind of configured credential onto the grant of the entry it sits in.</summary>
+    /// <remarks>
+    /// The first entry claiming a name wins rather than the last, and neither is a decision worth having: two entries
+    /// naming one credential identically is refused at startup by the secret validator, which is where an operator
+    /// reads about it. Composing the map is not the place to discover it, because raising here would replace that
+    /// message with a dictionary fault naming nothing an operator configured.
+    /// </remarks>
+    private static Dictionary<string, IReadOnlyList<MailFathomPermission>> GrantsByCredentialName(
+        IEnumerable<TransportAuthenticationOptions> methods,
+        Func<TransportAuthenticationOptions, ConfiguredSecret?> credentialIn,
+        ProtectedSurface surface)
+    {
+        ArgumentNullException.ThrowIfNull(methods);
+
+        return methods
+            .Select(method => (Credential: credentialIn(method), Method: method))
+            .Where(entry => entry.Credential is not null)
+            .GroupBy(entry => entry.Credential!.Name, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group.First().Method.GrantedPermissions(surface),
+                StringComparer.Ordinal);
     }
 
     /// <summary>Reports the OAuth entries that name a different resource from the first one.</summary>

--- a/src/Host/Configuration/Access/TransportAuthenticationConfiguration.cs
+++ b/src/Host/Configuration/Access/TransportAuthenticationConfiguration.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
 using MailFathom.Domain.Access;
 using MailFathom.Infrastructure.Secrets.Discovery;
 
@@ -62,7 +63,7 @@ internal static class TransportAuthenticationConfiguration
         ProtectedSurface surface) =>
         GrantsByCredentialName(methods, method => method.PublicKey, surface);
 
-    /// <summary>Applies the permissive default to every entry that stated no grant, which the binder cannot say and only the section can.</summary>
+    /// <summary>Tells each bound entry the two things only the section it came from knows: the key it was written under, and whether it stated a grant.</summary>
     /// <param name="endpointSection">The endpoint section the entries were bound from.</param>
     /// <param name="methods">The bound entries, in configuration order.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="endpointSection" /> or <paramref name="methods" /> is <see langword="null" />.</exception>
@@ -78,18 +79,35 @@ internal static class TransportAuthenticationConfiguration
     /// list, because the two come apart the moment a source numbers its entries with a gap: the binder appends a child
     /// per key it finds and keeps no record of which key that was, so an environment-variable configuration writing
     /// <c>…__0__…</c> and <c>…__2__…</c> binds two entries at positions 0 and 1. Reading a grant by position there
-    /// would hand the second entry the whole surface it had narrowed away from.
+    /// would hand the second entry the whole surface it had narrowed away from, and every refusal against that entry
+    /// would name a path the operator's configuration does not contain.
+    /// </para>
+    /// <para>
+    /// The pairing is positional, so it says nothing at all once the two lists are different lengths: pairing them
+    /// anyway would read one entry's grant off another entry's key. Today the binder makes an entry for every child it
+    /// finds, including an element carrying nothing, so the lengths agree and the guard below never fires. It is here
+    /// because what it guards is a grant: an element dropped by a binder this code does not own would otherwise hand a
+    /// narrowed entry the whole surface, and refusing to read is the direction to be wrong in.
     /// </para>
     /// </remarks>
-    internal static void GrantTheWholeSurfaceWhereNoneIsStated(
+    internal static void ReadWhatTheBinderCannotSay(
         IConfigurationSection endpointSection,
         IReadOnlyList<TransportAuthenticationOptions> methods)
     {
         ArgumentNullException.ThrowIfNull(endpointSection);
         ArgumentNullException.ThrowIfNull(methods);
 
-        foreach (var (entrySection, method) in endpointSection.GetSection(SettingName).GetChildren().Zip(methods))
+        var entrySections = endpointSection.GetSection(SettingName).GetChildren().ToArray();
+
+        if (entrySections.Length != methods.Count)
         {
+            return;
+        }
+
+        foreach (var (entrySection, method) in entrySections.Zip(methods))
+        {
+            method.RecordConfigurationKey(entrySection.Key);
+
             if (!entrySection.GetSection(nameof(TransportAuthenticationOptions.Permissions)).Exists())
             {
                 method.GrantTheWholeSurface();
@@ -162,7 +180,7 @@ internal static class TransportAuthenticationConfiguration
 
         foreach (var (index, method) in methods.Index())
         {
-            errors.AddRange(method.FindConfigurationErrors($"{sectionName}:{SettingName}:{index}", surface));
+            errors.AddRange(method.FindConfigurationErrors(SettingPathOf(sectionName, method, index), surface));
         }
 
         // The rules below read validated values, so they run only once every entry is usable on its own. Asking a
@@ -177,6 +195,19 @@ internal static class TransportAuthenticationConfiguration
 
         return errors;
     }
+
+    /// <summary>Composes the configuration path one entry is named by, everywhere an operator is told to go and edit it.</summary>
+    /// <param name="sectionName">The endpoint section the entries were bound from.</param>
+    /// <param name="method">The entry the path names.</param>
+    /// <param name="boundPosition">The position the entry bound at, which names it where no read established its key.</param>
+    /// <returns>The configuration path of the entry.</returns>
+    /// <remarks>
+    /// The key the entry was written under wherever the read established one, and the position it bound at otherwise.
+    /// The two are the same number until a source numbers its entries with a gap, and there the position names
+    /// something the operator's configuration does not contain.
+    /// </remarks>
+    internal static string SettingPathOf(string sectionName, TransportAuthenticationOptions method, int boundPosition) =>
+        $"{sectionName}:{SettingName}:{method.ConfigurationKey ?? boundPosition.ToString(CultureInfo.InvariantCulture)}";
 
     /// <summary>Maps one kind of configured credential onto the grant of the entry it sits in.</summary>
     /// <remarks>

--- a/src/Host/Configuration/Access/TransportAuthenticationOptions.cs
+++ b/src/Host/Configuration/Access/TransportAuthenticationOptions.cs
@@ -127,9 +127,17 @@ internal sealed class TransportAuthenticationOptions
     /// <returns>The granted permissions, in the published order.</returns>
     /// <exception cref="InvalidOperationException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />, which is what proves every written name is one this repository publishes.</exception>
     /// <remarks>
+    /// <para>
     /// This is the ceiling rather than what a particular caller holds. Where
     /// <see cref="PermissionsFromTokenScopes" /> is set, a token holds this narrowed by its own scopes, which is a
     /// question about the token and is asked where one is validated.
+    /// </para>
+    /// <para>
+    /// A grant is a set, so a written one is returned in the published order rather than the order it was typed in.
+    /// The order is what the startup line reads in and what the claims are stamped in, and two entries granting the
+    /// same permissions differently ordered are the same grant — reporting them as two would invite an operator to
+    /// look for a difference that is not there.
+    /// </para>
     /// </remarks>
     public IReadOnlyList<MailFathomPermission> GrantedPermissions(ProtectedSurface surface)
     {
@@ -138,14 +146,15 @@ internal sealed class TransportAuthenticationOptions
             return MailFathomPermission.PublishedFor(surface);
         }
 
-        return
-        [
-            .. this.Permissions.Select(configuredPermission =>
+        var granted = this.Permissions
+            .Select(configuredPermission =>
                 MailFathomPermission.TryParse(configuredPermission, out var permission)
                     ? permission
                     : throw new InvalidOperationException(
-                        "The grant was resolved before it was validated, so at least one written name is not a permission this repository publishes.")),
-        ];
+                        "The grant was resolved before it was validated, so at least one written name is not a permission this repository publishes."))
+            .ToHashSet();
+
+        return [.. MailFathomPermission.All.Where(granted.Contains)];
     }
 
     /// <summary>Finds everything an operator must fix before this entry can accept a credential.</summary>

--- a/src/Host/Configuration/Access/TransportAuthenticationOptions.cs
+++ b/src/Host/Configuration/Access/TransportAuthenticationOptions.cs
@@ -103,6 +103,10 @@ internal sealed class TransportAuthenticationOptions
     /// </remarks>
     internal bool GrantsTheWholeSurface { get; private set; }
 
+    /// <summary>Gets the configuration key this entry was written under, or <see langword="null" /> where no read established one.</summary>
+    /// <remarks>A source may number its entries with a gap, so the key an operator wrote and the position the binder appended the entry at are different numbers. A refusal names this one wherever it is known, because a path nobody wrote is a path nobody can go and correct.</remarks>
+    internal string? ConfigurationKey { get; private set; }
+
     /// <summary>Gets whether this entry states any credential at all.</summary>
     public bool StatesAMethod => this.ApiKey is not null || this.OAuth is not null || this.PublicKey is not null;
 
@@ -112,6 +116,11 @@ internal sealed class TransportAuthenticationOptions
     /// <summary>Records that the deployment stated no grant on this entry, which is what leaves it reaching the whole surface.</summary>
     /// <remarks>Called by the endpoint's own read, which is the only place that holds the configuration section this was bound from.</remarks>
     internal void GrantTheWholeSurface() => this.GrantsTheWholeSurface = true;
+
+    /// <summary>Records the configuration key this entry was written under, which every refusal against it is named by.</summary>
+    /// <param name="key">The key of the configuration child the entry was bound from.</param>
+    /// <remarks>The bound position is what a refusal falls back to, and the two are the same number only while the source numbers its entries without a gap — so an operator reading a refusal is given the path they wrote wherever the read could establish it.</remarks>
+    internal void RecordConfigurationKey(string key) => this.ConfigurationKey = key;
 
     /// <summary>Reports the permissions this entry grants, resolved once from what the operator wrote.</summary>
     /// <param name="surface">The surface this entry guards, which decides which half of the vocabulary an unwritten grant reaches.</param>

--- a/src/Host/Configuration/Access/TransportAuthenticationOptions.cs
+++ b/src/Host/Configuration/Access/TransportAuthenticationOptions.cs
@@ -70,11 +70,12 @@ internal sealed class TransportAuthenticationOptions
     /// <remarks>
     /// <para>
     /// An absent key and an empty list are opposite statements and the binder cannot tell them apart, so the property's
-    /// own default is the restrictive one — nothing — and the permissive default belongs to the read: an entry whose
-    /// key configuration never carried holds its surface's whole half, which <see cref="WasGrantWritten" /> is what
-    /// records. An operator who wrote <c>[]</c> has reached this setting and narrowed all the way, which is how a
-    /// credential is retired without its entry being deleted. An entry constructed anywhere but from configuration
-    /// therefore starts from the grant that reaches nothing.
+    /// own default is the restrictive one — nothing — and the permissive default belongs to the read: the endpoint's
+    /// own read calls <see cref="GrantTheWholeSurface" /> on an entry whose key configuration never carried. An
+    /// operator who wrote <c>[]</c> has reached this setting and narrowed all the way, which is how a credential is
+    /// retired without its entry being deleted. An entry constructed anywhere but from configuration therefore starts
+    /// from the grant that reaches nothing, which is why the permissive case is the one recorded rather than the
+    /// narrowed one.
     /// </para>
     /// <para>
     /// Every name is one <see cref="MailFathomPermission" /> publishes and belongs to this entry's own surface;
@@ -92,14 +93,15 @@ internal sealed class TransportAuthenticationOptions
     /// </remarks>
     public bool PermissionsFromTokenScopes { get; set; }
 
-    /// <summary>Gets whether the deployment wrote this entry's grant, as opposed to leaving the key out entirely.</summary>
+    /// <summary>Gets whether this entry left its grant unstated and therefore reaches everything its surface publishes.</summary>
     /// <remarks>
     /// It is what tells a grant narrowed to nothing from a grant nobody narrowed, which is the difference between a
     /// credential that is refused everything and one that reaches the whole surface. The binder cannot answer it — an
     /// absent list and an empty one bind identically — so it is read from configuration by the endpoint that owns the
-    /// section, exactly as the origin list and the clear-text redirect are.
+    /// section, exactly as the origin list and the clear-text redirect are. It is the permissive case that is recorded
+    /// rather than the narrowed one, so an entry no read ever reached grants nothing instead of everything.
     /// </remarks>
-    internal bool WasGrantWritten { get; private set; }
+    internal bool GrantsTheWholeSurface { get; private set; }
 
     /// <summary>Gets whether this entry states any credential at all.</summary>
     public bool StatesAMethod => this.ApiKey is not null || this.OAuth is not null || this.PublicKey is not null;
@@ -107,9 +109,9 @@ internal sealed class TransportAuthenticationOptions
     /// <summary>Gets whether this entry states a credential the deployment itself configured, which can carry no scope of its own.</summary>
     public bool StatesAConfiguredCredential => this.ApiKey is not null || this.PublicKey is not null;
 
-    /// <summary>Records that the deployment wrote this entry's grant.</summary>
+    /// <summary>Records that the deployment stated no grant on this entry, which is what leaves it reaching the whole surface.</summary>
     /// <remarks>Called by the endpoint's own read, which is the only place that holds the configuration section this was bound from.</remarks>
-    internal void MarkGrantWritten() => this.WasGrantWritten = true;
+    internal void GrantTheWholeSurface() => this.GrantsTheWholeSurface = true;
 
     /// <summary>Reports the permissions this entry grants, resolved once from what the operator wrote.</summary>
     /// <param name="surface">The surface this entry guards, which decides which half of the vocabulary an unwritten grant reaches.</param>
@@ -122,7 +124,7 @@ internal sealed class TransportAuthenticationOptions
     /// </remarks>
     public IReadOnlyList<MailFathomPermission> GrantedPermissions(ProtectedSurface surface)
     {
-        if (!this.WasGrantWritten)
+        if (this.GrantsTheWholeSurface)
         {
             return MailFathomPermission.PublishedFor(surface);
         }

--- a/src/Host/Configuration/Access/TransportAuthenticationOptions.cs
+++ b/src/Host/Configuration/Access/TransportAuthenticationOptions.cs
@@ -209,10 +209,13 @@ internal sealed class TransportAuthenticationOptions
 
         var claimedPermissions = new HashSet<string>(StringComparer.Ordinal);
 
-        foreach (var (index, configuredPermission) in this.Permissions.Index())
-        {
-            var permissionPath = $"{settingPath}:{nameof(this.Permissions)}:{index}";
+        // The list rather than a position inside it, because the position is where the binder appended the string and
+        // the operator may have written it under another key. Each message quotes the name, which is what they search
+        // their own file for.
+        var permissionPath = $"{settingPath}:{nameof(this.Permissions)}";
 
+        foreach (var configuredPermission in this.Permissions)
+        {
             if (!MailFathomPermission.TryParse(configuredPermission, out var permission))
             {
                 yield return $"{permissionPath} — '{configuredPermission}' is not a permission MailFathom publishes; write one of {PublishedNamesFor(surface)}.";

--- a/src/Host/Configuration/Access/TransportAuthenticationOptions.cs
+++ b/src/Host/Configuration/Access/TransportAuthenticationOptions.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Diagnostics.CodeAnalysis;
+using MailFathom.Domain.Access;
 using MailFathom.Infrastructure.Secrets.Discovery;
 
 namespace MailFathom.Host.Configuration.Access;
@@ -25,6 +26,12 @@ namespace MailFathom.Host.Configuration.Access;
 /// different requests — so which entry a block sits in is a matter of how an operator groups what they wrote, and the
 /// endpoint accepts every block across every entry. The one shape that says nothing is an entry carrying none, which is
 /// refused.
+/// </para>
+/// <para>
+/// The entry is also where a grant is written down, which is what makes that grouping consequential for anybody who
+/// writes one: <see cref="Permissions" /> is the ceiling on what every credential this entry admits may do, so two
+/// credentials to be granted differently are two entries. Nothing already configured changes meaning, because an entry
+/// that writes no grant holds what it always held.
 /// </para>
 /// <para>
 /// A method arriving later — a client certificate, say — is a block beside these. Nothing else moves, because nothing
@@ -59,11 +66,80 @@ internal sealed class TransportAuthenticationOptions
     /// </remarks>
     public ConfiguredSecret? PublicKey { get; set; }
 
+    /// <summary>Gets the published permission names every credential this entry admits may hold, which is the ceiling on what one may do.</summary>
+    /// <remarks>
+    /// <para>
+    /// An absent key and an empty list are opposite statements and the binder cannot tell them apart, so the property's
+    /// own default is the restrictive one — nothing — and the permissive default belongs to the read: an entry whose
+    /// key configuration never carried holds its surface's whole half, which <see cref="WasGrantWritten" /> is what
+    /// records. An operator who wrote <c>[]</c> has reached this setting and narrowed all the way, which is how a
+    /// credential is retired without its entry being deleted. An entry constructed anywhere but from configuration
+    /// therefore starts from the grant that reaches nothing.
+    /// </para>
+    /// <para>
+    /// Every name is one <see cref="MailFathomPermission" /> publishes and belongs to this entry's own surface;
+    /// startup refuses anything else rather than accepting a grant nothing enforces.
+    /// </para>
+    /// </remarks>
+    public IList<string> Permissions { get; } = [];
+
+    /// <summary>Gets or sets whether a token's own scopes narrow the ceiling above, instead of every credential holding all of it.</summary>
+    /// <remarks>
+    /// With it, a token holds the published names its scopes carry <em>and</em> this entry lists, so the authorization
+    /// server decides per subject within a bound the deployment fixed. Available only to an entry whose sole block is
+    /// <see cref="OAuth" />, because neither a key nor a public key can carry anything the deployment did not write, so
+    /// startup refuses it beside either rather than asking a credential a question it cannot answer.
+    /// </remarks>
+    public bool PermissionsFromTokenScopes { get; set; }
+
+    /// <summary>Gets whether the deployment wrote this entry's grant, as opposed to leaving the key out entirely.</summary>
+    /// <remarks>
+    /// It is what tells a grant narrowed to nothing from a grant nobody narrowed, which is the difference between a
+    /// credential that is refused everything and one that reaches the whole surface. The binder cannot answer it — an
+    /// absent list and an empty one bind identically — so it is read from configuration by the endpoint that owns the
+    /// section, exactly as the origin list and the clear-text redirect are.
+    /// </remarks>
+    internal bool WasGrantWritten { get; private set; }
+
     /// <summary>Gets whether this entry states any credential at all.</summary>
     public bool StatesAMethod => this.ApiKey is not null || this.OAuth is not null || this.PublicKey is not null;
 
+    /// <summary>Gets whether this entry states a credential the deployment itself configured, which can carry no scope of its own.</summary>
+    public bool StatesAConfiguredCredential => this.ApiKey is not null || this.PublicKey is not null;
+
+    /// <summary>Records that the deployment wrote this entry's grant.</summary>
+    /// <remarks>Called by the endpoint's own read, which is the only place that holds the configuration section this was bound from.</remarks>
+    internal void MarkGrantWritten() => this.WasGrantWritten = true;
+
+    /// <summary>Reports the permissions this entry grants, resolved once from what the operator wrote.</summary>
+    /// <param name="surface">The surface this entry guards, which decides which half of the vocabulary an unwritten grant reaches.</param>
+    /// <returns>The granted permissions, in the published order.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the settings have not passed <see cref="FindConfigurationErrors" />, which is what proves every written name is one this repository publishes.</exception>
+    /// <remarks>
+    /// This is the ceiling rather than what a particular caller holds. Where
+    /// <see cref="PermissionsFromTokenScopes" /> is set, a token holds this narrowed by its own scopes, which is a
+    /// question about the token and is asked where one is validated.
+    /// </remarks>
+    public IReadOnlyList<MailFathomPermission> GrantedPermissions(ProtectedSurface surface)
+    {
+        if (!this.WasGrantWritten)
+        {
+            return MailFathomPermission.PublishedFor(surface);
+        }
+
+        return
+        [
+            .. this.Permissions.Select(configuredPermission =>
+                MailFathomPermission.TryParse(configuredPermission, out var permission)
+                    ? permission
+                    : throw new InvalidOperationException(
+                        "The grant was resolved before it was validated, so at least one written name is not a permission this repository publishes.")),
+        ];
+    }
+
     /// <summary>Finds everything an operator must fix before this entry can accept a credential.</summary>
     /// <param name="settingPath">The configuration path this entry was bound from, which every message is written against.</param>
+    /// <param name="surface">The surface this entry guards, which decides which half of the published vocabulary its grant may name.</param>
     /// <returns>One message per faulty setting, each naming its configuration path, empty when the settings are usable.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="settingPath" /> is <see langword="null" />.</exception>
     /// <remarks>
@@ -75,7 +151,7 @@ internal sealed class TransportAuthenticationOptions
     /// machinery's questions and are answered by <see cref="SecretConfigurationValidator" /> against the same section.
     /// </para>
     /// </remarks>
-    public IReadOnlyList<string> FindConfigurationErrors(string settingPath)
+    public IReadOnlyList<string> FindConfigurationErrors(string settingPath, ProtectedSurface surface)
     {
         ArgumentNullException.ThrowIfNull(settingPath);
 
@@ -87,8 +163,51 @@ internal sealed class TransportAuthenticationOptions
             ];
         }
 
-        return this.OAuth is { } oauth
-            ? [.. oauth.FindConfigurationErrors().Select(error => $"{settingPath}:{nameof(this.OAuth)}:{error}")]
-            : [];
+        var errors = new List<string>(this.FindGrantErrors(settingPath, surface));
+
+        if (this.OAuth is { } oauth)
+        {
+            errors.AddRange(oauth.FindConfigurationErrors().Select(error => $"{settingPath}:{nameof(this.OAuth)}:{error}"));
+        }
+
+        return errors;
     }
+
+    /// <summary>Reports the grant an operator wrote that says something impossible.</summary>
+    /// <remarks>
+    /// An emptied list is deliberately not among them: it is a grant narrowed all the way, which is a posture rather
+    /// than a mistake. What is refused is a name nothing publishes, a name belonging to the other surface — which would
+    /// otherwise sit there granting nothing while an operator believed they had granted something — a name written
+    /// twice, and asking a credential this deployment configured to bring scopes it can never carry.
+    /// </remarks>
+    private IEnumerable<string> FindGrantErrors(string settingPath, ProtectedSurface surface)
+    {
+        if (this.PermissionsFromTokenScopes && this.StatesAConfiguredCredential)
+        {
+            yield return $"{settingPath}:{nameof(this.PermissionsFromTokenScopes)} — a token's scopes can narrow a grant and a credential this deployment configured carries none, so this entry cannot be read both ways. Move the '{nameof(this.OAuth)}' block to an entry of its own, or remove this setting and write the grant in '{nameof(this.Permissions)}'.";
+        }
+
+        var claimedPermissions = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (index, configuredPermission) in this.Permissions.Index())
+        {
+            var permissionPath = $"{settingPath}:{nameof(this.Permissions)}:{index}";
+
+            if (!MailFathomPermission.TryParse(configuredPermission, out var permission))
+            {
+                yield return $"{permissionPath} — '{configuredPermission}' is not a permission MailFathom publishes; write one of {PublishedNamesFor(surface)}.";
+            }
+            else if (permission.Surface != surface)
+            {
+                yield return $"{permissionPath} — '{configuredPermission}' belongs to the other protected surface and grants nothing here; write one of {PublishedNamesFor(surface)}, or move the entry to the endpoint that serves it.";
+            }
+            else if (!claimedPermissions.Add(configuredPermission))
+            {
+                yield return $"{permissionPath} — '{configuredPermission}' repeats a permission the grant already carries.";
+            }
+        }
+    }
+
+    private static string PublishedNamesFor(ProtectedSurface surface) =>
+        string.Join(", ", MailFathomPermission.PublishedFor(surface).Select(permission => $"'{permission.Name}'"));
 }

--- a/src/Host/Configuration/Endpoints/AdminEndpointOptions.cs
+++ b/src/Host/Configuration/Endpoints/AdminEndpointOptions.cs
@@ -164,7 +164,7 @@ internal sealed class AdminEndpointOptions
 
         // Each entry's grant is read the same way and for the same reason, and both endpoints ask it through one
         // method so the absent-versus-emptied reading exists once.
-        TransportAuthenticationConfiguration.GrantTheWholeSurfaceWhereNoneIsStated(section, [.. settings.Authentication]);
+        TransportAuthenticationConfiguration.ReadWhatTheBinderCannotSay(section, [.. settings.Authentication]);
 
         return settings;
     }

--- a/src/Host/Configuration/Endpoints/AdminEndpointOptions.cs
+++ b/src/Host/Configuration/Endpoints/AdminEndpointOptions.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Quic;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Infrastructure.Secrets.Discovery;
 
@@ -46,6 +47,10 @@ internal sealed class AdminEndpointOptions
 {
     /// <summary>The configuration section the endpoint settings are bound from.</summary>
     public const string SectionName = "AdminEndpoint";
+
+    /// <summary>The half of the published permission vocabulary a grant on this endpoint draws from.</summary>
+    /// <remarks>Stated once here rather than derived wherever a grant is read, so a permission belonging to the other surface is refused by the same rule everywhere the section is judged.</remarks>
+    public const ProtectedSurface GrantedSurface = ProtectedSurface.Administration;
 
     /// <summary>The path every administrative route is served beneath.</summary>
     /// <remarks>
@@ -157,6 +162,10 @@ internal sealed class AdminEndpointOptions
             settings.Https.Redirect.MarkStated();
         }
 
+        // Each entry's grant is read the same way and for the same reason, and both endpoints ask it through one
+        // method so the absent-versus-emptied reading exists once.
+        TransportAuthenticationConfiguration.MarkWrittenGrants(section, [.. settings.Authentication]);
+
         return settings;
     }
 
@@ -207,7 +216,8 @@ internal sealed class AdminEndpointOptions
 
         var authenticationErrors = TransportAuthenticationConfiguration.FindConfigurationErrors(
             SectionName,
-            [.. this.Authentication]);
+            [.. this.Authentication],
+            GrantedSurface);
 
         var errors = new List<string>(authenticationErrors);
 

--- a/src/Host/Configuration/Endpoints/AdminEndpointOptions.cs
+++ b/src/Host/Configuration/Endpoints/AdminEndpointOptions.cs
@@ -164,7 +164,7 @@ internal sealed class AdminEndpointOptions
 
         // Each entry's grant is read the same way and for the same reason, and both endpoints ask it through one
         // method so the absent-versus-emptied reading exists once.
-        TransportAuthenticationConfiguration.MarkWrittenGrants(section, [.. settings.Authentication]);
+        TransportAuthenticationConfiguration.GrantTheWholeSurfaceWhereNoneIsStated(section, [.. settings.Authentication]);
 
         return settings;
     }

--- a/src/Host/Configuration/Endpoints/AdminEndpointOptions.cs
+++ b/src/Host/Configuration/Endpoints/AdminEndpointOptions.cs
@@ -270,7 +270,7 @@ internal sealed class AdminEndpointOptions
                 continue;
             }
 
-            yield return $"{SectionName}:{TransportAuthenticationConfiguration.SettingName}:{index}:{nameof(TransportAuthenticationOptions.OAuth)}:{nameof(OAuthValidationOptions.Resource)} — the path must be '{RoutePrefix}', because that is where the endpoint's routes answer and it is what a client appends to the address it was given. Write the absolute https URL clients reach this endpoint at, ending in that prefix.";
+            yield return $"{TransportAuthenticationConfiguration.SettingPathOf(SectionName, method, index)}:{nameof(TransportAuthenticationOptions.OAuth)}:{nameof(OAuthValidationOptions.Resource)} — the path must be '{RoutePrefix}', because that is where the endpoint's routes answer and it is what a client appends to the address it was given. Write the absolute https URL clients reach this endpoint at, ending in that prefix.";
         }
     }
 

--- a/src/Host/Configuration/Endpoints/McpEndpointOptions.cs
+++ b/src/Host/Configuration/Endpoints/McpEndpointOptions.cs
@@ -171,7 +171,7 @@ internal sealed class McpEndpointOptions
 
         // Each entry's grant is read the same way and for the same reason, and both endpoints ask it through one
         // method so the absent-versus-emptied reading exists once.
-        TransportAuthenticationConfiguration.GrantTheWholeSurfaceWhereNoneIsStated(section, [.. settings.Authentication]);
+        TransportAuthenticationConfiguration.ReadWhatTheBinderCannotSay(section, [.. settings.Authentication]);
 
         return settings;
     }

--- a/src/Host/Configuration/Endpoints/McpEndpointOptions.cs
+++ b/src/Host/Configuration/Endpoints/McpEndpointOptions.cs
@@ -171,7 +171,7 @@ internal sealed class McpEndpointOptions
 
         // Each entry's grant is read the same way and for the same reason, and both endpoints ask it through one
         // method so the absent-versus-emptied reading exists once.
-        TransportAuthenticationConfiguration.MarkWrittenGrants(section, [.. settings.Authentication]);
+        TransportAuthenticationConfiguration.GrantTheWholeSurfaceWhereNoneIsStated(section, [.. settings.Authentication]);
 
         return settings;
     }

--- a/src/Host/Configuration/Endpoints/McpEndpointOptions.cs
+++ b/src/Host/Configuration/Endpoints/McpEndpointOptions.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Quic;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using MailFathom.Infrastructure.Security.ClientCertificates;
@@ -46,6 +47,10 @@ internal sealed class McpEndpointOptions
 {
     /// <summary>The configuration section the endpoint settings are bound from.</summary>
     public const string SectionName = "McpEndpoint";
+
+    /// <summary>The half of the published permission vocabulary a grant on this endpoint draws from.</summary>
+    /// <remarks>Stated once here rather than derived wherever a grant is read, so a permission belonging to the other surface is refused by the same rule everywhere the section is judged.</remarks>
+    public const ProtectedSurface GrantedSurface = ProtectedSurface.Mail;
 
     /// <summary>Gets or sets whether the MCP endpoint is served at all.</summary>
     /// <remarks>Disabled unless a deployment states otherwise, so reaching a mailbox over MCP is always something an operator turned on.</remarks>
@@ -164,6 +169,10 @@ internal sealed class McpEndpointOptions
             settings.Https.Redirect.MarkStated();
         }
 
+        // Each entry's grant is read the same way and for the same reason, and both endpoints ask it through one
+        // method so the absent-versus-emptied reading exists once.
+        TransportAuthenticationConfiguration.MarkWrittenGrants(section, [.. settings.Authentication]);
+
         return settings;
     }
 
@@ -219,7 +228,8 @@ internal sealed class McpEndpointOptions
 
         var errors = new List<string>(TransportAuthenticationConfiguration.FindConfigurationErrors(
             SectionName,
-            [.. this.Authentication]));
+            [.. this.Authentication],
+            GrantedSurface));
 
         errors.AddRange(this.Cors.FindConfigurationErrors()
             .Select(error => $"{SectionName}:{nameof(this.Cors)}:{error}"));

--- a/src/Host/HostComposition.cs
+++ b/src/Host/HostComposition.cs
@@ -968,6 +968,10 @@ internal static class HostComposition
         // whether it has anything to say. They stay separate services because an operator turns either bound off alone.
         builder.Services.AddHostedService<TransportRequestTimeoutStartupReport>();
         builder.Services.AddHostedService<ConnectionLimitsStartupReport>();
+
+        // Beside them for the same reason, and separate from the authentication warnings because it answers the other
+        // half of the question: those say whether a caller has to identify itself, this says what one may then do.
+        builder.Services.AddHostedService<TransportGrantStartupReport>();
         // Composed from the environment rather than resolved from the container, because the value it reports is one
         // OpenSSL read while it initialized and no configuration source can influence it afterwards. Registered
         // unconditionally for the same reason the warnings above are: the condition belongs in one place.

--- a/src/Host/Hosting/Warnings/TransportGrantStartupReport.cs
+++ b/src/Host/Hosting/Warnings/TransportGrantStartupReport.cs
@@ -120,7 +120,7 @@ internal sealed partial class TransportGrantStartupReport : IHostedService
         foreach (var (index, method) in methods.Index())
         {
             var grant = Describe(method.GrantedPermissions(surface));
-            var entryPath = $"{settingPath}:{index}";
+            var entryPath = TransportAuthenticationConfiguration.SettingPathOf(sectionName, method, index);
 
             // The narrowing setting is asked first because it holds whether or not a list was written: an entry whose
             // sole block is OAuth may set it and state no ceiling, and what each token there holds is still its own

--- a/src/Host/Hosting/Warnings/TransportGrantStartupReport.cs
+++ b/src/Host/Hosting/Warnings/TransportGrantStartupReport.cs
@@ -122,13 +122,16 @@ internal sealed partial class TransportGrantStartupReport : IHostedService
             var grant = Describe(method.GrantedPermissions(surface));
             var entryPath = $"{settingPath}:{index}";
 
-            if (!method.WasGrantWritten)
-            {
-                this.LogEntryGrantedWithoutBeingNarrowed(endpointName, entryPath, grant);
-            }
-            else if (method.PermissionsFromTokenScopes)
+            // The narrowing setting is asked first because it holds whether or not a list was written: an entry whose
+            // sole block is OAuth may set it and state no ceiling, and what each token there holds is still its own
+            // scopes rather than the whole surface the line would otherwise report.
+            if (method.PermissionsFromTokenScopes)
             {
                 this.LogEntryGrantNarrowedByTokenScopes(endpointName, entryPath, grant);
+            }
+            else if (method.GrantsTheWholeSurface)
+            {
+                this.LogEntryGrantedWithoutBeingNarrowed(endpointName, entryPath, grant);
             }
             else
             {

--- a/src/Host/Hosting/Warnings/TransportGrantStartupReport.cs
+++ b/src/Host/Hosting/Warnings/TransportGrantStartupReport.cs
@@ -1,0 +1,181 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Configuration.Access;
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Mcp;
+using Microsoft.Extensions.Options;
+
+namespace MailFathom.Host.Hosting.Warnings;
+
+/// <summary>States at startup what every configured credential entry may do, and what a surface with no entry grants.</summary>
+/// <remarks>
+/// <para>
+/// A grant nobody wrote down reaches the whole of its surface, which is what makes a deployment work before it is
+/// governed and is also the one thing about it an operator would otherwise never see. Reporting each entry's resolved
+/// grant is what turns that default into a posture somebody chose: they meet it in the log on the first run rather than
+/// inferring it later from what a credential turned out to be able to do.
+/// </para>
+/// <para>
+/// Both endpoints are reported by one service and each entry separately, because the two surfaces draw from disjoint
+/// halves of the vocabulary and an operator who narrowed one credential has to be able to read back that they narrowed
+/// the one they meant. An entry is named by its configuration path, which is the position they would edit; nothing here
+/// names a key, a public key, a token, an authorization server, or a subject, because a grant is what the deployment
+/// wrote and never who presented something.
+/// </para>
+/// <para>
+/// It records rather than warns, including for the surface that configures no entry at all. That posture is already a
+/// warning — <see cref="McpTransportAuthenticationWarning" /> and <see cref="AdminTransportSecurityWarning" /> each say
+/// what it means that anything reaching the address is served — and what this adds is the half those cannot state,
+/// which is how much such a caller then holds. Saying it twice at warning level would make the second one noise and the
+/// first one easier to scroll past.
+/// </para>
+/// <para>
+/// It runs as a hosted service so it appears among the other startup diagnostics, and it is registered whether or not
+/// either endpoint is enabled, because it is the report that decides whether it has anything to say.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The dependency injection container materializes this hosted service.")]
+internal sealed partial class TransportGrantStartupReport : IHostedService
+{
+    private const string McpEndpointName = "MCP";
+
+    private const string AdminEndpointName = "administrative";
+
+    private const string NothingGranted = "nothing";
+
+    private readonly McpEndpointOptions mcpEndpointSettings;
+    private readonly AdminEndpointOptions adminEndpointSettings;
+    private readonly ILogger<TransportGrantStartupReport> logger;
+
+    /// <summary>Initializes a new startup report.</summary>
+    /// <param name="mcpEndpointSettings">The MCP endpoint settings startup was composed from.</param>
+    /// <param name="adminEndpointSettings">The administrative endpoint settings startup was composed from.</param>
+    /// <param name="logger">The startup logger.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="mcpEndpointSettings" /> or <paramref name="adminEndpointSettings" /> is <see langword="null" />.</exception>
+    public TransportGrantStartupReport(
+        IOptions<McpEndpointOptions> mcpEndpointSettings,
+        IOptions<AdminEndpointOptions> adminEndpointSettings,
+        ILogger<TransportGrantStartupReport> logger)
+    {
+        ArgumentNullException.ThrowIfNull(mcpEndpointSettings);
+        ArgumentNullException.ThrowIfNull(adminEndpointSettings);
+
+        this.mcpEndpointSettings = mcpEndpointSettings.Value;
+        this.adminEndpointSettings = adminEndpointSettings.Value;
+        this.logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (this.mcpEndpointSettings.Enabled)
+        {
+            this.Report(
+                McpEndpointName,
+                McpEndpointRoute.Path,
+                McpEndpointOptions.SectionName,
+                McpEndpointOptions.GrantedSurface,
+                [.. this.mcpEndpointSettings.Authentication]);
+        }
+
+        if (this.adminEndpointSettings.Enabled)
+        {
+            this.Report(
+                AdminEndpointName,
+                AdminEndpointOptions.RoutePrefix,
+                AdminEndpointOptions.SectionName,
+                AdminEndpointOptions.GrantedSurface,
+                [.. this.adminEndpointSettings.Authentication]);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    /// <summary>States what one endpoint's entries resolved to, or what a caller holds where it configures none.</summary>
+    private void Report(
+        string endpointName,
+        string endpointPath,
+        string sectionName,
+        ProtectedSurface surface,
+        IReadOnlyList<TransportAuthenticationOptions> methods)
+    {
+        var settingPath = $"{sectionName}:{TransportAuthenticationConfiguration.SettingName}";
+
+        if (methods.Count == 0)
+        {
+            var wholeSurface = Describe(MailFathomPermission.PublishedFor(surface));
+
+            this.LogSurfaceGrantedWithoutAnyEntry(endpointName, endpointPath, wholeSurface, settingPath);
+
+            return;
+        }
+
+        foreach (var (index, method) in methods.Index())
+        {
+            var grant = Describe(method.GrantedPermissions(surface));
+            var entryPath = $"{settingPath}:{index}";
+
+            if (!method.WasGrantWritten)
+            {
+                this.LogEntryGrantedWithoutBeingNarrowed(endpointName, entryPath, grant);
+            }
+            else if (method.PermissionsFromTokenScopes)
+            {
+                this.LogEntryGrantNarrowedByTokenScopes(endpointName, entryPath, grant);
+            }
+            else
+            {
+                this.LogEntryGrant(endpointName, entryPath, grant);
+            }
+        }
+    }
+
+    /// <summary>Renders a resolved grant for a log line, naming emptiness rather than printing nothing.</summary>
+    /// <remarks>An empty list would otherwise read as a message that lost its argument, which is exactly the grant worth being unambiguous about: it is how a credential is retired without its entry being deleted.</remarks>
+    private static string Describe(IReadOnlyList<MailFathomPermission> permissions) => permissions.Count == 0
+        ? NothingGranted
+        : string.Join(", ", permissions.Select(permission => permission.Name));
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The {EndpointName} endpoint entry {EntrySettingPath} grants {GrantedPermissions} to every credential "
+            + "it admits.")]
+    private partial void LogEntryGrant(string endpointName, string entrySettingPath, string grantedPermissions);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The {EndpointName} endpoint entry {EntrySettingPath} grants at most {GrantedPermissions}, and each "
+            + "token holds whichever of those its own scopes carry.")]
+    private partial void LogEntryGrantNarrowedByTokenScopes(
+        string endpointName,
+        string entrySettingPath,
+        string grantedPermissions);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The {EndpointName} endpoint entry {EntrySettingPath} writes down no grant, so every credential it "
+            + "admits holds {GrantedPermissions} — everything this surface publishes. Write a 'Permissions' list on the "
+            + "entry to narrow it, or an empty one to grant nothing.")]
+    private partial void LogEntryGrantedWithoutBeingNarrowed(
+        string endpointName,
+        string entrySettingPath,
+        string grantedPermissions);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "The {EndpointName} endpoint on {EndpointPath} configures no credential entry, so every caller it "
+            + "serves holds {GrantedPermissions} — everything this surface publishes. There is no entry for a grant to "
+            + "be written on until one is added under {AuthenticationSettingPath}.")]
+    private partial void LogSurfaceGrantedWithoutAnyEntry(
+        string endpointName,
+        string endpointPath,
+        string grantedPermissions,
+        string authenticationSettingPath);
+}

--- a/src/Host/Hosting/Warnings/TransportGrantStartupReport.cs
+++ b/src/Host/Hosting/Warnings/TransportGrantStartupReport.cs
@@ -149,13 +149,15 @@ internal sealed partial class TransportGrantStartupReport : IHostedService
     [LoggerMessage(
         Level = LogLevel.Information,
         Message = "The {EndpointName} endpoint entry {EntrySettingPath} grants {GrantedPermissions} to every credential "
-            + "it admits.")]
+            + "it admits. Nothing consults a grant yet, so this states what those credentials are meant to reach rather "
+            + "than what they currently reach.")]
     private partial void LogEntryGrant(string endpointName, string entrySettingPath, string grantedPermissions);
 
     [LoggerMessage(
         Level = LogLevel.Information,
         Message = "The {EndpointName} endpoint entry {EntrySettingPath} grants at most {GrantedPermissions}, and each "
-            + "token holds whichever of those its own scopes carry.")]
+            + "token holds whichever of those its own scopes carry. Nothing consults a grant yet, so this states what "
+            + "those tokens are meant to reach rather than what they currently reach.")]
     private partial void LogEntryGrantNarrowedByTokenScopes(
         string endpointName,
         string entrySettingPath,
@@ -165,7 +167,8 @@ internal sealed partial class TransportGrantStartupReport : IHostedService
         Level = LogLevel.Information,
         Message = "The {EndpointName} endpoint entry {EntrySettingPath} writes down no grant, so every credential it "
             + "admits holds {GrantedPermissions} — everything this surface publishes. Write a 'Permissions' list on the "
-            + "entry to narrow it, or an empty one to grant nothing.")]
+            + "entry to narrow it, or an empty one to grant nothing — which states an intent rather than a bound, "
+            + "because nothing consults a grant yet.")]
     private partial void LogEntryGrantedWithoutBeingNarrowed(
         string endpointName,
         string entrySettingPath,
@@ -175,7 +178,8 @@ internal sealed partial class TransportGrantStartupReport : IHostedService
         Level = LogLevel.Information,
         Message = "The {EndpointName} endpoint on {EndpointPath} configures no credential entry, so every caller it "
             + "serves holds {GrantedPermissions} — everything this surface publishes. There is no entry for a grant to "
-            + "be written on until one is added under {AuthenticationSettingPath}.")]
+            + "be written on until one is added under {AuthenticationSettingPath}, and nothing consults a grant yet "
+            + "either.")]
     private partial void LogSurfaceGrantedWithoutAnyEntry(
         string endpointName,
         string endpointPath,

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -307,7 +307,7 @@ try
         {
             // Outside the group the requirement was attached to, and deliberately: its reader is a client that has no
             // credential yet and is reading this to find out where to obtain one.
-            app.MapAdminProtectedResourceMetadata(composition.Admin.OAuthMethods());
+            app.MapAdminProtectedResourceMetadata([.. composition.Admin.Authentication]);
         }
     }
 

--- a/src/Host/Security/ApiKeys/ApiKeyAuthenticationHandler.cs
+++ b/src/Host/Security/ApiKeys/ApiKeyAuthenticationHandler.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using MailFathom.Host.Security.Transport;
 using MailFathom.Infrastructure.Security.ApiKeys;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
@@ -68,8 +69,17 @@ internal sealed class ApiKeyAuthenticationHandler : AuthenticationHandler<ApiKey
             return AuthenticateResult.Fail("The request presented no usable credential.");
         }
 
+        // The grant was resolved from the entry that carries this key while the host was composed, so what a caller may
+        // do travels on the principal rather than being looked up behind it.
+        var grantedPermissions = this.Options.GrantsByKeyName.TryGetValue(keyName.Value!, out var permissions)
+            ? permissions
+            : [];
+
         var identity = new ClaimsIdentity(
-            [new Claim(ApiKeyAuthentication.ApiKeyNameClaimType, keyName.Value!)],
+            [
+                new Claim(ApiKeyAuthentication.ApiKeyNameClaimType, keyName.Value!),
+                .. TransportGrant.ClaimsFor(grantedPermissions),
+            ],
             this.Options.Surface.ApiKeySchemeName,
             ApiKeyAuthentication.ApiKeyNameClaimType,
             ApiKeyAuthentication.RoleClaimType);

--- a/src/Host/Security/ApiKeys/ApiKeyAuthenticationSchemeOptions.cs
+++ b/src/Host/Security/ApiKeys/ApiKeyAuthenticationSchemeOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Access;
 using MailFathom.Host.Security.Transport;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using Microsoft.AspNetCore.Authentication;
@@ -26,6 +27,16 @@ internal sealed class ApiKeyAuthenticationSchemeOptions : AuthenticationSchemeOp
 
     /// <summary>Gets or sets the API key references a request may present one of, empty when the surface accepts none.</summary>
     internal IReadOnlyList<ConfiguredSecret> ApiKeys { get; set; } = [];
+
+    /// <summary>Gets or sets what each key's own configuration entry granted, keyed by the key's configured name.</summary>
+    /// <remarks>
+    /// Resolved once while the host is composed rather than read per request, and carried here for the reason the keys
+    /// themselves are: it is the scheme's own option, so two surfaces register one handler over two grants. A key
+    /// missing from the map holds nothing, which is the same answer an entry that granted nothing gives — and it cannot
+    /// arise while the map and the key list are composed from the same entries.
+    /// </remarks>
+    internal IReadOnlyDictionary<string, IReadOnlyList<MailFathomPermission>> GrantsByKeyName { get; set; } =
+        new Dictionary<string, IReadOnlyList<MailFathomPermission>>(StringComparer.Ordinal);
 
     /// <inheritdoc />
     /// <exception cref="InvalidOperationException">Thrown when the scheme was registered without a surface, which would leave a successful authentication carrying no identity.</exception>

--- a/src/Host/Security/ClientAssertions/ClientAssertionAuthenticationHandler.cs
+++ b/src/Host/Security/ClientAssertions/ClientAssertionAuthenticationHandler.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using MailFathom.Host.Security.ApiKeys;
+using MailFathom.Host.Security.Transport;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 
@@ -71,8 +72,17 @@ internal sealed class ClientAssertionAuthenticationHandler
             return AuthenticateResult.Fail("The request presented no usable credential.");
         }
 
+        // The grant was resolved from the entry that carries this public key while the host was composed, so what a
+        // caller may do travels on the principal rather than being looked up behind it.
+        var grantedPermissions = this.Options.GrantsByKeyName.TryGetValue(keyName.Value!, out var permissions)
+            ? permissions
+            : [];
+
         var identity = new ClaimsIdentity(
-            [new Claim(ClientAssertionAuthentication.KeyNameClaimType, keyName.Value!)],
+            [
+                new Claim(ClientAssertionAuthentication.KeyNameClaimType, keyName.Value!),
+                .. TransportGrant.ClaimsFor(grantedPermissions),
+            ],
             this.Options.Surface.ClientAssertionSchemeName,
             ClientAssertionAuthentication.KeyNameClaimType,
             ClientAssertionAuthentication.RoleClaimType);

--- a/src/Host/Security/ClientAssertions/ClientAssertionAuthenticationSchemeOptions.cs
+++ b/src/Host/Security/ClientAssertions/ClientAssertionAuthenticationSchemeOptions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Access;
 using MailFathom.Host.Security.Transport;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using Microsoft.AspNetCore.Authentication;
@@ -26,6 +27,16 @@ internal sealed class ClientAssertionAuthenticationSchemeOptions : Authenticatio
 
     /// <summary>Gets or sets the client public key references an assertion may be verified against, empty when the surface accepts none.</summary>
     internal IReadOnlyList<ConfiguredSecret> PublicKeys { get; set; } = [];
+
+    /// <summary>Gets or sets what each public key's own configuration entry granted, keyed by the key's configured name.</summary>
+    /// <remarks>
+    /// Resolved once while the host is composed rather than read per request, and carried here for the reason the keys
+    /// themselves are: it is the scheme's own option, so two surfaces register one handler over two grants. A key
+    /// missing from the map holds nothing, which is the same answer an entry that granted nothing gives — and it cannot
+    /// arise while the map and the key list are composed from the same entries.
+    /// </remarks>
+    internal IReadOnlyDictionary<string, IReadOnlyList<MailFathomPermission>> GrantsByKeyName { get; set; } =
+        new Dictionary<string, IReadOnlyList<MailFathomPermission>>(StringComparer.Ordinal);
 
     /// <inheritdoc />
     /// <exception cref="InvalidOperationException">Thrown when the scheme was registered without a surface, which would leave the audience an assertion is judged against unstated.</exception>

--- a/src/Host/Security/Endpoints/AdminTransportSecurityExtensions.cs
+++ b/src/Host/Security/Endpoints/AdminTransportSecurityExtensions.cs
@@ -46,9 +46,7 @@ internal static class AdminTransportSecurityExtensions
 
         services.AddTransportAuthentication(
             TransportSurface.Admin,
-            endpointSettings.ApiKeys(),
-            endpointSettings.PublicKeys(),
-            endpointSettings.OAuthMethods(),
+            [.. endpointSettings.Authentication],
             ChallengeSchemeFor(endpointSettings));
 
         return services;

--- a/src/Host/Security/Mcp/McpTransportSecurityExtensions.cs
+++ b/src/Host/Security/Mcp/McpTransportSecurityExtensions.cs
@@ -84,14 +84,12 @@ internal static class McpTransportSecurityExtensions
 
         var authentication = services.AddTransportAuthentication(
             TransportSurface.Mcp,
-            endpointSettings.ApiKeys(),
-            endpointSettings.PublicKeys(),
-            oauthMethods,
+            [.. endpointSettings.Authentication],
             challengeSchemeName);
 
         if (oauthMethods.Count > 0)
         {
-            AddProtectedResourceMetadataScheme(authentication, oauthMethods);
+            AddProtectedResourceMetadataScheme(authentication, [.. endpointSettings.Authentication]);
             AddInsufficientScopeRefusal(services, oauthMethods);
         }
 
@@ -132,9 +130,9 @@ internal static class McpTransportSecurityExtensions
     /// </remarks>
     private static void AddProtectedResourceMetadataScheme(
         AuthenticationBuilder authentication,
-        IReadOnlyList<OAuthValidationOptions> oauthMethods)
+        IReadOnlyList<TransportAuthenticationOptions> methods)
     {
-        var published = PublishedOAuthMetadata.For(oauthMethods);
+        var published = PublishedOAuthMetadata.For(methods, McpEndpointOptions.GrantedSurface);
 
         authentication.AddMcp(mcpOptions =>
         {

--- a/src/Host/Security/Transport/TransportAccessPolicy.cs
+++ b/src/Host/Security/Transport/TransportAccessPolicy.cs
@@ -30,6 +30,12 @@ namespace MailFathom.Host.Security.Transport;
 /// that decides for itself who receives one, which is what makes both worth checking. Asking either of a configured
 /// credential would mean asking it for something nothing can ever put in it.
 /// </para>
+/// <para>
+/// What an admitted caller may then <em>do</em> is a separate question and is not asked here. The permissions its
+/// credential's configuration entry granted travel on the principal this judges, written by whichever scheme
+/// authenticated it and read back through <see cref="TransportGrant" />, so admission stays one shared judgement while
+/// each surface enforces the grant in the terms its own callers are answered in.
+/// </para>
 /// </remarks>
 internal static class TransportAccessPolicy
 {

--- a/src/Host/Security/Transport/TransportAccessPolicy.cs
+++ b/src/Host/Security/Transport/TransportAccessPolicy.cs
@@ -33,8 +33,9 @@ namespace MailFathom.Host.Security.Transport;
 /// <para>
 /// What an admitted caller may then <em>do</em> is a separate question and is not asked here. The permissions its
 /// credential's configuration entry granted travel on the principal this judges, written by whichever scheme
-/// authenticated it and read back through <see cref="TransportGrant" />, so admission stays one shared judgement while
-/// each surface enforces the grant in the terms its own callers are answered in.
+/// authenticated it, so that admission can stay one shared judgement while each surface comes to enforce the grant in
+/// the terms its own callers are answered in. Nothing reads them back yet: <see cref="TransportGrant" /> is how a
+/// surface will, and no route and no tool consults a permission today.
 /// </para>
 /// </remarks>
 internal static class TransportAccessPolicy

--- a/src/Host/Security/Transport/TransportGrant.cs
+++ b/src/Host/Security/Transport/TransportGrant.cs
@@ -1,0 +1,71 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Claims;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Host.Security.Transport;
+
+/// <summary>How the permissions a credential was granted travel on the principal that credential produced.</summary>
+/// <remarks>
+/// <para>
+/// The grant is resolved once, while the host is composed, from the configuration entry that admits the credential. It
+/// reaches a request as claims on the authenticated principal rather than as a lookup a policy performs, which is what
+/// keeps the decision where it was made: nothing per request re-reads a configuration section, and nothing downstream
+/// has to know which entry, which key, or which authorization server was involved.
+/// </para>
+/// <para>
+/// A claim per permission rather than one carrying a joined list, because that is what a claims principal is for and it
+/// leaves no separator for a permission name to be mistaken across. The names are MailFathom's own published
+/// identities, so nothing here discloses a credential, a subject, or anything an authorization server sent.
+/// </para>
+/// <para>
+/// A principal carrying none of these claims holds nothing, which is a credential whose entry granted nothing rather
+/// than one whose grant was never read: every scheme that authenticates writes the resolved grant, including the empty
+/// one. What a caller admitted where the surface configures no credential at all holds is a different question, decided
+/// by the surface rather than by a principal, and answered where that posture is enforced.
+/// </para>
+/// </remarks>
+internal static class TransportGrant
+{
+    /// <summary>The claim type carrying one permission the caller was granted.</summary>
+    /// <remarks>
+    /// A private claim type rather than a registered one: the value is a capability this repository publishes, not a
+    /// subject or an entitlement any other system issued. One claim type across every surface and every credential
+    /// kind, because the permission name already says which surface it belongs to and a principal never crosses one.
+    /// </remarks>
+    internal const string PermissionClaimType = "urn:mailfathom:permission";
+
+    /// <summary>Turns a resolved grant into the claims an identity carries it as.</summary>
+    /// <param name="permissions">The permissions the entry granted, empty when it granted none.</param>
+    /// <returns>One claim per permission, in the order given.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="permissions" /> is <see langword="null" />.</exception>
+    internal static IReadOnlyList<Claim> ClaimsFor(IEnumerable<MailFathomPermission> permissions)
+    {
+        ArgumentNullException.ThrowIfNull(permissions);
+
+        return [.. permissions.Select(permission => new Claim(PermissionClaimType, permission.Name))];
+    }
+
+    /// <summary>Reports the permissions an authenticated principal was granted.</summary>
+    /// <param name="principal">The principal a validated credential produced.</param>
+    /// <returns>The granted permissions, empty when the principal holds none.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="principal" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A claim naming something this repository does not publish is dropped rather than reported. Nothing outside this
+    /// process writes one — every claim here was composed from a published name a moment earlier — so an unmatched
+    /// value can only be a name a later release retired, and reading it as a permission is the one outcome that would
+    /// grant something.
+    /// </remarks>
+    internal static IReadOnlySet<MailFathomPermission> PermissionsCarriedBy(ClaimsPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        return principal
+            .FindAll(PermissionClaimType)
+            .Select(claim => MailFathomPermission.TryParse(claim.Value, out var permission) ? permission : default)
+            .Where(permission => permission.IsSpecified)
+            .ToHashSet();
+    }
+}

--- a/src/Host/Security/Transport/TransportSecurityExtensions.cs
+++ b/src/Host/Security/Transport/TransportSecurityExtensions.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Security.Claims;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Host.Security.ApiKeys;
 using MailFathom.Host.Security.ClientAssertions;
@@ -42,14 +43,17 @@ internal static class TransportSecurityExtensions
     /// <summary>Adds one surface's authentication schemes and its authorization requirement.</summary>
     /// <param name="services">The container to add to.</param>
     /// <param name="surface">The surface being protected, which names every scheme and the policy.</param>
-    /// <param name="apiKeys">The keys a request may present one of, empty where the surface accepts none.</param>
-    /// <param name="publicKeys">The client public keys a signed assertion may be verified against, empty where the surface accepts no assertion.</param>
-    /// <param name="oauthMethods">What a token must prove, one entry per configured OAuth block, empty where the surface accepts no access token.</param>
+    /// <param name="methods">The surface's configured credential entries, in configuration order.</param>
     /// <param name="challengeSchemeName">The scheme answering a request that presented no credential this surface can place, which is both what authenticates it and what challenges it.</param>
     /// <returns>The authentication builder, so a surface can add schemes only it needs.</returns>
     /// <exception cref="ArgumentNullException">Thrown when any reference argument is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="surface" /> is the struct default.</exception>
     /// <remarks>
+    /// <para>
+    /// The whole entries rather than the credentials pulled out of them, because an entry is what carries a grant as
+    /// well as a credential, and the two have to be registered together: a key is compared by the scheme its entry
+    /// selected, and what the caller may do afterwards is what that same entry wrote down.
+    /// </para>
     /// <para>
     /// The routing scheme becomes the application's default, so every part of the pipeline that asks for "the" scheme
     /// reaches the one place that knows how many schemes there are, and nothing downstream names an individual scheme.
@@ -66,21 +70,21 @@ internal static class TransportSecurityExtensions
     internal static AuthenticationBuilder AddTransportAuthentication(
         this IServiceCollection services,
         TransportSurface surface,
-        IReadOnlyList<ConfiguredSecret> apiKeys,
-        IReadOnlyList<ConfiguredSecret> publicKeys,
-        IReadOnlyList<OAuthValidationOptions> oauthMethods,
+        IReadOnlyList<TransportAuthenticationOptions> methods,
         string challengeSchemeName)
     {
         ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(apiKeys);
-        ArgumentNullException.ThrowIfNull(publicKeys);
-        ArgumentNullException.ThrowIfNull(oauthMethods);
+        ArgumentNullException.ThrowIfNull(methods);
         ArgumentNullException.ThrowIfNull(challengeSchemeName);
 
         if (!surface.IsSpecified)
         {
             throw new ArgumentException("A transport surface is required to name the schemes and the policy.", nameof(surface));
         }
+
+        var apiKeys = TransportAuthenticationConfiguration.ApiKeysIn(methods);
+        var publicKeys = TransportAuthenticationConfiguration.PublicKeysIn(methods);
+        var oauthMethods = TransportAuthenticationConfiguration.OAuthMethodsIn(methods);
 
         var authentication = services.AddAuthentication(surface.RoutingSchemeName);
 
@@ -100,6 +104,9 @@ internal static class TransportSecurityExtensions
                 {
                     schemeOptions.Surface = surface;
                     schemeOptions.PublicKeys = publicKeys;
+                    schemeOptions.GrantsByKeyName = TransportAuthenticationConfiguration.GrantsByPublicKeyName(
+                        methods,
+                        surface.GrantedSurface);
                 });
         }
 
@@ -115,6 +122,9 @@ internal static class TransportSecurityExtensions
                 {
                     schemeOptions.Surface = surface;
                     schemeOptions.ApiKeys = apiKeys;
+                    schemeOptions.GrantsByKeyName = TransportAuthenticationConfiguration.GrantsByApiKeyName(
+                        methods,
+                        surface.GrantedSurface);
                 });
         }
 
@@ -123,10 +133,14 @@ internal static class TransportSecurityExtensions
             AddMetadataBackchannel(services);
         }
 
-        // Each entry's own servers are registered against that entry's resource, which is what makes an entry the unit
-        // a token is judged by rather than one merged set the whole endpoint shares.
-        foreach (var oauthMethod in oauthMethods)
+        // Each entry's own servers are registered against that entry's resource and that entry's grant, which is what
+        // makes an entry the unit a token is judged by rather than one merged set the whole endpoint shares.
+        foreach (var method in methods.Where(method => method.OAuth is not null))
         {
+            var oauthMethod = method.OAuth!;
+            var grant = method.GrantedPermissions(surface.GrantedSurface);
+            var narrowedByTokenScopes = method.PermissionsFromTokenScopes;
+
             foreach (var authorizationServer in oauthMethod.AuthorizationServers)
             {
                 var schemeName = surface.OAuthSchemeNameFor(authorizationServer.Name!);
@@ -138,6 +152,8 @@ internal static class TransportSecurityExtensions
                             jwtOptions,
                             authorizationServer,
                             oauthMethod,
+                            grant,
+                            narrowedByTokenScopes,
                             transportFactory));
             }
         }
@@ -228,6 +244,8 @@ internal static class TransportSecurityExtensions
         JwtBearerOptions jwtOptions,
         AuthorizationServerOptions authorizationServer,
         OAuthValidationOptions oauthSettings,
+        IReadOnlyList<MailFathomPermission> grant,
+        bool narrowedByTokenScopes,
         IHttpClientFactory transportFactory)
     {
         var issuer = authorizationServer.ValidatedIssuer();
@@ -264,17 +282,27 @@ internal static class TransportSecurityExtensions
         jwtOptions.Events = new JwtBearerEvents
         {
             OnMessageReceived = RefuseATokenThatArrivedWithoutTransportEncryption,
-            OnTokenValidated = ReplacePrincipalWithMinimalIdentity,
+            OnTokenValidated = context =>
+                ReplacePrincipalWithMinimalIdentity(context, grant, narrowedByTokenScopes),
         };
     }
 
-    /// <summary>Reduces a validated token to the identity MailFathom keeps of it.</summary>
+    /// <summary>Reduces a validated token to the identity MailFathom keeps of it, and writes the grant it holds.</summary>
     /// <remarks>
+    /// <para>
     /// The validated principal carries every claim the authorization server chose to include, which routinely means a
     /// name, an address, and a set of groups. Replacing it here means nothing downstream can read one, so a later change
     /// cannot start depending on a claim the operator never mapped.
+    /// </para>
+    /// <para>
+    /// The grant is written onto the identity that survives rather than left to be recomposed later, which is what
+    /// keeps a permission the entry never granted unreachable however a token is read afterwards.
+    /// </para>
     /// </remarks>
-    private static Task ReplacePrincipalWithMinimalIdentity(TokenValidatedContext context)
+    private static Task ReplacePrincipalWithMinimalIdentity(
+        TokenValidatedContext context,
+        IReadOnlyList<MailFathomPermission> grant,
+        bool narrowedByTokenScopes)
     {
         var identity = context.Principal is { } validatedPrincipal
             ? OAuthIdentity.FromValidatedToken(validatedPrincipal.Claims, context.Scheme.Name)
@@ -287,9 +315,37 @@ internal static class TransportSecurityExtensions
             return Task.CompletedTask;
         }
 
+        identity.AddClaims(TransportGrant.ClaimsFor(GrantHeldByToken(identity, grant, narrowedByTokenScopes)));
+
         context.Principal = new ClaimsPrincipal(identity);
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>Reports which of the entry's permissions this particular token holds.</summary>
+    /// <remarks>
+    /// Without the narrowing setting every token the entry admits holds the whole ceiling, because the deployment wrote
+    /// the grant and the authorization server was never asked. With it, a scope bearing a published permission name
+    /// grants that permission and nothing else does — so the intersection is the answer, and a scope naming anything
+    /// else is ignored rather than refused, since a token legitimately carries scopes about its client's own session
+    /// and about resources that are not this one.
+    /// </remarks>
+    private static IEnumerable<MailFathomPermission> GrantHeldByToken(
+        ClaimsIdentity identity,
+        IReadOnlyList<MailFathomPermission> grant,
+        bool narrowedByTokenScopes)
+    {
+        if (!narrowedByTokenScopes)
+        {
+            return grant;
+        }
+
+        var tokenScopes = identity
+            .FindAll(OAuthIdentity.ScopeClaimType)
+            .Select(scope => scope.Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return grant.Where(permission => tokenScopes.Contains(permission.Name));
     }
 
     /// <summary>Registers the transport the discovery document and key set are retrieved through.</summary>

--- a/src/Host/Security/Transport/TransportSurface.cs
+++ b/src/Host/Security/Transport/TransportSurface.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Common.ClientAssertions;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Api;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.ApiKeys;
@@ -49,11 +50,13 @@ internal readonly record struct TransportSurface
         string name,
         string routePrefix,
         string clientAssertionAudience,
+        ProtectedSurface grantedSurface,
         string[]? furtherRoutePrefixes = null)
     {
         this.name = name;
         this.routePrefix = routePrefix;
         this.clientAssertionAudience = clientAssertionAudience;
+        this.GrantedSurface = grantedSurface;
         this.furtherRoutePrefixes = furtherRoutePrefixes;
     }
 
@@ -69,6 +72,7 @@ internal readonly record struct TransportSurface
         "Mcp",
         McpEndpointRoute.Path,
         ClientAssertion.McpAudience,
+        McpEndpointOptions.GrantedSurface,
         [EmailAttachmentDownloadEndpoint.RoutePrefix]);
 
     /// <summary>Gets the surface serving the administrative API the <c>mfctl</c> command reaches.</summary>
@@ -76,10 +80,20 @@ internal readonly record struct TransportSurface
     internal static TransportSurface Admin { get; } = new(
         "Admin",
         AdminEndpointOptions.RoutePrefix,
-        ClientAssertion.AdminAudience);
+        ClientAssertion.AdminAudience,
+        AdminEndpointOptions.GrantedSurface);
 
     /// <summary>Gets whether this value names a surface rather than the unusable struct default.</summary>
     internal bool IsSpecified => this.name is not null;
+
+    /// <summary>Gets the half of the published permission vocabulary this surface's grants draw from.</summary>
+    /// <remarks>
+    /// Read from the endpoint section's own constant rather than restated, so the surface a permission belongs to is
+    /// one decision: what configuration validation refuses a grant against and what a registered scheme resolves an
+    /// unwritten grant to cannot come apart. The struct default reports the first enum member like any unset field, so
+    /// ask <see cref="IsSpecified" /> before reading it.
+    /// </remarks>
+    internal ProtectedSurface GrantedSurface { get; }
 
     /// <summary>Gets the surface's name, which every scheme and policy name below is composed from.</summary>
     /// <exception cref="InvalidOperationException">Thrown when the value is the struct default rather than a surface.</exception>

--- a/tests/Domain.UnitTests/Access/MailFathomPermissionTests.cs
+++ b/tests/Domain.UnitTests/Access/MailFathomPermissionTests.cs
@@ -1,0 +1,210 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Reflection;
+using System.Text.Json;
+using MailFathom.Domain.Access;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Access;
+
+/// <summary>Covers the published permission vocabulary a grant is written from and a token carries as scopes.</summary>
+/// <remarks>
+/// The names travel outside this process — into an operator's configuration file, into a protected resource metadata
+/// document, and into an authorization server as scopes — so what is asserted here is the identity rather than the
+/// membership: the exact spelling, the surface each name belongs to, and the parsing that refuses everything else.
+/// </remarks>
+public sealed class MailFathomPermissionTests
+{
+    /// <summary>Two permissions sharing a name would be one grant an operator could write two ways and nothing could tell apart.</summary>
+    [Fact]
+    public void All_NamesAreUnique()
+    {
+        // Act
+        var distinctNames = MailFathomPermission.All.Select(permission => permission.Name).Distinct(StringComparer.Ordinal).Count();
+
+        // Assert
+        Assert.Equal(MailFathomPermission.All.Count, distinctNames);
+    }
+
+    /// <summary>
+    /// A declared permission left out of the registry is invisible to every other assertion here, and it is silently
+    /// unwritable: parsing, validation, and the startup record all resolve a name through the registry alone, so
+    /// startup would refuse the very permission this repository declares.
+    /// </summary>
+    [Fact]
+    public void All_ListsEveryDeclaredPermission()
+    {
+        // Arrange
+        var declaredPermissions = typeof(MailFathomPermission)
+            .GetProperties(BindingFlags.Public | BindingFlags.Static)
+            .Where(property => property.PropertyType == typeof(MailFathomPermission))
+            .Select(property => (MailFathomPermission)property.GetValue(null)!);
+
+        // Act
+        var unregistered = declaredPermissions.Where(permission => !MailFathomPermission.All.Contains(permission)).ToArray();
+
+        // Assert
+        Assert.Empty(unregistered);
+    }
+
+    /// <summary>The published set ADR 0012 fixed, asserted by name because a name is what an operator writes and an authorization server mints.</summary>
+    [Fact]
+    public void All_CarriesTheEightPublishedNames() =>
+        Assert.Equal(
+            [
+                "mailfathom.mail.read",
+                "mailfathom.mail.ask",
+                "mailfathom.admin.read",
+                "mailfathom.admin.audit.read",
+                "mailfathom.admin.operate",
+                "mailfathom.admin.credentials.write",
+                "mailfathom.admin.spend",
+                "mailfathom.admin.erase",
+            ],
+            MailFathomPermission.All.Select(permission => permission.Name));
+
+    /// <summary>The same string travels in a space-delimited <c>scope</c> claim, where a space or a quotation mark would split one permission into two.</summary>
+    [Fact]
+    public void All_NamesAreValidScopeTokens()
+    {
+        // Act
+        var unusableAsScopes = MailFathomPermission.All
+            .Where(permission => !permission.Name.All(character => character is > (char)0x20 and < (char)0x7F and not '"' and not '\\'))
+            .ToArray();
+
+        // Assert
+        Assert.Empty(unusableAsScopes);
+    }
+
+    /// <summary>The prefix is what a startup refusal reads to tell a grant written on the wrong endpoint from one that belongs there.</summary>
+    [Fact]
+    public void Surface_FollowsThePrefixOfTheName()
+    {
+        // Act
+        var mismatched = MailFathomPermission.All
+            .Where(permission => permission.Surface != ExpectedSurfaceOf(permission.Name))
+            .ToArray();
+
+        // Assert
+        Assert.Empty(mismatched);
+    }
+
+    /// <summary>The two halves are disjoint, which is what makes one vocabulary safe to publish for two surfaces.</summary>
+    [Fact]
+    public void PublishedFor_TheTwoSurfaces_PartitionTheWholeSet()
+    {
+        // Act
+        var mail = MailFathomPermission.PublishedFor(ProtectedSurface.Mail);
+        var administration = MailFathomPermission.PublishedFor(ProtectedSurface.Administration);
+
+        // Assert
+        Assert.Equal([MailFathomPermission.MailRead, MailFathomPermission.MailAsk], mail);
+        Assert.Equal(MailFathomPermission.All.Count, mail.Count + administration.Count);
+        Assert.Empty(mail.Intersect(administration));
+    }
+
+    [Fact]
+    public void TryParse_APublishedName_ReturnsThatPermission()
+    {
+        // Act
+        var parsed = MailFathomPermission.TryParse("mailfathom.admin.spend", out var permission);
+
+        // Assert
+        Assert.True(parsed);
+        Assert.Equal(MailFathomPermission.AdminSpend, permission);
+    }
+
+    /// <summary>A misspelling is unknown rather than reconstructed, which is what lets startup refuse it instead of granting something nothing enforces.</summary>
+    [Theory]
+    [InlineData("mailfathom.mail.write")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void TryParse_ANameNothingPublishes_ReportsUnspecified(string? written)
+    {
+        // Act
+        var parsed = MailFathomPermission.TryParse(written, out var permission);
+
+        // Assert
+        Assert.False(parsed);
+        Assert.False(permission.IsSpecified);
+    }
+
+    /// <summary>An authorization server compares a scope byte for byte, so a spelling accepted here that it would treat as another scope is a grant that means two things.</summary>
+    [Theory]
+    [InlineData("MailFathom.Mail.Read")]
+    [InlineData(" mailfathom.mail.read")]
+    [InlineData("mailfathom.mail.read ")]
+    public void TryParse_ASpellingAnAuthorizationServerWouldTreatAsAnotherScope_IsRefused(string written)
+    {
+        // Act
+        var parsed = MailFathomPermission.TryParse(written, out _);
+
+        // Assert
+        Assert.False(parsed);
+    }
+
+    [Fact]
+    public void Default_NamesNoPermission()
+    {
+        // Arrange
+        var permission = default(MailFathomPermission);
+
+        // Assert
+        Assert.False(permission.IsSpecified);
+        Assert.Equal("(unspecified)", permission.ToString());
+        Assert.Throws<InvalidOperationException>(() => permission.Name);
+    }
+
+    /// <summary>A log line and a startup record name the permission an operator wrote, not the structure carrying it.</summary>
+    [Fact]
+    public void ToString_IsThePublishedName() =>
+        Assert.Equal("mailfathom.mail.ask", MailFathomPermission.MailAsk.ToString());
+
+    [Fact]
+    public void JsonRoundTrip_PreservesThePermission()
+    {
+        // Act
+        var json = JsonSerializer.Serialize(MailFathomPermission.AdminErase);
+        var restored = JsonSerializer.Deserialize<MailFathomPermission>(json);
+
+        // Assert
+        Assert.Equal("\"mailfathom.admin.erase\"", json);
+        Assert.Equal(MailFathomPermission.AdminErase, restored);
+    }
+
+    [Fact]
+    public void JsonRoundTrip_AsAPropertyName_PreservesThePermission()
+    {
+        // Arrange
+        var granted = new Dictionary<MailFathomPermission, bool> { [MailFathomPermission.MailRead] = true };
+
+        // Act
+        var json = JsonSerializer.Serialize(granted);
+        var restored = JsonSerializer.Deserialize<Dictionary<MailFathomPermission, bool>>(json);
+
+        // Assert
+        Assert.Equal("{\"mailfathom.mail.read\":true}", json);
+        Assert.True(Assert.Single(restored!).Value);
+    }
+
+    [Theory]
+    [InlineData("42")]
+    [InlineData("\"mailfathom.mail.write\"")]
+    public void JsonRead_TokenThatNamesNoPublishedPermission_IsRejected(string json) =>
+        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MailFathomPermission>(json));
+
+    [Fact]
+    public void JsonRead_PropertyNameThatNamesNoPublishedPermission_IsRejected() =>
+        Assert.Throws<JsonException>(
+            () => JsonSerializer.Deserialize<Dictionary<MailFathomPermission, bool>>("{\"mailfathom.mail.write\":true}"));
+
+    [Fact]
+    public void JsonWrite_UnspecifiedPermission_IsRejected() =>
+        Assert.Throws<JsonException>(() => JsonSerializer.Serialize(default(MailFathomPermission)));
+
+    private static ProtectedSurface ExpectedSurfaceOf(string name) => name.StartsWith("mailfathom.mail.", StringComparison.Ordinal)
+        ? ProtectedSurface.Mail
+        : ProtectedSurface.Administration;
+}

--- a/tests/Host.UnitTests/Api/AdminProtectedResourceMetadataEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/AdminProtectedResourceMetadataEndpointTests.cs
@@ -29,7 +29,7 @@ public sealed class AdminProtectedResourceMetadataEndpointTests
         var oauthSettings = Configured();
 
         // Act
-        var document = ProtectedResourceMetadataDocument.For([oauthSettings]);
+        var document = ProtectedResourceMetadataDocument.For([new TransportAuthenticationOptions { OAuth = oauthSettings }]);
 
         // Assert
         Assert.Equal(Resource, document.Resource);
@@ -61,7 +61,7 @@ public sealed class AdminProtectedResourceMetadataEndpointTests
         });
 
         // Act
-        var document = ProtectedResourceMetadataDocument.For([Configured(), partners]);
+        var document = ProtectedResourceMetadataDocument.For([Entry(), new TransportAuthenticationOptions { OAuth = partners }]);
 
         // Assert
         Assert.Equal(Resource, document.Resource);
@@ -84,7 +84,7 @@ public sealed class AdminProtectedResourceMetadataEndpointTests
         oauthSettings.AdvertisedScopes.Add("offline_access");
 
         // Act
-        var document = ProtectedResourceMetadataDocument.For([oauthSettings]);
+        var document = ProtectedResourceMetadataDocument.For([new TransportAuthenticationOptions { OAuth = oauthSettings }]);
 
         // Assert
         Assert.Equal(["mailfathom.admin", "mailfathom.read", "offline_access"], document.ScopesSupported);
@@ -95,7 +95,7 @@ public sealed class AdminProtectedResourceMetadataEndpointTests
     public void For_AnySettings_OffersTheHeaderAsTheOnlyWayToPresentAToken()
     {
         // Act
-        var document = ProtectedResourceMetadataDocument.For([Configured()]);
+        var document = ProtectedResourceMetadataDocument.For([Entry()]);
 
         // Assert
         Assert.Equal(["header"], document.BearerMethodsSupported);
@@ -106,7 +106,7 @@ public sealed class AdminProtectedResourceMetadataEndpointTests
     public void Serialized_TheDocument_CarriesTheNamesRfc9728Defines()
     {
         // Arrange
-        var document = ProtectedResourceMetadataDocument.For([Configured()]);
+        var document = ProtectedResourceMetadataDocument.For([Entry()]);
 
         // Act
         using var serialized = JsonDocument.Parse(JsonSerializer.Serialize(document));
@@ -141,6 +141,9 @@ public sealed class AdminProtectedResourceMetadataEndpointTests
         // Assert
         Assert.Equal("/.well-known/oauth-protected-resource/api/admin", path);
     }
+
+    /// <summary>Wraps the configured OAuth block in the entry that carries it, which is the unit the document is composed from.</summary>
+    private static TransportAuthenticationOptions Entry() => new() { OAuth = Configured() };
 
     private static OAuthValidationOptions Configured()
     {

--- a/tests/Host.UnitTests/Api/AdminProtectedResourceMetadataEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/AdminProtectedResourceMetadataEndpointTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Text.Json;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Api;
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Host.Security.Transport;
@@ -99,6 +100,27 @@ public sealed class AdminProtectedResourceMetadataEndpointTests
 
         // Assert
         Assert.Equal(["header"], document.BearerMethodsSupported);
+    }
+
+    /// <summary>
+    /// The document is composed against this endpoint's own half of the vocabulary, and it is the only place that
+    /// argument is supplied. Composing it against the other half would tell an operator to create mail scopes in their
+    /// authorization server for the administrative surface, and leave every token they then minted holding nothing.
+    /// </summary>
+    [Fact]
+    public void For_AnEntryNarrowedByTokenScopes_PublishesTheAdministrativeHalfOfTheVocabulary()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { OAuth = Configured(), PermissionsFromTokenScopes = true };
+        entry.GrantTheWholeSurface();
+
+        // Act
+        var document = ProtectedResourceMetadataDocument.For([entry]);
+
+        // Assert
+        Assert.Equal(
+            MailFathomPermission.PublishedFor(ProtectedSurface.Administration).Select(permission => permission.Name),
+            document.ScopesSupported.Where(scope => scope.StartsWith("mailfathom.admin.", StringComparison.Ordinal)));
     }
 
     /// <summary>The names RFC 9728 fixes, which a client matches on and a rename inside this repository must not move.</summary>

--- a/tests/Host.UnitTests/Configuration/Access/PublishedOAuthMetadataTests.cs
+++ b/tests/Host.UnitTests/Configuration/Access/PublishedOAuthMetadataTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Access;
 using Xunit;
 
@@ -29,7 +30,7 @@ public sealed class PublishedOAuthMetadataTests
         var workforce = EntryFor(WorkforceIssuer, "workforce", "mailfathom.read");
 
         // Act
-        var published = PublishedOAuthMetadata.For([workforce]);
+        var published = Published(workforce);
 
         // Assert
         Assert.Equal(Resource, published.Resource);
@@ -49,7 +50,7 @@ public sealed class PublishedOAuthMetadataTests
         var partners = EntryFor(PartnerIssuer, "partners", "partners.read");
 
         // Act
-        var published = PublishedOAuthMetadata.For([workforce, partners]);
+        var published = Published(workforce, partners);
 
         // Assert
         Assert.Equal([WorkforceIssuer, PartnerIssuer], published.AuthorizationServers);
@@ -64,7 +65,7 @@ public sealed class PublishedOAuthMetadataTests
         var partners = EntryFor(PartnerIssuer, "partners", "mailfathom.read", "partners.read");
 
         // Act
-        var published = PublishedOAuthMetadata.For([workforce, partners]);
+        var published = Published(workforce, partners);
 
         // Assert
         Assert.Equal(["mailfathom.read", "partners.read"], published.ScopesSupported);
@@ -79,7 +80,7 @@ public sealed class PublishedOAuthMetadataTests
         var partners = EntryFor(PartnerIssuer, "partners");
 
         // Act
-        var published = PublishedOAuthMetadata.For([workforce, partners]);
+        var published = Published(workforce, partners);
 
         // Assert
         Assert.Equal(["mailfathom.read"], published.ScopesSupported);
@@ -89,7 +90,7 @@ public sealed class PublishedOAuthMetadataTests
     /// <summary>A surface accepting no token publishes no document, so composing one from nothing is a fault rather than an empty answer.</summary>
     [Fact]
     public void For_NoEntryAtAll_IsRefusedRatherThanPublishingAnEmptyDocument() =>
-        Assert.Throws<ArgumentException>(() => PublishedOAuthMetadata.For([]));
+        Assert.Throws<ArgumentException>(() => Published());
 
     /// <summary>
     /// The document states what a client should ask for, so a scope the deployment advertises without checking is in it
@@ -105,7 +106,7 @@ public sealed class PublishedOAuthMetadataTests
         workforce.AdvertisedScopes.Add("offline_access");
 
         // Act
-        var published = PublishedOAuthMetadata.For([workforce]);
+        var published = Published(workforce);
 
         // Assert
         Assert.Equal(["mailfathom.read", "offline_access"], published.ScopesSupported);
@@ -119,7 +120,7 @@ public sealed class PublishedOAuthMetadataTests
         var workforce = EntryFor(WorkforceIssuer, "workforce", "mailfathom.read");
 
         // Act
-        var published = PublishedOAuthMetadata.For([workforce]);
+        var published = Published(workforce);
 
         // Assert
         Assert.Equal(["mailfathom.read"], published.ScopesSupported);
@@ -138,7 +139,7 @@ public sealed class PublishedOAuthMetadataTests
         partners.AdvertisedScopes.Add("openid");
 
         // Act
-        var published = PublishedOAuthMetadata.For([workforce, partners]);
+        var published = Published(workforce, partners);
 
         // Assert
         Assert.Equal(
@@ -159,7 +160,7 @@ public sealed class PublishedOAuthMetadataTests
         workforce.AdvertisedScopes.Add("offline_access");
 
         // Act
-        var published = PublishedOAuthMetadata.For([workforce]);
+        var published = Published(workforce);
 
         // Assert
         Assert.Contains("offline_access", published.ScopesSupported);
@@ -175,11 +176,99 @@ public sealed class PublishedOAuthMetadataTests
         workforce.AdvertisedScopes.Add("offline_access");
 
         // Act
-        var published = PublishedOAuthMetadata.For([workforce]);
+        var published = Published(workforce);
 
         // Assert
         Assert.Equal(["offline_access"], published.ScopesSupported);
     }
+
+    /// <summary>
+    /// The field tells a client what to ask its authorization server for, so a permission the deployment grants from
+    /// configuration is not in it: no client can ask for one. Only an entry whose grant a token narrows contributes.
+    /// </summary>
+    [Fact]
+    public void For_AnEntryNarrowedByTokenScopes_PublishesItsPermissionsBesideTheScopes()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions
+        {
+            OAuth = EntryFor(WorkforceIssuer, "workforce", "mailfathom.read"),
+            PermissionsFromTokenScopes = true,
+        };
+
+        entry.Permissions.Add(MailFathomPermission.MailRead.Name);
+        entry.MarkGrantWritten();
+
+        // Act
+        var published = PublishedOAuthMetadata.For([entry], ProtectedSurface.Mail);
+
+        // Assert
+        Assert.Equal(["mailfathom.read", "mailfathom.mail.read"], published.ScopesSupported);
+    }
+
+    /// <summary>An entry granting from configuration alone advertises none of its permissions, because a client asking for one would be asking for something nothing reads.</summary>
+    [Fact]
+    public void For_AnEntryGrantingFromConfiguration_PublishesNoneOfItsPermissions()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { OAuth = EntryFor(WorkforceIssuer, "workforce", "mailfathom.read") };
+
+        entry.Permissions.Add(MailFathomPermission.MailAsk.Name);
+        entry.MarkGrantWritten();
+
+        // Act
+        var published = PublishedOAuthMetadata.For([entry], ProtectedSurface.Mail);
+
+        // Assert
+        Assert.Equal(["mailfathom.read"], published.ScopesSupported);
+    }
+
+    /// <summary>Such an entry genuinely admits a token bringing any of them, so the document names the half an operator has to create in their authorization server.</summary>
+    [Fact]
+    public void For_AnEntryNarrowedByTokenScopesThatWroteNoGrant_PublishesTheWholeSurface()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions
+        {
+            OAuth = EntryFor(WorkforceIssuer, "workforce"),
+            PermissionsFromTokenScopes = true,
+        };
+
+        // Act
+        var published = PublishedOAuthMetadata.For([entry], ProtectedSurface.Mail);
+
+        // Assert
+        Assert.Equal(
+            MailFathomPermission.PublishedFor(ProtectedSurface.Mail).Select(permission => permission.Name),
+            published.ScopesSupported);
+    }
+
+    /// <summary>An emptied grant grants nothing, so there is nothing a client should be told to ask for.</summary>
+    [Fact]
+    public void For_AnEntryNarrowedByTokenScopesThatGrantsNothing_PublishesNoPermission()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions
+        {
+            OAuth = EntryFor(WorkforceIssuer, "workforce"),
+            PermissionsFromTokenScopes = true,
+        };
+
+        entry.MarkGrantWritten();
+
+        // Act
+        var published = PublishedOAuthMetadata.For([entry], ProtectedSurface.Mail);
+
+        // Assert
+        Assert.Empty(published.ScopesSupported);
+    }
+
+    /// <summary>Publishes what the given OAuth blocks say, each on an entry of its own that writes down no grant.</summary>
+    /// <remarks>The unit is the entry rather than the block, because the grant belongs to the entry; a test about a grant builds its own entries, and the ones here are about what the blocks publish.</remarks>
+    private static PublishedOAuthMetadata Published(params OAuthValidationOptions[] oauthMethods) =>
+        PublishedOAuthMetadata.For(
+            [.. oauthMethods.Select(oauth => new TransportAuthenticationOptions { OAuth = oauth })],
+            ProtectedSurface.Mail);
 
     private static OAuthValidationOptions EntryFor(string issuer, string name, params string[] requiredScopes)
     {

--- a/tests/Host.UnitTests/Configuration/Access/PublishedOAuthMetadataTests.cs
+++ b/tests/Host.UnitTests/Configuration/Access/PublishedOAuthMetadataTests.cs
@@ -197,7 +197,6 @@ public sealed class PublishedOAuthMetadataTests
         };
 
         entry.Permissions.Add(MailFathomPermission.MailRead.Name);
-        entry.MarkGrantWritten();
 
         // Act
         var published = PublishedOAuthMetadata.For([entry], ProtectedSurface.Mail);
@@ -214,7 +213,6 @@ public sealed class PublishedOAuthMetadataTests
         var entry = new TransportAuthenticationOptions { OAuth = EntryFor(WorkforceIssuer, "workforce", "mailfathom.read") };
 
         entry.Permissions.Add(MailFathomPermission.MailAsk.Name);
-        entry.MarkGrantWritten();
 
         // Act
         var published = PublishedOAuthMetadata.For([entry], ProtectedSurface.Mail);
@@ -233,6 +231,8 @@ public sealed class PublishedOAuthMetadataTests
             OAuth = EntryFor(WorkforceIssuer, "workforce"),
             PermissionsFromTokenScopes = true,
         };
+
+        entry.GrantTheWholeSurface();
 
         // Act
         var published = PublishedOAuthMetadata.For([entry], ProtectedSurface.Mail);
@@ -254,7 +254,6 @@ public sealed class PublishedOAuthMetadataTests
             PermissionsFromTokenScopes = true,
         };
 
-        entry.MarkGrantWritten();
 
         // Act
         var published = PublishedOAuthMetadata.For([entry], ProtectedSurface.Mail);

--- a/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
@@ -101,6 +101,7 @@ public sealed class TransportAuthenticationOptionsTests
     {
         // Arrange
         var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
+        entry.GrantTheWholeSurface();
 
         // Act
         var granted = entry.GrantedPermissions(ProtectedSurface.Mail);
@@ -114,7 +115,6 @@ public sealed class TransportAuthenticationOptionsTests
     {
         // Arrange
         var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
-        entry.MarkGrantWritten();
 
         // Act
         var granted = entry.GrantedPermissions(ProtectedSurface.Mail);
@@ -132,7 +132,7 @@ public sealed class TransportAuthenticationOptionsTests
 
         // Assert
         Assert.Empty(entry.Permissions);
-        Assert.False(entry.WasGrantWritten);
+        Assert.False(entry.GrantsTheWholeSurface);
     }
 
     [Fact]
@@ -141,7 +141,6 @@ public sealed class TransportAuthenticationOptionsTests
         // Arrange
         var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
         entry.Permissions.Add(MailFathomPermission.MailRead.Name);
-        entry.MarkGrantWritten();
 
         // Act
         var granted = entry.GrantedPermissions(ProtectedSurface.Mail);
@@ -207,7 +206,6 @@ public sealed class TransportAuthenticationOptionsTests
     {
         // Arrange
         var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
-        entry.MarkGrantWritten();
 
         // Act, Assert
         Assert.Empty(entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail));
@@ -298,9 +296,9 @@ public sealed class TransportAuthenticationOptionsTests
         // Arrange
         var narrowed = new TransportAuthenticationOptions { ApiKey = AnApiKey("reporting-job") };
         narrowed.Permissions.Add(MailFathomPermission.MailRead.Name);
-        narrowed.MarkGrantWritten();
 
         var unnarrowed = new TransportAuthenticationOptions { ApiKey = AnApiKey("workstation") };
+        unnarrowed.GrantTheWholeSurface();
 
         // Act
         var grants = TransportAuthenticationConfiguration.GrantsByApiKeyName(
@@ -317,7 +315,6 @@ public sealed class TransportAuthenticationOptionsTests
     {
         // Arrange
         var retired = new TransportAuthenticationOptions { PublicKey = APublicKey("nightly") };
-        retired.MarkGrantWritten();
 
         // Act
         var grants = TransportAuthenticationConfiguration.GrantsByPublicKeyName([retired], ProtectedSurface.Mail);

--- a/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
@@ -150,6 +150,22 @@ public sealed class TransportAuthenticationOptionsTests
         Assert.Equal([MailFathomPermission.MailRead], granted);
     }
 
+    /// <summary>A grant is a set, and the order it resolves in is what the startup line reads in and what the claims are stamped in — so two entries granting the same permissions must not be reported as two different grants.</summary>
+    [Fact]
+    public void GrantedPermissions_AGrantWrittenOutOfOrder_ResolvesInThePublishedOrder()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
+        entry.Permissions.Add(MailFathomPermission.MailAsk.Name);
+        entry.Permissions.Add(MailFathomPermission.MailRead.Name);
+
+        // Act
+        var granted = entry.GrantedPermissions(ProtectedSurface.Mail);
+
+        // Assert
+        Assert.Equal([MailFathomPermission.MailRead, MailFathomPermission.MailAsk], granted);
+    }
+
     /// <summary>A name nothing publishes is a grant nobody enforces, so it fails startup rather than being written into a configuration file that reads as narrowed.</summary>
     [Fact]
     public void FindConfigurationErrors_AGrantNamingAnUnpublishedPermission_NamesTheEntryAndTheIndex()

--- a/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
@@ -293,7 +293,7 @@ public sealed class TransportAuthenticationOptionsTests
 
     /// <summary>The grant belongs to the entry, so which entry a credential sits in decides what it may do rather than only how the file was grouped.</summary>
     [Fact]
-    public void GrantsByApiKeyName_TwoEntriesGrantedDifferently_MapsEachKeyToItsOwnEntrysGrant()
+    public void GrantsByApiKeyName_TwoEntriesGrantedDifferently_MapsEachKeyToTheGrantOfItsOwnEntry()
     {
         // Arrange
         var narrowed = new TransportAuthenticationOptions { ApiKey = AnApiKey("reporting-job") };

--- a/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
@@ -179,7 +179,7 @@ public sealed class TransportAuthenticationOptionsTests
 
         // Assert
         var reported = Assert.Single(errors);
-        Assert.Contains($"{SettingPath}:Permissions:0", reported, StringComparison.Ordinal);
+        Assert.Contains($"{SettingPath}:Permissions", reported, StringComparison.Ordinal);
         Assert.Contains("mailfathom.mail.write", reported, StringComparison.Ordinal);
         Assert.Contains(MailFathomPermission.MailRead.Name, reported, StringComparison.Ordinal);
     }
@@ -197,7 +197,7 @@ public sealed class TransportAuthenticationOptionsTests
 
         // Assert
         var reported = Assert.Single(errors);
-        Assert.Contains($"{SettingPath}:Permissions:0", reported, StringComparison.Ordinal);
+        Assert.Contains($"{SettingPath}:Permissions", reported, StringComparison.Ordinal);
         Assert.Contains(MailFathomPermission.AdminSpend.Name, reported, StringComparison.Ordinal);
     }
 
@@ -214,7 +214,7 @@ public sealed class TransportAuthenticationOptionsTests
 
         // Assert
         var reported = Assert.Single(errors);
-        Assert.Contains($"{SettingPath}:Permissions:1", reported, StringComparison.Ordinal);
+        Assert.Contains($"{SettingPath}:Permissions", reported, StringComparison.Ordinal);
     }
 
     /// <summary>An emptied grant is a posture rather than a mistake, so it is the one arrangement here that is not refused.</summary>

--- a/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using Xunit;
@@ -35,7 +36,7 @@ public sealed class TransportAuthenticationOptionsTests
         var entry = new TransportAuthenticationOptions { PublicKey = APublicKey() };
 
         // Act, Assert
-        Assert.Empty(entry.FindConfigurationErrors(SettingPath));
+        Assert.Empty(entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail));
     }
 
     /// <summary>Nothing conflicts between the methods, so an operator who groups a key and a public key into one entry gets both rather than a refusal.</summary>
@@ -50,7 +51,7 @@ public sealed class TransportAuthenticationOptionsTests
         };
 
         // Act, Assert
-        Assert.Empty(entry.FindConfigurationErrors(SettingPath));
+        Assert.Empty(entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail));
     }
 
     /// <summary>The refusal has to name every block an operator could have meant, or the one they misspelled goes unmentioned.</summary>
@@ -61,7 +62,7 @@ public sealed class TransportAuthenticationOptionsTests
         var entry = new TransportAuthenticationOptions();
 
         // Act
-        var errors = entry.FindConfigurationErrors(SettingPath);
+        var errors = entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail);
 
         // Assert
         var reported = Assert.Single(errors);
@@ -90,6 +91,260 @@ public sealed class TransportAuthenticationOptionsTests
         Assert.Equal(["nightly", "nightly-next"], publicKeys.Select(key => key.Name));
     }
 
+    /// <summary>
+    /// The pair this whole reading exists for. An absent key and an emptied list arrive from the binder identically
+    /// and mean opposite things, so both are pinned together: one reaches the surface's whole half, the other reaches
+    /// nothing and is how a credential is retired without its entry being deleted.
+    /// </summary>
+    [Fact]
+    public void GrantedPermissions_AnEntryThatWroteNoGrant_ReachesTheWholeSurface()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
+
+        // Act
+        var granted = entry.GrantedPermissions(ProtectedSurface.Mail);
+
+        // Assert
+        Assert.Equal(MailFathomPermission.PublishedFor(ProtectedSurface.Mail), granted);
+    }
+
+    [Fact]
+    public void GrantedPermissions_AnEntryThatWroteAnEmptyGrant_ReachesNothing()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
+        entry.MarkGrantWritten();
+
+        // Act
+        var granted = entry.GrantedPermissions(ProtectedSurface.Mail);
+
+        // Assert
+        Assert.Empty(granted);
+    }
+
+    /// <summary>An entry built anywhere but from configuration starts from the grant that reaches nothing, so nothing composed by hand inherits the permissive default.</summary>
+    [Fact]
+    public void Permissions_AnEntryTheBinderNeverTouched_StartsFromNothing()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions();
+
+        // Assert
+        Assert.Empty(entry.Permissions);
+        Assert.False(entry.WasGrantWritten);
+    }
+
+    [Fact]
+    public void GrantedPermissions_AnEntryNamingPermissions_ReachesExactlyThose()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
+        entry.Permissions.Add(MailFathomPermission.MailRead.Name);
+        entry.MarkGrantWritten();
+
+        // Act
+        var granted = entry.GrantedPermissions(ProtectedSurface.Mail);
+
+        // Assert
+        Assert.Equal([MailFathomPermission.MailRead], granted);
+    }
+
+    /// <summary>A name nothing publishes is a grant nobody enforces, so it fails startup rather than being written into a configuration file that reads as narrowed.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AGrantNamingAnUnpublishedPermission_NamesTheEntryAndTheIndex()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
+        entry.Permissions.Add("mailfathom.mail.write");
+
+        // Act
+        var errors = entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail);
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains($"{SettingPath}:Permissions:0", reported, StringComparison.Ordinal);
+        Assert.Contains("mailfathom.mail.write", reported, StringComparison.Ordinal);
+        Assert.Contains(MailFathomPermission.MailRead.Name, reported, StringComparison.Ordinal);
+    }
+
+    /// <summary>A cross-surface name would sit in the file granting nothing while an operator believed they had granted something.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AGrantNamingTheOtherSurfacesPermission_IsRefused()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
+        entry.Permissions.Add(MailFathomPermission.AdminSpend.Name);
+
+        // Act
+        var errors = entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail);
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains($"{SettingPath}:Permissions:0", reported, StringComparison.Ordinal);
+        Assert.Contains(MailFathomPermission.AdminSpend.Name, reported, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindConfigurationErrors_AGrantRepeatingAPermission_IsRefused()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
+        entry.Permissions.Add(MailFathomPermission.MailRead.Name);
+        entry.Permissions.Add(MailFathomPermission.MailRead.Name);
+
+        // Act
+        var errors = entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail);
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains($"{SettingPath}:Permissions:1", reported, StringComparison.Ordinal);
+    }
+
+    /// <summary>An emptied grant is a posture rather than a mistake, so it is the one arrangement here that is not refused.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AnEmptiedGrant_ReportsNothing()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
+        entry.MarkGrantWritten();
+
+        // Act, Assert
+        Assert.Empty(entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail));
+    }
+
+    /// <summary>Neither credential can carry a scope, so asking a token to narrow the grant beside one is a question nothing could answer.</summary>
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void FindConfigurationErrors_TokenScopeNarrowingBesideAConfiguredCredential_IsRefused(
+        bool statesAnApiKey,
+        bool statesAPublicKey)
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions
+        {
+            ApiKey = statesAnApiKey ? AnApiKey() : null,
+            PublicKey = statesAPublicKey ? APublicKey() : null,
+            PermissionsFromTokenScopes = true,
+        };
+
+        // Act
+        var errors = entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail);
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains($"{SettingPath}:PermissionsFromTokenScopes", reported, StringComparison.Ordinal);
+    }
+
+    /// <summary>It is the form an entry whose sole block is OAuth exists to use, so it must not be refused there.</summary>
+    [Fact]
+    public void FindConfigurationErrors_TokenScopeNarrowingOnAnOAuthOnlyEntry_ReportsNothing()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions
+        {
+            OAuth = AnOAuthBlock(),
+            PermissionsFromTokenScopes = true,
+        };
+
+        // Act, Assert
+        Assert.Empty(entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail));
+    }
+
+    /// <summary>Requiring a permission would close the door on a caller the deployment meant to serve less, which is the opposite of narrowing them.</summary>
+    [Fact]
+    public void FindConfigurationErrors_APermissionWrittenIntoTheRequiredScopes_IsRefused()
+    {
+        // Arrange
+        var oauth = AnOAuthBlock();
+        oauth.RequiredScopes.Add(MailFathomPermission.MailRead.Name);
+
+        var entry = new TransportAuthenticationOptions { OAuth = oauth };
+
+        // Act
+        var errors = entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail);
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains($"{SettingPath}:OAuth:RequiredScopes:0", reported, StringComparison.Ordinal);
+        Assert.Contains(MailFathomPermission.MailRead.Name, reported, StringComparison.Ordinal);
+    }
+
+    /// <summary>The grant that reads a permission already advertises it, and an entry reading none would be telling a client to ask for something nothing here grants.</summary>
+    [Fact]
+    public void FindConfigurationErrors_APermissionWrittenIntoTheAdvertisedScopes_IsRefused()
+    {
+        // Arrange
+        var oauth = AnOAuthBlock();
+        oauth.AdvertisedScopes.Add(MailFathomPermission.MailAsk.Name);
+
+        var entry = new TransportAuthenticationOptions { OAuth = oauth };
+
+        // Act
+        var errors = entry.FindConfigurationErrors(SettingPath, ProtectedSurface.Mail);
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains($"{SettingPath}:OAuth:AdvertisedScopes:0", reported, StringComparison.Ordinal);
+        Assert.Contains(MailFathomPermission.MailAsk.Name, reported, StringComparison.Ordinal);
+    }
+
+    /// <summary>The grant belongs to the entry, so which entry a credential sits in decides what it may do rather than only how the file was grouped.</summary>
+    [Fact]
+    public void GrantsByApiKeyName_TwoEntriesGrantedDifferently_MapsEachKeyToItsOwnEntrysGrant()
+    {
+        // Arrange
+        var narrowed = new TransportAuthenticationOptions { ApiKey = AnApiKey("reporting-job") };
+        narrowed.Permissions.Add(MailFathomPermission.MailRead.Name);
+        narrowed.MarkGrantWritten();
+
+        var unnarrowed = new TransportAuthenticationOptions { ApiKey = AnApiKey("workstation") };
+
+        // Act
+        var grants = TransportAuthenticationConfiguration.GrantsByApiKeyName(
+            [narrowed, unnarrowed],
+            ProtectedSurface.Mail);
+
+        // Assert
+        Assert.Equal([MailFathomPermission.MailRead], grants["reporting-job"]);
+        Assert.Equal(MailFathomPermission.PublishedFor(ProtectedSurface.Mail), grants["workstation"]);
+    }
+
+    [Fact]
+    public void GrantsByPublicKeyName_AnEntryGrantedNothing_MapsItsKeyToAnEmptyGrant()
+    {
+        // Arrange
+        var retired = new TransportAuthenticationOptions { PublicKey = APublicKey("nightly") };
+        retired.MarkGrantWritten();
+
+        // Act
+        var grants = TransportAuthenticationConfiguration.GrantsByPublicKeyName([retired], ProtectedSurface.Mail);
+
+        // Assert
+        Assert.Empty(grants["nightly"]);
+    }
+
     private static ConfiguredSecret APublicKey(string name = "nightly") =>
         new() { Name = name, SecretReference = "file:/etc/mailfathom/nightly.pub" };
+
+    private static ConfiguredSecret AnApiKey(string name = "workstation") =>
+        new() { Name = name, SecretReference = "plaintext:a-key" };
+
+    private static OAuthValidationOptions AnOAuthBlock()
+    {
+        var oauth = new OAuthValidationOptions { Resource = "https://mail.example.test/mcp" };
+
+        var authorizationServer = new AuthorizationServerOptions
+        {
+            Name = "workforce",
+            Issuer = "https://sso.example.test",
+        };
+
+        authorizationServer.AuthorizedSubjects.Add("11111111-2222-3333-4444-555555555555");
+        oauth.AuthorizationServers.Add(authorizationServer);
+
+        return oauth;
+    }
 }

--- a/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Access/TransportAuthenticationOptionsTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Infrastructure.Secrets.Discovery;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace MailFathom.Host.UnitTests.Configuration.Access;
@@ -287,6 +288,34 @@ public sealed class TransportAuthenticationOptionsTests
         var reported = Assert.Single(errors);
         Assert.Contains($"{SettingPath}:OAuth:AdvertisedScopes:0", reported, StringComparison.Ordinal);
         Assert.Contains(MailFathomPermission.MailAsk.Name, reported, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The pairing is positional, so it means nothing once the children and the bound entries are different lengths.
+    /// Marking anyway would read one entry's grant off another entry's key, so nothing is marked and every entry keeps
+    /// the grant that reaches nothing — which is the direction to fail in if a binder ever drops an element.
+    /// </summary>
+    [Fact]
+    public void ReadWhatTheBinderCannotSay_MoreChildrenThanEntries_LeavesEveryGrantAtTheRestrictiveDefault()
+    {
+        // Arrange
+        var section = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["McpEndpoint:Authentication:0:ApiKey:Name"] = "workstation",
+                ["McpEndpoint:Authentication:1:ApiKey:Name"] = "reporting-job",
+            })
+            .Build()
+            .GetSection("McpEndpoint");
+
+        var method = new TransportAuthenticationOptions { ApiKey = AnApiKey() };
+
+        // Act
+        TransportAuthenticationConfiguration.ReadWhatTheBinderCannotSay(section, [method]);
+
+        // Assert
+        Assert.False(method.GrantsTheWholeSurface);
+        Assert.Null(method.ConfigurationKey);
     }
 
     /// <summary>The grant belongs to the entry, so which entry a credential sits in decides what it may do rather than only how the file was grouped.</summary>

--- a/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
@@ -284,6 +284,32 @@ public sealed class AdminEndpointOptionsTests
             error => error.Contains($"must be '{AdminEndpointOptions.RoutePrefix}'", StringComparison.Ordinal));
     }
 
+    /// <summary>This endpoint's own rule composes its path like every shared one, so an operator is sent to the key they wrote rather than to the position the binder appended the entry at.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AResourcePrefixRefusalOnAGappedSource_NamesTheKeyTheOperatorWrote()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["AdminEndpoint:Enabled"] = "true",
+                ["AdminEndpoint:Authentication:0:ApiKey:Name"] = "workstation",
+                ["AdminEndpoint:Authentication:0:ApiKey:SecretReference"] = "plaintext:a-key",
+                ["AdminEndpoint:Authentication:2:OAuth:Resource"] = "https://mail.example.test:8090/admin",
+                ["AdminEndpoint:Authentication:2:OAuth:AuthorizationServers:0:Name"] = "workforce",
+                ["AdminEndpoint:Authentication:2:OAuth:AuthorizationServers:0:Issuer"] = "https://sso.example.test/realms/mailfathom",
+                ["AdminEndpoint:Authentication:2:OAuth:AuthorizationServers:0:AuthorizedSubjects:0"] = "11111111-2222-3333-4444-555555555555",
+            })
+            .Build();
+
+        // Act
+        var errors = AdminEndpointOptions.ReadFrom(configuration).FindConfigurationErrors();
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains("AdminEndpoint:Authentication:2:OAuth:Resource", reported, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("https://mail.example.test:8090/api/admin")]
     [InlineData("https://mail.example.test:8090/api/admin/")]

--- a/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
@@ -176,7 +176,7 @@ public sealed class AdminEndpointOptionsTests
 
         // Assert
         var reported = Assert.Single(errors);
-        Assert.Contains("AdminEndpoint:Authentication:0:Permissions:0", reported, StringComparison.Ordinal);
+        Assert.Contains("AdminEndpoint:Authentication:0:Permissions", reported, StringComparison.Ordinal);
         Assert.Contains("mailfathom.mail.read", reported, StringComparison.Ordinal);
     }
 

--- a/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
@@ -114,6 +114,44 @@ public sealed class AdminEndpointOptionsTests
         Assert.Empty(settings.FindConfigurationErrors());
     }
 
+    /// <summary>The setting decides whether a token holds the entry's whole ceiling or only what its own scopes carry, and nothing else in the suite would notice it silently ceasing to bind.</summary>
+    [Fact]
+    public void ReadFrom_AnEntryNarrowingByTokenScopes_BindsTheSetting()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            {
+              "AdminEndpoint": {
+                "Enabled": true,
+                "Authentication": [
+                  {
+                    "OAuth": {
+                      "Resource": "https://mail.example.test/api/admin",
+                      "AuthorizationServers": [
+                        {
+                          "Name": "workforce",
+                          "Issuer": "https://sso.example.test/realms/mailfathom",
+                          "AuthorizedSubjects": [ "11111111-2222-3333-4444-555555555555" ]
+                        }
+                      ]
+                    },
+                    "Permissions": ["mailfathom.admin.read"],
+                    "PermissionsFromTokenScopes": true
+                  }
+                ]
+              }
+            }
+            """);
+
+        // Act
+        var settings = AdminEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        var entry = Assert.Single(settings.Authentication);
+        Assert.True(entry.PermissionsFromTokenScopes);
+        Assert.Empty(settings.FindConfigurationErrors());
+    }
+
     /// <summary>The half a grant draws from is the endpoint's own, so a mail permission written here grants nothing and is refused rather than left in the file.</summary>
     [Fact]
     public void FindConfigurationErrors_AGrantNamingAMailPermission_IsRefusedAsBelongingToTheOtherSurface()

--- a/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/AdminEndpointOptionsTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Text;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Transport;
@@ -68,6 +70,76 @@ public sealed class AdminEndpointOptionsTests
         Assert.True(settings.AllowsApiKey);
         Assert.True(settings.AllowsOAuth);
         Assert.Empty(settings.FindConfigurationErrors());
+    }
+
+    /// <summary>
+    /// Both endpoints read the grant through one method, so the pair that decides everything about it — an absent key
+    /// against an emptied list — has to answer here exactly as it does on the MCP endpoint. A reading that differed
+    /// would grant one surface what it refused the other from the same configuration.
+    /// </summary>
+    [Fact]
+    public void ReadFrom_TheGrantOnEachEntry_TellsAnAbsentKeyFromAnEmptiedList()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            {
+              "AdminEndpoint": {
+                "Enabled": true,
+                "Authentication": [
+                  { "ApiKey": { "Name": "workstation", "SecretReference": "plaintext:a-key" } },
+                  {
+                    "ApiKey": { "Name": "retired", "SecretReference": "plaintext:another-key" },
+                    "Permissions": []
+                  },
+                  {
+                    "ApiKey": { "Name": "reporting-job", "SecretReference": "plaintext:a-third-key" },
+                    "Permissions": ["mailfathom.admin.read"]
+                  }
+                ]
+              }
+            }
+            """);
+
+        // Act
+        var settings = AdminEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Equal(
+            MailFathomPermission.PublishedFor(AdminEndpointOptions.GrantedSurface),
+            settings.Authentication[0].GrantedPermissions(AdminEndpointOptions.GrantedSurface));
+        Assert.Empty(settings.Authentication[1].GrantedPermissions(AdminEndpointOptions.GrantedSurface));
+        Assert.Equal(
+            [MailFathomPermission.AdminRead],
+            settings.Authentication[2].GrantedPermissions(AdminEndpointOptions.GrantedSurface));
+        Assert.Empty(settings.FindConfigurationErrors());
+    }
+
+    /// <summary>The half a grant draws from is the endpoint's own, so a mail permission written here grants nothing and is refused rather than left in the file.</summary>
+    [Fact]
+    public void FindConfigurationErrors_AGrantNamingAMailPermission_IsRefusedAsBelongingToTheOtherSurface()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            {
+              "AdminEndpoint": {
+                "Enabled": true,
+                "Authentication": [
+                  {
+                    "ApiKey": { "Name": "workstation", "SecretReference": "plaintext:a-key" },
+                    "Permissions": ["mailfathom.mail.read"]
+                  }
+                ]
+              }
+            }
+            """);
+
+        // Act
+        var errors = AdminEndpointOptions.ReadFrom(configuration).FindConfigurationErrors();
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains("AdminEndpoint:Authentication:0:Permissions:0", reported, StringComparison.Ordinal);
+        Assert.Contains("mailfathom.mail.read", reported, StringComparison.Ordinal);
     }
 
     /// <summary>A value where the list belongs must never read as an unauthenticated deployment, which is what makes the binder raising on it a contract rather than an accident.</summary>
@@ -422,4 +494,12 @@ public sealed class AdminEndpointOptionsTests
 
     private static IConfiguration Configuration(Dictionary<string, string?> values) =>
         new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    /// <summary>Reads a JSON document, which is what tells an absent list from an emptied one; a dictionary provider can spell only the first.</summary>
+    private static IConfiguration ConfigurationFromJson(string document)
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(document));
+
+        return new ConfigurationBuilder().AddJsonStream(stream).Build();
+    }
 }

--- a/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
@@ -387,6 +387,34 @@ public sealed class McpEndpointOptionsBindingTests
         Assert.Contains("McpEndpoint:Authentication:2:Permissions:0", reported, StringComparison.Ordinal);
     }
 
+    /// <summary>Every refusal against an entry names the key it was written under, not only the ones a grant adds — a path composed per rule would drift back to the bound position one rule at a time.</summary>
+    [Fact]
+    public void FindConfigurationErrors_EntriesNumberedWithAGap_NameTheKeyInARefusalNoGrantProduced()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["McpEndpoint:Enabled"] = "true",
+                ["McpEndpoint:Authentication:0:OAuth:Resource"] = "https://mail.example.test/mcp",
+                ["McpEndpoint:Authentication:0:OAuth:AuthorizationServers:0:Name"] = "workforce",
+                ["McpEndpoint:Authentication:0:OAuth:AuthorizationServers:0:Issuer"] = "https://sso.example.test/realms/mailfathom",
+                ["McpEndpoint:Authentication:0:OAuth:AuthorizationServers:0:AuthorizedSubjects:0"] = "11111111-2222-3333-4444-555555555555",
+                ["McpEndpoint:Authentication:2:OAuth:Resource"] = "https://mail.example.test/elsewhere",
+                ["McpEndpoint:Authentication:2:OAuth:AuthorizationServers:0:Name"] = "partners",
+                ["McpEndpoint:Authentication:2:OAuth:AuthorizationServers:0:Issuer"] = "https://partners.example.test/realms/mailfathom",
+                ["McpEndpoint:Authentication:2:OAuth:AuthorizationServers:0:AuthorizedSubjects:0"] = "22222222-3333-4444-5555-666666666666",
+            })
+            .Build();
+
+        // Act
+        var errors = McpEndpointOptions.ReadFrom(configuration).FindConfigurationErrors();
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains("McpEndpoint:Authentication:2:OAuth:Resource", reported, StringComparison.Ordinal);
+    }
+
     /// <summary>
     /// An element carrying nothing binds to an entry rather than being dropped, so the children and the bound entries
     /// stay the same length and every grant is still read off the entry that wrote it. The empty element is refused

--- a/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
@@ -384,7 +384,7 @@ public sealed class McpEndpointOptionsBindingTests
 
         // Assert
         var reported = Assert.Single(errors);
-        Assert.Contains("McpEndpoint:Authentication:2:Permissions:0", reported, StringComparison.Ordinal);
+        Assert.Contains("McpEndpoint:Authentication:2:Permissions", reported, StringComparison.Ordinal);
     }
 
     /// <summary>Every refusal against an entry names the key it was written under, not only the ones a grant adds — a path composed per rule would drift back to the bound position one rule at a time.</summary>
@@ -512,7 +512,7 @@ public sealed class McpEndpointOptionsBindingTests
 
         // Assert
         var reported = Assert.Single(errors);
-        Assert.Contains("McpEndpoint:Authentication:0:Permissions:0", reported, StringComparison.Ordinal);
+        Assert.Contains("McpEndpoint:Authentication:0:Permissions", reported, StringComparison.Ordinal);
     }
 
     /// <summary>A misspelling that bound quietly would leave a security decision reading as one nobody made.</summary>

--- a/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Text;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Access;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Infrastructure.Secrets;
@@ -236,9 +237,130 @@ public sealed class McpEndpointOptionsBindingTests
         Assert.Empty(options.FindConfigurationErrors());
     }
 
+    /// <summary>
+    /// The grant is read the way the origin list is, and the pair is pinned from real JSON for the same reason: an
+    /// absent list and an emptied one bind identically, and only the section can say which the operator wrote.
+    /// </summary>
+    [Fact]
+    public void ReadFrom_AnEntryWithNoPermissionsKey_ReachesTheWholeSurface()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            {
+              "McpEndpoint": {
+                "Enabled": true,
+                "Authentication": [
+                  { "ApiKey": { "Name": "workstation", "SecretReference": "plaintext:a-key" } }
+                ]
+              }
+            }
+            """);
+
+        // Act
+        var options = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        var entry = Assert.Single(options.Authentication);
+        Assert.False(entry.WasGrantWritten);
+        Assert.Equal(
+            MailFathomPermission.PublishedFor(McpEndpointOptions.GrantedSurface),
+            entry.GrantedPermissions(McpEndpointOptions.GrantedSurface));
+    }
+
+    /// <summary>An emptied grant retires a credential without deleting its entry, so it must not read as the entry that never narrowed.</summary>
+    [Fact]
+    public void ReadFrom_AnEntryWithAnEmptyPermissionsList_ReachesNothing()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            {
+              "McpEndpoint": {
+                "Enabled": true,
+                "Authentication": [
+                  {
+                    "ApiKey": { "Name": "workstation", "SecretReference": "plaintext:a-key" },
+                    "Permissions": []
+                  }
+                ]
+              }
+            }
+            """);
+
+        // Act
+        var options = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        var entry = Assert.Single(options.Authentication);
+        Assert.True(entry.WasGrantWritten);
+        Assert.Empty(entry.GrantedPermissions(McpEndpointOptions.GrantedSurface));
+        Assert.Empty(options.FindConfigurationErrors());
+    }
+
+    /// <summary>The grant belongs to the entry, so the read has to answer the question once per entry rather than once per section.</summary>
+    [Fact]
+    public void ReadFrom_TwoEntriesGrantedDifferently_ReadsEachEntrysOwnGrant()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            {
+              "McpEndpoint": {
+                "Enabled": true,
+                "Authentication": [
+                  {
+                    "ApiKey": { "Name": "reporting-job", "SecretReference": "plaintext:a-key" },
+                    "Permissions": ["mailfathom.mail.read"]
+                  },
+                  { "ApiKey": { "Name": "workstation", "SecretReference": "plaintext:another-key" } }
+                ]
+              }
+            }
+            """);
+
+        // Act
+        var options = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Equal(["mailfathom.mail.read"], options.Authentication[0].Permissions);
+        Assert.Equal(
+            [MailFathomPermission.MailRead],
+            options.Authentication[0].GrantedPermissions(McpEndpointOptions.GrantedSurface));
+        Assert.Equal(
+            MailFathomPermission.PublishedFor(McpEndpointOptions.GrantedSurface),
+            options.Authentication[1].GrantedPermissions(McpEndpointOptions.GrantedSurface));
+    }
+
+    /// <summary>The whole point of a closed vocabulary is that a name nothing publishes fails startup instead of reading as a narrowed grant.</summary>
+    [Fact]
+    public void ReadFrom_AnEntryNamingAnUnpublishedPermission_IsRefusedNamingTheEntry()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            {
+              "McpEndpoint": {
+                "Enabled": true,
+                "Authentication": [
+                  {
+                    "ApiKey": { "Name": "workstation", "SecretReference": "plaintext:a-key" },
+                    "Permissions": ["mailfathom.mail.write"]
+                  }
+                ]
+              }
+            }
+            """);
+
+        // Act
+        var errors = McpEndpointOptions.ReadFrom(configuration).FindConfigurationErrors();
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains("McpEndpoint:Authentication:0:Permissions:0", reported, StringComparison.Ordinal);
+    }
+
     /// <summary>A misspelling that bound quietly would leave a security decision reading as one nobody made.</summary>
     [Theory]
     [InlineData("McpEndpoint:Enabeld", "true")]
+    [InlineData("McpEndpoint:Authentication:0:Permission:0", "mailfathom.mail.read")]
+    [InlineData("McpEndpoint:Authentication:0:PermissionsFromTokenScope", "true")]
     [InlineData("McpEndpoint:Authentication:0:ApiKeys:Name", "workstation")]
     [InlineData("McpEndpoint:Authentication:0:ApiKey:Named", "workstation")]
     [InlineData("McpEndpoint:ApiKeys:0:Name", "workstation")]

--- a/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
@@ -362,6 +362,66 @@ public sealed class McpEndpointOptionsBindingTests
             options.Authentication[1].GrantedPermissions(McpEndpointOptions.GrantedSurface));
     }
 
+    /// <summary>A refusal names the position an operator has to go and edit, and where the numbering has a gap that is the key they wrote rather than the one the binder appended at.</summary>
+    [Fact]
+    public void FindConfigurationErrors_EntriesNumberedWithAGap_NameTheKeyTheOperatorWrote()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["McpEndpoint:Enabled"] = "true",
+                ["McpEndpoint:Authentication:0:ApiKey:Name"] = "workstation",
+                ["McpEndpoint:Authentication:0:ApiKey:SecretReference"] = "plaintext:a-key",
+                ["McpEndpoint:Authentication:2:ApiKey:Name"] = "reporting-job",
+                ["McpEndpoint:Authentication:2:ApiKey:SecretReference"] = "plaintext:another-key",
+                ["McpEndpoint:Authentication:2:Permissions:0"] = "mailfathom.mail.write",
+            })
+            .Build();
+
+        // Act
+        var errors = McpEndpointOptions.ReadFrom(configuration).FindConfigurationErrors();
+
+        // Assert
+        var reported = Assert.Single(errors);
+        Assert.Contains("McpEndpoint:Authentication:2:Permissions:0", reported, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An element carrying nothing binds to an entry rather than being dropped, so the children and the bound entries
+    /// stay the same length and every grant is still read off the entry that wrote it. The empty element is refused
+    /// for stating no method, which is the answer it already had before a grant could be written on one.
+    /// </summary>
+    [Fact]
+    public void ReadFrom_AnEmptyElementInTheList_BindsAnEntryThatIsRefusedRatherThanShiftingTheGrants()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            {
+              "McpEndpoint": {
+                "Enabled": true,
+                "Authentication": [
+                  null,
+                  {
+                    "ApiKey": { "Name": "retired", "SecretReference": "plaintext:a-key" },
+                    "Permissions": []
+                  }
+                ]
+              }
+            }
+            """);
+
+        // Act
+        var options = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Equal(2, options.Authentication.Count);
+        Assert.Empty(options.Authentication[1].GrantedPermissions(McpEndpointOptions.GrantedSurface));
+
+        var reported = Assert.Single(options.FindConfigurationErrors());
+        Assert.Contains("McpEndpoint:Authentication:0", reported, StringComparison.Ordinal);
+    }
+
     /// <summary>The setting decides whether a token holds the entry's whole ceiling or only what its own scopes carry, and nothing else in the suite would notice it silently ceasing to bind.</summary>
     [Fact]
     public void ReadFrom_AnEntryNarrowingByTokenScopes_BindsTheSetting()

--- a/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
@@ -261,7 +261,7 @@ public sealed class McpEndpointOptionsBindingTests
 
         // Assert
         var entry = Assert.Single(options.Authentication);
-        Assert.False(entry.WasGrantWritten);
+        Assert.True(entry.GrantsTheWholeSurface);
         Assert.Equal(
             MailFathomPermission.PublishedFor(McpEndpointOptions.GrantedSurface),
             entry.GrantedPermissions(McpEndpointOptions.GrantedSurface));
@@ -291,7 +291,7 @@ public sealed class McpEndpointOptionsBindingTests
 
         // Assert
         var entry = Assert.Single(options.Authentication);
-        Assert.True(entry.WasGrantWritten);
+        Assert.False(entry.GrantsTheWholeSurface);
         Assert.Empty(entry.GrantedPermissions(McpEndpointOptions.GrantedSurface));
         Assert.Empty(options.FindConfigurationErrors());
     }
@@ -327,6 +327,77 @@ public sealed class McpEndpointOptionsBindingTests
         Assert.Equal(
             MailFathomPermission.PublishedFor(McpEndpointOptions.GrantedSurface),
             options.Authentication[1].GrantedPermissions(McpEndpointOptions.GrantedSurface));
+    }
+
+    /// <summary>
+    /// A configuration source numbering its entries with a gap — the environment-variable form a container deployment
+    /// writes — binds them into consecutive list positions, so a grant read by position would land on the wrong entry
+    /// and hand the narrowed one its surface's whole half.
+    /// </summary>
+    [Fact]
+    public void ReadFrom_EntriesNumberedWithAGap_ReadsEachGrantFromTheEntryThatWroteIt()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["McpEndpoint:Enabled"] = "true",
+                ["McpEndpoint:Authentication:0:ApiKey:Name"] = "workstation",
+                ["McpEndpoint:Authentication:0:ApiKey:SecretReference"] = "plaintext:a-key",
+                ["McpEndpoint:Authentication:2:ApiKey:Name"] = "reporting-job",
+                ["McpEndpoint:Authentication:2:ApiKey:SecretReference"] = "plaintext:another-key",
+                ["McpEndpoint:Authentication:2:Permissions:0"] = "mailfathom.mail.read",
+            })
+            .Build();
+
+        // Act
+        var options = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        Assert.Equal(
+            MailFathomPermission.PublishedFor(McpEndpointOptions.GrantedSurface),
+            options.Authentication[0].GrantedPermissions(McpEndpointOptions.GrantedSurface));
+        Assert.Equal(
+            [MailFathomPermission.MailRead],
+            options.Authentication[1].GrantedPermissions(McpEndpointOptions.GrantedSurface));
+    }
+
+    /// <summary>The setting decides whether a token holds the entry's whole ceiling or only what its own scopes carry, and nothing else in the suite would notice it silently ceasing to bind.</summary>
+    [Fact]
+    public void ReadFrom_AnEntryNarrowingByTokenScopes_BindsTheSetting()
+    {
+        // Arrange
+        var configuration = ConfigurationFromJson("""
+            {
+              "McpEndpoint": {
+                "Enabled": true,
+                "Authentication": [
+                  {
+                    "OAuth": {
+                      "Resource": "https://mail.example.test/mcp",
+                      "AuthorizationServers": [
+                        {
+                          "Name": "workforce",
+                          "Issuer": "https://sso.example.test/realms/mailfathom",
+                          "AuthorizedSubjects": [ "11111111-2222-3333-4444-555555555555" ]
+                        }
+                      ]
+                    },
+                    "Permissions": ["mailfathom.mail.read"],
+                    "PermissionsFromTokenScopes": true
+                  }
+                ]
+              }
+            }
+            """);
+
+        // Act
+        var options = McpEndpointOptions.ReadFrom(configuration);
+
+        // Assert
+        var entry = Assert.Single(options.Authentication);
+        Assert.True(entry.PermissionsFromTokenScopes);
+        Assert.Empty(options.FindConfigurationErrors());
     }
 
     /// <summary>The whole point of a closed vocabulary is that a name nothing publishes fails startup instead of reading as a narrowed grant.</summary>

--- a/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
+++ b/tests/Host.UnitTests/Configuration/Endpoints/McpEndpointOptionsBindingTests.cs
@@ -298,7 +298,7 @@ public sealed class McpEndpointOptionsBindingTests
 
     /// <summary>The grant belongs to the entry, so the read has to answer the question once per entry rather than once per section.</summary>
     [Fact]
-    public void ReadFrom_TwoEntriesGrantedDifferently_ReadsEachEntrysOwnGrant()
+    public void ReadFrom_TwoEntriesGrantedDifferently_ReadsTheGrantWrittenOnEachEntry()
     {
         // Arrange
         var configuration = ConfigurationFromJson("""

--- a/tests/Host.UnitTests/Hosting/Warnings/TransportGrantStartupReportTests.cs
+++ b/tests/Host.UnitTests/Hosting/Warnings/TransportGrantStartupReportTests.cs
@@ -1,0 +1,231 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+using MailFathom.Host.Configuration.Access;
+using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Hosting.Warnings;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Hosting.Warnings;
+
+/// <summary>Covers what an operator is told about how much each configured credential may do.</summary>
+/// <remarks>
+/// A grant nobody wrote down reaches the whole of its surface, and this report is the only place a deployment running
+/// on that default can read it. What matters most here is that an entry which never narrowed says so in its own line
+/// rather than being reported as though somebody had chosen the permissions it holds.
+/// </remarks>
+public sealed class TransportGrantStartupReportTests
+{
+    [Fact]
+    public async Task StartAsync_WithNeitherEndpointEnabled_SaysNothing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(new McpEndpointOptions(), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(logs.Records);
+    }
+
+    /// <summary>There is no entry for a grant to hang on, so a caller admitted here holds everything the surface publishes.</summary>
+    [Fact]
+    public async Task StartAsync_AnEnabledEndpointWithNoEntry_SaysEveryCallerHoldsTheWholeSurface()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(new McpEndpointOptions { Enabled = true }, new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.Equal("MCP", Assert.Contains("EndpointName", record.Properties));
+        Assert.Equal("/mcp", Assert.Contains("EndpointPath", record.Properties));
+        Assert.Equal(
+            "mailfathom.mail.read, mailfathom.mail.ask",
+            Assert.Contains("GrantedPermissions", record.Properties));
+        Assert.Equal("McpEndpoint:Authentication", Assert.Contains("AuthenticationSettingPath", record.Properties));
+    }
+
+    /// <summary>The line an operator meets on a first run: they wrote a credential and no grant, and this is what it turned out to hold.</summary>
+    [Fact]
+    public async Task StartAsync_AnEntryThatWroteNoGrant_NamesItAndWhatItThereforeHolds()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(McpEndpointWith(AnApiKeyEntry()), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Contains("writes down no grant", record.Message, StringComparison.Ordinal);
+        Assert.Equal("McpEndpoint:Authentication:0", Assert.Contains("EntrySettingPath", record.Properties));
+        Assert.Equal(
+            "mailfathom.mail.read, mailfathom.mail.ask",
+            Assert.Contains("GrantedPermissions", record.Properties));
+    }
+
+    [Fact]
+    public async Task StartAsync_AnEntryThatNarrowedItsGrant_StatesWhatItResolvedTo()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var entry = AnApiKeyEntry();
+        entry.Permissions.Add(MailFathomPermission.MailRead.Name);
+        entry.MarkGrantWritten();
+
+        var report = ReportFor(McpEndpointWith(entry), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal("mailfathom.mail.read", Assert.Contains("GrantedPermissions", record.Properties));
+        Assert.DoesNotContain("writes down no grant", record.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>An empty grant would otherwise read as a message that lost its argument, and it is the value worth being unambiguous about.</summary>
+    [Fact]
+    public async Task StartAsync_AnEntryGrantedNothing_NamesTheEmptinessRatherThanPrintingNothing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var entry = AnApiKeyEntry();
+        entry.MarkGrantWritten();
+
+        var report = ReportFor(McpEndpointWith(entry), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal("nothing", Assert.Contains("GrantedPermissions", record.Properties));
+    }
+
+    /// <summary>Such an entry states a ceiling rather than what each caller holds, and an operator reading the two the same way would over-read the grant.</summary>
+    [Fact]
+    public async Task StartAsync_AnEntryNarrowedByTokenScopes_SaysTheGrantIsACeiling()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var entry = new TransportAuthenticationOptions
+        {
+            OAuth = new OAuthValidationOptions { Resource = "https://mail.example.test/mcp" },
+            PermissionsFromTokenScopes = true,
+        };
+
+        entry.Permissions.Add(MailFathomPermission.MailAsk.Name);
+        entry.MarkGrantWritten();
+
+        var report = ReportFor(McpEndpointWith(entry), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Contains("at most", record.Message, StringComparison.Ordinal);
+        Assert.Equal("mailfathom.mail.ask", Assert.Contains("GrantedPermissions", record.Properties));
+    }
+
+    /// <summary>The two surfaces draw from disjoint halves, so an operator has to be able to read back that they narrowed the one they meant.</summary>
+    [Fact]
+    public async Task StartAsync_BothEndpointsEnabled_ReportsEachEntryAgainstItsOwnSurface()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var adminEndpoint = new AdminEndpointOptions { Enabled = true };
+        adminEndpoint.Authentication.Add(AnApiKeyEntry());
+
+        var report = ReportFor(McpEndpointWith(AnApiKeyEntry()), adminEndpoint, logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            ["MCP", "administrative"],
+            logs.Records.Select(record => Assert.Contains("EndpointName", record.Properties)));
+        Assert.Equal(
+            [
+                "mailfathom.mail.read, mailfathom.mail.ask",
+                string.Join(
+                    ", ",
+                    MailFathomPermission.PublishedFor(ProtectedSurface.Administration).Select(permission => permission.Name)),
+            ],
+            logs.Records.Select(record => Assert.Contains("GrantedPermissions", record.Properties)));
+    }
+
+    /// <summary>Every line names a configuration position and a published capability, and never the credential that sits there.</summary>
+    [Fact]
+    public async Task StartAsync_AnEntryCarryingACredential_NamesNeitherTheKeyNorItsReference()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(McpEndpointWith(AnApiKeyEntry()), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.DoesNotContain("workstation", record.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("plaintext:", record.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StopAsync_AfterStarting_SaysNothingFurther()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var report = ReportFor(McpEndpointWith(AnApiKeyEntry()), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+        await report.StopAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(logs.Records);
+    }
+
+    private static TransportAuthenticationOptions AnApiKeyEntry() => new()
+    {
+        ApiKey = new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:a-key" },
+    };
+
+    private static McpEndpointOptions McpEndpointWith(TransportAuthenticationOptions entry)
+    {
+        var endpointSettings = new McpEndpointOptions { Enabled = true };
+        endpointSettings.Authentication.Add(entry);
+
+        return endpointSettings;
+    }
+
+    private static TransportGrantStartupReport ReportFor(
+        McpEndpointOptions mcpEndpointSettings,
+        AdminEndpointOptions adminEndpointSettings,
+        RecordingLoggerProvider logs)
+    {
+        using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(logs));
+
+        return new TransportGrantStartupReport(
+            Options.Create(mcpEndpointSettings),
+            Options.Create(adminEndpointSettings),
+            loggerFactory.CreateLogger<TransportGrantStartupReport>());
+    }
+}

--- a/tests/Host.UnitTests/Hosting/Warnings/TransportGrantStartupReportTests.cs
+++ b/tests/Host.UnitTests/Hosting/Warnings/TransportGrantStartupReportTests.cs
@@ -64,7 +64,7 @@ public sealed class TransportGrantStartupReportTests
     {
         // Arrange
         using var logs = new RecordingLoggerProvider();
-        var report = ReportFor(McpEndpointWith(AnApiKeyEntry()), new AdminEndpointOptions(), logs);
+        var report = ReportFor(McpEndpointWith(AnEntryThatStatedNoGrant()), new AdminEndpointOptions(), logs);
 
         // Act
         await report.StartAsync(TestContext.Current.CancellationToken);
@@ -85,7 +85,6 @@ public sealed class TransportGrantStartupReportTests
         using var logs = new RecordingLoggerProvider();
         var entry = AnApiKeyEntry();
         entry.Permissions.Add(MailFathomPermission.MailRead.Name);
-        entry.MarkGrantWritten();
 
         var report = ReportFor(McpEndpointWith(entry), new AdminEndpointOptions(), logs);
 
@@ -105,7 +104,6 @@ public sealed class TransportGrantStartupReportTests
         // Arrange
         using var logs = new RecordingLoggerProvider();
         var entry = AnApiKeyEntry();
-        entry.MarkGrantWritten();
 
         var report = ReportFor(McpEndpointWith(entry), new AdminEndpointOptions(), logs);
 
@@ -130,7 +128,6 @@ public sealed class TransportGrantStartupReportTests
         };
 
         entry.Permissions.Add(MailFathomPermission.MailAsk.Name);
-        entry.MarkGrantWritten();
 
         var report = ReportFor(McpEndpointWith(entry), new AdminEndpointOptions(), logs);
 
@@ -143,6 +140,34 @@ public sealed class TransportGrantStartupReportTests
         Assert.Equal("mailfathom.mail.ask", Assert.Contains("GrantedPermissions", record.Properties));
     }
 
+    /// <summary>Such an entry states no ceiling and is still narrowed per token, so reporting it as the entry that wrote nothing down would tell an operator every token holds the whole surface.</summary>
+    [Fact]
+    public async Task StartAsync_AnEntryNarrowedByTokenScopesThatWroteNoList_StillSaysTheGrantIsACeiling()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var entry = new TransportAuthenticationOptions
+        {
+            OAuth = new OAuthValidationOptions { Resource = "https://mail.example.test/mcp" },
+            PermissionsFromTokenScopes = true,
+        };
+
+        entry.GrantTheWholeSurface();
+
+        var report = ReportFor(McpEndpointWith(entry), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Contains("at most", record.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("writes down no grant", record.Message, StringComparison.Ordinal);
+        Assert.Equal(
+            "mailfathom.mail.read, mailfathom.mail.ask",
+            Assert.Contains("GrantedPermissions", record.Properties));
+    }
+
     /// <summary>The two surfaces draw from disjoint halves, so an operator has to be able to read back that they narrowed the one they meant.</summary>
     [Fact]
     public async Task StartAsync_BothEndpointsEnabled_ReportsEachEntryAgainstItsOwnSurface()
@@ -150,9 +175,9 @@ public sealed class TransportGrantStartupReportTests
         // Arrange
         using var logs = new RecordingLoggerProvider();
         var adminEndpoint = new AdminEndpointOptions { Enabled = true };
-        adminEndpoint.Authentication.Add(AnApiKeyEntry());
+        adminEndpoint.Authentication.Add(AnEntryThatStatedNoGrant());
 
-        var report = ReportFor(McpEndpointWith(AnApiKeyEntry()), adminEndpoint, logs);
+        var report = ReportFor(McpEndpointWith(AnEntryThatStatedNoGrant()), adminEndpoint, logs);
 
         // Act
         await report.StartAsync(TestContext.Current.CancellationToken);
@@ -207,6 +232,15 @@ public sealed class TransportGrantStartupReportTests
     {
         ApiKey = new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:a-key" },
     };
+
+    /// <summary>An entry the endpoint's own read found no grant on, which is the permissive posture the report exists to state.</summary>
+    private static TransportAuthenticationOptions AnEntryThatStatedNoGrant()
+    {
+        var entry = AnApiKeyEntry();
+        entry.GrantTheWholeSurface();
+
+        return entry;
+    }
 
     private static McpEndpointOptions McpEndpointWith(TransportAuthenticationOptions entry)
     {

--- a/tests/Host.UnitTests/Hosting/Warnings/TransportGrantStartupReportTests.cs
+++ b/tests/Host.UnitTests/Hosting/Warnings/TransportGrantStartupReportTests.cs
@@ -168,6 +168,48 @@ public sealed class TransportGrantStartupReportTests
             Assert.Contains("GrantedPermissions", record.Properties));
     }
 
+    /// <summary>
+    /// The line is what an operator goes and edits, so it names the key they wrote rather than the position the binder
+    /// appended the entry at. A source numbering its entries with a gap makes the two different numbers, and the
+    /// position then names a path their configuration does not contain.
+    /// </summary>
+    [Fact]
+    public async Task StartAsync_AnEntryWrittenUnderAKeyOfItsOwn_NamesThatKeyRatherThanTheBoundPosition()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var entry = AnEntryThatStatedNoGrant();
+        entry.RecordConfigurationKey("2");
+
+        var report = ReportFor(McpEndpointWith(entry), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Equal("McpEndpoint:Authentication:2", Assert.Contains("EntrySettingPath", record.Properties));
+    }
+
+    /// <summary>The startup record is where an operator meets the posture first, so a line that stated a grant without saying nothing reads it would be the false answer the model exists to avoid.</summary>
+    [Fact]
+    public async Task StartAsync_AnyReportedEntry_SaysNothingConsultsAGrantYet()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        var entry = AnApiKeyEntry();
+        entry.Permissions.Add(MailFathomPermission.MailRead.Name);
+
+        var report = ReportFor(McpEndpointWith(entry), new AdminEndpointOptions(), logs);
+
+        // Act
+        await report.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        var record = Assert.Single(logs.Records);
+        Assert.Contains("Nothing consults a grant yet", record.Message, StringComparison.Ordinal);
+    }
+
     /// <summary>The two surfaces draw from disjoint halves, so an operator has to be able to read back that they narrowed the one they meant.</summary>
     [Fact]
     public async Task StartAsync_BothEndpointsEnabled_ReportsEachEntryAgainstItsOwnSurface()

--- a/tests/Host.UnitTests/Security/Mcp/McpTransportSecurityExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Mcp/McpTransportSecurityExtensionsTests.cs
@@ -195,7 +195,7 @@ public sealed class McpTransportSecurityExtensionsTests
         Assert.NotNull(published);
         Assert.Equal(["mailfathom.read", "offline_access"], published.ScopesSupported);
         Assert.Equal(
-            ProtectedResourceMetadataDocument.For([oauthSettings]).ScopesSupported,
+            ProtectedResourceMetadataDocument.For([new TransportAuthenticationOptions { OAuth = oauthSettings }]).ScopesSupported,
             published.ScopesSupported);
     }
 

--- a/tests/Host.UnitTests/Security/Transport/TransportGrantTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TransportGrantTests.cs
@@ -1,0 +1,80 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Claims;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Security.Transport;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Security.Transport;
+
+/// <summary>Covers how a resolved grant travels on the principal the transport policy judges.</summary>
+/// <remarks>
+/// The grant is decided while the host is composed and read again on every request, so what is asserted here is the
+/// round trip: what a scheme writes is exactly what a surface enforcing the grant later reads, and nothing else is.
+/// </remarks>
+public sealed class TransportGrantTests
+{
+    [Fact]
+    public void PermissionsCarriedBy_APrincipalCarryingWhatClaimsForWrote_ReportsTheSameGrant()
+    {
+        // Arrange
+        MailFathomPermission[] granted = [MailFathomPermission.MailRead, MailFathomPermission.MailAsk];
+        var principal = PrincipalCarrying(TransportGrant.ClaimsFor(granted));
+
+        // Act
+        var permissions = TransportGrant.PermissionsCarriedBy(principal);
+
+        // Assert
+        Assert.Equal(granted.ToHashSet(), permissions);
+    }
+
+    /// <summary>An entry that granted nothing produces a principal holding nothing, which is the posture an emptied grant states.</summary>
+    [Fact]
+    public void PermissionsCarriedBy_APrincipalCarryingAnEmptyGrant_ReportsNothing()
+    {
+        // Arrange
+        var principal = PrincipalCarrying(TransportGrant.ClaimsFor([]));
+
+        // Act, Assert
+        Assert.Empty(TransportGrant.PermissionsCarriedBy(principal));
+    }
+
+    /// <summary>The claim carries the published name, because that is the identity an operator wrote and an authorization server minted.</summary>
+    [Fact]
+    public void ClaimsFor_AGrant_WritesOneClaimPerPublishedName()
+    {
+        // Act
+        var claims = TransportGrant.ClaimsFor([MailFathomPermission.AdminSpend]);
+
+        // Assert
+        var claim = Assert.Single(claims);
+        Assert.Equal(TransportGrant.PermissionClaimType, claim.Type);
+        Assert.Equal("mailfathom.admin.spend", claim.Value);
+    }
+
+    /// <summary>
+    /// Reading a name nothing publishes as a permission is the one outcome that would grant something, so a claim
+    /// naming a value a later release retired is dropped rather than reported.
+    /// </summary>
+    [Fact]
+    public void PermissionsCarriedBy_AClaimNamingNoPublishedPermission_IsDropped()
+    {
+        // Arrange
+        var principal = PrincipalCarrying(
+            [
+                new Claim(TransportGrant.PermissionClaimType, "mailfathom.mail.write"),
+                new Claim(TransportGrant.PermissionClaimType, MailFathomPermission.MailRead.Name),
+            ]);
+
+        // Act
+        var permissions = TransportGrant.PermissionsCarriedBy(principal);
+
+        // Assert
+        Assert.Equal([MailFathomPermission.MailRead], permissions);
+    }
+
+    private static ClaimsPrincipal PrincipalCarrying(IEnumerable<Claim> claims) =>
+        new(new ClaimsIdentity(claims, "test"));
+}

--- a/tests/Host.UnitTests/Security/Transport/TransportSecurityExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TransportSecurityExtensionsTests.cs
@@ -2,8 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Security.Claims;
 using MailFathom.Common.ClientAssertions;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Access;
+using MailFathom.Host.Security.ApiKeys;
 using MailFathom.Host.Security.ClientAssertions;
 using MailFathom.Host.Security.Transport;
 using MailFathom.Infrastructure.Secrets.Discovery;
@@ -116,9 +119,7 @@ public sealed class TransportSecurityExtensionsTests
         // Act
         services.AddTransportAuthentication(
             TransportSurface.Admin,
-            apiKeys: [],
-            [publicKey],
-            oauthMethods: [],
+            [new TransportAuthenticationOptions { PublicKey = publicKey }],
             TransportSurface.Admin.ClientAssertionSchemeName);
 
         // Assert
@@ -249,9 +250,7 @@ public sealed class TransportSecurityExtensionsTests
         services.AddLogging();
         services.AddTransportAuthentication(
             TransportSurface.Mcp,
-            [],
-            [],
-            [AnAuthorizationServer()],
+            [new TransportAuthenticationOptions { OAuth = AnAuthorizationServer() }],
             TransportSurface.Mcp.OAuthSchemeNameFor("workforce"));
 
         using var composed = services.BuildServiceProvider();
@@ -283,9 +282,7 @@ public sealed class TransportSecurityExtensionsTests
         services.AddLogging();
         services.AddTransportAuthentication(
             TransportSurface.Mcp,
-            [],
-            [],
-            [AnAuthorizationServer()],
+            [new TransportAuthenticationOptions { OAuth = AnAuthorizationServer() }],
             TransportSurface.Mcp.OAuthSchemeNameFor("workforce"));
 
         using var composed = services.BuildServiceProvider();
@@ -315,9 +312,7 @@ public sealed class TransportSecurityExtensionsTests
         services.AddLogging();
         services.AddTransportAuthentication(
             TransportSurface.Mcp,
-            [],
-            [],
-            [AnAuthorizationServer()],
+            [new TransportAuthenticationOptions { OAuth = AnAuthorizationServer() }],
             TransportSurface.Mcp.OAuthSchemeNameFor("workforce"));
 
         using var composed = services.BuildServiceProvider();
@@ -353,9 +348,7 @@ public sealed class TransportSecurityExtensionsTests
         {
             services.AddTransportAuthentication(
                 surface,
-                [],
-                [],
-                [AnAuthorizationServer()],
+                [new TransportAuthenticationOptions { OAuth = AnAuthorizationServer() }],
                 surface.OAuthSchemeNameFor("workforce"));
         }
 
@@ -368,6 +361,187 @@ public sealed class TransportSecurityExtensionsTests
 
         var connection = Assert.IsType<SocketsHttpHandler>(chain[^1]);
         Assert.Equal(OAuthValidationOptions.MetadataConnectionLifetime, connection.PooledConnectionLifetime);
+    }
+
+    /// <summary>
+    /// The grant belongs to the entry, so the scheme has to be registered with each key's own entry's grant rather
+    /// than with one set for the surface. Registering a shared set would give a key an operator narrowed whatever the
+    /// entry beside it holds, which is the failure the entry-scoped grant exists to prevent.
+    /// </summary>
+    [Fact]
+    public void AddTransportAuthentication_TwoKeysGrantedDifferently_GivesTheApiKeySchemeEachEntrysOwnGrant()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var narrowed = new TransportAuthenticationOptions
+        {
+            ApiKey = new ConfiguredSecret { Name = "reporting-job", SecretReference = "plaintext:a-key" },
+        };
+
+        narrowed.Permissions.Add(MailFathomPermission.MailRead.Name);
+        narrowed.MarkGrantWritten();
+
+        var unnarrowed = new TransportAuthenticationOptions
+        {
+            ApiKey = new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:another-key" },
+        };
+
+        // Act
+        services.AddTransportAuthentication(
+            TransportSurface.Mcp,
+            [narrowed, unnarrowed],
+            TransportSurface.Mcp.ApiKeySchemeName);
+
+        // Assert
+        using var composed = services.BuildServiceProvider();
+        var schemeOptions = composed
+            .GetRequiredService<IOptionsMonitor<ApiKeyAuthenticationSchemeOptions>>()
+            .Get(TransportSurface.Mcp.ApiKeySchemeName);
+
+        Assert.Equal([MailFathomPermission.MailRead], schemeOptions.GrantsByKeyName["reporting-job"]);
+        Assert.Equal(
+            MailFathomPermission.PublishedFor(ProtectedSurface.Mail),
+            schemeOptions.GrantsByKeyName["workstation"]);
+    }
+
+    /// <summary>The assertion scheme carries the same map for the same reason, because a public key's entry is where its grant was written too.</summary>
+    [Fact]
+    public void AddTransportAuthentication_AnAssertionEntryGrantedNothing_GivesTheSchemeAnEmptyGrantForThatKey()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        var retired = new TransportAuthenticationOptions
+        {
+            PublicKey = new ConfiguredSecret { Name = "nightly", SecretReference = "plaintext:a-public-key" },
+        };
+
+        retired.MarkGrantWritten();
+
+        // Act
+        services.AddTransportAuthentication(
+            TransportSurface.Admin,
+            [retired],
+            TransportSurface.Admin.ClientAssertionSchemeName);
+
+        // Assert
+        using var composed = services.BuildServiceProvider();
+        var schemeOptions = composed
+            .GetRequiredService<IOptionsMonitor<ClientAssertionAuthenticationSchemeOptions>>()
+            .Get(TransportSurface.Admin.ClientAssertionSchemeName);
+
+        Assert.Empty(schemeOptions.GrantsByKeyName["nightly"]);
+    }
+
+    /// <summary>Without the narrowing setting the deployment wrote the grant and the authorization server was never asked, so every token the entry admits holds the whole ceiling.</summary>
+    [Fact]
+    public async Task OnTokenValidated_AnEntryGrantingFromConfiguration_GivesEveryTokenTheWholeGrant()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions { OAuth = AnAuthorizationServer() };
+        entry.Permissions.Add(MailFathomPermission.MailRead.Name);
+        entry.MarkGrantWritten();
+
+        var context = TokenValidatedFor(entry, tokenScopes: "mailfathom.mail.ask");
+
+        // Act
+        await ValidatedTokenEventOf(entry).Invoke(context);
+
+        // Assert
+        Assert.Equal(
+            [MailFathomPermission.MailRead],
+            TransportGrant.PermissionsCarriedBy(context.Principal!));
+    }
+
+    /// <summary>With it, the authorization server decides per subject within the bound the deployment fixed, so a token holds the intersection and nothing else.</summary>
+    [Fact]
+    public async Task OnTokenValidated_AnEntryNarrowedByTokenScopes_GivesTheTokenOnlyWhatItsScopesCarry()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions
+        {
+            OAuth = AnAuthorizationServer(),
+            PermissionsFromTokenScopes = true,
+        };
+
+        entry.Permissions.Add(MailFathomPermission.MailRead.Name);
+        entry.Permissions.Add(MailFathomPermission.MailAsk.Name);
+        entry.MarkGrantWritten();
+
+        var context = TokenValidatedFor(entry, tokenScopes: "mailfathom.mail.read offline_access");
+
+        // Act
+        await ValidatedTokenEventOf(entry).Invoke(context);
+
+        // Assert
+        Assert.Equal(
+            [MailFathomPermission.MailRead],
+            TransportGrant.PermissionsCarriedBy(context.Principal!));
+    }
+
+    /// <summary>A scope naming a permission the entry never granted must not widen it, or the authorization server would be deciding the ceiling rather than the deployment.</summary>
+    [Fact]
+    public async Task OnTokenValidated_ATokenCarryingAPermissionOutsideTheCeiling_HoldsNoneOfIt()
+    {
+        // Arrange
+        var entry = new TransportAuthenticationOptions
+        {
+            OAuth = AnAuthorizationServer(),
+            PermissionsFromTokenScopes = true,
+        };
+
+        entry.Permissions.Add(MailFathomPermission.MailRead.Name);
+        entry.MarkGrantWritten();
+
+        var context = TokenValidatedFor(entry, tokenScopes: "mailfathom.mail.ask");
+
+        // Act
+        await ValidatedTokenEventOf(entry).Invoke(context);
+
+        // Assert
+        Assert.Empty(TransportGrant.PermissionsCarriedBy(context.Principal!));
+    }
+
+    /// <summary>Reads the registered event that reduces a validated token to the identity this host keeps and writes the grant onto it.</summary>
+    /// <remarks>Reached through the registration rather than called directly, because what is under test is that the entry's grant was captured where the scheme was configured.</remarks>
+    private static Func<TokenValidatedContext, Task> ValidatedTokenEventOf(TransportAuthenticationOptions entry)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddTransportAuthentication(
+            TransportSurface.Mcp,
+            [entry],
+            TransportSurface.Mcp.OAuthSchemeNameFor("workforce"));
+
+        using var composed = services.BuildServiceProvider();
+
+        var schemeOptions = composed.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+            .Get(TransportSurface.Mcp.OAuthSchemeNameFor("workforce"));
+
+        return schemeOptions.Events!.OnTokenValidated;
+    }
+
+    /// <summary>Builds the context the authentication framework hands the event once a token's signature, issuer, audience, and lifetime have been checked.</summary>
+    private static TokenValidatedContext TokenValidatedFor(TransportAuthenticationOptions entry, string tokenScopes)
+    {
+        var scheme = new AuthenticationScheme(
+            TransportSurface.Mcp.OAuthSchemeNameFor("workforce"),
+            displayName: null,
+            typeof(JwtBearerHandler));
+
+        return new TokenValidatedContext(new DefaultHttpContext(), scheme, new JwtBearerOptions())
+        {
+            Principal = new ClaimsPrincipal(new ClaimsIdentity(
+                [
+                    new Claim("iss", entry.OAuth!.AuthorizationServers[0].Issuer!),
+                    new Claim("sub", "11111111-2222-3333-4444-555555555555"),
+                    new Claim("scope", tokenScopes),
+                ],
+                "test")),
+        };
     }
 
     /// <summary>Reads a built handler chain from its outermost handler down to the one that opens the connection.</summary>
@@ -399,9 +573,12 @@ public sealed class TransportSecurityExtensionsTests
     private static void AddApiKeyAuthentication(IServiceCollection services, TransportSurface surface) =>
         services.AddTransportAuthentication(
             surface,
-            [new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:not-a-real-key" }],
-            publicKeys: [],
-            oauthMethods: [],
+            [
+                new TransportAuthenticationOptions
+                {
+                    ApiKey = new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:not-a-real-key" },
+                },
+            ],
             surface.IsSpecified ? surface.ApiKeySchemeName : "unused");
 
     private static MessageReceivedContext MessageReceivedOver(string scheme)

--- a/tests/Host.UnitTests/Security/Transport/TransportSecurityExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TransportSecurityExtensionsTests.cs
@@ -381,12 +381,13 @@ public sealed class TransportSecurityExtensionsTests
         };
 
         narrowed.Permissions.Add(MailFathomPermission.MailRead.Name);
-        narrowed.MarkGrantWritten();
 
         var unnarrowed = new TransportAuthenticationOptions
         {
             ApiKey = new ConfiguredSecret { Name = "workstation", SecretReference = "plaintext:another-key" },
         };
+
+        unnarrowed.GrantTheWholeSurface();
 
         // Act
         services.AddTransportAuthentication(
@@ -419,7 +420,6 @@ public sealed class TransportSecurityExtensionsTests
             PublicKey = new ConfiguredSecret { Name = "nightly", SecretReference = "plaintext:a-public-key" },
         };
 
-        retired.MarkGrantWritten();
 
         // Act
         services.AddTransportAuthentication(
@@ -443,7 +443,6 @@ public sealed class TransportSecurityExtensionsTests
         // Arrange
         var entry = new TransportAuthenticationOptions { OAuth = AnAuthorizationServer() };
         entry.Permissions.Add(MailFathomPermission.MailRead.Name);
-        entry.MarkGrantWritten();
 
         var context = TokenValidatedFor(entry, tokenScopes: "mailfathom.mail.ask");
 
@@ -469,7 +468,6 @@ public sealed class TransportSecurityExtensionsTests
 
         entry.Permissions.Add(MailFathomPermission.MailRead.Name);
         entry.Permissions.Add(MailFathomPermission.MailAsk.Name);
-        entry.MarkGrantWritten();
 
         var context = TokenValidatedFor(entry, tokenScopes: "mailfathom.mail.read offline_access");
 
@@ -494,7 +492,6 @@ public sealed class TransportSecurityExtensionsTests
         };
 
         entry.Permissions.Add(MailFathomPermission.MailRead.Name);
-        entry.MarkGrantWritten();
 
         var context = TokenValidatedFor(entry, tokenScopes: "mailfathom.mail.ask");
 

--- a/tests/Host.UnitTests/Security/Transport/TransportSecurityExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TransportSecurityExtensionsTests.cs
@@ -369,7 +369,7 @@ public sealed class TransportSecurityExtensionsTests
     /// entry beside it holds, which is the failure the entry-scoped grant exists to prevent.
     /// </summary>
     [Fact]
-    public void AddTransportAuthentication_TwoKeysGrantedDifferently_GivesTheApiKeySchemeEachEntrysOwnGrant()
+    public void AddTransportAuthentication_TwoKeysGrantedDifferently_GivesTheApiKeySchemeTheGrantOfEachEntry()
     {
         // Arrange
         var services = new ServiceCollection();


### PR DESCRIPTION
Closes #584

An entry in `McpEndpoint:Authentication` or `AdminEndpoint:Authentication` now states what the credentials it admits may do, as `Permissions` — a list of names MailFathom publishes — and startup refuses a name it does not.

## The vocabulary

`MailFathomPermission` is a closed enumeration in `Domain`, because issue #585 puts the caller contract in `Application`, which references only `Domain`. It publishes eight names split into two disjoint halves, which `ProtectedSurface` names:

- **Mail** — `mailfathom.mail.read`, `mailfathom.mail.ask`
- **Administration** — `mailfathom.admin.read`, `mailfathom.admin.audit.read`, `mailfathom.admin.operate`, `mailfathom.admin.credentials.write`, `mailfathom.admin.spend`, `mailfathom.admin.erase`

A name written on the wrong surface is refused rather than sitting in the file granting nothing.

## How the grant is read

An absent `Permissions` key and an emptied one bind identically and mean opposite things, so the endpoint that owns the section asks configuration whether the key exists at all — `TransportAuthenticationConfiguration.MarkWrittenGrants`, called from both endpoints' `ReadFrom`, the same arrangement `McpCorsOptions.AllowedOrigins` uses. An entry that never wrote a grant holds its surface's whole half; `Permissions: []` grants nothing, which is how a credential is retired without deleting its entry.

`PermissionsFromTokenScopes` turns the list into a ceiling a token's own scopes narrow. It is available only where the entry's sole block is `OAuth`, because neither a key nor a public key can carry a scope, and such an entry's whole ceiling is published in `scopes_supported` — a client cannot ask for a permission nothing advertises. A permission name written into `RequiredScopes` or `AdvertisedScopes` is refused for the two reasons the documentation gives.

## Where it travels

The resolved grant is carried on the authenticated principal by whichever scheme admitted the caller — the two key schemes read it from a name-keyed map composed once while the host is built, and `OnTokenValidated` writes it onto the minimal identity, intersected with the token's scopes where the entry narrows that way. `TransportGrant` owns the claim type and the reading back.

**Nothing consults it yet.** Enforcement on the two surfaces is #586 and #587, and the caller contract is #585. What this change buys until then is that the posture is configurable and visible: `TransportGrantStartupReport` states at `Information` what every entry resolved to, and names the entries that wrote no grant and what they therefore hold.

## Public surfaces

**Nothing here breaks one.** Both settings are optional, every existing entry stays valid without them, and an entry that writes no grant holds what it always held. The MCP tool contract, the database schema, and the deployment contract are untouched. This is what ADR 0012 predicted for this child, and it is why the issue's acceptance item about recording a break has nothing to record.

## Verification

- `scripts/verify-full.sh` — passed
- 7359 unit tests, 0 failed
- `scripts/review-obligations.sh` — every row read and answered

## Documentation

`configuration-reference.md` carries the two new keys and the eight-permission table; `mcp-endpoint.md` and `admin-endpoint.md` each carry a *What a credential may do* section with the startup report's lines and an explicit statement that nothing varies by the grant today; `mcp-client-oauth.md` shows the scopes an operator creates and the entry that narrows by them; `getting-started.md` and `mcp-clients.md` say that a credential reaches the whole surface until its entry narrows it. `mcp-endpoint.md`'s claim that the account axis is "not configurable yet" was corrected to what ADR 0012 now says after #880: accounts are not part of this model, and every admitted caller reaches every configured account.
