### PR TITLE
[#752] Administer the contact book from mfctl, including the erasure and export paths

### DIFF
--- a/docs/features/contacts.md
+++ b/docs/features/contacts.md
@@ -1,15 +1,16 @@
 # Contacts
 
-<!-- describes: src/Domain/Contacts/**, src/Application/Contacts/**, src/Infrastructure/Persistence/Contacts/**, src/Infrastructure/Persistence/Entities/ContactEntity.cs, src/Infrastructure/Persistence/Entities/ContactAddressEntity.cs -->
+<!-- describes: src/Domain/Contacts/**, src/Application/Contacts/**, src/Infrastructure/Persistence/Contacts/**, src/Infrastructure/Persistence/Entities/ContactEntity.cs, src/Infrastructure/Persistence/Entities/ContactAddressEntity.cs, src/Host/Api/Contact*.cs, src/Cli/Commands/Contacts/**, src/Cli/Administration/Contacts/** -->
 
 MailFathom holds a contact book of its own: people, the addresses they use, and what an owner recorded about them, in
 the same PostgreSQL database the mail is in. This page describes the record and the rules every writer of it obeys —
 what identifies a person, when two addresses are the same address, who may change what, and what erasing somebody
 removes.
 
-**No surface publishes it yet.** The store, its rules, and the two data-subject paths are what exists today; the
-administration commands, the MCP tools, and collection from arriving mail are separate changes. Nothing writes to the
-book automatically, so an instance that nobody has written to holds no contacts at all.
+**`mfctl contact` is where the book is maintained**, over the deployment's administrative endpoint; [administering a
+deployment](../operations/admin-endpoint.md#administering-the-contact-book) holds the command group in full. The MCP
+tools over the book and collection from arriving mail are separate changes, so nothing writes to the book on its own and
+an instance nobody has written to holds no contacts at all.
 
 ## A contact is a person, not an address
 
@@ -134,6 +135,11 @@ a failure: the state the owner asked for is the state the book is in.
 **Exporting a contact produces everything held about them** as of the instant it was taken: the name, every address,
 which is preferred, the note, the origin, and both timestamps. What an owner reads is left to the surface that asks for
 it, so no surface can choose which parts of a person to hand back.
+
+Both are commands rather than seams something else is expected to reach: `mfctl contact delete` erases and
+`mfctl contact export` writes the document, because a data-subject path nothing invokes is one that will not work on the
+day somebody asks for it. The erasure asks before it runs and answers with what went — the identity and how many
+addresses — and never with the person.
 
 ## What the book is held under
 

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1,6 +1,6 @@
 # Administering a deployment
 
-<!-- describes: src/Host/Configuration/Endpoints/AdminEndpointOptions.cs, src/Host/Api/Admin*.cs, src/Host/Api/Embedding*.cs, src/Host/Api/Job*.cs, src/Host/Api/Mail*.cs, src/Host/Api/Spam*.cs, src/Host/Hosting/Startup/SurfaceIsolation.cs, src/Host/Hosting/Warnings/AdminTransportSecurityWarning.cs, src/Host/Hosting/Warnings/TransportGrantStartupReport.cs, src/Domain/Access/MailFathomPermission.cs, src/Host/Security/Endpoints/TransportListenerBinder.cs, src/Host/Security/Transport/TransportRateLimiting.cs, src/Cli/**, scripts/install-mfctl.sh -->
+<!-- describes: src/Host/Configuration/Endpoints/AdminEndpointOptions.cs, src/Host/Api/Admin*.cs, src/Host/Api/Contact*.cs, src/Host/Api/Embedding*.cs, src/Host/Api/Job*.cs, src/Host/Api/Mail*.cs, src/Host/Api/Spam*.cs, src/Host/Hosting/Startup/SurfaceIsolation.cs, src/Host/Hosting/Warnings/AdminTransportSecurityWarning.cs, src/Host/Hosting/Warnings/TransportGrantStartupReport.cs, src/Domain/Access/MailFathomPermission.cs, src/Host/Security/Endpoints/TransportListenerBinder.cs, src/Host/Security/Transport/TransportRateLimiting.cs, src/Cli/**, scripts/install-mfctl.sh -->
 
 How the `mfctl` command reaches a running deployment, and what that deployment has to have enabled before it will
 answer.
@@ -109,6 +109,12 @@ info: MailFathom.Host.Hosting.Warnings.TransportGrantStartupReport
 Nothing in those lines names a key, a public key, a token, an authorization server, or a subject: a grant is what the
 deployment wrote, never who presented something.
 
+**No name covers the contact book.** The six above were allocated against the routes that existed when they were, and
+the book's own routes — reading it, writing to it, exporting a person, erasing one — fall under none of them. Nothing
+follows from that today, because of the paragraph below; what it means is that a grant narrowing this surface does not
+narrow the book, and allocating names for it is a decision about the published permission set rather than about these
+routes.
+
 **Nothing on this surface varies by the grant today.** The permissions are read, validated, carried on the authenticated
 caller, and reported at startup; every route still serves any authenticated caller, which is what the note above says.
 
@@ -139,6 +145,14 @@ caller, and reported at startup; every route still serves any authenticated call
 | `POST /api/admin/jobs/dead-letters/retry` | Returns one stopped job to the queue under the identity it was enqueued with. |
 | `POST /api/admin/jobs/dead-letters/drop` | Decides one stopped job will never run, keeping the record of it. |
 | `POST /api/admin/folders/erasure` | Erases one bounded pass of the mail stored for a folder the account no longer mirrors. **This is the one route that disposes of mail.** |
+| `GET /api/admin/contacts` | Reads one bounded, keyset-paginated page of the [contact book](../features/contacts.md), optionally narrowed to one origin. |
+| `POST /api/admin/contacts` | Records a person the book does not yet hold, as a contact this deployment's owner asserted. |
+| `GET /api/admin/contacts/by-address` | Reads whoever uses one address, in whichever casing the book recorded it. |
+| `GET /api/admin/contacts/{id}` | Reads one contact by the identity the book gave it. |
+| `PUT /api/admin/contacts/{id}` | Amends one contact to the whole record the body states. |
+| `POST /api/admin/contacts/{id}/promotion` | Takes on a contact the deployment collected, so it becomes one the owner asserted. |
+| `DELETE /api/admin/contacts/{id}` | Erases one person and everything the book derived from them. **This is the one route that disposes of a contact, and it cannot be undone.** |
+| `GET /api/admin/contacts/{id}/export` | Produces everything the book holds about one person, as of the instant it was taken. |
 
 The write route's body carries a long-lived credential for a named mailbox owner, which is what makes the clear-text
 warning below matter more here than it does for a session probe. It refuses, with `400` and a sentence naming what was
@@ -695,6 +709,65 @@ omission rather than a refusal, because a caller writing a URL cannot express th
 **Neither route touches embeddings, and neither re-runs classification for a verdict already recorded.** Chunks and
 vectors stay the [embedding profile's](embedding-profiles.md) business, so a refresh cannot quietly spend the provider
 budget an operator has not asked to spend.
+
+### Administering the contact book
+
+`mfctl contact` is where the [contact book](../features/contacts.md) is maintained: people, the addresses they use, and
+what you recorded about them. The book's own rules — what identifies a person, when two addresses are the same address,
+who may change what — are that page's; this is the command group over them.
+
+```console
+$ mfctl contact create --name "Anna Kowalska" --address anna@example.test --note "Met at the conference."
+Recorded contact 018f2b1c-9b3a-7c41-8f7d-2c6a5e9d10ab.
+Contact:   018f2b1c-9b3a-7c41-8f7d-2c6a5e9d10ab
+Name:      Anna Kowalska
+Origin:    Asserted
+Addresses: anna@example.test  (preferred)
+Note:      Met at the conference.
+Recorded:  2026-08-16 09:00:00Z
+Amended:   2026-08-16 09:00:00Z
+```
+
+| Command | What it does |
+| --- | --- |
+| `contact create` | Records a person. `--address` is repeated for each address they use, and `--preferred` says which to use by default — required as soon as there is more than one, because that is your choice rather than an ordering accident |
+| `contact show` | Shows one person, by `--id` or by `--address`. Naming both, or neither, is refused |
+| `contact list` | Reads one page, optionally narrowed with `--origin`. `--page-size` bounds it and `--cursor` continues it |
+| `contact update` | Corrects `--name`, `--note`, `--preferred`, or the whole `--address` set. What you do not name is kept; `--clear-note` holds no note afterwards |
+| `contact add-address` | Adds one address, keeping the rest. `--preferred` names which address to use by default afterwards |
+| `contact remove-address` | Takes one address off. `--preferred` is required when the one being removed is the default |
+| `contact promote` | Takes on a contact the deployment collected, so it becomes one you asserted |
+| `contact delete` | Erases the person. **This cannot be undone**; see below |
+| `contact export` | Writes everything held about the person to standard output, as JSON |
+
+**Amendments state the whole record.** The book replaces what it is given rather than merging a difference, so
+`update`, `add-address`, and `remove-address` each read the contact first and send back what it is to become. Two
+operators editing one contact at once are therefore last-writer-wins; an edit racing an erasure is not, and is answered
+as a contact the book does not hold rather than putting the person back.
+
+**A contact the deployment collected is not amended in place.** Collection writes into its own origin and an owner does
+not edit those records directly — `contact promote` is the act of taking one on, after which every other command here
+works on it. Amending one without promoting it is refused, and the refusal says so.
+
+**`mfctl contact delete` is the contact book's erasure path.** It removes the person and their addresses from the
+database rather than marking them, and nothing in MailFathom can put the record back. The command shows the record and
+then asks, and `--yes` is how a scripted erasure states the agreement instead; an invocation with nobody at the terminal
+and no flag is refused rather than having an agreement read out of whatever was piped in. It answers with what went —
+the identity and how many addresses — and never with the person. Erasing somebody the book does not hold succeeds
+having removed nothing, because that is the state you asked for.
+
+**`mfctl contact export` is the access path**, and it writes one JSON document on standard output so it redirects into
+a file you can hand to the person who asked. It carries the complete record and the instant the export was taken;
+everything else the command prints goes to standard error.
+
+**The listing is bounded and there is no command that prints the whole book.** A page holds 50 contacts unless you ask
+for fewer and never more than 200, ordered by the name's comparison form and then by identity. That order is total, so
+walking a page at a time serves every contact exactly once. A page that has more behind it prints the cursor the next
+one is asked with.
+
+Every refusal names the rule rather than the value: a malformed address is reported as an address that is not usable and
+never echoed, and no name, address, or note reaches a log line, a problem document, a trace, or a failing command's
+output. What a failure names is the contact's identifier, which is the one part of the record that is not personal data.
 
 ## Rate limiting
 

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -18,12 +18,10 @@ in [configuration sources](../operations/configuration-sources.md); the command 
 database, and never touches the secret store. Nothing you do with it changes what the service will do on its next
 restart.
 
-> **One thing it does changes a running deployment: it can place a mailbox credential.** Everything else below verifies
-> who you are and keeps several deployments straight. Operational commands — inspecting synchronization, triggering
-> work, reading accounts — are not there yet.
->
-> The exception is [authorizing a mailbox](#authorizing-a-mailbox), which signs you in to a *mail provider* and can then
-> hand the resulting credential to your deployment to keep.
+> **What it does change is the deployment's own state rather than its configuration**: it can place a mailbox
+> credential, ask for work to be run, dispose of a folder's stored mail, and maintain the contact book. None of that is
+> a setting, and none of it survives as one — [configuration sources](../operations/configuration-sources.md) stays the
+> only place a deployment's behaviour is decided.
 
 ## Before it can answer
 
@@ -416,9 +414,36 @@ it](../operations/admin-endpoint.md#reading-the-background-work-that-stopped-and
 operator's reference, and [durable background work](../operations/telemetry.md#durable-background-work) is what your
 monitoring can watch instead of you reading this by hand.
 
+## Keeping your contact book
+
+MailFathom holds a contact book of its own — people, the addresses each of them uses, and what you wrote about them —
+and `mfctl contact` is where you keep it:
+
+```console
+$ mfctl contact create --name "Anna Kowalska" --address anna@example.test
+$ mfctl contact add-address --id 018f2b1c-9b3a-7c41-8f7d-2c6a5e9d10ab --address a.kowalska@work.example
+$ mfctl contact show --address a.kowalska@work.example
+```
+
+A contact is a *person* rather than an address, which is why the third command answers with Anna rather than with a
+match: one person uses a work address, a personal one, and an old one they still receive on, and the book knows those
+are the same person. [Contacts](../features/contacts.md) is what the record holds and every rule it obeys.
+
+Two of the commands are not conveniences. **`mfctl contact delete` erases somebody** — the record and their addresses go
+from the database and nothing can put them back, so the command shows you the record and asks first. **`mfctl contact
+export` writes everything held about a person** as JSON on standard output, which is what you redirect into a file and
+hand to somebody who asked what you have about them. Those are the two things you will need on a day when somebody asks,
+and they are commands so that you are not assembling either by hand on that day.
+
+Listing is paged on purpose: your contact book is other people's personal data, so there is no command that prints all
+of it in one go. `mfctl contact list` reads a page and prints the cursor for the next one. [Administering the contact
+book](../operations/admin-endpoint.md#administering-the-contact-book) is the operator's reference for every command,
+option, and refusal.
+
 ## Where to go next
 
 - [Administering a deployment](../operations/admin-endpoint.md) — the operator's reference for everything above
+- [Contacts](../features/contacts.md) — what the contact book holds, and every rule a writer of it obeys
 - [Mail rules](../features/mail-rules.md) — every fact, operator, and action a rule can use
 - [Mailbox OAuth](../operations/mailbox-oauth.md) — registering the application, and every mode of the sign-in above
 - [Changing the embedding model](../operations/embedding-profiles.md) — what activating, switching, and rolling back cost

--- a/src/Application/Contacts/ContactCursor.cs
+++ b/src/Application/Contacts/ContactCursor.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
 using MailFathom.Domain.Contacts;
 
 namespace MailFathom.Application.Contacts;
@@ -23,6 +26,30 @@ namespace MailFathom.Application.Contacts;
 /// </remarks>
 public sealed record ContactCursor
 {
+    /// <summary>The greatest number of characters an encoded cursor may carry before it is refused unread.</summary>
+    /// <remarks>
+    /// A name is bounded at <see cref="ContactDisplayName.MaximumLength" /> characters, each of which may cost four
+    /// bytes in UTF-8 before the encoding widens it again, so this is that ceiling rather than a round number: anything
+    /// longer was not issued here and is refused without being decoded.
+    /// </remarks>
+    public const int MaximumEncodedLength = 2_048;
+
+    /// <summary>
+    /// The encoded form's version. It leads the payload so a later change to the fields refuses the cursors this version
+    /// issued instead of misreading them.
+    /// </summary>
+    private const string FormatVersion = "1";
+
+    /// <summary>Separates the encoded fields.</summary>
+    /// <remarks>
+    /// The name's comparison form is written last and the split is bounded at three fields, because a name may itself
+    /// contain this character and a greedy split would then read part of somebody's name as a field of its own.
+    /// </remarks>
+    private const char FieldSeparator = '.';
+
+    /// <summary>How many fields the encoded payload carries.</summary>
+    private const int FieldCount = 3;
+
     private ContactCursor(string displayNameSortKey, ContactId contactId)
     {
         this.DisplayNameSortKey = displayNameSortKey;
@@ -41,4 +68,70 @@ public sealed record ContactCursor
     /// <returns>The boundary the following page reads beyond.</returns>
     public static ContactCursor After(ContactDisplayName displayName, ContactId contactId) =>
         new(displayName.SortKey, contactId);
+
+    /// <summary>Reads a cursor a caller presented.</summary>
+    /// <param name="text">The encoded cursor, as a previous page returned it.</param>
+    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise <see langword="null" />.</param>
+    /// <returns><see langword="true" /> when the text decoded into a usable cursor; otherwise <see langword="false" />.</returns>
+    public static bool TryDecode(string? text, out ContactCursor? cursor)
+    {
+        cursor = null;
+
+        if (text is null || text.Length is 0 or > MaximumEncodedLength)
+        {
+            return false;
+        }
+
+        // Validity is checked separately because the decoder's Try form reports only that a destination was too small
+        // and throws on text that is not base64url at all, which is the shape a caller most easily presents.
+        if (!Base64Url.IsValid(text))
+        {
+            return false;
+        }
+
+        var decoded = new byte[Base64Url.GetMaxDecodedLength(text.Length)];
+
+        if (!Base64Url.TryDecodeFromChars(text, decoded, out var decodedLength))
+        {
+            return false;
+        }
+
+        var fields = Encoding.UTF8.GetString(decoded, 0, decodedLength).Split(FieldSeparator, FieldCount);
+
+        if (fields is not [FormatVersion, var identifierField, var sortKeyField]
+            || !Guid.TryParseExact(identifierField, "N", out var identifier)
+            || identifier == Guid.Empty
+            || sortKeyField.Length is 0)
+        {
+            return false;
+        }
+
+        cursor = new ContactCursor(sortKeyField, ContactId.Create(identifier));
+
+        return true;
+    }
+
+    /// <summary>Writes the cursor as the opaque string a caller presents to continue the walk.</summary>
+    /// <returns>The encoded cursor.</returns>
+    /// <remarks>
+    /// <para>
+    /// The identity is written before the name's comparison form so the form can carry the separator without the
+    /// decoding having to guess where it ends.
+    /// </para>
+    /// <para>
+    /// Encoding is opacity rather than protection, exactly as it is for every other cursor here: a client that cannot
+    /// read one does not build one. It is not a place to put a value that must not travel — which is why the comparison
+    /// form the ordering needs is the only part of a person this carries, and why nothing logs a cursor.
+    /// </para>
+    /// </remarks>
+    public string Encode()
+    {
+        var payload = string.Join(
+            FieldSeparator,
+            FormatVersion,
+            this.ContactId.Value.ToString("N", CultureInfo.InvariantCulture),
+            this.DisplayNameSortKey);
+
+        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
+    }
 }

--- a/src/Cli/Administration/AdminApiClient.cs
+++ b/src/Cli/Administration/AdminApiClient.cs
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using MailFathom.Cli.Administration.Contacts;
 using MailFathom.Cli.Administration.Embeddings;
 using MailFathom.Cli.Administration.Folders;
 using MailFathom.Cli.Administration.Jobs;
@@ -584,6 +586,206 @@ internal sealed class AdminApiClient
             JsonContent.Create(
                 new MailFolderErasureRequest(account, folder),
                 CliJsonContext.Default.MailFolderErasureRequest));
+    }
+
+    /// <summary>Reads one bounded page of the deployment's contact book.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="origin">The origin to narrow to, or <see langword="null" /> for the whole book.</param>
+    /// <param name="pageSize">How many contacts the page may hold, or <see langword="null" /> for the deployment's default.</param>
+    /// <param name="cursor">The cursor a previous page returned, or <see langword="null" /> for the first page.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>The page, and the cursor the following one is asked with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="token" /> is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the request or the credential, could not be reached, or answered with something that is not a page.</exception>
+    internal Task<ContactPage> ReadContactPageAsync(
+        string token,
+        string? origin,
+        int? pageSize,
+        string? cursor,
+        CancellationToken cancellationToken) =>
+        this.RequestAsync(
+            HttpMethod.Get,
+            $"{AdminEndpointRoutes.ContactsPath}{ContactPageQuery(origin, pageSize, cursor)}",
+            token,
+            CliJsonContext.Default.ContactPage,
+            cancellationToken);
+
+    /// <summary>Asks the deployment to record a person its contact book does not yet hold.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="record">The record to write.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>The record as written, or the outcome that refused it.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the request or the credential, could not be reached, or answered with something that is not an outcome.</exception>
+    internal Task<ContactWriteAnswer> RecordContactAsync(
+        string token,
+        ContactRecordRequest record,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        return this.RequestAsync(
+            HttpMethod.Post,
+            AdminEndpointRoutes.ContactsPath,
+            token,
+            CliJsonContext.Default.ContactWriteAnswer,
+            cancellationToken,
+            JsonContent.Create(record, CliJsonContext.Default.ContactRecordRequest));
+    }
+
+    /// <summary>Reads one contact by the identity the deployment's book gave it.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="contactId">The contact to read.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>The contact, or an answer carrying none where the book holds no such person.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="token" /> is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the request or the credential, could not be reached, or answered with something that is not a lookup.</exception>
+    internal Task<ContactLookup> ReadContactAsync(
+        string token,
+        Guid contactId,
+        CancellationToken cancellationToken) =>
+        this.RequestAsync(
+            HttpMethod.Get,
+            AdminEndpointRoutes.ContactPath(contactId),
+            token,
+            CliJsonContext.Default.ContactLookup,
+            cancellationToken);
+
+    /// <summary>Reads the person who uses one address.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="address">The address to resolve.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>The contact, or an answer carrying none where nobody in the book holds it.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the request or the credential, could not be reached, or answered with something that is not a lookup.</exception>
+    internal Task<ContactLookup> ReadContactByAddressAsync(
+        string token,
+        string address,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(address);
+
+        return this.RequestAsync(
+            HttpMethod.Get,
+            $"{AdminEndpointRoutes.ContactByAddressPath}?address={Uri.EscapeDataString(address)}",
+            token,
+            CliJsonContext.Default.ContactLookup,
+            cancellationToken);
+    }
+
+    /// <summary>Asks the deployment to amend one contact to the record stated.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="contactId">The contact to amend.</param>
+    /// <param name="record">The record the contact is to have afterwards.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>The amended record, or the outcome that refused it.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the request or the credential, could not be reached, or answered with something that is not an outcome.</exception>
+    /// <remarks>
+    /// The whole record rather than the difference, which is what the deployment's book takes: a command changing one
+    /// field reads the contact first and sends what it is to become.
+    /// </remarks>
+    internal Task<ContactWriteAnswer> AmendContactAsync(
+        string token,
+        Guid contactId,
+        ContactRecordRequest record,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        return this.RequestAsync(
+            HttpMethod.Put,
+            AdminEndpointRoutes.ContactPath(contactId),
+            token,
+            CliJsonContext.Default.ContactWriteAnswer,
+            cancellationToken,
+            JsonContent.Create(record, CliJsonContext.Default.ContactRecordRequest));
+    }
+
+    /// <summary>Asks the deployment to promote a collected contact to one the owner has taken responsibility for.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="contactId">The contact to promote.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>The promoted record, or the outcome that refused it.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="token" /> is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the request or the credential, could not be reached, or answered with something that is not an outcome.</exception>
+    internal Task<ContactWriteAnswer> PromoteContactAsync(
+        string token,
+        Guid contactId,
+        CancellationToken cancellationToken) =>
+        this.RequestAsync(
+            HttpMethod.Post,
+            AdminEndpointRoutes.ContactPromotionPath(contactId),
+            token,
+            CliJsonContext.Default.ContactWriteAnswer,
+            cancellationToken);
+
+    /// <summary>Asks the deployment to erase one person and everything its book derived from them.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="contactId">The contact to erase.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>What the erasure removed, including a book that held no such contact.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="token" /> is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the request or the credential, could not be reached, or answered with something that is not an erasure.</exception>
+    /// <remarks>
+    /// The erasure removes rather than marks, and the answer says what went. Erasing somebody the book does not hold is
+    /// a completed erasure rather than a failure, so this reports it as an answer instead of raising.
+    /// </remarks>
+    internal Task<ContactErasure> EraseContactAsync(
+        string token,
+        Guid contactId,
+        CancellationToken cancellationToken) =>
+        this.RequestAsync(
+            HttpMethod.Delete,
+            AdminEndpointRoutes.ContactPath(contactId),
+            token,
+            CliJsonContext.Default.ContactErasure,
+            cancellationToken);
+
+    /// <summary>Asks the deployment for everything its book holds about one person.</summary>
+    /// <param name="token">The bearer credential to present.</param>
+    /// <param name="contactId">The contact to export.</param>
+    /// <param name="cancellationToken">Cancels the request.</param>
+    /// <returns>The export, or an answer carrying none where the book holds no such person.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="token" /> is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment refused the request or the credential, could not be reached, or answered with something that is not an export.</exception>
+    internal Task<ContactExport> ExportContactAsync(
+        string token,
+        Guid contactId,
+        CancellationToken cancellationToken) =>
+        this.RequestAsync(
+            HttpMethod.Get,
+            AdminEndpointRoutes.ContactExportPath(contactId),
+            token,
+            CliJsonContext.Default.ContactExport,
+            cancellationToken);
+
+    /// <summary>Writes the narrowing an operator asked a listing for as a query string.</summary>
+    /// <remarks>
+    /// A filter the operator left out is left out of the query rather than sent empty, so the request says what they
+    /// said: the deployment reads an absent origin as the whole book and an absent size as its own default, and a
+    /// parameter present but blank would be one more shape for it to have an opinion about.
+    /// </remarks>
+    private static string ContactPageQuery(string? origin, int? pageSize, string? cursor)
+    {
+        var filters = new List<string>(3);
+
+        if (origin is { Length: > 0 } narrowed)
+        {
+            filters.Add($"origin={Uri.EscapeDataString(narrowed)}");
+        }
+
+        if (pageSize is { } size)
+        {
+            filters.Add($"pageSize={size.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        if (cursor is { Length: > 0 } continuation)
+        {
+            filters.Add($"cursor={Uri.EscapeDataString(continuation)}");
+        }
+
+        return filters.Count == 0 ? string.Empty : $"?{string.Join('&', filters)}";
     }
 
     /// <summary>Writes the scope an operator named as a query string, escaping both halves.</summary>

--- a/src/Cli/Administration/AdminEndpointRoutes.cs
+++ b/src/Cli/Administration/AdminEndpointRoutes.cs
@@ -96,6 +96,36 @@ internal static class AdminEndpointRoutes
     /// </remarks>
     internal const string FolderErasurePath = $"{Prefix}/folders/erasure";
 
+    /// <summary>Where a deployment's contact book is listed and where a person is recorded in it.</summary>
+    internal const string ContactsPath = $"{Prefix}/contacts";
+
+    /// <summary>Where the person behind one address is read.</summary>
+    /// <remarks>
+    /// A path of its own rather than a filter on the listing, because it answers with one person rather than a page. The
+    /// segment is not a UUID, so nothing can confuse it with the path one contact is read at.
+    /// </remarks>
+    internal const string ContactByAddressPath = $"{ContactsPath}/by-address";
+
+    /// <summary>Where one contact is read, amended, and erased.</summary>
+    /// <param name="contactId">The contact the path names.</param>
+    /// <returns>The path, with the identity written the way a deployment's route constraint reads one.</returns>
+    internal static string ContactPath(Guid contactId) => $"{ContactsPath}/{contactId:D}";
+
+    /// <summary>Where a collected contact is promoted to one the owner has taken responsibility for.</summary>
+    /// <param name="contactId">The contact the path names.</param>
+    /// <returns>The path.</returns>
+    /// <remarks>
+    /// A path of its own rather than a field on the amendment, because promotion is the one act that changes an origin
+    /// and a body carrying which act was meant would make a mistyped value the difference between correcting a record
+    /// and taking it on.
+    /// </remarks>
+    internal static string ContactPromotionPath(Guid contactId) => $"{ContactPath(contactId)}/promotion";
+
+    /// <summary>Where everything the deployment holds about one person is exported from.</summary>
+    /// <param name="contactId">The contact the path names.</param>
+    /// <returns>The path.</returns>
+    internal static string ContactExportPath(Guid contactId) => $"{ContactPath(contactId)}/export";
+
     /// <summary>Where a deployment publishes the document naming its authorization servers, resource, and required scopes.</summary>
     /// <remarks>
     /// Composed rather than discovered from a challenge, because a client that knows which routes it is about to call

--- a/src/Cli/Administration/Contacts/ContactErasure.cs
+++ b/src/Cli/Administration/Contacts/ContactErasure.cs
@@ -1,0 +1,21 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Cli.Administration.Contacts;
+
+/// <summary>What erasing one contact removed from a deployment.</summary>
+/// <param name="Contact">The contact the erasure was asked for.</param>
+/// <param name="WasHeld">Whether the book held that contact when the erasure ran.</param>
+/// <param name="AddressesErased">How many addresses went with them.</param>
+/// <remarks>
+/// The counts are what the command reports rather than a bare success, because an owner who has just erased somebody is
+/// entitled to be told what went. Nothing about the person is in this answer: an erasure that echoed the record would be
+/// a copy of what was just removed, printed to a terminal and left in a shell's scrollback.
+/// </remarks>
+internal sealed record ContactErasure(
+    [property: JsonPropertyName("contact")] Guid Contact,
+    [property: JsonPropertyName("wasHeld")] bool WasHeld,
+    [property: JsonPropertyName("addressesErased")] int AddressesErased);

--- a/src/Cli/Administration/Contacts/ContactExport.cs
+++ b/src/Cli/Administration/Contacts/ContactExport.cs
@@ -1,0 +1,18 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Cli.Administration.Contacts;
+
+/// <summary>Everything a deployment holds about one person, as of the instant the export was taken.</summary>
+/// <param name="Contact">The complete record, or <see langword="null" /> when the book holds no such contact.</param>
+/// <param name="ProducedAt">When the export was produced, absent together with the contact.</param>
+/// <remarks>
+/// The data-subject access path. The command prints this document as it arrived rather than a rendering of it, so what
+/// an owner hands to the person who asked is the deployment's own answer and not one surface's summary of it.
+/// </remarks>
+internal sealed record ContactExport(
+    [property: JsonPropertyName("contact")] ContactRecord? Contact,
+    [property: JsonPropertyName("producedAt")] DateTimeOffset? ProducedAt);

--- a/src/Cli/Administration/Contacts/ContactPage.cs
+++ b/src/Cli/Administration/Contacts/ContactPage.cs
@@ -1,0 +1,20 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Cli.Administration.Contacts;
+
+/// <summary>One bounded page of a deployment's contact book, and where the walk continues.</summary>
+/// <param name="Contacts">The contacts this page holds, ordered by the name's comparison form and then by identity.</param>
+/// <param name="NextCursor">The cursor the following page is asked with, or <see langword="null" /> at the end of the book.</param>
+/// <remarks>
+/// The absent cursor is the end of the walk rather than a page that happened to be short, so the command stops when the
+/// cursor stops instead of comparing the count against the size it asked for. There is no command that walks the whole
+/// book in one call: the operator asks for the next page, which is what keeps a listing of somebody's correspondents an
+/// act rather than a side effect.
+/// </remarks>
+internal sealed record ContactPage(
+    [property: JsonPropertyName("contacts")] IReadOnlyList<ContactRecord>? Contacts,
+    [property: JsonPropertyName("nextCursor")] string? NextCursor);

--- a/src/Cli/Administration/Contacts/ContactRecord.cs
+++ b/src/Cli/Administration/Contacts/ContactRecord.cs
@@ -1,0 +1,40 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Cli.Administration.Contacts;
+
+/// <summary>One person as a deployment's contact book holds them.</summary>
+/// <param name="Id">The identity the book gave them, which every other command names them by.</param>
+/// <param name="DisplayName">The name the owner recorded, in the casing they wrote it.</param>
+/// <param name="Addresses">Every address they use, the preferred one first.</param>
+/// <param name="PreferredAddress">The address to use when something addresses them without naming which of theirs.</param>
+/// <param name="Note">What the owner wrote about them, or <see langword="null" /> where they wrote nothing.</param>
+/// <param name="Origin">How the contact came to be in the book, which decides who may amend it.</param>
+/// <param name="RecordedAt">When the contact entered the book.</param>
+/// <param name="AmendedAt">When it was last amended.</param>
+/// <remarks>
+/// Everything here but the identity and the origin is personal data about a third party. It is printed to the terminal
+/// the operator asked from and reaches nothing else: no failure message this command writes carries any of it, and the
+/// identifier is what a refusal names.
+/// </remarks>
+internal sealed record ContactRecord(
+    [property: JsonPropertyName("id")] Guid Id,
+    [property: JsonPropertyName("displayName")] string? DisplayName,
+    [property: JsonPropertyName("addresses")] IReadOnlyList<string>? Addresses,
+    [property: JsonPropertyName("preferredAddress")] string? PreferredAddress,
+    [property: JsonPropertyName("note")] string? Note,
+    [property: JsonPropertyName("origin")] string? Origin,
+    [property: JsonPropertyName("recordedAt")] DateTimeOffset RecordedAt,
+    [property: JsonPropertyName("amendedAt")] DateTimeOffset AmendedAt);
+
+/// <summary>The person a lookup found, or that the book holds none.</summary>
+/// <param name="Contact">The contact, or <see langword="null" /> when the book holds nobody matching what was asked.</param>
+/// <remarks>
+/// A book holding nobody is an answer rather than a refusal, so the deployment reports it in the body and the command
+/// says so plainly instead of reading a missing person as an endpoint that is not there.
+/// </remarks>
+internal sealed record ContactLookup(
+    [property: JsonPropertyName("contact")] ContactRecord? Contact);

--- a/src/Cli/Administration/Contacts/ContactRecordRequest.cs
+++ b/src/Cli/Administration/Contacts/ContactRecordRequest.cs
@@ -1,0 +1,22 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Cli.Administration.Contacts;
+
+/// <summary>The record the command asks a deployment to hold for one person.</summary>
+/// <param name="DisplayName">The name to record.</param>
+/// <param name="Addresses">Every address the person uses.</param>
+/// <param name="PreferredAddress">The address to use by default, which is one of <paramref name="Addresses" />.</param>
+/// <param name="Note">What the owner wrote about the person, or <see langword="null" /> to hold no note.</param>
+/// <remarks>
+/// One shape for recording a person and for correcting one, because an amendment states the whole record rather than
+/// the difference from the one held. Which of the two is meant is the route and the verb, never a field.
+/// </remarks>
+internal sealed record ContactRecordRequest(
+    [property: JsonPropertyName("displayName")] string DisplayName,
+    [property: JsonPropertyName("addresses")] IReadOnlyList<string> Addresses,
+    [property: JsonPropertyName("preferredAddress")] string PreferredAddress,
+    [property: JsonPropertyName("note")] string? Note);

--- a/src/Cli/Administration/Contacts/ContactWriteAnswer.cs
+++ b/src/Cli/Administration/Contacts/ContactWriteAnswer.cs
@@ -1,0 +1,59 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Cli.Administration.Contacts;
+
+/// <summary>What one write to a deployment's contact book produced.</summary>
+/// <param name="Outcome">How the write ended, by the name the deployment's own outcome carries.</param>
+/// <param name="Contact">The record the outcome is about, or <see langword="null" /> where the book held none.</param>
+/// <param name="AddressHolder">The contact already holding an address the write claimed, present exactly when that is what refused it.</param>
+/// <remarks>
+/// A refusal arrives as a named outcome with a success status rather than as an error, because each one is something the
+/// operator acts on and continues from: correcting a record whose address somebody else holds, promoting a collected
+/// contact before amending it, or discovering the person was erased meanwhile.
+/// </remarks>
+internal sealed record ContactWriteAnswer(
+    [property: JsonPropertyName("outcome")] string? Outcome,
+    [property: JsonPropertyName("contact")] ContactRecord? Contact,
+    [property: JsonPropertyName("addressHolder")] Guid? AddressHolder)
+{
+    /// <summary>The outcome naming a write the book performed.</summary>
+    internal const string Written = "Written";
+
+    /// <summary>The outcome naming a contact the book does not hold.</summary>
+    internal const string NotFound = "NotFound";
+
+    /// <summary>The outcome naming an address a different contact already holds.</summary>
+    internal const string AddressHeldByAnotherContact = "AddressHeldByAnotherContact";
+
+    /// <summary>The outcome naming a write the contact's origin does not admit.</summary>
+    internal const string OriginRefusesWriter = "OriginRefusesWriter";
+
+    /// <summary>The outcome naming a promotion asked of a contact that is already asserted.</summary>
+    internal const string AlreadyAsserted = "AlreadyAsserted";
+
+    /// <summary>Reports whether the book now holds what the operator asked for.</summary>
+    /// <returns><see langword="true" /> when the write was performed.</returns>
+    internal bool WasWritten() => string.Equals(this.Outcome, Written, StringComparison.Ordinal);
+
+    /// <summary>States what stopped the write, in terms of what the operator does next.</summary>
+    /// <returns>One sentence, naming no part of anybody's record beyond an identifier.</returns>
+    /// <remarks>
+    /// The holder of a clashing address is named by its identity alone, because the deployment answers with that and
+    /// nothing more: reading that person is a lookup the operator performs deliberately rather than something a refused
+    /// write hands them.
+    /// </remarks>
+    internal string DescribeRefusal() => this.Outcome switch
+    {
+        NotFound => "The deployment's contact book holds no contact of that identity.",
+        AddressHeldByAnotherContact =>
+            $"One of those addresses already belongs to contact {this.AddressHolder:D}. Read that contact, or drop the address from this record.",
+        OriginRefusesWriter =>
+            "That contact was collected from arriving mail rather than written down, and a collected record is not amended in place. Promote it first with 'mfctl contact promote'.",
+        AlreadyAsserted => "That contact is already asserted, so there was no promotion left to perform.",
+        _ => "The deployment refused the write without naming an outcome this command understands.",
+    };
+}

--- a/src/Cli/CliJsonContext.cs
+++ b/src/Cli/CliJsonContext.cs
@@ -4,6 +4,7 @@
 
 using System.Text.Json.Serialization;
 using MailFathom.Cli.Administration;
+using MailFathom.Cli.Administration.Contacts;
 using MailFathom.Cli.Administration.Embeddings;
 using MailFathom.Cli.Administration.Folders;
 using MailFathom.Cli.Administration.Jobs;
@@ -60,6 +61,12 @@ namespace MailFathom.Cli;
 [JsonSerializable(typeof(JobRecovery))]
 [JsonSerializable(typeof(MailFolderErasureRequest))]
 [JsonSerializable(typeof(MailFolderErasure))]
+[JsonSerializable(typeof(ContactRecordRequest))]
+[JsonSerializable(typeof(ContactLookup))]
+[JsonSerializable(typeof(ContactPage))]
+[JsonSerializable(typeof(ContactWriteAnswer))]
+[JsonSerializable(typeof(ContactErasure))]
+[JsonSerializable(typeof(ContactExport))]
 [JsonSerializable(typeof(StoredCredentials))]
 [JsonSerializable(typeof(ProtectedResourceMetadata))]
 [JsonSerializable(typeof(AuthorizationServerMetadata))]

--- a/src/Cli/Commands/CliRootCommand.cs
+++ b/src/Cli/Commands/CliRootCommand.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.CommandLine;
+using MailFathom.Cli.Commands.Contacts;
 using MailFathom.Cli.Commands.Folders;
 using MailFathom.Cli.Commands.Jobs;
 using MailFathom.Cli.Commands.Rules;
@@ -104,6 +105,22 @@ internal static class CliRootCommand
             EraseFolderCommand.Create(context),
         };
 
+        // The one group that writes something a person, rather than a mail server, put there. It is also the only place
+        // outside "folder erase" where a command disposes of data for good: "delete" is the contact book's data-subject
+        // erasure path and says so, and "export" is its access path, both commands rather than seams nothing invokes.
+        Command contactCommand = new("contact", "Administer the deployment's contact book.")
+        {
+            CreateContactCommand.Create(context),
+            ShowContactCommand.Create(context),
+            ListContactsCommand.Create(context),
+            UpdateContactCommand.Create(context),
+            AddContactAddressCommand.Create(context),
+            RemoveContactAddressCommand.Create(context),
+            PromoteContactCommand.Create(context),
+            DeleteContactCommand.Create(context),
+            ExportContactCommand.Create(context),
+        };
+
         return new RootCommand($"MailFathom administration tool ({version.Version}).")
         {
             LoginCommand.Create(context),
@@ -117,6 +134,7 @@ internal static class CliRootCommand
             spamCommand,
             jobsCommand,
             folderCommand,
+            contactCommand,
         };
     }
 }

--- a/src/Cli/Commands/Contacts/AddContactAddressCommand.cs
+++ b/src/Cli/Commands/Contacts/AddContactAddressCommand.cs
@@ -1,0 +1,93 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using MailFathom.Cli.Administration.Contacts;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Adds one more address to a person the deployment's book already holds.</summary>
+/// <remarks>
+/// A convenience over the amendment beneath it rather than an operation of its own: the book takes the whole record, so
+/// this reads the contact, appends the address, and sends the result. An address a different contact already holds is
+/// refused by the deployment naming which contact holds it, because one address belongs to one person across the book.
+/// </remarks>
+internal static class AddContactAddressCommand
+{
+    /// <summary>Builds the <c>contact add-address</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+        var identityOption = ContactOptions.Identity();
+        var addressOption = ContactOptions.Address("The address to add to the contact.");
+
+        Option<string?> preferredOption = new("--preferred")
+        {
+            Description =
+                "The address to use by default afterwards, which is the one being added or one the contact already holds.",
+        };
+
+        Command command = new("add-address", "Add one address to a contact the book already holds.")
+        {
+            identityOption,
+            addressOption,
+            preferredOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(identityOption),
+            result.GetValue(addressOption) ?? string.Empty,
+            result.GetValue(preferredOption),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            cancellationToken));
+
+        return command;
+    }
+
+    private static Task<int> RunAsync(
+        CliContext context,
+        Guid contactId,
+        string address,
+        string? preferred,
+        string? requestedDeployment,
+        CancellationToken cancellationToken) =>
+        ContactRecordEdit.AmendAsync(
+            context,
+            contactId,
+            requestedDeployment,
+            held => Extend(held, address, preferred),
+            "Added an address to",
+            cancellationToken);
+
+    /// <summary>Produces the record the contact is to have with the address added.</summary>
+    /// <exception cref="CliFailure">Thrown when the amendment would leave the record exactly as it already is.</exception>
+    /// <remarks>
+    /// An amendment that changes nothing is refused here rather than sent, because the book would merge the two
+    /// spellings and answer that the write succeeded — which would tell an operator that something was added when
+    /// nothing was. Naming a different preferred address is still a change, so that case is sent.
+    /// </remarks>
+    private static ContactRecordRequest Extend(ContactRecord held, string address, string? preferred)
+    {
+        var addresses = ContactRecordEdit.AddressesOf(held);
+        var alreadyHeld = ContactRecordEdit.Holds(addresses, address);
+        var preferredAfterwards = preferred ?? held.PreferredAddress ?? address;
+
+        if (alreadyHeld && ContactRecordEdit.Holds([held.PreferredAddress ?? address], preferredAfterwards))
+        {
+            throw new CliFailure(
+                $"Contact {held.Id:D} already holds that address and already uses that one by default, so there was nothing to change. Pass --preferred to change which address it uses by default.");
+        }
+
+        IReadOnlyList<string> extended = alreadyHeld ? addresses : [.. addresses, address];
+
+        return new ContactRecordRequest(held.DisplayName ?? string.Empty, extended, preferredAfterwards, held.Note);
+    }
+}

--- a/src/Cli/Commands/Contacts/ContactOptions.cs
+++ b/src/Cli/Commands/Contacts/ContactOptions.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>The options the contact commands share.</summary>
+/// <remarks>
+/// A contact is named by the identity the book gave it rather than by an address, because an address is a thing a person
+/// has rather than a thing they are: they give one up and gain another and stay the same contact. The one command that
+/// takes an address instead answers "who is this from", and it answers with a person.
+/// </remarks>
+internal static class ContactOptions
+{
+    /// <summary>Builds the option naming which contact a command acts on.</summary>
+    /// <returns>The option.</returns>
+    internal static Option<Guid> Identity() => new("--id")
+    {
+        Description = "The contact to act on, by the identifier the deployment's book gave it.",
+        Required = true,
+    };
+
+    /// <summary>Builds the option naming one address a command acts on.</summary>
+    /// <param name="description">What the address means for the command taking it.</param>
+    /// <returns>The option.</returns>
+    internal static Option<string> Address(string description) => new("--address")
+    {
+        Description = description,
+        Required = true,
+    };
+}

--- a/src/Cli/Commands/Contacts/ContactOutput.cs
+++ b/src/Cli/Commands/Contacts/ContactOutput.cs
@@ -1,0 +1,119 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Administration.Contacts;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Writes what the contact commands print, so every one of them prints a person the same way.</summary>
+/// <remarks>
+/// <para>
+/// A contact printed to a terminal is personal data on somebody's screen and in their shell's scrollback, so what
+/// reaches it is what the operator asked for and nothing beside it: a command that acted on one person prints that
+/// person, a listing prints one line each, and neither prints anybody a request did not name.
+/// </para>
+/// <para>
+/// Nothing here writes to standard error. A refusal names the outcome and the contact's identifier, which is the one
+/// part of the record that is not personal data — a name or an address in a failure message would end up in a log
+/// wherever the command is run from a script.
+/// </para>
+/// </remarks>
+internal static class ContactOutput
+{
+    /// <summary>Prints one contact in full.</summary>
+    /// <param name="console">The terminal to write to.</param>
+    /// <param name="contact">The contact to print.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The preferred address is marked where it sits rather than printed a second time, because it is one of the
+    /// addresses rather than a value of its own — and the deployment already serves it first.
+    /// </remarks>
+    internal static void WriteContact(ICliConsole console, ContactRecord contact)
+    {
+        ArgumentNullException.ThrowIfNull(console);
+        ArgumentNullException.ThrowIfNull(contact);
+
+        console.WriteLine($"Contact:   {contact.Id:D}");
+        console.WriteLine($"Name:      {contact.DisplayName}");
+        console.WriteLine($"Origin:    {contact.Origin}");
+
+        var addresses = contact.Addresses ?? [];
+
+        if (addresses.Count == 0)
+        {
+            console.WriteLine("Addresses: none reported");
+        }
+
+        foreach (var (address, position) in addresses.Select((address, position) => (address, position)))
+        {
+            var label = position == 0 ? "Addresses:" : "          ";
+            var preferred = string.Equals(address, contact.PreferredAddress, StringComparison.Ordinal)
+                ? "  (preferred)"
+                : string.Empty;
+
+            console.WriteLine($"{label} {address}{preferred}");
+        }
+
+        if (contact.Note is { Length: > 0 } note)
+        {
+            console.WriteLine($"Note:      {note}");
+        }
+
+        console.WriteLine($"Recorded:  {contact.RecordedAt:u}");
+        console.WriteLine($"Amended:   {contact.AmendedAt:u}");
+    }
+
+    /// <summary>Prints one contact as a line of a listing.</summary>
+    /// <param name="console">The terminal to write to.</param>
+    /// <param name="contact">The contact to print.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The preferred address alone rather than every address a person uses. A listing answers who is in the book, and a
+    /// page that unfolded every address would put most of the book's contents on a screen the operator was scanning.
+    /// </remarks>
+    internal static void WriteSummary(ICliConsole console, ContactRecord contact)
+    {
+        ArgumentNullException.ThrowIfNull(console);
+        ArgumentNullException.ThrowIfNull(contact);
+
+        console.WriteLine($"{contact.Id:D}  {contact.DisplayName} <{contact.PreferredAddress}>  ({contact.Origin})");
+    }
+
+    /// <summary>Reports what one write to the book produced, printing the record it wrote or the reason it did not.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <param name="answer">What the deployment answered.</param>
+    /// <param name="performed">What the command did, as a sentence's opening, such as <c>Recorded</c>.</param>
+    /// <returns>The exit code the command ends with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A refusal ends the command with a failing code and a sentence on standard error, which is what every other
+    /// command here does when it did not do what it was asked: a caller that redirected the output reads an empty result
+    /// and a reason rather than a sentence about nothing having happened mixed into what it captured.
+    /// </remarks>
+    internal static int ReportWrite(CliContext context, ContactWriteAnswer answer, string performed)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(answer);
+
+        if (!answer.WasWritten())
+        {
+            context.Console.WriteError(answer.DescribeRefusal());
+
+            return CliExitCode.Failure;
+        }
+
+        if (answer.Contact is not { } written)
+        {
+            context.Console.WriteError(
+                "The deployment reported the write as performed but answered with no record, which no operation here sends.");
+
+            return CliExitCode.Failure;
+        }
+
+        context.Console.WriteLine($"{performed} contact {written.Id:D}.");
+        WriteContact(context.Console, written);
+
+        return CliExitCode.Success;
+    }
+}

--- a/src/Cli/Commands/Contacts/ContactRecordEdit.cs
+++ b/src/Cli/Commands/Contacts/ContactRecordEdit.cs
@@ -1,0 +1,102 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Administration;
+using MailFathom.Cli.Administration.Contacts;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Changes part of a contact by reading the record the book holds and sending back what it is to become.</summary>
+/// <remarks>
+/// <para>
+/// The book takes the whole record rather than the difference from the one held, so correcting a name, adding an
+/// address, and dropping one are all this: read, apply the change to what came back, send the result. That is what keeps
+/// the invariants checkable — a record is only ever validated as a whole — and it is why there is no route that adds an
+/// address on its own.
+/// </para>
+/// <para>
+/// The read and the write are two requests, so two operators editing one contact at once are last-writer-wins, exactly
+/// as the book's own amendment rule states. What is not left to that is an amendment racing an erasure: the deployment
+/// answers such a write as a contact it does not hold rather than putting the person back.
+/// </para>
+/// </remarks>
+internal static class ContactRecordEdit
+{
+    /// <summary>Reads one contact, applies a change to it, and asks the deployment to hold the result.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <param name="contactId">The contact to amend.</param>
+    /// <param name="requestedDeployment">The deployment the operator named for this invocation, or <see langword="null" />.</param>
+    /// <param name="change">Produces the record the contact is to have, from the one it has.</param>
+    /// <param name="performed">What the command did, as a sentence's opening.</param>
+    /// <param name="cancellationToken">Cancels the requests.</param>
+    /// <returns>The exit code the command ends with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the deployment holds no such contact, or when the change is one the record leaves nothing to do.</exception>
+    internal static async Task<int> AmendAsync(
+        CliContext context,
+        Guid contactId,
+        string? requestedDeployment,
+        Func<ContactRecord, ContactRecordRequest> change,
+        string performed,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(change);
+
+        var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
+
+        using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
+        var deployment = new AdminApiClient(transport, context.Console);
+
+        var lookup = await deployment.ReadContactAsync(profile.Token, contactId, cancellationToken);
+
+        if (lookup.Contact is not { } held)
+        {
+            throw new CliFailure(
+                $"The deployment's contact book holds no contact {contactId:D}, so there was nothing to amend.");
+        }
+
+        var amended = await deployment.AmendContactAsync(
+            profile.Token,
+            contactId,
+            change(held),
+            cancellationToken);
+
+        return ContactOutput.ReportWrite(context, amended, performed);
+    }
+
+    /// <summary>Reads the addresses a held record carries, refusing one the deployment reported without any.</summary>
+    /// <param name="held">The contact as the book holds it.</param>
+    /// <returns>The addresses.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="held" /> is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when the record carries no address, which no contact the book admits can.</exception>
+    internal static IReadOnlyList<string> AddressesOf(ContactRecord held)
+    {
+        ArgumentNullException.ThrowIfNull(held);
+
+        return held.Addresses is { Count: > 0 } addresses
+            ? addresses
+            : throw new CliFailure(
+                $"The deployment answered for contact {held.Id:D} with a record holding no address, which no contact it admits can.");
+    }
+
+    /// <summary>Reports whether a record already holds an address, comparing the way the book does.</summary>
+    /// <param name="addresses">The addresses the record holds.</param>
+    /// <param name="address">The address to look for.</param>
+    /// <returns><see langword="true" /> when one of them names the same mailbox.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Case-insensitively over the whole address, which is the book's own rule: RFC 5321 makes the local part
+    /// case-sensitive and almost no provider honours it, so <c>Anna@example.test</c> and <c>anna@example.test</c> are one
+    /// address here exactly as they are there. Comparing any other way would have the command ask a deployment to add an
+    /// address it already holds, and be refused by it rather than by this.
+    /// </remarks>
+    internal static bool Holds(IReadOnlyList<string> addresses, string address)
+    {
+        ArgumentNullException.ThrowIfNull(addresses);
+        ArgumentNullException.ThrowIfNull(address);
+
+        return addresses.Any(held => string.Equals(held, address, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Cli/Commands/Contacts/CreateContactCommand.cs
+++ b/src/Cli/Commands/Contacts/CreateContactCommand.cs
@@ -1,0 +1,111 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using MailFathom.Cli.Administration;
+using MailFathom.Cli.Administration.Contacts;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Records a person the deployment's contact book does not yet hold.</summary>
+/// <remarks>
+/// A contact written from here is asserted: somebody wrote this person down. That is what distinguishes it from a record
+/// the deployment collected out of arriving mail, and it is what makes it amendable from here afterwards.
+/// </remarks>
+internal static class CreateContactCommand
+{
+    /// <summary>Builds the <c>contact create</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+
+        Option<string> nameOption = new("--name")
+        {
+            Description = "The name to record for the person, as you want to read it back.",
+            Required = true,
+        };
+
+        Option<string[]> addressOption = new("--address")
+        {
+            Description = "An address the person uses. Repeat it for every address they use.",
+            Required = true,
+            AllowMultipleArgumentsPerToken = false,
+        };
+
+        Option<string?> preferredOption = new("--preferred")
+        {
+            Description =
+                "Which address to use by default. Required once more than one --address is given, because which one it is is your choice rather than an ordering accident.",
+        };
+
+        Option<string?> noteOption = new("--note")
+        {
+            Description = "What you want recorded about the person beyond their name and addresses.",
+        };
+
+        Command command = new("create", "Record a person in the deployment's contact book.")
+        {
+            nameOption,
+            addressOption,
+            preferredOption,
+            noteOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(nameOption) ?? string.Empty,
+            result.GetValue(addressOption) ?? [],
+            result.GetValue(preferredOption),
+            result.GetValue(noteOption),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            cancellationToken));
+
+        return command;
+    }
+
+    private static async Task<int> RunAsync(
+        CliContext context,
+        string name,
+        IReadOnlyList<string> addresses,
+        string? preferred,
+        string? note,
+        string? requestedDeployment,
+        CancellationToken cancellationToken)
+    {
+        var record = new ContactRecordRequest(name, addresses, ChoosePreferred(addresses, preferred), note);
+
+        var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
+
+        using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
+        var written = await new AdminApiClient(transport, context.Console)
+            .RecordContactAsync(profile.Token, record, cancellationToken);
+
+        return ContactOutput.ReportWrite(context, written, "Recorded");
+    }
+
+    /// <summary>Reports which address the record is to prefer, refusing to pick one where the operator has a choice.</summary>
+    /// <remarks>
+    /// One address is no choice at all, so it is taken as the preferred one. Several are a decision that belongs to the
+    /// person keeping the book: picking the first would make the order the arguments happened to be typed in decide
+    /// which address a message to that person goes to.
+    /// </remarks>
+    private static string ChoosePreferred(IReadOnlyList<string> addresses, string? preferred)
+    {
+        if (preferred is { Length: > 0 } named)
+        {
+            return named;
+        }
+
+        return addresses.Count == 1
+            ? addresses[0]
+            : throw new CliFailure(
+                "Which address is preferred is your choice rather than an ordering accident, so pass --preferred naming one of the addresses you gave.");
+    }
+}

--- a/src/Cli/Commands/Contacts/DeleteContactCommand.cs
+++ b/src/Cli/Commands/Contacts/DeleteContactCommand.cs
@@ -1,0 +1,129 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using System.Globalization;
+using MailFathom.Cli.Administration;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Erases one person from the deployment's contact book, and everything the book derived from them.</summary>
+/// <remarks>
+/// <para>
+/// The data-subject erasure path, reached by somebody who means it. It removes rather than marks and it cannot be
+/// undone: the record and its addresses are gone from the database, and nothing in MailFathom can put them back.
+/// </para>
+/// <para>
+/// Which is why it shows the record and then asks. The confirmation is the default and <c>--yes</c> is the exception,
+/// exactly as it is for the other irreversible commands here, and an invocation with nobody at the terminal is told to
+/// pass the flag rather than having an agreement read out of whatever was piped in.
+/// </para>
+/// <para>
+/// A contact the book does not hold is a completed erasure rather than a failure: the state the operator asked for is
+/// the state the book is in, and reporting it as an error would only tell them whether somebody had already erased that
+/// person.
+/// </para>
+/// </remarks>
+internal static class DeleteContactCommand
+{
+    /// <summary>Builds the <c>contact delete</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+        var identityOption = ContactOptions.Identity();
+
+        Option<bool> confirmedOption = new("--yes", "-y")
+        {
+            Description = "Agree to the erasure without being asked, which is what a scripted erasure needs.",
+        };
+
+        Command command = new("delete", "Erase one person from the deployment's contact book. This cannot be undone.")
+        {
+            identityOption,
+            confirmedOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(identityOption),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            result.GetValue(confirmedOption),
+            cancellationToken));
+
+        return command;
+    }
+
+    private static async Task<int> RunAsync(
+        CliContext context,
+        Guid contactId,
+        string? requestedDeployment,
+        bool confirmedUpFront,
+        CancellationToken cancellationToken)
+    {
+        var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
+
+        using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
+        var deployment = new AdminApiClient(transport, context.Console);
+
+        var lookup = await deployment.ReadContactAsync(profile.Token, contactId, cancellationToken);
+
+        if (lookup.Contact is not { } held)
+        {
+            context.Console.WriteLine(
+                $"The deployment's contact book holds no contact {contactId:D}, so nothing was erased.");
+
+            return CliExitCode.Success;
+        }
+
+        ContactOutput.WriteContact(context.Console, held);
+
+        if (!Agreed(context, confirmedUpFront))
+        {
+            context.Console.WriteError("Nothing was erased.");
+
+            return CliExitCode.Failure;
+        }
+
+        var erasure = await deployment.EraseContactAsync(profile.Token, contactId, cancellationToken);
+
+        context.Console.WriteLine(erasure.WasHeld
+            ? $"Erased contact {erasure.Contact:D} and {DescribeAddresses(erasure.AddressesErased)}. Nothing in MailFathom can put the record back."
+            : $"The deployment's contact book held no contact {erasure.Contact:D} by the time the erasure ran, so nothing was erased.");
+
+        return CliExitCode.Success;
+    }
+
+    /// <summary>Reports whether the person running this agreed to the erasure, refusing to guess where nobody can answer.</summary>
+    /// <remarks>
+    /// A redirected input has nobody to ask, and reading the answer out of whatever was piped in would turn a stray line
+    /// into an agreement to erase somebody. Such an invocation is told to pass the flag instead, which is an operator
+    /// stating the agreement in the command rather than a command inferring it.
+    /// </remarks>
+    private static bool Agreed(CliContext context, bool confirmedUpFront)
+    {
+        if (confirmedUpFront)
+        {
+            return true;
+        }
+
+        if (!context.Console.CanConfirm)
+        {
+            throw new CliFailure(
+                "There is nobody at the terminal to agree to this, and erasing a contact cannot be undone. Pass --yes to erase without being asked.");
+        }
+
+        return context.Console.Confirm("Erase that contact and everything derived from it? [y/N] ");
+    }
+
+    /// <summary>Describes how many addresses went with the person, grouped invariantly for the reason every other figure this tool prints is.</summary>
+    private static string DescribeAddresses(int addressesErased) => string.Create(
+        CultureInfo.InvariantCulture,
+        $"{addressesErased} {(addressesErased == 1 ? "address" : "addresses")}");
+}

--- a/src/Cli/Commands/Contacts/ExportContactCommand.cs
+++ b/src/Cli/Commands/Contacts/ExportContactCommand.cs
@@ -1,0 +1,76 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using System.Text.Json;
+using MailFathom.Cli.Administration;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Produces everything the deployment holds about one person, as of the instant it was taken.</summary>
+/// <remarks>
+/// <para>
+/// The data-subject access path, which is why it is a command rather than something an operator assembles out of a
+/// listing: a seam nothing invokes is a seam that will not work when somebody asks for it, and what is handed to the
+/// person who asked has to be the deployment's own complete answer rather than one surface's summary of it.
+/// </para>
+/// <para>
+/// It is written as JSON on standard output, indented. That is one document a person reads and a tool parses, and it is
+/// what redirects into a file an owner can send. Everything else this command prints goes to standard error, so what is
+/// captured is the export and nothing beside it.
+/// </para>
+/// </remarks>
+internal static class ExportContactCommand
+{
+    /// <summary>Builds the <c>contact export</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+        var identityOption = ContactOptions.Identity();
+
+        Command command = new("export", "Produce everything the deployment holds about one person, as JSON.")
+        {
+            identityOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(identityOption),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            cancellationToken));
+
+        return command;
+    }
+
+    private static async Task<int> RunAsync(
+        CliContext context,
+        Guid contactId,
+        string? requestedDeployment,
+        CancellationToken cancellationToken)
+    {
+        var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
+
+        using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
+        var export = await new AdminApiClient(transport, context.Console)
+            .ExportContactAsync(profile.Token, contactId, cancellationToken);
+
+        if (export.Contact is null)
+        {
+            context.Console.WriteError(
+                $"The deployment's contact book holds no contact {contactId:D}, so there was nothing to export.");
+
+            return CliExitCode.Failure;
+        }
+
+        context.Console.WriteLine(JsonSerializer.Serialize(export, CliJsonContext.Default.ContactExport));
+
+        return CliExitCode.Success;
+    }
+}

--- a/src/Cli/Commands/Contacts/ListContactsCommand.cs
+++ b/src/Cli/Commands/Contacts/ListContactsCommand.cs
@@ -1,0 +1,117 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using MailFathom.Cli.Administration;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Reads one bounded page of the deployment's contact book.</summary>
+/// <remarks>
+/// <para>
+/// One page per invocation, and the operator asks for the next. There is deliberately no command that walks the whole
+/// book: a contact book printed in one call is every correspondent of a person's mailbox on one screen and in one shell
+/// history, and paging is what makes reading it an act rather than a side effect of asking who is in it.
+/// </para>
+/// <para>
+/// The order is the deployment's own — the name's comparison form, then the identity — which is total, so a walk serves
+/// every contact exactly once. The cursor a page prints is what continues it.
+/// </para>
+/// </remarks>
+internal static class ListContactsCommand
+{
+    /// <summary>Builds the <c>contact list</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+
+        Option<string?> originOption = new("--origin")
+        {
+            Description =
+                "Narrow to contacts of one origin: Asserted for the people written down, Collected for the addresses the deployment picked up. Defaults to the whole book.",
+        };
+
+        Option<int?> pageSizeOption = new("--page-size")
+        {
+            Description = "How many contacts to read. Defaults to what the deployment serves.",
+        };
+
+        Option<string?> cursorOption = new("--cursor")
+        {
+            Description = "Continue from where a previous page ended, using the cursor it printed.",
+        };
+
+        Command command = new("list", "Read one page of the deployment's contact book.")
+        {
+            originOption,
+            pageSizeOption,
+            cursorOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(originOption),
+            result.GetValue(pageSizeOption),
+            result.GetValue(cursorOption),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            cancellationToken));
+
+        return command;
+    }
+
+    private static async Task<int> RunAsync(
+        CliContext context,
+        string? origin,
+        int? pageSize,
+        string? cursor,
+        string? requestedDeployment,
+        CancellationToken cancellationToken)
+    {
+        var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
+
+        using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
+        var page = await new AdminApiClient(transport, context.Console)
+            .ReadContactPageAsync(profile.Token, origin, pageSize, cursor, cancellationToken);
+
+        if (page.Contacts is not { Count: > 0 } contacts)
+        {
+            context.Console.WriteLine(DescribeEmptyPage(origin, cursor));
+
+            return CliExitCode.Success;
+        }
+
+        foreach (var contact in contacts)
+        {
+            ContactOutput.WriteSummary(context.Console, contact);
+        }
+
+        if (page.NextCursor is { Length: > 0 } continuation)
+        {
+            context.Console.WriteLine(string.Empty);
+            context.Console.WriteLine($"More contacts follow. Continue with --cursor {continuation}");
+        }
+
+        return CliExitCode.Success;
+    }
+
+    /// <summary>States that the page held nobody, and what that usually means for the way it was asked.</summary>
+    /// <remarks>
+    /// A continued walk reaching an empty page is the end of the book rather than an empty book, and telling the two
+    /// apart is what stops an operator from reading a completed walk as a deployment that lost its contacts.
+    /// </remarks>
+    private static string DescribeEmptyPage(string? origin, string? cursor) => (origin, cursor) switch
+    {
+        (_, { Length: > 0 }) => "That cursor reached the end of the book, so there was nothing further to read.",
+        ({ Length: > 0 } narrowed, _) =>
+            $"The deployment's contact book holds no {narrowed} contacts. Nothing writes to the book on its own, so an instance nobody has written to holds none at all.",
+        _ =>
+            "The deployment's contact book is empty. Nothing writes to it on its own, so it holds nobody until somebody is recorded in it.",
+    };
+}

--- a/src/Cli/Commands/Contacts/PromoteContactCommand.cs
+++ b/src/Cli/Commands/Contacts/PromoteContactCommand.cs
@@ -1,0 +1,58 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using MailFathom.Cli.Administration;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Takes on a contact the deployment collected from arriving mail.</summary>
+/// <remarks>
+/// The one act that changes an origin, and it runs one way. A collected record is an address that appeared in mail
+/// rather than a person somebody wrote down, so it is not amended in place; promoting it is the owner saying this is
+/// their record now, after which every other command here works on it. Nothing turns an asserted contact back.
+/// </remarks>
+internal static class PromoteContactCommand
+{
+    /// <summary>Builds the <c>contact promote</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+        var identityOption = ContactOptions.Identity();
+
+        Command command = new("promote", "Take on a contact the deployment collected, so it becomes one you asserted.")
+        {
+            identityOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(identityOption),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            cancellationToken));
+
+        return command;
+    }
+
+    private static async Task<int> RunAsync(
+        CliContext context,
+        Guid contactId,
+        string? requestedDeployment,
+        CancellationToken cancellationToken)
+    {
+        var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
+
+        using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
+        var promoted = await new AdminApiClient(transport, context.Console)
+            .PromoteContactAsync(profile.Token, contactId, cancellationToken);
+
+        return ContactOutput.ReportWrite(context, promoted, "Took on");
+    }
+}

--- a/src/Cli/Commands/Contacts/RemoveContactAddressCommand.cs
+++ b/src/Cli/Commands/Contacts/RemoveContactAddressCommand.cs
@@ -1,0 +1,119 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using MailFathom.Cli.Administration.Contacts;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Takes one address off a person the deployment's book holds.</summary>
+/// <remarks>
+/// The address is removed from the record rather than marked, which is also what frees it for another contact to claim.
+/// A contact holds at least one address, so the last one cannot be removed: what removes a person from the book is
+/// <c>contact delete</c>, and it is a different act with a different answer.
+/// </remarks>
+internal static class RemoveContactAddressCommand
+{
+    /// <summary>Builds the <c>contact remove-address</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+        var identityOption = ContactOptions.Identity();
+        var addressOption = ContactOptions.Address("The address to take off the contact.");
+
+        Option<string?> preferredOption = new("--preferred")
+        {
+            Description =
+                "The address to use by default afterwards. Required when the one being removed is the preferred one.",
+        };
+
+        Command command = new("remove-address", "Take one address off a contact the book holds.")
+        {
+            identityOption,
+            addressOption,
+            preferredOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(identityOption),
+            result.GetValue(addressOption) ?? string.Empty,
+            result.GetValue(preferredOption),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            cancellationToken));
+
+        return command;
+    }
+
+    private static Task<int> RunAsync(
+        CliContext context,
+        Guid contactId,
+        string address,
+        string? preferred,
+        string? requestedDeployment,
+        CancellationToken cancellationToken) =>
+        ContactRecordEdit.AmendAsync(
+            context,
+            contactId,
+            requestedDeployment,
+            held => Without(held, address, preferred),
+            "Took an address off",
+            cancellationToken);
+
+    /// <summary>Produces the record the contact is to have with the address gone.</summary>
+    /// <exception cref="CliFailure">Thrown when the contact does not hold that address, when it is the only one, or when it is the preferred one and no replacement was named.</exception>
+    private static ContactRecordRequest Without(ContactRecord held, string address, string? preferred)
+    {
+        var addresses = ContactRecordEdit.AddressesOf(held);
+
+        if (!ContactRecordEdit.Holds(addresses, address))
+        {
+            throw new CliFailure(
+                $"Contact {held.Id:D} does not hold that address, so there was nothing to remove.");
+        }
+
+        if (addresses.Count == 1)
+        {
+            throw new CliFailure(
+                $"That is the only address contact {held.Id:D} holds, and a contact holds at least one. Erase the contact with 'mfctl contact delete' if that is what you meant.");
+        }
+
+        IReadOnlyList<string> remaining =
+            [.. addresses.Where(kept => !string.Equals(kept, address, StringComparison.OrdinalIgnoreCase))];
+
+        return new ContactRecordRequest(
+            held.DisplayName ?? string.Empty,
+            remaining,
+            ChoosePreferred(held, remaining, preferred),
+            held.Note);
+    }
+
+    /// <summary>Reports which address the record is to prefer once the removal is applied.</summary>
+    /// <remarks>
+    /// Removing an address the contact does not prefer leaves the preference where it was. Removing the preferred one
+    /// leaves the record without a default, and picking the next address in the list would decide on the operator's
+    /// behalf which address a message to that person goes to — so it is named or the removal is refused.
+    /// </remarks>
+    private static string ChoosePreferred(ContactRecord held, IReadOnlyList<string> remaining, string? preferred)
+    {
+        if (preferred is { Length: > 0 } named)
+        {
+            return named;
+        }
+
+        if (held.PreferredAddress is { Length: > 0 } kept && ContactRecordEdit.Holds(remaining, kept))
+        {
+            return kept;
+        }
+
+        throw new CliFailure(
+            $"That is the address contact {held.Id:D} uses by default, so removing it has to say which of the rest to use instead. Pass --preferred naming one of them.");
+    }
+}

--- a/src/Cli/Commands/Contacts/ShowContactCommand.cs
+++ b/src/Cli/Commands/Contacts/ShowContactCommand.cs
@@ -1,0 +1,101 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using MailFathom.Cli.Administration;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Shows everything the deployment's book holds about one person.</summary>
+/// <remarks>
+/// The two ways an operator arrives at a contact. By identity is how every other command names one; by address is the
+/// question "who is this from", which the book answers with a person rather than with a match, because one address
+/// belongs to one contact across the whole book.
+/// </remarks>
+internal static class ShowContactCommand
+{
+    /// <summary>Builds the <c>contact show</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+
+        Option<Guid?> identityOption = new("--id")
+        {
+            Description = "The contact to show, by the identifier the deployment's book gave it.",
+        };
+
+        Option<string?> addressOption = new("--address")
+        {
+            Description = "Show whoever uses this address, in whichever casing the book recorded it.",
+        };
+
+        Command command = new("show", "Show one contact, by its identifier or by an address it holds.")
+        {
+            identityOption,
+            addressOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(identityOption),
+            result.GetValue(addressOption),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            cancellationToken));
+
+        return command;
+    }
+
+    private static async Task<int> RunAsync(
+        CliContext context,
+        Guid? contactId,
+        string? address,
+        string? requestedDeployment,
+        CancellationToken cancellationToken)
+    {
+        var byIdentity = contactId is not null;
+        var byAddress = address is { Length: > 0 };
+
+        if (byIdentity == byAddress)
+        {
+            throw new CliFailure(
+                "Name the contact one way or the other: --id for the identifier the book gave it, or --address for whoever uses an address.");
+        }
+
+        var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
+
+        using var transport = context.OpenTransport(profile.Endpoint, profile.Trust);
+        var deployment = new AdminApiClient(transport, context.Console);
+
+        var lookup = contactId is { } identity
+            ? await deployment.ReadContactAsync(profile.Token, identity, cancellationToken)
+            : await deployment.ReadContactByAddressAsync(profile.Token, address!, cancellationToken);
+
+        if (lookup.Contact is not { } held)
+        {
+            context.Console.WriteError(DescribeAbsence(contactId));
+
+            return CliExitCode.Failure;
+        }
+
+        ContactOutput.WriteContact(context.Console, held);
+
+        return CliExitCode.Success;
+    }
+
+    /// <summary>States that the book holds nobody matching what was asked.</summary>
+    /// <remarks>
+    /// The address the operator asked with is not repeated back. It is somebody's address whether or not the book holds
+    /// them, and this sentence goes to standard error, which is where a scripted invocation's output is captured; the
+    /// operator has the address in front of them either way.
+    /// </remarks>
+    private static string DescribeAbsence(Guid? contactId) => contactId is { } identity
+        ? $"The deployment's contact book holds no contact {identity:D}."
+        : "The deployment's contact book holds nobody using that address.";
+}

--- a/src/Cli/Commands/Contacts/UpdateContactCommand.cs
+++ b/src/Cli/Commands/Contacts/UpdateContactCommand.cs
@@ -1,0 +1,182 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using MailFathom.Cli.Administration.Contacts;
+
+namespace MailFathom.Cli.Commands.Contacts;
+
+/// <summary>Corrects what the deployment's book holds about one person.</summary>
+/// <remarks>
+/// <para>
+/// What is not named is kept. The book itself takes the whole record rather than the difference, so this command reads
+/// the contact, replaces the parts the operator named, and sends back what it is to become — which is what lets a single
+/// invocation correct a name without restating every address.
+/// </para>
+/// <para>
+/// A collected contact is refused here rather than amended, because it is a record the deployment wrote from arriving
+/// mail. <c>contact promote</c> is the act that makes it the owner's, and the refusal says so.
+/// </para>
+/// </remarks>
+internal static class UpdateContactCommand
+{
+    /// <summary>Builds the <c>contact update</c> command.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <returns>The command.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    internal static Command Create(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var endpointOption = CliOptions.Endpoint();
+        var identityOption = ContactOptions.Identity();
+
+        Option<string?> nameOption = new("--name")
+        {
+            Description = "The name to record instead. Kept as it is when this is left out.",
+        };
+
+        Option<string[]> addressOption = new("--address")
+        {
+            Description =
+                "The addresses the person is to hold afterwards, replacing every one they hold now. Repeat it for each. Kept as they are when this is left out.",
+            AllowMultipleArgumentsPerToken = false,
+        };
+
+        Option<string?> preferredOption = new("--preferred")
+        {
+            Description = "The address to use by default afterwards, which is one of the addresses the record holds.",
+        };
+
+        Option<string?> noteOption = new("--note")
+        {
+            Description = "What to record about the person instead. Kept as it is when this is left out.",
+        };
+
+        Option<bool> clearNoteOption = new("--clear-note")
+        {
+            Description = "Hold no note about the person afterwards.",
+        };
+
+        Command command = new("update", "Correct what the deployment's book holds about one person.")
+        {
+            identityOption,
+            nameOption,
+            addressOption,
+            preferredOption,
+            noteOption,
+            clearNoteOption,
+            endpointOption,
+        };
+
+        command.SetAction((result, cancellationToken) => RunAsync(
+            context,
+            result.GetValue(identityOption),
+            new ContactCorrection(
+                result.GetValue(nameOption),
+                result.GetValue(addressOption) ?? [],
+                result.GetValue(preferredOption),
+                result.GetValue(noteOption),
+                result.GetValue(clearNoteOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            cancellationToken));
+
+        return command;
+    }
+
+    private static Task<int> RunAsync(
+        CliContext context,
+        Guid contactId,
+        ContactCorrection correction,
+        string? requestedDeployment,
+        CancellationToken cancellationToken)
+    {
+        correction.RefuseWhereItSaysNothing();
+
+        return ContactRecordEdit.AmendAsync(
+            context,
+            contactId,
+            requestedDeployment,
+            correction.ApplyTo,
+            "Corrected",
+            cancellationToken);
+    }
+
+    /// <summary>What the operator asked to change about one contact, and how it is applied to the record held.</summary>
+    /// <param name="DisplayName">The name to record instead, or <see langword="null" /> to keep the one held.</param>
+    /// <param name="Addresses">The addresses to hold afterwards, or empty to keep the ones held.</param>
+    /// <param name="PreferredAddress">The address to prefer afterwards, or <see langword="null" /> to keep the one held where it survives.</param>
+    /// <param name="Note">The note to record instead, or <see langword="null" /> to keep the one held.</param>
+    /// <param name="ClearsNote">Whether the contact is to hold no note afterwards.</param>
+    private sealed record ContactCorrection(
+        string? DisplayName,
+        IReadOnlyList<string> Addresses,
+        string? PreferredAddress,
+        string? Note,
+        bool ClearsNote)
+    {
+        /// <summary>Refuses an invocation that changes nothing, or one that asks for two opposite things.</summary>
+        /// <exception cref="CliFailure">Thrown when the invocation names no change, or names a note and asks to clear one.</exception>
+        /// <remarks>
+        /// Both are refused before the contact is read rather than after, so an operator who mistyped an option does not
+        /// send a write that restates the record they already have.
+        /// </remarks>
+        internal void RefuseWhereItSaysNothing()
+        {
+            if (this.Note is { Length: > 0 } && this.ClearsNote)
+            {
+                throw new CliFailure("A note is either recorded or cleared. Pass --note or --clear-note, not both.");
+            }
+
+            if (this.DisplayName is null
+                && this.Addresses.Count == 0
+                && this.PreferredAddress is null
+                && this.Note is null
+                && !this.ClearsNote)
+            {
+                throw new CliFailure(
+                    "The invocation names nothing to change. Pass --name, --address, --preferred, --note, or --clear-note.");
+            }
+        }
+
+        /// <summary>Produces the record the contact is to have, from the one the book holds.</summary>
+        /// <param name="held">The contact as the book holds it.</param>
+        /// <returns>The record to send.</returns>
+        /// <exception cref="CliFailure">Thrown when replacing the addresses leaves no preferred address the operator chose.</exception>
+        internal ContactRecordRequest ApplyTo(ContactRecord held)
+        {
+            var addresses = this.Addresses.Count > 0 ? this.Addresses : ContactRecordEdit.AddressesOf(held);
+            var note = this.ClearsNote ? null : this.Note ?? held.Note;
+
+            return new ContactRecordRequest(
+                this.DisplayName ?? held.DisplayName ?? string.Empty,
+                addresses,
+                this.ChoosePreferred(addresses, held),
+                note);
+        }
+
+        /// <summary>Reports which address the record is to prefer once the change is applied.</summary>
+        /// <remarks>
+        /// Naming one settles it. Otherwise the one the contact already prefers is kept where the record still holds it,
+        /// which is what makes correcting a name leave the rest alone; and a replacement that drops the preferred address
+        /// without naming a new one is refused rather than resolved, because which address a message to that person goes
+        /// to is the operator's decision rather than an ordering accident.
+        /// </remarks>
+        private string ChoosePreferred(IReadOnlyList<string> addresses, ContactRecord held)
+        {
+            if (this.PreferredAddress is { Length: > 0 } named)
+            {
+                return named;
+            }
+
+            if (held.PreferredAddress is { Length: > 0 } kept && ContactRecordEdit.Holds(addresses, kept))
+            {
+                return kept;
+            }
+
+            throw new CliFailure(
+                "The addresses given do not include the one the contact prefers, so the record has to say which of them it prefers instead. Pass --preferred naming one of them.");
+        }
+    }
+}

--- a/src/Host/Api/AdminApiEndpoints.cs
+++ b/src/Host/Api/AdminApiEndpoints.cs
@@ -70,9 +70,15 @@ namespace MailFathom.Host.Api;
 /// state is an operator's problem rather than anything a model reasons over.
 /// </para>
 /// <para>
-/// The last takes a folder's local mail away, which <see cref="MailFolderErasureEndpoint" /> describes. It is the only
+/// The next takes a folder's local mail away, which <see cref="MailFolderErasureEndpoint" /> describes. It is the only
 /// route that disposes of stored mail, which is why it is bounded by the same credential as everything else here and
 /// reachable from nowhere a model can write to.
+/// </para>
+/// <para>
+/// The last are the contact book, which <see cref="ContactEndpoints" /> describes: recording a person, correcting one,
+/// promoting a collected record, reading the book, and the two data-subject paths over it. They are here because the
+/// book is the most concentrated personal data this deployment holds, so what bounds administrative access is what
+/// should bound who may add to it, read it out, or erase somebody from it.
 /// </para>
 /// <para>
 /// Every one of them is mapped into one group so a route cannot be added outside the requirement the endpoint attaches
@@ -102,6 +108,7 @@ internal static class AdminApiEndpoints
         api.MapSpamClassification();
         api.MapJobDeadLetters();
         api.MapMailFolderErasure();
+        api.MapContacts();
 
         return api;
     }

--- a/src/Host/Api/ContactEndpoints.cs
+++ b/src/Host/Api/ContactEndpoints.cs
@@ -1,0 +1,570 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Contacts;
+using MailFathom.Domain.Contacts;
+using MailFathom.Domain.Emails;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace MailFathom.Host.Api;
+
+/// <summary>Serves the contact book: the five acts an owner performs on it, and the three ways it is read.</summary>
+/// <remarks>
+/// <para>
+/// Every write here acts under <see cref="ContactOrigin.Asserted" />, because this surface is the owner's own: what
+/// somebody types into <c>mfctl</c> is a person they wrote down. That is what makes amending a collected contact answer
+/// <c>OriginRefusesWriter</c> rather than silently taking a record collection owns — promoting it is the act that makes
+/// it the owner's, and it is a command of its own.
+/// </para>
+/// <para>
+/// They are here rather than on the MCP surface because the book is the most concentrated personal data this system
+/// holds, and what bounds administrative access is what should bound who may add to it, correct it, read it out, or
+/// erase somebody from it. The MCP tools over the book are a separate surface with separate reasoning.
+/// </para>
+/// <para>
+/// <strong>Nothing a contact carries reaches a refusal.</strong> A name, an address, and a note travel in a request and
+/// in the answer to the caller that asked for that person, and nowhere else: every refusal below names the rule that was
+/// broken rather than the value that broke it, so a malformed address is reported as an address that is not usable
+/// instead of being echoed into a problem document, a log, or a caller's shell history.
+/// </para>
+/// <para>
+/// A lookup, an export, and an erasure of somebody the book does not hold all answer <c>200</c>. The caller asked a
+/// question this deployment can answer and the answer is that nobody is recorded, so <c>404</c> keeps meaning what every
+/// client already reads it as here — that the port serves no administrative endpoint at all.
+/// </para>
+/// </remarks>
+internal static class ContactEndpoints
+{
+    /// <summary>The route the book is listed and written to, relative to the administrative prefix.</summary>
+    internal const string ContactsRoute = "/contacts";
+
+    /// <summary>The route one contact is read, amended, and erased at, relative to the administrative prefix.</summary>
+    internal const string ContactRoute = "/contacts/{contactId:guid}";
+
+    /// <summary>The route the person behind an address is read from, relative to the administrative prefix.</summary>
+    /// <remarks>
+    /// A route of its own rather than a filter on the listing, because it answers with one person rather than a page:
+    /// at most one contact can hold an address, which is the book's uniqueness rule rather than a property of a query.
+    /// The segment is not a UUID, so nothing can confuse it with the route above.
+    /// </remarks>
+    internal const string ContactByAddressRoute = "/contacts/by-address";
+
+    /// <summary>The route a collected contact is promoted at, relative to the administrative prefix.</summary>
+    internal const string ContactPromotionRoute = "/contacts/{contactId:guid}/promotion";
+
+    /// <summary>The route everything held about one person is exported from, relative to the administrative prefix.</summary>
+    internal const string ContactExportRoute = "/contacts/{contactId:guid}/export";
+
+    /// <summary>The greatest request body the two write routes read before refusing it.</summary>
+    /// <remarks>
+    /// A record carries a name, up to <see cref="Contact.MaximumAddressCount" /> addresses, and a note, which is around
+    /// fifteen kilobytes of text before JSON escaping widens it. Stated because the server's own default is measured in
+    /// tens of megabytes, which for these routes would let an authenticated client make the process buffer a body three
+    /// orders of magnitude larger than any contact could be.
+    /// </remarks>
+    internal const int MaxRecordRequestBytes = 64 * 1024;
+
+    /// <summary>The origin every write from this surface acts under.</summary>
+    /// <remarks>
+    /// Named once rather than repeated per handler, because it is one decision about what this endpoint is: the owner's
+    /// own surface, whose writes are people the owner wrote down.
+    /// </remarks>
+    private const ContactOrigin AdministrativeWriter = ContactOrigin.Asserted;
+
+    /// <summary>Maps the contact routes into the administrative group, so they inherit its authorization.</summary>
+    /// <param name="api">The administrative route group.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="api" /> is <see langword="null" />.</exception>
+    internal static void MapContacts(this RouteGroupBuilder api)
+    {
+        ArgumentNullException.ThrowIfNull(api);
+
+        api.MapGet(ContactsRoute, ListAsync);
+
+        // The attribute is reached for its metadata rather than as an MVC filter: it implements
+        // IRequestSizeLimitMetadata, which the routing pipeline applies to the request body feature, so a body over the
+        // bound is answered 413 before the handler is reached.
+        api.MapPost(ContactsRoute, RecordAsync)
+            .WithMetadata(new RequestSizeLimitAttribute(MaxRecordRequestBytes));
+
+        api.MapGet(ContactByAddressRoute, FindByAddressAsync);
+        api.MapGet(ContactRoute, FindAsync);
+
+        api.MapPut(ContactRoute, AmendAsync)
+            .WithMetadata(new RequestSizeLimitAttribute(MaxRecordRequestBytes));
+
+        api.MapDelete(ContactRoute, EraseAsync);
+        api.MapPost(ContactPromotionRoute, PromoteAsync);
+        api.MapGet(ContactExportRoute, ExportAsync);
+    }
+
+    /// <summary>Serves one bounded page of the book, or reports what was wrong with the request.</summary>
+    /// <param name="origin">The origin to narrow to, or <see langword="null" /> for the whole book.</param>
+    /// <param name="pageSize">How many contacts the page may hold, or <see langword="null" /> for the default.</param>
+    /// <param name="cursor">The cursor the previous page returned, or <see langword="null" /> for the first page.</param>
+    /// <param name="directory">Reads the page.</param>
+    /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
+    /// <returns><c>200</c> with the page, or <c>400</c> naming what was wrong with the request.</returns>
+    /// <remarks>
+    /// There is no unbounded reading of the book. A caller that names no page size is served the default rather than
+    /// everything, and a caller that asks for more than the ceiling is refused rather than quietly served the ceiling —
+    /// which is what stops a request from deciding how much of a person's correspondents leave the database at once.
+    /// </remarks>
+    internal static async Task<Results<Ok<ContactPageResponse>, ProblemHttpResult>> ListAsync(
+        [FromQuery] string? origin,
+        [FromQuery] int? pageSize,
+        [FromQuery] string? cursor,
+        [FromServices] IContactDirectory directory,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+
+        if (!TryReadOrigin(origin, out var narrowedOrigin))
+        {
+            return Refused($"A contact origin is either {nameof(ContactOrigin.Asserted)} or {nameof(ContactOrigin.Collected)}.");
+        }
+
+        ContactCursor? decodedCursor = null;
+
+        if (cursor is not null && !ContactCursor.TryDecode(cursor, out decodedCursor))
+        {
+            return Refused("The continuation cursor is not one this deployment issued.");
+        }
+
+        ContactQuery query;
+
+        try
+        {
+            query = ContactQuery.Create(narrowedOrigin, pageSize, decodedCursor);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return Refused($"A contact page holds between 1 and {ContactQuery.MaximumPageSize} contacts.");
+        }
+
+        var page = await directory.ReadPageAsync(query, cancellationToken);
+
+        return TypedResults.Ok(new ContactPageResponse(
+            [.. page.Contacts.Select(ContactResponse.For)],
+            page.NextCursor?.Encode()));
+    }
+
+    /// <summary>Records a person the book does not yet hold.</summary>
+    /// <param name="request">The record to write.</param>
+    /// <param name="book">Performs the write.</param>
+    /// <param name="cancellationToken">Cancels the write when the client disconnects.</param>
+    /// <returns><c>200</c> with the outcome, or <c>400</c> naming which rule the record broke.</returns>
+    internal static async Task<Results<Ok<ContactWriteResponse>, ProblemHttpResult>> RecordAsync(
+        [FromBody] ContactRecordRequest? request,
+        [FromServices] ContactBook book,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+
+        var read = ReadRecord(request);
+
+        if (read.Record is not { } record)
+        {
+            return Refused(read.Refusal!);
+        }
+
+        var written = await book.RecordAsync(
+            new NewContact
+            {
+                DisplayName = record.DisplayName,
+                Addresses = record.Addresses,
+                PreferredAddress = record.PreferredAddress,
+                Note = record.Note,
+                Origin = AdministrativeWriter,
+            },
+            cancellationToken);
+
+        return TypedResults.Ok(ContactWriteResponse.For(written));
+    }
+
+    /// <summary>Reads one contact by the identity the book gave it.</summary>
+    /// <param name="contactId">The contact to read.</param>
+    /// <param name="directory">Answers what the book holds.</param>
+    /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
+    /// <returns><c>200</c> with the contact, or <c>200</c> with none where the book holds no such person.</returns>
+    internal static async Task<Results<Ok<ContactLookupResponse>, ProblemHttpResult>> FindAsync(
+        Guid contactId,
+        [FromServices] IContactDirectory directory,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+
+        if (!TryReadContactId(contactId, out var identity))
+        {
+            return EmptyIdentity();
+        }
+
+        var held = await directory.FindAsync(identity, cancellationToken);
+
+        return TypedResults.Ok(new ContactLookupResponse(held is null ? null : ContactResponse.For(held)));
+    }
+
+    /// <summary>Reads the person who uses one address.</summary>
+    /// <param name="address">The address to resolve.</param>
+    /// <param name="directory">Answers what the book holds.</param>
+    /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
+    /// <returns><c>200</c> with the contact, <c>200</c> with none where nobody holds it, or <c>400</c> where the address is not one.</returns>
+    /// <remarks>
+    /// The lookup is by the address's comparison form, so a caller need not know which casing the book happens to have
+    /// recorded. The refusal names neither the address nor its length, because an address a caller mistyped is still
+    /// somebody's address.
+    /// </remarks>
+    internal static async Task<Results<Ok<ContactLookupResponse>, ProblemHttpResult>> FindByAddressAsync(
+        [FromQuery] string? address,
+        [FromServices] IContactDirectory directory,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+
+        if (!TryReadAddress(address, out var resolved))
+        {
+            return Refused("The lookup names no usable address.");
+        }
+
+        var held = await directory.FindByAddressAsync(resolved, cancellationToken);
+
+        return TypedResults.Ok(new ContactLookupResponse(held is null ? null : ContactResponse.For(held)));
+    }
+
+    /// <summary>Amends one contact to the record the caller states.</summary>
+    /// <param name="contactId">The contact to amend.</param>
+    /// <param name="request">The record the contact is to have afterwards.</param>
+    /// <param name="book">Performs the write.</param>
+    /// <param name="cancellationToken">Cancels the write when the client disconnects.</param>
+    /// <returns><c>200</c> with the outcome, or <c>400</c> naming which rule the record broke.</returns>
+    /// <remarks>
+    /// The whole record rather than the difference from the one held, which is what keeps adding an address, dropping
+    /// one, choosing a different preferred address, and correcting a name one operation whose result the book's
+    /// invariants are checked against.
+    /// </remarks>
+    internal static async Task<Results<Ok<ContactWriteResponse>, ProblemHttpResult>> AmendAsync(
+        Guid contactId,
+        [FromBody] ContactRecordRequest? request,
+        [FromServices] ContactBook book,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+
+        if (!TryReadContactId(contactId, out var identity))
+        {
+            return EmptyIdentity();
+        }
+
+        var read = ReadRecord(request);
+
+        if (read.Record is not { } record)
+        {
+            return Refused(read.Refusal!);
+        }
+
+        var amended = await book.AmendAsync(
+            new ContactAmendment
+            {
+                ContactId = identity,
+                Writer = AdministrativeWriter,
+                DisplayName = record.DisplayName,
+                Addresses = record.Addresses,
+                PreferredAddress = record.PreferredAddress,
+                Note = record.Note,
+            },
+            cancellationToken);
+
+        return TypedResults.Ok(ContactWriteResponse.For(amended));
+    }
+
+    /// <summary>Promotes a collected contact to one the owner has taken responsibility for.</summary>
+    /// <param name="contactId">The contact to promote.</param>
+    /// <param name="book">Performs the write.</param>
+    /// <param name="cancellationToken">Cancels the write when the client disconnects.</param>
+    /// <returns><c>200</c> with the outcome, including a contact that was already asserted.</returns>
+    internal static async Task<Results<Ok<ContactWriteResponse>, ProblemHttpResult>> PromoteAsync(
+        Guid contactId,
+        [FromServices] ContactBook book,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+
+        if (!TryReadContactId(contactId, out var identity))
+        {
+            return EmptyIdentity();
+        }
+
+        var promoted = await book.PromoteAsync(identity, AdministrativeWriter, cancellationToken);
+
+        return TypedResults.Ok(ContactWriteResponse.For(promoted));
+    }
+
+    /// <summary>Erases one person and everything the book derived from them.</summary>
+    /// <param name="contactId">The contact to erase.</param>
+    /// <param name="book">Performs the erasure.</param>
+    /// <param name="cancellationToken">Cancels the erasure when the client disconnects.</param>
+    /// <returns><c>200</c> with what was removed, including a book that held no such contact.</returns>
+    /// <remarks>
+    /// The data-subject erasure path, so it removes rather than marks and no origin gates it: somebody asking to be
+    /// taken out of a contact book is not answered with which half of the book they happen to be in.
+    /// </remarks>
+    internal static async Task<Results<Ok<ContactErasureResponse>, ProblemHttpResult>> EraseAsync(
+        Guid contactId,
+        [FromServices] ContactBook book,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+
+        if (!TryReadContactId(contactId, out var identity))
+        {
+            return EmptyIdentity();
+        }
+
+        var erasure = await book.EraseAsync(identity, cancellationToken);
+
+        return TypedResults.Ok(new ContactErasureResponse(
+            erasure.ContactId.Value,
+            erasure.WasHeld,
+            erasure.AddressesErased));
+    }
+
+    /// <summary>Produces everything the book holds about one person.</summary>
+    /// <param name="contactId">The contact to export.</param>
+    /// <param name="book">Produces the export.</param>
+    /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
+    /// <returns><c>200</c> with the export, or <c>200</c> with none where the book holds no such person.</returns>
+    internal static async Task<Results<Ok<ContactExportResponse>, ProblemHttpResult>> ExportAsync(
+        Guid contactId,
+        [FromServices] ContactBook book,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+
+        if (!TryReadContactId(contactId, out var identity))
+        {
+            return EmptyIdentity();
+        }
+
+        var export = await book.ExportAsync(identity, cancellationToken);
+
+        return TypedResults.Ok(export is null
+            ? new ContactExportResponse(Contact: null, ProducedAt: null)
+            : new ContactExportResponse(ContactResponse.For(export.Contact), export.ProducedAt));
+    }
+
+    /// <summary>Reads the identity a route named, refusing the one value a UUID route constraint still admits.</summary>
+    /// <remarks>
+    /// A contact identifier is never empty, and the constraint on the route cannot say so: it accepts the all-zero UUID
+    /// like any other. Refusing it here is what keeps a caller that wrote one out by hand meeting a stated refusal
+    /// rather than an unhandled guard reported as a fault in the deployment.
+    /// </remarks>
+    private static bool TryReadContactId(Guid contactId, out ContactId identity)
+    {
+        identity = default;
+
+        if (contactId == Guid.Empty)
+        {
+            return false;
+        }
+
+        identity = ContactId.Create(contactId);
+
+        return true;
+    }
+
+    /// <summary>States that the route named the one identifier no contact can carry.</summary>
+    private static ProblemHttpResult EmptyIdentity() => Refused("A contact identifier cannot be empty.");
+
+    /// <summary>Reads the origin a listing was narrowed to, refusing a value naming no origin.</summary>
+    /// <remarks>
+    /// An absent filter is the whole book rather than a refusal, and a blank one is read as absent: a caller writing
+    /// <c>?origin=</c> asked for no narrowing rather than for an origin whose name is empty.
+    /// </remarks>
+    private static bool TryReadOrigin(string? origin, out ContactOrigin? narrowedOrigin)
+    {
+        narrowedOrigin = null;
+
+        if (string.IsNullOrWhiteSpace(origin))
+        {
+            return true;
+        }
+
+        if (!Enum.TryParse<ContactOrigin>(origin.Trim(), ignoreCase: true, out var named) || !Enum.IsDefined(named))
+        {
+            return false;
+        }
+
+        narrowedOrigin = named;
+
+        return true;
+    }
+
+    /// <summary>Reads one address a caller supplied, keeping the addr-spec alone.</summary>
+    private static bool TryReadAddress(string? address, out EmailAddress resolved)
+    {
+        resolved = default;
+
+        return !string.IsNullOrWhiteSpace(address)
+            && address.Trim().Length <= Contact.MaximumAddressLength
+            && EmailAddress.TryCreate(displayName: null, address.Trim(), out resolved);
+    }
+
+    /// <summary>Reads the record a request states, or names the one rule it broke.</summary>
+    /// <remarks>
+    /// Every rule is checked here rather than left to the domain's own guards, because what a caller has to be told is
+    /// which rule it broke and the guards say that by naming a parameter of a constructor. What is left to the domain is
+    /// the pair of rules only it can state — which characters carry no glyph — and each is translated into a sentence of
+    /// its own rather than into the exception's text.
+    /// </remarks>
+    private static ContactRecordReading ReadRecord(ContactRecordRequest? request)
+    {
+        if (request is null)
+        {
+            return ContactRecordReading.Refuse("The request carries no contact record.");
+        }
+
+        if (!TryReadDisplayName(request.DisplayName, out var displayName, out var nameRefusal))
+        {
+            return ContactRecordReading.Refuse(nameRefusal);
+        }
+
+        if (request.Addresses is not { Count: > 0 } supplied)
+        {
+            return ContactRecordReading.Refuse("A contact holds at least one address.");
+        }
+
+        if (supplied.Count > Contact.MaximumAddressCount)
+        {
+            return ContactRecordReading.Refuse(
+                $"A contact cannot hold more than {Contact.MaximumAddressCount} addresses.");
+        }
+
+        var addresses = new List<EmailAddress>(supplied.Count);
+
+        foreach (var candidate in supplied)
+        {
+            if (!TryReadAddress(candidate, out var address))
+            {
+                return ContactRecordReading.Refuse(
+                    $"The record carries an address that is not a usable address of at most {Contact.MaximumAddressLength} characters.");
+            }
+
+            addresses.Add(address);
+        }
+
+        if (!TryReadAddress(request.PreferredAddress, out var preferred))
+        {
+            return ContactRecordReading.Refuse("The record names no usable preferred address.");
+        }
+
+        if (!addresses.Contains(preferred))
+        {
+            return ContactRecordReading.Refuse("The preferred address is one of the addresses the contact holds.");
+        }
+
+        if (!TryReadNote(request.Note, out var note, out var noteRefusal))
+        {
+            return ContactRecordReading.Refuse(noteRefusal);
+        }
+
+        return ContactRecordReading.Read(new ContactRecord(displayName, addresses, preferred, note));
+    }
+
+    /// <summary>Reads the name a request stated, or names the rule it broke.</summary>
+    private static bool TryReadDisplayName(
+        string? value,
+        out ContactDisplayName displayName,
+        out string refusal)
+    {
+        displayName = default;
+        refusal = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return Broken("A contact record names no display name.", out refusal);
+        }
+
+        if (value.Trim().Length > ContactDisplayName.MaximumLength)
+        {
+            return Broken(
+                $"A contact name cannot be longer than {ContactDisplayName.MaximumLength} characters.",
+                out refusal);
+        }
+
+        try
+        {
+            displayName = ContactDisplayName.Create(value);
+        }
+        catch (ArgumentException)
+        {
+            return Broken("A contact name cannot contain characters that carry no glyph of their own.", out refusal);
+        }
+
+        return true;
+    }
+
+    /// <summary>Reads the note a request stated, or names the rule it broke.</summary>
+    /// <remarks>
+    /// An absent note and a blank one are both the absence of a note, because a contact without one holds none: two ways
+    /// to say the same thing would leave every reader deciding which it was looking at, and a caller clearing a note
+    /// sends the field empty rather than reaching for a second verb.
+    /// </remarks>
+    private static bool TryReadNote(string? value, out ContactNote? note, out string refusal)
+    {
+        note = null;
+        refusal = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return true;
+        }
+
+        if (value.Trim().Length > ContactNote.MaximumLength)
+        {
+            return Broken($"A contact note cannot be longer than {ContactNote.MaximumLength} characters.", out refusal);
+        }
+
+        try
+        {
+            note = ContactNote.Create(value);
+        }
+        catch (ArgumentException)
+        {
+            return Broken(
+                "A contact note cannot contain characters that carry no glyph of their own, other than line breaks and tabs.",
+                out refusal);
+        }
+
+        return true;
+    }
+
+    /// <summary>States the rule a value broke, and reports it as broken.</summary>
+    private static bool Broken(string stated, out string refusal)
+    {
+        refusal = stated;
+
+        return false;
+    }
+
+    /// <summary>States what a caller has to change, without echoing anything about the person it was writing.</summary>
+    private static ProblemHttpResult Refused(string stated) =>
+        TypedResults.Problem(stated, statusCode: StatusCodes.Status400BadRequest);
+
+    /// <summary>The validated parts of a contact record a request stated.</summary>
+    private sealed record ContactRecord(
+        ContactDisplayName DisplayName,
+        IReadOnlyCollection<EmailAddress> Addresses,
+        EmailAddress PreferredAddress,
+        ContactNote? Note);
+
+    /// <summary>What reading a request's record produced: the record, or the one rule it broke.</summary>
+    private sealed record ContactRecordReading(ContactRecord? Record, string? Refusal)
+    {
+        /// <summary>Reports a record every rule admits.</summary>
+        internal static ContactRecordReading Read(ContactRecord record) => new(record, Refusal: null);
+
+        /// <summary>Reports the rule the request broke.</summary>
+        internal static ContactRecordReading Refuse(string refusal) => new(Record: null, refusal);
+    }
+}

--- a/src/Host/Api/ContactResponses.cs
+++ b/src/Host/Api/ContactResponses.cs
@@ -1,0 +1,134 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Contacts;
+using MailFathom.Domain.Contacts;
+
+namespace MailFathom.Host.Api;
+
+/// <summary>The record a caller states for a contact, whether it is being written for the first time or amended.</summary>
+/// <param name="DisplayName">The name to record for the person.</param>
+/// <param name="Addresses">Every address the person uses; two spellings of one address count once.</param>
+/// <param name="PreferredAddress">The address to use by default, which must be one of <paramref name="Addresses" />.</param>
+/// <param name="Note">What the owner wrote about the person, or nothing to hold no note.</param>
+/// <remarks>
+/// One request shape for both operations, because an amendment states the whole record rather than the difference from
+/// the one held: what a caller sends to create a contact and what it sends to correct one are the same four things, and
+/// a second record differing in nothing would be two contracts to keep in agreement. Which operation is meant is the
+/// route and the verb, never a field.
+/// </remarks>
+internal sealed record ContactRecordRequest(
+    string? DisplayName,
+    IReadOnlyList<string>? Addresses,
+    string? PreferredAddress,
+    string? Note);
+
+/// <summary>One person as the book holds them.</summary>
+/// <param name="Id">The identity the book gave them, which no amendment and no promotion changes.</param>
+/// <param name="DisplayName">The name the owner recorded, in the casing they wrote it.</param>
+/// <param name="Addresses">Every address they use, the preferred one first and the rest in comparison order.</param>
+/// <param name="PreferredAddress">The address to use when something addresses them without naming which of theirs.</param>
+/// <param name="Note">What the owner wrote about them, or nothing where they wrote nothing.</param>
+/// <param name="Origin">How the contact came to be in the book, which decides who may amend it.</param>
+/// <param name="RecordedAt">When the contact entered the book.</param>
+/// <param name="AmendedAt">When it was last amended, which equals <paramref name="RecordedAt" /> until one happens.</param>
+/// <remarks>
+/// Every field but the identity and the origin is personal data about a third party. It travels to the caller that
+/// asked for this person and reaches nothing else — no log line, no metric dimension, and no failure message.
+/// </remarks>
+internal sealed record ContactResponse(
+    Guid Id,
+    string DisplayName,
+    IReadOnlyList<string> Addresses,
+    string PreferredAddress,
+    string? Note,
+    string Origin,
+    DateTimeOffset RecordedAt,
+    DateTimeOffset AmendedAt)
+{
+    /// <summary>Describes one contact for a caller.</summary>
+    /// <param name="contact">The contact as the book holds it.</param>
+    /// <returns>The response body.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contact" /> is <see langword="null" />.</exception>
+    internal static ContactResponse For(Contact contact)
+    {
+        ArgumentNullException.ThrowIfNull(contact);
+
+        return new ContactResponse(
+            contact.Id.Value,
+            contact.DisplayName.Value,
+            [.. contact.Addresses.Select(address => address.Address)],
+            contact.PreferredAddress.Address,
+            contact.Note?.Value,
+            contact.Origin.ToString(),
+            contact.RecordedAt,
+            contact.AmendedAt);
+    }
+}
+
+/// <summary>The person a lookup found, or that the book holds none.</summary>
+/// <param name="Contact">The contact, or nothing when the book holds none matching what was asked.</param>
+/// <remarks>
+/// A book holding nobody of that identity or address is an outcome rather than a refusal, so the answer carries no
+/// contact instead of a <c>404</c>: the caller asked a question this deployment can answer, and the answer is that
+/// nobody is recorded. It also keeps <c>404</c> meaning what every client already reads it as on this surface — that
+/// the port serves no administrative endpoint.
+/// </remarks>
+internal sealed record ContactLookupResponse(ContactResponse? Contact);
+
+/// <summary>One bounded page of the book, and where the walk continues.</summary>
+/// <param name="Contacts">The contacts this page holds, ordered by the name's comparison form and then by identity.</param>
+/// <param name="NextCursor">The cursor the following page is asked with, or nothing at the end of the book.</param>
+/// <remarks>
+/// The absent cursor is the end of the walk rather than a page that happened to be short, so a caller stops when the
+/// cursor stops instead of comparing the count against the size it asked for.
+/// </remarks>
+internal sealed record ContactPageResponse(IReadOnlyList<ContactResponse> Contacts, string? NextCursor);
+
+/// <summary>What one write to the book produced.</summary>
+/// <param name="Outcome">How the write ended, by the name the application's own outcome carries.</param>
+/// <param name="Contact">The record the outcome is about, or nothing where the book held none.</param>
+/// <param name="AddressHolder">The contact already holding an address the write claimed, present exactly when that is what refused it.</param>
+/// <remarks>
+/// A refusal is answered with <c>200</c> and a named outcome rather than a status code, because each one is something
+/// the caller reports to its owner and continues from rather than a request that was malformed. Only the holder's
+/// identity is named: answering with somebody else's record would hand a third party out as a side effect of a refused
+/// write.
+/// </remarks>
+internal sealed record ContactWriteResponse(string Outcome, ContactResponse? Contact, Guid? AddressHolder)
+{
+    /// <summary>Describes what a write to the book produced.</summary>
+    /// <param name="result">The outcome the book answered with.</param>
+    /// <returns>The response body.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="result" /> is <see langword="null" />.</exception>
+    internal static ContactWriteResponse For(ContactWriteResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        return new ContactWriteResponse(
+            result.Outcome.ToString(),
+            result.Contact is null ? null : ContactResponse.For(result.Contact),
+            result.AddressHolder?.Value);
+    }
+}
+
+/// <summary>What erasing one contact removed.</summary>
+/// <param name="Contact">The contact the erasure was asked for.</param>
+/// <param name="WasHeld">Whether the book held that contact when the erasure ran.</param>
+/// <param name="AddressesErased">How many addresses went with them.</param>
+/// <remarks>
+/// The counts are what an owner is entitled to rather than a courtesy, and they are the whole of what an erasure says
+/// about a person: that they are gone, and how much went. No name, address, or note is in this answer, deliberately —
+/// a report of an erasure that echoed the record would be a copy of what was just removed.
+/// </remarks>
+internal sealed record ContactErasureResponse(Guid Contact, bool WasHeld, int AddressesErased);
+
+/// <summary>Everything the deployment holds about one person, as of the instant it was taken.</summary>
+/// <param name="Contact">The complete record, or nothing when the book holds no such contact.</param>
+/// <param name="ProducedAt">When the export was produced, absent together with the contact.</param>
+/// <remarks>
+/// The data-subject access path. It carries the same complete record every other surface over the book renders, because
+/// which parts of a person are handed back is not a decision any surface gets to make.
+/// </remarks>
+internal sealed record ContactExportResponse(ContactResponse? Contact, DateTimeOffset? ProducedAt);

--- a/tests/Application.UnitTests/Contacts/ContactCursorTests.cs
+++ b/tests/Application.UnitTests/Contacts/ContactCursorTests.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Buffers.Text;
+using System.Text;
 using MailFathom.Application.Contacts;
 using MailFathom.Domain.Contacts;
 using Xunit;
@@ -77,9 +79,27 @@ public sealed class ContactCursorTests
     [Theory]
     [InlineData("")]
     [InlineData("not base64url at all!")]
-    [InlineData("MS4xMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuQU5OQQ")]
     public void TryDecode_TextThisDidNotIssue_RefusesIt(string presented)
     {
+        // Act
+        var decoded = ContactCursor.TryDecode(presented, out var read);
+
+        // Assert
+        Assert.False(decoded);
+        Assert.Null(read);
+    }
+
+    /// <summary>
+    /// The shape a hand-built cursor actually takes: every field is present and only the identity is spelled the way a
+    /// person writes a UUID rather than the way this encodes one. Refusing it is what keeps a walk to the cursors this
+    /// deployment issued.
+    /// </summary>
+    [Fact]
+    public void TryDecode_ACursorAssembledByHandWithADashedIdentity_RefusesIt()
+    {
+        // Arrange
+        var presented = Base64Url.EncodeToString(Encoding.UTF8.GetBytes($"1.{Identity.Value:D}.ANNA"));
+
         // Act
         var decoded = ContactCursor.TryDecode(presented, out var read);
 

--- a/tests/Application.UnitTests/Contacts/ContactCursorTests.cs
+++ b/tests/Application.UnitTests/Contacts/ContactCursorTests.cs
@@ -1,0 +1,102 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Contacts;
+using MailFathom.Domain.Contacts;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Contacts;
+
+/// <summary>Covers the opaque form a caller presents to continue a walk of the contact book.</summary>
+/// <remarks>
+/// The cursor carries a name's comparison form, which is the one field here that is not a fixed shape: it may be any
+/// length up to a contact name's bound and may contain the character the fields are separated by. Both are what these
+/// tests are about, because either read wrongly would serve a contact twice or skip one, and a walk that skips somebody
+/// is a listing that is quietly incomplete.
+/// </remarks>
+public sealed class ContactCursorTests
+{
+    private static readonly ContactId Identity = ContactId.Create(new Guid("11111111-2222-3333-4444-555555555555"));
+
+    [Fact]
+    public void Encode_ACursor_ProducesTextThatDecodesBackToTheSameBoundary()
+    {
+        // Arrange
+        var cursor = ContactCursor.After(ContactDisplayName.Create("Anna Kowalska"), Identity);
+
+        // Act
+        var decoded = ContactCursor.TryDecode(cursor.Encode(), out var read);
+
+        // Assert
+        Assert.True(decoded);
+        Assert.Equal(cursor, read);
+    }
+
+    /// <summary>
+    /// The regression the field order exists for. A name may itself contain the separator, so a decoding that split
+    /// greedily would read part of somebody's name as a field of its own and refuse a cursor this deployment issued —
+    /// which reads to a caller as a walk that cannot be continued.
+    /// </summary>
+    [Fact]
+    public void Decode_ACursorForANameContainingTheFieldSeparator_ReadsTheWholeName()
+    {
+        // Arrange
+        var displayName = ContactDisplayName.Create("Anna J. Kowalska-Nowak.");
+        var cursor = ContactCursor.After(displayName, Identity);
+
+        // Act
+        var decoded = ContactCursor.TryDecode(cursor.Encode(), out var read);
+
+        // Assert
+        Assert.True(decoded);
+        Assert.Equal(displayName.SortKey, read?.DisplayNameSortKey);
+        Assert.Equal(Identity, read?.ContactId);
+    }
+
+    /// <summary>A name at the bound still encodes to a cursor this refuses nothing about, in every character width.</summary>
+    [Fact]
+    public void Encode_ACursorForTheLongestNameABookAdmits_StaysWithinWhatDecodingAccepts()
+    {
+        // Arrange
+        var displayName = ContactDisplayName.Create(new string('Å', ContactDisplayName.MaximumLength));
+
+        // Act
+        var encoded = ContactCursor.After(displayName, Identity).Encode();
+
+        // Assert
+        Assert.True(encoded.Length <= ContactCursor.MaximumEncodedLength);
+        Assert.True(ContactCursor.TryDecode(encoded, out var read));
+        Assert.Equal(displayName.SortKey, read?.DisplayNameSortKey);
+    }
+
+    /// <summary>
+    /// Anything a caller presents that this did not issue is refused rather than read, because a cursor decides which
+    /// contacts a page skips: one built by hand would silently start a walk in the middle of the book.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("not base64url at all!")]
+    [InlineData("MS4xMTExMTExMS0yMjIyLTMzMzMtNDQ0NC01NTU1NTU1NTU1NTUuQU5OQQ")]
+    public void TryDecode_TextThisDidNotIssue_RefusesIt(string presented)
+    {
+        // Act
+        var decoded = ContactCursor.TryDecode(presented, out var read);
+
+        // Assert
+        Assert.False(decoded);
+        Assert.Null(read);
+    }
+
+    /// <summary>Text longer than any cursor this issues is refused before it is decoded at all.</summary>
+    [Fact]
+    public void TryDecode_TextLongerThanAnyCursorThisIssues_RefusesItUnread()
+    {
+        // Act
+        var decoded = ContactCursor.TryDecode(new string('a', ContactCursor.MaximumEncodedLength + 1), out var read);
+
+        // Assert
+        Assert.False(decoded);
+        Assert.Null(read);
+    }
+}

--- a/tests/Cli.UnitTests/AdminEndpointRoutesTests.cs
+++ b/tests/Cli.UnitTests/AdminEndpointRoutesTests.cs
@@ -71,6 +71,30 @@ public sealed class AdminEndpointRoutesTests
     }
 
     /// <summary>
+    /// The contact-book paths, pinned for the reason every other path here is. The three composed ones are written out
+    /// rather than built from the constant, because what would break is the shape rather than the prefix: a deployment
+    /// serves one contact beneath a UUID segment, and a command composing the identity anywhere else would reach a 404
+    /// that reads exactly like an administrative endpoint nobody enabled.
+    /// </summary>
+    [Fact]
+    public void ContactPaths_AreTheRoutesTheDeploymentServesItsBookAt()
+    {
+        var contact = new Guid("11111111-2222-3333-4444-555555555555");
+
+        Assert.Equal("/api/admin/contacts", AdminEndpointRoutes.ContactsPath);
+        Assert.Equal("/api/admin/contacts/by-address", AdminEndpointRoutes.ContactByAddressPath);
+        Assert.Equal(
+            "/api/admin/contacts/11111111-2222-3333-4444-555555555555",
+            AdminEndpointRoutes.ContactPath(contact));
+        Assert.Equal(
+            "/api/admin/contacts/11111111-2222-3333-4444-555555555555/promotion",
+            AdminEndpointRoutes.ContactPromotionPath(contact));
+        Assert.Equal(
+            "/api/admin/contacts/11111111-2222-3333-4444-555555555555/export",
+            AdminEndpointRoutes.ContactExportPath(contact));
+    }
+
+    /// <summary>
     /// RFC 9728 places the document under a well-known segment with the resource's path appended, and the deployment
     /// refuses to start unless its resource path is the route prefix. Composing it here rather than reading it from a
     /// challenge is what makes a sign-in one request instead of two, and this is the assertion that keeps the

--- a/tests/Cli.UnitTests/ContactCommandTests.cs
+++ b/tests/Cli.UnitTests/ContactCommandTests.cs
@@ -1,0 +1,727 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json;
+using MailFathom.Cli.Credentials;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers what the contact commands accept, what they refuse without reaching a deployment, and what they print.</summary>
+/// <remarks>
+/// <para>
+/// Three things are asserted throughout. What a command sends, because an amendment states the whole record and a
+/// command that sent a difference would have the deployment refuse a record it never meant to write. What it refuses on
+/// its own, because a choice the operator has to make — which address is preferred, whether an erasure is agreed to —
+/// must not be resolved by the command on their behalf. And what reaches which stream, because a name or an address on
+/// standard error is a contact's personal data in whatever captures a scripted run's failures.
+/// </para>
+/// <para>
+/// The erasure is the one covered from both sides: that it asks before erasing, that a refused question erases nothing,
+/// and that the flag is the only way to state the agreement where nobody is at the terminal.
+/// </para>
+/// </remarks>
+public sealed class ContactCommandTests : IDisposable
+{
+    private const string Endpoint = "https://mail.example.test:8443";
+
+    private static readonly Uri EndpointAddress = new(Endpoint);
+
+    private static readonly string Identity = FakeContactDeployment.ContactIdentity.ToString("D");
+
+    private readonly string storeDirectory =
+        Path.Combine(Path.GetTempPath(), $"mailfathom-contact-tests-{Guid.NewGuid():N}");
+
+    private readonly RecordingCliConsole console = new();
+
+    private readonly FakeTimeProvider clock = new(new DateTimeOffset(2026, 8, 16, 12, 0, 0, TimeSpan.Zero));
+
+    /// <summary>One address is no choice, so the record prefers it without the operator having to say so.</summary>
+    [Fact]
+    public async Task Create_OneAddress_SendsItAsThePreferredOneAndPrintsTheWrittenRecord()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(write: FakeContactDeployment.Written());
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "create",
+            "--name",
+            "Anna Kowalska",
+            "--address",
+            "anna@example.test",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Equal("anna@example.test", SentRecord(deployment).GetProperty("preferredAddress").GetString());
+        Assert.Contains(this.console.Lines, line => line.Contains("Anna Kowalska", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Which address a message to somebody goes to is the operator's decision, so several addresses without a stated
+    /// preference is refused here rather than resolved by the order the arguments were typed in.
+    /// </summary>
+    [Fact]
+    public async Task Create_SeveralAddressesAndNoPreference_RefusesWithoutWritingAnything()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(write: FakeContactDeployment.Written());
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "create",
+            "--name",
+            "Anna Kowalska",
+            "--address",
+            "anna@example.test",
+            "--address",
+            "a.kowalska@work.example",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal(0, deployment.ContactRequestCount(HttpMethod.Post));
+        Assert.Contains(this.console.Errors, line => line.Contains("--preferred", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The deployment names the contact that holds a claimed address, and the command repeats that identity and nothing
+    /// else: reading that person is a lookup the operator performs rather than something a refused write hands them.
+    /// </summary>
+    [Fact]
+    public async Task Create_AnAddressAnotherContactHolds_ReportsTheHoldersIdentityAndFails()
+    {
+        // Arrange
+        var holder = new Guid("99999999-8888-7777-6666-555555555555");
+        using var deployment = FakeContactDeployment.Holding(
+            write: FakeContactDeployment.Refused("AddressHeldByAnotherContact", holder));
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "create",
+            "--name",
+            "Anna Kowalska",
+            "--address",
+            "anna@example.test",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(this.console.Errors, line => line.Contains(holder.ToString("D"), StringComparison.Ordinal));
+    }
+
+    /// <summary>Naming a contact both ways, or neither, is a mistake in the invocation rather than a lookup to attempt.</summary>
+    [Theory]
+    [InlineData("--id", "--address")]
+    [InlineData(null, null)]
+    public async Task Show_TheContactNamedBothWaysOrNeither_RefusesWithoutReachingTheBook(string? first, string? second)
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(lookup: FakeContactDeployment.Lookup());
+
+        string[] arguments = first is null
+            ? ["contact", "show", "--endpoint", Endpoint]
+            : ["contact", "show", first, Identity, second!, "anna@example.test", "--endpoint", Endpoint];
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, arguments);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal(0, deployment.ContactRequestCount(HttpMethod.Get));
+    }
+
+    /// <summary>A lookup by address answers with a person, which is what makes the book a book rather than a list.</summary>
+    [Fact]
+    public async Task Show_AnAddress_PrintsThePersonWhoUsesIt()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(lookup: FakeContactDeployment.Lookup());
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "show",
+            "--address",
+            "ANNA@EXAMPLE.TEST",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Contains(this.console.Lines, line => line.Contains("Anna Kowalska", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A book holding nobody is reported without the address being written back: it is somebody's address whether or not
+    /// the book holds them, and this sentence is what a scripted run captures.
+    /// </summary>
+    [Fact]
+    public async Task Show_AnAddressNobodyUses_FailsWithoutRepeatingTheAddress()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding();
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "show",
+            "--address",
+            "nobody@example.test",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.All(
+            this.console.Errors,
+            line => Assert.DoesNotContain("nobody@example.test", line, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>The narrowing and the page bound reach the deployment as the query it reads them from.</summary>
+    [Fact]
+    public async Task List_AnOriginAndAPageSize_AsksTheDeploymentForExactlyThose()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            page: FakeContactDeployment.Page(nextCursor: null, "Anna Kowalska"));
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "list",
+            "--origin",
+            "Collected",
+            "--page-size",
+            "25",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Equal("?origin=Collected&pageSize=25", deployment.LastListingQuery());
+    }
+
+    /// <summary>
+    /// A page that ends with a cursor says how to continue, because there is deliberately no command that walks the
+    /// whole book: the operator asks for the next page rather than having it printed at them.
+    /// </summary>
+    [Fact]
+    public async Task List_APageTheBookContinuesAfter_PrintsTheCursorTheNextPageIsAskedWith()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            page: FakeContactDeployment.Page("a-cursor-the-deployment-issued", "Anna Kowalska", "Bartosz Nowak"));
+
+        // Act
+        await this.RunAsync(deployment, "contact", "list", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("--cursor a-cursor-the-deployment-issued", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The whole record rather than the difference. Correcting a name has to send back every address the contact holds,
+    /// because the book replaces what it is given — a command sending the name alone would erase the addresses.
+    /// </summary>
+    [Fact]
+    public async Task Update_AName_SendsTheHeldAddressesBackWithIt()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(addresses: ["anna@example.test", "a.kowalska@work.example"]),
+            write: FakeContactDeployment.Written("Anna Nowak"));
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "update",
+            "--id",
+            Identity,
+            "--name",
+            "Anna Nowak",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+
+        var sent = SentRecord(deployment);
+        Assert.Equal("Anna Nowak", sent.GetProperty("displayName").GetString());
+        Assert.Equal(["anna@example.test", "a.kowalska@work.example"], AddressesOf(sent));
+        Assert.Equal("anna@example.test", sent.GetProperty("preferredAddress").GetString());
+    }
+
+    /// <summary>An invocation naming nothing to change is refused before the contact is read, rather than restating it.</summary>
+    [Fact]
+    public async Task Update_NothingNamed_RefusesWithoutReachingTheBook()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(lookup: FakeContactDeployment.Lookup());
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "contact", "update", "--id", Identity, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal(0, deployment.ContactRequestCount(HttpMethod.Get));
+    }
+
+    /// <summary>
+    /// A collected record is not amended in place, and the refusal says what unlocks the write rather than reporting a
+    /// permission the operator cannot act on.
+    /// </summary>
+    [Fact]
+    public async Task Update_AContactTheDeploymentCollected_ReportsThatPromotingItComesFirst()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(origin: "Collected"),
+            write: FakeContactDeployment.Refused("OriginRefusesWriter"));
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "update",
+            "--id",
+            Identity,
+            "--name",
+            "Anna Nowak",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(this.console.Errors, line => line.Contains("contact promote", StringComparison.Ordinal));
+    }
+
+    /// <summary>The added address joins the ones held, and the contact goes on preferring the one it preferred.</summary>
+    [Fact]
+    public async Task AddAddress_AnAddressTheContactDoesNotHold_SendsTheHeldOnesWithItAndKeepsThePreference()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(addresses: ["anna@example.test"]),
+            write: FakeContactDeployment.Written());
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "add-address",
+            "--id",
+            Identity,
+            "--address",
+            "a.kowalska@work.example",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+
+        var sent = SentRecord(deployment);
+        Assert.Equal(["anna@example.test", "a.kowalska@work.example"], AddressesOf(sent));
+        Assert.Equal("anna@example.test", sent.GetProperty("preferredAddress").GetString());
+    }
+
+    /// <summary>
+    /// The book merges two spellings of one address, so a command that sent one it already holds would report a record
+    /// as changed when nothing was added. Comparison is the book's own, which ignores case across the whole address.
+    /// </summary>
+    [Fact]
+    public async Task AddAddress_AnAddressTheContactAlreadyHoldsInAnotherCasing_RefusesWithoutWriting()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(addresses: ["anna@example.test"]),
+            write: FakeContactDeployment.Written());
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "add-address",
+            "--id",
+            Identity,
+            "--address",
+            "ANNA@EXAMPLE.TEST",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal(0, deployment.ContactRequestCount(HttpMethod.Put));
+    }
+
+    /// <summary>
+    /// <c>--preferred</c> means the same thing in every command that takes it: the address to use by default
+    /// afterwards. Naming the one being added is how an operator adds an address and makes it the default at once.
+    /// </summary>
+    [Fact]
+    public async Task AddAddress_PreferringTheAddedAddress_SendsItAsTheOneUsedByDefault()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(addresses: ["anna@example.test"]),
+            write: FakeContactDeployment.Written());
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "add-address",
+            "--id",
+            Identity,
+            "--address",
+            "a.kowalska@work.example",
+            "--preferred",
+            "a.kowalska@work.example",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+
+        var sent = SentRecord(deployment);
+        Assert.Equal(["anna@example.test", "a.kowalska@work.example"], AddressesOf(sent));
+        Assert.Equal("a.kowalska@work.example", sent.GetProperty("preferredAddress").GetString());
+    }
+
+    /// <summary>A contact holds at least one address, so the last one is not something this command takes away.</summary>
+    [Fact]
+    public async Task RemoveAddress_TheOnlyAddressTheContactHolds_RefusesAndNamesTheCommandThatErasesInstead()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(addresses: ["anna@example.test"]));
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "remove-address",
+            "--id",
+            Identity,
+            "--address",
+            "anna@example.test",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal(0, deployment.ContactRequestCount(HttpMethod.Put));
+        Assert.Contains(this.console.Errors, line => line.Contains("contact delete", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Removing the address a contact uses by default leaves the record without one, and choosing the next in the list
+    /// would decide on the operator's behalf which address a message to that person goes to.
+    /// </summary>
+    [Fact]
+    public async Task RemoveAddress_ThePreferredAddressWithNoReplacementNamed_RefusesWithoutWriting()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(addresses: ["anna@example.test", "a.kowalska@work.example"]));
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "remove-address",
+            "--id",
+            Identity,
+            "--address",
+            "anna@example.test",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal(0, deployment.ContactRequestCount(HttpMethod.Put));
+        Assert.Contains(this.console.Errors, line => line.Contains("--preferred", StringComparison.Ordinal));
+    }
+
+    /// <summary>The address the operator named is gone from the record the command sends, and the rest stay.</summary>
+    [Fact]
+    public async Task RemoveAddress_AnAddressTheContactDoesNotPrefer_SendsTheRecordWithoutIt()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(addresses: ["anna@example.test", "a.kowalska@work.example"]),
+            write: FakeContactDeployment.Written());
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "remove-address",
+            "--id",
+            Identity,
+            "--address",
+            "a.kowalska@work.example",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+
+        Assert.Equal(["anna@example.test"], AddressesOf(SentRecord(deployment)));
+    }
+
+    /// <summary>Promoting is a write of its own, sent to a path of its own rather than carried as a field.</summary>
+    [Fact]
+    public async Task Promote_ACollectedContact_AsksThePromotionPathAndPrintsTheRecordItTookOn()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(write: FakeContactDeployment.Written());
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "contact", "promote", "--id", Identity, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Contains(
+            deployment.RecordedRequests,
+            request => request.RequestUri?.AbsolutePath.EndsWith("/promotion", StringComparison.Ordinal) == true);
+    }
+
+    /// <summary>Erasing cannot be undone, so the record is shown and the question asked before anything is removed.</summary>
+    [Fact]
+    public async Task Delete_WithoutTheFlag_ShowsTheRecordAndAsksBeforeErasing()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(),
+            erasure: FakeContactDeployment.Erasure(wasHeld: true, addressesErased: 2));
+        this.console.AnswerToGive = true;
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "contact", "delete", "--id", Identity, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Single(this.console.Questions);
+        Assert.Contains(this.console.Lines, line => line.Contains("Anna Kowalska", StringComparison.Ordinal));
+        Assert.Contains(this.console.Lines, line => line.Contains("2 addresses", StringComparison.Ordinal));
+    }
+
+    /// <summary>The question is about a person, and what it names is the act rather than who it is about.</summary>
+    [Fact]
+    public async Task Delete_WithoutTheFlag_AsksAQuestionNamingNothingAboutThePerson()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(),
+            erasure: FakeContactDeployment.Erasure(wasHeld: true, addressesErased: 1));
+        this.console.AnswerToGive = true;
+
+        // Act
+        await this.RunAsync(deployment, "contact", "delete", "--id", Identity, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.DoesNotContain("Anna Kowalska", Assert.Single(this.console.Questions), StringComparison.Ordinal);
+        Assert.DoesNotContain("anna@example.test", Assert.Single(this.console.Questions), StringComparison.Ordinal);
+    }
+
+    /// <summary>A question answered no erases nothing, and says so where a scripted run captures failures.</summary>
+    [Fact]
+    public async Task Delete_TheQuestionDeclined_ErasesNothing()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(lookup: FakeContactDeployment.Lookup());
+        this.console.AnswerToGive = false;
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "contact", "delete", "--id", Identity, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal(0, deployment.ContactRequestCount(HttpMethod.Delete));
+        Assert.Contains("Nothing was erased.", this.console.Errors);
+    }
+
+    /// <summary>
+    /// Nobody at the terminal is told to state the agreement in the command, because reading it out of whatever was
+    /// piped in would turn a stray line into an agreement to erase somebody.
+    /// </summary>
+    [Fact]
+    public async Task Delete_WithNobodyAtTheTerminalAndNoFlag_RefusesRatherThanAssuming()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(lookup: FakeContactDeployment.Lookup());
+        this.console.AnswersQuestions = false;
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "contact", "delete", "--id", Identity, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal(0, deployment.ContactRequestCount(HttpMethod.Delete));
+        Assert.Contains(this.console.Errors, line => line.Contains("--yes", StringComparison.Ordinal));
+    }
+
+    /// <summary>The flag is what a scripted erasure states its agreement with, and nothing is asked.</summary>
+    [Fact]
+    public async Task Delete_WithTheFlag_ErasesWithoutAsking()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(
+            lookup: FakeContactDeployment.Lookup(),
+            erasure: FakeContactDeployment.Erasure(wasHeld: true, addressesErased: 1));
+        this.console.AnswersQuestions = false;
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "contact",
+            "delete",
+            "--id",
+            Identity,
+            "--yes",
+            "--endpoint",
+            Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Empty(this.console.Questions);
+        Assert.Equal(1, deployment.ContactRequestCount(HttpMethod.Delete));
+    }
+
+    /// <summary>Erasing somebody the book does not hold is the state the operator asked for, not a failure.</summary>
+    [Fact]
+    public async Task Delete_AContactTheBookDoesNotHold_SucceedsWithoutAskingOrErasing()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding();
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "contact", "delete", "--id", Identity, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Empty(this.console.Questions);
+        Assert.Equal(0, deployment.ContactRequestCount(HttpMethod.Delete));
+    }
+
+    /// <summary>
+    /// The export is one document on standard output, so redirecting the command produces the file an owner hands to
+    /// the person who asked, with nothing of the command's own mixed into it.
+    /// </summary>
+    [Fact]
+    public async Task Export_AContactTheBookHolds_WritesOneParsableDocumentAndNothingElse()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(export: FakeContactDeployment.Export());
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "contact", "export", "--id", Identity, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+
+        var document = Assert.Single(this.console.Lines);
+        Assert.Contains("Anna Kowalska", document, StringComparison.Ordinal);
+        Assert.Contains("producedAt", document, StringComparison.Ordinal);
+    }
+
+    /// <summary>A contact the book does not hold has nothing to export, and the failure carries only the identifier.</summary>
+    [Fact]
+    public async Task Export_AContactTheBookDoesNotHold_FailsWithoutWritingADocument()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding();
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "contact", "export", "--id", Identity, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Empty(this.console.Lines);
+        Assert.Contains(this.console.Errors, line => line.Contains(Identity, StringComparison.OrdinalIgnoreCase));
+    }
+
+    /// <summary>Every command that acts on one contact needs to be told which, because guessing would act on a person.</summary>
+    [Theory]
+    [InlineData("update")]
+    [InlineData("add-address")]
+    [InlineData("remove-address")]
+    [InlineData("promote")]
+    [InlineData("delete")]
+    [InlineData("export")]
+    public async Task ContactCommands_WithNoIdentityNamed_RefuseWithoutReachingTheDeployment(string command)
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(lookup: FakeContactDeployment.Lookup());
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "contact", command, "--endpoint", Endpoint);
+
+        // Assert
+        Assert.NotEqual(CliExitCode.Success, exitCode);
+        Assert.Equal(0, deployment.ContactRequestCount(HttpMethod.Get));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this.storeDirectory))
+        {
+            Directory.Delete(this.storeDirectory, recursive: true);
+        }
+    }
+
+    /// <summary>Reads the record a write carried, as the deployment would.</summary>
+    /// <remarks>
+    /// Parsed rather than matched as text, because the command writes the body indented: an assertion over the raw
+    /// string would be about the serializer's layout rather than about what the record said.
+    /// </remarks>
+    private static JsonElement SentRecord(FakeHttpMessageHandler deployment)
+    {
+        using var document = JsonDocument.Parse(deployment.LastWriteRequest() ?? "{}");
+
+        return document.RootElement.Clone();
+    }
+
+    /// <summary>Reads the addresses a written record carried, in the order it stated them.</summary>
+    private static IReadOnlyList<string?> AddressesOf(JsonElement record) =>
+        [.. record.GetProperty("addresses").EnumerateArray().Select(address => address.GetString())];
+
+    private Task<int> RunAsync(FakeHttpMessageHandler deployment, params string[] args)
+    {
+        var store = new CredentialStore(
+            Path.Combine(this.storeDirectory, "credentials.json"),
+            new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key")));
+
+        store.Save("production", EndpointAddress, "not-a-real-key", "workstation");
+
+        var context = new CliContext(
+            this.console,
+            store,
+            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
+            FakeMailboxRedirect.Silent(),
+            _ => false,
+            this.clock);
+
+        return CliRunner.RunAsync(context, args);
+    }
+}

--- a/tests/Cli.UnitTests/FakeContactDeployment.cs
+++ b/tests/Cli.UnitTests/FakeContactDeployment.cs
@@ -1,0 +1,223 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+using System.Net;
+using System.Text;
+using MailFathom.Cli.Administration;
+using MailFathom.TestSupport;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>A deployment answering the contact routes, as the contact commands meet one without a server.</summary>
+/// <remarks>
+/// Each route is answered from a body the caller scripted, because what these commands are about is what they send and
+/// what they print: an amendment is a read followed by a write, so the double has to answer both and record the second
+/// for the test to read.
+/// </remarks>
+internal static class FakeContactDeployment
+{
+    /// <summary>The identity every scripted contact carries, so a test names one contact in one place.</summary>
+    internal static readonly Guid ContactIdentity = new("11111111-2222-3333-4444-555555555555");
+
+    /// <summary>Builds a deployment answering the contact routes with the bodies given.</summary>
+    /// <param name="lookup">What a read of one contact answers, or <see langword="null" /> to answer that the book holds none.</param>
+    /// <param name="write">What a write answers, or <see langword="null" /> where the test asks for none.</param>
+    /// <param name="page">What a listing answers, or <see langword="null" /> where the test asks for none.</param>
+    /// <param name="erasure">What an erasure answers, or <see langword="null" /> where the test asks for none.</param>
+    /// <param name="export">What an export answers, or <see langword="null" /> where the test asks for none.</param>
+    /// <returns>The deployment.</returns>
+    /// <remarks>
+    /// The session route is answered unconditionally, because every command settles the two versions there before its
+    /// own operation and a double serving the contact routes alone would report a deployment nothing can be
+    /// administered on.
+    /// </remarks>
+    internal static FakeHttpMessageHandler Holding(
+        string? lookup = null,
+        string? write = null,
+        string? page = null,
+        string? erasure = null,
+        string? export = null) =>
+        new((request, _) => Task.FromResult(Answer(request, lookup, write, page, erasure, export)));
+
+    /// <summary>Writes the body a read of one contact answers with.</summary>
+    /// <param name="displayName">The name the contact carries.</param>
+    /// <param name="addresses">The addresses it holds, the preferred one first.</param>
+    /// <param name="origin">How the contact came to be in the book.</param>
+    /// <param name="note">What the owner wrote about the person, or <see langword="null" /> for none.</param>
+    /// <returns>The response body.</returns>
+    internal static string Lookup(
+        string displayName = "Anna Kowalska",
+        string[]? addresses = null,
+        string origin = "Asserted",
+        string? note = null) =>
+        $$"""{"contact":{{Contact(displayName, addresses, origin, note)}}}""";
+
+    /// <summary>Writes the body a write answers with when the book performed it.</summary>
+    /// <param name="displayName">The name the written record carries.</param>
+    /// <param name="addresses">The addresses it holds, the preferred one first.</param>
+    /// <param name="origin">How the contact came to be in the book.</param>
+    /// <returns>The response body.</returns>
+    internal static string Written(
+        string displayName = "Anna Kowalska",
+        string[]? addresses = null,
+        string origin = "Asserted") =>
+        $$"""{"outcome":"Written","contact":{{Contact(displayName, addresses, origin, note: null)}}}""";
+
+    /// <summary>Writes the body a write answers with when an outcome refused it.</summary>
+    /// <param name="outcome">The outcome that refused the write.</param>
+    /// <param name="addressHolder">The contact holding a claimed address, where that is what refused it.</param>
+    /// <returns>The response body.</returns>
+    internal static string Refused(string outcome, Guid? addressHolder = null) => addressHolder is { } holder
+        ? $$"""{"outcome":"{{outcome}}","contact":null,"addressHolder":"{{holder:D}}"}"""
+        : $$"""{"outcome":"{{outcome}}","contact":null,"addressHolder":null}""";
+
+    /// <summary>Writes the body a listing answers with.</summary>
+    /// <param name="nextCursor">The cursor the following page is asked with, or <see langword="null" /> at the end of the book.</param>
+    /// <param name="names">The names the page's contacts carry, in the order they are served.</param>
+    /// <returns>The response body.</returns>
+    internal static string Page(string? nextCursor, params string[] names)
+    {
+        var contacts = string.Join(
+            ',',
+            names.Select((name, position) => Contact(
+                name,
+                [$"person{position.ToString(CultureInfo.InvariantCulture)}@example.test"],
+                "Asserted",
+                note: null,
+                identity: new Guid(position + 1, 0, 0, [0, 0, 0, 0, 0, 0, 0, 1]))));
+
+        var cursor = nextCursor is null ? "null" : $"\"{nextCursor}\"";
+
+        return $$"""{"contacts":[{{contacts}}],"nextCursor":{{cursor}}}""";
+    }
+
+    /// <summary>Writes the body an erasure answers with.</summary>
+    /// <param name="wasHeld">Whether the book held the contact when the erasure ran.</param>
+    /// <param name="addressesErased">How many addresses went with the person.</param>
+    /// <returns>The response body.</returns>
+    internal static string Erasure(bool wasHeld, int addressesErased) => string.Create(
+        CultureInfo.InvariantCulture,
+        $$"""{"contact":"{{ContactIdentity:D}}","wasHeld":{{(wasHeld ? "true" : "false")}},"addressesErased":{{addressesErased}}}""");
+
+    /// <summary>Writes the body an export answers with.</summary>
+    /// <param name="displayName">The name the exported record carries.</param>
+    /// <returns>The response body.</returns>
+    internal static string Export(string displayName = "Anna Kowalska") =>
+        $$"""{"contact":{{Contact(displayName, addresses: null, "Asserted", note: null)}},"producedAt":"2026-08-16T09:00:00+00:00"}""";
+
+    /// <summary>Reports the body of the write the command last sent.</summary>
+    /// <param name="deployment">The deployment the command was pointed at.</param>
+    /// <returns>The request body, or <see langword="null" /> where no write was sent.</returns>
+    internal static string? LastWriteRequest(this FakeHttpMessageHandler deployment)
+    {
+        ArgumentNullException.ThrowIfNull(deployment);
+
+        return deployment.RecordedRequests
+            .LastOrDefault(request => request.Method == HttpMethod.Post || request.Method == HttpMethod.Put)?
+            .ContentAsUtf8String();
+    }
+
+    /// <summary>Reports how many requests the command sent to the contact routes.</summary>
+    /// <param name="deployment">The deployment the command was pointed at.</param>
+    /// <param name="method">The verb to count.</param>
+    /// <returns>The number of such requests.</returns>
+    internal static int ContactRequestCount(this FakeHttpMessageHandler deployment, HttpMethod method)
+    {
+        ArgumentNullException.ThrowIfNull(deployment);
+
+        return deployment.RecordedRequests.Count(request =>
+            request.Method == method
+            && request.RequestUri?.AbsolutePath.StartsWith(AdminEndpointRoutes.ContactsPath, StringComparison.Ordinal) == true);
+    }
+
+    /// <summary>Reports the query the command last listed the book with.</summary>
+    /// <param name="deployment">The deployment the command was pointed at.</param>
+    /// <returns>The query string, or <see langword="null" /> where no listing was asked for.</returns>
+    internal static string? LastListingQuery(this FakeHttpMessageHandler deployment)
+    {
+        ArgumentNullException.ThrowIfNull(deployment);
+
+        return deployment.RecordedRequests
+            .LastOrDefault(request =>
+                request.Method == HttpMethod.Get
+                && request.RequestUri?.AbsolutePath == AdminEndpointRoutes.ContactsPath)?
+            .RequestUri?.Query;
+    }
+
+    private static string Contact(
+        string displayName,
+        string[]? addresses,
+        string origin,
+        string? note,
+        Guid? identity = null)
+    {
+        var held = addresses ?? ["anna@example.test"];
+        var written = string.Join(',', held.Select(address => $"\"{address}\""));
+        var recorded = note is null ? "null" : $"\"{note}\"";
+
+        return $$"""
+                 {"id":"{{identity ?? ContactIdentity:D}}","displayName":"{{displayName}}","addresses":[{{written}}],"preferredAddress":"{{held[0]}}","note":{{recorded}},"origin":"{{origin}}","recordedAt":"2026-08-01T10:00:00+00:00","amendedAt":"2026-08-02T11:00:00+00:00"}
+                 """;
+    }
+
+    private static HttpResponseMessage Answer(
+        HttpRequestMessage request,
+        string? lookup,
+        string? write,
+        string? page,
+        string? erasure,
+        string? export)
+    {
+        var path = request.RequestUri?.AbsolutePath;
+
+        if (path == AdminEndpointRoutes.SessionPath)
+        {
+            return Json(
+                HttpStatusCode.OK,
+                FakeAdminEndpoint.SessionBody("workstation", FakeAdminEndpoint.CommandVersion));
+        }
+
+        if (path == AdminEndpointRoutes.ContactsPath)
+        {
+            return request.Method == HttpMethod.Get
+                ? Json(HttpStatusCode.OK, page ?? Page(nextCursor: null))
+                : Json(HttpStatusCode.OK, write ?? Written());
+        }
+
+        if (path == AdminEndpointRoutes.ContactByAddressPath)
+        {
+            return Json(HttpStatusCode.OK, lookup ?? """{"contact":null}""");
+        }
+
+        if (path?.EndsWith("/export", StringComparison.Ordinal) == true)
+        {
+            return Json(HttpStatusCode.OK, export ?? """{"contact":null,"producedAt":null}""");
+        }
+
+        if (path?.EndsWith("/promotion", StringComparison.Ordinal) == true)
+        {
+            return Json(HttpStatusCode.OK, write ?? Written());
+        }
+
+        if (path?.StartsWith(AdminEndpointRoutes.ContactsPath, StringComparison.Ordinal) == true)
+        {
+            if (request.Method == HttpMethod.Delete)
+            {
+                return Json(HttpStatusCode.OK, erasure ?? Erasure(wasHeld: true, addressesErased: 1));
+            }
+
+            return request.Method == HttpMethod.Get
+                ? Json(HttpStatusCode.OK, lookup ?? """{"contact":null}""")
+                : Json(HttpStatusCode.OK, write ?? Written());
+        }
+
+        return Json(HttpStatusCode.NotFound, string.Empty);
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) => new(status)
+    {
+        Content = new StringContent(body, Encoding.UTF8, "application/json"),
+    };
+}

--- a/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.Application.Accounts;
 using MailFathom.Application.AiProviders;
+using MailFathom.Application.Contacts;
 using MailFathom.Application.Emails.Embeddings.Administration;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generations;
@@ -105,9 +106,19 @@ public sealed class AdminApiEndpointsTests
 
         // The activation path, the rule-run path, the classification-run path, and the rewind path each appear twice,
         // because each is one resource read with a get and performed with a post, and both verbs are mapped separately.
+        // The contact-book paths appear twice and three times for the same reason: the book is listed and written to at
+        // one path, and one contact is read, amended, and erased at another.
         Assert.Equal(
             [
                 $"{AdminEndpointOptions.RoutePrefix}{MailAnsweringAuditEndpoint.Route}",
+                $"{AdminEndpointOptions.RoutePrefix}{ContactEndpoints.ContactsRoute}",
+                $"{AdminEndpointOptions.RoutePrefix}{ContactEndpoints.ContactsRoute}",
+                $"{AdminEndpointOptions.RoutePrefix}{ContactEndpoints.ContactByAddressRoute}",
+                $"{AdminEndpointOptions.RoutePrefix}{ContactEndpoints.ContactRoute}",
+                $"{AdminEndpointOptions.RoutePrefix}{ContactEndpoints.ContactRoute}",
+                $"{AdminEndpointOptions.RoutePrefix}{ContactEndpoints.ContactRoute}",
+                $"{AdminEndpointOptions.RoutePrefix}{ContactEndpoints.ContactExportRoute}",
+                $"{AdminEndpointOptions.RoutePrefix}{ContactEndpoints.ContactPromotionRoute}",
                 $"{AdminEndpointOptions.RoutePrefix}{EmbeddingProfileEndpoints.StatusRoute}",
                 $"{AdminEndpointOptions.RoutePrefix}{EmbeddingProfileEndpoints.ActivationRoute}",
                 $"{AdminEndpointOptions.RoutePrefix}{EmbeddingProfileEndpoints.ActivationRoute}",
@@ -191,6 +202,7 @@ public sealed class AdminApiEndpointsTests
         services.AddScoped(_ => Substitute.For<IMailAccountCatalog>());
         services.AddScoped(_ => Substitute.For<IMailboxMutationAuditEntryStore>());
         RegisterEmbeddingAdministration(services);
+        RegisterContactBook(services);
 
         return new TestEndpointRouteBuilder(services.BuildServiceProvider());
     }
@@ -235,5 +247,27 @@ public sealed class AdminApiEndpointsTests
             vectorIndex,
             retryPolicy,
             backfillSchedule));
+    }
+
+    /// <summary>Places what the contact routes resolve, for the reason the embedding registrations exist.</summary>
+    /// <remarks>
+    /// The book is a sealed class over application ports, so it is constructed here rather than substituted; the
+    /// directory is a port and is. Neither is invoked, because no request is made — what this exists for is that a route
+    /// whose parameters cannot be placed is refused at build time and would disappear from the assertions above.
+    /// </remarks>
+    private static void RegisterContactBook(IServiceCollection services)
+    {
+        var directory = Substitute.For<IContactDirectory>();
+        var timeProvider = new FakeTimeProvider();
+
+        services.AddScoped(_ => directory);
+        services.AddScoped(_ => new ContactBook(
+            Substitute.For<IContactStore>(),
+            directory,
+            new OptimisticConcurrencyRetryPolicy(
+                Substitute.For<IPersistenceSessionFactory>(),
+                new PersistenceConcurrencyOptions(),
+                timeProvider),
+            timeProvider));
     }
 }

--- a/tests/Host.UnitTests/Api/ContactEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/ContactEndpointsTests.cs
@@ -1,0 +1,480 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Contacts;
+using MailFathom.Application.Persistence;
+using MailFathom.Domain.Contacts;
+using MailFathom.Domain.Emails;
+using MailFathom.Host.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Time.Testing;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Api;
+
+/// <summary>Covers what the contact routes admit, what they refuse, and what a refusal is allowed to say.</summary>
+/// <remarks>
+/// <para>
+/// The book's own rules are covered against <c>ContactBook</c> and the domain, and are not repeated here. What these
+/// routes decide is the part above it: which request is a request at all, which origin a write from this surface acts
+/// under, and how an answer is shaped for a caller — including the two cases where the honest answer is that the book
+/// holds nobody rather than that the resource is missing.
+/// </para>
+/// <para>
+/// Every refusal is asserted for what it does <em>not</em> carry as much as for what it says. A name, an address, and a
+/// note are personal data about a third party, and a problem document is the one part of an answer that a proxy log, a
+/// trace, and a scripted caller's captured error all keep.
+/// </para>
+/// </remarks>
+public sealed class ContactEndpointsTests
+{
+    private static readonly Guid Identity = new("11111111-2222-3333-4444-555555555555");
+
+    private readonly IContactStore store = Substitute.For<IContactStore>();
+    private readonly IContactDirectory directory = Substitute.For<IContactDirectory>();
+    private readonly FakeTimeProvider clock = new(new DateTimeOffset(2026, 8, 16, 9, 0, 0, TimeSpan.Zero));
+
+    /// <summary>
+    /// The deployment's half of an agreement with a command it cannot reference. <c>mfctl</c> composes these paths from
+    /// constants of its own, and a rename on either side compiles cleanly while every contact command reaches a 404 that
+    /// reads exactly like an endpoint nobody enabled.
+    /// </summary>
+    [Fact]
+    public void ContactRoutes_AreThePathsTheCommandComposes()
+    {
+        Assert.Equal("/contacts", ContactEndpoints.ContactsRoute);
+        Assert.Equal("/contacts/by-address", ContactEndpoints.ContactByAddressRoute);
+        Assert.Equal("/contacts/{contactId:guid}", ContactEndpoints.ContactRoute);
+        Assert.Equal("/contacts/{contactId:guid}/promotion", ContactEndpoints.ContactPromotionRoute);
+        Assert.Equal("/contacts/{contactId:guid}/export", ContactEndpoints.ContactExportRoute);
+    }
+
+    /// <summary>A write from this surface is the owner writing somebody down, which is what makes it amendable here.</summary>
+    [Fact]
+    public async Task RecordAsync_ARecordTheBookAdmits_WritesItAsAContactTheOwnerAsserted()
+    {
+        // Arrange
+        this.HoldsNoAddresses();
+
+        // Act
+        var result = await ContactEndpoints.RecordAsync(
+            new ContactRecordRequest("Anna Kowalska", ["anna@example.test"], "anna@example.test", Note: null),
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var written = Assert.IsType<Ok<ContactWriteResponse>>(result.Result);
+        Assert.Equal(nameof(ContactWriteOutcome.Written), written.Value!.Outcome);
+        Assert.Equal(nameof(ContactOrigin.Asserted), written.Value.Contact!.Origin);
+
+        await this.store.Received(1).AddAsync(
+            Arg.Any<IPersistenceSession>(),
+            Arg.Is<Contact>(contact => contact != null && contact.Origin == ContactOrigin.Asserted),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>An amendment from this surface asks under the same origin, so a collected record is refused rather than taken.</summary>
+    [Fact]
+    public async Task AmendAsync_AContactTheDeploymentCollected_IsRefusedByItsOriginRatherThanWritten()
+    {
+        // Arrange
+        this.Holds(Collected("Anna Kowalska", "anna@example.test"));
+
+        // Act
+        var result = await ContactEndpoints.AmendAsync(
+            Identity,
+            new ContactRecordRequest("Anna Nowak", ["anna@example.test"], "anna@example.test", Note: null),
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var amended = Assert.IsType<Ok<ContactWriteResponse>>(result.Result);
+        Assert.Equal(nameof(ContactWriteOutcome.OriginRefusesWriter), amended.Value!.Outcome);
+
+        await this.store.DidNotReceive().ReplaceAsync(
+            Arg.Any<IPersistenceSession>(),
+            Arg.Any<Contact>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Each rule a record can break is named, and none of the answers repeats what broke it.</summary>
+    /// <remarks>
+    /// The cases are written as the wire's own values rather than as request objects, because the request type is
+    /// internal to the composition root and a public theory signature cannot carry it. Lengths are named as multiples of
+    /// the bounds the domain publishes, so a bound that moves moves these with it.
+    /// </remarks>
+    [Theory]
+    [InlineData("", "anna@example.test", "anna@example.test", null, "names no display name")]
+    [InlineData("Anna Kowalska", "", "", null, "at least one address")]
+    [InlineData("Anna Kowalska", "not an address", "not an address", null, "not a usable address")]
+    [InlineData("Anna Kowalska", "anna@example.test", "other@example.test", null, "one of the addresses the contact holds")]
+    [InlineData("Anna Kowalska", "anna@example.test", "", null, "names no usable preferred address")]
+    [InlineData("Anna\u200BKowalska", "anna@example.test", "anna@example.test", null, "carry no glyph of their own")]
+    public async Task RecordAsync_ARecordBreakingOneOfTheBooksRules_RefusesWithoutEchoingThePerson(
+        string displayName,
+        string address,
+        string preferredAddress,
+        string? note,
+        string expectedFragment)
+    {
+        // Arrange
+        this.HoldsNoAddresses();
+
+        // Act
+        var result = await ContactEndpoints.RecordAsync(
+            new ContactRecordRequest(
+                displayName,
+                address.Length == 0 ? [] : [address],
+                preferredAddress,
+                note),
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await this.AssertRefusedWithoutWriting(result, expectedFragment);
+    }
+
+    /// <summary>The two bounds a record can exceed, named by the constants the domain publishes rather than by a literal.</summary>
+    [Fact]
+    public async Task RecordAsync_ANameOrANoteBeyondItsBound_RefusesNamingTheBound()
+    {
+        // Arrange
+        this.HoldsNoAddresses();
+
+        // Act
+        var longName = await ContactEndpoints.RecordAsync(
+            new ContactRecordRequest(
+                new string('A', ContactDisplayName.MaximumLength + 1),
+                ["anna@example.test"],
+                "anna@example.test",
+                Note: null),
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        var longNote = await ContactEndpoints.RecordAsync(
+            new ContactRecordRequest(
+                "Anna Kowalska",
+                ["anna@example.test"],
+                "anna@example.test",
+                new string('n', ContactNote.MaximumLength + 1)),
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await this.AssertRefusedWithoutWriting(longName, "A contact name cannot be longer than");
+        await this.AssertRefusedWithoutWriting(longNote, "A contact note cannot be longer than");
+    }
+
+    /// <summary>A body the caller sent nothing in is refused rather than read as a record of blanks.</summary>
+    [Fact]
+    public async Task RecordAsync_ARequestCarryingNoRecord_RefusesWithoutWriting()
+    {
+        // Act
+        var result = await ContactEndpoints.RecordAsync(
+            request: null,
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await this.AssertRefusedWithoutWriting(result, "carries no contact record");
+    }
+
+    /// <summary>More addresses than one person may be recorded as using is refused before the domain sees them.</summary>
+    [Fact]
+    public async Task RecordAsync_MoreAddressesThanOneContactMayHold_RefusesNamingTheCeiling()
+    {
+        // Arrange
+        this.HoldsNoAddresses();
+
+        var addresses = Enumerable
+            .Range(0, Contact.MaximumAddressCount + 1)
+            .Select(position => $"person{position}@example.test")
+            .ToArray();
+
+        // Act
+        var result = await ContactEndpoints.RecordAsync(
+            new ContactRecordRequest("Anna Kowalska", addresses, addresses[0], Note: null),
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Contains(
+            Contact.MaximumAddressCount.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            refusal.ProblemDetails.Detail,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A book holding nobody is an outcome rather than a missing resource. Answering <c>404</c> would collide with what
+    /// every client already reads that as here — a port serving no administrative endpoint at all.
+    /// </summary>
+    [Fact]
+    public async Task FindAsync_AContactTheBookDoesNotHold_AnswersWithNoContactRatherThanNotFound()
+    {
+        // Arrange
+        this.directory.FindAsync(Arg.Any<ContactId>(), Arg.Any<CancellationToken>()).Returns((Contact?)null);
+
+        // Act
+        var result = await ContactEndpoints.FindAsync(
+            Identity,
+            this.directory,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var lookup = Assert.IsType<Ok<ContactLookupResponse>>(result.Result);
+        Assert.Null(lookup.Value!.Contact);
+    }
+
+    /// <summary>The one identifier a UUID route constraint still admits is refused rather than reaching a domain guard.</summary>
+    [Fact]
+    public async Task FindAsync_TheEmptyIdentifier_IsRefusedRatherThanReportedAsAFault()
+    {
+        // Act
+        var result = await ContactEndpoints.FindAsync(
+            Guid.Empty,
+            this.directory,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+
+        await this.directory.DidNotReceive().FindAsync(Arg.Any<ContactId>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>An address that is not one is refused without being written into the answer.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not an address")]
+    public async Task FindByAddressAsync_AValueThatIsNotAnAddress_RefusesWithoutRepeatingIt(string? address)
+    {
+        // Act
+        var result = await ContactEndpoints.FindByAddressAsync(
+            address,
+            this.directory,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        Assert.DoesNotContain("not an address", refusal.ProblemDetails.Detail!, StringComparison.Ordinal);
+    }
+
+    /// <summary>The listing is served the page the book read, with the cursor written as the opaque string a caller presents.</summary>
+    [Fact]
+    public async Task ListAsync_APageTheBookContinuesAfter_AnswersWithTheEncodedCursor()
+    {
+        // Arrange
+        var held = Asserted("Anna Kowalska", "anna@example.test");
+        var cursor = ContactCursor.After(held.DisplayName, held.Id);
+        this.directory.ReadPageAsync(Arg.Any<ContactQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new ContactPage([held], cursor));
+
+        // Act
+        var result = await ContactEndpoints.ListAsync(
+            origin: null,
+            pageSize: null,
+            cursor: null,
+            this.directory,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var page = Assert.IsType<Ok<ContactPageResponse>>(result.Result);
+        Assert.Equal(cursor.Encode(), page.Value!.NextCursor);
+        Assert.Equal("Anna Kowalska", Assert.Single(page.Value.Contacts).DisplayName);
+    }
+
+    /// <summary>The narrowing is read as the origin it names, and the query the book reads under carries it.</summary>
+    [Fact]
+    public async Task ListAsync_AnOriginNamedInAnyCasing_NarrowsTheQueryToIt()
+    {
+        // Arrange
+        this.directory.ReadPageAsync(Arg.Any<ContactQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new ContactPage([], NextCursor: null));
+
+        // Act
+        await ContactEndpoints.ListAsync(
+            "collected",
+            pageSize: null,
+            cursor: null,
+            this.directory,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await this.directory.Received(1).ReadPageAsync(
+            Arg.Is<ContactQuery>(query => query != null && query.Origin == ContactOrigin.Collected),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Each thing a listing can get wrong is refused rather than resolved into a page the caller did not ask for.</summary>
+    [Theory]
+    [InlineData("neither", null, null, "Asserted")]
+    [InlineData(null, 0, null, "between 1 and")]
+    [InlineData(null, 100_000, null, "between 1 and")]
+    [InlineData(null, null, "not-a-cursor-this-issued", "not one this deployment issued")]
+    public async Task ListAsync_ARequestTheBookCannotRead_RefusesNamingWhatToChange(
+        string? origin,
+        int? pageSize,
+        string? cursor,
+        string expectedFragment)
+    {
+        // Act
+        var result = await ContactEndpoints.ListAsync(
+            origin,
+            pageSize,
+            cursor,
+            this.directory,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        Assert.Contains(expectedFragment, refusal.ProblemDetails.Detail, StringComparison.Ordinal);
+
+        await this.directory.DidNotReceive().ReadPageAsync(Arg.Any<ContactQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>An erasure says what it removed, and says nothing about who it was.</summary>
+    [Fact]
+    public async Task EraseAsync_AContactTheBookHolds_AnswersWithTheCountsAndNothingAboutThePerson()
+    {
+        // Arrange
+        this.store.EraseAsync(Arg.Any<IPersistenceSession>(), Arg.Any<ContactId>(), Arg.Any<CancellationToken>())
+            .Returns(new ContactErasure(ContactId.Create(Identity), WasHeld: true, AddressesErased: 3));
+
+        // Act
+        var result = await ContactEndpoints.EraseAsync(
+            Identity,
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var erasure = Assert.IsType<Ok<ContactErasureResponse>>(result.Result);
+        Assert.Equal((Identity, true, 3), (
+            erasure.Value!.Contact,
+            erasure.Value.WasHeld,
+            erasure.Value.AddressesErased));
+    }
+
+    /// <summary>Exporting somebody the book does not hold produces no document rather than an empty one.</summary>
+    [Fact]
+    public async Task ExportAsync_AContactTheBookDoesNotHold_AnswersWithNeitherRecordNorInstant()
+    {
+        // Arrange
+        this.directory.FindAsync(Arg.Any<ContactId>(), Arg.Any<CancellationToken>()).Returns((Contact?)null);
+
+        // Act
+        var result = await ContactEndpoints.ExportAsync(
+            Identity,
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var export = Assert.IsType<Ok<ContactExportResponse>>(result.Result);
+        Assert.Null(export.Value!.Contact);
+        Assert.Null(export.Value.ProducedAt);
+    }
+
+    /// <summary>The export carries the whole record and the instant it was taken, which is what dates the answer.</summary>
+    [Fact]
+    public async Task ExportAsync_AContactTheBookHolds_AnswersWithTheCompleteRecordAndWhenItWasTaken()
+    {
+        // Arrange
+        this.Holds(Asserted("Anna Kowalska", "anna@example.test", "Met at the conference."));
+
+        // Act
+        var result = await ContactEndpoints.ExportAsync(
+            Identity,
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var export = Assert.IsType<Ok<ContactExportResponse>>(result.Result);
+        Assert.Equal("Anna Kowalska", export.Value!.Contact!.DisplayName);
+        Assert.Equal("Met at the conference.", export.Value.Contact.Note);
+        Assert.Equal(this.clock.GetUtcNow(), export.Value.ProducedAt);
+    }
+
+    private static Contact Asserted(string displayName, string address, string? note = null) =>
+        Build(displayName, address, ContactOrigin.Asserted, note);
+
+    private static Contact Collected(string displayName, string address) =>
+        Build(displayName, address, ContactOrigin.Collected, note: null);
+
+    private static Contact Build(string displayName, string address, ContactOrigin origin, string? note)
+    {
+        Assert.True(EmailAddress.TryCreate(displayName: null, address, out var mailbox));
+
+        return Contact.Create(
+            ContactId.Create(Identity),
+            ContactDisplayName.Create(displayName),
+            [mailbox],
+            mailbox,
+            note is null ? null : ContactNote.Create(note),
+            origin,
+            new DateTimeOffset(2026, 8, 1, 10, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 8, 2, 11, 0, 0, TimeSpan.Zero));
+    }
+
+    /// <summary>Asserts that a write was refused for the rule named, wrote nothing, and echoed nobody.</summary>
+    /// <remarks>
+    /// The two absences are the point as much as the sentence. A problem document is the part of an answer a proxy log,
+    /// a trace, and a scripted caller's captured error all keep, so a refusal naming the person it refused would put a
+    /// contact's own data everywhere a request went.
+    /// </remarks>
+    private async Task AssertRefusedWithoutWriting(
+        Results<Ok<ContactWriteResponse>, ProblemHttpResult> result,
+        string expectedFragment)
+    {
+        var refusal = Assert.IsType<ProblemHttpResult>(result.Result);
+
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        Assert.Contains(expectedFragment, refusal.ProblemDetails.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain("Anna", refusal.ProblemDetails.Detail!, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("example.test", refusal.ProblemDetails.Detail!, StringComparison.OrdinalIgnoreCase);
+
+        await this.store.DidNotReceive().AddAsync(
+            Arg.Any<IPersistenceSession>(),
+            Arg.Any<Contact>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private void Holds(Contact contact)
+    {
+        this.directory.FindAsync(Arg.Any<ContactId>(), Arg.Any<CancellationToken>()).Returns(contact);
+        this.HoldsNoAddresses();
+    }
+
+    /// <summary>States that no other contact claims the addresses a write is about, which is the ordinary case.</summary>
+    private void HoldsNoAddresses() =>
+        this.directory
+            .FindHoldersOfAsync(Arg.Any<IReadOnlyCollection<EmailAddress>>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<EmailAddress, ContactId>());
+
+    /// <summary>Builds the book the handlers write through, over substituted ports and a session that commits.</summary>
+    private ContactBook Book()
+    {
+        var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
+        sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
+
+        return new ContactBook(
+            this.store,
+            this.directory,
+            new OptimisticConcurrencyRetryPolicy(sessionFactory, new PersistenceConcurrencyOptions(), this.clock),
+            this.clock);
+    }
+
+    /// <summary>A session that commits whatever was staged in it, which is what a write's ordinary path needs.</summary>
+    private sealed class CommittingSession : IPersistenceSession
+    {
+        public Task<PersistenceCommitResult> CommitAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(PersistenceCommitResult.Committed);
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/IntegrationTests/Hosting/ComposedContactEndpointTests.cs
+++ b/tests/IntegrationTests/Hosting/ComposedContactEndpointTests.cs
@@ -1,0 +1,158 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using MailFathom.AppHost;
+using MailFathom.IntegrationTests.Orchestration;
+using Xunit;
+
+namespace MailFathom.IntegrationTests.Hosting;
+
+/// <summary>Proves that the contact routes are served, are behind the administrative credential, and reach the book.</summary>
+/// <remarks>
+/// <para>
+/// What only a composed host can establish is that these routes exist at all and inherit the group's requirement: the
+/// unit suite maps the group and reads its metadata, which says nothing about a process that never bound the listener
+/// or a route the composition dropped. The credential half is asserted the way
+/// <see cref="ComposedAdminEndpointSecurityTests" /> asserts it for the surface, because a book of identified third
+/// parties served to an unauthenticated caller is the failure this endpoint's placement exists to prevent.
+/// </para>
+/// <para>
+/// The round trip is the second thing nothing else reaches. Recording a person, reading them back by identity and by
+/// address, and erasing them exercises the store, the unique index over addresses, and the erasure's cascade through a
+/// real database — and it leaves the book as it found it, which is what lets it share the schema with everything else in
+/// the collection.
+/// </para>
+/// <para>
+/// Nothing here carries <c>[RequiresIntegrationCoverage]</c>, for the reason the two security suites beside it state:
+/// the classes exercised are either unit-covered already or belong to <c>Host</c>, which is outside the coverage
+/// denominator.
+/// </para>
+/// </remarks>
+[Collection(ComposedHostCollectionDefinition.Name)]
+public sealed class ComposedContactEndpointTests
+{
+    /// <summary>The route the book is listed and recorded at, which is the cheapest thing the group answers here.</summary>
+    private const string ContactsRoute = "/api/admin/contacts";
+
+    private readonly MailFathomOrchestrationFixture orchestration;
+
+    /// <summary>Initializes the tests against the assembly's orchestration.</summary>
+    /// <param name="orchestration">The orchestration fixture, which starts the host on first request.</param>
+    public ComposedContactEndpointTests(MailFathomOrchestrationFixture orchestration) =>
+        this.orchestration = orchestration;
+
+    /// <summary>
+    /// A contact book is the most concentrated personal data this deployment holds, so the listing being refused without
+    /// a credential is the claim this endpoint's placement rests on — and it is refused before any handler answers.
+    /// </summary>
+    [Fact]
+    public async Task ContactRoutes_ARequestCarryingNoCredential_AreRefusedBeforeTheBookIsRead()
+    {
+        // Arrange
+        using var client = await this.orchestration.OpenAdminEndpointClientAsync(TestContext.Current.CancellationToken);
+        using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(ContactsRoute, UriKind.Relative));
+
+        // Act
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("Bearer", Assert.Single(response.Headers.WwwAuthenticate).Scheme);
+        Assert.DoesNotContain(
+            "contacts",
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The whole path, once: the route is served, the record reaches PostgreSQL, both lookups answer from it, and the
+    /// erasure takes the person and their addresses away. One test rather than five, because each would otherwise pay
+    /// for the same composition — and because what it establishes is that they work together.
+    /// </summary>
+    [Fact]
+    public async Task ContactRoutes_ARecordedPerson_IsReadBackByIdentityAndAddressAndThenErased()
+    {
+        // Arrange
+        using var client = await this.orchestration.OpenAdminEndpointClientAsync(TestContext.Current.CancellationToken);
+
+        // An address of this test's own, so the book's uniqueness rule cannot collide with another class's contact.
+        var address = $"composed-contact-{Guid.NewGuid():N}@example.test";
+
+        // Act
+        using var recorded = await this.SendAsync(
+            client,
+            HttpMethod.Post,
+            ContactsRoute,
+            JsonContent.Create(new
+            {
+                displayName = "Composed Endpoint Contact",
+                addresses = new[] { address },
+                preferredAddress = address,
+                note = "Recorded by the composed-host suite.",
+            }));
+
+        Assert.Equal(HttpStatusCode.OK, recorded.StatusCode);
+
+        using var written = JsonDocument.Parse(
+            await recorded.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("Written", written.RootElement.GetProperty("outcome").GetString());
+
+        var identity = written.RootElement.GetProperty("contact").GetProperty("id").GetGuid();
+
+        using var byIdentity = await this.SendAsync(client, HttpMethod.Get, $"{ContactsRoute}/{identity:D}");
+        using var byAddress = await this.SendAsync(
+            client,
+            HttpMethod.Get,
+            $"{ContactsRoute}/by-address?address={Uri.EscapeDataString(address.ToUpperInvariant())}");
+        using var erased = await this.SendAsync(client, HttpMethod.Delete, $"{ContactsRoute}/{identity:D}");
+        using var afterwards = await this.SendAsync(client, HttpMethod.Get, $"{ContactsRoute}/{identity:D}");
+
+        // Assert
+        Assert.Equal(identity, await ContactIdentityOf(byIdentity));
+
+        // The lookup by address is asked in a casing the record was not written in, because two spellings of one address
+        // are one address everywhere in the book — including in the index the lookup is served from.
+        Assert.Equal(identity, await ContactIdentityOf(byAddress));
+
+        using var erasure = JsonDocument.Parse(
+            await erased.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.True(erasure.RootElement.GetProperty("wasHeld").GetBoolean());
+        Assert.Equal(1, erasure.RootElement.GetProperty("addressesErased").GetInt32());
+
+        using var gone = JsonDocument.Parse(
+            await afterwards.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(JsonValueKind.Null, gone.RootElement.GetProperty("contact").ValueKind);
+    }
+
+    /// <summary>Reads the identity a lookup answered with, failing the test where it answered with nobody.</summary>
+    private static async Task<Guid> ContactIdentityOf(HttpResponseMessage response)
+    {
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var lookup = JsonDocument.Parse(
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        return lookup.RootElement.GetProperty("contact").GetProperty("id").GetGuid();
+    }
+
+    /// <summary>Sends one credentialed request to the administrative endpoint.</summary>
+    private async Task<HttpResponseMessage> SendAsync(
+        HttpClient client,
+        HttpMethod method,
+        string route,
+        HttpContent? content = null)
+    {
+        using var request = new HttpRequestMessage(method, new Uri(route, UriKind.Relative)) { Content = content };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", OrchestrationContract.AdminApiKey);
+
+        return await client.SendAsync(request, TestContext.Current.CancellationToken);
+    }
+}


### PR DESCRIPTION
The contact book landed in #751 with a store, a domain, and both data-subject paths — and nothing that could reach any of them. This publishes it on the administrative endpoint and gives `mfctl` the command group that speaks to it, so erasing and exporting a person are commands an owner runs rather than seams something else was expected to reach one day.

Closes #752

## What the endpoint serves

Exactly what `ContactBook` does, and nothing invented beside it: record, amend, promote, erase, export, plus lookup by identity, lookup by address, and a bounded page of the book.

| Method | Route | What it does |
| --- | --- | --- |
| `GET` | `/admin/contacts` | A page of the book, narrowable to one origin, continued by a cursor |
| `POST` | `/admin/contacts` | Records a contact the owner asserts |
| `GET` | `/admin/contacts/by-address` | Who holds an address, matched on the book's own comparison form |
| `GET` | `/admin/contacts/{id}` | The record |
| `PUT` | `/admin/contacts/{id}` | Amends it, stating the whole record |
| `DELETE` | `/admin/contacts/{id}` | Erases the person and everything derived from them |
| `POST` | `/admin/contacts/{id}/promotion` | Takes responsibility for a collected contact |
| `GET` | `/admin/contacts/{id}/export` | Everything held about them, as of the instant it was taken |

A lookup that finds nobody answers `200` with a null contact rather than `404`, because `AdminApiClient` already reads `404` as "this port serves no administrative endpoint" and the two answers must not collide. `Guid.Empty` is refused at the boundary as `400` rather than reaching the domain as a `500`. A body is capped at 64 KiB and a page at 200 contacts.

**No refusal echoes a name, an address, or a note.** The contact's own identifier is what a failure names — it is the one part of the record that is not personal data — and a test asserts the refusal detail carries neither the name nor the domain it was given.

## The cursor

`ContactCursor` gains the wire form the listing needs: `version . identity . sort key`, base64url, refused above 2048 characters before anything decodes it. Identity comes before the sort key deliberately, because a display name may itself contain the separator and the split has to stop counting fields before it reaches one.

It carries a name's comparison form and travels in a query string, which was weighed rather than assumed: the ASP.NET Core OpenTelemetry instrumentation redacts `url.query` by default, log scopes are off, and the listing prints those same names to the operator's terminal anyway. The reasoning is written into `Encode`'s remarks.

## The command group

`mfctl contact` — `create`, `show`, `list`, `update`, `add-address`, `remove-address`, `promote`, `delete`, `export`.

The book takes the whole record, so `add-address` and `remove-address` are conveniences over that amendment rather than operations of their own: read, change, send. An amendment that would leave the record exactly as it is gets refused in the client instead of sent, because the book would merge the two spellings and answer that the write succeeded — telling an operator something was added when nothing was.

`delete` prints the record, asks, and only then erases; `--yes` skips the question and a non-interactive terminal without it is refused rather than assumed. It answers with the identity and how many addresses went with it, never with the person. `export` writes the document to stdout.

## Contracts

**No public surface breaks.** The administrative endpoint gains routes; no published permission name covers the contact book, so nothing an operator configured changes meaning, and the page says so rather than leaving a reader to infer it. No configuration key, database schema, or MCP tool contract is touched, and no migration is owed.

## Verification

- `scripts/verify-full.sh` — passed over exactly this content.
- `scripts/verify-fast.sh` — 7804 tests, 0 failed.
- `dotnet msbuild .config/CodeCoverage.proj -t:Collect` — 96.01% aggregate line coverage (23070/24029), required 85%.
- `scripts/review-obligations.sh` — every row read in the file it points at; none is a finding.

The integration suite gains `ComposedContactEndpointTests`, which walks record → read by identity → read by address in a different casing → erase → confirm gone against a composed host, and asserts the routes refuse an unauthenticated caller. It runs only when the owner dispatches it.
