### PR TITLE
[#757] Decide whether a message's authenticated author is one this deployment recognizes

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -62,6 +62,24 @@ previous reading behind. The domains are stored in the upper-cased comparison fo
 on; [sender authentication](../features/sender-authentication.md) states how the verdict is reached and which header it
 is allowed to come from.
 
+### What this deployment made of that author
+
+Three more columns record the second verdict: `SenderTrustLevel`, `SenderTrustGrantedBy`, and
+`SenderTrustPolicyRevision`. The two enums are text for the reason the four above are, each defaulting to the value that
+recognizes nobody — `Unknown` and `None` — so the migration that adds them fills every stored message in with what was
+true of it. The revision is `character varying(32)` and **nullable on purpose**: its absence is what separates a row no
+policy ever judged, including one recorded from an envelope whose payload was never stored, from one a policy judged and
+left unknown.
+
+They are columns beside the authentication verdict rather than a group of their own because they are read together and
+written together — a re-derivation replaces both, so an answer can never sit beside an identity a different list
+judged. `SenderTrustLevel` has two values and nothing more, because the difference between an author nobody named and an
+author nothing established is the authentication columns' to state. What the revision buys is that a change to a
+trusted-sender list is legible rather than silent: a stored verdict keeps the answer it was given, and the revision says
+which list gave it.
+[Sender authentication](../features/sender-authentication.md#whether-the-author-is-one-this-deployment-recognizes)
+states the rule the verdict follows.
+
 ### Bounds on what a header may contribute
 
 Nothing between the mail server and a row bounds a header's length or how many addresses it names. The MIME reader bounds a message's *structure* — part count and nesting depth — but not the width of a single header, so the persistence mapping applies its own ceilings: 320 octets per address, 998 per message identifier, 256 addresses per recipient array, and 64 thread ancestors.

--- a/docs/features/sender-authentication.md
+++ b/docs/features/sender-authentication.md
@@ -1,6 +1,6 @@
 # Sender authentication
 
-<!-- describes: src/Domain/Emails/Authentication/**, src/Application/Mail/ITrustedAuthenticationAuthorityReader.cs, src/Infrastructure/Mail/Mime/AuthenticationResultsHeaderReader.cs, src/Infrastructure/Mail/Mime/MimeKitEmailMimeReader.cs -->
+<!-- describes: src/Domain/Emails/Authentication/**, src/Application/Mail/ITrustedAuthenticationAuthorityReader.cs, src/Application/Mail/ISenderTrustPolicyReader.cs, src/Application/Emails/Extraction/SenderTrustEvaluatingEmailMimeReader.cs, src/Infrastructure/Mail/Mime/AuthenticationResultsHeaderReader.cs, src/Infrastructure/Mail/Mime/MimeKitEmailMimeReader.cs -->
 
 Everything about deciding whether a message is from who it says rests on one question: which domain actually sent it?
 The obvious answer is wrong. `From` is a header the sender writes, it is what a mail client displays, and it is what
@@ -12,8 +12,10 @@ observed the connection. It saw the envelope sender and could check SPF against 
 verify a DKIM signature against a key the signing domain publishes. RFC 8601's `Authentication-Results` header is where
 it writes both down. MailFathom reads that header back and records what it said; it verifies nothing itself.
 
-This page describes what is recorded and how the header is chosen. Deciding whether an authenticated domain counts as
-*trusted* is a separate step and is not implemented yet.
+Knowing what the receiving server established is half the question. The other half is whether the message's author is
+somebody this deployment recognizes, which is a decision about a list rather than a fact about the message, and the two
+are recorded separately for that reason. This page describes both: what is recorded, how the header is chosen, and what
+makes an author *trusted*.
 
 ## The header is only believed from one server
 
@@ -96,25 +98,133 @@ characters. A header past the length bound is passed over unread rather than tru
 contributes nothing rather than failing the extraction. Either way the message is still extracted and simply has one
 header fewer to read — which, where that was the only trusted header, is the not-established verdict.
 
+## Whether the author is one this deployment recognizes
+
+A domain that authenticated is still a stranger until something says otherwise, so a second verdict is recorded beside
+the first: **trusted** or **unknown**. The rule is deliberately narrow. An author is trusted when their domain belongs
+to an account this deployment synchronizes, or when an entry on the receiving account's trusted-sender list names them.
+Everything else is unknown — including most legitimate mail, and that is the intended outcome. The claim being made is
+*this deployment does not know who wrote this*, never *this is suspicious*; whether a message is wanted is [spam
+classification](spam-classification.md)'s question and is reached by other means entirely.
+
+The two verdicts are independent axes and are read together. **Authenticated and unknown** is the ordinary state of
+almost every message in a mailbox and says nothing against it, while **failed and unknown** is a message whose author
+was checked and did not hold. Which of them applies stays where it was recorded, on the authentication verdict above;
+nothing is folded into the trust value, which has exactly two values and answers only about this deployment's list.
+
+### What the list is held against
+
+**The subject of the decision is the message's authenticated author, never the raw `From` header and never whichever
+identity happened to authenticate.** Both of the alternatives are forgeries waiting to happen:
+
+- `From` is written by whoever sent the message, so holding it against a list would let anybody be recognized by
+  claiming to be somebody who is on one.
+- The identity a receiving server authenticates belongs to whoever handed the message over. A relay, a mailing list, and
+  a delivery provider all authenticate as themselves while carrying somebody else's `From`, so recognizing one of them
+  would recognize every message it ever relays, whoever it says wrote them.
+
+Two things establish an author, and neither believes the header on its own. A trusted `dmarc=pass` is the receiving
+server's own statement that the displayed domain passed under its published policy, so the displayed domain is the
+answer. Failing that, an authenticated DKIM or SPF identity whose domain is exactly the displayed one is the same claim
+reached without DMARC. Everything else — nothing established, an authentication that failed, `dmarc=fail`, an identity
+belonging to somebody other than the displayed author — establishes no author, and the list is not consulted at all.
+
+Only the one DKIM identity the authentication verdict names is considered, so a message carrying a second signature over
+the displayed domain beside an unrelated first one reads as establishing no author. That withholds an author rather than
+inventing one, which is the direction a mistake here has to fall in.
+
+### The deployment's own domains
+
+Mail whose author writes from a domain one of this deployment's own accounts uses is trusted, on every account rather
+than on the account that owns the domain. An instance synchronizing a work mailbox and a personal one is synchronizing
+one person's correspondence, and mail that person sends from the first to the second is the least suspicious mail in the
+mailbox; recognizing it only against the receiving account's own domain would leave the owner's own mail unknown.
+
+The set is derived from the configured accounts rather than restated in configuration, so adding an account extends it
+and removing one narrows it without a second edit. It is read from each account's IMAP user name, which is the only
+mailbox identity an IMAP account states — a server is reached at a host that is rarely the mail domain, and the account
+identifier is a key an operator invented. **An account whose user name is a bare login therefore contributes nothing**,
+and a deployment in that position names its domains on the accounts' own lists instead. Only the domain itself counts
+and never the names beneath it.
+
+`MailSynchronization:TrustOwnAccountDomains` is what turns the whole set off, and it defaults to on because that mail is
+either the owner's own or somebody who has taken their mailbox, and the first is far more common. **The case for turning
+it off is an account on a large shared provider**: every user of that provider writes from the same domain, so the set
+would recognize all of them. A deployment that turns it off names the domains it does mean on the per-account list
+below.
+
+### The trusted-sender list
+
+Each account has one, and it is per account because the accounts an instance synchronizes are different correspondence:
+a work account's counterparties have nothing to do with a personal one's, and a single list would either recognize too
+much on one account or make an owner maintain the union of both.
+
+An entry names a domain or a single address, never both, and the two are different claims.
+
+- **A domain entry** recognizes an author established as writing from that domain. Reaching under it is opt-in per entry
+  — `IncludeSubdomains` — rather than a mode the list runs in, so an organization signing everything as one name can be
+  given its subdomains while a single host recognized inside a domain full of unrecognized ones does not drag the rest
+  in.
+- **An address entry** narrows that to one mailbox, and it is worth knowing what it rests on. What is ever established
+  is a domain and never a mailbox — DKIM signs as `d=`, SPF answers for the envelope sender's domain, and DMARC states
+  that one of those held for the displayed domain — so an address entry matches when the author's domain is the entry's
+  own **and** the message's `From` header displays exactly the entry's address. The claim is therefore: this domain
+  wrote the message, and it presents it as coming from this mailbox of its own. That is worth something, because a
+  domain answerable for its own `From` is answerable for the whole address in it; it is worth less than a domain entry,
+  because a domain that can authenticate can display any local part it likes. A message whose `From` is missing or
+  unusable is unknown to an address entry.
+
+Comparison is case-insensitive, and an internationalized domain is held in one encoding rather than compared in two: a
+name is put into its ASCII A-labels wherever it comes from, so an entry written `bücher.example` recognizes a message
+that carried `xn--bcher-kva.example`. A name no encoder accepts is refused rather than compared as it arrived, because
+a value nothing else can produce would match nothing and look like an author who is simply not on a list.
+
+**The list has two halves and one matcher reads both.** Configuration holds what an operator declared when they set the
+deployment up; a store holds what somebody added while it was running, because the useful act when a reader meets a
+warning on mail from a correspondent they trust is to trust them, and editing a file and restarting is not that act. An
+entry in either half recognizes, and neither can undo the other — configuration is not editable at runtime and the
+store is not editable by a configuration reload. Where both name one author the configured half is reported, so a
+deployment's declared trust is never described as something added later. The stored half and the surfaces that edit it
+are [issue #760](https://github.com/Krzysztof318/MailFathom/issues/760); until it exists the effective list is the
+configured one.
+
+An entry that names neither a domain nor an address, names both, writes one nothing can compare, or asks for subdomains
+on an address **fails startup**, naming the account and the entry's position and never the value it holds. The
+alternative is indistinguishable afterwards: a list nobody wrote and a list whose entries match nothing both leave
+every author unknown, and an operator would meet the difference as mail that never stops carrying a warning.
+
+### The verdict outlives the list
+
+The answer is stored on the message rather than decided when the message is read, so a reader — and later a rule — can
+ask whether an author is trusted without re-evaluating a policy that may since have changed. What makes that legible is
+the **policy revision** recorded beside it: a digest of the effective list, so two verdicts carrying different revisions
+were reached under different lists, and one carrying none was never put to a policy at all. Reordering a list is not a
+change to it and produces the same revision; adding to either half produces a different one.
+
+Adding a domain therefore does not silently rewrite what a reader was already shown. What re-judges mail already stored
+is [the extraction backfill](imap-synchronization.md#backfilling-messages-stored-earlier), the same deliberate act that
+re-reads mail after an account gains a trusted authority.
+
 ## What MailFathom does not do
 
 - It resolves no DNS, verifies no DKIM signature, and evaluates no SPF or DMARC policy. Everything recorded was read
   back out of one header.
 - It does not reason from the `Received` chain beyond identifying the trusted header.
-- It never acts on the verdict. Nothing here files, flags, or hides a message, and no rule reads it yet.
+- It never acts on either verdict. Nothing here files, flags, or hides a message, and no rule reads them yet.
 
 ## Re-deriving what is already stored
 
-The verdict is derived from the raw MIME the deployment stored, so it is re-derivable from it. Configuring a trusted
-identifier for an account that previously had none changes what a later extraction records and leaves mail already
-stored on the verdict it was given; [the extraction
-backfill](imap-synchronization.md#backfilling-messages-stored-earlier) is what re-reads that mail. The
-migration that adds the columns fills every stored message in with the not-established verdict, which is what was true
-of them.
+The authentication verdict is derived from the raw MIME the deployment stored, so it is re-derivable from it, and the
+trust verdict is re-derived in the same pass against whatever list is in force then. Configuring a trusted identifier
+for an account that previously had none changes what a later extraction records and leaves mail already stored on the
+verdict it was given; [the extraction backfill](imap-synchronization.md#backfilling-messages-stored-earlier) is what
+re-reads that mail. The migration that adds each group of columns fills every stored message in with what was true of it
+— the not-established verdict, and the unknown answer under no policy at all.
 
 ## What is not recorded anywhere else
 
-Every domain the verdict names is personal data, so no log line, metric, or exception message carries one. What those
-may report is the occurrence identity and the outcome. The startup refusal for an unusable configured identifier names
-the account and not the value, for the same reason the failure rules refuse a host name in any message a boundary
-publishes.
+Every domain either verdict names is personal data, and so is every entry of a trusted-sender list, which says who
+somebody corresponds with. No log line, metric, or exception message carries one. What those may report is the
+occurrence identity and the outcome. The startup refusal for an unusable configured identifier names the account and
+not the value, and the refusal for an unusable trusted-sender entry names the account and the entry's position, for the
+same reason the failure rules refuse a host name in any message a boundary publishes.

--- a/docs/features/toc.yml
+++ b/docs/features/toc.yml
@@ -42,7 +42,7 @@
   description: How a credential that arrived in a mailbox is kept out of a provider's context window, a retrieval snippet, and a log line.
 - name: Sender authentication
   href: sender-authentication.md
-  description: How the domain that actually sent a message is established from what the receiving server authenticated, rather than from the From header anybody can write.
+  description: How the domain that actually sent a message is established from what the receiving server authenticated rather than from the From header anybody can write, and whether the message's author is one this deployment recognizes.
 - name: Spam classification
   href: spam-classification.md
   description: How mail written to deceive a reader is recognized from what the receiving server already decided, and what that changes downstream.

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -98,6 +98,7 @@ shape the coordinator loop itself, which are read once at start and marked *rest
 | `MailSynchronization:MaxConsecutivePushFailures` | int | `3` | 1 – 100 | reload |
 | `MailSynchronization:PushDegradationPeriod` | TimeSpan | `00:15:00` | 10 s – 1 day | reload |
 | `MailSynchronization:MaxSubscribedFolders` | int | `20` | 1 – 100; how many folders one push subscription may name on a server supporting `NOTIFY`, the rest synchronizing on the account's interval | reload |
+| `MailSynchronization:TrustOwnAccountDomains` | bool | `true` | Whether an author writing from a domain one of the configured accounts uses counts as trusted on every account. The set is read from each account's `UserName` where that is an address, so it needs no list of its own | reload; the next extraction judges against it |
 
 ### One account — `MailSynchronization:Accounts:<n>`
 
@@ -122,6 +123,10 @@ shape the coordinator loop itself, which are read once at start and marked *rest
 | `…:AuditTrail:Retention` | TimeSpan | `90.00:00:00` | 1 day – 3650 days; how long this account's audit entries are kept | reload; the next account run erases against the new window |
 | `…:AnsweringAuditTrail:Enabled` | bool | `false` | Whether a finished `ask_mail` run leaves a durable entry naming the mail it read from this account | reload; governs runs from then on |
 | `…:AnsweringAuditTrail:Retention` | TimeSpan | `30.00:00:00` | 1 day – 3650 days; how long this account's answering entries are kept | reload; the next account run erases against the new window |
+| `…:TrustedSenders` | list | empty | The authors this account recognizes on top of the deployment's own domains; each entry below | reload; the next extraction judges against it |
+| `…:TrustedSenders:<n>:Domain` | string | unset | A domain this account recognizes. Exactly one of `Domain` and `Address` is written, and an entry writing neither or both fails startup naming the account and the entry's position | reload |
+| `…:TrustedSenders:<n>:Address` | string | unset | A single mailbox this account recognizes. It matches when the established author's domain is that address's own **and** the message's `From` displays exactly that address | reload |
+| `…:TrustedSenders:<n>:IncludeSubdomains` | bool | `false` | Whether a domain entry also reaches the names beneath that domain. Refused on an address entry, where it could mean nothing | reload |
 | `…:Folders` | list | inbox by role | Aliases unique; each entry below | reload |
 
 `TrustedAuthenticationServiceIdentifier` names the one server whose `Authentication-Results` headers this account
@@ -130,6 +135,16 @@ default it to, because the right value is a property of who receives this accoun
 believes no header and every message it holds records that nothing was established.
 [Sender authentication](../features/sender-authentication.md) states how the header is chosen and what the verdict
 holds.
+
+`TrustedSenders` and `TrustOwnAccountDomains` are the second half of that: they decide whether a message's author is
+somebody this deployment recognizes, which is a separate question from what the receiving server established. Both
+lists are held against an **authenticated author** — the domain the receiving server's DMARC result or a matching
+DKIM or SPF identity established for the `From` header — and never against the raw header, so naming a correspondent
+here cannot be exploited by writing their address into a message. Most legitimate mail stays unknown and that is the
+intended outcome: the claim is that this deployment does not know the author, not that the message is suspicious.
+Turning `TrustOwnAccountDomains` off is the right move for a deployment whose accounts sit on a large shared provider,
+since every user of that provider writes from the same domain; the same page states what an address entry rests on and
+what it deliberately does not establish.
 
 `RuleActions` is what a rule is judged against rather than what it is filtered by: a rule declaring an action this
 account does not permit **fails startup** naming the rule, the action, and the account, rather than running with that

--- a/src/Application/Emails/Extraction/ExtractedEmailMetadata.cs
+++ b/src/Application/Emails/Extraction/ExtractedEmailMetadata.cs
@@ -32,4 +32,14 @@ public sealed record ExtractedEmailMetadata(
     EmailThreadReferences ThreadReferences,
     EmailAttachmentSummary Attachments,
     ExtractedEmailText Text,
-    SenderAuthentication SenderAuthentication);
+    SenderAuthentication SenderAuthentication)
+{
+    /// <summary>Gets what this deployment made of the message's authenticated author.</summary>
+    /// <remarks>
+    /// Not a parameter of the reading, because it is not read out of the message: the parsing adapter establishes what
+    /// the receiving server said and <see cref="SenderTrustEvaluatingEmailMimeReader" /> holds the author that follows
+    /// from it against the account's trusted senders afterwards. Its default is therefore the verdict of a reading no
+    /// policy has spoken over, which is unknown and carries no policy revision to say otherwise.
+    /// </remarks>
+    public SenderTrust SenderTrust { get; init; } = SenderTrust.NotEvaluated;
+}

--- a/src/Application/Emails/Extraction/SenderTrustEvaluatingEmailMimeReader.cs
+++ b/src/Application/Emails/Extraction/SenderTrustEvaluatingEmailMimeReader.cs
@@ -1,0 +1,79 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.EmailContent.Storage;
+using MailFathom.Application.Mail;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Emails.Extraction;
+
+/// <summary>Holds the author a message authenticated as against what the receiving account recognizes.</summary>
+/// <remarks>
+/// <para>
+/// A decorator rather than a step inside the parsing adapter, because the two halves answer different questions: what
+/// the receiving server established is read out of the message's bytes and is true of the message forever, while whether
+/// this deployment recognizes the author it established is a decision about a list an operator and a reader both write
+/// to. Keeping the decision above the parser is what leaves the parser with no opinion to hold.
+/// </para>
+/// <para>
+/// It sits at this seam for the reason <see cref="RedactingEmailMimeReader" /> does: both paths that produce a reading
+/// — synchronization reading a message it has just fetched, and the backfill re-reading raw MIME stored earlier — reach
+/// it through this port, so the verdict is written wherever a reading is and re-derived wherever one is re-derived.
+/// </para>
+/// <para>
+/// The verdict is stored rather than recomputed on read, so a later change to a list does not silently rewrite what a
+/// reader was already shown. What re-judges mail already stored is the extraction backfill, which is the same
+/// deliberate act that re-reads it after an account gained a trusted authority.
+/// </para>
+/// </remarks>
+public sealed class SenderTrustEvaluatingEmailMimeReader : IEmailMimeReader
+{
+    private readonly IEmailMimeReader inner;
+    private readonly ISenderTrustPolicyReader policies;
+
+    /// <summary>Initializes a reader that judges the author the one it wraps established.</summary>
+    /// <param name="inner">The reader that turns raw MIME into normalized metadata.</param>
+    /// <param name="policies">Resolves the trusted senders an account judges its mail by.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public SenderTrustEvaluatingEmailMimeReader(IEmailMimeReader inner, ISenderTrustPolicyReader policies)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(policies);
+
+        this.inner = inner;
+        this.policies = policies;
+    }
+
+    /// <inheritdoc />
+    public async Task<EmailMimeExtractionResult> ReadMetadataAsync(
+        RemoteEmailContent content,
+        CancellationToken cancellationToken)
+    {
+        var extraction = await this.inner.ReadMetadataAsync(content, cancellationToken);
+
+        // A message nobody could parse establishes no author to judge, and reaches storage with the columns the envelope
+        // alone supports — which is the unknown answer, and the same one it already carries.
+        if (extraction.Metadata is not { } metadata)
+        {
+            return extraction;
+        }
+
+        var policy = this.policies.GetTrustPolicy(metadata.OccurrenceId.AccountId);
+
+        return EmailMimeExtractionResult.Extracted(metadata with
+        {
+            SenderTrust = policy.Evaluate(metadata.SenderAuthentication, DisplayedSenderOf(metadata)),
+        });
+    }
+
+    /// <summary>Reads the address a mail client displays as the message's author.</summary>
+    /// <remarks>
+    /// Taken from <c>From</c> alone and never from <c>Sender</c>, which is the same choice the author identity itself
+    /// makes and for the same reason: an address entry is a claim about the mailbox a reader sees, and <c>Sender</c>
+    /// names whoever submitted a message written on somebody else's behalf. The first mailbox wins where the header
+    /// carried several, because a message can display only one author.
+    /// </remarks>
+    private static EmailAddress? DisplayedSenderOf(ExtractedEmailMetadata metadata) =>
+        metadata.Participants.FirstOrDefault(participant => participant.Role == EmailAddressRole.From)?.Address;
+}

--- a/src/Application/Mail/ISenderTrustPolicyReader.cs
+++ b/src/Application/Mail/ISenderTrustPolicyReader.cs
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails.Authentication;
+
+namespace MailFathom.Application.Mail;
+
+/// <summary>Resolves the trusted senders one account judges its arriving mail by.</summary>
+/// <remarks>
+/// <para>
+/// The list is per account because the accounts an instance synchronizes are different correspondence: a work account's
+/// counterparties have nothing to do with a personal one's, and a single list would either recognize too much on one
+/// account or make an owner maintain the union of both. What is deployment-wide is the set of domains the configured
+/// accounts themselves use, which every account's policy is built with unless the deployment says otherwise.
+/// </para>
+/// <para>
+/// The configured half is validated at startup, so this never fails and never returns a policy a caller has to check
+/// again. An account this deployment no longer configures answers with
+/// <see cref="SenderTrustPolicy.RecognizingNobody" /> for the reason every per-account reader here does: a
+/// reading over mail whose account a reload removed must recognize nobody rather than throw.
+/// </para>
+/// </remarks>
+public interface ISenderTrustPolicyReader
+{
+    /// <summary>Gets the policy one account's mail is judged by.</summary>
+    /// <param name="accountId">The local account identifier.</param>
+    /// <returns>The effective policy, or <see cref="SenderTrustPolicy.RecognizingNobody" /> when the account is no longer configured.</returns>
+    SenderTrustPolicy GetTrustPolicy(MailAccountId accountId);
+}

--- a/src/Domain/Emails/Authentication/SenderAuthentication.cs
+++ b/src/Domain/Emails/Authentication/SenderAuthentication.cs
@@ -90,9 +90,15 @@ public sealed record SenderAuthentication
     /// Two things establish an author here, and neither of them believes the header on its own. A trusted
     /// <see cref="DmarcOutcome.Pass" /> is the receiving server's own statement that the displayed domain passed under
     /// its published policy, so the displayed domain is the answer. Failing that, an authenticated identity whose domain
-    /// is exactly the displayed one is the same claim reached without DMARC. Everything else — including
-    /// <see cref="DmarcOutcome.Fail" />, which is a statement <em>against</em> the author — establishes nothing and
+    /// is exactly the displayed one is the same claim reached without DMARC. Everything else establishes nothing and
     /// answers <see langword="null" />.
+    /// </para>
+    /// <para>
+    /// <see cref="DmarcOutcome.Fail" /> ends the question rather than falling through to that second route. It is the
+    /// receiving server's statement <em>against</em> the displayed domain, reached with the domain's own published
+    /// policy in hand, so it outranks an identity comparison made here without one. The result no DMARC evaluation
+    /// produced, and the one that ran and found no policy, both leave the second route open — which is what most mail
+    /// actually arrives with.
     /// </para>
     /// <para>
     /// Only the one DKIM identity this verdict names is considered, so a message carrying a second signature over the
@@ -109,9 +115,9 @@ public sealed record SenderAuthentication
                 return null;
             }
 
-            if (this.Dmarc == DmarcOutcome.Pass)
+            if (this.Dmarc is DmarcOutcome.Pass or DmarcOutcome.Fail)
             {
-                return displayed;
+                return this.Dmarc == DmarcOutcome.Pass ? displayed : null;
             }
 
             var authenticatedAsDisplayed = this.Outcome == SenderAuthenticationOutcome.Authenticated

--- a/src/Domain/Emails/Authentication/SenderAuthentication.cs
+++ b/src/Domain/Emails/Authentication/SenderAuthentication.cs
@@ -78,6 +78,49 @@ public sealed record SenderAuthentication
     /// <summary>Gets whether the authenticated domain is the displayed one.</summary>
     public SenderDomainAlignment Alignment { get; }
 
+    /// <summary>Gets the domain of the displayed author where this verdict establishes it, or <see langword="null" />.</summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="AuthenticatedDomain" /> is an identity the receiving server checked; it says nothing about who the
+    /// message displays as its author. A relay, a mailing list, and a delivery provider all authenticate as themselves
+    /// while carrying somebody else's <c>From</c>, so anything deciding what to make of the <em>author</em> reads this
+    /// and never that one.
+    /// </para>
+    /// <para>
+    /// Two things establish an author here, and neither of them believes the header on its own. A trusted
+    /// <see cref="DmarcOutcome.Pass" /> is the receiving server's own statement that the displayed domain passed under
+    /// its published policy, so the displayed domain is the answer. Failing that, an authenticated identity whose domain
+    /// is exactly the displayed one is the same claim reached without DMARC. Everything else — including
+    /// <see cref="DmarcOutcome.Fail" />, which is a statement <em>against</em> the author — establishes nothing and
+    /// answers <see langword="null" />.
+    /// </para>
+    /// <para>
+    /// Only the one DKIM identity this verdict names is considered, so a message carrying a second signature over the
+    /// displayed domain that the trusted header reported alongside an unrelated first one reads as establishing no
+    /// author. That is the conservative direction: it withholds an author rather than inventing one.
+    /// </para>
+    /// </remarks>
+    public SenderDomain? AuthenticatedAuthorDomain
+    {
+        get
+        {
+            if (this.FromDomain is not { } displayed)
+            {
+                return null;
+            }
+
+            if (this.Dmarc == DmarcOutcome.Pass)
+            {
+                return displayed;
+            }
+
+            var authenticatedAsDisplayed = this.Outcome == SenderAuthenticationOutcome.Authenticated
+                && (this.DkimDomain == displayed || this.SpfDomain == displayed);
+
+            return authenticatedAsDisplayed ? displayed : null;
+        }
+    }
+
     /// <summary>Records that nothing was established about a message's sender.</summary>
     /// <param name="fromDomain">The domain the message displays as its sender, where it wrote a usable one.</param>
     /// <param name="dmarc">What the trusted header reported for DMARC, where one was read at all.</param>

--- a/src/Domain/Emails/Authentication/SenderDomain.cs
+++ b/src/Domain/Emails/Authentication/SenderDomain.cs
@@ -2,20 +2,31 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
+using System.Text;
+
 namespace MailFathom.Domain.Emails.Authentication;
 
 /// <summary>Names the domain half of a mail identity, in the one form everything about a sender compares on.</summary>
 /// <remarks>
 /// <para>
-/// A sending domain arrives from three unrelated places — a DKIM signature's <c>d=</c> tag, an SPF check's envelope
-/// sender, and the <c>From</c> header a client displays — and the whole point of a verdict is that those three can be
-/// held against each other. A comparison form derived at each of those call sites would drift between them, so the
-/// normalization is the type's own rule and <see cref="NormalizedValue" /> is the only form anything compares.
+/// A sending domain arrives from four unrelated places — a DKIM signature's <c>d=</c> tag, an SPF check's envelope
+/// sender, the <c>From</c> header a client displays, and an entry an operator wrote on a trusted-sender list — and the
+/// whole point of a verdict is that those can be held against each other. A comparison form derived at each of those
+/// call sites would drift between them, so the normalization is the type's own rule and <see cref="NormalizedValue" />
+/// is the only form anything compares.
 /// </para>
 /// <para>
 /// The form is upper-cased for the reason <see cref="EmailAddress.NormalizedAddress" /> is: upper case round-trips in
 /// every culture, so the key means the same thing in memory, in a query, and in a database whose collation MailFathom
 /// does not control.
+/// </para>
+/// <para>
+/// It is also the ASCII form of an internationalized name. The same domain reaches this type written both ways — a
+/// header carries the A-labels a transport agreed on while an operator types the name their language spells — and
+/// comparing the two encodings against each other would answer no on names that are the same name. Everything is
+/// therefore held in A-labels, which is the encoding the wire already uses, so an ASCII value is its own normal form
+/// and costs no conversion at all.
 /// </para>
 /// <para>
 /// A domain name is personal data once it is attached to a message, so nothing here may be logged.
@@ -48,19 +59,23 @@ public readonly record struct SenderDomain
     /// <remarks>
     /// A malformed domain is refused rather than repaired, for the reason a malformed address is: guessing what an
     /// unparseable header meant would put a domain nobody wrote into a verdict a reader is later shown. What refusal
-    /// costs is one identity of one message, which the not-established verdict already has a value for.
+    /// costs is one identity of one message, which the not-established verdict already has a value for. A name whose
+    /// A-labels no encoder can produce is refused the same way, and so is one whose ASCII form outgrows the bounds
+    /// below, since it is that form a column has to hold.
     /// </remarks>
     public static bool TryCreate(string? candidate, out SenderDomain domain)
     {
         domain = default;
 
         var trimmed = candidate?.Trim() ?? string.Empty;
-        if (!IsUsableDomain(trimmed))
+        if (!IsUsableDomain(trimmed)
+            || !TryNormalize(trimmed, out var normalized)
+            || !IsUsableDomain(normalized))
         {
             return false;
         }
 
-        domain = new SenderDomain(trimmed, trimmed.ToUpperInvariant());
+        domain = new SenderDomain(trimmed, normalized);
 
         return true;
     }
@@ -82,6 +97,21 @@ public readonly record struct SenderDomain
         return TryCreate(separatorIndex < 0 ? trimmed : trimmed[(separatorIndex + 1)..], out domain);
     }
 
+    /// <summary>Answers whether this domain lies beneath another one in the naming tree.</summary>
+    /// <param name="ancestor">The domain this one may sit under.</param>
+    /// <returns><see langword="true" /> when this is a strictly lower name than <paramref name="ancestor" />.</returns>
+    /// <remarks>
+    /// The comparison is on whole labels rather than on a suffix of characters, which is what separates
+    /// <c>mail.example.test</c> from <c>notexample.test</c>: both end in <c>example.test</c> as text and only the first
+    /// is beneath it. A domain is not beneath itself, so a caller that means "this name or anything under it" says both.
+    /// </remarks>
+    public bool IsSubdomainOf(SenderDomain ancestor) =>
+        this.NormalizedValue is { Length: > 0 } descendant
+        && ancestor.NormalizedValue is { Length: > 0 } parent
+        && descendant.Length > parent.Length + 1
+        && descendant[descendant.Length - parent.Length - 1] == '.'
+        && descendant.EndsWith(parent, StringComparison.Ordinal);
+
     /// <summary>Compares two domains by the form they were normalized to.</summary>
     /// <param name="other">The domain to compare with.</param>
     /// <returns><see langword="true" /> when both name the same domain.</returns>
@@ -100,13 +130,46 @@ public readonly record struct SenderDomain
     /// </remarks>
     public override string ToString() => this.NormalizedValue ?? string.Empty;
 
+    /// <summary>Puts a name into the ASCII encoding everything compares on.</summary>
+    /// <remarks>
+    /// An all-ASCII name is already in that encoding, so it is upper-cased and nothing else — which is both the fast
+    /// path for essentially every message and the guarantee that ordinary mail is unaffected by the conversion existing.
+    /// Anything else is a name written in its own script, and the encoder is what turns it into the A-labels a DKIM
+    /// signature and an SMTP envelope carry. A name the encoder refuses is refused here rather than compared in the
+    /// encoding it arrived in, because a value nothing else can produce would match nothing and silently look like a
+    /// sender who is simply not on a list.
+    /// </remarks>
+    private static bool TryNormalize(string domain, out string normalized)
+    {
+        if (Ascii.IsValid(domain))
+        {
+            normalized = domain.ToUpperInvariant();
+
+            return true;
+        }
+
+        try
+        {
+            normalized = new IdnMapping().GetAscii(domain).ToUpperInvariant();
+
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            normalized = string.Empty;
+
+            return false;
+        }
+    }
+
     /// <summary>Accepts a dot-separated name of the shape every resolver and every mail transport agrees on.</summary>
     /// <remarks>
     /// The check stays narrower than the DNS grammar and deliberately says nothing about which characters a label may
-    /// hold: an internationalized domain reaches this type in whichever encoding its header carried, and settling on one
-    /// of those encodings is a matching decision rather than a parsing one. What is refused is what would make an
-    /// unusable comparison key — an empty name, one past the length a resolver accepts, whitespace, a control character,
-    /// an at-sign that says a mailbox was handed over whole, and an empty or over-long label.
+    /// hold, because which script a name is written in is <see cref="TryNormalize" />'s question rather than this one's.
+    /// What is refused is what would make an unusable comparison key — an empty name, one past the length a resolver
+    /// accepts, whitespace, a control character, an at-sign that says a mailbox was handed over whole, and an empty or
+    /// over-long label. It is applied to both encodings of a name, since the ASCII form of an internationalized one is
+    /// the longer of the two and is what a column has to hold.
     /// </remarks>
     private static bool IsUsableDomain(string domain)
     {

--- a/src/Domain/Emails/Authentication/SenderTrust.cs
+++ b/src/Domain/Emails/Authentication/SenderTrust.cs
@@ -1,0 +1,87 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Emails.Authentication;
+
+/// <summary>What this deployment decided about the author one message authenticated as.</summary>
+/// <remarks>
+/// <para>
+/// It is the second of a message's two sender verdicts and reads the first. <see cref="SenderAuthentication" /> says
+/// what the receiving server established about the message, which is a fact about the message; this says whether the
+/// authenticated author is one this deployment recognizes, which is a decision about a list an operator and a reader
+/// both write to. Keeping them apart is what lets the list change without the facts changing under it, and it is why
+/// this carries no value for <em>the author was not authenticated</em> — that is the other verdict's to state.
+/// </para>
+/// <para>
+/// It is stored rather than computed on read, so a message keeps the answer it was judged with. What makes that
+/// legible is <see cref="PolicyRevision" />: it names the list the answer came from, and a verdict nothing judged
+/// carries <see cref="SenderTrustPolicyRevision.None" />.
+/// </para>
+/// </remarks>
+public sealed record SenderTrust
+{
+    private SenderTrust(
+        SenderTrustLevel level,
+        SenderTrustSource grantedBy,
+        SenderTrustPolicyRevision policyRevision)
+    {
+        this.Level = level;
+        this.GrantedBy = grantedBy;
+        this.PolicyRevision = policyRevision;
+    }
+
+    /// <summary>Gets the verdict a message reaching persistence without a policy having spoken carries.</summary>
+    /// <remarks>
+    /// Unknown, because that is the answer that claims nothing, and carrying no revision, which is what says a policy
+    /// never ran rather than that one ran and recognized nobody. It is what an extraction produces before the
+    /// deployment's policy is applied to it, and what a message whose payload was never stored keeps.
+    /// </remarks>
+    public static SenderTrust NotEvaluated { get; } = new(
+        SenderTrustLevel.Unknown,
+        SenderTrustSource.None,
+        SenderTrustPolicyRevision.None);
+
+    /// <summary>Gets what this deployment decided, which is the value everything above this reads first.</summary>
+    public SenderTrustLevel Level { get; }
+
+    /// <summary>Gets which half of what this deployment knows recognized the author, or that none did.</summary>
+    public SenderTrustSource GrantedBy { get; }
+
+    /// <summary>Gets the trusted-sender policy the decision was reached under.</summary>
+    public SenderTrustPolicyRevision PolicyRevision { get; }
+
+    /// <summary>Gets whether this deployment recognized the message's authenticated author.</summary>
+    public bool IsTrusted => this.Level == SenderTrustLevel.Trusted;
+
+    /// <summary>Records that this deployment recognizes nobody in the message.</summary>
+    /// <param name="policyRevision">The policy that was applied.</param>
+    /// <returns>The verdict.</returns>
+    /// <remarks>
+    /// It covers every way of arriving there: no author was authenticated, the author's authentication failed, or an
+    /// author authenticated and nothing this deployment knows names them. Those differ in what the receiving server
+    /// established rather than in what this deployment decided, so they stay on <see cref="SenderAuthentication" />
+    /// instead of being folded in here.
+    /// </remarks>
+    public static SenderTrust Unknown(SenderTrustPolicyRevision policyRevision) =>
+        new(SenderTrustLevel.Unknown, SenderTrustSource.None, policyRevision);
+
+    /// <summary>Records that this deployment recognized the message's authenticated author.</summary>
+    /// <param name="grantedBy">Which half named the author.</param>
+    /// <param name="policyRevision">The policy that was applied.</param>
+    /// <returns>The verdict.</returns>
+    /// <exception cref="ArgumentException">Thrown when no half is named, which is not a trusted message.</exception>
+    public static SenderTrust Trusted(
+        SenderTrustSource grantedBy,
+        SenderTrustPolicyRevision policyRevision)
+    {
+        if (grantedBy == SenderTrustSource.None)
+        {
+            throw new ArgumentException(
+                "A trusted verdict names what recognized the author, so it cannot be reached by nothing.",
+                nameof(grantedBy));
+        }
+
+        return new SenderTrust(SenderTrustLevel.Trusted, grantedBy, policyRevision);
+    }
+}

--- a/src/Domain/Emails/Authentication/SenderTrustLevel.cs
+++ b/src/Domain/Emails/Authentication/SenderTrustLevel.cs
@@ -1,0 +1,30 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Emails.Authentication;
+
+/// <summary>Whether this deployment counts a message's authenticated author as somebody it knows.</summary>
+/// <remarks>
+/// <para>
+/// This is a decision about a list an operator and a reader write to, and it is deliberately independent of what the
+/// receiving server established: <see cref="SenderAuthentication" /> answers whether an identity held, and this answers
+/// whether the identity that held is one this deployment recognizes. Reading the two together is what makes a message
+/// legible — an authenticated author nobody has named reads very differently from an author whose authentication failed,
+/// and both are <see cref="Unknown" /> here.
+/// </para>
+/// <para>
+/// <see cref="Unknown" /> is therefore the ordinary answer rather than a negative one. Most legitimate mail arrives from
+/// a correspondent nobody has ever named and reads exactly as a forgery does at this level, so nothing derived from this
+/// value alone may read as an accusation. Whether a message is unwanted is spam classification's question and is reached
+/// by other means entirely.
+/// </para>
+/// </remarks>
+public enum SenderTrustLevel
+{
+    /// <summary>This deployment recognizes nobody in the message, whether or not an author was authenticated.</summary>
+    Unknown = 0,
+
+    /// <summary>The authenticated author is one this deployment recognizes, and the verdict says what named them.</summary>
+    Trusted = 1,
+}

--- a/src/Domain/Emails/Authentication/SenderTrustPolicy.cs
+++ b/src/Domain/Emails/Authentication/SenderTrustPolicy.cs
@@ -1,0 +1,136 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Emails.Authentication;
+
+/// <summary>Decides whether one account recognizes the author a message authenticated as.</summary>
+/// <remarks>
+/// <para>
+/// The rule is deliberately narrow. An author is recognized when their domain belongs to an account this deployment
+/// synchronizes, or when an entry on the receiving account's trusted-sender list names them. Everything else is unknown,
+/// including most legitimate mail, because the claim being published is <em>this deployment does not know who wrote
+/// this</em> rather than <em>this is suspicious</em>.
+/// </para>
+/// <para>
+/// <b>Every configured account's domain counts, not only the receiving one.</b> An instance synchronizing a work
+/// mailbox and a personal one is synchronizing one person's correspondence, and mail sent from the first to the second
+/// is the least suspicious mail in the mailbox; recognizing it only against the receiving account's own domain would
+/// leave the owner's own mail unrecognized. Whether the set is consulted at all is the deployment's choice, and a
+/// policy built without it simply receives no domains.
+/// </para>
+/// <para>
+/// <b>The trusted-sender list has two halves and this is the one matcher over both.</b> Configuration holds what an
+/// operator declared when they set the deployment up and a store holds what somebody added while it was running, an
+/// entry in either recognizes, and neither can undo the other — configuration is not editable at runtime and the store
+/// is not editable by a configuration reload. The configured half is consulted first, so where both name one sender the
+/// verdict reports the deployment's declared trust rather than something added later.
+/// </para>
+/// </remarks>
+public sealed class SenderTrustPolicy
+{
+    private readonly HashSet<SenderDomain> ownAccountDomains;
+    private readonly IReadOnlyList<TrustedSenderEntry> configuredEntries;
+    private readonly IReadOnlyList<TrustedSenderEntry> storedEntries;
+
+    private SenderTrustPolicy(
+        HashSet<SenderDomain> ownAccountDomains,
+        IReadOnlyList<TrustedSenderEntry> configuredEntries,
+        IReadOnlyList<TrustedSenderEntry> storedEntries)
+    {
+        this.ownAccountDomains = ownAccountDomains;
+        this.configuredEntries = configuredEntries;
+        this.storedEntries = storedEntries;
+
+        this.Revision = SenderTrustPolicyRevision.Of(
+        [
+            .. ownAccountDomains.Select(static domain => $"account:{domain.NormalizedValue}"),
+            .. configuredEntries.Select(static entry => $"configured:{entry.ToPolicyStatement()}"),
+            .. storedEntries.Select(static entry => $"stored:{entry.ToPolicyStatement()}"),
+        ]);
+    }
+
+    /// <summary>Gets the policy that recognizes nobody, which is what an account this deployment no longer serves has.</summary>
+    /// <remarks>
+    /// It carries <see cref="SenderTrustPolicyRevision.None" />, so a verdict reached under it is indistinguishable
+    /// from one no policy produced — which is the honest reading, since a deployment that has forgotten an account has
+    /// no opinion about its mail rather than a negative one.
+    /// </remarks>
+    public static SenderTrustPolicy RecognizingNobody { get; } = new([], [], []);
+
+    /// <summary>Gets the revision that names this policy, which every verdict it reaches is stored with.</summary>
+    public SenderTrustPolicyRevision Revision { get; }
+
+    /// <summary>Builds the policy one account judges its mail by.</summary>
+    /// <param name="ownAccountDomains">The domains of the accounts this deployment synchronizes, or none where they do not count.</param>
+    /// <param name="configuredTrustedSenders">What the account's configuration declares it recognizes.</param>
+    /// <param name="storedTrustedSenders">What was added to the account's stored list while the deployment was running.</param>
+    /// <returns>The policy, which recognizes nobody when all three are empty.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    public static SenderTrustPolicy Create(
+        IEnumerable<SenderDomain> ownAccountDomains,
+        IEnumerable<TrustedSenderEntry> configuredTrustedSenders,
+        IEnumerable<TrustedSenderEntry> storedTrustedSenders)
+    {
+        ArgumentNullException.ThrowIfNull(ownAccountDomains);
+        ArgumentNullException.ThrowIfNull(configuredTrustedSenders);
+        ArgumentNullException.ThrowIfNull(storedTrustedSenders);
+
+        return new SenderTrustPolicy(
+            [.. ownAccountDomains],
+            [.. configuredTrustedSenders],
+            [.. storedTrustedSenders]);
+    }
+
+    /// <summary>Decides what this deployment makes of one message's author.</summary>
+    /// <param name="authentication">What the receiving mail server established about the message.</param>
+    /// <param name="displayedSender">The address the message's <c>From</c> header displays, where it wrote a usable one.</param>
+    /// <returns>The verdict, always carrying <see cref="Revision" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="authentication" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// <b>The subject of the decision is <see cref="SenderAuthentication.AuthenticatedAuthorDomain" /> and nothing
+    /// else.</b> The <c>From</c> header on its own is written by whoever sent the message, so holding it against a list
+    /// would let anybody be recognized by claiming to be; and the identity the receiving server happened to authenticate
+    /// belongs to whoever handed the message over, which for a relay, a mailing list, or a delivery provider is not the
+    /// author at all. Recognizing a provider one correspondent uses would otherwise recognize every message that
+    /// provider ever relays, whoever it says wrote them.
+    /// </para>
+    /// <para>
+    /// So a message whose author was not established — nothing authenticated, an authentication that failed, or an
+    /// identity that authenticated as somebody other than the displayed author — reaches
+    /// <see cref="SenderTrustLevel.Unknown" /> without the list being consulted at all. Which of those it was stays on
+    /// <see cref="SenderAuthentication" />, where it was recorded.
+    /// </para>
+    /// </remarks>
+    public SenderTrust Evaluate(SenderAuthentication authentication, EmailAddress? displayedSender)
+    {
+        ArgumentNullException.ThrowIfNull(authentication);
+
+        if (authentication.AuthenticatedAuthorDomain is not { } authorDomain)
+        {
+            return SenderTrust.Unknown(this.Revision);
+        }
+
+        if (this.ownAccountDomains.Contains(authorDomain))
+        {
+            return SenderTrust.Trusted(SenderTrustSource.OwnAccountDomain, this.Revision);
+        }
+
+        if (Recognizes(this.configuredEntries, authorDomain, displayedSender))
+        {
+            return SenderTrust.Trusted(SenderTrustSource.ConfiguredTrustedSender, this.Revision);
+        }
+
+        return Recognizes(this.storedEntries, authorDomain, displayedSender)
+            ? SenderTrust.Trusted(SenderTrustSource.StoredTrustedSender, this.Revision)
+            : SenderTrust.Unknown(this.Revision);
+    }
+
+    /// <summary>Answers whether one half of the list names the author.</summary>
+    private static bool Recognizes(
+        IReadOnlyList<TrustedSenderEntry> entries,
+        SenderDomain authorDomain,
+        EmailAddress? displayedSender) =>
+        entries.Any(entry => entry.Matches(authorDomain, displayedSender));
+}

--- a/src/Domain/Emails/Authentication/SenderTrustPolicyRevision.cs
+++ b/src/Domain/Emails/Authentication/SenderTrustPolicyRevision.cs
@@ -1,0 +1,82 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MailFathom.Domain.Emails.Authentication;
+
+/// <summary>Names the trusted-sender policy one stored verdict was reached under.</summary>
+/// <remarks>
+/// <para>
+/// A verdict outlives the policy that produced it. An operator adds a domain, a reader trusts a correspondent, an
+/// account is removed — and every message already judged keeps the answer it was judged with, because rewriting stored
+/// verdicts would change what a reader was shown without anybody having reread the mail. The revision is what makes
+/// that legible rather than silent: two verdicts carrying different revisions were reached under different lists, and
+/// one carrying <see cref="None" /> was never put to a policy at all.
+/// </para>
+/// <para>
+/// It is a digest of the effective policy rather than a counter, so it needs no stored state to allocate it and the
+/// same list always names itself the same way — including after a restart, and including on a second deployment
+/// configured identically. It is not a secret and protects nothing; what it has to do is differ whenever the list does.
+/// </para>
+/// </remarks>
+public readonly record struct SenderTrustPolicyRevision
+{
+    /// <summary>The number of characters a revision is written as, which every column holding one is sized for.</summary>
+    public const int Length = 32;
+
+    /// <summary>How many bytes of the digest are kept, which is what <see cref="Length" /> hexadecimal characters carry.</summary>
+    private const int RetainedDigestBytes = Length / 2;
+
+    private SenderTrustPolicyRevision(string value) => this.Value = value;
+
+    /// <summary>Gets the revision that names no policy, which is what a verdict no policy produced carries.</summary>
+    public static SenderTrustPolicyRevision None => default;
+
+    /// <summary>Gets the revision as the text a column stores, or the empty string for <see cref="None" />.</summary>
+    public string Value { get; }
+
+    /// <summary>Gets whether this revision names a policy, which is false exactly for <see cref="None" />.</summary>
+    public bool NamesAPolicy => !string.IsNullOrEmpty(this.Value);
+
+    /// <summary>Derives the revision of a policy from the statements it is made of.</summary>
+    /// <param name="statements">Every statement the policy verifies by, each already in its comparison form.</param>
+    /// <returns>The revision, which is <see cref="None" /> when the policy verifies nothing.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="statements" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The statements are sorted and joined with a separator none of them may contain, so the revision follows what a
+    /// policy says rather than the order an operator happened to write it in — reordering a list is not a change to it,
+    /// and a deployment that reordered one must not have every later verdict read as reached under a different policy.
+    /// A policy with nothing to say verifies nothing and is deliberately indistinguishable from no policy at all.
+    /// </remarks>
+    public static SenderTrustPolicyRevision Of(IEnumerable<string> statements)
+    {
+        ArgumentNullException.ThrowIfNull(statements);
+
+        var canonical = string.Join('\n', statements.Order(StringComparer.Ordinal));
+
+        if (canonical.Length == 0)
+        {
+            return None;
+        }
+
+        var digest = SHA256.HashData(Encoding.UTF8.GetBytes(canonical));
+
+        return new SenderTrustPolicyRevision(Convert.ToHexStringLower(digest.AsSpan(0, RetainedDigestBytes)));
+    }
+
+    /// <summary>Reads back a revision a column stored.</summary>
+    /// <param name="stored">The stored text, or <see langword="null" /> where the row carries none.</param>
+    /// <returns>The revision, which is <see cref="None" /> when the row carries none.</returns>
+    /// <remarks>
+    /// Nothing re-derives a stored revision, so nothing here re-checks one either: the value is opaque to every reader
+    /// and is only ever compared with another revision for equality.
+    /// </remarks>
+    public static SenderTrustPolicyRevision FromStoredValue(string? stored) =>
+        string.IsNullOrWhiteSpace(stored) ? None : new SenderTrustPolicyRevision(stored.Trim());
+
+    /// <inheritdoc />
+    public override string ToString() => this.Value ?? string.Empty;
+}

--- a/src/Domain/Emails/Authentication/SenderTrustPolicyRevision.cs
+++ b/src/Domain/Emails/Authentication/SenderTrustPolicyRevision.cs
@@ -30,13 +30,20 @@ public readonly record struct SenderTrustPolicyRevision
     /// <summary>How many bytes of the digest are kept, which is what <see cref="Length" /> hexadecimal characters carry.</summary>
     private const int RetainedDigestBytes = Length / 2;
 
-    private SenderTrustPolicyRevision(string value) => this.Value = value;
+    private readonly string? value;
+
+    private SenderTrustPolicyRevision(string value) => this.value = value;
 
     /// <summary>Gets the revision that names no policy, which is what a verdict no policy produced carries.</summary>
     public static SenderTrustPolicyRevision None => default;
 
     /// <summary>Gets the revision as the text a column stores, or the empty string for <see cref="None" />.</summary>
-    public string Value { get; }
+    /// <remarks>
+    /// The field behind it is nullable and this is not, because <see cref="None" /> is the default instance and a
+    /// default struct never runs a constructor — so the absence has to be answered here rather than left for every
+    /// caller to meet as a <see langword="null" /> the annotation said could not happen.
+    /// </remarks>
+    public string Value => this.value ?? string.Empty;
 
     /// <summary>Gets whether this revision names a policy, which is false exactly for <see cref="None" />.</summary>
     public bool NamesAPolicy => !string.IsNullOrEmpty(this.Value);
@@ -78,5 +85,5 @@ public readonly record struct SenderTrustPolicyRevision
         string.IsNullOrWhiteSpace(stored) ? None : new SenderTrustPolicyRevision(stored.Trim());
 
     /// <inheritdoc />
-    public override string ToString() => this.Value ?? string.Empty;
+    public override string ToString() => this.Value;
 }

--- a/src/Domain/Emails/Authentication/SenderTrustSource.cs
+++ b/src/Domain/Emails/Authentication/SenderTrustSource.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Emails.Authentication;
+
+/// <summary>Which part of what this deployment knows recognized an authenticated author.</summary>
+/// <remarks>
+/// A verdict that says only <em>trusted</em> cannot be reviewed. Trust an operator declared when they set the
+/// deployment up, trust that follows from the accounts they synchronize, and trust somebody granted while it was running
+/// are three different statements, and the last of them is the one worth being able to find again — particularly where
+/// the somebody was an agent. So the verdict names the half that matched rather than only the fact that one did.
+/// </remarks>
+public enum SenderTrustSource
+{
+    /// <summary>Nothing recognized the author, which is what every <see cref="SenderTrustLevel.Unknown" /> verdict carries.</summary>
+    None = 0,
+
+    /// <summary>The author's domain belongs to an account this deployment synchronizes.</summary>
+    /// <remarks>
+    /// Every configured account's domain counts and not only the receiving one, because an instance synchronizing a
+    /// work mailbox and a personal one is synchronizing one person's correspondence. It is a default rather than the
+    /// only option, and a deployment whose accounts sit on a large shared provider is the case for turning it off.
+    /// </remarks>
+    OwnAccountDomain = 1,
+
+    /// <summary>An entry on the receiving account's configured trusted-sender list named the author.</summary>
+    ConfiguredTrustedSender = 2,
+
+    /// <summary>An entry somebody added to the receiving account's stored trusted-sender list named the author.</summary>
+    /// <remarks>
+    /// The stored half is what a reader adds without editing a file and restarting. Where both halves name the same
+    /// author the configured one is reported, so a deployment's declared trust is never described as something added
+    /// later.
+    /// </remarks>
+    StoredTrustedSender = 3,
+}

--- a/src/Domain/Emails/Authentication/TrustedSenderEntry.cs
+++ b/src/Domain/Emails/Authentication/TrustedSenderEntry.cs
@@ -1,0 +1,157 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace MailFathom.Domain.Emails.Authentication;
+
+/// <summary>One author an account's owner said this deployment recognizes.</summary>
+/// <remarks>
+/// <para>
+/// An entry names either a whole domain or a single address, and the two are different claims. A domain entry says that
+/// an author established as writing from that domain is recognized, which is the right shape for a counterparty whose
+/// mail all comes from one organization and the wrong one for a correspondent at a provider everybody else uses too. An
+/// address entry narrows that to one mailbox, at the cost described on <see cref="Matches" />.
+/// </para>
+/// <para>
+/// Reaching under a domain is opt-in per entry rather than a mode the whole list runs in, because both answers are
+/// defensible and a deployment needs both: an organization signing everything as one name wants its subdomains, and a
+/// single host trusted inside a domain full of untrusted ones must not drag the rest in with it.
+/// </para>
+/// <para>
+/// An entry is personal data — it names who somebody corresponds with — so nothing here may be logged.
+/// </para>
+/// </remarks>
+public sealed record TrustedSenderEntry
+{
+    private TrustedSenderEntry(SenderDomain domain, bool includesSubdomains, string? normalizedLocalPart)
+    {
+        this.Domain = domain;
+        this.IncludesSubdomains = includesSubdomains;
+        this.NormalizedLocalPart = normalizedLocalPart;
+    }
+
+    /// <summary>Gets the domain this entry recognizes, which for an address entry is that address's domain.</summary>
+    public SenderDomain Domain { get; }
+
+    /// <summary>Gets whether the entry reaches the names beneath <see cref="Domain" /> as well as the domain itself.</summary>
+    public bool IncludesSubdomains { get; }
+
+    /// <summary>Gets the comparison form of the address's local part, or <see langword="null" /> for a domain entry.</summary>
+    public string? NormalizedLocalPart { get; }
+
+    /// <summary>Builds an entry that recognizes a whole domain.</summary>
+    /// <param name="domain">The domain text an operator or a reader supplied.</param>
+    /// <param name="includeSubdomains">Whether the entry also reaches the names beneath that domain.</param>
+    /// <param name="entry">The entry, when the text is a domain this system compares on.</param>
+    /// <returns><see langword="true" /> when the text is usable; otherwise <see langword="false" />.</returns>
+    public static bool TryCreateForDomain(
+        string? domain,
+        bool includeSubdomains,
+        [NotNullWhen(true)] out TrustedSenderEntry? entry)
+    {
+        entry = null;
+
+        if (!SenderDomain.TryCreate(domain, out var trustedDomain))
+        {
+            return false;
+        }
+
+        entry = new TrustedSenderEntry(trustedDomain, includeSubdomains, normalizedLocalPart: null);
+
+        return true;
+    }
+
+    /// <summary>Builds an entry that recognizes one mailbox.</summary>
+    /// <param name="address">The address text an operator or a reader supplied.</param>
+    /// <param name="entry">The entry, when the text is an address this system compares on.</param>
+    /// <returns><see langword="true" /> when the text is usable; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// The address is split the way every address in this system is, at the last at-sign, because a quoted local part
+    /// may contain one. Its domain half is held in the same comparison form a domain entry's is, so an entry written in
+    /// one encoding of an internationalized name recognizes a message that carried the other.
+    /// </remarks>
+    public static bool TryCreateForAddress(string? address, [NotNullWhen(true)] out TrustedSenderEntry? entry)
+    {
+        entry = null;
+
+        if (!EmailAddress.TryCreate(displayName: null, address, out var mailbox)
+            || !TrySplitMailbox(mailbox, out var localPart, out var domain))
+        {
+            return false;
+        }
+
+        entry = new TrustedSenderEntry(domain, includesSubdomains: false, localPart);
+
+        return true;
+    }
+
+    /// <summary>Answers whether this entry recognizes one message's authenticated author.</summary>
+    /// <param name="authorDomain">The domain of the author the receiving server's verdict established.</param>
+    /// <param name="displayedSender">The address the message's <c>From</c> header displays, where it wrote a usable one.</param>
+    /// <returns><see langword="true" /> when the entry names that author.</returns>
+    /// <remarks>
+    /// <para>
+    /// A domain entry is held against the author's domain alone, which is the only identity established at all: what a
+    /// receiving server authenticates is a domain, never a mailbox — DKIM signs as <c>d=</c>, SPF answers for the
+    /// envelope sender's domain, and DMARC states that one of those held for the displayed domain.
+    /// </para>
+    /// <para>
+    /// <b>An address entry therefore narrows an established domain by a local part nothing established.</b> It matches
+    /// when the author's domain is the entry's own and the displayed address is exactly the entry's, so the claim it
+    /// makes is: this domain wrote the message, and it presents it as coming from this mailbox of its own. That is worth
+    /// something because a domain answerable for its own <c>From</c> is answerable for the whole address in it, and it
+    /// is worth less than a domain entry, because a domain that can authenticate can display any local part it likes.
+    /// What it never does is recognize a message whose displayed address is missing or unusable, which the caller cannot
+    /// rule out from the domain alone.
+    /// </para>
+    /// </remarks>
+    public bool Matches(SenderDomain authorDomain, EmailAddress? displayedSender)
+    {
+        if (this.NormalizedLocalPart is not { } localPart)
+        {
+            return authorDomain == this.Domain
+                || (this.IncludesSubdomains && authorDomain.IsSubdomainOf(this.Domain));
+        }
+
+        return authorDomain == this.Domain
+            && displayedSender is { } sender
+            && TrySplitMailbox(sender, out var displayedLocalPart, out var displayedDomain)
+            && displayedDomain == this.Domain
+            && string.Equals(displayedLocalPart, localPart, StringComparison.Ordinal);
+    }
+
+    /// <summary>Writes the entry as the one line the policy revision is derived from.</summary>
+    /// <returns>The comparison form of what this entry recognizes.</returns>
+    /// <remarks>
+    /// Every distinguishable entry writes a distinguishable line, since two entries producing one line would make a
+    /// change to the list invisible in the revision. The prefixes are what keeps a domain, a domain reaching under
+    /// itself, and an address apart.
+    /// </remarks>
+    public string ToPolicyStatement() => this.NormalizedLocalPart is { } localPart
+        ? $"mailbox:{localPart}@{this.Domain.NormalizedValue}"
+        : $"domain{(this.IncludesSubdomains ? "+sub" : string.Empty)}:{this.Domain.NormalizedValue}";
+
+    /// <summary>Splits a mailbox into the two halves that are compared separately.</summary>
+    /// <remarks>
+    /// The local part takes the address's own comparison form, and the domain takes the domain type's, because the two
+    /// halves normalize differently: only the domain has an encoding to settle.
+    /// </remarks>
+    private static bool TrySplitMailbox(EmailAddress mailbox, out string localPart, out SenderDomain domain)
+    {
+        localPart = string.Empty;
+        domain = default;
+
+        var separatorIndex = mailbox.Address.LastIndexOf('@');
+
+        if (separatorIndex <= 0 || !SenderDomain.TryCreate(mailbox.Address[(separatorIndex + 1)..], out domain))
+        {
+            return false;
+        }
+
+        localPart = mailbox.Address[..separatorIndex].ToUpperInvariant();
+
+        return true;
+    }
+}

--- a/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
+++ b/src/Host/Configuration/Mail/MailSynchronizationOptions.cs
@@ -41,6 +41,7 @@ internal sealed class MailSynchronizationOptions
         IMailAnsweringAuditSettingsReader,
         IMailAccountCatalog,
         ITrustedAuthenticationAuthorityReader,
+        ISenderTrustPolicyReader,
         IMailFolderParticipationReader,
         IJunkMailFolderCatalog,
         IMailFolderMappingReader
@@ -53,15 +54,23 @@ internal sealed class MailSynchronizationOptions
 
     private readonly Lazy<IReadOnlyDictionary<string, IReadOnlyList<MailFolderMapping>>> mappingsByAccount;
 
+    private readonly Lazy<IReadOnlyDictionary<string, SenderTrustPolicy>> senderTrustPolicies;
+
     /// <summary>Initializes the options the binder is about to write into.</summary>
     /// <remarks>
-    /// The mapping cache is deferred rather than built here, because nothing is bound yet when this runs. What forces
-    /// it is the first folder lookup, which happens long after binding and after validation, and a reload binds a new
-    /// instance rather than rewriting this one — so the built dictionary can never describe superseded configuration.
+    /// Both caches are deferred rather than built here, because nothing is bound yet when this runs. What forces them
+    /// is the first lookup, which happens long after binding and after validation, and a reload binds a new instance
+    /// rather than rewriting this one — so a built value can never describe superseded configuration. The verification
+    /// policies are cached for a second reason as well: each one derives a revision over the whole effective list, and
+    /// every arriving message asks for one.
     /// </remarks>
-    public MailSynchronizationOptions() => this.mappingsByAccount = new(
-        this.ReadMappingsByAccount,
-        LazyThreadSafetyMode.ExecutionAndPublication);
+    public MailSynchronizationOptions()
+    {
+        this.mappingsByAccount = new(this.ReadMappingsByAccount, LazyThreadSafetyMode.ExecutionAndPublication);
+        this.senderTrustPolicies = new(
+            this.ReadSenderTrustPolicies,
+            LazyThreadSafetyMode.ExecutionAndPublication);
+    }
 
     /// <summary>Gets or sets whether periodic synchronization is enabled.</summary>
     public bool Enabled { get; set; }
@@ -351,6 +360,23 @@ internal sealed class MailSynchronizationOptions
     [Range(1_000, 200_000)]
     public int MaxExtractedTextCharacters { get; set; } = 100_000;
 
+    /// <summary>Gets or sets whether an author writing from a domain one of this deployment's accounts uses is recognized.</summary>
+    /// <remarks>
+    /// <para>
+    /// The set of domains is derived from the configured accounts rather than restated here, so adding an account
+    /// extends it and removing one narrows it without a second edit. It is deployment-wide rather than per account
+    /// because an instance synchronizing a work mailbox and a personal one is synchronizing one person's
+    /// correspondence, and mail sent from the first to the second is the least suspicious mail in the mailbox.
+    /// </para>
+    /// <para>
+    /// It defaults to on because that mail is either the owner's own or somebody who has taken their mailbox, and the
+    /// first is far more common. The case for turning it off is an account on a large shared provider, where every
+    /// user of that provider writes from the same domain and the set would recognize all of them; a deployment that
+    /// turns it off names the domains it does mean on the accounts' own trusted-sender lists instead.
+    /// </para>
+    /// </remarks>
+    public bool TrustOwnAccountDomains { get; set; } = true;
+
     /// <summary>Gets or sets configured accounts and folders to synchronize.</summary>
     public List<MailSynchronizationAccountOptions> Accounts { get; set; } = [];
 
@@ -463,6 +489,70 @@ internal sealed class MailSynchronizationOptions
     /// </remarks>
     public TrustedAuthenticationAuthority GetTrustedAuthority(MailAccountId accountId) =>
         this.FindConfiguredAccount(accountId)?.CreateTrustedAuthority() ?? TrustedAuthenticationAuthority.None;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Answered from the cache below rather than rebuilt, because every arriving message asks for one and building a
+    /// policy derives a revision over the whole effective list. An account this snapshot no longer names recognizes
+    /// nobody, for the reason the trusted authority above answers with none.
+    /// </remarks>
+    public SenderTrustPolicy GetTrustPolicy(MailAccountId accountId) =>
+        this.senderTrustPolicies.Value.TryGetValue(accountId.Value, out var policy)
+            ? policy
+            : SenderTrustPolicy.RecognizingNobody;
+
+    /// <summary>Builds every account's verification policy once, keyed by the account identifier the lookups arrive with.</summary>
+    /// <remarks>
+    /// The stored half of each list is empty here and is what <see href="https://github.com/Krzysztof318/MailFathom/issues/760">#760</see>
+    /// fills in: the matcher already takes both halves, so the store arrives as a second list rather than as a second
+    /// rule. An entry whose text is unusable is skipped rather than raised over, and two accounts configured under one
+    /// identifier keep the first, both for the reason the folder mappings do — startup validation refuses each of
+    /// those, and a reload being rejected must not make a lookup throw.
+    /// </remarks>
+    private Dictionary<string, SenderTrustPolicy> ReadSenderTrustPolicies()
+    {
+        IReadOnlyList<SenderDomain> ownAccountDomains = this.TrustOwnAccountDomains ? this.ReadOwnAccountDomains() : [];
+
+        return (this.Accounts ?? [])
+            .Select(static account => (Id: TryReadAccountId(account.AccountId), account.ConfiguredTrustedSenders))
+            .Where(static account => account.Id is not null)
+            .GroupBy(static account => account.Id!, StringComparer.Ordinal)
+            .ToDictionary(
+                static account => account.Key,
+                account => SenderTrustPolicy.Create(
+                    ownAccountDomains,
+                    account.First().ConfiguredTrustedSenders,
+                    storedTrustedSenders: []),
+                StringComparer.Ordinal);
+    }
+
+    /// <summary>Reads the domains the configured accounts themselves send and receive under.</summary>
+    /// <remarks>
+    /// Derived from each account's user name, which is the only mailbox identity an IMAP account states: a server is
+    /// reached at a host that is rarely the mail domain, and the account identifier is a key an operator invented. An
+    /// account whose user name is a bare login rather than an address therefore contributes nothing, which is the
+    /// honest answer — inventing a domain out of the host would recognize senders nobody named.
+    /// </remarks>
+    private IReadOnlyList<SenderDomain> ReadOwnAccountDomains() =>
+    [
+        .. (this.Accounts ?? [])
+            .Select(static account => TryReadOwnDomain(account.UserName))
+            .OfType<SenderDomain>()
+            .Distinct(),
+    ];
+
+    /// <summary>Reads the mail domain one account's user name states, or nothing when it states none.</summary>
+    /// <remarks>
+    /// The at-sign is what separates the two shapes an IMAP user name takes. Without one the value is a login and
+    /// naming a domain from it would be a guess; with one it is the mailbox address the account belongs to, and the
+    /// domain is what follows the last at-sign for the reason every address in this system is split there.
+    /// </remarks>
+    private static SenderDomain? TryReadOwnDomain(string? userName) =>
+        userName is not null
+        && userName.Contains('@', StringComparison.Ordinal)
+        && SenderDomain.TryCreateFromMailbox(userName, out var domain)
+            ? domain
+            : null;
 
     /// <inheritdoc />
     public bool SynchronizationEnabled => this.Enabled;
@@ -855,6 +945,35 @@ internal sealed class MailSynchronizationAccountOptions : IValidatableObject
     /// </remarks>
     public string? TrustedAuthenticationServiceIdentifier { get; set; }
 
+    /// <summary>Gets or sets the senders this account recognizes on top of the domains this deployment's own accounts use.</summary>
+    /// <remarks>
+    /// <para>
+    /// Per account rather than deployment-wide, because the accounts an instance synchronizes are different
+    /// correspondence: a work account's counterparties have nothing to do with a personal one's, and one list would
+    /// either recognize too much on one account or make an owner maintain the union of both.
+    /// </para>
+    /// <para>
+    /// This is the declared half of the list and the store holds the half somebody adds while the deployment is
+    /// running; an entry in either recognizes a sender, and a reload can no more remove a stored entry than a stored
+    /// entry can shadow one written here. An entry that names neither a domain nor an address, names both, or writes
+    /// one nothing can compare fails startup naming this account and the entry's position.
+    /// </para>
+    /// </remarks>
+    public List<TrustedSenderOptions> TrustedSenders { get; set; } = [];
+
+    /// <summary>Gets the configured entries as the values the matcher holds a sender against, dropping the unusable ones.</summary>
+    /// <remarks>
+    /// An unusable entry is skipped here rather than raised over, because startup validation refuses that configuration
+    /// and a reload being rejected must not make an arriving message throw. What that costs is one entry of one
+    /// account's list, and the cost is in the safe direction: an entry nobody could read recognizes nobody.
+    /// </remarks>
+    internal IReadOnlyList<TrustedSenderEntry> ConfiguredTrustedSenders =>
+    [
+        .. (this.TrustedSenders ?? [])
+            .Select(static configured => configured.TryCreateEntry(out var entry) ? entry : null)
+            .OfType<TrustedSenderEntry>(),
+    ];
+
     /// <summary>Gets or sets the earliest date the mail server may have received an email on for it to be synchronized.</summary>
     /// <remarks>
     /// Omitting it synchronizes every email the server still holds, which is the default. It binds as a plain date such
@@ -1011,6 +1130,11 @@ internal sealed class MailSynchronizationAccountOptions : IValidatableObject
                 [nameof(this.TrustedAuthenticationServiceIdentifier)]);
         }
 
+        foreach (var result in this.ValidateTrustedSenders())
+        {
+            yield return result;
+        }
+
         // Checked here rather than through a data annotation because nothing binds the block as an options graph of its
         // own, so an annotation on it would be read by nothing. The window decides when personal data is destroyed, so
         // a typo in it fails startup instead of quietly selecting a period nobody wrote.
@@ -1106,6 +1230,41 @@ internal sealed class MailSynchronizationAccountOptions : IValidatableObject
             foreach (var result in this.ValidateAuthenticationCredentials())
             {
                 yield return result;
+            }
+        }
+    }
+
+    /// <summary>Reports every trusted-sender entry that names no sender this system can compare against.</summary>
+    /// <returns>One result per unusable entry, empty when every entry names exactly one usable sender.</returns>
+    /// <remarks>
+    /// <para>
+    /// A typo here fails startup rather than degrading to an entry that recognizes nobody, because the two are
+    /// indistinguishable afterwards: a list nobody wrote and a list whose entries match nothing both leave every
+    /// sender unrecognized, and an operator would meet the difference as mail that never stops carrying a warning.
+    /// </para>
+    /// <para>
+    /// The message names the account and the entry's position and never the value it holds, because a domain and an
+    /// address are both personal data and a validation failure is written to a log.
+    /// </para>
+    /// </remarks>
+    private IEnumerable<ValidationResult> ValidateTrustedSenders()
+    {
+        if (this.TrustedSenders is null)
+        {
+            yield return new ValidationResult(
+                $"Account '{this.AccountId}': the trusted sender configuration must be a list.",
+                [nameof(this.TrustedSenders)]);
+
+            yield break;
+        }
+
+        foreach (var (entry, position) in this.TrustedSenders.Select(static (entry, index) => (Entry: entry, Position: index)))
+        {
+            if (entry is null || !entry.TryCreateEntry(out _))
+            {
+                yield return new ValidationResult(
+                    $"Account '{this.AccountId}': trusted sender {position} must name exactly one of a usable domain or a usable address, and may ask to include subdomains only where it names a domain.",
+                    [nameof(this.TrustedSenders)]);
             }
         }
     }

--- a/src/Host/Configuration/Mail/TrustedSenderOptions.cs
+++ b/src/Host/Configuration/Mail/TrustedSenderOptions.cs
@@ -1,0 +1,59 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Domain.Emails.Authentication;
+
+namespace MailFathom.Host.Configuration.Mail;
+
+/// <summary>Configures one sender an account recognizes without anything else vouching for them.</summary>
+/// <remarks>
+/// <para>
+/// An entry names a domain or an address and never both, because the two are different claims and an entry meaning
+/// both would be an entry nobody could read. Which one is written decides what the entry is matched against, which
+/// <see cref="TrustedSenderEntry.Matches" /> states.
+/// </para>
+/// <para>
+/// This is the declared half of the list. The half somebody adds while the deployment is running lives in the database,
+/// is not editable by a configuration reload, and cannot shadow anything written here.
+/// </para>
+/// </remarks>
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "The options framework materializes this type during configuration binding.")]
+internal sealed class TrustedSenderOptions
+{
+    /// <summary>Gets or sets the domain this account recognizes, or nothing when the entry names an address.</summary>
+    public string? Domain { get; set; }
+
+    /// <summary>Gets or sets the single address this account recognizes, or nothing when the entry names a domain.</summary>
+    public string? Address { get; set; }
+
+    /// <summary>Gets or sets whether a domain entry also reaches the names beneath that domain.</summary>
+    /// <remarks>
+    /// Opt-in per entry rather than a mode the list runs in, because both answers are needed: an organization signing
+    /// everything as one name wants its subdomains, and one host recognized inside a domain full of unrecognized ones
+    /// must not drag the rest in. It says nothing about an address entry and startup refuses it there rather than
+    /// accepting a setting that would do nothing.
+    /// </remarks>
+    public bool IncludeSubdomains { get; set; }
+
+    /// <summary>Reads the entry as the domain value the matcher holds a sender against.</summary>
+    /// <param name="entry">The entry, when this configuration names exactly one usable sender.</param>
+    /// <returns><see langword="true" /> when the entry is usable; otherwise <see langword="false" />.</returns>
+    internal bool TryCreateEntry([NotNullWhen(true)] out TrustedSenderEntry? entry)
+    {
+        entry = null;
+
+        var namesDomain = !string.IsNullOrWhiteSpace(this.Domain);
+        var namesAddress = !string.IsNullOrWhiteSpace(this.Address);
+
+        if (namesDomain == namesAddress)
+        {
+            return false;
+        }
+
+        return namesDomain
+            ? TrustedSenderEntry.TryCreateForDomain(this.Domain, this.IncludeSubdomains, out entry)
+            : !this.IncludeSubdomains && TrustedSenderEntry.TryCreateForAddress(this.Address, out entry);
+    }
+}

--- a/src/Host/HostComposition.cs
+++ b/src/Host/HostComposition.cs
@@ -502,6 +502,7 @@ internal static class HostComposition
         builder.Services.AddScoped<IMailAnsweringAuditSettingsReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
         builder.Services.AddScoped<IMailAccountCatalog>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
         builder.Services.AddScoped<ITrustedAuthenticationAuthorityReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
+        builder.Services.AddScoped<ISenderTrustPolicyReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
         builder.Services.AddScoped<IMailFolderParticipationReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
         builder.Services.AddScoped<IJunkMailFolderCatalog>(provider => provider.GetRequiredService<MailSynchronizationOptions>());
         builder.Services.AddScoped<IMailFolderMappingReader>(provider => provider.GetRequiredService<MailSynchronizationOptions>());

--- a/src/Infrastructure/Persistence/Emails/StoredEmailMetadataMapping.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailMetadataMapping.cs
@@ -71,6 +71,7 @@ internal static class StoredEmailMetadataMapping
 
         ApplyAttachmentSummary(entity, metadata.Attachments);
         ApplySenderAuthentication(entity, metadata.SenderAuthentication);
+        ApplySenderTrust(entity, metadata.SenderTrust);
     }
 
     /// <summary>Records what the receiving mail server established about who sent the message.</summary>
@@ -88,6 +89,22 @@ internal static class StoredEmailMetadataMapping
         entity.SpfMailFromDomain = authentication.SpfDomain?.NormalizedValue;
         entity.DmarcOutcome = authentication.Dmarc;
         entity.SenderDomainAlignment = authentication.Alignment;
+    }
+
+    /// <summary>Records what this deployment made of the author the message authenticated as.</summary>
+    /// <remarks>
+    /// Written whole beside the verdict it reads, so a re-derivation after a trusted-sender list changed replaces both
+    /// halves rather than leaving an answer beside the identity a different list judged. A revision that names no
+    /// policy is stored as absent rather than as an empty string, because the column's null is what says no policy
+    /// judged this row.
+    /// </remarks>
+    private static void ApplySenderTrust(StoredEmailEntity entity, SenderTrust trust)
+    {
+        entity.SenderTrustLevel = trust.Level;
+        entity.SenderTrustGrantedBy = trust.GrantedBy;
+        entity.SenderTrustPolicyRevision = trust.PolicyRevision.NamesAPolicy
+            ? trust.PolicyRevision.Value
+            : null;
     }
 
     /// <summary>Records the one participant a timeline names as the message's sender.</summary>

--- a/src/Infrastructure/Persistence/Entities/StoredEmailEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/StoredEmailEntity.cs
@@ -109,6 +109,26 @@ internal sealed class StoredEmailEntity
     /// <summary>Gets or sets whether the authenticated domain is the one the message displays as its sender.</summary>
     public SenderDomainAlignment SenderDomainAlignment { get; set; }
 
+    /// <summary>Gets or sets what this deployment made of the author the columns above establish.</summary>
+    /// <remarks>
+    /// Stored rather than decided when a message is read, because the trusted-sender list it was decided against
+    /// changes: an operator adds a domain and a reader trusts a correspondent, and neither act may quietly rewrite the
+    /// answer a message was already shown with. <see cref="SenderTrustPolicyRevision" /> is what says which list
+    /// produced this row's answer.
+    /// </remarks>
+    public SenderTrustLevel SenderTrustLevel { get; set; }
+
+    /// <summary>Gets or sets which half of what this deployment knows recognized the author, or that none did.</summary>
+    public SenderTrustSource SenderTrustGrantedBy { get; set; }
+
+    /// <summary>Gets or sets the trusted-sender policy the verdict was reached under, absent where no policy reached one.</summary>
+    /// <remarks>
+    /// Nullable because its absence is a statement: a row written before this deployment judged authors at all, and one
+    /// recorded from an envelope whose payload was never stored, were judged by nothing rather than judged and left
+    /// unknown.
+    /// </remarks>
+    public string? SenderTrustPolicyRevision { get; set; }
+
     /// <summary>Gets or sets the normalized <c>To</c> addresses, which recipient filters test for containment.</summary>
     /// <remarks>
     /// Only the comparison form is kept, for the reason the per-attachment list is not kept at all: a display name is

--- a/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -362,6 +362,23 @@ internal sealed class MailFathomDbContext : DbContext
             entity.Property(email => email.DkimSignerDomain).HasMaxLength(StoredEmailEntity.MaximumDomainLength);
             entity.Property(email => email.SpfMailFromDomain).HasMaxLength(StoredEmailEntity.MaximumDomainLength);
 
+            // What this deployment made of that verdict, stored the same way and defaulted the same way: a row written
+            // before authors were judged at all recognized nobody, which is exactly what the two defaults say. The
+            // revision is nullable rather than defaulted, because its absence is what separates a row no policy judged
+            // from one a policy judged and left unknown.
+            entity.Property(email => email.SenderTrustLevel)
+                .HasConversion<string>()
+                .HasMaxLength(64)
+                .HasDefaultValue(SenderTrustLevel.Unknown)
+                .IsRequired();
+            entity.Property(email => email.SenderTrustGrantedBy)
+                .HasConversion<string>()
+                .HasMaxLength(64)
+                .HasDefaultValue(SenderTrustSource.None)
+                .IsRequired();
+            entity.Property(email => email.SenderTrustPolicyRevision)
+                .HasMaxLength(SenderTrustPolicyRevision.Length);
+
             ConfigureStoredEmailIndexes(entity);
 
             entity.HasOne(email => email.MailFolder)

--- a/src/Infrastructure/Persistence/Migrations/20260816151132_AddStoredEmailSenderTrust.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260816151132_AddStoredEmailSenderTrust.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260816151132_AddStoredEmailSenderTrust")]
+    partial class AddStoredEmailSenderTrust
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1154,10 +1157,6 @@ namespace MailFathom.Infrastructure.Persistence.Migrations
                     b.Property<DateTimeOffset?>("RemoteFlagsObservedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.PrimitiveCollection<string[]>("RemoteKeywords")
-                        .IsRequired()
-                        .HasColumnType("text[]");
-
                     b.PrimitiveCollection<string[]>("ReplyToAddresses")
                         .IsRequired()
                         .HasColumnType("text[]");
@@ -1251,11 +1250,6 @@ namespace MailFathom.Infrastructure.Persistence.Migrations
                         .HasDatabaseName("ix_stored_emails_cc_addresses");
 
                     NpgsqlIndexBuilderExtensions.HasMethod(b.HasIndex("CcAddresses"), "GIN");
-
-                    b.HasIndex("RemoteKeywords")
-                        .HasDatabaseName("ix_stored_emails_remote_keywords");
-
-                    NpgsqlIndexBuilderExtensions.HasMethod(b.HasIndex("RemoteKeywords"), "GIN");
 
                     b.HasIndex("ReplyToAddresses")
                         .HasDatabaseName("ix_stored_emails_reply_to_addresses");

--- a/src/Infrastructure/Persistence/Migrations/20260816151132_AddStoredEmailSenderTrust.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260816151132_AddStoredEmailSenderTrust.cs
@@ -1,0 +1,57 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStoredEmailSenderTrust : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SenderTrustGrantedBy",
+                table: "stored_emails",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "None");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SenderTrustLevel",
+                table: "stored_emails",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                defaultValue: "Unknown");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SenderTrustPolicyRevision",
+                table: "stored_emails",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SenderTrustGrantedBy",
+                table: "stored_emails");
+
+            migrationBuilder.DropColumn(
+                name: "SenderTrustLevel",
+                table: "stored_emails");
+
+            migrationBuilder.DropColumn(
+                name: "SenderTrustPolicyRevision",
+                table: "stored_emails");
+        }
+    }
+}

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -407,11 +407,17 @@ public static class ServiceCollectionExtensions
         // search document, the passages cut from it, and the vectors built from those all descend from one extraction,
         // and both writers of one reach it through here. Decided from the guard rather than from configuration this
         // project does not bind, and left unwrapped where nothing is scanned so a message is read exactly as it was.
-        services.AddScoped<IEmailMimeReader>(provider =>
+        // The sender verdict is decided at the same seam and for the same reason, and is wrapped unconditionally: a
+        // deployment that recognizes nobody still records that it recognized nobody, which is what a reader is shown.
+        // It sits directly over the parse because it reads what the parse established and touches nothing else, so the
+        // redaction above it is unaffected either way.
+        services.AddScoped(provider =>
         {
-            var reader = new MimeKitEmailMimeReader(
-                provider.GetRequiredService<EmailMimeExtractionOptions>(),
-                provider.GetRequiredService<ITrustedAuthenticationAuthorityReader>());
+            IEmailMimeReader reader = new SenderTrustEvaluatingEmailMimeReader(
+                new MimeKitEmailMimeReader(
+                    provider.GetRequiredService<EmailMimeExtractionOptions>(),
+                    provider.GetRequiredService<ITrustedAuthenticationAuthorityReader>()),
+                provider.GetRequiredService<ISenderTrustPolicyReader>());
 
             return provider.GetRequiredService<SensitiveContentDerivationGuard>() is { IsActive: true } guard
                 ? new RedactingEmailMimeReader(reader, guard)

--- a/tests/Application.UnitTests/Emails/Extraction/SenderTrustEvaluatingEmailMimeReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/Extraction/SenderTrustEvaluatingEmailMimeReaderTests.cs
@@ -1,0 +1,204 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.EmailContent.Storage;
+using MailFathom.Application.Emails.Extraction;
+using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Mail;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
+using MailFathom.Domain.Folders;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Emails.Extraction;
+
+/// <summary>Covers the seam at which an authenticated author is held against what the receiving account recognizes.</summary>
+public sealed class SenderTrustEvaluatingEmailMimeReaderTests
+{
+    /// <summary>The account's own list is what judges the message, and the verdict says which half named the author.</summary>
+    [Fact]
+    public async Task ReadMetadataAsync_AnAuthorTheReceivingAccountRecognizes_IsRecordedAsTrusted()
+    {
+        // Arrange
+        var policy = PolicyRecognizing("partner.example");
+        var reader = new SenderTrustEvaluatingEmailMimeReader(
+            ReaderYielding(WrittenBy("partner.example"), "alice@partner.example"),
+            PolicyReaderFor("primary", policy));
+
+        // Act
+        var extraction = await reader.ReadMetadataAsync(Content(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, extraction.Metadata?.SenderTrust.Level);
+        Assert.Equal(
+            SenderTrustSource.ConfiguredTrustedSender,
+            extraction.Metadata?.SenderTrust.GrantedBy);
+        Assert.Equal(policy.Revision, extraction.Metadata?.SenderTrust.PolicyRevision);
+    }
+
+    /// <summary>Most legitimate mail comes from somebody nobody named, and that answer is recorded rather than left blank.</summary>
+    [Fact]
+    public async Task ReadMetadataAsync_AnAuthorNobodyNamed_IsRecordedAsUnknownUnderThePolicyThatJudgedIt()
+    {
+        // Arrange
+        var policy = PolicyRecognizing("partner.example");
+        var reader = new SenderTrustEvaluatingEmailMimeReader(
+            ReaderYielding(WrittenBy("stranger.example"), "bob@stranger.example"),
+            PolicyReaderFor("primary", policy));
+
+        // Act
+        var extraction = await reader.ReadMetadataAsync(Content(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, extraction.Metadata?.SenderTrust.Level);
+        Assert.Equal(policy.Revision, extraction.Metadata?.SenderTrust.PolicyRevision);
+    }
+
+    /// <summary>An address entry needs the mailbox a client displays, which is read from <c>From</c> and not from <c>Sender</c>.</summary>
+    [Fact]
+    public async Task ReadMetadataAsync_AnAddressEntryAndAFromHeaderNamingIt_IsRecordedAsTrusted()
+    {
+        // Arrange
+        Assert.True(TrustedSenderEntry.TryCreateForAddress("alice@partner.example", out var entry));
+        Assert.NotNull(entry);
+        var policy = SenderTrustPolicy.Create([], [entry], []);
+        var reader = new SenderTrustEvaluatingEmailMimeReader(
+            ReaderYielding(WrittenBy("partner.example"), from: "alice@partner.example", sender: "relay@partner.example"),
+            PolicyReaderFor("primary", policy));
+
+        // Act
+        var extraction = await reader.ReadMetadataAsync(Content(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, extraction.Metadata?.SenderTrust.Level);
+    }
+
+    /// <summary>Reading the submitting mailbox instead of the displayed one would recognize an author nobody named.</summary>
+    [Fact]
+    public async Task ReadMetadataAsync_AnAddressEntryNamingOnlyTheSenderHeader_IsNotRecognized()
+    {
+        // Arrange
+        Assert.True(TrustedSenderEntry.TryCreateForAddress("relay@partner.example", out var entry));
+        Assert.NotNull(entry);
+        var policy = SenderTrustPolicy.Create([], [entry], []);
+        var reader = new SenderTrustEvaluatingEmailMimeReader(
+            ReaderYielding(WrittenBy("partner.example"), from: "alice@partner.example", sender: "relay@partner.example"),
+            PolicyReaderFor("primary", policy));
+
+        // Act
+        var extraction = await reader.ReadMetadataAsync(Content(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, extraction.Metadata?.SenderTrust.Level);
+    }
+
+    /// <summary>Content nobody could parse carries no author to judge, and the failure has to reach the caller unchanged.</summary>
+    [Fact]
+    public async Task ReadMetadataAsync_ContentNoReaderCouldParse_IsCarriedThroughAsTheFailureItIs()
+    {
+        // Arrange
+        var policies = Substitute.For<ISenderTrustPolicyReader>();
+        var inner = Substitute.For<IEmailMimeReader>();
+        inner.ReadMetadataAsync(Arg.Any<RemoteEmailContent>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(EmailMimeExtractionResult.MalformedContent()));
+        var reader = new SenderTrustEvaluatingEmailMimeReader(inner, policies);
+
+        // Act
+        var extraction = await reader.ReadMetadataAsync(Content(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmailMimeExtractionOutcome.MalformedContent, extraction.Outcome);
+        policies.DidNotReceive().GetTrustPolicy(Arg.Any<MailAccountId>());
+    }
+
+    /// <summary>The verdict the parsing reader established is what the decision reads, and it is left exactly as it was.</summary>
+    [Fact]
+    public async Task ReadMetadataAsync_AnyMessage_LeavesWhatTheServerEstablishedUntouched()
+    {
+        // Arrange
+        var authentication = WrittenBy("partner.example");
+        var reader = new SenderTrustEvaluatingEmailMimeReader(
+            ReaderYielding(authentication, "alice@partner.example"),
+            PolicyReaderFor("primary", PolicyRecognizing("partner.example")));
+
+        // Act
+        var extraction = await reader.ReadMetadataAsync(Content(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(authentication, extraction.Metadata?.SenderAuthentication);
+        Assert.Equal("Subject", extraction.Metadata?.Subject);
+    }
+
+    private static ISenderTrustPolicyReader PolicyReaderFor(string accountId, SenderTrustPolicy policy)
+    {
+        var policies = Substitute.For<ISenderTrustPolicyReader>();
+
+        policies.GetTrustPolicy(MailAccountId.Create(accountId)).Returns(policy);
+
+        return policies;
+    }
+
+    private static SenderTrustPolicy PolicyRecognizing(string domain)
+    {
+        Assert.True(TrustedSenderEntry.TryCreateForDomain(domain, includeSubdomains: false, out var entry));
+        Assert.NotNull(entry);
+
+        return SenderTrustPolicy.Create([], [entry], []);
+    }
+
+    /// <summary>Builds the verdict of a message whose displayed author the receiving server established.</summary>
+    private static SenderAuthentication WrittenBy(string domain)
+    {
+        Assert.True(SenderDomain.TryCreate(domain, out var author));
+
+        return SenderAuthentication.Authenticated(author, spfDomain: null, author, DmarcOutcome.Pass);
+    }
+
+    private static IEmailMimeReader ReaderYielding(
+        SenderAuthentication authentication,
+        string from,
+        string? sender = null)
+    {
+        var reader = Substitute.For<IEmailMimeReader>();
+
+        reader.ReadMetadataAsync(Arg.Any<RemoteEmailContent>(), Arg.Any<CancellationToken>())
+            .Returns(call => Task.FromResult(EmailMimeExtractionResult.Extracted(new ExtractedEmailMetadata(
+                call.Arg<RemoteEmailContent>()!.OccurrenceId,
+                Subject: "Subject",
+                SentAt: null,
+                ReceivedAt: null,
+                ParticipantsOf(from, sender),
+                EmailThreadReferences.None,
+                EmailAttachmentSummary.None,
+                ExtractedEmailText.FromPlainTextBody("body", "body"),
+                authentication))));
+
+        return reader;
+    }
+
+    private static IReadOnlyList<EmailParticipant> ParticipantsOf(string from, string? sender) => sender is null
+        ? [new EmailParticipant(EmailAddressRole.From, AddressOf(from))]
+        :
+        [
+            new EmailParticipant(EmailAddressRole.Sender, AddressOf(sender)),
+            new EmailParticipant(EmailAddressRole.From, AddressOf(from)),
+        ];
+
+    private static EmailAddress AddressOf(string written)
+    {
+        Assert.True(EmailAddress.TryCreate(displayName: null, written, out var address));
+
+        return address;
+    }
+
+    private static RemoteEmailContent Content() => new(
+        EmailOccurrenceId.Create(
+            MailAccountId.Create("primary"),
+            new MailFolderResolutionId(MailFolderAlias.Create("inbox"), MailFolderResolutionGeneration.First),
+            ImapUidValidity.Create(5),
+            ImapUid.Create(11)),
+        new byte[] { 1, 2, 3 });
+}

--- a/tests/Application.UnitTests/Emails/Extraction/SenderTrustEvaluatingEmailMimeReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/Extraction/SenderTrustEvaluatingEmailMimeReaderTests.cs
@@ -95,6 +95,51 @@ public sealed class SenderTrustEvaluatingEmailMimeReaderTests
         Assert.Equal(SenderTrustLevel.Unknown, extraction.Metadata?.SenderTrust.Level);
     }
 
+    /// <summary>A message can display only one author, so the first mailbox the header carried is the one judged.</summary>
+    [Fact]
+    public async Task ReadMetadataAsync_SeveralFromParticipants_JudgesTheFirstOne()
+    {
+        // Arrange
+        Assert.True(TrustedSenderEntry.TryCreateForAddress("alice@partner.example", out var entry));
+        Assert.NotNull(entry);
+        var reader = new SenderTrustEvaluatingEmailMimeReader(
+            ReaderYielding(
+                WrittenBy("partner.example"),
+                [
+                    new EmailParticipant(EmailAddressRole.From, AddressOf("alice@partner.example")),
+                    new EmailParticipant(EmailAddressRole.From, AddressOf("mallory@partner.example")),
+                ]),
+            PolicyReaderFor("primary", SenderTrustPolicy.Create([], [entry], [])));
+
+        // Act
+        var extraction = await reader.ReadMetadataAsync(Content(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, extraction.Metadata?.SenderTrust.Level);
+    }
+
+    /// <summary>A message displaying no author at all is judged rather than refused, and recognizes nobody.</summary>
+    [Fact]
+    public async Task ReadMetadataAsync_NoFromParticipant_IsRecordedAsUnknown()
+    {
+        // Arrange
+        Assert.True(TrustedSenderEntry.TryCreateForAddress("alice@partner.example", out var entry));
+        Assert.NotNull(entry);
+        var policy = SenderTrustPolicy.Create([], [entry], []);
+        var reader = new SenderTrustEvaluatingEmailMimeReader(
+            ReaderYielding(
+                WrittenBy("partner.example"),
+                [new EmailParticipant(EmailAddressRole.To, AddressOf("owner@work.example"))]),
+            PolicyReaderFor("primary", policy));
+
+        // Act
+        var extraction = await reader.ReadMetadataAsync(Content(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, extraction.Metadata?.SenderTrust.Level);
+        Assert.Equal(policy.Revision, extraction.Metadata?.SenderTrust.PolicyRevision);
+    }
+
     /// <summary>Content nobody could parse carries no author to judge, and the failure has to reach the caller unchanged.</summary>
     [Fact]
     public async Task ReadMetadataAsync_ContentNoReaderCouldParse_IsCarriedThroughAsTheFailureItIs()
@@ -160,7 +205,12 @@ public sealed class SenderTrustEvaluatingEmailMimeReaderTests
     private static IEmailMimeReader ReaderYielding(
         SenderAuthentication authentication,
         string from,
-        string? sender = null)
+        string? sender = null) =>
+        ReaderYielding(authentication, ParticipantsOf(from, sender));
+
+    private static IEmailMimeReader ReaderYielding(
+        SenderAuthentication authentication,
+        IReadOnlyList<EmailParticipant> participants)
     {
         var reader = Substitute.For<IEmailMimeReader>();
 
@@ -170,7 +220,7 @@ public sealed class SenderTrustEvaluatingEmailMimeReaderTests
                 Subject: "Subject",
                 SentAt: null,
                 ReceivedAt: null,
-                ParticipantsOf(from, sender),
+                participants,
                 EmailThreadReferences.None,
                 EmailAttachmentSummary.None,
                 ExtractedEmailText.FromPlainTextBody("body", "body"),

--- a/tests/Domain.UnitTests/Emails/Authentication/SenderAuthenticationTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/SenderAuthenticationTests.cs
@@ -58,4 +58,95 @@ public sealed class SenderAuthenticationTests
         Assert.Equal("BANK.TEST", authentication.FromDomain?.NormalizedValue);
         Assert.Equal(DmarcOutcome.Fail, authentication.Dmarc);
     }
+
+    /// <summary>A trusted DMARC pass is the receiving server's own statement about the displayed author.</summary>
+    [Fact]
+    public void AuthenticatedAuthorDomain_DmarcPassOverAnUnrelatedSignature_IsTheDisplayedDomain()
+    {
+        // Arrange
+        SenderDomain.TryCreate("provider.test", out var signer);
+        SenderDomain.TryCreate("partner.test", out var displayed);
+
+        // Act
+        var authentication = SenderAuthentication.Authenticated(
+            signer,
+            spfDomain: null,
+            displayed,
+            DmarcOutcome.Pass);
+
+        // Assert
+        Assert.Equal(displayed, authentication.AuthenticatedAuthorDomain);
+    }
+
+    /// <summary>Without DMARC, an identity that authenticated as the displayed domain establishes the author.</summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AuthenticatedAuthorDomain_IdentityEqualToTheDisplayedDomain_IsThatDomain(bool throughDkim)
+    {
+        // Arrange
+        SenderDomain.TryCreate("partner.test", out var displayed);
+        SenderDomain.TryCreate("relay.test", out var relay);
+
+        // Act
+        var authentication = SenderAuthentication.Authenticated(
+            throughDkim ? displayed : relay,
+            throughDkim ? null : displayed,
+            displayed,
+            DmarcOutcome.NotReported);
+
+        // Assert
+        Assert.Equal(displayed, authentication.AuthenticatedAuthorDomain);
+    }
+
+    /// <summary>An identity belonging to somebody other than the displayed author establishes no author at all.</summary>
+    [Theory]
+    [InlineData(DmarcOutcome.Fail)]
+    [InlineData(DmarcOutcome.NotReported)]
+    public void AuthenticatedAuthorDomain_IdentityUnrelatedToTheDisplayedDomain_IsAbsent(DmarcOutcome dmarc)
+    {
+        // Arrange
+        SenderDomain.TryCreate("relay.test", out var relay);
+        SenderDomain.TryCreate("bank.test", out var displayed);
+
+        // Act
+        var authentication = SenderAuthentication.Authenticated(relay, spfDomain: null, displayed, dmarc);
+
+        // Assert
+        Assert.Null(authentication.AuthenticatedAuthorDomain);
+    }
+
+    /// <summary>A verdict that establishes nothing, and one that refused an identity, establish no author either.</summary>
+    [Fact]
+    public void AuthenticatedAuthorDomain_NothingEstablishedOrRefused_IsAbsent()
+    {
+        // Arrange
+        SenderDomain.TryCreate("bank.test", out var displayed);
+
+        // Act
+        var unestablished = SenderAuthentication.NotEstablished(displayed);
+        var refused = SenderAuthentication.Failed(displayed, DmarcOutcome.Fail);
+
+        // Assert
+        Assert.Null(unestablished.AuthenticatedAuthorDomain);
+        Assert.Null(refused.AuthenticatedAuthorDomain);
+    }
+
+    /// <summary>A message displaying no usable domain has no author to establish, whatever authenticated.</summary>
+    [Fact]
+    public void AuthenticatedAuthorDomain_NoDisplayedDomain_IsAbsent()
+    {
+        // Arrange
+        SenderDomain.TryCreate("partner.test", out var signer);
+
+        // Act
+        var authentication = SenderAuthentication.Authenticated(
+            signer,
+            spfDomain: null,
+            fromDomain: null,
+            DmarcOutcome.Pass);
+
+        // Assert
+        Assert.Null(authentication.AuthenticatedAuthorDomain);
+    }
 }

--- a/tests/Domain.UnitTests/Emails/Authentication/SenderAuthenticationTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/SenderAuthenticationTests.cs
@@ -78,11 +78,20 @@ public sealed class SenderAuthenticationTests
         Assert.Equal(displayed, authentication.AuthenticatedAuthorDomain);
     }
 
-    /// <summary>Without DMARC, an identity that authenticated as the displayed domain establishes the author.</summary>
+    /// <summary>Where DMARC decided nothing, an identity that authenticated as the displayed domain establishes the author.</summary>
+    /// <remarks>
+    /// Both results that decided nothing are covered, because they are different facts about the receiving server: one
+    /// evaluation never ran and the other ran and found no policy to apply. Neither is a statement about the author, so
+    /// neither may close the route that most mail actually arrives by.
+    /// </remarks>
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void AuthenticatedAuthorDomain_IdentityEqualToTheDisplayedDomain_IsThatDomain(bool throughDkim)
+    [InlineData(true, DmarcOutcome.NotReported)]
+    [InlineData(false, DmarcOutcome.NotReported)]
+    [InlineData(true, DmarcOutcome.NoPolicyPublished)]
+    [InlineData(false, DmarcOutcome.NoPolicyPublished)]
+    public void AuthenticatedAuthorDomain_IdentityEqualToTheDisplayedDomain_IsThatDomain(
+        bool throughDkim,
+        DmarcOutcome dmarc)
     {
         // Arrange
         SenderDomain.TryCreate("partner.test", out var displayed);
@@ -93,10 +102,36 @@ public sealed class SenderAuthenticationTests
             throughDkim ? displayed : relay,
             throughDkim ? null : displayed,
             displayed,
-            DmarcOutcome.NotReported);
+            dmarc);
 
         // Assert
         Assert.Equal(displayed, authentication.AuthenticatedAuthorDomain);
+    }
+
+    /// <summary>A DMARC failure ends the question, so an identity equal to the displayed domain does not reopen it.</summary>
+    /// <remarks>
+    /// The receiving server reached that result with the displayed domain's own published policy in hand, which is more
+    /// than an identity comparison made here has. Treating the comparison as the stronger of the two would let a message
+    /// the author's own domain disowned establish that author.
+    /// </remarks>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void AuthenticatedAuthorDomain_IdentityEqualToTheDisplayedDomainButDmarcFailed_IsAbsent(bool throughDkim)
+    {
+        // Arrange
+        SenderDomain.TryCreate("partner.test", out var displayed);
+        SenderDomain.TryCreate("relay.test", out var relay);
+
+        // Act
+        var authentication = SenderAuthentication.Authenticated(
+            throughDkim ? displayed : relay,
+            throughDkim ? null : displayed,
+            displayed,
+            DmarcOutcome.Fail);
+
+        // Assert
+        Assert.Null(authentication.AuthenticatedAuthorDomain);
     }
 
     /// <summary>An identity belonging to somebody other than the displayed author establishes no author at all.</summary>

--- a/tests/Domain.UnitTests/Emails/Authentication/SenderDomainTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/SenderDomainTests.cs
@@ -86,6 +86,67 @@ public sealed class SenderDomainTests
         Assert.False(created);
     }
 
+    /// <summary>One internationalized name written in two encodings is one name, which is what a list has to match on.</summary>
+    [Theory]
+    [InlineData("bücher.example")]
+    [InlineData("BÜCHER.example")]
+    [InlineData("xn--bcher-kva.example")]
+    [InlineData("XN--BCHER-KVA.EXAMPLE")]
+    public void TryCreate_InternationalizedDomainInEitherEncoding_ProducesOneComparisonForm(string written)
+    {
+        // Act
+        var created = SenderDomain.TryCreate(written, out var domain);
+
+        // Assert
+        Assert.True(created);
+        Assert.Equal("XN--BCHER-KVA.EXAMPLE", domain.NormalizedValue);
+    }
+
+    /// <summary>The written form survives the conversion, because only the comparison form is meant to be an encoding.</summary>
+    [Fact]
+    public void TryCreate_InternationalizedDomain_KeepsWhatTheSourceWrote()
+    {
+        // Act
+        SenderDomain.TryCreate("bücher.example", out var domain);
+
+        // Assert
+        Assert.Equal("bücher.example", domain.Value);
+    }
+
+    /// <summary>A name no encoder can put into A-labels matches nothing, so it is refused rather than compared as it arrived.</summary>
+    [Fact]
+    public void TryCreate_DomainNoEncoderAccepts_IsRefused()
+    {
+        // Act
+        var created = SenderDomain.TryCreate("͸.example", out _);
+
+        // Assert
+        Assert.False(created);
+    }
+
+    /// <summary>Only a strictly lower name is beneath a domain, and a shared suffix of characters is not one.</summary>
+    [Theory]
+    [InlineData("mail.example.test", "example.test", true)]
+    [InlineData("a.b.example.test", "example.test", true)]
+    [InlineData("example.test", "example.test", false)]
+    [InlineData("notexample.test", "example.test", false)]
+    [InlineData("example.test", "mail.example.test", false)]
+    public void IsSubdomainOf_NameAndCandidateAncestor_AnswersOnWholeLabels(
+        string candidate,
+        string ancestor,
+        bool expected)
+    {
+        // Arrange
+        SenderDomain.TryCreate(candidate, out var descendant);
+        SenderDomain.TryCreate(ancestor, out var parent);
+
+        // Act
+        var isBeneath = descendant.IsSubdomainOf(parent);
+
+        // Assert
+        Assert.Equal(expected, isBeneath);
+    }
+
     /// <summary>An SPF identity is written as a mailbox, and the domain is what follows the last at-sign.</summary>
     [Theory]
     [InlineData("bounce@relay.test", "RELAY.TEST")]

--- a/tests/Domain.UnitTests/Emails/Authentication/SenderDomainTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/SenderDomainTests.cs
@@ -113,6 +113,26 @@ public sealed class SenderDomainTests
         Assert.Equal("bücher.example", domain.Value);
     }
 
+    /// <summary>A name within the resolver limits in its own script can leave them once encoded, and is refused there.</summary>
+    /// <remarks>
+    /// This is why the bounds are applied to both forms rather than only to what a header wrote: A-labels are the
+    /// longer encoding, and they are what a column and a resolver actually have to hold. Every label here stays inside
+    /// the label limit in both forms, so what refuses the name is the whole encoded name's length and nothing else.
+    /// </remarks>
+    [Fact]
+    public void TryCreate_DomainWithinTheLimitsUntilItIsEncoded_IsRefused()
+    {
+        // Arrange
+        var written = string.Join('.', Enumerable.Repeat(string.Concat(Enumerable.Repeat("ąćęłńóśźż", 3)), 8));
+
+        // Act
+        var created = SenderDomain.TryCreate(written, out _);
+
+        // Assert
+        Assert.True(written.Length <= SenderDomain.MaximumLength);
+        Assert.False(created);
+    }
+
     /// <summary>A name no encoder can put into A-labels matches nothing, so it is refused rather than compared as it arrived.</summary>
     [Fact]
     public void TryCreate_DomainNoEncoderAccepts_IsRefused()

--- a/tests/Domain.UnitTests/Emails/Authentication/SenderTrustPolicyTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/SenderTrustPolicyTests.cs
@@ -1,0 +1,362 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Emails.Authentication;
+
+/// <summary>Covers which authors one account recognizes, which half recognized them, and what the answer is stored with.</summary>
+public sealed class SenderTrustPolicyTests
+{
+    /// <summary>Mail one of this deployment's own accounts wrote is recognized wherever it was delivered.</summary>
+    [Fact]
+    public void Evaluate_AuthorAtAnotherConfiguredAccountsDomain_IsRecognizedAsOwn()
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create(
+            [DomainOf("work.example"), DomainOf("personal.example")],
+            configuredTrustedSenders: [],
+            storedTrustedSenders: []);
+
+        // Act
+        var trust = policy.Evaluate(WrittenBy("work.example"), AddressOf("owner@work.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, trust.Level);
+        Assert.Equal(SenderTrustSource.OwnAccountDomain, trust.GrantedBy);
+    }
+
+    /// <summary>A deployment whose accounts share a provider with everybody says so by supplying no own domains.</summary>
+    [Fact]
+    public void Evaluate_OwnDomainsWithheld_LeavesTheSameAuthorUnknown()
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create(
+            ownAccountDomains: [],
+            configuredTrustedSenders: [],
+            storedTrustedSenders: []);
+
+        // Act
+        var trust = policy.Evaluate(WrittenBy("work.example"), AddressOf("owner@work.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+        Assert.Equal(SenderTrustSource.None, trust.GrantedBy);
+    }
+
+    /// <summary>An own domain is the account's own name and never the names beneath it.</summary>
+    [Fact]
+    public void Evaluate_SubdomainOfAnOwnDomain_IsNotRecognizedAsOwn()
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create([DomainOf("work.example")], [], []);
+
+        // Act
+        var trust = policy.Evaluate(WrittenBy("mail.work.example"), displayedSender: null);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+    }
+
+    /// <summary>An entry in either half recognizes, and the half that did is what the verdict reports.</summary>
+    [Theory]
+    [InlineData(true, false, SenderTrustSource.ConfiguredTrustedSender)]
+    [InlineData(false, true, SenderTrustSource.StoredTrustedSender)]
+    [InlineData(true, true, SenderTrustSource.ConfiguredTrustedSender)]
+    public void Evaluate_EntryInEitherHalf_RecognizesAndNamesTheHalf(
+        bool configured,
+        bool stored,
+        SenderTrustSource expected)
+    {
+        // Arrange
+        var entry = DomainEntry("partner.example", includeSubdomains: false);
+        var policy = SenderTrustPolicy.Create(
+            ownAccountDomains: [],
+            configured ? [entry] : [],
+            stored ? [entry] : []);
+
+        // Act
+        var trust = policy.Evaluate(WrittenBy("partner.example"), displayedSender: null);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, trust.Level);
+        Assert.Equal(expected, trust.GrantedBy);
+    }
+
+    /// <summary>A displayed author nothing established is never held against the list, however the list names them.</summary>
+    /// <remarks>
+    /// This is the forgery the whole design is arranged against: anybody can write a trusted correspondent's address
+    /// into <c>From</c>, so an entry naming that correspondent must recognize nothing until something other than the
+    /// header says the message really came from them.
+    /// </remarks>
+    [Theory]
+    [InlineData(DmarcOutcome.Fail)]
+    [InlineData(DmarcOutcome.NotReported)]
+    public void Evaluate_TrustedAuthorDisplayedButAuthenticationFailed_LeavesTheMessageUnknown(DmarcOutcome dmarc)
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create(
+            ownAccountDomains: [],
+            [DomainEntry("partner.example", includeSubdomains: false)],
+            storedTrustedSenders: []);
+
+        // Act
+        var trust = policy.Evaluate(
+            SenderAuthentication.Failed(DomainOf("partner.example"), dmarc),
+            AddressOf("alice@partner.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+        Assert.Equal(SenderTrustSource.None, trust.GrantedBy);
+    }
+
+    /// <summary>A recognized signer cannot vouch for an author it is not, which is what an allow-listed relay would be.</summary>
+    /// <remarks>
+    /// The message really was signed by a domain the account named, and the domain it displays as its author is not
+    /// that one. Anything reading the authenticated identity here would recognize every message the signer ever relays,
+    /// whoever it says wrote them.
+    /// </remarks>
+    [Theory]
+    [InlineData(DmarcOutcome.Fail)]
+    [InlineData(DmarcOutcome.NotReported)]
+    public void Evaluate_TrustedThirdPartySignatureOverAnotherAuthor_LeavesTheMessageUnknown(DmarcOutcome dmarc)
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create(
+            ownAccountDomains: [],
+            [DomainEntry("relay.example", includeSubdomains: false)],
+            storedTrustedSenders: []);
+
+        // Act
+        var trust = policy.Evaluate(
+            SenderAuthentication.Authenticated(
+                DomainOf("relay.example"),
+                spfDomain: null,
+                DomainOf("bank.example"),
+                dmarc),
+            AddressOf("security@bank.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+        Assert.Equal(SenderTrustSource.None, trust.GrantedBy);
+    }
+
+    /// <summary>The receiving server's own DMARC result establishes the displayed author whatever signed the message.</summary>
+    [Fact]
+    public void Evaluate_TrustedAuthorEstablishedByDmarcAlone_RecognizesTheAuthor()
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create(
+            ownAccountDomains: [],
+            [DomainEntry("partner.example", includeSubdomains: false)],
+            storedTrustedSenders: []);
+
+        // Act
+        var trust = policy.Evaluate(
+            SenderAuthentication.Authenticated(
+                DomainOf("provider.example"),
+                spfDomain: null,
+                DomainOf("partner.example"),
+                DmarcOutcome.Pass),
+            AddressOf("alice@partner.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, trust.Level);
+    }
+
+    /// <summary>Without DMARC, an identity that authenticated as the displayed author establishes them all the same.</summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Evaluate_IdentityMatchingTheDisplayedAuthorWithoutDmarc_RecognizesTheAuthor(bool throughDkim)
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create(
+            ownAccountDomains: [],
+            [DomainEntry("partner.example", includeSubdomains: false)],
+            storedTrustedSenders: []);
+
+        // Act
+        var trust = policy.Evaluate(
+            SenderAuthentication.Authenticated(
+                throughDkim ? DomainOf("partner.example") : DomainOf("relay.example"),
+                throughDkim ? null : DomainOf("partner.example"),
+                DomainOf("partner.example"),
+                DmarcOutcome.NotReported),
+            AddressOf("alice@partner.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, trust.Level);
+    }
+
+    /// <summary>A message whose author was authenticated and whom nobody named is the ordinary answer.</summary>
+    [Fact]
+    public void Evaluate_AuthenticatedAuthorNobodyNamed_LeavesTheMessageUnknown()
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create(
+            [DomainOf("work.example")],
+            [DomainEntry("partner.example", includeSubdomains: false)],
+            storedTrustedSenders: []);
+
+        // Act
+        var trust = policy.Evaluate(WrittenBy("stranger.example"), AddressOf("someone@stranger.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+        Assert.Equal(SenderTrustSource.None, trust.GrantedBy);
+    }
+
+    /// <summary>A message nothing was established about is judged against no list at all.</summary>
+    [Fact]
+    public void Evaluate_NothingEstablished_LeavesTheMessageUnknown()
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create([DomainOf("work.example")], [], []);
+
+        // Act
+        var trust = policy.Evaluate(
+            SenderAuthentication.NotEstablished(DomainOf("work.example")),
+            AddressOf("owner@work.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+        Assert.Equal(SenderTrustSource.None, trust.GrantedBy);
+    }
+
+    /// <summary>A message displaying no usable author has nobody to recognize, whatever else authenticated.</summary>
+    [Fact]
+    public void Evaluate_NoDisplayedAuthorDomain_LeavesTheMessageUnknown()
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create(
+            ownAccountDomains: [],
+            [DomainEntry("partner.example", includeSubdomains: false)],
+            storedTrustedSenders: []);
+
+        // Act
+        var trust = policy.Evaluate(
+            SenderAuthentication.Authenticated(
+                DomainOf("partner.example"),
+                spfDomain: null,
+                fromDomain: null,
+                DmarcOutcome.Pass),
+            displayedSender: null);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+    }
+
+    /// <summary>An entry written in one encoding of an internationalized name recognizes the other one a message carried.</summary>
+    [Fact]
+    public void Evaluate_InternationalizedEntryAndAsciiVerdict_RecognizesOneName()
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create(
+            ownAccountDomains: [],
+            [DomainEntry("bücher.example", includeSubdomains: false)],
+            storedTrustedSenders: []);
+
+        // Act
+        var trust = policy.Evaluate(WrittenBy("xn--bcher-kva.example"), displayedSender: null);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, trust.Level);
+    }
+
+    /// <summary>Every verdict carries the list it was reached under, so a later change to that list is legible.</summary>
+    [Fact]
+    public void Evaluate_AnyMessage_CarriesTheRevisionOfThePolicyThatJudgedIt()
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create([DomainOf("work.example")], [], []);
+
+        // Act
+        var recognized = policy.Evaluate(WrittenBy("work.example"), displayedSender: null);
+        var unrecognized = policy.Evaluate(WrittenBy("stranger.example"), displayedSender: null);
+
+        // Assert
+        Assert.True(policy.Revision.NamesAPolicy);
+        Assert.Equal(policy.Revision, recognized.PolicyRevision);
+        Assert.Equal(policy.Revision, unrecognized.PolicyRevision);
+    }
+
+    /// <summary>Reordering a list is not a change to it, and adding to either half is.</summary>
+    [Fact]
+    public void Revision_ListsThatSayTheSameThing_AreOneRevision()
+    {
+        // Arrange
+        var first = DomainEntry("a.example", includeSubdomains: false);
+        var second = DomainEntry("b.example", includeSubdomains: true);
+
+        // Act
+        var written = SenderTrustPolicy.Create([], [first, second], []).Revision;
+        var reordered = SenderTrustPolicy.Create([], [second, first], []).Revision;
+        var moved = SenderTrustPolicy.Create([], [first], [second]).Revision;
+        var extended = SenderTrustPolicy.Create([], [first, second], [DomainEntry("c.example", false)]).Revision;
+
+        // Assert
+        Assert.Equal(written, reordered);
+        Assert.NotEqual(written, moved);
+        Assert.NotEqual(written, extended);
+    }
+
+    /// <summary>A deployment that recognizes nobody names no policy, so its verdicts read as judged by nothing.</summary>
+    [Fact]
+    public void Revision_PolicyWithNothingToSay_NamesNoPolicy()
+    {
+        // Act
+        var revision = SenderTrustPolicy.RecognizingNobody.Revision;
+
+        // Assert
+        Assert.False(revision.NamesAPolicy);
+        Assert.Equal(SenderTrustPolicyRevision.None, revision);
+    }
+
+    /// <summary>An account this deployment no longer serves recognizes nobody rather than failing.</summary>
+    [Fact]
+    public void Evaluate_PolicyRecognizingNobody_LeavesEveryAuthorUnknown()
+    {
+        // Act
+        var trust = SenderTrustPolicy.RecognizingNobody.Evaluate(
+            WrittenBy("partner.example"),
+            AddressOf("alice@partner.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+        Assert.False(trust.PolicyRevision.NamesAPolicy);
+    }
+
+    /// <summary>Builds the verdict of a message whose displayed author the receiving server established.</summary>
+    private static SenderAuthentication WrittenBy(string domain) =>
+        SenderAuthentication.Authenticated(
+            DomainOf(domain),
+            spfDomain: null,
+            DomainOf(domain),
+            DmarcOutcome.Pass);
+
+    private static TrustedSenderEntry DomainEntry(string domain, bool includeSubdomains)
+    {
+        Assert.True(TrustedSenderEntry.TryCreateForDomain(domain, includeSubdomains, out var entry));
+        Assert.NotNull(entry);
+
+        return entry;
+    }
+
+    private static SenderDomain DomainOf(string written)
+    {
+        Assert.True(SenderDomain.TryCreate(written, out var domain));
+
+        return domain;
+    }
+
+    private static EmailAddress AddressOf(string written)
+    {
+        Assert.True(EmailAddress.TryCreate(displayName: null, written, out var address));
+
+        return address;
+    }
+}

--- a/tests/Domain.UnitTests/Emails/Authentication/SenderTrustTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/SenderTrustTests.cs
@@ -1,0 +1,68 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails.Authentication;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Emails.Authentication;
+
+/// <summary>Covers the shape of the verdict itself, and the revision that says which list produced one.</summary>
+public sealed class SenderTrustTests
+{
+    /// <summary>A reading no policy has spoken over claims nothing and says that no policy reached it.</summary>
+    [Fact]
+    public void NotEvaluated_BeforeAPolicyRuns_IsUnknownAndNamesNoPolicy()
+    {
+        // Act
+        var trust = SenderTrust.NotEvaluated;
+
+        // Assert
+        Assert.False(trust.IsTrusted);
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+        Assert.Equal(SenderTrustSource.None, trust.GrantedBy);
+        Assert.False(trust.PolicyRevision.NamesAPolicy);
+    }
+
+    /// <summary>A verdict that recognized an author says what recognized them, so it cannot be reached by nothing.</summary>
+    [Fact]
+    public void Trusted_WithoutNamingWhatRecognizedTheAuthor_IsRefused()
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentException>(() => SenderTrust.Trusted(
+            SenderTrustSource.None,
+            SenderTrustPolicyRevision.None));
+
+        // Assert
+        Assert.Equal("grantedBy", refusal.ParamName);
+    }
+
+    /// <summary>The same list always names itself the same way, including in another process.</summary>
+    [Fact]
+    public void Of_TheSameStatements_ProducesTheSameRevision()
+    {
+        // Act
+        var first = SenderTrustPolicyRevision.Of(["domain:A.EXAMPLE", "domain:B.EXAMPLE"]);
+        var second = SenderTrustPolicyRevision.Of(["domain:B.EXAMPLE", "domain:A.EXAMPLE"]);
+
+        // Assert
+        Assert.Equal(first, second);
+        Assert.Equal(SenderTrustPolicyRevision.Length, first.Value.Length);
+        Assert.Equal(first.Value, first.ToString());
+    }
+
+    /// <summary>A stored revision is opaque, so reading one back neither re-derives nor re-checks it.</summary>
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    [InlineData("   ", false)]
+    [InlineData("0123456789abcdef0123456789abcdef", true)]
+    public void FromStoredValue_WhatAColumnHeld_NamesAPolicyOnlyWhenTheColumnDid(string? stored, bool expected)
+    {
+        // Act
+        var revision = SenderTrustPolicyRevision.FromStoredValue(stored);
+
+        // Assert
+        Assert.Equal(expected, revision.NamesAPolicy);
+    }
+}

--- a/tests/Domain.UnitTests/Emails/Authentication/TrustedSenderEntryTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/TrustedSenderEntryTests.cs
@@ -1,0 +1,186 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Emails.Authentication;
+
+/// <summary>Covers what one entry of a trusted-sender list recognizes, and what it deliberately does not.</summary>
+public sealed class TrustedSenderEntryTests
+{
+    /// <summary>A domain entry recognizes exactly the domain it names.</summary>
+    [Theory]
+    [InlineData("partner.example", true)]
+    [InlineData("Partner.Example", true)]
+    [InlineData("mail.partner.example", false)]
+    [InlineData("otherpartner.example", false)]
+    public void Matches_DomainEntryWithoutSubdomains_RecognizesThatDomainAlone(string authenticated, bool expected)
+    {
+        // Arrange
+        var entry = DomainEntry("partner.example", includeSubdomains: false);
+
+        // Act
+        var recognized = entry.Matches(DomainOf(authenticated), displayedSender: null);
+
+        // Assert
+        Assert.Equal(expected, recognized);
+    }
+
+    /// <summary>The opt-in is what reaches under a domain, and it reaches the domain itself as well.</summary>
+    [Theory]
+    [InlineData("partner.example", true)]
+    [InlineData("mail.partner.example", true)]
+    [InlineData("a.b.partner.example", true)]
+    [InlineData("otherpartner.example", false)]
+    public void Matches_DomainEntryIncludingSubdomains_RecognizesTheWholeBranch(string authenticated, bool expected)
+    {
+        // Arrange
+        var entry = DomainEntry("partner.example", includeSubdomains: true);
+
+        // Act
+        var recognized = entry.Matches(DomainOf(authenticated), displayedSender: null);
+
+        // Assert
+        Assert.Equal(expected, recognized);
+    }
+
+    /// <summary>An address entry reads the local part from the header the authenticated domain answers for.</summary>
+    [Fact]
+    public void Matches_AddressEntryAndTheDisplayedSenderItNames_RecognizesTheSender()
+    {
+        // Arrange
+        var entry = AddressEntry("alice@partner.example");
+
+        // Act
+        var recognized = entry.Matches(DomainOf("partner.example"), AddressOf("Alice@Partner.Example"));
+
+        // Assert
+        Assert.True(recognized);
+    }
+
+    /// <summary>A verdict that names only a domain recognizes nobody through an address entry, whatever the domain is.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("bob@partner.example")]
+    [InlineData("alice@elsewhere.example")]
+    public void Matches_AddressEntryAgainstADomainOnlyVerdict_RecognizesNobody(string? displayed)
+    {
+        // Arrange
+        var entry = AddressEntry("alice@partner.example");
+
+        // Act
+        var recognized = entry.Matches(DomainOf("partner.example"), displayed is null ? null : AddressOf(displayed));
+
+        // Assert
+        Assert.False(recognized);
+    }
+
+    /// <summary>An address entry never reaches beneath its own domain, because a mailbox has nothing beneath it.</summary>
+    [Fact]
+    public void Matches_AddressEntryAgainstASubdomain_RecognizesNobody()
+    {
+        // Arrange
+        var entry = AddressEntry("alice@partner.example");
+
+        // Act
+        var recognized = entry.Matches(DomainOf("mail.partner.example"), AddressOf("alice@mail.partner.example"));
+
+        // Assert
+        Assert.False(recognized);
+    }
+
+    /// <summary>An entry written in one encoding of an internationalized name recognizes mail that carried the other.</summary>
+    [Fact]
+    public void Matches_DomainEntryWrittenInUnicode_RecognizesTheAsciiFormAMessageCarried()
+    {
+        // Arrange
+        var entry = DomainEntry("bücher.example", includeSubdomains: false);
+
+        // Act
+        var recognized = entry.Matches(DomainOf("xn--bcher-kva.example"), displayedSender: null);
+
+        // Assert
+        Assert.True(recognized);
+    }
+
+    /// <summary>Text nothing can compare on names no sender, so no entry is built from it.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("part ner.example")]
+    [InlineData("alice@partner.example")]
+    public void TryCreateForDomain_UnusableText_IsRefused(string? written)
+    {
+        // Act
+        var created = TrustedSenderEntry.TryCreateForDomain(written, includeSubdomains: false, out _);
+
+        // Assert
+        Assert.False(created);
+    }
+
+    /// <summary>An address entry needs a mailbox, and a bare domain is not one.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("partner.example")]
+    [InlineData("alice@")]
+    [InlineData("@partner.example")]
+    [InlineData("alice@partner..example")]
+    public void TryCreateForAddress_UnusableText_IsRefused(string? written)
+    {
+        // Act
+        var created = TrustedSenderEntry.TryCreateForAddress(written, out _);
+
+        // Assert
+        Assert.False(created);
+    }
+
+    /// <summary>Two entries that recognize different senders write different lines, so a change to the list is never invisible.</summary>
+    [Fact]
+    public void ToPolicyStatement_EntriesRecognizingDifferentSenders_AreDistinguishable()
+    {
+        // Arrange
+        var exact = DomainEntry("partner.example", includeSubdomains: false);
+        var branch = DomainEntry("partner.example", includeSubdomains: true);
+        var mailbox = AddressEntry("alice@partner.example");
+
+        // Act
+        var statements = new[] { exact, branch, mailbox }.Select(entry => entry.ToPolicyStatement()).ToArray();
+
+        // Assert
+        Assert.Equal(statements.Length, statements.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    private static TrustedSenderEntry DomainEntry(string domain, bool includeSubdomains)
+    {
+        Assert.True(TrustedSenderEntry.TryCreateForDomain(domain, includeSubdomains, out var entry));
+        Assert.NotNull(entry);
+
+        return entry;
+    }
+
+    private static TrustedSenderEntry AddressEntry(string address)
+    {
+        Assert.True(TrustedSenderEntry.TryCreateForAddress(address, out var entry));
+        Assert.NotNull(entry);
+
+        return entry;
+    }
+
+    private static SenderDomain DomainOf(string written)
+    {
+        Assert.True(SenderDomain.TryCreate(written, out var domain));
+
+        return domain;
+    }
+
+    private static EmailAddress AddressOf(string written)
+    {
+        Assert.True(EmailAddress.TryCreate(displayName: null, written, out var address));
+
+        return address;
+    }
+}

--- a/tests/Host.UnitTests/Configuration/Mail/SenderTrustPolicyConfigurationTests.cs
+++ b/tests/Host.UnitTests/Configuration/Mail/SenderTrustPolicyConfigurationTests.cs
@@ -1,0 +1,232 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
+using MailFathom.Host.Configuration.Mail;
+using MailFathom.Infrastructure.Mail;
+using MailFathom.Infrastructure.Secrets.Discovery;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Configuration.Mail;
+
+/// <summary>Covers which authors configuration says an account recognizes, and what an unusable entry costs.</summary>
+public sealed class SenderTrustPolicyConfigurationTests
+{
+    /// <summary>An instance synchronizing two mailboxes is synchronizing one person's correspondence.</summary>
+    [Fact]
+    public void GetTrustPolicy_MailFromOneConfiguredAccountToAnother_IsRecognized()
+    {
+        // Arrange
+        var options = OptionsFor(
+            AccountAt("work", "owner@work.example"),
+            AccountAt("personal", "owner@personal.example"));
+
+        // Act
+        var trust = options
+            .GetTrustPolicy(MailAccountId.Create("personal"))
+            .Evaluate(WrittenBy("work.example"), AddressOf("owner@work.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, trust.Level);
+        Assert.Equal(SenderTrustSource.OwnAccountDomain, trust.GrantedBy);
+    }
+
+    /// <summary>A deployment whose accounts sit on a shared provider turns the set off, and the same mail is unrecognized.</summary>
+    [Fact]
+    public void GetTrustPolicy_OwnAccountDomainsTurnedOff_LeavesTheSameMailUnrecognized()
+    {
+        // Arrange
+        var options = OptionsFor(
+            AccountAt("work", "owner@work.example"),
+            AccountAt("personal", "owner@personal.example"));
+        options.TrustOwnAccountDomains = false;
+
+        // Act
+        var trust = options
+            .GetTrustPolicy(MailAccountId.Create("personal"))
+            .Evaluate(WrittenBy("work.example"), AddressOf("owner@work.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+    }
+
+    /// <summary>An IMAP user name that is a bare login names no mail domain, so the account contributes none.</summary>
+    [Fact]
+    public void GetTrustPolicy_AccountWhoseUserNameIsALogin_ContributesNoOwnDomain()
+    {
+        // Arrange
+        var options = OptionsFor(AccountAt("work", "mailfathom"));
+
+        // Act
+        var trust = options
+            .GetTrustPolicy(MailAccountId.Create("work"))
+            .Evaluate(WrittenBy("work.example"), AddressOf("owner@work.example"));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, trust.Level);
+    }
+
+    /// <summary>The list is per account, so recognizing a counterparty on one mailbox recognizes them on that one alone.</summary>
+    [Fact]
+    public void GetTrustPolicy_AnEntryOnOneAccount_DoesNotReachAnother()
+    {
+        // Arrange
+        var work = AccountAt("work", "owner@work.example");
+        work.TrustedSenders = [new TrustedSenderOptions { Domain = "partner.example" }];
+        var options = OptionsFor(work, AccountAt("personal", "owner@personal.example"));
+
+        // Act
+        var onWork = options
+            .GetTrustPolicy(MailAccountId.Create("work"))
+            .Evaluate(WrittenBy("partner.example"), displayedSender: null);
+        var onPersonal = options
+            .GetTrustPolicy(MailAccountId.Create("personal"))
+            .Evaluate(WrittenBy("partner.example"), displayedSender: null);
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, onWork.Level);
+        Assert.Equal(SenderTrustSource.ConfiguredTrustedSender, onWork.GrantedBy);
+        Assert.Equal(SenderTrustLevel.Unknown, onPersonal.Level);
+    }
+
+    /// <summary>Reaching under a domain is asked for per entry, so an entry that did not ask does not reach.</summary>
+    [Theory]
+    [InlineData(false, SenderTrustLevel.Unknown)]
+    [InlineData(true, SenderTrustLevel.Trusted)]
+    public void GetTrustPolicy_SubdomainOfAConfiguredDomain_FollowsWhatTheEntryAskedFor(
+        bool includeSubdomains,
+        SenderTrustLevel expected)
+    {
+        // Arrange
+        var account = AccountAt("work", "owner@work.example");
+        account.TrustedSenders =
+            [new TrustedSenderOptions { Domain = "partner.example", IncludeSubdomains = includeSubdomains }];
+
+        // Act
+        var trust = OptionsFor(account)
+            .GetTrustPolicy(MailAccountId.Create("work"))
+            .Evaluate(WrittenBy("mail.partner.example"), displayedSender: null);
+
+        // Assert
+        Assert.Equal(expected, trust.Level);
+    }
+
+    /// <summary>An extraction may run over an account a reload removed, and recognizing nobody is the answer.</summary>
+    [Fact]
+    public void GetTrustPolicy_AccountThisSnapshotNoLongerNames_RecognizesNobody()
+    {
+        // Act
+        var policy = OptionsFor(AccountAt("work", "owner@work.example"))
+            .GetTrustPolicy(MailAccountId.Create("removed"));
+
+        // Assert
+        Assert.Same(SenderTrustPolicy.RecognizingNobody, policy);
+    }
+
+    /// <summary>An entry nothing could read fails startup, because it is indistinguishable from a list nobody wrote.</summary>
+    [Theory]
+    [InlineData(null, null, false)]
+    [InlineData("partner.example", "alice@partner.example", false)]
+    [InlineData("part ner.example", null, false)]
+    [InlineData(null, "not-an-address", false)]
+    [InlineData(null, "alice@partner.example", true)]
+    public void ValidateForSynchronization_TrustedSenderEntry_IsRefusedWhenItDoesNotNameExactlyOneSender(
+        string? domain,
+        string? address,
+        bool includeSubdomains)
+    {
+        // Arrange
+        var account = AccountAt("work", "owner@work.example");
+        account.TrustedSenders =
+            [new TrustedSenderOptions { Domain = domain, Address = address, IncludeSubdomains = includeSubdomains }];
+
+        // Act
+        var messages = OptionsFor(account)
+            .ValidateForSynchronization()
+            .Select(result => result.ErrorMessage)
+            .ToArray();
+
+        // Assert
+        Assert.Contains(messages, message => message!.Contains("trusted sender 0", StringComparison.Ordinal));
+    }
+
+    /// <summary>The refusal names the account and the entry's position, never the domain or the address it holds.</summary>
+    [Fact]
+    public void ValidateForSynchronization_UnusableTrustedSender_DoesNotEchoTheValue()
+    {
+        // Arrange
+        var account = AccountAt("work", "owner@work.example");
+        account.TrustedSenders =
+        [
+            new TrustedSenderOptions { Domain = "partner.example" },
+            new TrustedSenderOptions { Domain = "secret partner.example" },
+        ];
+
+        // Act
+        var refusal = Assert.Single(
+            OptionsFor(account).ValidateForSynchronization().Select(result => result.ErrorMessage),
+            message => message!.Contains("trusted sender", StringComparison.Ordinal));
+
+        // Assert
+        Assert.Contains("trusted sender 1", refusal, StringComparison.Ordinal);
+        Assert.Contains("work", refusal, StringComparison.Ordinal);
+        Assert.DoesNotContain("partner.example", refusal, StringComparison.Ordinal);
+    }
+
+    /// <summary>A usable list is not a mistake, so it produces no startup refusal.</summary>
+    [Fact]
+    public void ValidateForSynchronization_UsableTrustedSenders_AreAccepted()
+    {
+        // Arrange
+        var account = AccountAt("work", "owner@work.example");
+        account.TrustedSenders =
+        [
+            new TrustedSenderOptions { Domain = "partner.example", IncludeSubdomains = true },
+            new TrustedSenderOptions { Address = "alice@elsewhere.example" },
+        ];
+
+        // Act
+        var messages = OptionsFor(account)
+            .ValidateForSynchronization()
+            .Select(result => result.ErrorMessage)
+            .ToArray();
+
+        // Assert
+        Assert.DoesNotContain(messages, message => message!.Contains("trusted sender", StringComparison.Ordinal));
+    }
+
+    /// <summary>Builds the verdict of a message whose displayed author the receiving server established.</summary>
+    private static SenderAuthentication WrittenBy(string domain)
+    {
+        Assert.True(SenderDomain.TryCreate(domain, out var author));
+
+        return SenderAuthentication.Authenticated(author, spfDomain: null, author, DmarcOutcome.Pass);
+    }
+
+    private static EmailAddress AddressOf(string written)
+    {
+        Assert.True(EmailAddress.TryCreate(displayName: null, written, out var address));
+
+        return address;
+    }
+
+    private static MailSynchronizationOptions OptionsFor(params MailSynchronizationAccountOptions[] accounts) => new()
+    {
+        Accounts = [.. accounts],
+    };
+
+    private static MailSynchronizationAccountOptions AccountAt(string accountId, string userName) => new()
+    {
+        AccountId = accountId,
+        DisplayName = $"Account {accountId}",
+        Host = "imap.example.test",
+        UserName = userName,
+        Secrets = new MailAccountSecretOptions
+        {
+            Password = new ConfiguredSecret { SecretReference = $"systemd-credential:imap-{accountId}-password" },
+        },
+    };
+}

--- a/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailMetadataMappingTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailMetadataMappingTests.cs
@@ -400,6 +400,69 @@ public sealed class StoredEmailMetadataMappingTests
         Assert.Equal(SenderDomainAlignment.NotAssessed, entity.SenderDomainAlignment);
     }
 
+    /// <summary>What this deployment made of the author reaches its own columns beside the identity it judged.</summary>
+    [Fact]
+    public void ApplyExtractedMetadata_RecognizedAuthor_RecordsTheVerdictAndThePolicyThatReachedIt()
+    {
+        // Arrange
+        var entity = CreateEntity();
+        var revision = SenderTrustPolicyRevision.Of(["domain:PARTNER.EXAMPLE"]);
+
+        // Act
+        StoredEmailMetadataMapping.ApplyExtractedMetadata(
+            entity,
+            CreateExtractedMetadata(
+                senderTrust: SenderTrust.Trusted(
+                    SenderTrustSource.ConfiguredTrustedSender,
+                    revision)));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Trusted, entity.SenderTrustLevel);
+        Assert.Equal(SenderTrustSource.ConfiguredTrustedSender, entity.SenderTrustGrantedBy);
+        Assert.Equal(revision.Value, entity.SenderTrustPolicyRevision);
+    }
+
+    /// <summary>A row no policy judged says so through an absent revision rather than through an empty one.</summary>
+    [Fact]
+    public void ApplyExtractedMetadata_ReadingNoPolicyJudged_LeavesTheRevisionAbsent()
+    {
+        // Arrange
+        var entity = CreateEntity();
+
+        // Act
+        StoredEmailMetadataMapping.ApplyExtractedMetadata(entity, CreateExtractedMetadata());
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, entity.SenderTrustLevel);
+        Assert.Equal(SenderTrustSource.None, entity.SenderTrustGrantedBy);
+        Assert.Null(entity.SenderTrustPolicyRevision);
+    }
+
+    /// <summary>A re-derivation under a narrower list must replace the whole verdict, not leave the half that recognized.</summary>
+    [Fact]
+    public void ApplyExtractedMetadata_UnknownAfterARecognizedReading_ReplacesTheWholeVerdict()
+    {
+        // Arrange
+        var entity = CreateEntity();
+        var narrowed = SenderTrustPolicyRevision.Of(["domain:ELSEWHERE.EXAMPLE"]);
+        StoredEmailMetadataMapping.ApplyExtractedMetadata(
+            entity,
+            CreateExtractedMetadata(
+                senderTrust: SenderTrust.Trusted(
+                    SenderTrustSource.StoredTrustedSender,
+                    SenderTrustPolicyRevision.Of(["domain:PARTNER.EXAMPLE"]))));
+
+        // Act
+        StoredEmailMetadataMapping.ApplyExtractedMetadata(
+            entity,
+            CreateExtractedMetadata(senderTrust: SenderTrust.Unknown(narrowed)));
+
+        // Assert
+        Assert.Equal(SenderTrustLevel.Unknown, entity.SenderTrustLevel);
+        Assert.Equal(SenderTrustSource.None, entity.SenderTrustGrantedBy);
+        Assert.Equal(narrowed.Value, entity.SenderTrustPolicyRevision);
+    }
+
     private static AttachmentFileName FileName(string decodedFileName)
     {
         Assert.True(AttachmentFileName.TryNormalize(decodedFileName, out var fileName));
@@ -419,7 +482,8 @@ public sealed class StoredEmailMetadataMappingTests
         EmailThreadReferences? threadReferences = null,
         EmailAttachmentSummary? attachments = null,
         ExtractedEmailText? text = null,
-        SenderAuthentication? senderAuthentication = null) =>
+        SenderAuthentication? senderAuthentication = null,
+        SenderTrust? senderTrust = null) =>
         new(
             OccurrenceId,
             "Quarterly report",
@@ -429,7 +493,10 @@ public sealed class StoredEmailMetadataMappingTests
             threadReferences ?? EmailThreadReferences.None,
             attachments ?? EmailAttachmentSummary.None,
             text ?? ExtractedEmailText.NoTextualBody,
-            senderAuthentication ?? SenderAuthentication.NotEstablished());
+            senderAuthentication ?? SenderAuthentication.NotEstablished())
+        {
+            SenderTrust = senderTrust ?? SenderTrust.NotEvaluated,
+        };
 
     private static RemoteEmailMetadata CreateRemoteMetadata(string internetMessageId) =>
         new(OccurrenceId, internetMessageId, "Quarterly report", SentAt, SizeOctets: 4096);

--- a/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -332,6 +332,7 @@ public sealed class ServiceCollectionExtensionsTests
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton(new EmailMimeExtractionOptions());
         services.AddSingleton(Substitute.For<ITrustedAuthenticationAuthorityReader>());
+        services.AddSingleton(Substitute.For<ISenderTrustPolicyReader>());
         services.AddSingleton(SensitiveContentPlan.Create(
             SensitiveContentScanBounds.Default,
             [
@@ -365,6 +366,7 @@ public sealed class ServiceCollectionExtensionsTests
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton(new EmailMimeExtractionOptions());
         services.AddSingleton(Substitute.For<ITrustedAuthenticationAuthorityReader>());
+        services.AddSingleton(Substitute.For<ISenderTrustPolicyReader>());
 
         // Act
         services.AddInfrastructure(
@@ -377,6 +379,34 @@ public sealed class ServiceCollectionExtensionsTests
         using var scope = provider.CreateScope();
 
         Assert.IsNotType<RedactingEmailMimeReader>(scope.ServiceProvider.GetRequiredService<IEmailMimeReader>());
+    }
+
+    /// <summary>
+    /// The trust verdict is not a deployment's choice the way redaction is: a deployment that recognizes nobody still
+    /// records that it recognized nobody, which is the answer a reader is later shown. An undecorated reader would
+    /// store the value of a reading no policy judged on mail a policy was in force for.
+    /// </summary>
+    [Fact]
+    public void AddInfrastructure_WithoutAScanner_ResolvesAMimeReaderThatJudgesTheAuthor()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton(new EmailMimeExtractionOptions());
+        services.AddSingleton(Substitute.For<ITrustedAuthenticationAuthorityReader>());
+        services.AddSingleton(Substitute.For<ISenderTrustPolicyReader>());
+
+        // Act
+        services.AddInfrastructure(
+            _ => new PostgresConnectionSettings("Host=localhost;Database=mailfathom", null, null),
+            PostgresTextSearchConfiguration.Default,
+            MailAnsweringBudget.Default);
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        Assert.IsType<SenderTrustEvaluatingEmailMimeReader>(scope.ServiceProvider.GetRequiredService<IEmailMimeReader>());
     }
 
     /// <summary>

--- a/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -424,7 +424,11 @@ public sealed class ServiceCollectionExtensionsTests
     public async Task AddInfrastructure_WithARedactor_ResolvesAMimeReaderThatStillJudgesTheAuthor()
     {
         // Arrange
-        var policy = SenderTrustPolicy.Create([], [], []);
+        // The policy has to recognize somebody, so that its revision is not the one a reading no policy judged carries:
+        // an empty policy digests to None, which is exactly what the undecorated reader would leave behind.
+        Assert.True(TrustedSenderEntry.TryCreateForDomain("partner.example", includeSubdomains: false, out var entry));
+        Assert.NotNull(entry);
+        var policy = SenderTrustPolicy.Create([], [entry], []);
         var policies = Substitute.For<ISenderTrustPolicyReader>();
         policies.GetTrustPolicy(Arg.Any<MailAccountId>()).Returns(policy);
 
@@ -459,6 +463,8 @@ public sealed class ServiceCollectionExtensionsTests
 
         // Assert
         Assert.Equal(EmailMimeExtractionOutcome.Extracted, extraction.Outcome);
+        Assert.True(policy.Revision.NamesAPolicy);
+        Assert.NotEqual(SenderTrust.NotEvaluated.PolicyRevision, extraction.Metadata?.SenderTrust.PolicyRevision);
         Assert.Equal(policy.Revision, extraction.Metadata?.SenderTrust.PolicyRevision);
     }
 

--- a/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
+++ b/tests/Infrastructure.UnitTests/ServiceCollectionExtensionsTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Text;
+using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generation;
 using MailFathom.Application.Emails.Extraction;
@@ -14,6 +16,10 @@ using MailFathom.Application.SensitiveContent;
 using MailFathom.Application.SensitiveContent.Detection;
 using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.SensitiveContent.Redaction;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
+using MailFathom.Domain.Folders;
 using MailFathom.Infrastructure.Persistence;
 using MailFathom.Infrastructure.Persistence.Connections;
 using MailFathom.Infrastructure.Secrets.Resolution;
@@ -408,6 +414,67 @@ public sealed class ServiceCollectionExtensionsTests
 
         Assert.IsType<SenderTrustEvaluatingEmailMimeReader>(scope.ServiceProvider.GetRequiredService<IEmailMimeReader>());
     }
+
+    /// <summary>
+    /// The redactor wraps the judging reader rather than replacing it, and only the composed pipeline's behavior says
+    /// so: the outer type is the same either way. A deployment that configures a scanner would otherwise stop recording
+    /// trust verdicts entirely, and every existing assertion about either decorator would still pass.
+    /// </summary>
+    [Fact]
+    public async Task AddInfrastructure_WithARedactor_ResolvesAMimeReaderThatStillJudgesTheAuthor()
+    {
+        // Arrange
+        var policy = SenderTrustPolicy.Create([], [], []);
+        var policies = Substitute.For<ISenderTrustPolicyReader>();
+        policies.GetTrustPolicy(Arg.Any<MailAccountId>()).Returns(policy);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(TimeProvider.System);
+        services.AddSingleton(new EmailMimeExtractionOptions());
+        services.AddSingleton(Substitute.For<ITrustedAuthenticationAuthorityReader>());
+        services.AddSingleton(policies);
+        services.AddSingleton(SensitiveContentPlan.Create(
+            SensitiveContentScanBounds.Default,
+            [
+                SensitiveContentScannerPlan.Create(
+                    SensitiveContentScannerKind.Secrets,
+                    [SensitiveContentCategory.Create("ProviderToken")],
+                    []),
+            ])!);
+        services.AddSingleton<SensitiveContentRedactor>();
+        services.AddSecretContentScanning();
+
+        services.AddInfrastructure(
+            _ => new PostgresConnectionSettings("Host=localhost;Database=mailfathom", null, null),
+            PostgresTextSearchConfiguration.Default,
+            MailAnsweringBudget.Default);
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+
+        // Act
+        var extraction = await scope.ServiceProvider
+            .GetRequiredService<IEmailMimeReader>()
+            .ReadMetadataAsync(OrdinaryMessage(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(EmailMimeExtractionOutcome.Extracted, extraction.Outcome);
+        Assert.Equal(policy.Revision, extraction.Metadata?.SenderTrust.PolicyRevision);
+    }
+
+    /// <summary>Builds the smallest message both decorators read end to end.</summary>
+    private static RemoteEmailContent OrdinaryMessage() => new(
+        EmailOccurrenceId.Create(
+            MailAccountId.Create("primary"),
+            new MailFolderResolutionId(MailFolderAlias.Create("inbox"), MailFolderResolutionGeneration.First),
+            ImapUidValidity.Create(5),
+            ImapUid.Create(11)),
+        Encoding.ASCII.GetBytes(
+            "From: alice@partner.example\r\n"
+            + "To: owner@work.example\r\n"
+            + "Subject: Subject\r\n"
+            + "\r\n"
+            + "body\r\n"));
 
     /// <summary>
     /// The other half of the same decision: an instance that declared a chain registers both units of work. Asserted


### PR DESCRIPTION
Closes #757

Records a second verdict beside the sender-authentication one: whether a message's author is somebody this deployment
recognizes. The two are independent axes and are stored separately, because who the receiving server established is a
fact about the message while whether this deployment knows them is a decision about a list an operator and a reader both
write to.

## What the list is held against

Following the issue's clarification after #756 and #885, the subject of the decision is the **authenticated author** and
nothing else:

- never the raw `From` header, which the sender writes — otherwise anybody would be recognized by claiming to be
  somebody on a list;
- never whichever identity happened to authenticate, which for a relay, a mailing list, or a delivery provider is not the
  author — otherwise allow-listing one would recognize every message it ever relays, whoever it says wrote them.

`SenderAuthentication.AuthenticatedAuthorDomain` is what establishes the author, from what the trusted
`Authentication-Results` header already records: a trusted `dmarc=pass` is the receiving server's own statement about the
displayed domain, and failing that a DKIM or SPF identity exactly equal to the displayed domain is the same claim reached
without DMARC. Everything else — nothing established, an authentication that failed, `dmarc=fail`, an identity belonging
to somebody else — establishes no author, and the list is not consulted at all. Only the one DKIM identity the verdict
names is considered, so a second signature over the displayed domain beside an unrelated first one withholds an author
rather than inventing one.

Tests cover each of the acceptance cases: a spoofed allow-listed `From` whose author authentication failed, an
allow-listed third-party signature over another author (with `dmarc=fail` and without DMARC), an authenticated author on
and off the list, an author established by DMARC alone, an author established by an exact DKIM or SPF match, nothing
established, and a message displaying no usable author.

## The verdict

`SenderTrustLevel` has two values, `Trusted` and `Unknown`, using the terminology the issue asked for rather than
`Verified`/`Unverified`, which conflates authentication with local trust. Whether an author was established at all stays
on the authentication verdict, so `Authenticated + Unknown` — the ordinary state of nearly every message — is
distinguishable from `Failed` and `NotEstablished` by reading the two together.

An author is trusted when their domain belongs to a configured account (`MailSynchronization:TrustOwnAccountDomains`,
default on, derived from each account's IMAP user name) or when an entry on the receiving account's `TrustedSenders`
list names them. An entry names a domain, optionally reaching the names beneath it, or narrows to a single mailbox, which
matches when the author's domain is the entry's own and `From` displays exactly the entry's address. Domains are compared
in one encoding, so an entry written `bücher.example` recognizes a message that carried `xn--bcher-kva.example`. An entry
nothing can compare fails startup, naming the account and the entry's position and never the value.

Every verdict carries a digest of the effective list, so a later change to the list is legible rather than silent, and
the answer is stored rather than recomputed on read. The evaluation sits as a decorator over `IEmailMimeReader`, so both
synchronization and the extraction backfill reach it.

The stored half of the list and the surfaces that edit it stay with #760; until then the effective list is the configured
one.

## Breaking changes

- **Database schema.** `stored_emails` gains `SenderTrustLevel`, `SenderTrustGrantedBy`, and
  `SenderTrustPolicyRevision` through one additive migration. An operator applies the release's schema artifact before
  starting the new version; existing rows take the defaults, which say no policy judged them.
- **Configuration.** `MailSynchronization:TrustOwnAccountDomains` and the per-account `TrustedSenders` list are new and
  both optional, so an existing configuration keeps working unchanged. Nothing existing was renamed or removed.

## Verification

- `scripts/verify-full.sh` — passed.
- Aggregate line coverage 96.05% (required 85%); every new type at 100%.
- Migration reviewed as SQL, applied to the orchestrated database over a reset, schema dumped, and `mailfathom-host`
  reached `Running`/`Healthy` against it.
