### PR TITLE
[#585] Carry the authorized caller into the application layer, and enforce there as well as at the transport

### DIFF
--- a/docs/architecture/authorized-principal.md
+++ b/docs/architecture/authorized-principal.md
@@ -45,7 +45,7 @@ There are three kinds of principal, and none of them is a weaker version of anot
 
 | Kind | What it is | What it holds |
 | --- | --- | --- |
-| Caller | Somebody who presented a credential a configured entry admits | Whatever that entry's grant resolved to |
+| Caller | Somebody who presented a credential a configured entry admits, or — where the surface configures no entry at all — somebody who presented nothing | Whatever that entry's grant resolved to, and everything the surface publishes where there is no entry |
 | Process identity | MailFathom itself, running work no caller requested | Nothing, by construction |
 | Signed capability | A ticket this deployment signed for one object | Nothing; the ticket is the authorization |
 

--- a/docs/architecture/authorized-principal.md
+++ b/docs/architecture/authorized-principal.md
@@ -37,8 +37,9 @@ references cannot refuse on their own.
 
 The identity is not one shape. Where an operator wrote the credential it is that entry's own name; where a token brought
 it, it is the issuer and subject the deployment authorized — a host name and that authorization server's identifier for
-a person. So a boundary that names the caller to its own readers reads the identity and decides for itself what it may
-show, and a refusal never carries it.
+a person; and where the surface configures no credential at all it is the fixed word `anonymous`, because there is
+nothing to tell one caller apart from another. So a boundary that names the caller to its own readers reads the identity
+and decides for itself what it may show, and a refusal never carries it.
 
 There are three kinds of principal, and none of them is a weaker version of another:
 
@@ -75,10 +76,13 @@ The host composes one `IAuthorizedPrincipalSource` per scope, which for a served
 configures no `Authentication` entry at all, the caller holds everything the surface publishes — there is no entry for a
 grant to hang on, which is the posture ADR 0012 settled and the startup record already states, so reporting no principal
 there would have a use case refuse every call on a deployment whose own record says it grants everything. Where the
-surface does configure a credential, such a request is none of the three, and that is what protects the download route:
-it is reached without a credential legitimately, and a principal appearing out of the transport there would be a second
-and weaker way into an attachment than the signature the route exists to check. The route's own statement overrides
-either answer once the ticket verifies.
+surface does configure a credential, such a request is none of the three.
+
+**The download route is withheld from that grant on either posture.** The MCP surface serves it beside the protocol
+route, so the paragraph above would otherwise admit it out of the transport wherever the deployment configures no MCP
+credential — a second and weaker way into an attachment than the signature the route exists to check, and one holding on
+one posture only. The adapter therefore answers no principal for a path that route serves before it asks either surface,
+and the route's own statement, made once the ticket verifies, is the only thing that authorizes it.
 
 ## What a refusal is, and what each boundary does with it
 

--- a/docs/architecture/authorized-principal.md
+++ b/docs/architecture/authorized-principal.md
@@ -29,11 +29,16 @@ transport having already asked, and the transport never relies on the use case b
 
 ## What the application layer is told
 
-`AuthorizedPrincipal` is the whole of it: the configured identity the work was admitted under, and the permissions that
-identity holds. Nothing from `System.Security.Claims`, ASP.NET Core, or the MCP SDK crosses that line, and no use case
-learns *which* credential admitted a caller — that is a question the transport already answered. `Boundaries.UnitTests`
-holds a rule keeping claims types out of `Application` and `Domain`, because those are the one family of types the
-project references cannot refuse on their own.
+`AuthorizedPrincipal` is the whole of it: the identity the work was admitted under, and the permissions that identity
+holds. Nothing from `System.Security.Claims`, ASP.NET Core, or the MCP SDK crosses that line, and no use case learns
+*which* credential admitted a caller — that is a question the transport already answered. `Boundaries.UnitTests` holds a
+rule keeping claims types out of `Application` and `Domain`, because those are the one family of types the project
+references cannot refuse on their own.
+
+The identity is not one shape. Where an operator wrote the credential it is that entry's own name; where a token brought
+it, it is the issuer and subject the deployment authorized — a host name and that authorization server's identifier for
+a person. So a boundary that names the caller to its own readers reads the identity and decides for itself what it may
+show, and a refusal never carries it.
 
 There are three kinds of principal, and none of them is a weaker version of another:
 
@@ -57,19 +62,23 @@ so the next capability-authorized route does not have to argue for its own.
 
 The host composes one `IAuthorizedPrincipalSource` per scope, which for a served request is that request:
 
-- **A request an authentication scheme validated** becomes a caller, named by what this deployment configured — an API
-  key's name, a client public key's name, or the subject the access policy checked against the configured authorization
-  servers. The permissions travel as claims the scheme wrote when the credential was judged, so nothing per request
-  re-reads a configuration section.
+- **A request an authentication scheme validated** becomes a caller, named by what this deployment authorized — an API
+  key's name, a client public key's name, or the issuer and subject the access policy checked against the configured
+  authorization servers. The permissions travel as claims the scheme wrote when the credential was judged, so nothing
+  per request re-reads a configuration section.
 - **A scope with no request behind it** is the process's own identity. Work reached outside a request in this process is
   work no caller asked for.
 - **A route that verified a capability** states that principal onto its own scope before it reaches the use case. The
   download route is the one that does.
 
-**A request that authenticated nothing is none of the three**, and is reported as none rather than as an anonymous
-caller holding nothing. The difference matters at the download route, which is reached that way legitimately: a
-principal appearing out of the transport there would be a second and weaker way into an attachment than the signature
-the route exists to check.
+**A request that authenticated nothing depends on what the surface it reached configures.** Where that surface
+configures no `Authentication` entry at all, the caller holds everything the surface publishes — there is no entry for a
+grant to hang on, which is the posture ADR 0012 settled and the startup record already states, so reporting no principal
+there would have a use case refuse every call on a deployment whose own record says it grants everything. Where the
+surface does configure a credential, such a request is none of the three, and that is what protects the download route:
+it is reached without a credential legitimately, and a principal appearing out of the transport there would be a second
+and weaker way into an attachment than the signature the route exists to check. The route's own statement overrides
+either answer once the ticket verifies.
 
 ## What a refusal is, and what each boundary does with it
 

--- a/docs/architecture/authorized-principal.md
+++ b/docs/architecture/authorized-principal.md
@@ -1,0 +1,91 @@
+# Who a use case is running for
+
+<!-- describes: src/Application/Access/**, src/Host/Security/Transport/TransportAuthorizedPrincipalSource.cs, src/Host/Security/Transport/TransportCallerIdentity.cs, src/Host/Api/EmailAttachmentDownloadEndpoint.cs -->
+
+A use case can be reached by more than one thing. Today an MCP tool, an administrative route, a background worker, and
+the attachment download link all end at application-layer code, and each of them arrives by a different path with
+different checks in front of it. This page describes what that code is told about whoever reached it, and why the check
+that acts on it lives there rather than only in the middleware a request happened to pass through.
+
+The vocabulary of named permissions itself — what a permission is, which ones exist, and how a credential comes to hold
+one — is
+[ADR 0012](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0012-authorization-model-named-permissions-and-where-they-are-enforced.md)
+and [the configuration reference](../operations/configuration-reference.md). What follows is only how that grant reaches
+the code that acts on it.
+
+## Two checks, and why neither replaces the other
+
+**The transport refuses cheaply.** A check at the endpoint turns a request away without reaching a use case at all, and
+it is the only place a decision can be reflected in what a caller is offered rather than only in what it is told. It is
+where admission is decided today, and where a grant will be weighed as well.
+
+**The use case is the authority.** An entrypoint added later — a rule action, a worker, a command, a second protocol —
+reaches the same code without passing that middleware, so a check that lived only there is one the new entrypoint
+forgets. Asking inside the use case makes the answer a property of the operation rather than of the route somebody
+happened to arrive by, which is what leaves a new entrypoint safe by default instead of safe by the author remembering.
+
+The two are not redundant, because they are answering for different sets of callers. A use case never relies on the
+transport having already asked, and the transport never relies on the use case being the only way in.
+
+## What the application layer is told
+
+`AuthorizedPrincipal` is the whole of it: the configured identity the work was admitted under, and the permissions that
+identity holds. Nothing from `System.Security.Claims`, ASP.NET Core, or the MCP SDK crosses that line, and no use case
+learns *which* credential admitted a caller — that is a question the transport already answered. `Boundaries.UnitTests`
+holds a rule keeping claims types out of `Application` and `Domain`, because those are the one family of types the
+project references cannot refuse on their own.
+
+There are three kinds of principal, and none of them is a weaker version of another:
+
+| Kind | What it is | What it holds |
+| --- | --- | --- |
+| Caller | Somebody who presented a credential a configured entry admits | Whatever that entry's grant resolved to |
+| Process identity | MailFathom itself, running work no caller requested | Nothing, by construction |
+| Signed capability | A ticket this deployment signed for one object | Nothing; the ticket is the authorization |
+
+The process identity is a kind of its own rather than a caller holding everything, and that is the point of modelling
+it. A principal that could be admitted by holding a permission would be reachable by whoever an operator granted that
+permission to — so a use case that may run without a caller admits it **by name**, and never by a permission check.
+
+The signed capability is what `GET /attachments/{capability}` runs under. That route authenticates nobody by design: the
+URL carries a ticket verified against the deployment's key ring, and what it names is one attachment of one email rather
+than a surface. So the capability *is* the authorization, already bounded to a single object and a lifetime, and the use
+case behind it admits that kind and asks for no permission beside it. It is a principal kind rather than an exception,
+so the next capability-authorized route does not have to argue for its own.
+
+## How it gets there
+
+The host composes one `IAuthorizedPrincipalSource` per scope, which for a served request is that request:
+
+- **A request an authentication scheme validated** becomes a caller, named by what this deployment configured — an API
+  key's name, a client public key's name, or the subject the access policy checked against the configured authorization
+  servers. The permissions travel as claims the scheme wrote when the credential was judged, so nothing per request
+  re-reads a configuration section.
+- **A scope with no request behind it** is the process's own identity. Work reached outside a request in this process is
+  work no caller asked for.
+- **A route that verified a capability** states that principal onto its own scope before it reaches the use case. The
+  download route is the one that does.
+
+**A request that authenticated nothing is none of the three**, and is reported as none rather than as an anonymous
+caller holding nothing. The difference matters at the download route, which is reached that way legitimately: a
+principal appearing out of the transport there would be a second and weaker way into an attachment than the signature
+the route exists to check.
+
+## What a refusal is, and what each boundary does with it
+
+A use case refuses by raising `PrincipalNotAuthorizedException`, which carries error code `14001` and, where the
+requirement was a grant rather than a kind, the permission that would have sufficed. It is an application failure rather
+than a status code or a protocol result, because the same refusal is meant to reach two boundaries that answer it
+differently — and a use case that raised either shape directly would have decided both.
+
+A use case reached under no principal at all is refused the same way. That is the case an entrypoint produces by
+omission — it never said what admitted the work — and refusing it is what "fails rather than defaulting to permitted"
+means in the one place the decision is taken.
+
+**No use case requires a permission yet.** What a caller may do on either surface is still decided by the credential it
+authenticated with, exactly as
+[the configuration reference](../operations/configuration-reference.md) states under `Permissions`:
+the grant is read, validated, carried, and reported, and nothing acts on it. The one requirement in force today is the
+download route's, which admits a signed capability and nothing else. So the boundary mappings a refusal will need — what
+the MCP surface tells a caller, and what the administrative surface names — do not exist yet, and neither surface can
+produce this refusal.

--- a/docs/architecture/toc.yml
+++ b/docs/architecture/toc.yml
@@ -8,6 +8,9 @@
 - name: Solution structure
   href: solution-structure.md
   description: The projects, which way their dependencies point, and what belongs inside each boundary.
+- name: Who a use case is running for
+  href: authorized-principal.md
+  description: The three kinds of principal the application layer models, how each one reaches it, and why the use case checks a grant as well as the transport.
 - name: The arrival pipeline
   href: arrival-pipeline.md
   description: The order a newly arrived message passes through — classification, rules, redaction, chunking, embedding — drawn once, with what each stage waits for and what each classification outcome permits.

--- a/docs/decisions/0012-authorization-model-named-permissions-and-where-they-are-enforced.md
+++ b/docs/decisions/0012-authorization-model-named-permissions-and-where-they-are-enforced.md
@@ -9,7 +9,7 @@ informed:
 
 # Make a permission a named capability MailFathom publishes, grant it on the credential's own configuration entry or from a token's scopes, and enforce it in the use case as well as at the transport
 
-<!-- describes: src/Host/Security/**, src/Host/Configuration/Access/**, src/Host/Api/**, src/Mcp/Tools/** -->
+<!-- describes: src/Domain/Access/**, src/Application/Access/**, src/Host/Security/**, src/Host/Configuration/Access/**, src/Host/Api/**, src/Mcp/Tools/** -->
 
 ## Context and Problem Statement
 

--- a/src/Application/Access/AccessAuthorization.cs
+++ b/src/Application/Access/AccessAuthorization.cs
@@ -1,0 +1,96 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Access;
+
+/// <summary>What a use case asks before it does the work it was reached for.</summary>
+/// <remarks>
+/// <para>
+/// The transport refuses what it can refuse cheaply, and this is the authority. An entrypoint added later — a rule
+/// action, a worker, a command, a second protocol — reaches a use case without passing any middleware, so a check that
+/// lived only there is one the new entrypoint forgets. Asking here is what makes the answer a property of the operation
+/// instead of a property of the route somebody happened to arrive by.
+/// </para>
+/// <para>
+/// Each method admits exactly one kind of principal and refuses every other, including a principal that holds more.
+/// <see cref="RequireProcessIdentity" /> in particular is not "a caller with everything granted": a principal that
+/// could be admitted by holding a permission would be reachable by whoever an operator granted that permission to,
+/// which is the opposite of what work no caller requested runs under.
+/// </para>
+/// <para>
+/// Every method refuses when the work was reached under no principal, so an entrypoint that never stated what admitted
+/// it fails rather than defaulting to permitted.
+/// </para>
+/// </remarks>
+public sealed class AccessAuthorization
+{
+    private readonly IAuthorizedPrincipalSource principals;
+
+    /// <summary>Initializes the authorization over the principal of the unit of work in hand.</summary>
+    /// <param name="principals">Reports whoever the work is running for.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="principals" /> is <see langword="null" />.</exception>
+    public AccessAuthorization(IAuthorizedPrincipalSource principals)
+    {
+        ArgumentNullException.ThrowIfNull(principals);
+
+        this.principals = principals;
+    }
+
+    /// <summary>Requires that an admitted caller holding one named capability is what reached this use case.</summary>
+    /// <param name="permission">The capability the operation is published under.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="permission" /> names no published capability, which is a defect in the calling use case rather than a refusal.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the work was reached under no principal, under a principal that is not a caller, or by a caller whose grant omits the permission.</exception>
+    public void RequirePermission(MailFathomPermission permission)
+    {
+        if (!permission.IsSpecified)
+        {
+            throw new ArgumentException(
+                "A use case must require a published permission rather than the unspecified default.",
+                nameof(permission));
+        }
+
+        var principal = this.RequirePrincipal();
+
+        if (principal.Kind != AuthorizedPrincipalKind.Caller)
+        {
+            throw PrincipalNotAuthorizedException.WrongPrincipalKind(
+                AuthorizedPrincipalKind.Caller,
+                principal.Identity);
+        }
+
+        if (!principal.Holds(permission))
+        {
+            throw PrincipalNotAuthorizedException.MissingPermission(permission, principal.Identity);
+        }
+    }
+
+    /// <summary>Requires that this use case was reached as work no caller requested.</summary>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the work was reached under no principal, or under one that is not MailFathom's own identity.</exception>
+    /// <remarks>This is how a use case that runs on a schedule, out of a queue, or as part of an account run states that "there is no caller" is a case it models rather than a null nobody checked.</remarks>
+    public void RequireProcessIdentity() => this.RequireKind(AuthorizedPrincipalKind.ProcessIdentity);
+
+    /// <summary>Requires that a capability this deployment signed is what reached this use case.</summary>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the work was reached under no principal, or under one that is not a verified capability.</exception>
+    /// <remarks>
+    /// The capability is the authorization, so no permission is asked for beside it. What confines the work is the
+    /// verified ticket the use case is separately handed, which names one object and expires; this method establishes
+    /// only that a signature rather than an unidentified caller is what got here.
+    /// </remarks>
+    public void RequireSignedCapability() => this.RequireKind(AuthorizedPrincipalKind.SignedCapability);
+
+    private void RequireKind(AuthorizedPrincipalKind admittedKind)
+    {
+        var principal = this.RequirePrincipal();
+
+        if (principal.Kind != admittedKind)
+        {
+            throw PrincipalNotAuthorizedException.WrongPrincipalKind(admittedKind, principal.Identity);
+        }
+    }
+
+    private AuthorizedPrincipal RequirePrincipal() =>
+        this.principals.Current ?? throw PrincipalNotAuthorizedException.NoPrincipal();
+}

--- a/src/Application/Access/AccessAuthorization.cs
+++ b/src/Application/Access/AccessAuthorization.cs
@@ -56,14 +56,12 @@ public sealed class AccessAuthorization
 
         if (principal.Kind != AuthorizedPrincipalKind.Caller)
         {
-            throw PrincipalNotAuthorizedException.WrongPrincipalKind(
-                AuthorizedPrincipalKind.Caller,
-                principal.Identity);
+            throw PrincipalNotAuthorizedException.WrongPrincipalKind(AuthorizedPrincipalKind.Caller);
         }
 
         if (!principal.Holds(permission))
         {
-            throw PrincipalNotAuthorizedException.MissingPermission(permission, principal.Identity);
+            throw PrincipalNotAuthorizedException.MissingPermission(permission);
         }
     }
 
@@ -87,7 +85,7 @@ public sealed class AccessAuthorization
 
         if (principal.Kind != admittedKind)
         {
-            throw PrincipalNotAuthorizedException.WrongPrincipalKind(admittedKind, principal.Identity);
+            throw PrincipalNotAuthorizedException.WrongPrincipalKind(admittedKind);
         }
     }
 

--- a/src/Application/Access/AuthorizedPrincipal.cs
+++ b/src/Application/Access/AuthorizedPrincipal.cs
@@ -54,8 +54,9 @@ public sealed class AuthorizedPrincipal
     /// <remarks>
     /// <para>
     /// For a caller it is what the transport admitted it as, and that is not one shape: a configured key's own name
-    /// where the operator wrote the credential, and the issuer and subject the deployment authorized where a token
-    /// brought it. Never the credential material either way. For the process identity it is
+    /// where the operator wrote the credential, the issuer and subject the deployment authorized where a token brought
+    /// it, and the fixed word <c>anonymous</c> where the surface configures no credential for one caller to be told
+    /// apart from another. Never the credential material in any of the three. For the process identity it is
     /// <see cref="ProcessIdentityName" />, and for a signed capability it is the object the signature was bounded to.
     /// </para>
     /// <para>

--- a/src/Application/Access/AuthorizedPrincipal.cs
+++ b/src/Application/Access/AuthorizedPrincipal.cs
@@ -9,8 +9,8 @@ namespace MailFathom.Application.Access;
 /// <summary>Whoever a unit of work is running for, and what they were granted.</summary>
 /// <remarks>
 /// <para>
-/// This is the whole of what the application layer learns about the outside of a request. It carries the configured
-/// identity the work was admitted under and the permissions that identity holds, and nothing else: no credential, no
+/// This is the whole of what the application layer learns about the outside of a request. It carries the identity the
+/// work was admitted under and the permissions that identity holds, and nothing else: no credential, no
 /// claim an authorization server issued, no scheme, no transport. Which credential admitted a caller is a question the
 /// transport answered and no use case has any business re-deciding, which is why nothing here can be asked it.
 /// </para>
@@ -50,35 +50,42 @@ public sealed class AuthorizedPrincipal
     /// <summary>Gets which of the three things this principal is.</summary>
     public AuthorizedPrincipalKind Kind { get; }
 
-    /// <summary>Gets the configured identity the work was admitted under.</summary>
+    /// <summary>Gets the identity the work was admitted under.</summary>
     /// <remarks>
-    /// For a caller it is MailFathom's own name for the credential entry that admitted it, never the material and never
-    /// a claim beyond the subject the deployment already authorized. For the process identity it is
+    /// <para>
+    /// For a caller it is what the transport admitted it as, and that is not one shape: a configured key's own name
+    /// where the operator wrote the credential, and the issuer and subject the deployment authorized where a token
+    /// brought it. Never the credential material either way. For the process identity it is
     /// <see cref="ProcessIdentityName" />, and for a signed capability it is the object the signature was bounded to.
-    /// It exists so an operator's record of a refusal names something they can act on; nothing decides access from it.
+    /// </para>
+    /// <para>
+    /// Nothing decides access from it. It is here for a boundary that has to name the caller to its own readers, and
+    /// because the token form carries a host name and a remote party's identifier for a person, it never reaches a
+    /// failure message — <see cref="PrincipalNotAuthorizedException" /> states why.
+    /// </para>
     /// </remarks>
     public string Identity { get; }
 
     /// <summary>Gets the permissions this principal holds, which is empty for every kind but a caller.</summary>
     public IReadOnlySet<MailFathomPermission> Permissions { get; }
 
-    /// <summary>Describes a caller a configured entry admitted.</summary>
-    /// <param name="configuredIdentity">MailFathom's own name for the credential entry that admitted the caller.</param>
-    /// <param name="grantedPermissions">The permissions that entry resolved to, empty when it granted none.</param>
+    /// <summary>Describes a caller the transport admitted.</summary>
+    /// <param name="identity">What the transport admitted the caller as, in the two forms <see cref="Identity" /> describes.</param>
+    /// <param name="grantedPermissions">The permissions the entry that admitted it resolved to, empty when it granted none.</param>
     /// <returns>The principal the use cases the caller reaches are consulted with.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuredIdentity" /> or <paramref name="grantedPermissions" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="configuredIdentity" /> is empty or white space, which would leave a refusal naming nothing.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="identity" /> or <paramref name="grantedPermissions" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="identity" /> is empty or white space, which would leave a principal nothing can be reported by.</exception>
     /// <remarks>An unspecified permission is dropped rather than carried, because the struct default names no capability and holding one would mean holding nothing under a name that reads like something.</remarks>
     public static AuthorizedPrincipal Caller(
-        string configuredIdentity,
+        string identity,
         IEnumerable<MailFathomPermission> grantedPermissions)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(configuredIdentity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity);
         ArgumentNullException.ThrowIfNull(grantedPermissions);
 
         return new AuthorizedPrincipal(
             AuthorizedPrincipalKind.Caller,
-            configuredIdentity,
+            identity,
             grantedPermissions.Where(permission => permission.IsSpecified).ToHashSet());
     }
 

--- a/src/Application/Access/AuthorizedPrincipal.cs
+++ b/src/Application/Access/AuthorizedPrincipal.cs
@@ -71,7 +71,7 @@ public sealed class AuthorizedPrincipal
     public IReadOnlySet<MailFathomPermission> Permissions { get; }
 
     /// <summary>Describes a caller the transport admitted.</summary>
-    /// <param name="identity">What the transport admitted the caller as, in the two forms <see cref="Identity" /> describes.</param>
+    /// <param name="identity">What the transport admitted the caller as, in the forms <see cref="Identity" /> describes.</param>
     /// <param name="grantedPermissions">The permissions the entry that admitted it resolved to, empty when it granted none.</param>
     /// <returns>The principal the use cases the caller reaches are consulted with.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="identity" /> or <paramref name="grantedPermissions" /> is <see langword="null" />.</exception>

--- a/src/Application/Access/AuthorizedPrincipal.cs
+++ b/src/Application/Access/AuthorizedPrincipal.cs
@@ -1,0 +1,111 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Access;
+
+/// <summary>Whoever a unit of work is running for, and what they were granted.</summary>
+/// <remarks>
+/// <para>
+/// This is the whole of what the application layer learns about the outside of a request. It carries the configured
+/// identity the work was admitted under and the permissions that identity holds, and nothing else: no credential, no
+/// claim an authorization server issued, no scheme, no transport. Which credential admitted a caller is a question the
+/// transport answered and no use case has any business re-deciding, which is why nothing here can be asked it.
+/// </para>
+/// <para>
+/// It is an ordinary class rather than a record, because two principals are never compared. A record's generated
+/// equality would compare <see cref="Permissions" /> by reference and report two identical grants as different, which
+/// is worse than having no equality at all.
+/// </para>
+/// <para>
+/// The three factories below are the only way to obtain one, so a principal always states which kind it is and a kind
+/// added later cannot arrive with an unset identity. <see cref="Process" /> is a single instance because there is one
+/// process and it holds no per-work state.
+/// </para>
+/// </remarks>
+public sealed class AuthorizedPrincipal
+{
+    /// <summary>The name the process's own identity is reported under, which is MailFathom itself rather than anything an operator configured.</summary>
+    public const string ProcessIdentityName = "mailfathom";
+
+    private AuthorizedPrincipal(
+        AuthorizedPrincipalKind kind,
+        string identity,
+        IReadOnlySet<MailFathomPermission> permissions)
+    {
+        this.Kind = kind;
+        this.Identity = identity;
+        this.Permissions = permissions;
+    }
+
+    /// <summary>Gets the principal work no caller requested runs under.</summary>
+    /// <remarks>It holds no permission by construction, so a use case reachable by a caller refuses it exactly as it refuses a caller granted nothing. Admitting it is a decision a use case states, never one a permission carries.</remarks>
+    public static AuthorizedPrincipal Process { get; } = new(
+        AuthorizedPrincipalKind.ProcessIdentity,
+        ProcessIdentityName,
+        new HashSet<MailFathomPermission>());
+
+    /// <summary>Gets which of the three things this principal is.</summary>
+    public AuthorizedPrincipalKind Kind { get; }
+
+    /// <summary>Gets the configured identity the work was admitted under.</summary>
+    /// <remarks>
+    /// For a caller it is MailFathom's own name for the credential entry that admitted it, never the material and never
+    /// a claim beyond the subject the deployment already authorized. For the process identity it is
+    /// <see cref="ProcessIdentityName" />, and for a signed capability it is the object the signature was bounded to.
+    /// It exists so an operator's record of a refusal names something they can act on; nothing decides access from it.
+    /// </remarks>
+    public string Identity { get; }
+
+    /// <summary>Gets the permissions this principal holds, which is empty for every kind but a caller.</summary>
+    public IReadOnlySet<MailFathomPermission> Permissions { get; }
+
+    /// <summary>Describes a caller a configured entry admitted.</summary>
+    /// <param name="configuredIdentity">MailFathom's own name for the credential entry that admitted the caller.</param>
+    /// <param name="grantedPermissions">The permissions that entry resolved to, empty when it granted none.</param>
+    /// <returns>The principal the use cases the caller reaches are consulted with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configuredIdentity" /> or <paramref name="grantedPermissions" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="configuredIdentity" /> is empty or white space, which would leave a refusal naming nothing.</exception>
+    /// <remarks>An unspecified permission is dropped rather than carried, because the struct default names no capability and holding one would mean holding nothing under a name that reads like something.</remarks>
+    public static AuthorizedPrincipal Caller(
+        string configuredIdentity,
+        IEnumerable<MailFathomPermission> grantedPermissions)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configuredIdentity);
+        ArgumentNullException.ThrowIfNull(grantedPermissions);
+
+        return new AuthorizedPrincipal(
+            AuthorizedPrincipalKind.Caller,
+            configuredIdentity,
+            grantedPermissions.Where(permission => permission.IsSpecified).ToHashSet());
+    }
+
+    /// <summary>Describes the principal a verified signature produced.</summary>
+    /// <param name="authorizedObject">MailFathom's own description of the one object the signature was bounded to.</param>
+    /// <returns>The principal the use case behind the capability is consulted with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="authorizedObject" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="authorizedObject" /> is empty or white space.</exception>
+    /// <remarks>
+    /// The bound itself stays where a signature put it: the verified ticket the use case is handed names the object,
+    /// and reading that is what confines the work. What this principal adds is the statement that a signature — rather
+    /// than a credential or this process — is what authorized the work at all, so a use case reached under a capability
+    /// admits that kind by name instead of admitting an unidentified caller.
+    /// </remarks>
+    public static AuthorizedPrincipal SignedCapability(string authorizedObject)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(authorizedObject);
+
+        return new AuthorizedPrincipal(
+            AuthorizedPrincipalKind.SignedCapability,
+            authorizedObject,
+            new HashSet<MailFathomPermission>());
+    }
+
+    /// <summary>Reports whether this principal was granted one named capability.</summary>
+    /// <param name="permission">The capability being asked about.</param>
+    /// <returns><see langword="true" /> when the principal holds it.</returns>
+    /// <remarks>Asks the grant alone. That a kind other than a caller never holds one is a property of how a principal is composed rather than a case decided here.</remarks>
+    public bool Holds(MailFathomPermission permission) => this.Permissions.Contains(permission);
+}

--- a/src/Application/Access/AuthorizedPrincipalKind.cs
+++ b/src/Application/Access/AuthorizedPrincipalKind.cs
@@ -1,0 +1,31 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Access;
+
+/// <summary>Which of the three things a use case can be reached under produced the work in hand.</summary>
+/// <remarks>
+/// <para>
+/// The three are not degrees of the same thing and none of them is the absence of another. A caller presented a
+/// credential this deployment admits and holds whatever that credential's entry granted; the process identity is what
+/// work nobody asked for runs under; and a signed capability is a ticket this deployment issued for one object, which
+/// is the whole of the authorization rather than a grant over a surface.
+/// </para>
+/// <para>
+/// Modelling the process identity as its own kind is what keeps it from being a caller with everything granted. A
+/// principal admitted by holding permissions would pass every ordinary check, so a use case that may run without a
+/// caller says so by naming this kind instead.
+/// </para>
+/// </remarks>
+public enum AuthorizedPrincipalKind
+{
+    /// <summary>Somebody who presented a credential a configured entry admits, holding what that entry granted.</summary>
+    Caller = 0,
+
+    /// <summary>MailFathom itself, running work no caller requested.</summary>
+    ProcessIdentity = 1,
+
+    /// <summary>A ticket this deployment signed, bounded to the one object it names and to the lifetime it was minted with.</summary>
+    SignedCapability = 2,
+}

--- a/src/Application/Access/IAuthorizedPrincipalSource.cs
+++ b/src/Application/Access/IAuthorizedPrincipalSource.cs
@@ -1,0 +1,28 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Access;
+
+/// <summary>Reports whoever the unit of work in hand is running for.</summary>
+/// <remarks>
+/// <para>
+/// The one seam between the application layer and whatever admitted the work. An adapter outside this layer populates
+/// it per unit of work — a host adapter from the authenticated principal of a request, a route from a capability it has
+/// just verified — so that nothing here has to know what a request, a scheme, or a claim is.
+/// </para>
+/// <para>
+/// <see langword="null" /> is a real answer and means the work was reached under none of the three principal kinds. It
+/// is never read as permission: <see cref="AccessAuthorization" /> refuses it, so an entrypoint that forgets to state
+/// what it admitted fails rather than being served.
+/// </para>
+/// <para>
+/// An implementation is registered per unit of work, which for a served request is its scope. A use case asks
+/// <see cref="AccessAuthorization" /> rather than this port directly.
+/// </para>
+/// </remarks>
+public interface IAuthorizedPrincipalSource
+{
+    /// <summary>Gets the principal this unit of work is running for, or <see langword="null" /> when it was reached under none.</summary>
+    AuthorizedPrincipal? Current { get; }
+}

--- a/src/Application/Access/PrincipalNotAuthorizedException.cs
+++ b/src/Application/Access/PrincipalNotAuthorizedException.cs
@@ -21,8 +21,11 @@ namespace MailFathom.Application.Access;
 /// does, and a boundary reports <see cref="RequiredPermission" /> rather than parsing prose.
 /// </para>
 /// <para>
-/// The message carries a published permission name, the identity the work was admitted under, or neither. All three are
-/// MailFathom's own configured names, which is what the message rule on <see cref="MailFathomException" /> permits.
+/// The message names a published permission, a kind of principal, or neither, and never the identity the work was
+/// admitted under. That identity is MailFathom's own name for a configured key, but for a token it is the issuer and
+/// subject the deployment authorized — a host name and a remote party's identifier for a person — and the message rule
+/// on <see cref="MailFathomException" /> admits neither. A boundary that has to name the caller reads
+/// <see cref="AuthorizedPrincipal.Identity" /> and decides for itself what its own readers may see.
 /// </para>
 /// </remarks>
 public sealed class PrincipalNotAuthorizedException : MailFathomException
@@ -43,25 +46,15 @@ public sealed class PrincipalNotAuthorizedException : MailFathomException
 
     /// <summary>Reports a caller that reached an operation its grant does not carry.</summary>
     /// <param name="requiredPermission">The permission the operation requires.</param>
-    /// <param name="identity">The configured identity the work was admitted under.</param>
     /// <returns>The failure to raise.</returns>
-    internal static PrincipalNotAuthorizedException MissingPermission(
-        MailFathomPermission requiredPermission,
-        string identity) =>
-        new(
-            $"'{identity}' was not granted '{requiredPermission.Name}'.",
-            requiredPermission);
+    internal static PrincipalNotAuthorizedException MissingPermission(MailFathomPermission requiredPermission) =>
+        new($"The caller was not granted '{requiredPermission.Name}'.", requiredPermission);
 
     /// <summary>Reports an operation reached under a kind of principal it does not admit.</summary>
     /// <param name="admittedKind">The one kind the operation admits.</param>
-    /// <param name="identity">The configured identity the work was admitted under.</param>
     /// <returns>The failure to raise.</returns>
-    internal static PrincipalNotAuthorizedException WrongPrincipalKind(
-        AuthorizedPrincipalKind admittedKind,
-        string identity) =>
-        new(
-            $"The operation is reached under {Describe(admittedKind)} and '{identity}' is not one.",
-            default);
+    internal static PrincipalNotAuthorizedException WrongPrincipalKind(AuthorizedPrincipalKind admittedKind) =>
+        new($"The operation is reached under {Describe(admittedKind)}, and what reached it is not one.", default);
 
     /// <summary>Reports an operation reached under no principal at all.</summary>
     /// <returns>The failure to raise.</returns>

--- a/src/Application/Access/PrincipalNotAuthorizedException.cs
+++ b/src/Application/Access/PrincipalNotAuthorizedException.cs
@@ -1,0 +1,79 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Failures;
+
+namespace MailFathom.Application.Access;
+
+/// <summary>The failure raised when a use case is reached by a principal that was not granted it.</summary>
+/// <remarks>
+/// <para>
+/// It travels as an application failure rather than as a status code or a protocol result, because the same refusal has
+/// to reach two boundaries that answer it differently: the MCP surface says nothing a caller can tell from a tool that
+/// does not exist, and the administrative surface names the permission that would have sufficed. A use case that raised
+/// either shape directly would have decided both.
+/// </para>
+/// <para>
+/// One failure covers a caller whose grant omits the permission, work admitted under the wrong kind of principal, and a
+/// use case reached under no principal at all. The message separates them for an operator reading a log; nothing else
+/// does, and a boundary reports <see cref="RequiredPermission" /> rather than parsing prose.
+/// </para>
+/// <para>
+/// The message carries a published permission name, the identity the work was admitted under, or neither. All three are
+/// MailFathom's own configured names, which is what the message rule on <see cref="MailFathomException" /> permits.
+/// </para>
+/// </remarks>
+public sealed class PrincipalNotAuthorizedException : MailFathomException
+{
+    private PrincipalNotAuthorizedException(string operatorSafeMessage, MailFathomPermission requiredPermission)
+        : base(operatorSafeMessage) => this.RequiredPermission = requiredPermission;
+
+    /// <summary>Gets the permission that would have sufficed, unspecified when the refusal was about the kind of principal rather than about a grant.</summary>
+    /// <remarks>
+    /// The closed enumeration already models "no permission", so absence is expressed in the value rather than by a
+    /// nullable property. Ask <see cref="MailFathomPermission.IsSpecified" /> before reporting it: a boundary that
+    /// names a permission where none was required would tell an operator to grant something that would not have helped.
+    /// </remarks>
+    public MailFathomPermission RequiredPermission { get; }
+
+    /// <inheritdoc />
+    public override MailFathomErrorCode ErrorCode => MailFathomErrorCode.PrincipalNotAuthorized;
+
+    /// <summary>Reports a caller that reached an operation its grant does not carry.</summary>
+    /// <param name="requiredPermission">The permission the operation requires.</param>
+    /// <param name="identity">The configured identity the work was admitted under.</param>
+    /// <returns>The failure to raise.</returns>
+    internal static PrincipalNotAuthorizedException MissingPermission(
+        MailFathomPermission requiredPermission,
+        string identity) =>
+        new(
+            $"'{identity}' was not granted '{requiredPermission.Name}'.",
+            requiredPermission);
+
+    /// <summary>Reports an operation reached under a kind of principal it does not admit.</summary>
+    /// <param name="admittedKind">The one kind the operation admits.</param>
+    /// <param name="identity">The configured identity the work was admitted under.</param>
+    /// <returns>The failure to raise.</returns>
+    internal static PrincipalNotAuthorizedException WrongPrincipalKind(
+        AuthorizedPrincipalKind admittedKind,
+        string identity) =>
+        new(
+            $"The operation is reached under {Describe(admittedKind)} and '{identity}' is not one.",
+            default);
+
+    /// <summary>Reports an operation reached under no principal at all.</summary>
+    /// <returns>The failure to raise.</returns>
+    /// <remarks>This is the entrypoint that never stated what admitted it, so the refusal names nothing to grant: an operator's remedy is the missing adapter rather than a wider grant.</remarks>
+    internal static PrincipalNotAuthorizedException NoPrincipal() =>
+        new("The operation was reached under no principal.", default);
+
+    private static string Describe(AuthorizedPrincipalKind kind) => kind switch
+    {
+        AuthorizedPrincipalKind.Caller => "an admitted caller",
+        AuthorizedPrincipalKind.ProcessIdentity => "MailFathom's own identity",
+        AuthorizedPrincipalKind.SignedCapability => "a capability this deployment signed",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "The value names no principal kind."),
+    };
+}

--- a/src/Application/Emails/DownloadAttachment/EmailAttachmentDownloadReader.cs
+++ b/src/Application/Emails/DownloadAttachment/EmailAttachmentDownloadReader.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.EmailContent.Attachments;
 using MailFathom.Application.EmailContent.Repair;
 using MailFathom.Application.EmailContent.Storage;
@@ -41,6 +42,7 @@ public sealed class EmailAttachmentDownloadReader
     private readonly IEmailAttachmentContentReader attachmentContentReader;
     private readonly IEmailContentRepairRequestStore repairRequestStore;
     private readonly MailboxScopeResolver scopeResolver;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes the use case.</summary>
     /// <param name="summaryReader">Reads one stored email's summary by its identity.</param>
@@ -48,25 +50,29 @@ public sealed class EmailAttachmentDownloadReader
     /// <param name="attachmentContentReader">Opens one attachment of that stored MIME by its position.</param>
     /// <param name="repairRequestStore">Records durably that a local copy has to be fetched or read again.</param>
     /// <param name="scopeResolver">Answers whether a tool may read the mailbox an email was stored from.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public EmailAttachmentDownloadReader(
         IStoredEmailSummaryReader summaryReader,
         IEmailContentStore contentStore,
         IEmailAttachmentContentReader attachmentContentReader,
         IEmailContentRepairRequestStore repairRequestStore,
-        MailboxScopeResolver scopeResolver)
+        MailboxScopeResolver scopeResolver,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(summaryReader);
         ArgumentNullException.ThrowIfNull(contentStore);
         ArgumentNullException.ThrowIfNull(attachmentContentReader);
         ArgumentNullException.ThrowIfNull(repairRequestStore);
         ArgumentNullException.ThrowIfNull(scopeResolver);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.summaryReader = summaryReader;
         this.contentStore = contentStore;
         this.attachmentContentReader = attachmentContentReader;
         this.repairRequestStore = repairRequestStore;
         this.scopeResolver = scopeResolver;
+        this.authorization = authorization;
     }
 
     /// <summary>Opens the attachment the ticket authorizes.</summary>
@@ -74,16 +80,27 @@ public sealed class EmailAttachmentDownloadReader
     /// <param name="cancellationToken">Cancels the read when the reader disconnects.</param>
     /// <returns>The opened attachment, which the caller owns and must dispose, or <see langword="null" /> when there is nothing to serve.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ticket" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached under anything but a capability this deployment signed.</exception>
     /// <remarks>
+    /// <para>
+    /// The principal is asked for before the ticket is acted on, and it is asked for here rather than only at the route,
+    /// so that an entrypoint added later cannot reach an attachment by holding a mailbox grant. A capability is the
+    /// authorization in full — it names one attachment of one email and expires — which is why this use case admits that
+    /// kind alone and asks for no permission beside it.
+    /// </para>
+    /// <para>
     /// A damaged or missing local copy records a repair request before the refusal, exactly as reading the message's
     /// content does. The finding is about the stored copy rather than about who asked for it, so discarding it because
     /// the request happened to arrive through a link would leave a defect discovered and unrecorded.
+    /// </para>
     /// </remarks>
     public async Task<IOpenedEmailAttachment?> OpenAsync(
         AttachmentDownloadTicket ticket,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(ticket);
+
+        this.authorization.RequireSignedCapability();
 
         var summary = await this.summaryReader.FindAsync(ticket.StoredEmailId, cancellationToken);
 

--- a/src/Domain/Failures/MailFathomErrorCode.cs
+++ b/src/Domain/Failures/MailFathomErrorCode.cs
@@ -55,6 +55,15 @@ public readonly record struct MailFathomErrorCode
     /// <summary>Gets subcategory 3, mailbox access tokens: an operator-driven authorization run did not produce a refresh token to provision.</summary>
     public static MailFathomErrorCode MailboxAuthorizationFailed { get; } = new(13002);
 
+    /// <summary>Gets subcategory 4, principal authorization: a use case was reached by a principal that was not granted it.</summary>
+    /// <remarks>
+    /// One code covers every way the answer is no — a caller whose grant omits the permission, work admitted under the
+    /// wrong kind of principal, and a use case reached under no principal at all — because each boundary turns the
+    /// refusal into what its own callers understand rather than reporting the distinction. It sits in this category
+    /// because a grant is written in the deployment's configuration, which is where an operator resolves the refusal.
+    /// </remarks>
+    public static MailFathomErrorCode PrincipalNotAuthorized { get; } = new(14001);
+
     #endregion
 
     #region Category 2 — Mail protocol
@@ -374,6 +383,7 @@ public readonly record struct MailFathomErrorCode
         EnvironmentOnlySettingMisplaced,
         MailAccessTokenUnavailable,
         MailboxAuthorizationFailed,
+        PrincipalNotAuthorized,
         MailAuthenticationMechanismUnavailable,
         MailboxUnavailable,
         MailboxFolderRecreated,

--- a/src/Host/Api/AdminApiEndpoints.cs
+++ b/src/Host/Api/AdminApiEndpoints.cs
@@ -4,7 +4,7 @@
 
 using System.Security.Claims;
 using MailFathom.Host.Configuration.Endpoints;
-using MailFathom.Host.Security.ApiKeys;
+using MailFathom.Host.Security.Transport;
 using MailFathom.Versioning;
 
 namespace MailFathom.Host.Api;
@@ -134,16 +134,8 @@ internal sealed record AdminSessionResponse(string Service, string Version, stri
             NameOf(caller));
     }
 
-    /// <summary>Reports the configured name of whatever authenticated, without reaching for a claim nothing issued.</summary>
-    private static string NameOf(ClaimsPrincipal caller)
-    {
-        if (caller.Identity is not { IsAuthenticated: true })
-        {
-            return AnonymousCaller;
-        }
-
-        return caller.FindFirstValue(ApiKeyAuthentication.ApiKeyNameClaimType)
-            ?? caller.Identity.Name
-            ?? AnonymousCaller;
-    }
+    /// <summary>Reports the configured name of whatever authenticated, or that nothing did.</summary>
+    /// <remarks>The naming rule is the transport's own, shared with what the application layer is told the work is running for, so this response and a record of a refusal cannot call one caller two things.</remarks>
+    private static string NameOf(ClaimsPrincipal caller) =>
+        TransportCallerIdentity.NameOf(caller) ?? AnonymousCaller;
 }

--- a/src/Host/Api/AdminApiEndpoints.cs
+++ b/src/Host/Api/AdminApiEndpoints.cs
@@ -118,8 +118,6 @@ internal static class AdminApiEndpoints
 /// </remarks>
 internal sealed record AdminSessionResponse(string Service, string Version, string Credential)
 {
-    private const string AnonymousCaller = "anonymous";
-
     /// <summary>Describes the caller a validated credential produced.</summary>
     /// <param name="caller">The principal the authentication scheme produced.</param>
     /// <returns>The response body.</returns>
@@ -137,5 +135,5 @@ internal sealed record AdminSessionResponse(string Service, string Version, stri
     /// <summary>Reports the configured name of whatever authenticated, or that nothing did.</summary>
     /// <remarks>The naming rule is the transport's own, shared with what the application layer is told the work is running for, so this response and a record of a refusal cannot call one caller two things.</remarks>
     private static string NameOf(ClaimsPrincipal caller) =>
-        TransportCallerIdentity.NameOf(caller) ?? AnonymousCaller;
+        TransportCallerIdentity.NameOf(caller) ?? TransportCallerIdentity.AnonymousCaller;
 }

--- a/src/Host/Api/EmailAttachmentDownloadEndpoint.cs
+++ b/src/Host/Api/EmailAttachmentDownloadEndpoint.cs
@@ -2,9 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
+using MailFathom.Application.Access;
 using MailFathom.Application.EmailContent.Attachments;
 using MailFathom.Application.Emails.DownloadAttachment;
 using MailFathom.Application.Emails.Extraction;
+using MailFathom.Host.Security.Transport;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Net.Http.Headers;
@@ -61,19 +64,28 @@ internal static class EmailAttachmentDownloadEndpoint
     /// <param name="capability">The capability the URL carried, which is entirely untrusted.</param>
     /// <param name="ticketReader">Verifies the capability against the deployment's key ring.</param>
     /// <param name="downloadReader">Opens the attachment the verified capability names.</param>
+    /// <param name="principals">Carries what authorized this request into the application layer.</param>
     /// <param name="context">The request being answered, whose response body the attachment is written to.</param>
     /// <param name="cancellationToken">Cancels the read when the reader disconnects.</param>
     /// <returns>The attachment's octets, or <c>404</c> with a body that says nothing about why.</returns>
     /// <exception cref="ArgumentNullException">Thrown when any resolved dependency is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The verified ticket is what the request runs under, and it is stated onto the scope before the use case is
+    /// reached. Nothing authenticated here, so without that statement the use case would be reached under no principal
+    /// and would refuse — which is the same rule that makes an entrypoint added later say what admitted it rather than
+    /// inherit a permission from somewhere.
+    /// </remarks>
     internal static async Task<Results<EmptyHttpResult, NotFound<ProblemDetails>>> DownloadAsync(
         string capability,
         IAttachmentDownloadTicketReader ticketReader,
         EmailAttachmentDownloadReader downloadReader,
+        TransportAuthorizedPrincipalSource principals,
         HttpContext context,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(ticketReader);
         ArgumentNullException.ThrowIfNull(downloadReader);
+        ArgumentNullException.ThrowIfNull(principals);
         ArgumentNullException.ThrowIfNull(context);
 
         var ticket = await ticketReader.RedeemAsync(capability, cancellationToken);
@@ -81,6 +93,8 @@ internal static class EmailAttachmentDownloadEndpoint
         {
             return Refused();
         }
+
+        principals.Assume(AuthorizedPrincipal.SignedCapability(AuthorizedObjectOf(ticket)));
 
         await using var attachment = await downloadReader.OpenAsync(ticket, cancellationToken);
         if (attachment is null)
@@ -136,6 +150,15 @@ internal static class EmailAttachmentDownloadEndpoint
         response.Headers.XContentTypeOptions = "nosniff";
         response.Headers.CacheControl = "no-store";
     }
+
+    /// <summary>Names the one object the signature was bounded to, in MailFathom's own identifiers.</summary>
+    /// <remarks>
+    /// It is what a record of a refusal names the work by, so it carries the stored email's identity and the position
+    /// within it and nothing from the message: a file name, a media type, or a subject would be mail content.
+    /// </remarks>
+    private static string AuthorizedObjectOf(AttachmentDownloadTicket ticket) => string.Create(
+        CultureInfo.InvariantCulture,
+        $"{RoutePrefix}/{ticket.StoredEmailId.Value}/{ticket.AttachmentPosition}");
 
     private static NotFound<ProblemDetails> Refused() =>
         TypedResults.NotFound(new ProblemDetails

--- a/src/Host/HostComposition.cs
+++ b/src/Host/HostComposition.cs
@@ -5,6 +5,7 @@
 using MailFathom.AI;
 using MailFathom.AI.Chat;
 using MailFathom.AI.Providers;
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.EmailContent;
@@ -128,6 +129,13 @@ internal static class HostComposition
         builder.AddServiceDefaults();
         builder.Services.AddProblemDetails();
         builder.Services.AddSingleton(TimeProvider.System);
+        // What the application layer is told a unit of work is running for. Registered here rather than beside the
+        // transport, because it answers for work reached outside a request as well: a scope with no request behind it
+        // is this process's own, and a use case that runs without a caller depends on being told so.
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddScoped<TransportAuthorizedPrincipalSource>();
+        builder.Services.AddScoped<IAuthorizedPrincipalSource>(provider =>
+            provider.GetRequiredService<TransportAuthorizedPrincipalSource>());
         // ReferenceOnly is the default, so a deployment that configures nothing gets the mode under which a plain-text value
         // where a reference belongs fails startup instead of authenticating.
         builder.Services.AddSecretResolution(

--- a/src/Host/Security/Transport/TransportAuthorizedPrincipalSource.cs
+++ b/src/Host/Security/Transport/TransportAuthorizedPrincipalSource.cs
@@ -3,6 +3,9 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Configuration.Endpoints;
+using Microsoft.Extensions.Options;
 
 namespace MailFathom.Host.Security.Transport;
 
@@ -41,23 +44,38 @@ namespace MailFathom.Host.Security.Transport;
 /// </item>
 /// </list>
 /// <para>
-/// A request that authenticated nothing is none of the three, and is reported as such rather than as an anonymous
-/// caller holding nothing: the difference matters at the one route that is reached that way legitimately, where a
-/// principal appearing out of the transport instead of out of a verified signature would be a second, weaker way in.
+/// A request that authenticated nothing is a caller only where the surface it reached configures no credential at all,
+/// and that caller holds everything the surface publishes — ADR 0012 decided that posture and the startup report states
+/// it, so a use case refusing there would refuse on a deployment whose own record says it grants everything. Where the
+/// surface does configure a credential, a request that authenticated nothing is none of the three: the difference
+/// matters at the one route reached that way legitimately, where a principal appearing out of the transport instead of
+/// out of a verified signature would be a second, weaker way in.
 /// </para>
 /// </remarks>
 internal sealed class TransportAuthorizedPrincipalSource : IAuthorizedPrincipalSource
 {
     private readonly IHttpContextAccessor httpContextAccessor;
+    private readonly McpEndpointOptions mcpEndpointSettings;
+    private readonly AdminEndpointOptions adminEndpointSettings;
 
     /// <summary>Initializes the adapter over the request being served, if there is one.</summary>
     /// <param name="httpContextAccessor">Reports the request this scope belongs to, or nothing outside one.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpContextAccessor" /> is <see langword="null" />.</exception>
-    public TransportAuthorizedPrincipalSource(IHttpContextAccessor httpContextAccessor)
+    /// <param name="mcpEndpointSettings">The MCP endpoint settings startup was composed from.</param>
+    /// <param name="adminEndpointSettings">The administrative endpoint settings startup was composed from.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    /// <remarks>The settings are the startup snapshot the schemes were registered from, which is the same one the startup report states the resolved grant out of; reading a reloaded value here would answer for a posture no scheme was composed against.</remarks>
+    public TransportAuthorizedPrincipalSource(
+        IHttpContextAccessor httpContextAccessor,
+        IOptions<McpEndpointOptions> mcpEndpointSettings,
+        IOptions<AdminEndpointOptions> adminEndpointSettings)
     {
         ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        ArgumentNullException.ThrowIfNull(mcpEndpointSettings);
+        ArgumentNullException.ThrowIfNull(adminEndpointSettings);
 
         this.httpContextAccessor = httpContextAccessor;
+        this.mcpEndpointSettings = mcpEndpointSettings.Value;
+        this.adminEndpointSettings = adminEndpointSettings.Value;
     }
 
     /// <inheritdoc />
@@ -83,6 +101,31 @@ internal sealed class TransportAuthorizedPrincipalSource : IAuthorizedPrincipalS
 
         return TransportCallerIdentity.NameOf(context.User) is { } identity
             ? AuthorizedPrincipal.Caller(identity, TransportGrant.PermissionsCarriedBy(context.User))
-            : null;
+            : this.UnnarrowedCallerOn(context.Request.Path);
     }
+
+    /// <summary>Describes the caller a surface admits where it configures no credential for one to be told apart by.</summary>
+    /// <remarks>
+    /// There is no entry for a grant to hang on, so the grant is the surface's whole half. The administrative surface is
+    /// asked first because it is the narrower of the two paths, and a surface that does configure a credential answers
+    /// nothing here: a request that reached it without authenticating was admitted by nothing.
+    /// </remarks>
+    private AuthorizedPrincipal? UnnarrowedCallerOn(PathString path)
+    {
+        if (TransportSurface.Admin.Serves(path))
+        {
+            return this.adminEndpointSettings.RequiresAuthentication ? null : WholeSurfaceCaller(TransportSurface.Admin);
+        }
+
+        if (TransportSurface.Mcp.Serves(path))
+        {
+            return this.mcpEndpointSettings.RequiresAuthentication ? null : WholeSurfaceCaller(TransportSurface.Mcp);
+        }
+
+        return null;
+    }
+
+    private static AuthorizedPrincipal WholeSurfaceCaller(TransportSurface surface) => AuthorizedPrincipal.Caller(
+        TransportCallerIdentity.AnonymousCaller,
+        MailFathomPermission.PublishedFor(surface.GrantedSurface));
 }

--- a/src/Host/Security/Transport/TransportAuthorizedPrincipalSource.cs
+++ b/src/Host/Security/Transport/TransportAuthorizedPrincipalSource.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.Application.Access;
 using MailFathom.Domain.Access;
+using MailFathom.Host.Api;
 using MailFathom.Host.Configuration.Endpoints;
 using Microsoft.Extensions.Options;
 
@@ -47,9 +48,13 @@ namespace MailFathom.Host.Security.Transport;
 /// A request that authenticated nothing is a caller only where the surface it reached configures no credential at all,
 /// and that caller holds everything the surface publishes — ADR 0012 decided that posture and the startup report states
 /// it, so a use case refusing there would refuse on a deployment whose own record says it grants everything. Where the
-/// surface does configure a credential, a request that authenticated nothing is none of the three: the difference
-/// matters at the one route reached that way legitimately, where a principal appearing out of the transport instead of
-/// out of a verified signature would be a second, weaker way in.
+/// surface does configure a credential, a request that authenticated nothing is none of the three.
+/// </para>
+/// <para>
+/// A path the attachment download route serves is withheld from that grant on both postures, before either surface is
+/// asked. It is served by the MCP surface and authorized by a signed capability alone, so the grant would otherwise
+/// admit it out of the transport instead of out of the verified ticket — a second way in, and one holding on the
+/// permissive posture only, which is the worst shape a protection can take.
 /// </para>
 /// </remarks>
 internal sealed class TransportAuthorizedPrincipalSource : IAuthorizedPrincipalSource
@@ -112,6 +117,11 @@ internal sealed class TransportAuthorizedPrincipalSource : IAuthorizedPrincipalS
     /// </remarks>
     private AuthorizedPrincipal? UnnarrowedCallerOn(PathString path)
     {
+        if (ReachedOnlyUnderACapability(path))
+        {
+            return null;
+        }
+
         if (TransportSurface.Admin.Serves(path))
         {
             return this.adminEndpointSettings.RequiresAuthentication ? null : WholeSurfaceCaller(TransportSurface.Admin);
@@ -124,6 +134,17 @@ internal sealed class TransportAuthorizedPrincipalSource : IAuthorizedPrincipalS
 
         return null;
     }
+
+    /// <summary>Reports whether a route admitting a signed capability and nothing else serves the path.</summary>
+    /// <remarks>
+    /// The MCP surface serves the attachment download route beside the protocol route, so the grant above would reach it
+    /// on a deployment configuring no MCP credential and answer a caller holding the surface's whole half. That is a
+    /// second and weaker way into the route than the signature it verifies for itself, and it would hold on one posture
+    /// only. The route states its own principal through <see cref="Assume" /> once the capability is redeemed, so the
+    /// transport answers nothing for it on either posture and the ticket remains the only thing that authorizes it.
+    /// </remarks>
+    private static bool ReachedOnlyUnderACapability(PathString path) =>
+        path.StartsWithSegments(EmailAttachmentDownloadEndpoint.RoutePrefix);
 
     private static AuthorizedPrincipal WholeSurfaceCaller(TransportSurface surface) => AuthorizedPrincipal.Caller(
         TransportCallerIdentity.AnonymousCaller,

--- a/src/Host/Security/Transport/TransportAuthorizedPrincipalSource.cs
+++ b/src/Host/Security/Transport/TransportAuthorizedPrincipalSource.cs
@@ -1,0 +1,88 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+
+namespace MailFathom.Host.Security.Transport;
+
+/// <summary>Tells the application layer what admitted the work in hand, from what the transport already established.</summary>
+/// <remarks>
+/// <para>
+/// The one adapter between authentication and authorization, and the only place a <c>ClaimsPrincipal</c> is turned into
+/// something the application layer can read. It is registered per scope, which for a served request is that request, so
+/// a use case reached twice in one process is answered about the caller that reached it rather than about whichever was
+/// last seen.
+/// </para>
+/// <para>
+/// Three answers, matching the three kinds of principal the application layer models:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// A request an authentication scheme validated is a caller, named by what this deployment configured and holding the
+/// grant its entry resolved to. The claims were written when the credential was judged, so nothing here re-reads a
+/// configuration section and nothing learns which scheme was involved.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// No request at all is the process's own identity. Work reached outside a request in this process is work no caller
+/// asked for — a worker, a scheduled pass, a startup gate — and saying so is what lets a use case that runs without a
+/// caller admit it by name instead of meeting a null nobody checked.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// A capability a route verified is stated onto the scope by that route, through <see cref="Assume" />, and takes
+/// precedence over everything above. It is the answer for the attachment download route, which authenticates nobody by
+/// design.
+/// </description>
+/// </item>
+/// </list>
+/// <para>
+/// A request that authenticated nothing is none of the three, and is reported as such rather than as an anonymous
+/// caller holding nothing: the difference matters at the one route that is reached that way legitimately, where a
+/// principal appearing out of the transport instead of out of a verified signature would be a second, weaker way in.
+/// </para>
+/// </remarks>
+internal sealed class TransportAuthorizedPrincipalSource : IAuthorizedPrincipalSource
+{
+    private readonly IHttpContextAccessor httpContextAccessor;
+
+    /// <summary>Initializes the adapter over the request being served, if there is one.</summary>
+    /// <param name="httpContextAccessor">Reports the request this scope belongs to, or nothing outside one.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpContextAccessor" /> is <see langword="null" />.</exception>
+    public TransportAuthorizedPrincipalSource(IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+
+        this.httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <inheritdoc />
+    public AuthorizedPrincipal? Current { get => field ?? this.FromTransport(); private set; }
+
+    /// <summary>States the principal a route established for itself, which nothing about the transport could have told it.</summary>
+    /// <param name="principal">What the route verified.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="principal" /> is <see langword="null" />.</exception>
+    /// <remarks>Stating one twice in a scope is a route contradicting itself, so the second statement replaces the first rather than being merged with it; nothing in this process states one more than once.</remarks>
+    internal void Assume(AuthorizedPrincipal principal)
+    {
+        ArgumentNullException.ThrowIfNull(principal);
+
+        this.Current = principal;
+    }
+
+    private AuthorizedPrincipal? FromTransport()
+    {
+        if (this.httpContextAccessor.HttpContext is not { } context)
+        {
+            return AuthorizedPrincipal.Process;
+        }
+
+        return TransportCallerIdentity.NameOf(context.User) is { } identity
+            ? AuthorizedPrincipal.Caller(identity, TransportGrant.PermissionsCarriedBy(context.User))
+            : null;
+    }
+}

--- a/src/Host/Security/Transport/TransportCallerIdentity.cs
+++ b/src/Host/Security/Transport/TransportCallerIdentity.cs
@@ -7,12 +7,14 @@ using MailFathom.Host.Security.ApiKeys;
 
 namespace MailFathom.Host.Security.Transport;
 
-/// <summary>MailFathom's own name for whoever a validated credential turned out to be.</summary>
+/// <summary>What a validated credential turned out to name.</summary>
 /// <remarks>
 /// <para>
-/// Every scheme sets its identity's name claim to the thing this deployment configured — an API key's name, a client
-/// public key's name, or the subject the access policy checked against the authorization servers an operator wrote
-/// down — so one reading covers all three and none of them discloses credential material.
+/// Every scheme sets its identity's name claim to something this deployment authorized — an API key's name, a client
+/// public key's name, or the issuer and subject the access policy checked against the authorization servers an operator
+/// wrote down — so one reading covers all three and none of them discloses credential material. The three are not one
+/// shape: the first two are names an operator chose, and the third carries a host name and that server's own identifier
+/// for a person, which is why a caller reported by this is never named in a failure message.
 /// </para>
 /// <para>
 /// It is read in two places that must not drift: what the session route reports back to a caller, and what the
@@ -22,6 +24,10 @@ namespace MailFathom.Host.Security.Transport;
 /// </remarks>
 internal static class TransportCallerIdentity
 {
+    /// <summary>What a caller is named where nothing authenticated, because the surface it reached configures no credential.</summary>
+    /// <remarks>The one caller this deployment cannot tell apart from any other, so the word says exactly that rather than borrowing a name no entry carries.</remarks>
+    internal const string AnonymousCaller = "anonymous";
+
     /// <summary>Names the caller a validated credential produced.</summary>
     /// <param name="caller">The principal an authentication scheme produced.</param>
     /// <returns>The configured name, or <see langword="null" /> when nothing authenticated.</returns>

--- a/src/Host/Security/Transport/TransportCallerIdentity.cs
+++ b/src/Host/Security/Transport/TransportCallerIdentity.cs
@@ -1,0 +1,41 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Claims;
+using MailFathom.Host.Security.ApiKeys;
+
+namespace MailFathom.Host.Security.Transport;
+
+/// <summary>MailFathom's own name for whoever a validated credential turned out to be.</summary>
+/// <remarks>
+/// <para>
+/// Every scheme sets its identity's name claim to the thing this deployment configured — an API key's name, a client
+/// public key's name, or the subject the access policy checked against the authorization servers an operator wrote
+/// down — so one reading covers all three and none of them discloses credential material.
+/// </para>
+/// <para>
+/// It is read in two places that must not drift: what the session route reports back to a caller, and what the
+/// application layer is told the work is running for. A second copy of the rule would let a deployment name a caller
+/// one way in its own answers and another in its record of a refusal.
+/// </para>
+/// </remarks>
+internal static class TransportCallerIdentity
+{
+    /// <summary>Names the caller a validated credential produced.</summary>
+    /// <param name="caller">The principal an authentication scheme produced.</param>
+    /// <returns>The configured name, or <see langword="null" /> when nothing authenticated.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="caller" /> is <see langword="null" />.</exception>
+    /// <remarks>The API key claim is read ahead of the name claim rather than instead of it, so a scheme that stops naming its identity is still reported by the claim it writes.</remarks>
+    internal static string? NameOf(ClaimsPrincipal caller)
+    {
+        ArgumentNullException.ThrowIfNull(caller);
+
+        if (caller.Identity is not { IsAuthenticated: true })
+        {
+            return null;
+        }
+
+        return caller.FindFirstValue(ApiKeyAuthentication.ApiKeyNameClaimType) ?? caller.Identity.Name;
+    }
+}

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Contacts;
@@ -224,6 +225,12 @@ public static class ServiceCollectionExtensions
         ArgumentNullException.ThrowIfNull(currentConnectionSettings);
         ArgumentNullException.ThrowIfNull(textSearchConfiguration);
         ArgumentNullException.ThrowIfNull(answeringBudget);
+
+        // What a use case asks before it does the work it was reached for. The principal behind it comes from whatever
+        // admitted that work, which only a composition root knows, so IAuthorizedPrincipalSource is registered there and
+        // this line says only that the question is asked in the application layer rather than at whichever entrypoint
+        // arrived first.
+        services.AddScoped<AccessAuthorization>();
 
         // A value rather than an accessor, unlike the connection settings beside it: this one is compiled into the
         // search vector's column definition, so it is fixed for a deployment's schema and a reload cannot adopt a new

--- a/tests/Application.UnitTests/Access/AccessAuthorizationTests.cs
+++ b/tests/Application.UnitTests/Access/AccessAuthorizationTests.cs
@@ -1,0 +1,190 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Failures;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Access;
+
+/// <summary>Covers what a use case is told when it asks who reached it.</summary>
+/// <remarks>
+/// Every test here runs with no transport of any kind, which is the point: the transport refuses cheaply and this is
+/// the authority, so an entrypoint that never passed any middleware has to meet the same answer.
+/// </remarks>
+public sealed class AccessAuthorizationTests
+{
+    private const string ConfiguredCredentialName = "mcp-key";
+
+    [Fact]
+    public void RequirePermission_CallerGrantedIt_Permits()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(
+            AuthorizedPrincipal.Caller(ConfiguredCredentialName, [MailFathomPermission.MailRead]));
+
+        // Act
+        var refusal = Record.Exception(() => authorization.RequirePermission(MailFathomPermission.MailRead));
+
+        // Assert
+        Assert.Null(refusal);
+    }
+
+    /// <summary>No permission implies another, so holding one of a surface's names says nothing about holding the next.</summary>
+    [Fact]
+    public void RequirePermission_CallerGrantedADifferentPermission_RefusesNamingWhatWouldHaveSufficed()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(
+            AuthorizedPrincipal.Caller(ConfiguredCredentialName, [MailFathomPermission.MailRead]));
+
+        // Act
+        var refusal = Assert.Throws<PrincipalNotAuthorizedException>(() =>
+            authorization.RequirePermission(MailFathomPermission.MailAsk));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.MailAsk, refusal.RequiredPermission);
+        Assert.Equal(MailFathomErrorCode.PrincipalNotAuthorized, refusal.ErrorCode);
+    }
+
+    /// <summary>An entry an operator emptied grants nothing, and a credential it admits is refused every operation.</summary>
+    [Fact]
+    public void RequirePermission_CallerGrantedNothing_Refuses()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(AuthorizedPrincipal.Caller(ConfiguredCredentialName, []));
+
+        // Act & Assert
+        Assert.Throws<PrincipalNotAuthorizedException>(() =>
+            authorization.RequirePermission(MailFathomPermission.MailRead));
+    }
+
+    /// <summary>
+    /// The process identity must never be admitted by holding a permission, because a principal that passes an ordinary
+    /// check is a caller with everything granted wearing a different label.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(EveryPublishedPermission))]
+    public void RequirePermission_ProcessIdentity_RefusesWhicheverPermissionIsAsked(MailFathomPermission permission)
+    {
+        // Arrange
+        var authorization = AuthorizationOver(AuthorizedPrincipal.Process);
+
+        // Act & Assert
+        Assert.Throws<PrincipalNotAuthorizedException>(() => authorization.RequirePermission(permission));
+    }
+
+    /// <summary>A capability is bounded to one object, so it is never a way to reach an operation published over a surface.</summary>
+    [Fact]
+    public void RequirePermission_SignedCapability_Refuses()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(AuthorizedPrincipal.SignedCapability("/attachments/an-object/0"));
+
+        // Act & Assert
+        Assert.Throws<PrincipalNotAuthorizedException>(() =>
+            authorization.RequirePermission(MailFathomPermission.MailRead));
+    }
+
+    [Fact]
+    public void RequireProcessIdentity_WorkNoCallerRequested_Permits()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(AuthorizedPrincipal.Process);
+
+        // Act
+        var refusal = Record.Exception(authorization.RequireProcessIdentity);
+
+        // Assert
+        Assert.Null(refusal);
+    }
+
+    /// <summary>
+    /// Work the process runs for itself is not something a credential reaches, whatever that credential was granted, so
+    /// the refusal names no permission for an operator to add.
+    /// </summary>
+    [Fact]
+    public void RequireProcessIdentity_ACallerGrantedEverything_RefusesNamingNoPermission()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(
+            AuthorizedPrincipal.Caller(ConfiguredCredentialName, MailFathomPermission.All));
+
+        // Act
+        var refusal = Assert.Throws<PrincipalNotAuthorizedException>(authorization.RequireProcessIdentity);
+
+        // Assert
+        Assert.False(refusal.RequiredPermission.IsSpecified);
+    }
+
+    [Fact]
+    public void RequireSignedCapability_AVerifiedCapability_Permits()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(AuthorizedPrincipal.SignedCapability("/attachments/an-object/0"));
+
+        // Act
+        var refusal = Record.Exception(authorization.RequireSignedCapability);
+
+        // Assert
+        Assert.Null(refusal);
+    }
+
+    [Fact]
+    public void RequireSignedCapability_TheProcessIdentity_Refuses()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(AuthorizedPrincipal.Process);
+
+        // Act & Assert
+        Assert.Throws<PrincipalNotAuthorizedException>(authorization.RequireSignedCapability);
+    }
+
+    /// <summary>
+    /// The case an entrypoint added later produces by omission: nothing said what admitted the work. Every requirement
+    /// refuses it, which is what "fails rather than defaulting to permitted" means in the one place it is decided.
+    /// </summary>
+    [Fact]
+    public void EveryRequirement_ReachedUnderNoPrincipal_Refuses()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(principal: null);
+
+        // Act
+        var refusals = new Action[]
+        {
+            () => authorization.RequirePermission(MailFathomPermission.MailRead),
+            authorization.RequireProcessIdentity,
+            authorization.RequireSignedCapability,
+        }.Select(requirement => Record.Exception(requirement));
+
+        // Assert
+        Assert.All(refusals, refusal => Assert.IsType<PrincipalNotAuthorizedException>(refusal));
+    }
+
+    /// <summary>A use case requiring the struct default would be requiring nothing, which is a defect in it rather than a caller's refusal.</summary>
+    [Fact]
+    public void RequirePermission_TheUnspecifiedPermission_IsRejectedAsAnArgument()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(
+            AuthorizedPrincipal.Caller(ConfiguredCredentialName, MailFathomPermission.All));
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => authorization.RequirePermission(default));
+    }
+
+    public static TheoryData<MailFathomPermission> EveryPublishedPermission() =>
+        [.. MailFathomPermission.All];
+
+    private static AccessAuthorization AuthorizationOver(AuthorizedPrincipal? principal)
+    {
+        var principals = Substitute.For<IAuthorizedPrincipalSource>();
+        principals.Current.Returns(principal);
+
+        return new AccessAuthorization(principals);
+    }
+}

--- a/tests/Application.UnitTests/Access/AccessAuthorizationTests.cs
+++ b/tests/Application.UnitTests/Access/AccessAuthorizationTests.cs
@@ -73,20 +73,27 @@ public sealed class AccessAuthorizationTests
         // Arrange
         var authorization = AuthorizationOver(AuthorizedPrincipal.Process);
 
-        // Act & Assert
-        Assert.Throws<PrincipalNotAuthorizedException>(() => authorization.RequirePermission(permission));
+        // Act
+        var refusal = Assert.Throws<PrincipalNotAuthorizedException>(() =>
+            authorization.RequirePermission(permission));
+
+        // Assert
+        Assert.False(refusal.RequiredPermission.IsSpecified);
     }
 
     /// <summary>A capability is bounded to one object, so it is never a way to reach an operation published over a surface.</summary>
     [Fact]
-    public void RequirePermission_SignedCapability_Refuses()
+    public void RequirePermission_SignedCapability_RefusesNamingNoPermission()
     {
         // Arrange
         var authorization = AuthorizationOver(AuthorizedPrincipal.SignedCapability("/attachments/an-object/0"));
 
-        // Act & Assert
-        Assert.Throws<PrincipalNotAuthorizedException>(() =>
+        // Act
+        var refusal = Assert.Throws<PrincipalNotAuthorizedException>(() =>
             authorization.RequirePermission(MailFathomPermission.MailRead));
+
+        // Assert
+        Assert.False(refusal.RequiredPermission.IsSpecified);
     }
 
     [Fact]

--- a/tests/Application.UnitTests/Access/AccessAuthorizationTests.cs
+++ b/tests/Application.UnitTests/Access/AccessAuthorizationTests.cs
@@ -152,14 +152,15 @@ public sealed class AccessAuthorizationTests
     {
         // Arrange
         var authorization = AuthorizationOver(principal: null);
-
-        // Act
-        var refusals = new Action[]
-        {
+        Action[] requirements =
+        [
             () => authorization.RequirePermission(MailFathomPermission.MailRead),
             authorization.RequireProcessIdentity,
             authorization.RequireSignedCapability,
-        }.Select(requirement => Record.Exception(requirement));
+        ];
+
+        // Act
+        Exception?[] refusals = [.. requirements.Select(Record.Exception)];
 
         // Assert
         Assert.All(refusals, refusal => Assert.IsType<PrincipalNotAuthorizedException>(refusal));

--- a/tests/Application.UnitTests/Access/AuthorizedPrincipalTests.cs
+++ b/tests/Application.UnitTests/Access/AuthorizedPrincipalTests.cs
@@ -1,0 +1,77 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Access;
+
+/// <summary>Covers what the application layer learns about whoever a unit of work is running for.</summary>
+public sealed class AuthorizedPrincipalTests
+{
+    [Fact]
+    public void Caller_AGrantAnEntryResolvedTo_IsHeldUnderTheConfiguredIdentity()
+    {
+        // Arrange & Act
+        var caller = AuthorizedPrincipal.Caller("admin-key", [MailFathomPermission.AdminRead]);
+
+        // Assert
+        Assert.Equal(AuthorizedPrincipalKind.Caller, caller.Kind);
+        Assert.Equal("admin-key", caller.Identity);
+        Assert.True(caller.Holds(MailFathomPermission.AdminRead));
+        Assert.False(caller.Holds(MailFathomPermission.AdminSpend));
+    }
+
+    /// <summary>The struct default names no capability, so carrying one would mean holding nothing under a name that reads like something.</summary>
+    [Fact]
+    public void Caller_AnUnspecifiedPermissionInTheGrant_IsNotCarried()
+    {
+        // Arrange & Act
+        var caller = AuthorizedPrincipal.Caller("admin-key", [default, MailFathomPermission.AdminRead]);
+
+        // Assert
+        Assert.Equal([MailFathomPermission.AdminRead], caller.Permissions);
+    }
+
+    /// <summary>A refusal has to name something an operator can act on, so an entry with no name is a defect rather than an anonymous caller.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Caller_AnIdentityThatNamesNothing_IsRejected(string identity)
+    {
+        // Arrange, Act & Assert
+        Assert.Throws<ArgumentException>(() => AuthorizedPrincipal.Caller(identity, []));
+    }
+
+    /// <summary>
+    /// The process identity is a kind rather than a caller holding everything. Nothing composes a grant onto it, so no
+    /// permission check can ever be what admits it.
+    /// </summary>
+    [Fact]
+    public void Process_TheIdentityWorkNoCallerRequestedRunsUnder_HoldsNothing()
+    {
+        // Arrange & Act
+        var process = AuthorizedPrincipal.Process;
+
+        // Assert
+        Assert.Equal(AuthorizedPrincipalKind.ProcessIdentity, process.Kind);
+        Assert.Equal(AuthorizedPrincipal.ProcessIdentityName, process.Identity);
+        Assert.Empty(process.Permissions);
+        Assert.All(MailFathomPermission.All, permission => Assert.False(process.Holds(permission)));
+    }
+
+    /// <summary>A capability is the authorization in full, bounded to the object it names, so it carries no grant over a surface either.</summary>
+    [Fact]
+    public void SignedCapability_AVerifiedTicket_NamesItsObjectAndHoldsNothing()
+    {
+        // Arrange & Act
+        var capability = AuthorizedPrincipal.SignedCapability("/attachments/an-object/0");
+
+        // Assert
+        Assert.Equal(AuthorizedPrincipalKind.SignedCapability, capability.Kind);
+        Assert.Equal("/attachments/an-object/0", capability.Identity);
+        Assert.Empty(capability.Permissions);
+    }
+}

--- a/tests/Application.UnitTests/Emails/DownloadAttachment/EmailAttachmentDownloadReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/DownloadAttachment/EmailAttachmentDownloadReaderTests.cs
@@ -5,6 +5,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 using System.Text;
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.EmailContent.Attachments;
 using MailFathom.Application.EmailContent.Repair;
@@ -16,6 +17,7 @@ using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
@@ -36,6 +38,10 @@ public sealed class EmailAttachmentDownloadReaderTests
     private const string ServedAccountId = "primary";
 
     private static readonly byte[] StoredRawMime = Encoding.UTF8.GetBytes("From: sender@example.test\r\n\r\nBody");
+
+    /// <summary>The principal the download route states once it has verified a link, which is what this use case admits.</summary>
+    private static readonly AuthorizedPrincipal RedeemedCapability =
+        AuthorizedPrincipal.SignedCapability("/attachments/0198f0aa-0000-7000-8000-000000000000/0");
 
     [Fact]
     public async Task OpenAsync_AttachmentOfAServedEmail_OpensItThroughTheStoredCopy()
@@ -228,6 +234,54 @@ public sealed class EmailAttachmentDownloadReaderTests
     }
 
     /// <summary>
+    /// The transport is what usually states the principal, so this is the case where an entrypoint reached the use case
+    /// without saying what admitted it. It refuses rather than serving the attachment the ticket names, which is what
+    /// makes the check the authority instead of a second opinion.
+    /// </summary>
+    [Fact]
+    public async Task OpenAsync_ReachedUnderNoPrincipal_RefusesWithoutReadingStoredContent()
+    {
+        // Arrange
+        var summary = SyntheticEmailSummaries.Create(attachmentCount: 1);
+        var contentStore = ContentStoreReturning(IntactContent());
+        var reader = ReaderOver(summary, contentStore, authorization: AuthorizationOver(principal: null));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(async () =>
+            await reader.OpenAsync(
+                new AttachmentDownloadTicket(summary.StoredEmailId, AttachmentPosition: 0),
+                TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.False(refusal.RequiredPermission.IsSpecified);
+        await contentStore
+            .DidNotReceive()
+            .FindStoredContentAsync(Arg.Any<StoredEmailId>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// A capability is the authorization here, so holding a mailbox grant is not a second way in. A caller granted
+    /// everything the mail surface publishes is refused exactly as one granted nothing is.
+    /// </summary>
+    [Fact]
+    public async Task OpenAsync_ReachedByACallerRatherThanACapability_Refuses()
+    {
+        // Arrange
+        var summary = SyntheticEmailSummaries.Create(attachmentCount: 1);
+        var reader = ReaderOver(
+            summary,
+            authorization: AuthorizationOver(AuthorizedPrincipal.Caller(
+                "mcp-key",
+                MailFathomPermission.PublishedFor(ProtectedSurface.Mail))));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(async () =>
+            await reader.OpenAsync(
+                new AttachmentDownloadTicket(summary.StoredEmailId, AttachmentPosition: 0),
+                TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>
     /// Serving a file must never fetch one, which is the acceptance criterion the whole content path exists under. The
     /// use case holds no mailbox port, so the guarantee is structural rather than a rule somebody has to keep.
     /// </summary>
@@ -258,7 +312,8 @@ public sealed class EmailAttachmentDownloadReaderTests
         IEmailAttachmentContentReader? contentReader = null,
         IEmailContentRepairRequestStore? repairRequestStore = null,
         IMailAccountCatalog? accountCatalog = null,
-        IMailFolderParticipationReader? folderParticipation = null) => new(
+        IMailFolderParticipationReader? folderParticipation = null,
+        AccessAuthorization? authorization = null) => new(
         SummaryReaderReturning(summary),
         contentStore ?? ContentStoreReturning(IntactContent()),
         contentReader ?? ContentReaderOpening("invoice.pdf"),
@@ -267,7 +322,17 @@ public sealed class EmailAttachmentDownloadReaderTests
             accountCatalog ?? CatalogServing(MailAccountId.Create(summary?.AccountId.Value ?? ServedAccountId)),
             folderParticipation ?? MappingFolderOf(summary),
             StubJunkMailFolderCatalog.None,
-            StubMailFolderMappings.ResolvingNothing));
+            StubMailFolderMappings.ResolvingNothing),
+        authorization ?? AuthorizationOver(RedeemedCapability));
+
+    /// <summary>Composes the authorization a use case asks, over whichever principal a test says reached it.</summary>
+    private static AccessAuthorization AuthorizationOver(AuthorizedPrincipal? principal)
+    {
+        var principals = Substitute.For<IAuthorizedPrincipalSource>();
+        principals.Current.Returns(principal);
+
+        return new AccessAuthorization(principals);
+    }
 
     /// <summary>Maps the folder this email was stored from, which is what a deployment holding it has configured.</summary>
     /// <remarks>

--- a/tests/Boundaries.UnitTests/AuthorizationBoundaryTests.cs
+++ b/tests/Boundaries.UnitTests/AuthorizationBoundaryTests.cs
@@ -1,0 +1,51 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using ArchUnitNET.Fluent;
+using ArchUnitNET.xUnitV3;
+using Xunit;
+using static ArchUnitNET.Fluent.ArchRuleDefinition;
+
+namespace MailFathom.Boundaries.UnitTests;
+
+/// <summary>Covers what the layers below the transport are allowed to know about who is calling.</summary>
+/// <remarks>
+/// <para>
+/// ADR 0012 settles that the application layer receives an application-owned description of the principal and nothing
+/// from the frameworks that produced it. Two of the three types that could carry one are already unreachable from
+/// <c>Application</c> and <c>Domain</c> by project reference: ASP.NET Core and the MCP SDK are not referenced there at
+/// all, and <c>ApplicationDependencyBoundaryTests</c> asserts that exact reference set.
+/// </para>
+/// <para>
+/// <c>System.Security.Claims</c> is the one that no reference set can refuse, because it ships in the shared framework
+/// and is therefore compilable from every project in the solution. A rule is the only thing that keeps it out, and it
+/// belongs here rather than beside the reference assertions because a claims type obtained inside a method body and
+/// never stored is invisible to reflection over signatures.
+/// </para>
+/// </remarks>
+public sealed class AuthorizationBoundaryTests
+{
+    private const string ApplicationAndDomainPattern = @"^MailFathom\.(Application|Domain)\.";
+
+    private const string ClaimsPattern = @"^System\.Security\.Claims\.";
+
+    [Fact]
+    public void ClaimsTypes_InApplicationAndDomain_AreUnreachable()
+    {
+        // Arrange
+        IArchRule claimsStayAboveTheApplicationLayer = Types()
+            .That()
+            .HaveFullNameMatching(ApplicationAndDomainPattern)
+            .Should()
+            .NotDependOnAnyTypesThat()
+            .HaveFullNameMatching(ClaimsPattern)
+            .Because(
+                "a use case is told who it is running for through MailFathom's own AuthorizedPrincipal, so a "
+                    + "ClaimsPrincipal, a ClaimsIdentity, or a Claim appearing below the transport would put an "
+                    + "authentication framework's vocabulary into a layer that has to outlive it");
+
+        // Act & Assert
+        claimsStayAboveTheApplicationLayer.Check(CompiledBoundaries.Solution);
+    }
+}

--- a/tests/Host.UnitTests/Api/EmailAttachmentDownloadEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/EmailAttachmentDownloadEndpointTests.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.EmailContent.Attachments;
 using MailFathom.Application.EmailContent.Repair;
@@ -16,6 +17,7 @@ using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Host.Api;
+using MailFathom.Host.Security.Transport;
 using MailFathom.TestSupport;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -41,6 +43,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     {
         // Arrange
         var context = new DefaultHttpContext();
+        var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
 
@@ -48,7 +51,8 @@ public sealed class EmailAttachmentDownloadEndpointTests
         var result = await EmailAttachmentDownloadEndpoint.DownloadAsync(
             "capability",
             TicketReaderRedeeming(new AttachmentDownloadTicket(StoredEmailId.Create(Guid.CreateVersion7()), 0)),
-            AttachmentOpening(new StubOpenedEmailAttachment("invoice.pdf", "application/pdf", "%PDF-1.7"u8.ToArray())),
+            AttachmentOpening(principals, new StubOpenedEmailAttachment("invoice.pdf", "application/pdf", "%PDF-1.7"u8.ToArray())),
+            principals,
             context,
             TestContext.Current.CancellationToken);
 
@@ -69,6 +73,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     {
         // Arrange
         var context = new DefaultHttpContext();
+        var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
 
@@ -76,10 +81,11 @@ public sealed class EmailAttachmentDownloadEndpointTests
         await EmailAttachmentDownloadEndpoint.DownloadAsync(
             "capability",
             TicketReaderRedeeming(new AttachmentDownloadTicket(StoredEmailId.Create(Guid.CreateVersion7()), 0)),
-            AttachmentOpening(new StubOpenedEmailAttachment(
+            AttachmentOpening(principals, new StubOpenedEmailAttachment(
                 "page.html",
                 "text/html",
                 "<script>alert(1)</script>"u8.ToArray())),
+            principals,
             context,
             TestContext.Current.CancellationToken);
 
@@ -99,6 +105,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     {
         // Arrange
         var context = new DefaultHttpContext();
+        var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
 
@@ -106,7 +113,8 @@ public sealed class EmailAttachmentDownloadEndpointTests
         await EmailAttachmentDownloadEndpoint.DownloadAsync(
             "capability",
             TicketReaderRedeeming(new AttachmentDownloadTicket(StoredEmailId.Create(Guid.CreateVersion7()), 0)),
-            AttachmentOpening(new StubOpenedEmailAttachment("invoice.pdf", "application/pdf", "%PDF-1.7"u8.ToArray())),
+            AttachmentOpening(principals, new StubOpenedEmailAttachment("invoice.pdf", "application/pdf", "%PDF-1.7"u8.ToArray())),
+            principals,
             context,
             TestContext.Current.CancellationToken);
 
@@ -123,6 +131,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     {
         // Arrange
         var context = new DefaultHttpContext();
+        var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
 
@@ -130,10 +139,11 @@ public sealed class EmailAttachmentDownloadEndpointTests
         await EmailAttachmentDownloadEndpoint.DownloadAsync(
             "capability",
             TicketReaderRedeeming(new AttachmentDownloadTicket(StoredEmailId.Create(Guid.CreateVersion7()), 0)),
-            AttachmentOpening(new StubOpenedEmailAttachment(
+            AttachmentOpening(principals, new StubOpenedEmailAttachment(
                 "faktura \"żółć\"; x=1.pdf",
                 "application/pdf",
                 "bytes"u8.ToArray())),
+            principals,
             context,
             TestContext.Current.CancellationToken);
 
@@ -155,6 +165,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     {
         // Arrange
         var context = new DefaultHttpContext();
+        var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
 
@@ -162,7 +173,8 @@ public sealed class EmailAttachmentDownloadEndpointTests
         await EmailAttachmentDownloadEndpoint.DownloadAsync(
             "capability",
             TicketReaderRedeeming(new AttachmentDownloadTicket(StoredEmailId.Create(Guid.CreateVersion7()), 0)),
-            AttachmentOpening(new StubOpenedEmailAttachment("file.bin", declared, "bytes"u8.ToArray())),
+            AttachmentOpening(principals, new StubOpenedEmailAttachment("file.bin", declared, "bytes"u8.ToArray())),
+            principals,
             context,
             TestContext.Current.CancellationToken);
 
@@ -176,6 +188,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     {
         // Arrange
         var context = new DefaultHttpContext();
+        var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
 
@@ -183,7 +196,8 @@ public sealed class EmailAttachmentDownloadEndpointTests
         await EmailAttachmentDownloadEndpoint.DownloadAsync(
             "capability",
             TicketReaderRedeeming(new AttachmentDownloadTicket(StoredEmailId.Create(Guid.CreateVersion7()), 0)),
-            AttachmentOpening(new StubOpenedEmailAttachment(fileName: null, "image/png", "png"u8.ToArray())),
+            AttachmentOpening(principals, new StubOpenedEmailAttachment(fileName: null, "image/png", "png"u8.ToArray())),
+            principals,
             context,
             TestContext.Current.CancellationToken);
 
@@ -202,6 +216,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
         // Arrange
         var ticket = new AttachmentDownloadTicket(StoredEmailId.Create(Guid.CreateVersion7()), 0);
         var context = new DefaultHttpContext();
+        var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
 
@@ -209,14 +224,16 @@ public sealed class EmailAttachmentDownloadEndpointTests
         var refusedCapability = await EmailAttachmentDownloadEndpoint.DownloadAsync(
             "forged",
             TicketReaderRedeeming(null),
-            AttachmentOpening(null),
+            AttachmentOpening(principals, null),
+            principals,
             context,
             TestContext.Current.CancellationToken);
 
         var refusedMail = await EmailAttachmentDownloadEndpoint.DownloadAsync(
             "capability",
             TicketReaderRedeeming(ticket),
-            AttachmentOpening(null),
+            AttachmentOpening(principals, null),
+            principals,
             context,
             TestContext.Current.CancellationToken);
 
@@ -237,12 +254,14 @@ public sealed class EmailAttachmentDownloadEndpointTests
         // Arrange
         var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
         var context = new DefaultHttpContext();
+        var principals = PrincipalsFor(context);
 
         // Act
         var result = await EmailAttachmentDownloadEndpoint.DownloadAsync(
             "a-capability-somebody-presented",
             TicketReaderRedeeming(new AttachmentDownloadTicket(storedEmailId, 3)),
-            AttachmentOpening(null),
+            AttachmentOpening(principals, null),
+            principals,
             context,
             TestContext.Current.CancellationToken);
 
@@ -251,6 +270,20 @@ public sealed class EmailAttachmentDownloadEndpointTests
         var body = $"{refusal.Value?.Title} {refusal.Value?.Detail}";
         Assert.DoesNotContain(storedEmailId.Value.ToString(), body, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("a-capability-somebody-presented", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>The one scope a request is served in, which the route states its own principal onto.</summary>
+    /// <remarks>
+    /// The endpoint and the use case behind it are handed the same instance, exactly as a request scope hands them one.
+    /// That is what makes these tests about the route establishing what authorized it rather than about a value passed
+    /// along beside the call.
+    /// </remarks>
+    private static TransportAuthorizedPrincipalSource PrincipalsFor(HttpContext context)
+    {
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext.Returns(context);
+
+        return new TransportAuthorizedPrincipalSource(httpContextAccessor);
     }
 
     private static IAttachmentDownloadTicketReader TicketReaderRedeeming(AttachmentDownloadTicket? ticket)
@@ -269,7 +302,9 @@ public sealed class EmailAttachmentDownloadEndpointTests
     /// honest shape as well: what this endpoint has to get right is how an opened attachment becomes a response and how
     /// an absent one becomes a refusal, and both travel through the real reader either way.
     /// </remarks>
-    private static EmailAttachmentDownloadReader AttachmentOpening(IOpenedEmailAttachment? attachment)
+    private static EmailAttachmentDownloadReader AttachmentOpening(
+        IAuthorizedPrincipalSource principals,
+        IOpenedEmailAttachment? attachment)
     {
         var summary = SummaryOf();
 
@@ -307,7 +342,8 @@ public sealed class EmailAttachmentDownloadEndpointTests
                 StubMailFolderParticipation.Mapping(
                     new MailFolderIdentity(summary.AccountId, summary.FolderAlias)),
                 StubJunkMailFolderCatalog.None,
-                StubMailFolderMappings.ResolvingNothing));
+                StubMailFolderMappings.ResolvingNothing),
+            new AccessAuthorization(principals));
     }
 
     private static EmailSummary SummaryOf() => new()

--- a/tests/Host.UnitTests/Api/EmailAttachmentDownloadEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/EmailAttachmentDownloadEndpointTests.cs
@@ -17,7 +17,6 @@ using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Host.Api;
-using MailFathom.Host.Configuration.Access;
 using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Transport;
 using MailFathom.TestSupport;
@@ -45,7 +44,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     public async Task DownloadAsync_ValidCapability_WritesTheAttachmentAndStatesWhatItIs()
     {
         // Arrange
-        var context = new DefaultHttpContext();
+        var context = RequestToTheRoute();
         var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
@@ -75,7 +74,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     public async Task DownloadAsync_ValidCapability_ServesTheFileAsADownloadRatherThanSomethingToRender()
     {
         // Arrange
-        var context = new DefaultHttpContext();
+        var context = RequestToTheRoute();
         var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
@@ -107,7 +106,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     public async Task DownloadAsync_ValidCapability_ForbidsAnIntermediaryFromStoringTheResponse()
     {
         // Arrange
-        var context = new DefaultHttpContext();
+        var context = RequestToTheRoute();
         var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
@@ -133,7 +132,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     public async Task DownloadAsync_AttachmentNamedWithHeaderSyntax_EncodesTheNameRatherThanEmittingIt()
     {
         // Arrange
-        var context = new DefaultHttpContext();
+        var context = RequestToTheRoute();
         var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
@@ -167,7 +166,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
         string expected)
     {
         // Arrange
-        var context = new DefaultHttpContext();
+        var context = RequestToTheRoute();
         var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
@@ -190,7 +189,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     public async Task DownloadAsync_UnnamedAttachment_StatesTheDispositionWithoutAFileName()
     {
         // Arrange
-        var context = new DefaultHttpContext();
+        var context = RequestToTheRoute();
         var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
@@ -218,7 +217,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     {
         // Arrange
         var ticket = new AttachmentDownloadTicket(StoredEmailId.Create(Guid.CreateVersion7()), 0);
-        var context = new DefaultHttpContext();
+        var context = RequestToTheRoute();
         var principals = PrincipalsFor(context);
         using var body = new MemoryStream();
         context.Response.Body = body;
@@ -256,7 +255,7 @@ public sealed class EmailAttachmentDownloadEndpointTests
     {
         // Arrange
         var storedEmailId = StoredEmailId.Create(Guid.CreateVersion7());
-        var context = new DefaultHttpContext();
+        var context = RequestToTheRoute();
         var principals = PrincipalsFor(context);
 
         // Act
@@ -275,6 +274,11 @@ public sealed class EmailAttachmentDownloadEndpointTests
         Assert.DoesNotContain("a-capability-somebody-presented", body, StringComparison.Ordinal);
     }
 
+    /// <summary>Composes a request to this route's own path, which is what decides the principal the scope reports.</summary>
+    /// <remarks>An empty path would leave the arrangement below deciding nothing, because a path neither surface serves is refused for that reason instead of for being this route's.</remarks>
+    private static DefaultHttpContext RequestToTheRoute() =>
+        new() { Request = { Path = EmailAttachmentDownloadEndpoint.RoutePrefix + "/a-capability-somebody-presented" } };
+
     /// <summary>The one scope a request is served in, which the route states its own principal onto.</summary>
     /// <remarks>
     /// The endpoint and the use case behind it are handed the same instance, exactly as a request scope hands them one.
@@ -286,14 +290,12 @@ public sealed class EmailAttachmentDownloadEndpointTests
         var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
         httpContextAccessor.HttpContext.Returns(context);
 
-        // The MCP endpoint configures a credential here, so nothing about the transport hands this route a caller: what
-        // the use case is told is only what the route states once the ticket has verified.
-        var mcpEndpoint = new McpEndpointOptions();
-        mcpEndpoint.Authentication.Add(new TransportAuthenticationOptions());
-
+        // Neither endpoint configures a credential, which is the posture whose whole-surface grant would otherwise reach
+        // this route. Nothing about the transport hands it a caller even so, so what the use case is told is only what
+        // the route states once the ticket has verified.
         return new TransportAuthorizedPrincipalSource(
             httpContextAccessor,
-            Options.Create(mcpEndpoint),
+            Options.Create(new McpEndpointOptions()),
             Options.Create(new AdminEndpointOptions()));
     }
 

--- a/tests/Host.UnitTests/Api/EmailAttachmentDownloadEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/EmailAttachmentDownloadEndpointTests.cs
@@ -17,11 +17,14 @@ using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Host.Api;
+using MailFathom.Host.Configuration.Access;
+using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.Transport;
 using MailFathom.TestSupport;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
@@ -283,7 +286,15 @@ public sealed class EmailAttachmentDownloadEndpointTests
         var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
         httpContextAccessor.HttpContext.Returns(context);
 
-        return new TransportAuthorizedPrincipalSource(httpContextAccessor);
+        // The MCP endpoint configures a credential here, so nothing about the transport hands this route a caller: what
+        // the use case is told is only what the route states once the ticket has verified.
+        var mcpEndpoint = new McpEndpointOptions();
+        mcpEndpoint.Authentication.Add(new TransportAuthenticationOptions());
+
+        return new TransportAuthorizedPrincipalSource(
+            httpContextAccessor,
+            Options.Create(mcpEndpoint),
+            Options.Create(new AdminEndpointOptions()));
     }
 
     private static IAttachmentDownloadTicketReader TicketReaderRedeeming(AttachmentDownloadTicket? ticket)

--- a/tests/Host.UnitTests/HostCompositionTests.cs
+++ b/tests/Host.UnitTests/HostCompositionTests.cs
@@ -4,8 +4,10 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Xml.Linq;
+using MailFathom.Application.Access;
 using MailFathom.Host.Hosting;
 using MailFathom.Host.Hosting.Startup;
+using MailFathom.Host.Security.Transport;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using Microsoft.AspNetCore.DataProtection.Repositories;
@@ -307,6 +309,27 @@ public sealed class HostCompositionTests
         Assert.DoesNotContain(
             registrations,
             registration => registration.Name == PersonalDataAnalyzerHealthCheck.Name);
+    }
+
+    /// <summary>
+    /// The attachment download route states its principal on the concrete adapter and the use case behind it reads the
+    /// port, so the two have to be one object per request. Registering the port by its implementation type instead of
+    /// forwarding to the registered adapter composes cleanly and resolves everything, and then every download refuses:
+    /// the reader's port would answer what the transport says about that path, which is nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task Compose_TheAuthorizedPrincipalPort_ResolvesTheOneAdapterTheRouteStatesOnto()
+    {
+        // Arrange
+        await using var provider = ComposeServices("probes only").BuildServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+
+        // Act
+        var stated = scope.ServiceProvider.GetRequiredService<TransportAuthorizedPrincipalSource>();
+        var read = scope.ServiceProvider.GetRequiredService<IAuthorizedPrincipalSource>();
+
+        // Assert
+        Assert.Same(stated, read);
     }
 
     /// <summary>Composes one shape and hands back what it registered.</summary>

--- a/tests/Host.UnitTests/Security/Transport/TransportAuthorizedPrincipalSourceTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TransportAuthorizedPrincipalSourceTests.cs
@@ -1,0 +1,123 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Claims;
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Security.ApiKeys;
+using MailFathom.Host.Security.Transport;
+using Microsoft.AspNetCore.Http;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Security.Transport;
+
+/// <summary>Covers the one adapter that turns what the transport established into what the application layer reads.</summary>
+/// <remarks>
+/// Three answers are asserted, one per principal kind the application layer models, and so is the fourth case that is
+/// none of them: a request that authenticated nothing. That last one is the reason the adapter cannot simply report a
+/// caller holding nothing — the download route is reached that way legitimately, and a principal appearing out of the
+/// transport there would be a second and weaker way into an attachment.
+/// </remarks>
+public sealed class TransportAuthorizedPrincipalSourceTests
+{
+    private const string ConfiguredKeyName = "mcp-key";
+
+    [Fact]
+    public void Current_AnAuthenticatedRequest_ReportsTheCallerAndTheGrantItsEntryResolvedTo()
+    {
+        // Arrange
+        var context = RequestBy(AuthenticatedCallerHolding(MailFathomPermission.MailRead));
+        var source = SourceOver(context);
+
+        // Act
+        var principal = source.Current;
+
+        // Assert
+        Assert.NotNull(principal);
+        Assert.Equal(AuthorizedPrincipalKind.Caller, principal.Kind);
+        Assert.Equal(ConfiguredKeyName, principal.Identity);
+        Assert.Equal([MailFathomPermission.MailRead], principal.Permissions);
+    }
+
+    /// <summary>An entry an operator emptied admits a caller that holds nothing, which is a caller rather than nobody.</summary>
+    [Fact]
+    public void Current_AnAuthenticatedRequestWhoseEntryGrantedNothing_ReportsACallerHoldingNothing()
+    {
+        // Arrange
+        var context = RequestBy(AuthenticatedCallerHolding());
+        var source = SourceOver(context);
+
+        // Act
+        var principal = source.Current;
+
+        // Assert
+        Assert.Equal(AuthorizedPrincipalKind.Caller, principal?.Kind);
+        Assert.Empty(principal?.Permissions ?? new HashSet<MailFathomPermission>());
+    }
+
+    /// <summary>
+    /// A request nothing authenticated is none of the three kinds. Reporting it as an anonymous caller would give the
+    /// download route a principal it never verified, which is what its capability is for.
+    /// </summary>
+    [Fact]
+    public void Current_ARequestThatAuthenticatedNothing_ReportsNoPrincipal()
+    {
+        // Arrange
+        var source = SourceOver(new DefaultHttpContext());
+
+        // Act & Assert
+        Assert.Null(source.Current);
+    }
+
+    /// <summary>
+    /// Work reached outside a request in this process is work no caller asked for, which is exactly what the process
+    /// identity names. Saying so is what lets a use case that runs without a caller admit it by name.
+    /// </summary>
+    [Fact]
+    public void Current_NoRequestAtAll_ReportsTheProcessIdentity()
+    {
+        // Arrange
+        var source = SourceOver(context: null);
+
+        // Act & Assert
+        Assert.Same(AuthorizedPrincipal.Process, source.Current);
+    }
+
+    /// <summary>A route that verified a capability states it for itself, and that statement is what the use case behind it reads.</summary>
+    [Fact]
+    public void Current_ACapabilityStatedByARoute_ReportsItOverWhateverTheTransportSaid()
+    {
+        // Arrange
+        var source = SourceOver(RequestBy(AuthenticatedCallerHolding(MailFathomPermission.MailRead)));
+        var capability = AuthorizedPrincipal.SignedCapability("/attachments/an-object/0");
+
+        // Act
+        source.Assume(capability);
+
+        // Assert
+        Assert.Same(capability, source.Current);
+    }
+
+    private static TransportAuthorizedPrincipalSource SourceOver(HttpContext? context)
+    {
+        var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
+        httpContextAccessor.HttpContext.Returns(context);
+
+        return new TransportAuthorizedPrincipalSource(httpContextAccessor);
+    }
+
+    private static DefaultHttpContext RequestBy(ClaimsPrincipal caller) => new() { User = caller };
+
+    /// <summary>Composes the principal an API key scheme produces, which names the entry and carries the grant it resolved to.</summary>
+    private static ClaimsPrincipal AuthenticatedCallerHolding(params MailFathomPermission[] granted) =>
+        new(new ClaimsIdentity(
+            [
+                new Claim(ApiKeyAuthentication.ApiKeyNameClaimType, ConfiguredKeyName),
+                .. TransportGrant.ClaimsFor(granted),
+            ],
+            "test",
+            ApiKeyAuthentication.ApiKeyNameClaimType,
+            ApiKeyAuthentication.RoleClaimType));
+}

--- a/tests/Host.UnitTests/Security/Transport/TransportAuthorizedPrincipalSourceTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TransportAuthorizedPrincipalSourceTests.cs
@@ -20,10 +20,11 @@ namespace MailFathom.Host.UnitTests.Security.Transport;
 
 /// <summary>Covers the one adapter that turns what the transport established into what the application layer reads.</summary>
 /// <remarks>
-/// Three answers are asserted, one per principal kind the application layer models, and so is the fourth case that is
-/// none of them: a request that authenticated nothing. That last one is the reason the adapter cannot simply report a
-/// caller holding nothing — the download route is reached that way legitimately, and a principal appearing out of the
-/// transport there would be a second and weaker way into an attachment.
+/// Three answers are asserted, one per principal kind the application layer models, and so is a request that
+/// authenticated nothing, which is decided by what the surface it reached configures: a caller holding everything that
+/// surface publishes where it configures no entry, and none of the three where it configures one. The download route is
+/// withheld from the permissive half of that before either surface is asked, because a principal appearing out of the
+/// transport there would be a second and weaker way into an attachment than the signature the route verifies.
 /// </remarks>
 public sealed class TransportAuthorizedPrincipalSourceTests
 {

--- a/tests/Host.UnitTests/Security/Transport/TransportAuthorizedPrincipalSourceTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TransportAuthorizedPrincipalSourceTests.cs
@@ -125,6 +125,7 @@ public sealed class TransportAuthorizedPrincipalSourceTests
 
         // Assert
         Assert.Equal(AuthorizedPrincipalKind.Caller, principal?.Kind);
+        Assert.Equal(TransportCallerIdentity.AnonymousCaller, principal?.Identity);
         Assert.Equal(
             MailFathomPermission.PublishedFor(surface).ToHashSet(),
             principal?.Permissions);

--- a/tests/Host.UnitTests/Security/Transport/TransportAuthorizedPrincipalSourceTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TransportAuthorizedPrincipalSourceTests.cs
@@ -63,15 +63,42 @@ public sealed class TransportAuthorizedPrincipalSourceTests
     }
 
     /// <summary>
-    /// A request nothing authenticated, on a surface that configures a credential, is none of the three kinds.
-    /// Reporting it as an anonymous caller would give the download route a principal it never verified, which is what
-    /// its capability is for.
+    /// A request nothing authenticated, on a surface that configures a credential, is none of the three kinds: what
+    /// reached the surface without presenting what the surface asks for was admitted by nothing. Both surfaces are
+    /// stated, because each reads its own settings and one arm answering for the other would go unnoticed.
     /// </summary>
-    [Fact]
-    public void Current_ARequestThatAuthenticatedNothingWhereTheSurfaceConfiguresACredential_ReportsNoPrincipal()
+    [Theory]
+    [InlineData(McpEndpointRoute.Path, true, false)]
+    [InlineData(AdminEndpointOptions.RoutePrefix + "/session", false, true)]
+    public void Current_ARequestThatAuthenticatedNothingWhereTheSurfaceConfiguresACredential_ReportsNoPrincipal(
+        string path,
+        bool mcpConfiguresACredential,
+        bool adminConfiguresACredential)
     {
         // Arrange
-        var source = SourceOver(RequestTo(McpEndpointRoute.Path), mcpConfiguresACredential: true);
+        var source = SourceOver(RequestTo(path), mcpConfiguresACredential, adminConfiguresACredential);
+
+        // Act & Assert
+        Assert.Null(source.Current);
+    }
+
+    /// <summary>
+    /// The MCP surface serves the download route beside the protocol route, so the whole-surface grant would reach it
+    /// wherever the deployment configures no MCP credential — a second and weaker way into an attachment than the
+    /// signature the route verifies for itself, and one holding on that posture alone. The transport therefore answers
+    /// nothing for it under either, and the redeemed ticket the route states for itself remains the only thing that
+    /// authorizes the download.
+    /// </summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Current_ARequestToTheDownloadRoute_ReportsNoPrincipalWhateverTheMcpSurfaceConfigures(
+        bool mcpConfiguresACredential)
+    {
+        // Arrange
+        var source = SourceOver(
+            RequestTo(EmailAttachmentDownloadEndpoint.RoutePrefix + "/a-capability-somebody-presented"),
+            mcpConfiguresACredential);
 
         // Act & Assert
         Assert.Null(source.Current);
@@ -84,7 +111,6 @@ public sealed class TransportAuthorizedPrincipalSourceTests
     /// </summary>
     [Theory]
     [InlineData(McpEndpointRoute.Path, ProtectedSurface.Mail)]
-    [InlineData(EmailAttachmentDownloadEndpoint.RoutePrefix + "/an-object", ProtectedSurface.Mail)]
     [InlineData(AdminEndpointOptions.RoutePrefix + "/session", ProtectedSurface.Administration)]
     public void Current_ARequestOnASurfaceConfiguringNoCredential_ReportsACallerHoldingThatWholeSurface(
         string path,

--- a/tests/Host.UnitTests/Security/Transport/TransportAuthorizedPrincipalSourceTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TransportAuthorizedPrincipalSourceTests.cs
@@ -5,9 +5,14 @@
 using System.Security.Claims;
 using MailFathom.Application.Access;
 using MailFathom.Domain.Access;
+using MailFathom.Host.Api;
+using MailFathom.Host.Configuration.Access;
+using MailFathom.Host.Configuration.Endpoints;
 using MailFathom.Host.Security.ApiKeys;
 using MailFathom.Host.Security.Transport;
+using MailFathom.Mcp;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 using NSubstitute;
 using Xunit;
 
@@ -58,14 +63,52 @@ public sealed class TransportAuthorizedPrincipalSourceTests
     }
 
     /// <summary>
-    /// A request nothing authenticated is none of the three kinds. Reporting it as an anonymous caller would give the
-    /// download route a principal it never verified, which is what its capability is for.
+    /// A request nothing authenticated, on a surface that configures a credential, is none of the three kinds.
+    /// Reporting it as an anonymous caller would give the download route a principal it never verified, which is what
+    /// its capability is for.
     /// </summary>
     [Fact]
-    public void Current_ARequestThatAuthenticatedNothing_ReportsNoPrincipal()
+    public void Current_ARequestThatAuthenticatedNothingWhereTheSurfaceConfiguresACredential_ReportsNoPrincipal()
     {
         // Arrange
-        var source = SourceOver(new DefaultHttpContext());
+        var source = SourceOver(RequestTo(McpEndpointRoute.Path), mcpConfiguresACredential: true);
+
+        // Act & Assert
+        Assert.Null(source.Current);
+    }
+
+    /// <summary>
+    /// ADR 0012 leaves a surface with no <c>Authentication</c> entry granting its whole half, because there is no entry
+    /// for a grant to hang on, and the startup report tells the operator exactly that. Reporting no principal here
+    /// would have a use case refuse every call on a deployment whose own record says it grants everything.
+    /// </summary>
+    [Theory]
+    [InlineData(McpEndpointRoute.Path, ProtectedSurface.Mail)]
+    [InlineData(EmailAttachmentDownloadEndpoint.RoutePrefix + "/an-object", ProtectedSurface.Mail)]
+    [InlineData(AdminEndpointOptions.RoutePrefix + "/session", ProtectedSurface.Administration)]
+    public void Current_ARequestOnASurfaceConfiguringNoCredential_ReportsACallerHoldingThatWholeSurface(
+        string path,
+        ProtectedSurface surface)
+    {
+        // Arrange
+        var source = SourceOver(RequestTo(path));
+
+        // Act
+        var principal = source.Current;
+
+        // Assert
+        Assert.Equal(AuthorizedPrincipalKind.Caller, principal?.Kind);
+        Assert.Equal(
+            MailFathomPermission.PublishedFor(surface).ToHashSet(),
+            principal?.Permissions);
+    }
+
+    /// <summary>A path neither surface serves is nobody's, so the posture of either endpoint decides nothing about it.</summary>
+    [Fact]
+    public void Current_ARequestToAPathNeitherSurfaceServes_ReportsNoPrincipal()
+    {
+        // Arrange
+        var source = SourceOver(RequestTo("/health"));
 
         // Act & Assert
         Assert.Null(source.Current);
@@ -100,15 +143,37 @@ public sealed class TransportAuthorizedPrincipalSourceTests
         Assert.Same(capability, source.Current);
     }
 
-    private static TransportAuthorizedPrincipalSource SourceOver(HttpContext? context)
+    /// <summary>Composes the adapter over one request, and over endpoints that configure a credential or do not.</summary>
+    /// <remarks>Both endpoints default to configuring none, which is the posture whose grant the tests above are about; a test that needs the ordinary posture says so.</remarks>
+    private static TransportAuthorizedPrincipalSource SourceOver(
+        HttpContext? context,
+        bool mcpConfiguresACredential = false,
+        bool adminConfiguresACredential = false)
     {
         var httpContextAccessor = Substitute.For<IHttpContextAccessor>();
         httpContextAccessor.HttpContext.Returns(context);
 
-        return new TransportAuthorizedPrincipalSource(httpContextAccessor);
+        var mcpEndpoint = new McpEndpointOptions();
+        var adminEndpoint = new AdminEndpointOptions();
+        if (mcpConfiguresACredential)
+        {
+            mcpEndpoint.Authentication.Add(new TransportAuthenticationOptions());
+        }
+
+        if (adminConfiguresACredential)
+        {
+            adminEndpoint.Authentication.Add(new TransportAuthenticationOptions());
+        }
+
+        return new TransportAuthorizedPrincipalSource(
+            httpContextAccessor,
+            Options.Create(mcpEndpoint),
+            Options.Create(adminEndpoint));
     }
 
     private static DefaultHttpContext RequestBy(ClaimsPrincipal caller) => new() { User = caller };
+
+    private static DefaultHttpContext RequestTo(string path) => new() { Request = { Path = path } };
 
     /// <summary>Composes the principal an API key scheme produces, which names the entry and carries the grant it resolved to.</summary>
     private static ClaimsPrincipal AuthenticatedCallerHolding(params MailFathomPermission[] granted) =>

--- a/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
+++ b/tests/IntegrationTests/Orchestration/OrchestratedMailFathomServices.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.AI;
 using MailFathom.AI.Chat;
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.EmailContent;
 using MailFathom.Application.EmailContent.Attachments;
@@ -294,6 +295,10 @@ internal sealed class OrchestratedMailFathomServices : IAsyncDisposable
         builder.Services.AddDeterministicTextEmbeddings(
             DeterministicEmbeddingDimension,
             DeterministicEmbeddingInputCharacterLimit);
+        // What a use case is told admitted the work. A composition root supplies it from the request being served, and
+        // this suite serves none: every class it exercises is driven directly, which is work no caller requested and is
+        // exactly what the process identity names.
+        builder.Services.AddScoped<IAuthorizedPrincipalSource>(_ => new ProcessAuthorizedPrincipalSource());
         builder.Services.AddInfrastructure(
             _ => new PostgresConnectionSettings(orchestration.DatabaseConnectionString, null, null),
             PostgresTextSearchConfiguration.Default,

--- a/tests/IntegrationTests/Orchestration/ProcessAuthorizedPrincipalSource.cs
+++ b/tests/IntegrationTests/Orchestration/ProcessAuthorizedPrincipalSource.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+
+namespace MailFathom.IntegrationTests.Orchestration;
+
+/// <summary>Reports that work this suite drives is MailFathom's own rather than anybody's request.</summary>
+/// <remarks>
+/// A composition root supplies this port from the request being served, and this suite starts no request: it composes
+/// the production registrations and calls the classes under them directly, which is the same thing a worker does. The
+/// answer is therefore the process identity rather than a caller, so a use case that requires a permission is refused
+/// here exactly as it would be in a worker — which is the behaviour a test would want to meet rather than one to
+/// arrange around.
+/// </remarks>
+internal sealed class ProcessAuthorizedPrincipalSource : IAuthorizedPrincipalSource
+{
+    /// <inheritdoc />
+    public AuthorizedPrincipal? Current => AuthorizedPrincipal.Process;
+}


### PR DESCRIPTION
A use case is reached by more than one thing — an MCP tool, an administrative route, a background worker, the attachment
download link — and until now none of them told it who asked. This carries that in, and makes the use case the place the
answer is acted on.

## What the application layer now receives

`AuthorizedPrincipal` carries the configured identity the work was admitted under and the permissions that identity
holds, and nothing else. No use case learns which credential admitted a caller, and nothing from `System.Security.Claims`,
ASP.NET Core, or the MCP SDK crosses the boundary. `Boundaries.UnitTests` gains the rule for the one of those three the
project references cannot refuse on their own, since `ClaimsPrincipal` ships in the shared framework.

Three kinds, none of them a weaker version of another:

| Kind | What it is | What it holds |
| --- | --- | --- |
| Caller | Somebody a configured entry admitted, or — where the surface configures no entry at all — somebody who presented nothing | Whatever that entry's grant resolved to, and everything the surface publishes where there is no entry |
| Process identity | MailFathom itself, running work no caller requested | Nothing, by construction |
| Signed capability | A ticket this deployment signed for one object | Nothing; the ticket is the authorization |

The process identity holds nothing by construction, so it can never be admitted by passing an ordinary permission check —
a principal that could be would be a caller with everything granted wearing a different label. The signed capability is
what `GET /attachments/{capability}` runs under: the ticket names one attachment of one email and expires, so the
capability *is* the authorization and the use case behind it admits that kind and asks for no permission beside it.

`AccessAuthorization` is the one thing a use case consults, and every requirement it publishes refuses work reached under
no principal at all. That is the case an entrypoint added later produces by omission, and refusing it is what stops a
check that lived only in middleware from being one the new entrypoint forgets.

## How it gets there

`TransportAuthorizedPrincipalSource` answers per scope from what the transport already established: an authenticated
request is a caller named by whatever this deployment configured, a scope with no request behind it is this process's own
identity, and a route that verified a capability states it for itself through `Assume`. The download route is the one
that does.

**A request that authenticated nothing is decided by what the surface it reached configures.** Where that surface
configures no `Authentication` entry at all, it is a caller named `anonymous` holding everything the surface publishes —
every `mailfathom.mail.*` name on the MCP surface, every `mailfathom.admin.*` name on the administrative one. ADR 0012
settled that posture and `TransportGrantStartupReport` states it at startup, so reporting no principal would have a use
case refuse every call on a deployment whose own record says it grants everything. Where the surface does configure a
credential, such a request is none of the three.

**The attachment download route is withheld from that grant on either posture**, before either surface is asked. The MCP
surface serves it beside the protocol route, so the grant above would otherwise reach it wherever the deployment
configures no MCP credential — a second and weaker way into an attachment than the signature the route verifies for
itself, and one holding on that posture alone. `ReachedOnlyUnderACapability` is what withholds it; the redeemed ticket
the route states for itself stays the only thing that authorizes a download.

The naming rule for a caller is shared with what `GET /api/admin/session` already reports, rather than copied, so this
deployment cannot call one caller two things in its own answer and in its record of a refusal.

## Which use cases ask

`EmailAttachmentDownloadReader` is the one that asks today, and it is the one neither sibling issue owns. The per-tool
and per-route wiring is #586's and #587's acceptance verbatim — *"the use case behind each tool/route refuses an
unauthorized principal on its own, proved with the transport absent"* — over the mechanism this change delivers. The
refusal travels as an application failure carrying error code `14001`, and, where the requirement was a grant rather
than a kind, the permission that would have sufficed, so neither surface has to decide the other's answer: the MCP
surface answers as an unknown tool and the administrative surface names the permission.

## Break record

**Nothing breaks.** No configuration key, MCP tool argument, database column, or deployment contract moves, and no grant
is enforced on either surface yet, so a shipped deployment serves exactly what it served. The whole-surface caller above
grants no access a deployment did not already have: a surface configuring no credential already served every request
that reached it. Per ADR 0012 there is nothing to record, and no operator action follows.

## Notes for the reviewer

- `AccessAuthorization` is registered by `AddInfrastructure` beside the use cases that consult it; `IAuthorizedPrincipalSource`
  is registered by a composition root, because only a composition root knows what admitted a unit of work. The
  integration harness composes `AddInfrastructure` and serves no request, so it registers the process identity — added
  here rather than left for the first sibling issue to discover in a suite that runs only in the pipeline.
- The port forwards to the registered adapter rather than being registered by its implementation type, because the route
  states the principal on the concrete instance and the use case reads it through the port: two instances per request
  would refuse every download. `HostCompositionTests` asserts they are one.
- ADR 0012's `describes:` marker is widened to reach `src/Domain/Access/**` and `src/Application/Access/**`. Marker only;
  no decision text is touched.

## Verification

- `scripts/verify-full.sh` — green: 7776 unit tests, 0 failed; aggregate line coverage 96.03% (required 85%); 212
  workflow-contract assertions, 0 failed.
- `$check-docs-licenses` — Docs `pass`, Changelog `n/a`, Licenses `pass` with an empty inventory: no package added,
  upgraded, or removed, and no lock file moves.
- `scripts/review-obligations.sh` — every row read in the file it pointed at.

Closes #585
