### PR TITLE
[#888] Publish the sender verdict every read tool already had stored

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -42,17 +42,28 @@ Recipients are PostgreSQL `text[]` columns — `to_addresses`, `cc_addresses`, `
 
 ### The sender-authentication verdict
 
-Eight columns record what the receiving mail server established about who actually sent the message:
+Nine columns record what the receiving mail server established about who actually sent the message:
 `SenderAuthenticationOutcome`, `SenderAuthenticationMethod`, `AuthenticatedSenderDomain`, `DkimSignerDomain`,
-`SpfMailFromDomain`, `DmarcOutcome`, `AuthorAuthenticationOutcome`, and `AuthenticatedAuthorDomain`. The four enums are
-text for the reason `content_availability` is, and the four domains are `character varying(253)` — the length a
+`SpfMailFromDomain`, `DmarcOutcome`, `AuthorAuthenticationOutcome`, `AuthenticatedAuthorDomain`, and
+`DisplayedAuthorDomain`. The four enums are
+text for the reason `content_availability` is, and the five domains are `character varying(253)` — the length a
 resolver accepts, which the domain value already refuses to exceed, so no value ever reaches a column that would reject
 it.
 
-The last two are a conclusion about the author the message displays, which is a different question from the six before
-them: those name the identity that handed the message over, and a relay, a mailing list, or a delivery provider
-authenticates as itself while carrying somebody else's `From`. `AuthenticatedAuthorDomain` is present exactly when the
-author authenticated, and it is the domain a reader was shown rather than whichever identity established it.
+The last three are about the author the message displays, which is a different question from the six before them: those
+name the identity that handed the message over, and a relay, a mailing list, or a delivery provider authenticates as
+itself while carrying somebody else's `From`. `AuthenticatedAuthorDomain` is present exactly when the author
+authenticated, and it is the domain a reader was shown rather than whichever identity established it.
+
+`DisplayedAuthorDomain` is the domain the `From` header wrote, recorded whether or not anything held it, so the two
+halves of the comparison exist on the row where they are most needed — the messages whose author was *not* established,
+where `AuthenticatedAuthorDomain` is empty by construction. It overlaps that column and does not replace it: one says
+what a trusted server stood behind, and this says what the message claimed. It is not derivable from the sender columns
+either, because those fall back to `Sender` for a message that named no author while this is `From`'s alone. A message
+stored before the column existed holds null in it and nothing fills that in by itself, because neither synchronization
+pass re-reads mail that stayed where it was; [`mfctl mailbox
+rederive`](../features/imap-synchronization.md#bringing-stored-mail-up-to-a-later-release) is the pass that does, from
+the raw MIME the deployment already holds.
 
 They are columns on the row rather than a table hanging off it, unlike [what classification
 concluded](#what-classification-concluded-about-a-message). The rows would not be sparse: every message whose MIME was
@@ -62,7 +73,9 @@ so a join per row would buy a nullable association nothing is ever without.
 
 Every enum column carries a database default naming the value that establishes nothing — `NotEstablished`, `None`,
 `NotReported`, and `NotEstablished` again for the author — so the migration that adds them fills every stored message
-in with what was true of it rather than with a value nothing wrote. The whole group is written together on every extraction, so re-reading a
+in with what was true of it rather than with a value nothing wrote. A domain column takes no default and is simply
+absent on a row written before it existed, which reads the same as a message that wrote no such domain at all: the two
+are indistinguishable from the row, and re-reading the message is what tells them apart. The whole group is written together on every extraction, so re-reading a
 message after its account gained a trusted identifier replaces the verdict rather than leaving one column of the
 previous reading behind. The domains are stored in the upper-cased comparison form, which is what a later reader matches
 on; [sender authentication](../features/sender-authentication.md) states how the verdict is reached and which header it

--- a/docs/features/email-content.md
+++ b/docs/features/email-content.md
@@ -110,10 +110,11 @@ stored too — the body says why there is none, and the verdict beside it is the
 
 The verdict pair is what every read tool publishes. The evidence is what only this one does, because it is how a reader
 judges a verdict rather than what a reader acts on, and a listing exists to let somebody recognize a message rather than
-to weigh one they have already found. Comparing the authenticated domain with the displayed author's domain is what
-makes a message that authenticated as one domain while displaying another visible as exactly that; each value states its
-own absence, since a message nothing authenticated names no authenticated domain and one displaying no usable `From`
-mailbox names no displayed one. [Sender authentication](sender-authentication.md#what-the-read-tools-publish) holds what
+to weigh one they have already found. The authenticated domain and the displayed author's domain are read beside the
+verdict rather than against each other: the first is whichever identity authenticated the transport, so the two differ
+on ordinary mail a provider relayed and signed as itself, and `authorAuthentication` is what says the displayed author
+was not established. Each value states its own absence, since a message nothing authenticated names no authenticated
+domain and one displaying no usable `From` mailbox names no displayed one. [Sender authentication](sender-authentication.md#what-the-read-tools-publish) holds what
 each value means and what it deliberately does not claim.
 
 ### Headers come from the message, not from the row

--- a/docs/features/email-content.md
+++ b/docs/features/email-content.md
@@ -98,6 +98,23 @@ fact whether it named one email or ten.
 | `AttachmentSummary` | The counts for what the message carries besides its body, absent when nobody has counted them |
 | `Attachments` | One entry per attachment, re-derived from the stored raw MIME, each carrying a link to fetch it or the reason it carries none |
 | `RemoteFlags` | The flags a server last showed, and when they were read |
+| `SenderVerification` | What was established about the author the message displays, and what this deployment made of them |
+| `SenderAuthenticationEvidence` | What that conclusion was reached from: the authenticated domain, the displayed author's domain, the check that established the first, and the DMARC result |
+
+### The sender verdict is read from the row, and only here is its evidence published
+
+Both values come from the summary the read already loaded rather than from the parse, because both are conclusions
+reached when the message was stored. A read evaluates nothing: it resolves no DNS, verifies no signature, and does not
+re-read the `Authentication-Results` header the verdict came from. That holds for a message whose raw MIME was never
+stored too — the body says why there is none, and the verdict beside it is the same one a listing publishes.
+
+The verdict pair is what every read tool publishes. The evidence is what only this one does, because it is how a reader
+judges a verdict rather than what a reader acts on, and a listing exists to let somebody recognize a message rather than
+to weigh one they have already found. Comparing the authenticated domain with the displayed author's domain is what
+makes a message that authenticated as one domain while displaying another visible as exactly that; each value states its
+own absence, since a message nothing authenticated names no authenticated domain and one displaying no usable `From`
+mailbox names no displayed one. [Sender authentication](sender-authentication.md#what-the-read-tools-publish) holds what
+each value means and what it deliberately does not claim.
 
 ### Headers come from the message, not from the row
 
@@ -351,8 +368,8 @@ ordinary mail never reaches a second pass.
 Where [sensitive-content scanning](sensitive-content-scanning.md#reading-a-message-is-scanned-in-flight) is switched on,
 what the message's author wrote is scanned on every read and returned with each detection replaced by
 `[redacted:<category>]`: both body representations, the subject, and each participant's display name. The addresses
-beside those names, the identifiers, the sizes, the flags, and every attachment's file name are left as they are, on the
-line that page draws between a routing identity and free text.
+beside those names, the identifiers, the sizes, the flags, the two domains the sender verdict's evidence publishes, and
+every attachment's file name are left as they are, on the line that page draws between a routing identity and free text.
 
 The display names of the first 40 named participants of a message are scanned, and past that the address is published
 with no display name at all. A scan is a round trip where the personal-data analyzer runs in a container of its own, and

--- a/docs/features/mail-answering.md
+++ b/docs/features/mail-answering.md
@@ -342,10 +342,15 @@ Each passage is a bounded extract plus the identity an answer is traced through:
 - the stable local message identifier, which is the same one every other read names an email by;
 - the account and the folder alias it was read from;
 - the subject and the received time, where the message carried them;
+- what was established about the author the message displays, and what this deployment made of them;
 - the extract itself, already cut to the bound above.
 
 Nothing else travels. The participants, the size, the flags, and the attachment summary that a listing publishes are
 dropped before a provider is reached, because an answer does not need them.
+
+The sender verdict rides with the passage so a citation can state it without reading the message a second time, and a
+provider never sees it: the envelope a passage is formatted into names the message, the account, the folder, the
+received time, and the subject, and carries the extract. The verdict reaches the caller instead, on the citation.
 
 A message whose body yielded no text — encrypted mail, or mail whose content lives entirely in an attachment — can match
 on its subject or its participants and still produce no extract. Such a match is dropped rather than sent as an
@@ -485,6 +490,11 @@ The citations are one per email rather than one per passage. A run makes several
 than one of them; a reader given a list of sources wants the messages, not the number of times each was found. Neither
 one carries an extract: the passage has already reached a provider, and returning it to the caller as well would publish
 mail content from a call whose result is an answer.
+
+Each citation does carry the sender verdict, in the shape a listing publishes it in and without the evidence behind it.
+An answer is worth what the mail behind it is worth, so a reader deciding whether to act on a claim is told whether the
+message it came from had an author anybody established and whether this deployment recognizes that author. What the
+verdict is reached from stays with the single-email read the citation resolves through.
 
 ## When a deployment answers questions at all
 

--- a/docs/features/mailbox-queries.md
+++ b/docs/features/mailbox-queries.md
@@ -201,8 +201,8 @@ values, beside the total attachment size and the encrypted, unverified-signature
 
 `EmailSummary` is the bounded projection a listing returns: the stable local identifier every later request names the
 email by, its account and folder alias, the message identifier, subject, sent and received timestamps, size, the sender's
-display name and address, the `To` addresses, the attachment summary, whether raw MIME is stored locally, and the remote
-flag snapshot.
+display name and address, the sender verdict, the `To` addresses, the attachment summary, whether raw MIME is stored
+locally, and the remote flag snapshot.
 
 It carries no raw MIME, no body, and no attachment bytes, and the query that produces it selects only the columns it
 publishes — a privacy control before a performance one, because it makes the stored content unreachable through this
@@ -220,6 +220,24 @@ caller acts on, and are protected by who may reach this deployment rather than b
 answer refuses the listing. Both switches are off by default, and nothing on this path is scanned then.
 [Sensitive-content scanning § the guarded egress
 points](sensitive-content-scanning.md#the-guarded-egress-points) holds the contract.
+
+### The sender verdict a summary carries
+
+The sender's address is what the message wrote about itself, so the summary carries beside it what somebody else
+established: `SenderVerification`, the pair of *what the receiving mail server concluded about the displayed author* and
+*whether this deployment recognizes that author*. Both are read from the columns synchronization wrote. A listing
+evaluates no policy, resolves no DNS, and re-reads no header — a query that reached a verdict of its own would answer a
+different question from the one the message was stored with.
+
+The summary carries a second value the listing does not publish: `SenderAuthenticationEvidence`, the domain that
+authenticated, the domain the `From` header displayed, which check established the first, and the DMARC result. One
+projection reads both because the single-email read is built from this same summary and is where the evidence is
+published; a second query for it would let the two reads disagree about one message. [Sender
+authentication](sender-authentication.md#what-the-read-tools-publish) holds what each value means, and
+[MCP tools](mcp-tools.md#list_emails) holds the published shape.
+
+Every domain either value names is personal data on the same footing as an address, and neither reaches a log line, a
+metric label, or an exception message.
 
 ### The remote flag snapshot
 

--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -443,8 +443,12 @@ Eight parts of it are worth reading before a caller writes against them:
   adds is `headers.senderAuthentication`: `authenticatedDomain`, the domain that actually authenticated;
   `displayedAuthorDomain`, the domain the `From` header wrote; `authenticatedBy`, the check that established the first —
   `dkim`, `spf`, or `none`; and `dmarc`, the result the trusted server reported. Both domains are published in the
-  comparison form MailFathom stores — upper-cased, and an internationalized name in its ASCII form — so **comparing them
-  is what shows an email that authenticated as one domain while displaying another.** A `null` domain is an ordinary
+  comparison form MailFathom stores — upper-cased, and an internationalized name in its ASCII form. **A difference
+  between them is not by itself a spoofed author:** `authenticatedDomain` is whichever identity authenticated the
+  transport, and `dkim` is reported where both checks produced one, so an email sent through a provider that signs as
+  itself while `spf` passes for the author's own domain differs here and is authenticated exactly as it appears.
+  `senderVerification.authorAuthentication` is the conclusion, and it is reached against every identity that
+  authenticated rather than against the one published here. A `null` domain is an ordinary
   outcome rather than missing data: nothing authenticated, or the email wrote no usable `From` mailbox. Nothing here is
   evaluated on the read path, and an email whose raw MIME was never stored carries the same stored verdict as any other.
 - **Truncation travels inside each representation, and names the bound.** `plainText` and `sanitizedHtml` each carry

--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -302,14 +302,24 @@ states whether the account's junk folder took part, and `folderFreshness` states
 covered folder is.
 
 Each summary carries the stable local identifier a content read is performed by, the account identifier and the display
-name it is published under, the folder alias, the message identifier, the subject, the sender address and display name, the `To` addresses, the sent and received timestamps, the
+name it is published under, the folder alias, the message identifier, the subject, the sender address and display name, the sender verdict, the `To` addresses, the sent and received timestamps, the
 size in bytes, the attachment summary, the remote flags with the time they were observed, and whether raw content is
 available locally. It is the use case's projection published as it stands, not narrowed a second time here — a boundary
 that re-decided what a listing may carry would put the privacy rule in two places and leave the one a client reads
 untested. [Mailbox queries](mailbox-queries.md#what-a-summary-carries) records what it carries and why.
 
-Three parts of it are worth reading before a caller writes against them:
+Four parts of it are worth reading before a caller writes against them:
 
+- **`senderVerification` is two answers, never one.** `senderAddress` beside it is a claim the email wrote about itself,
+  and nothing on the way to a listing verified it. `authorAuthentication` is what the receiving mail server established
+  about the author the email displays — `authenticated`, `failed`, or `notEstablished` — and `deploymentTrust` is
+  whether this deployment's own trusted-sender configuration names that author — `trusted` or `unknown`. Neither is
+  derived from the other and no field merges them, because **`authenticated` beside `unknown` is the ordinary state of
+  legitimate mail from a correspondent nobody has named** and must not read as a finding against the message. `unknown`
+  is also what an email whose author failed carries, which is why the pair is read together. Both values are read from
+  what synchronization stored; a listing evaluates nothing and contacts no mail server. [Sender
+  authentication](sender-authentication.md#what-the-read-tools-publish) records what each value means and what it
+  deliberately does not claim.
 - **`toAddresses` and nothing beyond it.** `Cc` and `Reply-To` are searchable but not listed, and recipient display names
   are not returned at all. A listing exists to let a reader recognize a message; the full participant set belongs to
   reading one.
@@ -419,14 +429,24 @@ in it.
 |---|---|
 | `accountId`, `folderAlias` | Where the email is, in MailFathom's own names |
 | `sizeBytes` | The size of the whole email as the mail server reported it |
-| `headers` | Subject, sent and received timestamps, every participant with its header role, and the three threading identifiers |
+| `senderVerification` | The same verdict pair a listing publishes: what was established about the displayed author, and what this deployment made of them |
+| `headers` | Subject, sent and received timestamps, every participant with its header role, the three threading identifiers, and `senderAuthentication` — the evidence the verdict was reached from |
 | `body` | The representations, or the reason there are none |
 | `attachments` | One entry per attachment, always: normalized file name, media type, and decoded size, plus a short-lived address to fetch it from when the call asked for one |
 | `attachmentCounts` | What the email carries besides its body, returned either way, or `null` when nothing has ever read its parts |
 | `remoteFlags` | The flags a server last showed, and when they were read |
 
-Seven parts of it are worth reading before a caller writes against them:
+Eight parts of it are worth reading before a caller writes against them:
 
+- **The verdict is beside the headers and its evidence is inside them.** `senderVerification` is the pair a listing, a
+  search match, and a citation all publish, in one shape, so a client reads one thing everywhere. What only this read
+  adds is `headers.senderAuthentication`: `authenticatedDomain`, the domain that actually authenticated;
+  `displayedAuthorDomain`, the domain the `From` header wrote; `authenticatedBy`, the check that established the first —
+  `dkim`, `spf`, or `none`; and `dmarc`, the result the trusted server reported. Both domains are published in the
+  comparison form MailFathom stores — upper-cased, and an internationalized name in its ASCII form — so **comparing them
+  is what shows an email that authenticated as one domain while displaying another.** A `null` domain is an ordinary
+  outcome rather than missing data: nothing authenticated, or the email wrote no usable `From` mailbox. Nothing here is
+  evaluated on the read path, and an email whose raw MIME was never stored carries the same stored verdict as any other.
 - **Truncation travels inside each representation, and names the bound.** `plainText` and `sanitizedHtml` each carry
   `text`, `originalCharacterCount`, and `truncatedBy`, because a body and the fact that it is incomplete are never useful
   apart: a model handed only the text would summarize a cut message as a whole one. `truncatedBy` is `none`,
@@ -546,7 +566,8 @@ because an argument added later would be the one thing that quietly changes what
 | `folderFreshness` | How current the local copy of each covered folder is, exactly as a listing reports it |
 
 Each match carries `summary`, which is the same shape `list_emails` publishes and is documented above, together with
-`relevanceRank` and `snippets`.
+`relevanceRank` and `snippets`. `senderVerification` therefore arrives with the summary rather than as a shape of its
+own, so a client written against a listing reads a match's sender verdict with nothing new.
 
 - **`relevanceRank` is comparable within one response and nowhere else.** It is computed for the query that produced it,
   so storing it or comparing it with a rank from another call compares two different scales — and the scale itself
@@ -685,10 +706,16 @@ same refusals; the section above records that rule once.
 | `retrievalTruncated` | Whether the run hit this deployment's ceiling on how much mail one question may read |
 
 Each citation carries the `storedEmailId` a content read is performed by, the account identifier and the display name it
-is published under, the folder alias, the subject, and the received time. It deliberately carries no extract: the passage
-the run retrieved has already reached a model, and returning it here would put mail content into a response whose purpose
-is an answer. The subject and the received time
+is published under, the folder alias, the subject, the received time, and `senderVerification`. It deliberately carries
+no extract: the passage the run retrieved has already reached a model, and returning it here would put mail content into
+a response whose purpose is an answer. The subject and the received time
 are what let a reader recognize a message before fetching it.
+
+`senderVerification` is the same pair a listing publishes, in the same shape and without the evidence, so an answer says
+what was established about the author of each message it was drawn from. It is what a reader weighs a claim by: an
+answer is worth what the mail behind it is worth, and a claim traced to a message whose displayed author failed
+authentication is worth reading differently from one traced to a correspondent this deployment recognizes. The evidence
+behind the verdict stays with the single-email read the citation points at.
 
 **The citations are what the run retrieved, not what the model demonstrably used.** Nothing outside the model knows which
 of them it drew on, so publishing the narrower set would state something this system cannot observe. What they are good

--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -461,9 +461,9 @@ Eight parts of it are worth reading before a caller writes against them:
   `[redacted:<category>]`. The marker means material of that kind stood there and was withheld; it is never text the
   message contained, and the same call returns the same marker. Every participant past that fortieth name is published
   with no display name at all rather than with one nothing scanned, so on such a deployment an absent `displayName` can
-  mean either that the sender wrote none or that the bound was reached. Addresses, identifiers, sizes, and flags are
-  never redacted, nothing stored is rewritten, and a detector that cannot answer fails the call rather than returning
-  unfiltered content. [Sensitive-content
+  mean either that the sender wrote none or that the bound was reached. Addresses, identifiers, sizes, flags, and the
+  two domains `headers.senderAuthentication` publishes are never redacted, nothing stored is rewritten, and a detector
+  that cannot answer fails the call rather than returning unfiltered content. [Sensitive-content
   scanning](sensitive-content-scanning.md#reading-a-message-is-scanned-in-flight) is the whole contract.
 - **`availability` rather than an empty body.** `readable` means the text is the message, and an empty body under it
   means the message displayed nothing. `encryptedNotReadableLocally` is mail this deployment cannot decrypt,

--- a/docs/features/sender-authentication.md
+++ b/docs/features/sender-authentication.md
@@ -252,11 +252,17 @@ conclusions exist to make.
 recognize a message and already narrows `Cc` and `Reply-To` away, and the two outcomes are what a caller branches on;
 the domains, the method, and the DMARC result are how a reader judges the verdict rather than acts on it, so they sit
 with the rest of the headers, on the read of a message somebody has already found. Both domains are published in the
-comparison form the columns hold — upper-cased, and an internationalized name in its ASCII form — so comparing them is
-exact, and a message that authenticated as one domain while displaying another is visible as precisely that. A `null`
-domain is an ordinary outcome rather than missing data: nothing authenticated, or the message wrote no usable `From`
-mailbox. Nothing published restates the comparison as a flag of its own; the conclusion drawn from it is
-`authorAuthentication`.
+comparison form the columns hold — upper-cased, and an internationalized name in its ASCII form. A `null` domain is an
+ordinary outcome rather than missing data: nothing authenticated, or the message wrote no usable `From` mailbox.
+
+**The two domains differing is not by itself a spoofed author.** The authenticated one is whichever identity
+authenticated the transport, and where both checks produced an identity that is the DKIM domain — while the author is
+established by *any* authenticated identity matching the displayed domain, the SPF one included. A message relayed by a
+provider that signs as itself, whose envelope sender passes for the author's own domain, therefore publishes two
+different domains and is authenticated exactly as it appears. That is why nothing here restates the comparison as a flag
+of its own: `authorAuthentication` is the conclusion, reached against every identity that authenticated rather than
+against the one kept as evidence, and the domains say what stood behind the message rather than answering the question
+themselves.
 
 **Every published value was stored when the message was extracted.** A read evaluates nothing, resolves no DNS, re-reads
 no header, and triggers no IMAP fetch. Mail stored before the columns existed therefore reads as *not established* and

--- a/docs/features/sender-authentication.md
+++ b/docs/features/sender-authentication.md
@@ -228,8 +228,8 @@ were reached under different lists, and one carrying none was never put to a pol
 change to it and produces the same revision; adding to either half produces a different one.
 
 Adding a domain therefore does not silently rewrite what a reader was already shown. What re-judges mail already stored
-is [the extraction backfill](imap-synchronization.md#backfilling-messages-stored-earlier), the same deliberate act that
-re-reads mail after an account gains a trusted authority.
+is [`mfctl mailbox rederive`](imap-synchronization.md#bringing-stored-mail-up-to-a-later-release), the same deliberate
+act that re-reads mail after an account gains a trusted authority.
 
 ## What the read tools publish
 
@@ -292,8 +292,8 @@ of them characterizes the message or the sender's intent. A failed authenticatio
 The authentication verdict is derived from the raw MIME the deployment stored, so it is re-derivable from it, and the
 trust verdict is re-derived in the same pass against whatever list is in force then. Configuring a trusted identifier
 for an account that previously had none changes what a later extraction records and leaves mail already stored on the
-verdict it was given; [the extraction backfill](imap-synchronization.md#backfilling-messages-stored-earlier) is what
-re-reads that mail. The migration that adds each group of columns fills every stored message in with what was true of it
+verdict it was given; [`mfctl mailbox rederive`](imap-synchronization.md#bringing-stored-mail-up-to-a-later-release) is
+what re-reads that mail, writing the whole group of columns back through the extraction that first wrote them. The migration that adds each group of columns fills every stored message in with what was true of it
 — the not-established verdict, and the unknown answer under no policy at all.
 
 ## What is not recorded anywhere else

--- a/docs/features/sender-authentication.md
+++ b/docs/features/sender-authentication.md
@@ -64,6 +64,7 @@ holds the columns.
 | The DKIM signing domain and the SPF envelope domain, separately | The two disagreeing is itself a fact about the message |
 | The DMARC result the server reported | It is where an authenticated domain meets the displayed one, under the sender's own published policy |
 | Whether the displayed author authenticated, and their domain where they did | The identity a reader is shown is the one an impersonation gets wrong, and it is a different fact from the identity that handed the message over |
+| The domain the `From` header displayed, whether or not anything held | It is the other half of the comparison, and the half a reader needs most on the messages where nothing established an author. It is read from `From` alone, never from the `Sender` fallback a timeline names a message's sender by, so it cannot be derived from the stored address |
 
 **DKIM is the authoritative identity wherever both checks produced one.** It is cryptographic — a key the signing
 domain publishes signed these bytes — while SPF says only that a particular address was permitted to connect on behalf
@@ -230,13 +231,61 @@ Adding a domain therefore does not silently rewrite what a reader was already sh
 is [the extraction backfill](imap-synchronization.md#backfilling-messages-stored-earlier), the same deliberate act that
 re-reads mail after an account gains a trusted authority.
 
+## What the read tools publish
+
+Every read tool publishes the verdict, because a caller that cannot see it cannot weigh a message — and the caller these
+tools were built for is an agent, which reads a listing row as fact. What reaches a caller is **two published values and
+never one**: `authorAuthentication`, which is [the conclusion about the displayed
+author](#whether-the-displayed-author-authenticated) with its three values intact, and `deploymentTrust`, which is
+[whether this deployment recognizes them](#whether-the-author-is-one-this-deployment-recognizes) with its two. Neither
+is derived from the other and no published field merges them, because a single value would lose the distinction the two
+conclusions exist to make.
+
+| Tool | What it publishes |
+| --- | --- |
+| `list_emails` | The pair, on each listed email's summary |
+| `search_emails` | The same pair, by republishing that summary rather than reshaping it |
+| `get_email_content` | The pair, and beside it the evidence: the domain that authenticated, the domain the `From` header displayed, which check established the first, and the DMARC result |
+| `ask_mail` | The pair, on each citation, without the evidence |
+
+**The listing carries the verdict and the single-email read carries the evidence.** A listing exists to let a reader
+recognize a message and already narrows `Cc` and `Reply-To` away, and the two outcomes are what a caller branches on;
+the domains, the method, and the DMARC result are how a reader judges the verdict rather than acts on it, so they sit
+with the rest of the headers, on the read of a message somebody has already found. Both domains are published in the
+comparison form the columns hold — upper-cased, and an internationalized name in its ASCII form — so comparing them is
+exact, and a message that authenticated as one domain while displaying another is visible as precisely that. A `null`
+domain is an ordinary outcome rather than missing data: nothing authenticated, or the message wrote no usable `From`
+mailbox. Nothing published restates the comparison as a flag of its own; the conclusion drawn from it is
+`authorAuthentication`.
+
+**Every published value was stored when the message was extracted.** A read evaluates nothing, resolves no DNS, re-reads
+no header, and triggers no IMAP fetch. Mail stored before the columns existed therefore reads as *not established* and
+*unknown*, with every domain absent, which is what its row holds rather than a state invented for it — and an absent
+domain there is indistinguishable from a message that displayed none. [`mfctl mailbox
+rederive`](imap-synchronization.md#bringing-stored-mail-up-to-a-later-release) is what fills it in, by re-reading the raw
+MIME the deployment already stored back through the same extraction that wrote the columns in the first place. It is
+that pass rather than [the extraction backfill](imap-synchronization.md#backfilling-messages-stored-earlier), which
+selects only messages carrying no search document and therefore steps over every message already extracted — which is
+all of them, on a deployment where the gap is a column a later release added rather than an extraction that never ran.
+
+The published descriptions are the advertised output schema and are therefore the whole of what a model is told about
+these values, so they say what the values mean rather than only what they are called: that deployment trust is this
+deployment's own classification and not an authentication result, that *unknown* is the ordinary state of legitimate
+mail from a new correspondent, and that the sender address beside them is a claim the message wrote about itself. None
+of them characterizes the message or the sender's intent. A failed authentication is stated as a failed authentication.
+[MCP tools](mcp-tools.md#list_emails) holds the published shape of each result.
+
 ## What MailFathom does not do
 
 - It resolves no DNS, verifies no DKIM signature, and evaluates no SPF or DMARC policy. It computes no organizational
   domain and consults no public suffix list, so it never reconstructs DMARC's relaxed alignment for itself. Everything
   recorded was read back out of one header.
 - It does not reason from the `Received` chain beyond identifying the trusted header.
-- It never acts on either verdict. Nothing here files, flags, or hides a message, and no rule reads them yet.
+- It never acts on either verdict. Nothing here files, flags, or hides a message, and no rule reads them yet. Publishing
+  them through the read tools is not acting on them: what a caller is handed is the stored conclusion, and what to make
+  of it is the caller's.
+- It does not let a caller filter or sort a listing or a search by either verdict. That is a question about what may be
+  asked for rather than about what a result carries, and it is a decision of its own.
 
 ## Re-deriving what is already stored
 

--- a/docs/users/usage.md
+++ b/docs/users/usage.md
@@ -49,9 +49,15 @@ are, and a folder it does not name is one this deployment does not have.
 
 A summary is enough to recognize a message — subject, sender, recipients, timestamps, size, attachment counts, remote
 flags — and carries `storedEmailId`, the identifier a content read uses. It names its account both ways, as `accountId`
-and `accountDisplayName`, so telling a person which mailbox a message came from needs no second call. Three fields prevent
+and `accountDisplayName`, so telling a person which mailbox a message came from needs no second call. Four fields prevent
 common misreadings:
 
+- `senderVerification` is what somebody else established, next to the `senderAddress` the message wrote about itself.
+  `authorAuthentication` is what your mail server concluded about the sender shown in `From` — `authenticated`,
+  `failed`, or `notEstablished` — and `deploymentTrust` is whether your own trusted-sender configuration names that
+  sender — `trusted` or `unknown`. **Read the two together.** `authenticated` beside `unknown` is ordinary mail from
+  somebody you have never listed and says nothing against it; `unknown` on its own says only that this deployment does
+  not recognize the sender, and it is what an email whose sender failed authentication carries too.
 - `attachments` counts real attachments separately from inline images, so a message whose only payload is a logo in
   its signature does not read as one carrying a document.
 - `remoteFlags` reports what the mail server last said about the message, including `flagged` — the star a mail client
@@ -116,8 +122,14 @@ Reading the top few results of a search is therefore one call rather than one pe
 order you named them, and each carries either `content` or a `failure` saying why there is none, so one message this
 deployment cannot serve does not discard the others.
 
-Seven parts of the result exist so that an agent does not misreport a message:
+Eight parts of the result exist so that an agent does not misreport a message:
 
+- **The sender verdict comes with the evidence behind it.** `senderVerification` is the same pair a listing carries, and
+  `headers.senderAuthentication` adds what it was reached from: the domain that actually authenticated, the domain the
+  `From` header displayed, which check established the first (`dkim`, `spf`, or `none`), and the DMARC result your
+  server reported. Comparing the two domains is what shows a message that authenticated as one domain while displaying
+  another. Either domain can be `null`, which means nothing authenticated or the message wrote no usable `From` — an
+  outcome rather than missing data.
 - **Truncation is explicit, and says which limit cut.** Each body representation carries `truncatedBy` and the original
   character count, so a cut message is never summarized as a whole one. `bodyCharacterLimit` means the message is longer
   than any single call returns; `readCharacterBudget` means the messages named before it used up the call's shared
@@ -206,8 +218,10 @@ neither can the model.
 Five parts of the result are worth reading before an agent presents it:
 
 - **`citations` is what makes the answer checkable.** Each entry carries the `storedEmailId` you pass straight to
-  `get_email_content`, plus the account, folder, subject, and received time. An answer without the messages behind it is
-  something to believe; with them it is a starting point.
+  `get_email_content`, plus the account, folder, subject, received time, and the same `senderVerification` pair a
+  listing carries — so a claim drawn from a message whose sender failed authentication reads differently from one drawn
+  from a correspondent you recognize. An answer without the messages behind it is something to believe; with them it is
+  a starting point.
 - **They are what the run *retrieved*, not what the model provably used.** Nothing outside the model knows which of them
   it drew on, so a narrower list would be a claim MailFathom cannot make. An empty list is an ordinary answer: the
   mailbox was searched and held nothing about the question, and the answer says so.

--- a/docs/users/usage.md
+++ b/docs/users/usage.md
@@ -127,8 +127,10 @@ Eight parts of the result exist so that an agent does not misreport a message:
 - **The sender verdict comes with the evidence behind it.** `senderVerification` is the same pair a listing carries, and
   `headers.senderAuthentication` adds what it was reached from: the domain that actually authenticated, the domain the
   `From` header displayed, which check established the first (`dkim`, `spf`, or `none`), and the DMARC result your
-  server reported. Comparing the two domains is what shows a message that authenticated as one domain while displaying
-  another. Either domain can be `null`, which means nothing authenticated or the message wrote no usable `From` — an
+  server reported. The two domains differing is ordinary rather than a warning: the authenticated one is whichever
+  identity authenticated the transport, so mail sent through a provider that signs as itself differs there and is
+  authenticated exactly as it appears. `authorAuthentication` is the answer to whether the displayed author was
+  established. Either domain can be `null`, which means nothing authenticated or the message wrote no usable `From` — an
   outcome rather than missing data.
 - **Truncation is explicit, and says which limit cut.** Each body representation carries `truncatedBy` and the original
   character count, so a cut message is never summarized as a whole one. `bodyCharacterLimit` means the message is longer

--- a/src/Application/Emails/GetEmailContent/EmailContentReader.cs
+++ b/src/Application/Emails/GetEmailContent/EmailContentReader.cs
@@ -496,6 +496,8 @@ public sealed class EmailContentReader
             AttachmentSummary = SummaryOf(rendering.AttachmentSummary),
             Attachments = attachments,
             RemoteFlags = summary.RemoteFlags,
+            SenderVerification = summary.SenderVerification,
+            SenderAuthenticationEvidence = summary.SenderAuthenticationEvidence,
         };
     }
 
@@ -546,6 +548,8 @@ public sealed class EmailContentReader
             AttachmentSummary = null,
             Attachments = [],
             RemoteFlags = summary.RemoteFlags,
+            SenderVerification = summary.SenderVerification,
+            SenderAuthenticationEvidence = summary.SenderAuthenticationEvidence,
         };
     }
 

--- a/src/Application/Emails/GetEmailContent/ReadEmailContent.cs
+++ b/src/Application/Emails/GetEmailContent/ReadEmailContent.cs
@@ -86,4 +86,17 @@ public sealed record ReadEmailContent
     /// <summary>Gets the flags a mail server last showed for the email, and when they were read.</summary>
     /// <remarks>Reading content never changes them: the whole operation is served from local storage and speaks to no mail server.</remarks>
     public required RemoteEmailFlagSnapshot RemoteFlags { get; init; }
+
+    /// <summary>Gets what was established about the author the message displays, and what this deployment made of it.</summary>
+    /// <remarks>
+    /// The same pair a listing carries, taken from the same summary, so the two reads cannot disagree about one message.
+    /// </remarks>
+    public required SenderVerification SenderVerification { get; init; }
+
+    /// <summary>Gets what the author conclusion above was reached from.</summary>
+    /// <remarks>
+    /// A single-email read is where the evidence belongs: it is how a reader judges the verdict rather than what they
+    /// act on, and it is read from the stored columns rather than by re-reading the message's headers.
+    /// </remarks>
+    public required SenderAuthenticationEvidence SenderAuthenticationEvidence { get; init; }
 }

--- a/src/Application/Emails/Summaries/EmailSummary.cs
+++ b/src/Application/Emails/Summaries/EmailSummary.cs
@@ -58,6 +58,22 @@ public sealed record EmailSummary
     /// <summary>Gets the comparison forms of the <c>To</c> addresses, in header order.</summary>
     public IReadOnlyList<string> ToAddresses { get; init; } = [];
 
+    /// <summary>Gets what was established about the author the message displays, and what this deployment made of it.</summary>
+    /// <remarks>
+    /// Carried by the summary rather than read separately because it is what a reader weighs a listed message by, and
+    /// because the single-email read is built from this same summary — so a listing and a read cannot disagree about
+    /// one message.
+    /// </remarks>
+    public required SenderVerification SenderVerification { get; init; }
+
+    /// <summary>Gets what the verdict above was reached from, which only a single-email read publishes.</summary>
+    /// <remarks>
+    /// Projected with the summary rather than fetched by a second query, because one projection is what keeps every
+    /// read path publishing the same columns. A listing carries it without publishing it: a listing exists to let a
+    /// reader recognize a message, and the evidence is for judging one already found.
+    /// </remarks>
+    public required SenderAuthenticationEvidence SenderAuthenticationEvidence { get; init; }
+
     /// <summary>Gets what the email carries besides its body.</summary>
     public required StoredEmailAttachmentSummary Attachments { get; init; }
 

--- a/src/Application/Emails/Summaries/SenderAuthenticationEvidence.cs
+++ b/src/Application/Emails/Summaries/SenderAuthenticationEvidence.cs
@@ -1,0 +1,51 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails.Authentication;
+
+namespace MailFathom.Application.Emails.Summaries;
+
+/// <summary>What a stored email's authentication verdict was reached from, read back as it was stored.</summary>
+/// <remarks>
+/// <para>
+/// It is how a reader judges <see cref="SenderVerification.AuthorAuthentication" /> rather than what a reader acts on,
+/// which is why it travels apart from the pair and why only the single-email read publishes it. Comparing
+/// <see cref="AuthenticatedDomain" /> with <see cref="DisplayedAuthorDomain" /> is what makes a message that
+/// authenticated as one domain while displaying another visible as exactly that; the conclusion drawn from the
+/// comparison is the verdict's and is not restated here.
+/// </para>
+/// <para>
+/// Every absent value is an ordinary outcome rather than missing data. A message nothing authenticated names no
+/// authenticated domain, a message displaying no usable <c>From</c> mailbox names no displayed one, and a server that
+/// evaluated no DMARC policy reports that it did not.
+/// </para>
+/// <para>
+/// Each domain is personal data and inherits the classification of the mail it was read from.
+/// </para>
+/// </remarks>
+public sealed record SenderAuthenticationEvidence
+{
+    /// <summary>Gets the evidence a row carries where nothing trusted was read for the message.</summary>
+    public static SenderAuthenticationEvidence None { get; } = new()
+    {
+        AuthenticatedBy = SenderAuthenticationMethod.None,
+        Dmarc = DmarcOutcome.NotReported,
+    };
+
+    /// <summary>Gets the domain that authenticated, or <see langword="null" /> where none did.</summary>
+    public SenderDomain? AuthenticatedDomain { get; init; }
+
+    /// <summary>Gets the domain the message displayed in <c>From</c>, or <see langword="null" /> where it wrote no usable one.</summary>
+    /// <remarks>
+    /// The <c>From</c> header alone, never the <c>Sender</c> fallback a timeline names a message's sender by, because
+    /// the author a mail client displays is what an impersonation gets wrong. It is recorded and never believed.
+    /// </remarks>
+    public SenderDomain? DisplayedAuthorDomain { get; init; }
+
+    /// <summary>Gets which check established <see cref="AuthenticatedDomain" />, or that none did.</summary>
+    public required SenderAuthenticationMethod AuthenticatedBy { get; init; }
+
+    /// <summary>Gets the DMARC result the trusted header reported, or that it reported none.</summary>
+    public required DmarcOutcome Dmarc { get; init; }
+}

--- a/src/Application/Emails/Summaries/SenderAuthenticationEvidence.cs
+++ b/src/Application/Emails/Summaries/SenderAuthenticationEvidence.cs
@@ -10,10 +10,16 @@ namespace MailFathom.Application.Emails.Summaries;
 /// <remarks>
 /// <para>
 /// It is how a reader judges <see cref="SenderVerification.AuthorAuthentication" /> rather than what a reader acts on,
-/// which is why it travels apart from the pair and why only the single-email read publishes it. Comparing
-/// <see cref="AuthenticatedDomain" /> with <see cref="DisplayedAuthorDomain" /> is what makes a message that
-/// authenticated as one domain while displaying another visible as exactly that; the conclusion drawn from the
-/// comparison is the verdict's and is not restated here.
+/// which is why it travels apart from the pair and why only the single-email read publishes it. The conclusion is the
+/// verdict's and is not restated here.
+/// </para>
+/// <para>
+/// The two domains are read beside that verdict rather than against each other. <see cref="AuthenticatedDomain" /> is
+/// the identity that authenticated the transport, and where both checks produced one it is the DKIM domain — which need
+/// not be the identity that established the author, since an SPF domain matching the displayed one establishes it just
+/// as well. So a message relayed by a provider that signs as itself while SPF matches the author's own domain publishes
+/// two different domains and is authenticated exactly as it appears. What says the displayed author was not established
+/// is <see cref="SenderVerification.AuthorAuthentication" />, never a difference between these two.
 /// </para>
 /// <para>
 /// Every absent value is an ordinary outcome rather than missing data. A message nothing authenticated names no

--- a/src/Application/Emails/Summaries/SenderVerification.cs
+++ b/src/Application/Emails/Summaries/SenderVerification.cs
@@ -1,0 +1,43 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails.Authentication;
+
+namespace MailFathom.Application.Emails.Summaries;
+
+/// <summary>The two conclusions a stored email carries about the author it displays, read back as they were stored.</summary>
+/// <remarks>
+/// <para>
+/// The pair is never collapsed into one value. <see cref="AuthorAuthentication" /> is what the receiving mail server
+/// established about the displayed author, and <see cref="DeploymentTrust" /> is whether this deployment recognizes the
+/// author it established — a fact about the message beside a decision about a list. An authenticated author nobody has
+/// named is the ordinary state of legitimate mail and carries the same trust value as an author whose authentication
+/// failed, so a reader that had only one of the two could not tell those apart.
+/// </para>
+/// <para>
+/// It is read rather than reached. Nothing on a read path evaluates a policy, resolves DNS, or re-reads a header to
+/// produce it: the values are the columns extraction wrote, and a message extraction never reached carries
+/// <see cref="NotEstablished" /> because that is what its row holds.
+/// </para>
+/// </remarks>
+public sealed record SenderVerification
+{
+    /// <summary>Gets the pair a row carries where nothing has established an author and no policy has judged one.</summary>
+    /// <remarks>
+    /// It is the stored default rather than an absence, which is what mail stored before the columns existed reads as
+    /// until a re-derivation reaches it. Publishing it as it stands is deliberate: inventing a third state for
+    /// "unfilled" would say something about the message that nothing established.
+    /// </remarks>
+    public static SenderVerification NotEstablished { get; } = new()
+    {
+        AuthorAuthentication = AuthorAuthenticationOutcome.NotEstablished,
+        DeploymentTrust = SenderTrustLevel.Unknown,
+    };
+
+    /// <summary>Gets what the receiving mail server established about the author the message displays.</summary>
+    public required AuthorAuthenticationOutcome AuthorAuthentication { get; init; }
+
+    /// <summary>Gets whether this deployment recognizes the author, which is its own classification and not a check.</summary>
+    public required SenderTrustLevel DeploymentTrust { get; init; }
+}

--- a/src/Application/Retrieval/AskMail/MailAnswerCitation.cs
+++ b/src/Application/Retrieval/AskMail/MailAnswerCitation.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
@@ -14,6 +15,7 @@ namespace MailFathom.Application.Retrieval.AskMail;
 /// <param name="FolderAlias">The folder alias it was read from.</param>
 /// <param name="Subject">The subject it carried, or <see langword="null" /> when it carried none.</param>
 /// <param name="ReceivedAt">When the last receiving hop recorded it, or <see langword="null" /> when no header carried a usable date.</param>
+/// <param name="SenderVerification">What was established about the author it displays, and what this deployment made of them.</param>
 /// <remarks>
 /// <para>
 /// A citation is what turns an answer into a starting point rather than something to be believed: the identifier
@@ -28,10 +30,16 @@ namespace MailFathom.Application.Retrieval.AskMail;
 /// One per email rather than one per passage. A run makes several lookups and one message can answer more than one of
 /// them, and a caller reading a list of sources wants the messages rather than the number of times each was found.
 /// </para>
+/// <para>
+/// It carries the sender verdict for the reason it carries the subject: an answer drawn from mail is worth exactly what
+/// the mail behind it is worth, and a reader deciding whether to act on a claim needs to know whether the message it
+/// came from had an author anybody established. The evidence behind that verdict stays with the single-email read.
+/// </para>
 /// </remarks>
 public sealed record MailAnswerCitation(
     StoredEmailId StoredEmailId,
     MailAccountId AccountId,
     MailFolderAlias FolderAlias,
     string? Subject,
-    DateTimeOffset? ReceivedAt);
+    DateTimeOffset? ReceivedAt,
+    SenderVerification SenderVerification);

--- a/src/Application/Retrieval/AskMail/MailboxQuestionReader.cs
+++ b/src/Application/Retrieval/AskMail/MailboxQuestionReader.cs
@@ -308,7 +308,8 @@ public sealed class MailboxQuestionReader
                     SensitiveContentEgressPoint.McpSnippet,
                     passage.Subject,
                     cancellationToken),
-                passage.ReceivedAt));
+                passage.ReceivedAt,
+                passage.SenderVerification));
         }
 
         return cited;

--- a/src/Application/Retrieval/EmailKnowledgePassage.cs
+++ b/src/Application/Retrieval/EmailKnowledgePassage.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
@@ -41,6 +42,14 @@ public sealed record EmailKnowledgePassage
 
     /// <summary>Gets when the last receiving hop recorded the message, or <see langword="null" /> when no header carried a usable date.</summary>
     public DateTimeOffset? ReceivedAt { get; init; }
+
+    /// <summary>Gets what was established about the author of the message the extract came from.</summary>
+    /// <remarks>
+    /// It travels with the passage so that a citation can state it without a second read of the message. Nothing in the
+    /// retrieval path acts on it and nothing puts it in front of a model: what a provider receives is the extract, and
+    /// this reaches the caller instead, as part of saying where a claim came from.
+    /// </remarks>
+    public required SenderVerification SenderVerification { get; init; }
 
     /// <summary>Gets the extract itself, already cut to the size one passage may carry.</summary>
     public required string Text { get; init; }

--- a/src/Application/Retrieval/MailboxKnowledgeSearch.cs
+++ b/src/Application/Retrieval/MailboxKnowledgeSearch.cs
@@ -114,6 +114,7 @@ public sealed class MailboxKnowledgeSearch : IEmailKnowledgeSearch
             FolderAlias = summary.FolderAlias,
             Subject = summary.Subject,
             ReceivedAt = summary.ReceivedAt,
+            SenderVerification = summary.SenderVerification,
             Text = this.Bounded(string.Join(SnippetSeparator, match.Snippets)),
         };
     }

--- a/src/Infrastructure/Persistence/Emails/StoredEmailMetadataMapping.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailMetadataMapping.cs
@@ -87,6 +87,7 @@ internal static class StoredEmailMetadataMapping
         entity.AuthenticatedSenderDomain = authentication.AuthenticatedDomain?.NormalizedValue;
         entity.DkimSignerDomain = authentication.DkimDomain?.NormalizedValue;
         entity.SpfMailFromDomain = authentication.SpfDomain?.NormalizedValue;
+        entity.DisplayedAuthorDomain = authentication.FromDomain?.NormalizedValue;
         entity.DmarcOutcome = authentication.Dmarc;
         entity.AuthorAuthenticationOutcome = authentication.AuthorAuthentication;
         entity.AuthenticatedAuthorDomain = authentication.AuthenticatedAuthorDomain?.NormalizedValue;

--- a/src/Infrastructure/Persistence/Emails/StoredEmailSummaryRow.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailSummaryRow.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Emails.Summaries;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
 using MailFathom.Domain.Folders;
 using MailFathom.Infrastructure.Persistence.Entities;
 
@@ -20,9 +21,11 @@ namespace MailFathom.Infrastructure.Persistence.Emails;
 /// Mapping outside the query keeps what PostgreSQL computes and what the process computes separable by reading.
 /// </para>
 /// <para>
-/// It carries exactly the columns the summary publishes and no others. Notably absent are the <c>Cc</c>, <c>Reply-To</c>,
+/// It carries exactly the columns the summary carries and no others. Notably absent are the <c>Cc</c>, <c>Reply-To</c>,
 /// and thread-reference arrays, which are filterable but not listed, and every column of the raw MIME table, which no
-/// summary query joins to at all.
+/// summary query joins to at all. The sender-authentication columns are the one group a listing reads without
+/// publishing all of it: the single-email read is built from this same summary and publishes the evidence, and one
+/// projection reading it is cheaper than a second query for the read that needs it.
 /// </para>
 /// <para>
 /// The projection and the mapping live on the row rather than in either reader, because a listing and a single-email
@@ -56,7 +59,13 @@ internal sealed record StoredEmailSummaryRow(
     bool IsRemotelyFlagged,
     bool IsRemotelyDraft,
     bool IsRemotelyDeleted,
-    string[] RemoteKeywords)
+    string[] RemoteKeywords,
+    AuthorAuthenticationOutcome AuthorAuthenticationOutcome,
+    SenderTrustLevel SenderTrustLevel,
+    string? AuthenticatedSenderDomain,
+    string? DisplayedAuthorDomain,
+    SenderAuthenticationMethod SenderAuthenticationMethod,
+    DmarcOutcome DmarcOutcome)
 {
     /// <summary>Gets the projection every summary query selects, which is what keeps the two readers publishing one shape.</summary>
     public static Expression<Func<StoredEmailEntity, StoredEmailSummaryRow>> Projection { get; } = email =>
@@ -85,7 +94,13 @@ internal sealed record StoredEmailSummaryRow(
             email.IsRemotelyFlagged,
             email.IsRemotelyDraft,
             email.IsRemotelyDeleted,
-            email.RemoteKeywords);
+            email.RemoteKeywords,
+            email.AuthorAuthenticationOutcome,
+            email.SenderTrustLevel,
+            email.AuthenticatedSenderDomain,
+            email.DisplayedAuthorDomain,
+            email.SenderAuthenticationMethod,
+            email.DmarcOutcome);
 
     /// <summary>Turns the returned columns into the application read model.</summary>
     /// <returns>The summary, with every domain value object built by its own factory.</returns>
@@ -121,5 +136,26 @@ internal sealed record StoredEmailSummaryRow(
             // Rebuilt through the factory rather than wrapped, because the column is what an earlier build's
             // normalization left behind and this one's rules are the ones a caller's filter is folded by.
             RemoteEmailKeywords.Create(this.RemoteKeywords)),
+        SenderVerification = new SenderVerification
+        {
+            AuthorAuthentication = this.AuthorAuthenticationOutcome,
+            DeploymentTrust = this.SenderTrustLevel,
+        },
+        SenderAuthenticationEvidence = new SenderAuthenticationEvidence
+        {
+            AuthenticatedDomain = StoredDomain(this.AuthenticatedSenderDomain),
+            DisplayedAuthorDomain = StoredDomain(this.DisplayedAuthorDomain),
+            AuthenticatedBy = this.SenderAuthenticationMethod,
+            Dmarc = this.DmarcOutcome,
+        },
     };
+
+    /// <summary>Reads one stored domain column back into its value object, or reports that the column holds none.</summary>
+    /// <remarks>
+    /// A column value the factory refuses is read as absent rather than raised, because the alternative is a stored
+    /// email that can never be listed again. Nothing writes one: the columns are written from the same value object,
+    /// and its own bound is what the column length was taken from.
+    /// </remarks>
+    private static SenderDomain? StoredDomain(string? domain) =>
+        domain is not null && SenderDomain.TryCreate(domain, out var stored) ? stored : null;
 }

--- a/src/Infrastructure/Persistence/Entities/StoredEmailEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/StoredEmailEntity.cs
@@ -103,6 +103,20 @@ internal sealed class StoredEmailEntity
     /// </remarks>
     public string? SpfMailFromDomain { get; set; }
 
+    /// <summary>Gets or sets the domain the message displayed in <c>From</c>, absent where it wrote no usable one.</summary>
+    /// <remarks>
+    /// The <c>From</c> header alone, which is not the same address as <see cref="SenderAddress" />: a timeline names a
+    /// message's sender from <c>Sender</c> where no author was written, while this is the domain a mail client displays
+    /// and therefore the one an impersonation controls. Deriving it from the address column would be wrong for exactly
+    /// those messages and would re-parse a header on a read path besides.
+    /// <para>
+    /// It overlaps <see cref="AuthenticatedAuthorDomain" /> and does not replace it. That column carries the domain a
+    /// trusted server stood behind and is absent whenever nothing established the author, which is the case a reader
+    /// most needs the displayed domain for; this one carries what the message claimed whether or not anything held.
+    /// </para>
+    /// </remarks>
+    public string? DisplayedAuthorDomain { get; set; }
+
     /// <summary>Gets or sets the DMARC result the trusted header reported, or that it reported none.</summary>
     public DmarcOutcome DmarcOutcome { get; set; }
 

--- a/src/Infrastructure/Persistence/Entities/StoredEmailEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/StoredEmailEntity.cs
@@ -80,8 +80,8 @@ internal sealed class StoredEmailEntity
     /// nothing is ever without.
     /// </para>
     /// <para>
-    /// The whole group is written by extraction from the stored raw MIME and is re-derivable from it, which is what the
-    /// extraction backfill does after a trusted authority is configured for an account that had none.
+    /// The whole group is written by extraction from the stored raw MIME and is re-derivable from it, which is what a
+    /// re-derivation pass does after a trusted authority is configured for an account that had none.
     /// </para>
     /// </remarks>
     public SenderAuthenticationOutcome SenderAuthenticationOutcome { get; set; }

--- a/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -365,7 +365,7 @@ internal sealed class MailFathomDbContext : DbContext
             // by the length a resolver accepts, which the domain value already refuses to exceed. Each enum carries a
             // database default naming the value that establishes nothing, because that is what is true of a row written
             // before this deployment read the header: the migration that adds the columns fills every stored message in
-            // with it, and a mailbox re-reads its own raw MIME through the extraction backfill.
+            // with it, and a mailbox re-reads its own raw MIME through a re-derivation pass.
             entity.Property(email => email.SenderAuthenticationOutcome)
                 .HasConversion<string>()
                 .HasMaxLength(64)

--- a/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -390,6 +390,7 @@ internal sealed class MailFathomDbContext : DbContext
             entity.Property(email => email.DkimSignerDomain).HasMaxLength(StoredEmailEntity.MaximumDomainLength);
             entity.Property(email => email.SpfMailFromDomain).HasMaxLength(StoredEmailEntity.MaximumDomainLength);
             entity.Property(email => email.AuthenticatedAuthorDomain).HasMaxLength(StoredEmailEntity.MaximumDomainLength);
+            entity.Property(email => email.DisplayedAuthorDomain).HasMaxLength(StoredEmailEntity.MaximumDomainLength);
 
             // What this deployment made of that verdict, stored the same way and defaulted the same way: a row written
             // before authors were judged at all recognized nobody, which is exactly what the two defaults say. The

--- a/src/Infrastructure/Persistence/Migrations/20260816185554_AddStoredEmailDisplayedAuthorDomain.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260816185554_AddStoredEmailDisplayedAuthorDomain.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260816185554_AddStoredEmailDisplayedAuthorDomain")]
+    partial class AddStoredEmailDisplayedAuthorDomain
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -45,85 +48,6 @@ namespace MailFathom.Infrastructure.Persistence.Migrations
                     b.HasKey("Name");
 
                     b.ToTable("backfill_positions", (string)null);
-                });
-
-            modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.ContactAddressEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("Address")
-                        .IsRequired()
-                        .HasMaxLength(320)
-                        .HasColumnType("character varying(320)");
-
-                    b.Property<Guid>("ContactId")
-                        .HasColumnType("uuid");
-
-                    b.Property<string>("NormalizedAddress")
-                        .IsRequired()
-                        .HasMaxLength(320)
-                        .HasColumnType("character varying(320)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("ContactId");
-
-                    b.HasIndex("NormalizedAddress")
-                        .IsUnique()
-                        .HasDatabaseName("ix_contact_addresses_normalized_address");
-
-                    b.ToTable("contact_addresses", (string)null);
-                });
-
-            modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.ContactEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTimeOffset>("AmendedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.Property<uint>("ConcurrencyVersion")
-                        .IsConcurrencyToken()
-                        .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("xid")
-                        .HasColumnName("xmin");
-
-                    b.Property<string>("DisplayName")
-                        .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
-
-                    b.Property<string>("DisplayNameSortKey")
-                        .IsRequired()
-                        .HasMaxLength(256)
-                        .HasColumnType("character varying(256)")
-                        .UseCollation("C");
-
-                    b.Property<string>("Note")
-                        .HasMaxLength(4000)
-                        .HasColumnType("character varying(4000)");
-
-                    b.Property<string>("Origin")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)");
-
-                    b.Property<string>("PreferredNormalizedAddress")
-                        .IsRequired()
-                        .HasMaxLength(320)
-                        .HasColumnType("character varying(320)");
-
-                    b.Property<DateTimeOffset>("RecordedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("DisplayNameSortKey", "Id")
-                        .HasDatabaseName("ix_contacts_display_name_sort_key_id");
-
-                    b.ToTable("contacts", (string)null);
                 });
 
             modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.EmailChunkEntity", b =>
@@ -679,34 +603,6 @@ namespace MailFathom.Infrastructure.Persistence.Migrations
                         .HasDatabaseName("ix_mail_folders_account_alias_generation");
 
                     b.ToTable("mail_folders", (string)null);
-                });
-
-            modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.MailRederivationPositionEntity", b =>
-                {
-                    b.Property<string>("MailboxAccountId")
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<string>("FolderAlias")
-                        .HasMaxLength(128)
-                        .HasColumnType("character varying(128)");
-
-                    b.Property<uint>("ConcurrencyVersion")
-                        .IsConcurrencyToken()
-                        .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("xid")
-                        .HasColumnName("xmin");
-
-                    b.Property<Guid>("LastProcessedStoredEmailId")
-                        .HasColumnType("uuid");
-
-                    b.Property<DateTimeOffset>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone");
-
-                    b.HasKey("MailboxAccountId", "FolderAlias")
-                        .HasName("pk_mail_rederivation_positions");
-
-                    b.ToTable("mail_rederivation_positions", (string)null);
                 });
 
             modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.MailRuleEvaluationRunEntity", b =>
@@ -1448,15 +1344,6 @@ namespace MailFathom.Infrastructure.Persistence.Migrations
                     b.ToTable("synchronization_checkpoints", (string)null);
                 });
 
-            modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.ContactAddressEntity", b =>
-                {
-                    b.HasOne("MailFathom.Infrastructure.Persistence.Entities.ContactEntity", null)
-                        .WithMany("Addresses")
-                        .HasForeignKey("ContactId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-                });
-
             modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.EmailChunkEntity", b =>
                 {
                     b.HasOne("MailFathom.Infrastructure.Persistence.Entities.StoredEmailEntity", "StoredEmail")
@@ -1638,11 +1525,6 @@ namespace MailFathom.Infrastructure.Persistence.Migrations
                         .IsRequired();
 
                     b.Navigation("MailFolder");
-                });
-
-            modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.ContactEntity", b =>
-                {
-                    b.Navigation("Addresses");
                 });
 
             modelBuilder.Entity("MailFathom.Infrastructure.Persistence.Entities.EmailChunkEntity", b =>

--- a/src/Infrastructure/Persistence/Migrations/20260816185554_AddStoredEmailDisplayedAuthorDomain.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260816185554_AddStoredEmailDisplayedAuthorDomain.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStoredEmailDisplayedAuthorDomain : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DisplayedAuthorDomain",
+                table: "stored_emails",
+                type: "character varying(253)",
+                maxLength: 253,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DisplayedAuthorDomain",
+                table: "stored_emails");
+        }
+    }
+}

--- a/src/Mcp/Tools/Content/NormalizedEmailHeaders.cs
+++ b/src/Mcp/Tools/Content/NormalizedEmailHeaders.cs
@@ -12,9 +12,11 @@ namespace MailFathom.Mcp.Tools.Content;
 /// <summary>Publishes the normalized headers one email displays above its body.</summary>
 /// <remarks>
 /// <para>
-/// These are read from the stored message rather than from the columns a listing is served out of, so they carry what
-/// the listing deliberately narrows away: display names, every participant role, and the threading identifiers. An
-/// email whose content the size limit kept out of storage is the one exception, and its body state says so.
+/// Most of these are read from the stored message rather than from the columns a listing is served out of, so they
+/// carry what the listing deliberately narrows away: display names, every participant role, and the threading
+/// identifiers. An email whose content the size limit kept out of storage carries none of that, and its body state says
+/// so. <see cref="SenderAuthentication" /> departs from all of it: it is read off the stored columns on every read,
+/// including that one, because nothing here re-derives an authentication result from a header it parsed itself.
 /// </para>
 /// <para>
 /// The three threading identifiers are published beside the rest rather than nested under a heading of their own,

--- a/src/Mcp/Tools/Content/NormalizedEmailHeaders.cs
+++ b/src/Mcp/Tools/Content/NormalizedEmailHeaders.cs
@@ -4,6 +4,8 @@
 
 using System.ComponentModel;
 using MailFathom.Application.EmailContent.Rendering;
+using MailFathom.Application.Emails.Summaries;
+using MailFathom.Mcp.Tools.Senders;
 
 namespace MailFathom.Mcp.Tools.Content;
 
@@ -50,16 +52,33 @@ internal sealed record NormalizedEmailHeaders
     [Description("The identifiers of the earlier emails in the conversation, in the order the References header listed them, which is the path back to its root. Empty when the email carried none. A path longer than 256 identifiers is published as its root followed by its most recent ancestors.")]
     public required IReadOnlyList<string> References { get; init; }
 
+    /// <summary>Gets what the email's author conclusion was reached from.</summary>
+    /// <remarks>
+    /// It sits with the headers because that is what it describes: the trusted receiving server wrote its findings into
+    /// one of them, and the domain the email displayed is the <c>From</c> header's own. The conclusion itself is
+    /// published beside the headers rather than inside them, as the result's <c>senderVerification</c>.
+    /// </remarks>
+    public required ReportedSenderAuthentication SenderAuthentication { get; init; }
+
     /// <summary>Publishes the headers a read produced.</summary>
     /// <param name="headers">The headers the use case returned.</param>
+    /// <param name="evidence">What the email's stored author conclusion was reached from.</param>
     /// <returns>The wire representation of <paramref name="headers" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="headers" /> is <see langword="null" />.</exception>
-    public static NormalizedEmailHeaders From(EmailContentHeaders headers)
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="headers" /> or <paramref name="evidence" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The evidence arrives beside the headers rather than within them because the two come from different places: the
+    /// headers were parsed out of the stored raw MIME by this read, and the evidence was read off the columns
+    /// synchronization wrote. An email whose raw MIME was never stored has the narrower headers a row can answer for and
+    /// the same stored evidence as any other.
+    /// </remarks>
+    public static NormalizedEmailHeaders From(EmailContentHeaders headers, SenderAuthenticationEvidence evidence)
     {
         ArgumentNullException.ThrowIfNull(headers);
+        ArgumentNullException.ThrowIfNull(evidence);
 
         return new NormalizedEmailHeaders
         {
+            SenderAuthentication = ReportedSenderAuthentication.From(evidence),
             Subject = headers.Subject,
             SentAt = headers.SentAt,
             ReceivedAt = headers.ReceivedAt,

--- a/src/Mcp/Tools/Content/RetrievedEmailContent.cs
+++ b/src/Mcp/Tools/Content/RetrievedEmailContent.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel;
 using MailFathom.Application.Emails.GetEmailContent;
+using MailFathom.Mcp.Tools.Senders;
 using MailFathom.Mcp.Tools.Summaries;
 
 namespace MailFathom.Mcp.Tools.Content;
@@ -40,6 +41,13 @@ internal sealed record RetrievedEmailContent
     [Description("The size of the whole email in bytes, as reported by the mail server. No sum over the body and the attachments reproduces it, because it counts the headers and the MIME encoding as well.")]
     public required long SizeBytes { get; init; }
 
+    /// <summary>Gets what was established about the author the email displays, and what this deployment made of it.</summary>
+    /// <remarks>
+    /// The same pair a listing and a citation publish, so one client shape reads all three. What this read adds is the
+    /// evidence behind it, which sits with the headers it was read out of.
+    /// </remarks>
+    public required ReportedSenderVerification SenderVerification { get; init; }
+
     /// <summary>Gets the normalized headers the email displays.</summary>
     public required NormalizedEmailHeaders Headers { get; init; }
 
@@ -70,7 +78,8 @@ internal sealed record RetrievedEmailContent
             AccountId = content.AccountId.Value,
             FolderAlias = content.FolderAlias.Value,
             SizeBytes = content.SizeOctets,
-            Headers = NormalizedEmailHeaders.From(content.Headers),
+            SenderVerification = ReportedSenderVerification.From(content.SenderVerification),
+            Headers = NormalizedEmailHeaders.From(content.Headers, content.SenderAuthenticationEvidence),
             Body = EmailBodyContent.From(content.Body),
             Attachments = [.. content.Attachments.Select(RetrievedEmailAttachment.From)],
             AttachmentCounts = content.AttachmentSummary is { } attachmentSummary

--- a/src/Mcp/Tools/Results/CitedEmail.cs
+++ b/src/Mcp/Tools/Results/CitedEmail.cs
@@ -4,6 +4,7 @@
 
 using System.ComponentModel;
 using MailFathom.Application.Retrieval.AskMail;
+using MailFathom.Mcp.Tools.Senders;
 
 namespace MailFathom.Mcp.Tools.Results;
 
@@ -40,6 +41,13 @@ internal sealed record CitedEmail
     [Description("When the last receiving hop recorded the message, as an ISO 8601 timestamp, or null when no header carried a usable date.")]
     public DateTimeOffset? ReceivedAt { get; init; }
 
+    /// <summary>Gets what was established about the author of the email the claim came from.</summary>
+    /// <remarks>
+    /// The same shape a listing publishes, so a reader weighs a cited message exactly as they would a listed one. The
+    /// evidence behind it stays with the single-email read the citation points at.
+    /// </remarks>
+    public required ReportedSenderVerification SenderVerification { get; init; }
+
     /// <summary>Publishes one citation the use case produced.</summary>
     /// <param name="citation">The citation to publish.</param>
     /// <param name="accountNames">Reads the name the citation's account is published under.</param>
@@ -58,6 +66,7 @@ internal sealed record CitedEmail
             FolderAlias = citation.FolderAlias.Value,
             Subject = citation.Subject,
             ReceivedAt = citation.ReceivedAt,
+            SenderVerification = ReportedSenderVerification.From(citation.SenderVerification),
         };
     }
 }

--- a/src/Mcp/Tools/Senders/AuthorAuthenticationState.cs
+++ b/src/Mcp/Tools/Senders/AuthorAuthenticationState.cs
@@ -1,0 +1,23 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Mcp.Tools.Senders;
+
+/// <summary>Reports what the receiving mail server established about the author an email displays, as the protocol spells it.</summary>
+/// <remarks>
+/// The transport carries its own enumeration for the reason every other published one does: the member names are the
+/// wire values, so they belong to the boundary that publishes them rather than to the domain that happens to describe
+/// the same states today.
+/// </remarks>
+internal enum AuthorAuthenticationState
+{
+    /// <summary>Nothing trusted was enough to conclude either way about the displayed author.</summary>
+    NotEstablished = 0,
+
+    /// <summary>The receiving server evaluated the displayed author under its own domain's policy and it did not hold.</summary>
+    Failed = 1,
+
+    /// <summary>The receiving server established that the displayed author authenticated.</summary>
+    Authenticated = 2,
+}

--- a/src/Mcp/Tools/Senders/DeploymentTrustState.cs
+++ b/src/Mcp/Tools/Senders/DeploymentTrustState.cs
@@ -1,0 +1,19 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Mcp.Tools.Senders;
+
+/// <summary>Reports whether this deployment recognizes an email's authenticated author, as the protocol spells it.</summary>
+/// <remarks>
+/// It is this deployment's own classification rather than the result of any check, which is why it is published beside
+/// <see cref="AuthorAuthenticationState" /> and never folded into it.
+/// </remarks>
+internal enum DeploymentTrustState
+{
+    /// <summary>This deployment recognizes nobody in the email, which is the ordinary state of legitimate mail.</summary>
+    Unknown = 0,
+
+    /// <summary>The email's authenticated author is one this deployment recognizes.</summary>
+    Trusted = 1,
+}

--- a/src/Mcp/Tools/Senders/DmarcResult.cs
+++ b/src/Mcp/Tools/Senders/DmarcResult.cs
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Mcp.Tools.Senders;
+
+/// <summary>Reports what the trusted receiving server said about DMARC for an email, as the protocol spells it.</summary>
+/// <remarks>
+/// Read back from one header rather than evaluated here. MailFathom resolves no DNS and reads no published policy, so
+/// every value below is the receiving server's statement and not this deployment's.
+/// </remarks>
+internal enum DmarcResult
+{
+    /// <summary>The trusted header reported no DMARC result at all.</summary>
+    NotReported = 0,
+
+    /// <summary>An authenticated domain lined up with the displayed one under the sender's published policy.</summary>
+    Pass = 1,
+
+    /// <summary>The displayed domain published a policy and the email did not satisfy it.</summary>
+    Fail = 2,
+
+    /// <summary>The evaluation ran and the displayed domain publishes no DMARC record, so its policy decided nothing.</summary>
+    NoPolicyPublished = 3,
+
+    /// <summary>The evaluation could not complete and may succeed if repeated.</summary>
+    TemporaryError = 4,
+
+    /// <summary>The evaluation could not complete and will not succeed if repeated.</summary>
+    PermanentError = 5,
+}

--- a/src/Mcp/Tools/Senders/ReportedSenderAuthentication.cs
+++ b/src/Mcp/Tools/Senders/ReportedSenderAuthentication.cs
@@ -16,9 +16,11 @@ namespace MailFathom.Mcp.Tools.Senders;
 /// message; this is for the message they went on to open.
 /// </para>
 /// <para>
-/// The two domains beside each other are the point. An email that authenticated as one domain while displaying another
-/// is the case the whole verdict exists to make visible, and publishing both in the same normalized form is what lets a
-/// client show it without parsing an address itself.
+/// The two domains are published beside the verdict rather than against each other. An email relayed by a provider that
+/// signs as itself, while the envelope sender passes for the author's own domain, authenticates exactly as it appears
+/// and still names two different domains here, because the authenticated one is whichever identity authenticated the
+/// transport. Publishing both in the same normalized form is what lets a client show what stood behind an email; what
+/// says its displayed author was not established is the verdict.
 /// </para>
 /// <para>
 /// Every value was read back out of one header the receiving mail server wrote, whose result was recorded when the
@@ -33,7 +35,7 @@ internal sealed record ReportedSenderAuthentication
     public string? AuthenticatedDomain { get; init; }
 
     /// <summary>Gets the domain the email displayed as its author, or <see langword="null" /> where it wrote no usable one.</summary>
-    [Description("The domain of the From header, which is what a mail client displays and what the email claims about itself. Published in the same comparison form as authenticatedDomain, so the two can be compared directly: an email that authenticated as one domain while displaying another is visible as exactly that. The conclusion drawn from that comparison is senderVerification.authorAuthentication and is not restated here. Null when the email wrote no usable From mailbox.")]
+    [Description("The domain of the From header, which is what a mail client displays and what the email claims about itself. Published in the same comparison form as authenticatedDomain. Do not read a difference between the two as impersonation: authenticatedDomain is whichever identity authenticated the transport, so an email sent through a provider that signs as itself while spf passes for the author's own domain differs here and is authenticated exactly as it appears. senderVerification.authorAuthentication is what says whether the displayed author was established. Null when the email wrote no usable From mailbox.")]
     public string? DisplayedAuthorDomain { get; init; }
 
     /// <summary>Gets which check established the authenticated domain, or that none did.</summary>

--- a/src/Mcp/Tools/Senders/ReportedSenderAuthentication.cs
+++ b/src/Mcp/Tools/Senders/ReportedSenderAuthentication.cs
@@ -1,0 +1,100 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.ComponentModel;
+using MailFathom.Application.Emails.Summaries;
+using MailFathom.Domain.Emails.Authentication;
+
+namespace MailFathom.Mcp.Tools.Senders;
+
+/// <summary>Publishes what an email's author conclusion was reached from.</summary>
+/// <remarks>
+/// <para>
+/// Only the single-email read publishes it, and it sits with the headers rather than with the verdict, because it is
+/// what a reader judges the verdict by rather than what a reader acts on. A listing exists to let somebody recognize a
+/// message; this is for the message they went on to open.
+/// </para>
+/// <para>
+/// The two domains beside each other are the point. An email that authenticated as one domain while displaying another
+/// is the case the whole verdict exists to make visible, and publishing both in the same normalized form is what lets a
+/// client show it without parsing an address itself.
+/// </para>
+/// <para>
+/// Every value was read back out of one header the receiving mail server wrote, whose result was recorded when the
+/// email was stored. Nothing here is evaluated, re-read, or recomputed when the email is read.
+/// </para>
+/// </remarks>
+[Description("What the author conclusion was reached from, read back from the header the receiving mail server wrote when the email arrived. Evidence for judging senderVerification rather than something to act on.")]
+internal sealed record ReportedSenderAuthentication
+{
+    /// <summary>Gets the domain that authenticated, or <see langword="null" /> where none did.</summary>
+    [Description("The domain that authenticated, which belongs to whoever handed the email over and is often a relay, a mailing list, or a delivery provider rather than the displayed author. Published in the comparison form MailFathom stores: upper-cased, and an internationalized name in its ASCII form. Null when nothing authenticated, which is an ordinary outcome and not missing data.")]
+    public string? AuthenticatedDomain { get; init; }
+
+    /// <summary>Gets the domain the email displayed as its author, or <see langword="null" /> where it wrote no usable one.</summary>
+    [Description("The domain of the From header, which is what a mail client displays and what the email claims about itself. Published in the same comparison form as authenticatedDomain, so the two can be compared directly: an email that authenticated as one domain while displaying another is visible as exactly that. The conclusion drawn from that comparison is senderVerification.authorAuthentication and is not restated here. Null when the email wrote no usable From mailbox.")]
+    public string? DisplayedAuthorDomain { get; init; }
+
+    /// <summary>Gets which check established the authenticated domain, or that none did.</summary>
+    [Description("Which check established authenticatedDomain: 'dkim' for a signature that verified against a key the signing domain publishes, 'spf' for an envelope sender that passed the policy the connecting address was checked against, or 'none' where nothing authenticated. DKIM is reported where both checks produced a domain, because it is the stronger claim.")]
+    public required SenderAuthenticationCheck AuthenticatedBy { get; init; }
+
+    /// <summary>Gets the DMARC result the trusted header reported.</summary>
+    [Description("The DMARC result the receiving mail server reported: 'pass', 'fail', 'noPolicyPublished' when the evaluation ran and the displayed domain publishes no DMARC record, 'temporaryError' or 'permanentError' when it could not complete, and 'notReported' when the server stated no DMARC result at all. MailFathom evaluates no policy and resolves no DNS; this is read back from what the server wrote.")]
+    public required DmarcResult Dmarc { get; init; }
+
+    /// <summary>Publishes the evidence a read returned.</summary>
+    /// <param name="evidence">The stored evidence to publish.</param>
+    /// <returns>The wire representation of <paramref name="evidence" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="evidence" /> is <see langword="null" />.</exception>
+    public static ReportedSenderAuthentication From(SenderAuthenticationEvidence evidence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+
+        return new ReportedSenderAuthentication
+        {
+            AuthenticatedDomain = evidence.AuthenticatedDomain?.NormalizedValue,
+            DisplayedAuthorDomain = evidence.DisplayedAuthorDomain?.NormalizedValue,
+            AuthenticatedBy = PublishedCheck(evidence.AuthenticatedBy),
+            Dmarc = PublishedDmarcResult(evidence.Dmarc),
+        };
+    }
+
+    /// <summary>Reads the published value the stored method names.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when a stored method has no published value, which means one was added to the domain without deciding what
+    /// a client should be told about it.
+    /// </exception>
+    private static SenderAuthenticationCheck PublishedCheck(SenderAuthenticationMethod method) =>
+        method switch
+        {
+            SenderAuthenticationMethod.None => SenderAuthenticationCheck.None,
+            SenderAuthenticationMethod.DomainKeysIdentifiedMail => SenderAuthenticationCheck.Dkim,
+            SenderAuthenticationMethod.SenderPolicyFramework => SenderAuthenticationCheck.Spf,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(method),
+                method,
+                "The stored sender-authentication method has no published protocol value."),
+        };
+
+    /// <summary>Reads the published value the stored DMARC outcome names.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when a stored outcome has no published value, which means one was added to the domain without deciding
+    /// what a client should be told about it.
+    /// </exception>
+    private static DmarcResult PublishedDmarcResult(DmarcOutcome outcome) =>
+        outcome switch
+        {
+            DmarcOutcome.NotReported => DmarcResult.NotReported,
+            DmarcOutcome.Pass => DmarcResult.Pass,
+            DmarcOutcome.Fail => DmarcResult.Fail,
+            DmarcOutcome.NoPolicyPublished => DmarcResult.NoPolicyPublished,
+            DmarcOutcome.TemporaryError => DmarcResult.TemporaryError,
+            DmarcOutcome.PermanentError => DmarcResult.PermanentError,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(outcome),
+                outcome,
+                "The stored DMARC outcome has no published protocol value."),
+        };
+}

--- a/src/Mcp/Tools/Senders/ReportedSenderVerification.cs
+++ b/src/Mcp/Tools/Senders/ReportedSenderVerification.cs
@@ -1,0 +1,88 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.ComponentModel;
+using MailFathom.Application.Emails.Summaries;
+using MailFathom.Domain.Emails.Authentication;
+
+namespace MailFathom.Mcp.Tools.Senders;
+
+/// <summary>Publishes the two conclusions an email carries about the author it displays.</summary>
+/// <remarks>
+/// <para>
+/// One shape, published by every tool that names an email: a listing row, a search match, the single-email read, and an
+/// answer's citation all carry this record and nothing else, so a client written against one reads all four. The
+/// evidence the first value was reached from is published only by the single-email read, as
+/// <see cref="ReportedSenderAuthentication" />.
+/// </para>
+/// <para>
+/// The two values answer different questions and neither is derived from the other, which is what the descriptions have
+/// to carry: they are the advertised output schema and therefore the whole of what a model reading a result is told.
+/// The trap this shape exists to avoid is a reader taking <see cref="DeploymentTrustState.Unknown" /> for a finding
+/// against the message, when it is what almost every legitimate email in a mailbox carries.
+/// </para>
+/// <para>
+/// Nothing here characterizes the email or the sender's intent, and nothing here is computed when the email is read.
+/// Both values were established when the message was stored and are published as they stand.
+/// </para>
+/// </remarks>
+[Description("What was established about the author this email displays. Two independent answers: whether the displayed author was authenticated, and whether this deployment recognizes them. Neither is a judgement about whether the email is wanted or unwanted.")]
+internal sealed record ReportedSenderVerification
+{
+    /// <summary>Gets what the receiving mail server established about the displayed author.</summary>
+    [Description("What the receiving mail server established about the author shown in the From header: 'authenticated' when it confirmed the displayed author, 'failed' when it evaluated the displayed domain under that domain's own published policy and the email did not satisfy it, and 'notEstablished' when nothing trusted was enough to conclude either way — which is also what an email carries when the mailbox trusts no authentication-reporting server, and what mail stored before this deployment recorded the answer carries until it is re-read. It is not derived from senderAddress, which is a claim the email wrote about itself.")]
+    public required AuthorAuthenticationState AuthorAuthentication { get; init; }
+
+    /// <summary>Gets whether this deployment recognizes the author it authenticated.</summary>
+    [Description("Whether this deployment's own trusted-sender configuration recognizes the authenticated author: 'trusted' when it names them, 'unknown' otherwise. This is this deployment's classification and not an authentication result. 'unknown' is the ordinary state of legitimate mail from a correspondent nobody has named, and is also what an email whose author was not authenticated carries, so it says nothing on its own — read it together with authorAuthentication.")]
+    public required DeploymentTrustState DeploymentTrust { get; init; }
+
+    /// <summary>Publishes the verdict pair a read returned.</summary>
+    /// <param name="verification">The stored verdict pair to publish.</param>
+    /// <returns>The wire representation of <paramref name="verification" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="verification" /> is <see langword="null" />.</exception>
+    public static ReportedSenderVerification From(SenderVerification verification)
+    {
+        ArgumentNullException.ThrowIfNull(verification);
+
+        return new ReportedSenderVerification
+        {
+            AuthorAuthentication = PublishedAuthorAuthentication(verification.AuthorAuthentication),
+            DeploymentTrust = PublishedDeploymentTrust(verification.DeploymentTrust),
+        };
+    }
+
+    /// <summary>Reads the published value the stored author conclusion names.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when a stored conclusion has no published value, which means one was added to the domain without deciding
+    /// what a client should be told about it.
+    /// </exception>
+    private static AuthorAuthenticationState PublishedAuthorAuthentication(AuthorAuthenticationOutcome outcome) =>
+        outcome switch
+        {
+            AuthorAuthenticationOutcome.NotEstablished => AuthorAuthenticationState.NotEstablished,
+            AuthorAuthenticationOutcome.Failed => AuthorAuthenticationState.Failed,
+            AuthorAuthenticationOutcome.Authenticated => AuthorAuthenticationState.Authenticated,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(outcome),
+                outcome,
+                "The stored author-authentication outcome has no published protocol value."),
+        };
+
+    /// <summary>Reads the published value the stored trust level names.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when a stored level has no published value, which means one was added to the domain without deciding what
+    /// a client should be told about it.
+    /// </exception>
+    private static DeploymentTrustState PublishedDeploymentTrust(SenderTrustLevel level) =>
+        level switch
+        {
+            SenderTrustLevel.Unknown => DeploymentTrustState.Unknown,
+            SenderTrustLevel.Trusted => DeploymentTrustState.Trusted,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(level),
+                level,
+                "The stored sender-trust level has no published protocol value."),
+        };
+}

--- a/src/Mcp/Tools/Senders/SenderAuthenticationCheck.cs
+++ b/src/Mcp/Tools/Senders/SenderAuthenticationCheck.cs
@@ -1,0 +1,22 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Mcp.Tools.Senders;
+
+/// <summary>Reports which check established an email's authenticated domain, as the protocol spells it.</summary>
+/// <remarks>
+/// The wire values are the two protocol names a reader already knows, rather than the domain's spelled-out member
+/// names: <c>dkim</c> and <c>spf</c> are how RFC 8601 writes them and how anybody reading a mail header meets them.
+/// </remarks>
+internal enum SenderAuthenticationCheck
+{
+    /// <summary>No identity was established, so nothing named one.</summary>
+    None = 0,
+
+    /// <summary>A DKIM signature verified against a key the signing domain publishes.</summary>
+    Dkim = 1,
+
+    /// <summary>The envelope sender passed the SPF policy the connecting address was checked against.</summary>
+    Spf = 2,
+}

--- a/src/Mcp/Tools/Summaries/ListedEmailSummary.cs
+++ b/src/Mcp/Tools/Summaries/ListedEmailSummary.cs
@@ -5,6 +5,7 @@
 using System.ComponentModel;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Domain.Emails;
+using MailFathom.Mcp.Tools.Senders;
 
 namespace MailFathom.Mcp.Tools.Summaries;
 
@@ -50,12 +51,20 @@ internal sealed record ListedEmailSummary
     public string? Subject { get; init; }
 
     /// <summary>Gets the sender address as the email wrote it, or <see langword="null" /> when it carried no usable one.</summary>
-    [Description("The sender address as written by the email, or null when it carried no usable sender address.")]
+    [Description("The sender address as written by the email, or null when it carried no usable sender address. This is a claim the email made about itself and nothing here verified it; senderVerification is what says whether anything did.")]
     public string? SenderAddress { get; init; }
 
     /// <summary>Gets the sender display name, or <see langword="null" /> when the email carried none.</summary>
     [Description("The display name the sender wrote, or null when the header carried none.")]
     public string? SenderDisplayName { get; init; }
+
+    /// <summary>Gets what was established about the author the email displays, and what this deployment made of it.</summary>
+    /// <remarks>
+    /// It sits beside the sender address deliberately: the address is what the email wrote about itself, and this is
+    /// what a trusted server established and what this deployment recognized. A listing carries the verdict and not the
+    /// evidence behind it, which the single-email read publishes.
+    /// </remarks>
+    public required ReportedSenderVerification SenderVerification { get; init; }
 
     /// <summary>Gets the <c>To</c> addresses in header order.</summary>
     [Description("The To addresses in header order. Cc and Reply-To are searchable but not listed, and recipient display names are not returned; the full participant set belongs to a single-email read.")]
@@ -103,6 +112,7 @@ internal sealed record ListedEmailSummary
             Subject = summary.Subject,
             SenderAddress = summary.SenderAddress,
             SenderDisplayName = summary.SenderDisplayName,
+            SenderVerification = ReportedSenderVerification.From(summary.SenderVerification),
             ToAddresses = summary.ToAddresses,
             SentAt = summary.SentAt,
             ReceivedAt = summary.ReceivedAt,

--- a/tests/AI.UnitTests/Retrieval/RetrievedMailContextFormatterTests.cs
+++ b/tests/AI.UnitTests/Retrieval/RetrievedMailContextFormatterTests.cs
@@ -7,7 +7,9 @@ using System.Xml.Linq;
 using MailFathom.AI.Retrieval;
 using MailFathom.AI.UnitTests.TestDoubles;
 using MailFathom.Application.Emails.Search;
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Retrieval;
+using MailFathom.Domain.Emails.Authentication;
 using Xunit;
 
 namespace MailFathom.AI.UnitTests.Retrieval;
@@ -42,6 +44,35 @@ public sealed class RetrievedMailContextFormatterTests
         Assert.Equal("ARCHIVE", Attribute(message, RetrievedMailContextFormatter.FolderAttributeName));
         Assert.Equal("Invoice 41", Element(message, RetrievedMailContextFormatter.SubjectElementName));
         Assert.Equal("the invoice is attached", Element(message, RetrievedMailContextFormatter.ExtractElementName));
+    }
+
+    /// <summary>The sender verdict travels to a citation and never to a provider, so the envelope must not carry it.</summary>
+    /// <remarks>
+    /// A passage holds the verdict because the citation cut from it publishes one. The envelope is the other direction —
+    /// what a model is handed — and a verdict there would put this deployment's own judgement of a correspondent into a
+    /// prompt, where it becomes something a model reasons from and an injected extract can argue with.
+    /// </remarks>
+    [Fact]
+    public void Format_APassageCarryingAVerdict_LeavesItOutOfWhatTheModelIsHanded()
+    {
+        // Arrange
+        var passage = KnowledgePassages.Create(
+            "the invoice is attached",
+            subject: "Invoice 41",
+            senderVerification: new SenderVerification
+            {
+                AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+                DeploymentTrust = SenderTrustLevel.Trusted,
+            });
+
+        // Act
+        var envelope = RetrievedMailContextFormatter.Format([passage], EmailSearchRetrievalMode.Hybrid, retrievalLimitReached: false);
+
+        // Assert
+        Assert.DoesNotContain("Authenticated", envelope, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Trusted", envelope, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("verification", envelope, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("the invoice is attached", envelope, StringComparison.Ordinal);
     }
 
     /// <summary>Ranked order is what the search decided, and an answer citing the first result must find it first.</summary>

--- a/tests/AI.UnitTests/TestDoubles/KnowledgePassages.cs
+++ b/tests/AI.UnitTests/TestDoubles/KnowledgePassages.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Retrieval;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
@@ -31,6 +32,7 @@ internal static class KnowledgePassages
             FolderAlias = MailFolderAlias.Create(folderAlias),
             Subject = subject,
             ReceivedAt = null,
+            SenderVerification = SenderVerification.NotEstablished,
             Text = text,
         };
 }

--- a/tests/AI.UnitTests/TestDoubles/KnowledgePassages.cs
+++ b/tests/AI.UnitTests/TestDoubles/KnowledgePassages.cs
@@ -19,20 +19,26 @@ internal static class KnowledgePassages
     /// <param name="accountId">The account the message belongs to.</param>
     /// <param name="folderAlias">The folder alias the message belongs to.</param>
     /// <param name="subject">The subject, or <see langword="null" /> for a message that carried none.</param>
+    /// <param name="senderVerification">
+    /// What was established about the message's author, or <see langword="null" /> for the stored default. A test about
+    /// what reaches a model states it, because the guarantee there is that the verdict reaches no provider — which a
+    /// passage carrying the default could not tell apart from one whose verdict was dropped.
+    /// </param>
     /// <returns>The passage.</returns>
     public static EmailKnowledgePassage Create(
         string text,
         Guid? storedEmailId = null,
         string accountId = "primary",
         string folderAlias = "INBOX",
-        string? subject = null) => new()
+        string? subject = null,
+        SenderVerification? senderVerification = null) => new()
         {
             StoredEmailId = StoredEmailId.Create(storedEmailId ?? Guid.CreateVersion7()),
             AccountId = MailAccountId.Create(accountId),
             FolderAlias = MailFolderAlias.Create(folderAlias),
             Subject = subject,
             ReceivedAt = null,
-            SenderVerification = SenderVerification.NotEstablished,
+            SenderVerification = senderVerification ?? SenderVerification.NotEstablished,
             Text = text,
         };
 }

--- a/tests/Application.UnitTests/Retrieval/AskMail/MailboxQuestionReaderTests.cs
+++ b/tests/Application.UnitTests/Retrieval/AskMail/MailboxQuestionReaderTests.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Chat;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
 using MailFathom.Application.Retrieval.AskMail.Audit;
@@ -614,15 +615,19 @@ public sealed class MailboxQuestionReaderTests
     private static Task<AskMailResult> AnswerAsync(MailboxQuestionReader reader, AskMailRequest request) =>
         reader.AnswerQuestionAsync(request, TestContext.Current.CancellationToken);
 
-    private static EmailKnowledgePassage PassageOf(int position, string text) => new()
-    {
-        StoredEmailId = StoredEmailId.Create(EmailIdentityAt(position)),
-        AccountId = MailAccountId.Create(ServedAccountId),
-        FolderAlias = MailFolderAlias.Create("INBOX"),
-        Subject = "Quarterly invoice",
-        ReceivedAt = Now,
-        Text = text,
-    };
+    private static EmailKnowledgePassage PassageOf(
+        int position,
+        string text,
+        SenderVerification? senderVerification = null) => new()
+        {
+            StoredEmailId = StoredEmailId.Create(EmailIdentityAt(position)),
+            AccountId = MailAccountId.Create(ServedAccountId),
+            FolderAlias = MailFolderAlias.Create("INBOX"),
+            Subject = "Quarterly invoice",
+            ReceivedAt = Now,
+            SenderVerification = senderVerification ?? SenderVerification.NotEstablished,
+            Text = text,
+        };
 
     /// <summary>Names one email by its position, so the same run of a test always uses the same identifiers.</summary>
     private static Guid EmailIdentityAt(int position) => new($"00000000-0000-0000-0000-{position:D12}");

--- a/tests/Application.UnitTests/Retrieval/AskMail/MailboxQuestionReaderTests.cs
+++ b/tests/Application.UnitTests/Retrieval/AskMail/MailboxQuestionReaderTests.cs
@@ -18,6 +18,7 @@ using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Answering.Audit;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
 using MailFathom.Domain.Folders;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
@@ -274,7 +275,15 @@ public sealed class MailboxQuestionReaderTests
     public async Task AnswerQuestionAsync_ACitedEmail_CarriesTheIdentityAndTheFieldsThatRecognizeIt()
     {
         // Arrange
-        var answerer = new RecordingMailQuestionAnswerer().Answering("An answer.", PassageOf(1, "an extract"));
+        var cited = PassageOf(
+            1,
+            "an extract",
+            senderVerification: new SenderVerification
+            {
+                AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+                DeploymentTrust = SenderTrustLevel.Trusted,
+            });
+        var answerer = new RecordingMailQuestionAnswerer().Answering("An answer.", cited);
         var reader = ReaderOver(answerer);
 
         // Act
@@ -287,6 +296,8 @@ public sealed class MailboxQuestionReaderTests
         Assert.Equal(MailFolderAlias.Create("INBOX"), citation.FolderAlias);
         Assert.Equal("Quarterly invoice", citation.Subject);
         Assert.Equal(Now, citation.ReceivedAt);
+        Assert.Equal(AuthorAuthenticationOutcome.Authenticated, citation.SenderVerification.AuthorAuthentication);
+        Assert.Equal(SenderTrustLevel.Trusted, citation.SenderVerification.DeploymentTrust);
     }
 
     /// <summary>Retrieval finding nothing is an ordinary outcome, and the answer that says so is a real answer.</summary>

--- a/tests/Application.UnitTests/Retrieval/EmailKnowledgeLookupTests.cs
+++ b/tests/Application.UnitTests/Retrieval/EmailKnowledgeLookupTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Emails.Search;
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Retrieval;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
@@ -54,6 +55,7 @@ public sealed class EmailKnowledgeLookupTests
         StoredEmailId = StoredEmailId.Create(Guid.CreateVersion7()),
         AccountId = MailAccountId.Create("work"),
         FolderAlias = MailFolderAlias.Create("inbox"),
+        SenderVerification = SenderVerification.NotEstablished,
         Text = "the invoice is attached",
     };
 }

--- a/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
+++ b/tests/Application.UnitTests/Retrieval/MailboxKnowledgeSearchTests.cs
@@ -8,11 +8,13 @@ using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Search;
 using MailFathom.Application.Emails.SearchEmails;
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails.Authentication;
 using MailFathom.Domain.Folders;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
@@ -99,6 +101,34 @@ public sealed class MailboxKnowledgeSearchTests
         Assert.Equal("the invoice", passage.Subject);
         Assert.Equal(FirstJuly, passage.ReceivedAt);
         Assert.Equal("the invoice is attached", passage.Text);
+    }
+
+    /// <summary>A citation says whether the message it quotes was verified, and this is the hop that carries the verdict to it.</summary>
+    [Fact]
+    public async Task FindPassagesAsync_AMatch_CarriesTheSenderVerdictItsSummaryWasStoredWith()
+    {
+        // Arrange
+        var matched = SyntheticEmailSummaries.Create(
+            FirstJuly,
+            senderVerification: new SenderVerification
+            {
+                AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+                DeploymentTrust = SenderTrustLevel.Trusted,
+            });
+        var index = new InMemoryEmailSearchIndex().With(matched, snippets: "the invoice is attached");
+        var search = SearchOver(index);
+
+        // Act
+        var passages = (await search.FindPassagesAsync(
+            EveryAccount,
+            EmailKnowledgeQuery.ForText("invoice"),
+            TestContext.Current.CancellationToken)).Passages;
+
+        // Assert
+        var passage = Assert.Single(passages);
+
+        Assert.Equal(AuthorAuthenticationOutcome.Authenticated, passage.SenderVerification.AuthorAuthentication);
+        Assert.Equal(SenderTrustLevel.Trusted, passage.SenderVerification.DeploymentTrust);
     }
 
     /// <summary>The count is the bound on how many messages one question can draw on, and it is asked of the search itself.</summary>

--- a/tests/Application.UnitTests/TestDoubles/SyntheticEmailSummaries.cs
+++ b/tests/Application.UnitTests/TestDoubles/SyntheticEmailSummaries.cs
@@ -35,6 +35,8 @@ internal static class SyntheticEmailSummaries
     /// <param name="remoteFlagsObservedAt">When the flags were observed, or <see langword="null" /> when they never were.</param>
     /// <param name="attachmentCount">How many attachments the classification counted.</param>
     /// <param name="inlineResourceCount">How many inline resources the classification counted.</param>
+    /// <param name="senderVerification">What was established about the displayed author, or the stored default.</param>
+    /// <param name="senderAuthenticationEvidence">What that conclusion was reached from, or the stored default.</param>
     /// <returns>The summary.</returns>
     public static EmailSummary Create(
         DateTimeOffset? receivedAt = null,
@@ -47,7 +49,9 @@ internal static class SyntheticEmailSummaries
         bool isRemotelySeen = false,
         DateTimeOffset? remoteFlagsObservedAt = null,
         int attachmentCount = 0,
-        int inlineResourceCount = 0) => new()
+        int inlineResourceCount = 0,
+        SenderVerification? senderVerification = null,
+        SenderAuthenticationEvidence? senderAuthenticationEvidence = null) => new()
         {
             StoredEmailId = StoredEmailId.Create(storedEmailId ?? Guid.CreateVersion7()),
             AccountId = MailAccountId.Create(accountId),
@@ -76,6 +80,8 @@ internal static class SyntheticEmailSummaries
                 IsDraft: false,
                 IsDeleted: false,
                 Keywords: RemoteEmailKeywords.None),
+            SenderVerification = senderVerification ?? SenderVerification.NotEstablished,
+            SenderAuthenticationEvidence = senderAuthenticationEvidence ?? SenderAuthenticationEvidence.None,
         };
 
     /// <summary>Builds a run of summaries one day apart, oldest first, so a test can page over a known order.</summary>

--- a/tests/Host.UnitTests/Api/EmailAttachmentDownloadEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/EmailAttachmentDownloadEndpointTests.cs
@@ -321,6 +321,8 @@ public sealed class EmailAttachmentDownloadEndpointTests
         ToAddresses = ["reader@example.test"],
         SizeOctets = 1024,
         RemoteFlags = RemoteEmailFlagSnapshot.NeverObserved,
+        SenderVerification = SenderVerification.NotEstablished,
+        SenderAuthenticationEvidence = SenderAuthenticationEvidence.None,
         ContentAvailability = StoredEmailContentAvailability.Available,
         Attachments = new StoredEmailAttachmentSummary(
             AttachmentCount: 1,

--- a/tests/Infrastructure.UnitTests/Observability/MailAnsweringRunTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/MailAnsweringRunTelemetryTests.cs
@@ -5,6 +5,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
 using MailFathom.Common.Observability;
@@ -165,6 +166,7 @@ public sealed class MailAnsweringRunTelemetryTests : IDisposable
         FolderAlias = MailFolderAlias.Create("inbox"),
         Subject = "Quarterly invoice",
         ReceivedAt = StartedAt,
+        SenderVerification = SenderVerification.NotEstablished,
         Text = "the invoice is attached",
     };
 

--- a/tests/Infrastructure.UnitTests/Persistence/Answering/MailAnsweringAuditTrailTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Answering/MailAnsweringAuditTrailTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
@@ -258,6 +259,7 @@ public sealed class MailAnsweringAuditTrailTests : IDisposable
         FolderAlias = MailFolderAlias.Create("inbox"),
         Subject = "Quarterly invoice",
         ReceivedAt = StartedAt,
+        SenderVerification = SenderVerification.NotEstablished,
         Text = "the invoice is attached",
     };
 

--- a/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailMetadataMappingTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Emails/StoredEmailMetadataMappingTests.cs
@@ -365,9 +365,57 @@ public sealed class StoredEmailMetadataMappingTests
         Assert.Equal("SIGNER.TEST", entity.AuthenticatedSenderDomain);
         Assert.Equal("SIGNER.TEST", entity.DkimSignerDomain);
         Assert.Equal("RELAY.TEST", entity.SpfMailFromDomain);
+        Assert.Equal("BANK.TEST", entity.DisplayedAuthorDomain);
         Assert.Equal(DmarcOutcome.Fail, entity.DmarcOutcome);
         Assert.Equal(AuthorAuthenticationOutcome.Failed, entity.AuthorAuthenticationOutcome);
         Assert.Null(entity.AuthenticatedAuthorDomain);
+    }
+
+    /// <summary>The displayed author's domain is recorded whether or not anything established it.</summary>
+    /// <remarks>
+    /// It is the half of the comparison a reader needs most where the author was not established, which is exactly
+    /// where the column holding the established author is empty.
+    /// </remarks>
+    [Fact]
+    public void ApplyExtractedMetadata_UnestablishedAuthor_StillRecordsTheDisplayedDomain()
+    {
+        // Arrange
+        var entity = CreateEntity();
+        Assert.True(SenderDomain.TryCreate("Bank.Test", out var fromDomain));
+
+        // Act
+        StoredEmailMetadataMapping.ApplyExtractedMetadata(
+            entity,
+            CreateExtractedMetadata(
+                senderAuthentication: SenderAuthentication.Failed(fromDomain, DmarcOutcome.Fail)));
+
+        // Assert
+        Assert.Equal("BANK.TEST", entity.DisplayedAuthorDomain);
+        Assert.Null(entity.AuthenticatedAuthorDomain);
+        Assert.Null(entity.AuthenticatedSenderDomain);
+    }
+
+    /// <summary>A message that wrote no author displays none, whatever address the timeline names it by.</summary>
+    /// <remarks>
+    /// The row's sender falls back to the submitting address, and the displayed author's domain deliberately does not:
+    /// the two answer different questions, which is why the domain is stored rather than derived from the address.
+    /// </remarks>
+    [Fact]
+    public void ApplyExtractedMetadata_MessageWithoutAnAuthor_RecordsNoDisplayedDomainBesideTheSubmittersAddress()
+    {
+        // Arrange
+        var entity = CreateEntity();
+
+        // Act
+        StoredEmailMetadataMapping.ApplyExtractedMetadata(
+            entity,
+            CreateExtractedMetadata(
+                participants: [Participant(EmailAddressRole.Sender, null, "list@example.test")],
+                senderAuthentication: SenderAuthentication.NotEstablished()));
+
+        // Assert
+        Assert.Equal("list@example.test", entity.SenderAddress);
+        Assert.Null(entity.DisplayedAuthorDomain);
     }
 
     /// <summary>An established author reaches a column of its own, so a stored trust verdict names who it judged.</summary>
@@ -422,6 +470,7 @@ public sealed class StoredEmailMetadataMappingTests
         Assert.Null(entity.AuthenticatedSenderDomain);
         Assert.Null(entity.DkimSignerDomain);
         Assert.Null(entity.SpfMailFromDomain);
+        Assert.Null(entity.DisplayedAuthorDomain);
         Assert.Equal(DmarcOutcome.NotReported, entity.DmarcOutcome);
         Assert.Equal(AuthorAuthenticationOutcome.NotEstablished, entity.AuthorAuthenticationOutcome);
         Assert.Null(entity.AuthenticatedAuthorDomain);

--- a/tests/IntegrationTests/Persistence/OrchestratedMailAnsweringAuditTrailTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedMailAnsweringAuditTrailTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Retrieval;
@@ -161,6 +162,7 @@ public sealed class OrchestratedMailAnsweringAuditTrailTests(MailFathomOrchestra
         FolderAlias = Inbox.Alias,
         Subject = "Quarterly invoice",
         ReceivedAt = Clock.GetUtcNow(),
+        SenderVerification = SenderVerification.NotEstablished,
         Text = "the invoice is attached",
     };
 

--- a/tests/Mcp.UnitTests/Tools/AskMailInjectionResistanceTests.cs
+++ b/tests/Mcp.UnitTests/Tools/AskMailInjectionResistanceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
 using MailFathom.Domain.Accounts;
@@ -186,6 +187,7 @@ public sealed class AskMailInjectionResistanceTests
         FolderAlias = MailFolderAlias.Create("INBOX"),
         Subject = "Quarterly invoice",
         ReceivedAt = Now,
+        SenderVerification = SenderVerification.NotEstablished,
         Text = "an extract",
     };
 

--- a/tests/Mcp.UnitTests/Tools/AskMailToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/AskMailToolTests.cs
@@ -4,12 +4,15 @@
 
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Retrieval;
 using MailFathom.Application.Retrieval.AskMail;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
 using MailFathom.Domain.Folders;
 using MailFathom.Mcp.Tools;
+using MailFathom.Mcp.Tools.Senders;
 using MailFathom.Mcp.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
 using Xunit;
@@ -108,6 +111,48 @@ public sealed class AskMailToolTests
             });
     }
 
+    /// <summary>A citation says what was established about the author of the message a claim was drawn from.</summary>
+    /// <remarks>
+    /// The pair and nothing else: the evidence behind it belongs to the single-email read the citation points at, and
+    /// an answer is not the place to publish a domain the reader did not ask to see.
+    /// </remarks>
+    [Fact]
+    public async Task AskMailAsync_ARunThatRetrievedMail_PublishesTheSenderVerdictOfEachCitedEmail()
+    {
+        // Arrange
+        var answerer = new StubMailQuestionAnswerer().Answering(
+            "They agreed to pay 400.",
+            PassageOf(
+                1,
+                new SenderVerification
+                {
+                    AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+                    DeploymentTrust = SenderTrustLevel.Trusted,
+                }),
+            PassageOf(
+                2,
+                new SenderVerification
+                {
+                    AuthorAuthentication = AuthorAuthenticationOutcome.Failed,
+                    DeploymentTrust = SenderTrustLevel.Unknown,
+                }));
+        var tool = ToolOver(answerer);
+
+        // Act
+        var result = await tool.AskMailAsync(Question, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            [
+                (AuthorAuthenticationState.Authenticated, DeploymentTrustState.Trusted),
+                (AuthorAuthenticationState.Failed, DeploymentTrustState.Unknown),
+            ],
+            [
+                .. result.Citations.Select(static citation =>
+                    (citation.SenderVerification.AuthorAuthentication, citation.SenderVerification.DeploymentTrust)),
+            ]);
+    }
+
     /// <summary>
     /// A question asked in one language about mail written in another is the ordinary case for a multilingual mailbox,
     /// and nothing this boundary owns reads either language: the question travels as it was asked, the citations are
@@ -200,7 +245,7 @@ public sealed class AskMailToolTests
         var tool = ToolOver(
             new StubMailQuestionAnswerer().Answering(
                 "An answer.",
-                [.. Enumerable.Range(1, 4).Select(PassageOf)]),
+                [.. Enumerable.Range(1, 4).Select(position => PassageOf(position))]),
             MailAnswerBounds.Create(20_000, 2));
 
         // Act
@@ -296,13 +341,14 @@ public sealed class AskMailToolTests
             AnsweringDeployment.AccountCatalog());
     }
 
-    private static EmailKnowledgePassage PassageOf(int position) => new()
+    private static EmailKnowledgePassage PassageOf(int position, SenderVerification? senderVerification = null) => new()
     {
         StoredEmailId = StoredEmailId.Create(EmailIdentityAt(position)),
         AccountId = MailAccountId.Create(AnsweringDeployment.ServedAccountId),
         FolderAlias = MailFolderAlias.Create("INBOX"),
         Subject = "Quarterly invoice",
         ReceivedAt = Now,
+        SenderVerification = senderVerification ?? SenderVerification.NotEstablished,
         Text = "an extract",
     };
 

--- a/tests/Mcp.UnitTests/Tools/GetEmailContentToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/GetEmailContentToolTests.cs
@@ -17,11 +17,14 @@ using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Observability;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
 using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
 using MailFathom.Mcp.Tools;
 using MailFathom.Mcp.Tools.Content;
 using MailFathom.Mcp.Tools.Results;
+using MailFathom.Mcp.Tools.Senders;
+using MailFathom.Mcp.Tools.Summaries;
 using MailFathom.Mcp.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
 using NSubstitute;
@@ -118,6 +121,129 @@ public sealed class GetEmailContentToolTests
         Assert.True(content.RemoteFlags.Seen);
         Assert.Equal(observedAt, content.RemoteFlags.ObservedAt);
         Assert.True(content.RemoteFlags.WasObserved);
+    }
+
+    /// <summary>An email that authenticated as one domain while displaying another is published as exactly that.</summary>
+    /// <remarks>
+    /// The case the whole verdict exists for. A delivery provider's signature verified, so the transport authenticated
+    /// and an unrelated domain is named; the displayed author failed under its own published policy. The read publishes
+    /// the conclusion and both domains, and the listing publishes the same conclusion for the same message.
+    /// </remarks>
+    [Fact]
+    public async Task GetEmailContentAsync_DisplayedAuthorFailedWhileAnotherDomainAuthenticated_PublishesBothDomainsAndTheFailedVerdict()
+    {
+        // Arrange
+        var summary = SummaryOf(
+            senderVerification: new SenderVerification
+            {
+                AuthorAuthentication = AuthorAuthenticationOutcome.Failed,
+                DeploymentTrust = SenderTrustLevel.Unknown,
+            },
+            senderAuthenticationEvidence: new SenderAuthenticationEvidence
+            {
+                AuthenticatedDomain = DomainOf("delivery.example.test"),
+                DisplayedAuthorDomain = DomainOf("bank.example.test"),
+                AuthenticatedBy = SenderAuthenticationMethod.DomainKeysIdentifiedMail,
+                Dmarc = DmarcOutcome.Fail,
+            });
+        var tool = ToolOver(new StubStoredEmailSummaryReader(summary));
+
+        // Act
+        var result = await tool.GetEmailContentAsync(
+            [summary.StoredEmailId.ToString()],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var content = ContentOf(Assert.Single(result.Emails));
+        Assert.Equal(AuthorAuthenticationState.Failed, content.SenderVerification.AuthorAuthentication);
+        Assert.Equal(DeploymentTrustState.Unknown, content.SenderVerification.DeploymentTrust);
+        Assert.Equal("DELIVERY.EXAMPLE.TEST", content.Headers.SenderAuthentication.AuthenticatedDomain);
+        Assert.Equal("BANK.EXAMPLE.TEST", content.Headers.SenderAuthentication.DisplayedAuthorDomain);
+        Assert.Equal(SenderAuthenticationCheck.Dkim, content.Headers.SenderAuthentication.AuthenticatedBy);
+        Assert.Equal(DmarcResult.Fail, content.Headers.SenderAuthentication.Dmarc);
+        Assert.Equal(ListedVerdictOf(summary), content.SenderVerification);
+    }
+
+    /// <summary>An authenticated author nobody has named is published as unknown rather than as anything against it.</summary>
+    [Fact]
+    public async Task GetEmailContentAsync_AuthenticatedAuthorOnNoTrustList_PublishesTrustUnknownBesideTheAuthentication()
+    {
+        // Arrange
+        var summary = SummaryOf(
+            senderVerification: new SenderVerification
+            {
+                AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+                DeploymentTrust = SenderTrustLevel.Unknown,
+            });
+        var tool = ToolOver(new StubStoredEmailSummaryReader(summary));
+
+        // Act
+        var result = await tool.GetEmailContentAsync(
+            [summary.StoredEmailId.ToString()],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var content = ContentOf(Assert.Single(result.Emails));
+        Assert.Equal(AuthorAuthenticationState.Authenticated, content.SenderVerification.AuthorAuthentication);
+        Assert.Equal(DeploymentTrustState.Unknown, content.SenderVerification.DeploymentTrust);
+        Assert.Equal(ListedVerdictOf(summary), content.SenderVerification);
+    }
+
+    /// <summary>Mail stored before the verdict was recorded is published as it is stored.</summary>
+    /// <remarks>
+    /// The stored default is what such a row holds, so it is published rather than replaced with a state saying the
+    /// value is unfilled. The domains are absent for the same reason, which is an ordinary outcome rather than a gap.
+    /// </remarks>
+    [Fact]
+    public async Task GetEmailContentAsync_EmailStoredBeforeTheVerdictWasRecorded_PublishesTheStoredDefault()
+    {
+        // Arrange
+        var summary = SummaryOf();
+        var tool = ToolOver(new StubStoredEmailSummaryReader(summary));
+
+        // Act
+        var result = await tool.GetEmailContentAsync(
+            [summary.StoredEmailId.ToString()],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var content = ContentOf(Assert.Single(result.Emails));
+        Assert.Equal(AuthorAuthenticationState.NotEstablished, content.SenderVerification.AuthorAuthentication);
+        Assert.Equal(DeploymentTrustState.Unknown, content.SenderVerification.DeploymentTrust);
+        Assert.Null(content.Headers.SenderAuthentication.AuthenticatedDomain);
+        Assert.Null(content.Headers.SenderAuthentication.DisplayedAuthorDomain);
+        Assert.Equal(SenderAuthenticationCheck.None, content.Headers.SenderAuthentication.AuthenticatedBy);
+        Assert.Equal(DmarcResult.NotReported, content.Headers.SenderAuthentication.Dmarc);
+    }
+
+    /// <summary>An email whose raw MIME was never stored still carries the verdict its row holds.</summary>
+    /// <remarks>
+    /// The narrower headers such a read produces come from the row rather than from a parse, and so does the verdict —
+    /// so a caller reading an oversized message is told the same thing about its author as a listing tells them.
+    /// </remarks>
+    [Fact]
+    public async Task GetEmailContentAsync_EmailStoredWithoutItsContent_StillPublishesTheStoredVerdict()
+    {
+        // Arrange
+        var summary = SummaryOf(
+            contentAvailability: StoredEmailContentAvailability.ExceededSizeLimit,
+            senderVerification: new SenderVerification
+            {
+                AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+                DeploymentTrust = SenderTrustLevel.Trusted,
+            });
+        var tool = ToolOver(new StubStoredEmailSummaryReader(summary));
+
+        // Act
+        var result = await tool.GetEmailContentAsync(
+            [summary.StoredEmailId.ToString()],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var content = ContentOf(Assert.Single(result.Emails));
+        Assert.Equal(EmailBodyAvailabilityState.NotStoredExceededSizeLimit, content.Body.Availability);
+        Assert.Equal(AuthorAuthenticationState.Authenticated, content.SenderVerification.AuthorAuthentication);
+        Assert.Equal(DeploymentTrustState.Trusted, content.SenderVerification.DeploymentTrust);
     }
 
     /// <summary>A body and the fact that it is incomplete are never useful apart, so the second travels inside the first.</summary>
@@ -916,6 +1042,22 @@ public sealed class GetEmailContentToolTests
             ? type.GetGenericArguments()[0]
             : type;
 
+    /// <summary>Publishes one summary the way a listing would, so a read's verdict can be compared with a listing's.</summary>
+    /// <remarks>
+    /// The mapping the listing tool itself uses rather than a restatement of it, which is what makes the comparison a
+    /// claim about the two tools agreeing rather than about this test's own arithmetic.
+    /// </remarks>
+    private static ReportedSenderVerification ListedVerdictOf(EmailSummary summary) =>
+        ListedEmailSummary.From(summary, PublishedAccountNames.From(new StubMailAccountCatalog(ServedAccountId)))
+            .SenderVerification;
+
+    private static SenderDomain DomainOf(string value)
+    {
+        Assert.True(SenderDomain.TryCreate(value, out var domain));
+
+        return domain;
+    }
+
     private static RetrievedEmailContent ContentOf(RetrievedEmail email) =>
         email.Content ?? throw new InvalidOperationException(
             $"The email was not served: {email.Failure?.Message}");
@@ -957,7 +1099,9 @@ public sealed class GetEmailContentToolTests
         DateTimeOffset? receivedAt = null,
         DateTimeOffset? observedAt = null,
         string accountId = ServedAccountId,
-        StoredEmailContentAvailability contentAvailability = StoredEmailContentAvailability.Available) => new()
+        StoredEmailContentAvailability contentAvailability = StoredEmailContentAvailability.Available,
+        SenderVerification? senderVerification = null,
+        SenderAuthenticationEvidence? senderAuthenticationEvidence = null) => new()
         {
             StoredEmailId = StoredEmailId.Create(Guid.CreateVersion7()),
             AccountId = MailAccountId.Create(accountId),
@@ -982,6 +1126,8 @@ public sealed class GetEmailContentToolTests
                     IsDeleted: false,
                     Keywords: RemoteEmailKeywords.None)
                 : RemoteEmailFlagSnapshot.NeverObserved,
+            SenderVerification = senderVerification ?? SenderVerification.NotEstablished,
+            SenderAuthenticationEvidence = senderAuthenticationEvidence ?? SenderAuthenticationEvidence.None,
         };
 
     private static EmailContentRendering RenderingOf(

--- a/tests/Mcp.UnitTests/Tools/GetEmailContentToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/GetEmailContentToolTests.cs
@@ -123,11 +123,13 @@ public sealed class GetEmailContentToolTests
         Assert.True(content.RemoteFlags.WasObserved);
     }
 
-    /// <summary>An email that authenticated as one domain while displaying another is published as exactly that.</summary>
+    /// <summary>An email whose displayed author failed while another domain authenticated is published as exactly that.</summary>
     /// <remarks>
     /// The case the whole verdict exists for. A delivery provider's signature verified, so the transport authenticated
     /// and an unrelated domain is named; the displayed author failed under its own published policy. The read publishes
-    /// the conclusion and both domains, and the listing publishes the same conclusion for the same message.
+    /// the conclusion and both domains, and the listing publishes the same conclusion for the same message. What makes
+    /// this the spoofed case is the verdict rather than the two domains differing — the test below is the same
+    /// difference on mail that authenticated.
     /// </remarks>
     [Fact]
     public async Task GetEmailContentAsync_DisplayedAuthorFailedWhileAnotherDomainAuthenticated_PublishesBothDomainsAndTheFailedVerdict()
@@ -162,6 +164,46 @@ public sealed class GetEmailContentToolTests
         Assert.Equal(SenderAuthenticationCheck.Dkim, content.Headers.SenderAuthentication.AuthenticatedBy);
         Assert.Equal(DmarcResult.Fail, content.Headers.SenderAuthentication.Dmarc);
         Assert.Equal(ListedVerdictOf(summary), content.SenderVerification);
+    }
+
+    /// <summary>Two different domains on an authenticated email are published as they are, with the verdict unchanged.</summary>
+    /// <remarks>
+    /// The authenticated domain is whichever identity authenticated the transport, and DKIM is kept where both checks
+    /// produced one — so a provider that signs as itself while the envelope sender passes for the author's own domain
+    /// publishes two domains that differ on mail that is authenticated exactly as it appears. Nothing on the read path
+    /// compares them or lets the difference reach the verdict, which is what the published descriptions promise.
+    /// </remarks>
+    [Fact]
+    public async Task GetEmailContentAsync_AuthenticatedAuthorRelayedByAnotherDomain_PublishesBothDomainsWithoutWeakeningTheVerdict()
+    {
+        // Arrange
+        var summary = SummaryOf(
+            senderVerification: new SenderVerification
+            {
+                AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+                DeploymentTrust = SenderTrustLevel.Trusted,
+            },
+            senderAuthenticationEvidence: new SenderAuthenticationEvidence
+            {
+                AuthenticatedDomain = DomainOf("delivery.example.test"),
+                DisplayedAuthorDomain = DomainOf("bank.example.test"),
+                AuthenticatedBy = SenderAuthenticationMethod.DomainKeysIdentifiedMail,
+                Dmarc = DmarcOutcome.Pass,
+            });
+        var tool = ToolOver(new StubStoredEmailSummaryReader(summary));
+
+        // Act
+        var result = await tool.GetEmailContentAsync(
+            [summary.StoredEmailId.ToString()],
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var content = ContentOf(Assert.Single(result.Emails));
+        Assert.Equal(AuthorAuthenticationState.Authenticated, content.SenderVerification.AuthorAuthentication);
+        Assert.Equal(DeploymentTrustState.Trusted, content.SenderVerification.DeploymentTrust);
+        Assert.Equal("DELIVERY.EXAMPLE.TEST", content.Headers.SenderAuthentication.AuthenticatedDomain);
+        Assert.Equal("BANK.EXAMPLE.TEST", content.Headers.SenderAuthentication.DisplayedAuthorDomain);
+        Assert.Equal(DmarcResult.Pass, content.Headers.SenderAuthentication.Dmarc);
     }
 
     /// <summary>An authenticated author nobody has named is published as unknown rather than as anything against it.</summary>

--- a/tests/Mcp.UnitTests/Tools/GetEmailContentToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/GetEmailContentToolTests.cs
@@ -216,13 +216,14 @@ public sealed class GetEmailContentToolTests
         Assert.Equal(DmarcResult.NotReported, content.Headers.SenderAuthentication.Dmarc);
     }
 
-    /// <summary>An email whose raw MIME was never stored still carries the verdict its row holds.</summary>
+    /// <summary>An email whose raw MIME was never stored still carries the verdict its row holds, and its evidence.</summary>
     /// <remarks>
-    /// The narrower headers such a read produces come from the row rather than from a parse, and so does the verdict —
-    /// so a caller reading an oversized message is told the same thing about its author as a listing tells them.
+    /// The narrower headers such a read produces come from the row rather than from a parse, and so do the verdict and
+    /// the evidence — so a caller reading an oversized message is told the same thing about its author as a listing
+    /// tells them, and told what that answer rests on.
     /// </remarks>
     [Fact]
-    public async Task GetEmailContentAsync_EmailStoredWithoutItsContent_StillPublishesTheStoredVerdict()
+    public async Task GetEmailContentAsync_EmailStoredWithoutItsContent_StillPublishesTheStoredVerdictAndItsEvidence()
     {
         // Arrange
         var summary = SummaryOf(
@@ -231,6 +232,13 @@ public sealed class GetEmailContentToolTests
             {
                 AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
                 DeploymentTrust = SenderTrustLevel.Trusted,
+            },
+            senderAuthenticationEvidence: new SenderAuthenticationEvidence
+            {
+                AuthenticatedDomain = DomainOf("bank.example.test"),
+                DisplayedAuthorDomain = DomainOf("bank.example.test"),
+                AuthenticatedBy = SenderAuthenticationMethod.DomainKeysIdentifiedMail,
+                Dmarc = DmarcOutcome.Pass,
             });
         var tool = ToolOver(new StubStoredEmailSummaryReader(summary));
 
@@ -244,6 +252,10 @@ public sealed class GetEmailContentToolTests
         Assert.Equal(EmailBodyAvailabilityState.NotStoredExceededSizeLimit, content.Body.Availability);
         Assert.Equal(AuthorAuthenticationState.Authenticated, content.SenderVerification.AuthorAuthentication);
         Assert.Equal(DeploymentTrustState.Trusted, content.SenderVerification.DeploymentTrust);
+        Assert.Equal("BANK.EXAMPLE.TEST", content.Headers.SenderAuthentication.AuthenticatedDomain);
+        Assert.Equal("BANK.EXAMPLE.TEST", content.Headers.SenderAuthentication.DisplayedAuthorDomain);
+        Assert.Equal(SenderAuthenticationCheck.Dkim, content.Headers.SenderAuthentication.AuthenticatedBy);
+        Assert.Equal(DmarcResult.Pass, content.Headers.SenderAuthentication.Dmarc);
     }
 
     /// <summary>A body and the fact that it is incomplete are never useful apart, so the second travels inside the first.</summary>

--- a/tests/Mcp.UnitTests/Tools/ListEmailsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/ListEmailsToolTests.cs
@@ -12,10 +12,12 @@ using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
 using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
 using MailFathom.Mcp.Tools;
 using MailFathom.Mcp.Tools.Results;
+using MailFathom.Mcp.Tools.Senders;
 using MailFathom.Mcp.Tools.Summaries;
 using MailFathom.Mcp.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
@@ -453,6 +455,12 @@ public sealed class ListEmailsToolTests
                 IsDraft: false,
                 IsDeleted: false,
                 Keywords: RemoteEmailKeywords.Create(["$Junk"])),
+            SenderVerification = new SenderVerification
+            {
+                AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+                DeploymentTrust = SenderTrustLevel.Trusted,
+            },
+            SenderAuthenticationEvidence = SenderAuthenticationEvidence.None,
         };
         var tool = ToolOver(new StubStoredEmailTimelineReader(summary));
 
@@ -486,6 +494,54 @@ public sealed class ListEmailsToolTests
         Assert.Equal(["$JUNK"], published.RemoteFlags.Keywords);
         Assert.Equal(observedAt, published.RemoteFlags.ObservedAt);
         Assert.True(published.RemoteFlags.WasObserved);
+        Assert.Equal(AuthorAuthenticationState.Authenticated, published.SenderVerification.AuthorAuthentication);
+        Assert.Equal(DeploymentTrustState.Trusted, published.SenderVerification.DeploymentTrust);
+    }
+
+    /// <summary>A listed email whose author authenticated but whom nobody has named is published as unknown, not as a failure.</summary>
+    /// <remarks>
+    /// The ordinary state of legitimate mail from a first-time correspondent, and the reading a caller most easily gets
+    /// wrong: the two values answer different questions, so an unknown beside an authenticated author says only that
+    /// this deployment's own list does not name them.
+    /// </remarks>
+    [Fact]
+    public async Task ListEmailsAsync_AuthenticatedAuthorOnNoTrustList_PublishesTrustUnknownBesideTheAuthentication()
+    {
+        // Arrange
+        var summary = SummaryReceivedAt(new DateTimeOffset(2026, 3, 1, 8, 0, 0, TimeSpan.Zero)) with
+        {
+            SenderVerification = new SenderVerification
+            {
+                AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+                DeploymentTrust = SenderTrustLevel.Unknown,
+            },
+        };
+        var tool = ToolOver(new StubStoredEmailTimelineReader(summary));
+
+        // Act
+        var result = await tool.ListEmailsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var published = Assert.Single(result.Emails);
+        Assert.Equal(AuthorAuthenticationState.Authenticated, published.SenderVerification.AuthorAuthentication);
+        Assert.Equal(DeploymentTrustState.Unknown, published.SenderVerification.DeploymentTrust);
+    }
+
+    /// <summary>A listed email stored before the verdict was recorded is published as its row holds it.</summary>
+    [Fact]
+    public async Task ListEmailsAsync_EmailStoredBeforeTheVerdictWasRecorded_PublishesTheStoredDefault()
+    {
+        // Arrange
+        var tool = ToolOver(new StubStoredEmailTimelineReader(
+            SummaryReceivedAt(new DateTimeOffset(2026, 3, 1, 8, 0, 0, TimeSpan.Zero))));
+
+        // Act
+        var result = await tool.ListEmailsAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var published = Assert.Single(result.Emails);
+        Assert.Equal(AuthorAuthenticationState.NotEstablished, published.SenderVerification.AuthorAuthentication);
+        Assert.Equal(DeploymentTrustState.Unknown, published.SenderVerification.DeploymentTrust);
     }
 
     /// <summary>An email waiting for storage room is published as waiting, rather than ending the listing.</summary>
@@ -676,6 +732,8 @@ public sealed class ListEmailsToolTests
         Attachments = StoredEmailAttachmentSummary.None,
         ContentAvailability = StoredEmailContentAvailability.Available,
         RemoteFlags = RemoteEmailFlagSnapshot.NeverObserved,
+        SenderVerification = SenderVerification.NotEstablished,
+        SenderAuthenticationEvidence = SenderAuthenticationEvidence.None,
     };
 
     private static ListEmailsTool ToolOver(

--- a/tests/Mcp.UnitTests/Tools/SearchEmailsToolTests.cs
+++ b/tests/Mcp.UnitTests/Tools/SearchEmailsToolTests.cs
@@ -14,10 +14,12 @@ using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.Synchronization.Checkpoints;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
 using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
 using MailFathom.Mcp.Tools;
 using MailFathom.Mcp.Tools.Results;
+using MailFathom.Mcp.Tools.Summaries;
 using MailFathom.Mcp.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
@@ -350,6 +352,30 @@ public sealed class SearchEmailsToolTests
         Assert.Equal(["the **invoice** for March", "your **invoice** is attached"], published.Snippets);
     }
 
+    /// <summary>A search publishes the sender verdict by republishing the listing's summary rather than a shape of its own.</summary>
+    /// <remarks>
+    /// The assertion is against the summary the listing tool would publish for the same email, so a client written
+    /// against a listing needs nothing new to read a match's verdict.
+    /// </remarks>
+    [Fact]
+    public async Task SearchEmailsAsync_MatchedEmail_RepublishesTheListingsSenderVerdict()
+    {
+        // Arrange
+        var summary = SummaryOf(EmailIdentityAt(1), new DateTimeOffset(2026, 3, 1, 8, 0, 0, TimeSpan.Zero));
+        var tool = ToolOver(new StubEmailSearchIndexReader(
+            new EmailSearchMatch(summary, RelevanceRank: 0.5f, Snippets: [])));
+
+        // Act
+        var result = await tool.SearchEmailsAsync(Query, cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert
+        var published = Assert.Single(result.Matches);
+        Assert.Equal(
+            ListedEmailSummary.From(summary, PublishedAccountNames.From(new StubMailAccountCatalog(ServedAccountId)))
+                .SenderVerification,
+            published.Summary.SenderVerification);
+    }
+
     /// <summary>An email matched on its subject or a participant carries no extract, because the summary publishes both whole.</summary>
     [Fact]
     public async Task SearchEmailsAsync_MatchWithNoIndexedBodyText_PublishesNoSnippets()
@@ -559,6 +585,12 @@ public sealed class SearchEmailsToolTests
         Attachments = StoredEmailAttachmentSummary.None,
         ContentAvailability = StoredEmailContentAvailability.Available,
         RemoteFlags = RemoteEmailFlagSnapshot.NeverObserved,
+        SenderVerification = new SenderVerification
+        {
+            AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+            DeploymentTrust = SenderTrustLevel.Unknown,
+        },
+        SenderAuthenticationEvidence = SenderAuthenticationEvidence.None,
     };
 
     private static MailboxFolderFreshness FreshnessOf(string folderAlias, DateTimeOffset? synchronizedAt) => new(

--- a/tests/Mcp.UnitTests/Tools/Senders/ReportedSenderAuthenticationTests.cs
+++ b/tests/Mcp.UnitTests/Tools/Senders/ReportedSenderAuthenticationTests.cs
@@ -12,11 +12,12 @@ namespace MailFathom.Mcp.UnitTests.Tools.Senders;
 /// <summary>What the boundary publishes for the evidence an email's author conclusion was reached from.</summary>
 public sealed class ReportedSenderAuthenticationTests
 {
-    /// <summary>An email that authenticated as one domain while displaying another publishes both, side by side.</summary>
+    /// <summary>An email whose authenticated domain differs from the displayed one publishes both, side by side.</summary>
     /// <remarks>
-    /// This is the case the whole verdict exists to make visible, and it is what a reader compares. The verdict beside
-    /// it says the displayed author was not established; nothing here restates that as an alignment flag. Both domains
-    /// are published in the comparison form the row holds, which is what makes the comparison exact.
+    /// Both domains are published in the comparison form the row holds, and neither is dropped for differing from the
+    /// other. Nothing here restates the difference as an alignment flag, deliberately: the authenticated domain is
+    /// whichever identity authenticated the transport, so mail a provider relayed and signed as itself differs here
+    /// while being authenticated exactly as it appears, and the verdict is what answers that question.
     /// </remarks>
     [Fact]
     public void From_AuthenticatedDomainDifferingFromTheDisplayedOne_PublishesBoth()

--- a/tests/Mcp.UnitTests/Tools/Senders/ReportedSenderAuthenticationTests.cs
+++ b/tests/Mcp.UnitTests/Tools/Senders/ReportedSenderAuthenticationTests.cs
@@ -1,0 +1,135 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Summaries;
+using MailFathom.Domain.Emails.Authentication;
+using MailFathom.Mcp.Tools.Senders;
+using Xunit;
+
+namespace MailFathom.Mcp.UnitTests.Tools.Senders;
+
+/// <summary>What the boundary publishes for the evidence an email's author conclusion was reached from.</summary>
+public sealed class ReportedSenderAuthenticationTests
+{
+    /// <summary>An email that authenticated as one domain while displaying another publishes both, side by side.</summary>
+    /// <remarks>
+    /// This is the case the whole verdict exists to make visible, and it is what a reader compares. The verdict beside
+    /// it says the displayed author was not established; nothing here restates that as an alignment flag. Both domains
+    /// are published in the comparison form the row holds, which is what makes the comparison exact.
+    /// </remarks>
+    [Fact]
+    public void From_AuthenticatedDomainDifferingFromTheDisplayedOne_PublishesBoth()
+    {
+        // Arrange
+        var evidence = new SenderAuthenticationEvidence
+        {
+            AuthenticatedDomain = DomainOf("delivery.example.test"),
+            DisplayedAuthorDomain = DomainOf("bank.example.test"),
+            AuthenticatedBy = SenderAuthenticationMethod.DomainKeysIdentifiedMail,
+            Dmarc = DmarcOutcome.NotReported,
+        };
+
+        // Act
+        var published = ReportedSenderAuthentication.From(evidence);
+
+        // Assert
+        Assert.Equal("DELIVERY.EXAMPLE.TEST", published.AuthenticatedDomain);
+        Assert.Equal("BANK.EXAMPLE.TEST", published.DisplayedAuthorDomain);
+    }
+
+    /// <summary>An email nothing authenticated names no authenticated domain, which is an outcome rather than a gap.</summary>
+    [Fact]
+    public void From_EvidenceNothingWasReadFor_PublishesAbsentDomainsAndNoCheck()
+    {
+        // Act
+        var published = ReportedSenderAuthentication.From(SenderAuthenticationEvidence.None);
+
+        // Assert
+        Assert.Null(published.AuthenticatedDomain);
+        Assert.Null(published.DisplayedAuthorDomain);
+        Assert.Equal("None", published.AuthenticatedBy.ToString());
+        Assert.Equal("NotReported", published.Dmarc.ToString());
+    }
+
+    /// <summary>Each check is published under the name a reader of a mail header already knows it by.</summary>
+    [Theory]
+    [InlineData(SenderAuthenticationMethod.None, "None")]
+    [InlineData(SenderAuthenticationMethod.DomainKeysIdentifiedMail, "Dkim")]
+    [InlineData(SenderAuthenticationMethod.SenderPolicyFramework, "Spf")]
+    public void From_StoredCheck_PublishesTheProtocolName(SenderAuthenticationMethod method, string expected)
+    {
+        // Arrange
+        var evidence = SenderAuthenticationEvidence.None with { AuthenticatedBy = method };
+
+        // Act
+        var published = ReportedSenderAuthentication.From(evidence);
+
+        // Assert
+        Assert.Equal(expected, published.AuthenticatedBy.ToString());
+    }
+
+    /// <summary>Every DMARC result the trusted header can report has a published value of its own.</summary>
+    /// <remarks>
+    /// A server that evaluated DMARC and found no published policy is deliberately not the same answer as a server
+    /// that reported no DMARC result at all, so both are published rather than folded into one absence.
+    /// </remarks>
+    [Theory]
+    [InlineData(DmarcOutcome.NotReported, "NotReported")]
+    [InlineData(DmarcOutcome.Pass, "Pass")]
+    [InlineData(DmarcOutcome.Fail, "Fail")]
+    [InlineData(DmarcOutcome.NoPolicyPublished, "NoPolicyPublished")]
+    [InlineData(DmarcOutcome.TemporaryError, "TemporaryError")]
+    [InlineData(DmarcOutcome.PermanentError, "PermanentError")]
+    public void From_StoredDmarcOutcome_PublishesTheServersOwnResult(DmarcOutcome outcome, string expected)
+    {
+        // Arrange
+        var evidence = SenderAuthenticationEvidence.None with { Dmarc = outcome };
+
+        // Act
+        var published = ReportedSenderAuthentication.From(evidence);
+
+        // Assert
+        Assert.Equal(expected, published.Dmarc.ToString());
+    }
+
+    /// <summary>A stored check nobody decided how to publish is refused rather than guessed at.</summary>
+    [Fact]
+    public void From_CheckWithNoPublishedValue_IsRefused()
+    {
+        // Arrange
+        var evidence = SenderAuthenticationEvidence.None with
+        {
+            AuthenticatedBy = (SenderAuthenticationMethod)99,
+        };
+
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => ReportedSenderAuthentication.From(evidence));
+    }
+
+    /// <summary>A stored DMARC result nobody decided how to publish is refused rather than guessed at.</summary>
+    [Fact]
+    public void From_DmarcOutcomeWithNoPublishedValue_IsRefused()
+    {
+        // Arrange
+        var evidence = SenderAuthenticationEvidence.None with { Dmarc = (DmarcOutcome)99 };
+
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => ReportedSenderAuthentication.From(evidence));
+    }
+
+    /// <summary>Nothing is published for evidence that was never handed over.</summary>
+    [Fact]
+    public void From_WithoutEvidence_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => ReportedSenderAuthentication.From(null!));
+    }
+
+    private static SenderDomain DomainOf(string value)
+    {
+        Assert.True(SenderDomain.TryCreate(value, out var domain));
+
+        return domain;
+    }
+}

--- a/tests/Mcp.UnitTests/Tools/Senders/ReportedSenderVerificationTests.cs
+++ b/tests/Mcp.UnitTests/Tools/Senders/ReportedSenderVerificationTests.cs
@@ -1,0 +1,103 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Emails.Summaries;
+using MailFathom.Domain.Emails.Authentication;
+using MailFathom.Mcp.Tools.Senders;
+using Xunit;
+
+namespace MailFathom.Mcp.UnitTests.Tools.Senders;
+
+/// <summary>What the boundary publishes for the two conclusions an email carries about its displayed author.</summary>
+/// <remarks>
+/// The expected values are asserted as their member names rather than as the internal enumeration, because the wire
+/// value is the camel-cased member name and a public test signature cannot carry an internal enum. Naming them here is
+/// therefore both what the accessibility rules allow and what states the published contract.
+/// </remarks>
+public sealed class ReportedSenderVerificationTests
+{
+    /// <summary>Every combination the two axes reach is published as two independent values.</summary>
+    /// <remarks>
+    /// Six rows because the axes are independent and neither is derived from the other. The pair that matters most is
+    /// authenticated beside unknown, which is the ordinary state of legitimate mail from a correspondent nobody has
+    /// named and must never read as a failed authentication.
+    /// </remarks>
+    [Theory]
+    [InlineData(AuthorAuthenticationOutcome.NotEstablished, SenderTrustLevel.Unknown, "NotEstablished", "Unknown")]
+    [InlineData(AuthorAuthenticationOutcome.NotEstablished, SenderTrustLevel.Trusted, "NotEstablished", "Trusted")]
+    [InlineData(AuthorAuthenticationOutcome.Failed, SenderTrustLevel.Unknown, "Failed", "Unknown")]
+    [InlineData(AuthorAuthenticationOutcome.Failed, SenderTrustLevel.Trusted, "Failed", "Trusted")]
+    [InlineData(AuthorAuthenticationOutcome.Authenticated, SenderTrustLevel.Unknown, "Authenticated", "Unknown")]
+    [InlineData(AuthorAuthenticationOutcome.Authenticated, SenderTrustLevel.Trusted, "Authenticated", "Trusted")]
+    public void From_StoredPair_PublishesBothOutcomesSeparately(
+        AuthorAuthenticationOutcome authorAuthentication,
+        SenderTrustLevel deploymentTrust,
+        string expectedAuthorAuthentication,
+        string expectedDeploymentTrust)
+    {
+        // Arrange
+        var stored = new SenderVerification
+        {
+            AuthorAuthentication = authorAuthentication,
+            DeploymentTrust = deploymentTrust,
+        };
+
+        // Act
+        var published = ReportedSenderVerification.From(stored);
+
+        // Assert
+        Assert.Equal(expectedAuthorAuthentication, published.AuthorAuthentication.ToString());
+        Assert.Equal(expectedDeploymentTrust, published.DeploymentTrust.ToString());
+    }
+
+    /// <summary>Mail stored before the columns existed is published as it is stored, not as a state nobody recorded.</summary>
+    [Fact]
+    public void From_VerdictNothingEverJudged_PublishesTheStoredDefaultRatherThanInventingAState()
+    {
+        // Act
+        var published = ReportedSenderVerification.From(SenderVerification.NotEstablished);
+
+        // Assert
+        Assert.Equal("NotEstablished", published.AuthorAuthentication.ToString());
+        Assert.Equal("Unknown", published.DeploymentTrust.ToString());
+    }
+
+    /// <summary>A stored author conclusion nobody decided how to publish is refused rather than guessed at.</summary>
+    [Fact]
+    public void From_AuthorConclusionWithNoPublishedValue_IsRefused()
+    {
+        // Arrange
+        var stored = new SenderVerification
+        {
+            AuthorAuthentication = (AuthorAuthenticationOutcome)99,
+            DeploymentTrust = SenderTrustLevel.Unknown,
+        };
+
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => ReportedSenderVerification.From(stored));
+    }
+
+    /// <summary>A stored trust level nobody decided how to publish is refused rather than guessed at.</summary>
+    [Fact]
+    public void From_TrustLevelWithNoPublishedValue_IsRefused()
+    {
+        // Arrange
+        var stored = new SenderVerification
+        {
+            AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+            DeploymentTrust = (SenderTrustLevel)99,
+        };
+
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => ReportedSenderVerification.From(stored));
+    }
+
+    /// <summary>Nothing is published for a pair that was never handed over.</summary>
+    [Fact]
+    public void From_WithoutAPair_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => ReportedSenderVerification.From(null!));
+    }
+}


### PR DESCRIPTION
## What this changes

Synchronization has decided two things about every message it stored — whether the author the message displays was
authenticated, and whether this deployment recognizes that author — and until now no read tool said either one out
loud. A model reading a listing met `senderAddress`, which is a claim the message wrote about itself, with nothing
beside it saying whether anything had verified the claim.

Every read path now publishes the verdict, and one of them publishes the evidence behind it.

- **`list_emails`, `search_emails`** — each summary carries `senderVerification`, a pair of `authorAuthentication`
  (`notEstablished` / `failed` / `authenticated`) and `deploymentTrust` (`unknown` / `trusted`).
- **`get_email_content`** — the same pair, plus `headers.senderAuthentication`: the authenticated domain, the domain the
  message displayed, the check that authenticated it, and the DMARC result. This is the tool a reader reaches for when
  the verdict itself is what they are questioning, so it is the one place the evidence is published.
- **`ask_mail`** — each citation carries the pair, so an answer's sources say what was verified.

The two axes stay independent, as [#885](https://github.com/Krzysztof318/MailFathom/issues/885) and
[#757](https://github.com/Krzysztof318/MailFathom/issues/757) settled them: `unknown` trust is the ordinary state of
legitimate mail from a new correspondent and says nothing about authentication, and the published descriptions say so,
because a `[Description]` is the whole of what a model is told.

## How it is built

`EmailSummary` carries the pair, read from the stored columns by the single projection in `StoredEmailSummaryRow`, so a
listing, a search, and a single message cannot disagree about one message. Nothing is recomputed at the read boundary —
no DNS, no header re-read, no IMAP fetch — which is what keeps an MCP read local.

The MCP boundary re-declares its four enumerations (`AuthorAuthenticationState`, `DeploymentTrustState`,
`SenderAuthenticationCheck`, `DmarcResult`) rather than publishing the domain ones, the way `ListedEmailContentAvailability`
already does, and each mapping refuses an undecided value rather than inventing one.

## The one new column

"The domain the message displayed as its author" could not be derived from anything stored. `SenderAuthentication.FromDomain`
is `From` alone, while the stored sender address falls back to `Sender` for a message that named no author — two different
values, and the acceptance requires every published value to be read from what synchronization stored. So an additive,
nullable `DisplayedAuthorDomain` (`character varying(253)`) joins the other authentication columns, written where they are
written. Scripted SQL: `ALTER TABLE stored_emails ADD "DisplayedAuthorDomain" character varying(253);` — no rewrite, no
default, no lock beyond the catalog update.

## Contract break

**MCP tool contract, additive.** `list_emails`, `search_emails`, `get_email_content`, and `ask_mail` each gain a field in
their result. A client that ignores unknown fields needs no action; a client that validates its input against a closed
schema updates it.

**Database schema, additive.** One nullable column; the release is deployable over the previous release's data.

**Operator action.** Mail synchronized before this release holds no `displayedAuthorDomain` and publishes it as absent —
indistinguishable from a message that displayed none. `mfctl mailbox rederive` fills it in from the raw MIME the
deployment already stores, through the same extraction that writes the column on arrival. The extraction backfill does
not: it selects only messages carrying no search document, so it steps over every message already extracted. Every other
published value was already on the row and needs nothing.

## Deviation from the issue

The acceptance names five evidence values, including "whether the two domains aligned".
[#885](https://github.com/Krzysztof318/MailFathom/issues/885) deleted the `SenderDomainAlignment` column, and the
alignment conclusion is exactly what `authorAuthentication` states. Rather than reviving a boolean the model no longer
holds, this publishes the two domains side by side and lets the caller see the disagreement itself — which is strictly
more than a flag, and is what makes a spoofed author legible in the result.

## Verification

- `scripts/verify-full.sh` — passed.
- 7485 unit tests, 0 failed.
- Aggregate line coverage 96.08% (21584/22464), required 85%.
- Migration applied to the orchestrated database and the host's schema gate accepted it.
- `$check-docs-licenses` — Docs `pass`, Changelog `n/a`, Licenses `n/a` (no dependency added).

Closes #888
