### PR TITLE
Keep Codex project configuration local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,4 +85,5 @@ deploy/quadlet/config/*.json
 .claude/launch.json
 .claude/loop.md
 .claude/scheduled_tasks.json
+.codex/config.toml
 .claude/settings.json

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -13,3 +13,6 @@ CLAUDE.local.md
 # the same permissions without this line. It is listed anyway so the file is present on disk for
 # tooling that reads it directly; the main checkout stays the copy to edit.
 .claude/settings.local.json
+
+# Codex copies this ignored machine-local configuration into worktrees it creates.
+.codex/config.toml


### PR DESCRIPTION
Closes #883

## What changes

- Ignore the machine-local `.codex/config.toml` file.
- Copy that ignored file into Codex-managed worktrees through `.worktreeinclude`.
- Keep the configuration contents outside the public repository and its examples.

## How it was verified

- `scripts/review-obligations.sh` reported no production-test or register obligations; the existing agent-workflow documentation remains accurate.
- `scripts/verify-fast.sh` passed with 7,292 tests.
- `scripts/verify-full.sh` passed with 7,292 tests, 96.03% aggregate line coverage, and 212 workflow-contract tests.
- The complete tracked diff was checked for private integration names, endpoints, credential identifiers, credential values, and commands; none are present.

## Checklist

- [x] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [x] No production behavior changes require new unit tests, and the coverage gate passes.
- [x] The changed worktree manifest documents the new entry; existing durable workflow documentation remains accurate.
- [x] `bash scripts/review-obligations.sh` was run, and every reported row was inspected.
- [x] `CHANGELOG.md` is untouched.
- [x] No new C# file was added.
- [x] No dependency, service, container image, or externally sourced sample is introduced by the tracked change.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.
