### PR TITLE
[#908] Record what mfctl did in a local log beside its credentials

### DIFF
--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1327,24 +1327,32 @@ and `outcome` is `Completed`, `Failed`, or `Faulted` — the last meaning the in
 which is what a cancelled command and a defect both leave behind. A field the invocation has nothing for is left out
 rather than written as a null.
 
-**Nothing you typed is in it, and nothing the command printed is either.** The command is named from the parser rather
-than from your argument list, which is where an address, an account alias, a folder alias, a message identity and — for
-a sign-in — a credential are; and a contact, an address, or a subject a command showed you is the answer to that command
-rather than a fact about running it. This is exactly the file that gets pasted into a support conversation, so it holds
-only what is safe there.
+**No credential and no mail is in it.** A credential never reaches a failure message in the first place, because those
+are written to be shown on your terminal; and a contact, an address, or a subject a command printed for you is the
+answer to that command rather than a fact about running it, so none of it is offered to the log at all.
+
+**Your own deployment can be named in it.** `command` carries no argument value, but the other two fields are not blind
+to where a deployment is. `deployment` is your name for the profile, and a sign-in that passed no `--name` is named
+after the deployment's own host. `failure` is the line the command already printed, and several of those quote the
+address or the alias you typed — `Not signed in to https://…` is the common one. Scrubbing both was considered and
+rejected: this file sits beside `credentials.json`, which records every profile's endpoint in clear, so a log naming
+none of them would be protecting an address the same directory already holds, at the cost of the field you read the log
+for. Treat the file as you treat that directory, which is to say read it before you paste it anywhere.
 
 It is created readable by its owner alone, on the same terms and for the same reason the credential store is, and it is
 bounded at one mebibyte: past that the current file becomes `mfctl.log.1`, replacing whatever was there, and a new one
-starts — so the log occupies at most two mebibytes however long you administer a deployment for. There is no retention
-policy beyond that, because retention for files on your own machine is yours to decide rather than this command's.
+starts — so the log occupies at most two mebibytes however long you administer a deployment for. A recorded failure is
+bounded as well, so one record stays one line. There is no retention policy beyond that, because retention for files on
+your own machine is yours to decide rather than this command's.
 
 Turn it off for one invocation with `--no-log`, which is accepted after the subcommand as well, and for a shell session
 with `MAILFATHOM_LOG=off`. What you typed beats what your shell was told, and the default is on; every other value of
 the variable leaves the log on rather than failing a command over a typo in it.
 
-A record that cannot be written — a read-only home directory, a full disk, a directory that was removed — is reported as
-one line on standard error and changes nothing else. The command's exit code and its own output stay exactly what they
-would have been, because the command's job is the command.
+A record that cannot be written — a read-only home directory, a full disk — is reported as one line on standard error
+and changes nothing else. The command's exit code and its own output stay exactly what they would have been, because
+the command's job is the command. Deleting the directory is not one of those cases: every append recreates it, so
+removing the log is a way to start a new one rather than a way to turn it off.
 
 ## Troubleshooting
 

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1304,6 +1304,48 @@ your machine can read the key too, and on Linux nothing prevents that; the file 
 encryption answers the copy. Holding the credential in the platform's own secret service is tracked as
 [#318](https://github.com/Krzysztof318/MailFathom/issues/318).
 
+## What the command records about itself
+
+Every invocation appends one line to a log beside the credential store, and that file is the only durable record of
+what `mfctl` did. The command holds no exporter and opens no span, so once your terminal's scrollback is gone nothing
+else on the machine answers *what did I run against that deployment, when, and how did it end*.
+
+| Platform | Path |
+| --- | --- |
+| Linux | `$XDG_CONFIG_HOME/MailFathom/mfctl.log`, or `~/.config/MailFathom/mfctl.log` |
+| Windows | `%APPDATA%\MailFathom\mfctl.log` |
+
+One record per line, as JSON, so `tail`, `grep`, and `jq` each work on it without a parser that spans lines:
+
+```console
+$ tail -1 ~/.config/MailFathom/mfctl.log
+{"at":"2026-08-17T09:41:22.184+00:00","command":"mfctl contact delete","outcome":"Failed","durationMilliseconds":412,"exitCode":1,"deployment":"production","failure":"The deployment answered 404 rather than a contact."}
+```
+
+`command` is the path of names `mfctl` declares, `deployment` is your own name for the profile the command settled on,
+and `outcome` is `Completed`, `Failed`, or `Faulted` — the last meaning the invocation never reported an exit code,
+which is what a cancelled command and a defect both leave behind. A field the invocation has nothing for is left out
+rather than written as a null.
+
+**Nothing you typed is in it, and nothing the command printed is either.** The command is named from the parser rather
+than from your argument list, which is where an address, an account alias, a folder alias, a message identity and — for
+a sign-in — a credential are; and a contact, an address, or a subject a command showed you is the answer to that command
+rather than a fact about running it. This is exactly the file that gets pasted into a support conversation, so it holds
+only what is safe there.
+
+It is created readable by its owner alone, on the same terms and for the same reason the credential store is, and it is
+bounded at one mebibyte: past that the current file becomes `mfctl.log.1`, replacing whatever was there, and a new one
+starts — so the log occupies at most two mebibytes however long you administer a deployment for. There is no retention
+policy beyond that, because retention for files on your own machine is yours to decide rather than this command's.
+
+Turn it off for one invocation with `--no-log`, which is accepted after the subcommand as well, and for a shell session
+with `MAILFATHOM_LOG=off`. What you typed beats what your shell was told, and the default is on; every other value of
+the variable leaves the log on rather than failing a command over a typo in it.
+
+A record that cannot be written — a read-only home directory, a full disk, a directory that was removed — is reported as
+one line on standard error and changes nothing else. The command's exit code and its own output stay exactly what they
+would have been, because the command's job is the command.
+
 ## Troubleshooting
 
 | What you see | What it means |

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1363,9 +1363,10 @@ for. Treat the file as you treat that directory, which is to say read it before 
 
 It is created readable by its owner alone, on the same terms and for the same reason the credential store is, and it is
 bounded at one mebibyte: past that the current file becomes `mfctl.log.1`, replacing whatever was there, and a new one
-starts — so the log occupies at most two mebibytes however long you administer a deployment for. A recorded failure is
-bounded as well, so one record stays one line. There is no retention policy beyond that, because retention for files on
-your own machine is yours to decide rather than this command's.
+starts — so the log occupies at most two mebibytes however long you administer a deployment for. Every field of variable
+length is bounded as well — `failure`, `fault`, and the `deployment` name you chose — so one record stays one line.
+There is no retention policy beyond that, because retention for files on your own machine is yours to decide rather
+than this command's.
 
 Turn it off for one invocation with `--no-log`, which is accepted after the subcommand as well, and for a shell session
 with `MAILFATHOM_LOG=off`. What you typed beats what your shell was told, and the default is on; every other value of

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1347,10 +1347,10 @@ stopped it and not what it had done by then.
 
 **No credential and no mail is in it.** A credential never reaches a failure message in the first place, because those
 are written to be shown on your terminal. Mail is out by the split the command already keeps: what you asked for goes
-to standard output — a contact, an address, a subject — and only standard error is read back for `failure`, which is
-where a sentence written to be read beside a failing exit code goes. Those sentences already avoid naming a person, for
-the same reason the log exists: a refusal that named one would end up in a file wherever the command is run from a
-script.
+to standard output — a contact, an address, a subject — and `failure` is read back from the failure lines alone, which
+is narrower still than the stream carrying them: the guidance a command writes while it works and the cautions it
+raises are their own kinds and are passed over. Those failure sentences already avoid naming a person, for the same
+reason the log exists: a refusal that named one would end up in a file wherever the command is run from a script.
 
 **Your own deployment can be named in it.** `command` carries no argument value, but the other two fields are not blind
 to where a deployment is. `deployment` is your name for the profile, and a sign-in that passed no `--name` is named

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1332,12 +1332,18 @@ on. A field the invocation has nothing for is left out rather than written as a 
 | `Completed` | The command did what you asked | `exitCode` `0` |
 | `Failed` | Something you can act on, already printed to your terminal | `exitCode` `1`, and `failure` with that same line |
 | `Faulted` | The command raised something that is a defect rather than your mistake | `fault` with the type of it, and no exit code |
-| `Cancelled` | You stopped it before it finished | no exit code |
+| `Cancelled` | You stopped it before it finished, and it stopped where it was | no exit code |
 
 `fault` is the type's name and nothing else about it — not the message, which is written for whoever will fix the
 defect and quotes what the code was working on, and not the stack, which is frames rather than data but would end the
 one-record-per-line shape. The stack itself went to your terminal, so what the log adds is that the crash happened at
 all, when, under which command, and what kind it was.
+
+`folder erase` and `mailbox rederive` are the exception to the last row, and deliberately. Both work through a mailbox
+in passes, so an interruption leaves a partial result rather than nothing: each catches the interruption itself, tells
+you how much it got through and that running it again continues from there, and reports that as a failure. Their
+records read `Failed` with that sentence, which is the more useful of the two answers — `Cancelled` would say you
+stopped it and not what it had done by then.
 
 **No credential and no mail is in it.** A credential never reaches a failure message in the first place, because those
 are written to be shown on your terminal. Mail is out by the split the command already keeps: what you asked for goes

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1346,7 +1346,8 @@ answer to that command rather than a fact about running it, so none of it is off
 **Your own deployment can be named in it.** `command` carries no argument value, but the other two fields are not blind
 to where a deployment is. `deployment` is your name for the profile, and a sign-in that passed no `--name` is named
 after the deployment's own host. `failure` is the line the command already printed, and several of those quote the
-address or the alias you typed — `Not signed in to https://…` is the common one. Scrubbing both was considered and
+address or the alias you typed — `Not signed in to https://…` is the common one, and an invocation the parser refused
+outright carries whichever token it refused. Scrubbing both was considered and
 rejected: this file sits beside `credentials.json`, which records every profile's endpoint in clear, so a log naming
 none of them would be protecting an address the same directory already holds, at the cost of the field you read the log
 for. Treat the file as you treat that directory, which is to say read it before you paste it anywhere.

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1322,10 +1322,22 @@ $ tail -1 ~/.config/MailFathom/mfctl.log
 {"at":"2026-08-17T09:41:22.184+00:00","command":"mfctl contact delete","outcome":"Failed","durationMilliseconds":412,"exitCode":1,"deployment":"production","failure":"The deployment answered 404 rather than a contact."}
 ```
 
-`command` is the path of names `mfctl` declares, `deployment` is your own name for the profile the command settled on,
-and `outcome` is `Completed`, `Failed`, or `Faulted` — the last meaning the invocation never reported an exit code,
-which is what a cancelled command and a defect both leave behind. A field the invocation has nothing for is left out
-rather than written as a null.
+`command` is the path of names `mfctl` declares and `deployment` is your own name for the profile the command settled
+on. A field the invocation has nothing for is left out rather than written as a null.
+
+`outcome` is one of four, and the last two are what makes this file worth having when something goes wrong:
+
+| `outcome` | What happened | What else the record carries |
+| --- | --- | --- |
+| `Completed` | The command did what you asked | `exitCode` `0` |
+| `Failed` | Something you can act on, already printed to your terminal | `exitCode` `1`, and `failure` with that same line |
+| `Faulted` | The command raised something that is a defect rather than your mistake | `fault` with the type of it, and no exit code |
+| `Cancelled` | You stopped it before it finished | no exit code |
+
+`fault` is the type's name and nothing else about it — not the message, which is written for whoever will fix the
+defect and quotes what the code was working on, and not the stack, which is frames rather than data but would end the
+one-record-per-line shape. The stack itself went to your terminal, so what the log adds is that the crash happened at
+all, when, under which command, and what kind it was.
 
 **No credential and no mail is in it.** A credential never reaches a failure message in the first place, because those
 are written to be shown on your terminal; and a contact, an address, or a subject a command printed for you is the

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1340,8 +1340,11 @@ one-record-per-line shape. The stack itself went to your terminal, so what the l
 all, when, under which command, and what kind it was.
 
 **No credential and no mail is in it.** A credential never reaches a failure message in the first place, because those
-are written to be shown on your terminal; and a contact, an address, or a subject a command printed for you is the
-answer to that command rather than a fact about running it, so none of it is offered to the log at all.
+are written to be shown on your terminal. Mail is out by the split the command already keeps: what you asked for goes
+to standard output — a contact, an address, a subject — and only standard error is read back for `failure`, which is
+where a sentence written to be read beside a failing exit code goes. Those sentences already avoid naming a person, for
+the same reason the log exists: a refusal that named one would end up in a file wherever the command is run from a
+script.
 
 **Your own deployment can be named in it.** `command` carries no argument value, but the other two fields are not blind
 to where a deployment is. `deployment` is your name for the profile, and a sign-in that passed no `--name` is named

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -701,8 +701,14 @@ to a file beside its credential store. Neither is a telemetry signal and neither
 answer to the command, read by the person who typed it, and the second is the only durable record that the command ran
 at all, which is what an operator has left once the scrollback is gone. [What the command records about
 itself](admin-endpoint.md#what-the-command-records-about-itself) states the path, the fields, and the two ways to turn
-it off. It is held to the rule below as strictly as an exported signal is, for a reason that has nothing to do with a
-collector: that file is exactly the one that gets pasted into a support conversation.
+it off.
+
+That file is held to the half of the rule below that is about disclosure and not to the half that is about a collector,
+and the difference is worth being exact about. No credential and no mail reaches it, exactly as here. A deployment's own
+address does — through the operator's name for a profile, and through a failure line quoting what they typed — which
+this page forbids in every signal above. What makes that sound there and not here is the boundary each one crosses: an
+exported signal leaves the machine for a store somebody else may read, and this file stays in the operator's own
+directory beside a credential store that already records every profile's endpoint in clear.
 
 ## What no signal carries, and what holds every signal to it
 

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -1,6 +1,6 @@
 # Telemetry and the Aspire dashboard
 
-<!-- describes: src/Application/Observability/**, src/Common/Observability/**, src/Host/Observability/**, src/Host/ServiceDefaultsExtensions.cs, src/Host/Hosting/Workers/**, src/Infrastructure/Observability/**, src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, src/Infrastructure/HostApplicationBuilderExtensions.cs, src/Mcp/Observability/**, src/AppHost/**, src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs -->
+<!-- describes: src/Application/Observability/**, src/Common/Observability/**, src/Host/Observability/**, src/Host/ServiceDefaultsExtensions.cs, src/Host/Hosting/Workers/**, src/Infrastructure/Observability/**, src/Infrastructure/Mail/MailKit/MailKitImapClientFactory.cs, src/Infrastructure/HostApplicationBuilderExtensions.cs, src/Mcp/Observability/**, src/Cli/Diagnostics/**, src/AppHost/**, src/AI/ProviderAdapters/OpenAiCompatibleClientFactory.cs -->
 
 The host instruments itself with OpenTelemetry throughout — logs, metrics, and traces — and exports none of it unless
 the environment names a destination. Today exactly one environment does that out of the box: a local run under the
@@ -696,8 +696,13 @@ listener in a binary published trimmed and self-contained for the sake of holdin
 traces an operator correlates by time is the cheaper answer, and the deployment's own spans are the ones that carry
 what the act actually did.
 
-What the command writes instead is its own output, to the terminal the operator ran it in. That is not a telemetry
-signal and is not collected anywhere; it is the answer to the command, read by the person who typed it.
+What the command writes instead is its own output, to the terminal the operator ran it in, and one line per invocation
+to a file beside its credential store. Neither is a telemetry signal and neither is collected anywhere: the first is the
+answer to the command, read by the person who typed it, and the second is the only durable record that the command ran
+at all, which is what an operator has left once the scrollback is gone. [What the command records about
+itself](admin-endpoint.md#what-the-command-records-about-itself) states the path, the fields, and the two ways to turn
+it off. It is held to the rule below as strictly as an exported signal is, for a reason that has nothing to do with a
+collector: that file is exactly the one that gets pasted into a support conversation.
 
 ## What no signal carries, and what holds every signal to it
 

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -170,6 +170,18 @@ Every command exits `0` when it did what you asked and `1` when it did not, havi
 first. [The troubleshooting table](../operations/admin-endpoint.md#troubleshooting) reads each message back to you as
 a cause.
 
+Each invocation also leaves a line in `~/.config/MailFathom/mfctl.log` — what ran, against which of your profiles, how
+long it took, and how it ended — so a command you ran yesterday is still answerable today once the scrollback is gone:
+
+```console
+$ tail -3 ~/.config/MailFathom/mfctl.log | jq -r '"\(.at) \(.command) \(.outcome)"'
+```
+
+It records nothing you typed and nothing a command printed, it is bounded so it cannot fill a disk, and `--no-log`
+leaves it out for one invocation. [What the command records about
+itself](../operations/admin-endpoint.md#what-the-command-records-about-itself) has the path on each platform, the
+fields, and the switch that turns it off for a whole session.
+
 ## Authorizing a mailbox
 
 A mailbox at a provider that no longer accepts a password — a Google Workspace account, anything on Exchange Online —

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -177,10 +177,11 @@ long it took, and how it ended — so a command you ran yesterday is still answe
 $ tail -3 ~/.config/MailFathom/mfctl.log | jq -r '"\(.at) \(.command) \(.outcome)"'
 ```
 
-It records nothing you typed and nothing a command printed, it is bounded so it cannot fill a disk, and `--no-log`
-leaves it out for one invocation. [What the command records about
-itself](../operations/admin-endpoint.md#what-the-command-records-about-itself) has the path on each platform, the
-fields, and the switch that turns it off for a whole session.
+No credential and no mail goes into it, it is bounded so it cannot fill a disk, and `--no-log` leaves one invocation
+out. What it does name is your own deployment — the profile, and the address where a failure message quoted the one you
+typed — so read it before you paste it anywhere, the way you would the credentials file beside it. [What the command
+records about itself](../operations/admin-endpoint.md#what-the-command-records-about-itself) has the path on each
+platform, every field, and the switch that turns it off for a whole session.
 
 ## Authorizing a mailbox
 

--- a/src/Cli/Administration/DeploymentAccess.cs
+++ b/src/Cli/Administration/DeploymentAccess.cs
@@ -4,6 +4,7 @@
 
 using MailFathom.Cli.Authorization;
 using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Diagnostics;
 using MailFathom.Cli.Transport;
 
 namespace MailFathom.Cli.Administration;
@@ -32,16 +33,25 @@ internal sealed class DeploymentAccess
     private readonly CredentialStore store;
     private readonly Func<Uri, StoredTransportTrust, DeploymentTransport> openTransport;
     private readonly TimeProvider timeProvider;
+    private readonly CliInvocationRecord? invocation;
 
     /// <summary>Initializes access over the store, the transport, and the clock a command was given.</summary>
     /// <param name="store">Where the profiles live.</param>
     /// <param name="openTransport">Opens a transport aimed at one address; this type disposes what it opens.</param>
     /// <param name="timeProvider">Decides whether the stored access token is still usable.</param>
-    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <param name="invocation">What this invocation is recording, so its log line names the deployment acted on; <see langword="null" /> records nothing.</param>
+    /// <exception cref="ArgumentNullException">Thrown when an argument other than <paramref name="invocation" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// This is the one place that knows which deployment a command settled on, because settling it is what this type
+    /// does — the option, the environment variable, and the stored default are reconciled here and nowhere else. That
+    /// is why the record is threaded to here rather than read off the argument list, where the answer would be absent
+    /// for every invocation that relied on the default.
+    /// </remarks>
     internal DeploymentAccess(
         CredentialStore store,
         Func<Uri, StoredTransportTrust, DeploymentTransport> openTransport,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        CliInvocationRecord? invocation = null)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(openTransport);
@@ -50,6 +60,7 @@ internal sealed class DeploymentAccess
         this.store = store;
         this.openTransport = openTransport;
         this.timeProvider = timeProvider;
+        this.invocation = invocation;
     }
 
     /// <summary>Settles which deployment a command acts on, renewing its access token when the stored one is spent.</summary>
@@ -60,6 +71,8 @@ internal sealed class DeploymentAccess
     internal async Task<SignedInProfile> ReachAsync(string? requestedDeployment, CancellationToken cancellationToken)
     {
         var profile = this.store.Resolve(requestedDeployment);
+
+        this.invocation?.ReachedDeployment(profile.Name);
 
         if (profile.KeyPair is { } keyPair)
         {

--- a/src/Cli/CliContext.cs
+++ b/src/Cli/CliContext.cs
@@ -24,6 +24,7 @@ namespace MailFathom.Cli;
 /// <param name="OpenBrowser">Opens an address in this machine's browser, reporting whether the attempt was made.</param>
 /// <param name="Clock">Decides whether a stored access token is still usable, and paces a device sign-in's polling.</param>
 /// <param name="Log">Where the record of this invocation is appended, or <see langword="null" /> to keep none — which is what a test not about the log wants.</param>
+/// <param name="ReadEnvironmentVariable">Reads a variable of the shell the command was run from, or <see langword="null" /> for the process's own environment.</param>
 internal sealed record CliContext(
     ICliConsole Console,
     CredentialStore Store,
@@ -31,7 +32,8 @@ internal sealed record CliContext(
     Func<Uri, IMailboxRedirectAwaiter> AwaitRedirect,
     Func<Uri, bool> OpenBrowser,
     TimeProvider Clock,
-    ICliInvocationLog? Log = null)
+    ICliInvocationLog? Log = null,
+    Func<string, string?>? ReadEnvironmentVariable = null)
 {
     /// <summary>Gets what this invocation turns out to have done, filled in by the layers that each know part of it.</summary>
     /// <remarks>
@@ -40,6 +42,22 @@ internal sealed record CliContext(
     /// contexts for equality.
     /// </remarks>
     internal CliInvocationRecord Invocation { get; } = new(Clock);
+
+    /// <summary>Reads a variable of the shell this invocation was run from.</summary>
+    /// <param name="name">The variable's name.</param>
+    /// <returns>Its value, or <see langword="null" /> when it is unset.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="name" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A seam rather than a direct read, because the process environment is shared by every test in an assembly that
+    /// runs them in parallel: a test asserting what an invocation recorded would otherwise depend on whether the shell
+    /// that started the run had turned the log off — which is a thing the documentation tells operators to do.
+    /// </remarks>
+    internal string? Variable(string name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+
+        return this.ReadEnvironmentVariable is { } read ? read(name) : Environment.GetEnvironmentVariable(name);
+    }
 
     /// <summary>Builds the context the command runs under in production.</summary>
     /// <returns>The context.</returns>

--- a/src/Cli/CliContext.cs
+++ b/src/Cli/CliContext.cs
@@ -38,8 +38,10 @@ internal sealed record CliContext(
     /// <summary>Gets what this invocation turns out to have done, filled in by the layers that each know part of it.</summary>
     /// <remarks>
     /// Timed from here rather than from the runner, so what is recorded is how long the operator waited rather than how
-    /// long the parsed command took. It is the one mutable thing this record holds, which is why nothing compares two
-    /// contexts for equality.
+    /// long the parsed command took. It is the one mutable thing this record holds, and it joins the synthesized
+    /// equality like every other field — so two contexts are never equal, whatever they were built from. Nothing
+    /// compares them, and there is no way to exclude it short of not storing it: a record's <c>Equals</c> reads the
+    /// instance fields, so moving this behind a private one would change where it is written and not what is compared.
     /// </remarks>
     internal CliInvocationRecord Invocation { get; } = new(Clock);
 

--- a/src/Cli/CliContext.cs
+++ b/src/Cli/CliContext.cs
@@ -5,6 +5,7 @@
 using MailFathom.Cli.Administration;
 using MailFathom.Cli.Authorization;
 using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Diagnostics;
 using MailFathom.Cli.Transport;
 
 namespace MailFathom.Cli;
@@ -22,14 +23,24 @@ namespace MailFathom.Cli;
 /// <param name="AwaitRedirect">Binds the loopback address an authorization redirect arrives at; the caller disposes it.</param>
 /// <param name="OpenBrowser">Opens an address in this machine's browser, reporting whether the attempt was made.</param>
 /// <param name="Clock">Decides whether a stored access token is still usable, and paces a device sign-in's polling.</param>
+/// <param name="Log">Where the record of this invocation is appended, or <see langword="null" /> to keep none — which is what a test not about the log wants.</param>
 internal sealed record CliContext(
     ICliConsole Console,
     CredentialStore Store,
     Func<Uri, StoredTransportTrust, DeploymentTransport> OpenTransport,
     Func<Uri, IMailboxRedirectAwaiter> AwaitRedirect,
     Func<Uri, bool> OpenBrowser,
-    TimeProvider Clock)
+    TimeProvider Clock,
+    ICliInvocationLog? Log = null)
 {
+    /// <summary>Gets what this invocation turns out to have done, filled in by the layers that each know part of it.</summary>
+    /// <remarks>
+    /// Timed from here rather than from the runner, so what is recorded is how long the operator waited rather than how
+    /// long the parsed command took. It is the one mutable thing this record holds, which is why nothing compares two
+    /// contexts for equality.
+    /// </remarks>
+    internal CliInvocationRecord Invocation { get; } = new(Clock);
+
     /// <summary>Builds the context the command runs under in production.</summary>
     /// <returns>The context.</returns>
     internal static CliContext ForTerminal() => new(
@@ -38,11 +49,12 @@ internal sealed record CliContext(
         DeploymentTransport.Open,
         redirectUri => new LoopbackRedirectAwaiter(redirectUri),
         WebBrowserLauncher.TryOpen,
-        TimeProvider.System);
+        TimeProvider.System,
+        new FileCliInvocationLog(FileCliInvocationLog.DefaultPath()));
 
     /// <summary>Reaches the deployment a command acts on, renewing a spent access token on the way.</summary>
     /// <returns>The access seam every command that sends a request goes through.</returns>
-    internal DeploymentAccess Deployment() => new(this.Store, this.OpenTransport, this.Clock);
+    internal DeploymentAccess Deployment() => new(this.Store, this.OpenTransport, this.Clock, this.Invocation);
 
     /// <summary>Opens a transport aimed at an address no profile has accepted anything about.</summary>
     /// <param name="address">The address, which is an authorization server rather than a deployment.</param>

--- a/src/Cli/CliContext.cs
+++ b/src/Cli/CliContext.cs
@@ -37,11 +37,19 @@ internal sealed record CliContext(
 {
     /// <summary>Gets what this invocation turns out to have done, filled in by the layers that each know part of it.</summary>
     /// <remarks>
+    /// <para>
     /// Timed from here rather than from the runner, so what is recorded is how long the operator waited rather than how
-    /// long the parsed command took. It is the one mutable thing this record holds, and it joins the synthesized
-    /// equality like every other field — so two contexts are never equal, whatever they were built from. Nothing
-    /// compares them, and there is no way to exclude it short of not storing it: a record's <c>Equals</c> reads the
-    /// instance fields, so moving this behind a private one would change where it is written and not what is compared.
+    /// long the parsed command took. A <c>with</c> expression keeps the same one rather than starting a second: the
+    /// initializer runs in the constructor and a record's copy constructor copies the field instead of running it, which
+    /// is what lets <see cref="CliRunner" /> swap the console for one that watches it without splitting the record in
+    /// two.
+    /// </para>
+    /// <para>
+    /// It is the one mutable thing this record holds, and it joins the synthesized equality like every other field — so
+    /// two contexts are never equal, whatever they were built from. Nothing compares them, and there is no way to
+    /// exclude it short of not storing it: a record's <c>Equals</c> reads the instance fields, so moving this behind a
+    /// private one would change where it is written and not what is compared.
+    /// </para>
     /// </remarks>
     internal CliInvocationRecord Invocation { get; } = new(Clock);
 

--- a/src/Cli/CliOptions.cs
+++ b/src/Cli/CliOptions.cs
@@ -50,20 +50,13 @@ internal static class CliOptions
 
     /// <summary>Decides whether this invocation is recorded in the local log.</summary>
     /// <param name="parseResult">What the operator typed, parsed.</param>
-    /// <returns><see langword="true" /> when the invocation is recorded.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="parseResult" /> is <see langword="null" />.</exception>
-    internal static bool RecordsInvocation(ParseResult parseResult) =>
-        RecordsInvocation(parseResult, Environment.GetEnvironmentVariable(LogVariable));
-
-    /// <summary>Decides whether this invocation is recorded, against a stated value of the variable.</summary>
-    /// <param name="parseResult">What the operator typed, parsed.</param>
     /// <param name="logVariable">What <see cref="LogVariable" /> holds, or <see langword="null" /> when it is unset.</param>
     /// <returns><see langword="true" /> when the invocation is recorded.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="parseResult" /> is <see langword="null" />.</exception>
     /// <remarks>
     /// The same order every other input here follows: what an operator typed beats what their shell was told, and the
-    /// default is on. The variable is a parameter rather than read here so that the order can be asserted without a
-    /// test writing to the process environment, which every other test in the suite shares.
+    /// default is on. The variable is a parameter rather than read here, so that neither this nor a test driving a whole
+    /// invocation depends on the process environment every test in an assembly shares.
     /// </remarks>
     internal static bool RecordsInvocation(ParseResult parseResult, string? logVariable)
     {

--- a/src/Cli/CliOptions.cs
+++ b/src/Cli/CliOptions.cs
@@ -24,6 +24,55 @@ internal static class CliOptions
     /// <summary>The environment variable naming the deployment, so a shell can state it once for a session.</summary>
     internal const string EndpointVariable = "MAILFATHOM_ENDPOINT";
 
+    /// <summary>The environment variable that turns the invocation log off for a shell session.</summary>
+    internal const string LogVariable = "MAILFATHOM_LOG";
+
+    /// <summary>The one value of <see cref="LogVariable" /> that means anything.</summary>
+    /// <remarks>
+    /// Every other value, including an empty one, leaves the log on. A variable that failed an invocation over a typo
+    /// would make a diagnostic aid something that can break a command, and a variable with several spellings for
+    /// <c>off</c> is one an operator has to remember the accepted list of.
+    /// </remarks>
+    internal const string LogOff = "off";
+
+    /// <summary>The name of the option that turns the invocation log off for one invocation.</summary>
+    /// <remarks>Named as a constant because the value is read back by name rather than through the instance, which is what lets the option be built per command tree like every other one here.</remarks>
+    internal const string NoLogName = "--no-log";
+
+    /// <summary>Builds the option that turns the invocation log off for one invocation.</summary>
+    /// <returns>The option.</returns>
+    /// <remarks>Recursive, so that it is accepted after the subcommand as well — which is where an operator reaching for it will type it.</remarks>
+    internal static Option<bool> NoLog() => new(NoLogName)
+    {
+        Description = $"Do not record this invocation in the local log. A shell turns it off for a session with ${LogVariable}={LogOff}.",
+        Recursive = true,
+    };
+
+    /// <summary>Decides whether this invocation is recorded in the local log.</summary>
+    /// <param name="parseResult">What the operator typed, parsed.</param>
+    /// <returns><see langword="true" /> when the invocation is recorded.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="parseResult" /> is <see langword="null" />.</exception>
+    internal static bool RecordsInvocation(ParseResult parseResult) =>
+        RecordsInvocation(parseResult, Environment.GetEnvironmentVariable(LogVariable));
+
+    /// <summary>Decides whether this invocation is recorded, against a stated value of the variable.</summary>
+    /// <param name="parseResult">What the operator typed, parsed.</param>
+    /// <param name="logVariable">What <see cref="LogVariable" /> holds, or <see langword="null" /> when it is unset.</param>
+    /// <returns><see langword="true" /> when the invocation is recorded.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="parseResult" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The same order every other input here follows: what an operator typed beats what their shell was told, and the
+    /// default is on. The variable is a parameter rather than read here so that the order can be asserted without a
+    /// test writing to the process environment, which every other test in the suite shares.
+    /// </remarks>
+    internal static bool RecordsInvocation(ParseResult parseResult, string? logVariable)
+    {
+        ArgumentNullException.ThrowIfNull(parseResult);
+
+        return !parseResult.GetValue<bool>(NoLogName)
+            && !StringComparer.OrdinalIgnoreCase.Equals(logVariable, LogOff);
+    }
+
     /// <summary>Builds the option naming which deployment to reach.</summary>
     /// <returns>The option.</returns>
     internal static Option<string?> Endpoint() => new("--endpoint")

--- a/src/Cli/CliRunner.cs
+++ b/src/Cli/CliRunner.cs
@@ -3,7 +3,9 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using MailFathom.Cli.Commands;
+using MailFathom.Cli.Diagnostics;
 
 namespace MailFathom.Cli;
 
@@ -22,9 +24,16 @@ internal static class CliRunner
     /// <returns>The exit code the process reports.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> or <paramref name="args" /> is <see langword="null" />.</exception>
     /// <remarks>
+    /// <para>
     /// A <see cref="CliFailure" /> is reported as one line rather than as a stack trace, because every failure of that
     /// kind is something the operator can act on. Anything else propagates, because a stack trace is the right answer
     /// to a defect.
+    /// </para>
+    /// <para>
+    /// However the invocation ends, it is recorded in the local log, which is why the append is in a <c>finally</c>
+    /// rather than beside each <c>return</c>: an invocation that faulted or was cancelled is the one an operator most
+    /// wants a line for afterwards, and it reaches neither of the two paths that report an exit code.
+    /// </para>
     /// </remarks>
     internal static async Task<int> RunAsync(
         CliContext context,
@@ -38,16 +47,78 @@ internal static class CliRunner
         // before this method sees it. What an operator should read for a refused credential is one line, and deciding
         // that is this method's job rather than the parser's.
         var invocation = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+        var parseResult = CliRootCommand.Create(context).Parse(args);
+        var command = CommandPathOf(parseResult);
+
+        CliInvocationEntry? entry = null;
 
         try
         {
-            return await CliRootCommand.Create(context).Parse(args).InvokeAsync(invocation, cancellationToken);
+            var exitCode = await parseResult.InvokeAsync(invocation, cancellationToken);
+
+            entry = context.Invocation.Ended(command, exitCode, failure: null);
+
+            return exitCode;
         }
         catch (CliFailure failure)
         {
             context.Console.WriteError(failure.Message);
 
+            entry = context.Invocation.Ended(command, CliExitCode.Failure, failure.Message);
+
             return CliExitCode.Failure;
+        }
+        finally
+        {
+            Record(context, parseResult, entry ?? context.Invocation.Faulted(command));
+        }
+    }
+
+    /// <summary>Appends the invocation to the local log, unless this invocation asked for none.</summary>
+    /// <remarks>
+    /// A log that could not be written is said once and changes nothing else. The command's job is the command, so a
+    /// read-only home directory or a full disk must not turn an invocation that did what it was asked into one that
+    /// reports a failure — and an operator who is never told would go on believing there is a record to go back to.
+    /// </remarks>
+    private static void Record(CliContext context, ParseResult parseResult, CliInvocationEntry entry)
+    {
+        if (context.Log is not { } log || !CliOptions.RecordsInvocation(parseResult))
+        {
+            return;
+        }
+
+        if (!log.TryAppend(entry))
+        {
+            context.Console.WriteError($"This invocation could not be recorded in {log.Location}.");
+        }
+    }
+
+    /// <summary>Names the command that was invoked, as the path of declared names from the root down.</summary>
+    /// <remarks>
+    /// Read from the parse result rather than from the argument list, because an argument list is where a deployment
+    /// address, an account alias, a folder alias, a message identity and — for a sign-in — a credential are, and none
+    /// of that may reach a file. An unparsable invocation resolves to the root alone, which is the honest answer: no
+    /// subcommand ran.
+    /// </remarks>
+    private static string CommandPathOf(ParseResult parseResult) =>
+        string.Join(
+            ' ',
+            [CliRootCommand.CommandName, .. SubcommandNamesUpFrom(parseResult.CommandResult).Reverse()]);
+
+    /// <summary>Walks from the invoked command up to the root, naming each subcommand on the way.</summary>
+    /// <remarks>
+    /// The root itself is left out and supplied as the declared constant instead, because the parser names the root
+    /// after the running executable — which is the published binary's name on an operator's machine and the test host's
+    /// name under a test, and only one of those is a name this repository chose.
+    /// </remarks>
+    private static IEnumerable<string> SubcommandNamesUpFrom(SymbolResult? result)
+    {
+        for (var current = result; current is not null; current = current.Parent)
+        {
+            if (current is CommandResult { Parent: not null } command)
+            {
+                yield return command.Command.Name;
+            }
         }
     }
 }

--- a/src/Cli/CliRunner.cs
+++ b/src/Cli/CliRunner.cs
@@ -68,9 +68,26 @@ internal static class CliRunner
 
             return CliExitCode.Failure;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            entry = context.Invocation.Cancelled(command);
+
+            throw;
+        }
+        catch (Exception fault)
+        {
+            entry = context.Invocation.Faulted(command, fault);
+
+            throw;
+        }
         finally
         {
-            Record(context, parseResult, entry ?? context.Invocation.Faulted(command));
+            // Every path above closes the record, so the guard covers only a catch block that itself raised — writing
+            // the failure line to a terminal that has gone away. Nothing left to say about that invocation is true.
+            if (entry is { } closed)
+            {
+                Record(context, parseResult, closed);
+            }
         }
     }
 

--- a/src/Cli/CliRunner.cs
+++ b/src/Cli/CliRunner.cs
@@ -47,6 +47,15 @@ internal static class CliRunner
         // before this method sees it. What an operator should read for a refused credential is one line, and deciding
         // that is this method's job rather than the parser's.
         var invocation = new InvocationConfiguration { EnableDefaultExceptionHandler = false };
+
+        // The commands run against a terminal that remembers what they reported, because a dozen of them refuse by
+        // writing one sentence and returning a failing code rather than by raising. Copying the context keeps the
+        // record: a record's copy constructor copies the field the initializer filled instead of running it again, so
+        // the deployment a command notes is noted on the same one this method reads back.
+        var refusals = new RefusalWatchingConsole(context.Console);
+
+        context = context with { Console = refusals };
+
         var parseResult = CliRootCommand.Create(context).Parse(args);
         var command = CommandPathOf(parseResult);
 
@@ -56,7 +65,7 @@ internal static class CliRunner
         {
             var exitCode = await parseResult.InvokeAsync(invocation, cancellationToken);
 
-            entry = context.Invocation.Ended(command, exitCode, RefusalOf(parseResult, exitCode));
+            entry = context.Invocation.Ended(command, exitCode, RefusalOf(parseResult, refusals, exitCode));
 
             return exitCode;
         }
@@ -122,16 +131,27 @@ internal static class CliRunner
         }
     }
 
-    /// <summary>Reads back why the parser refused an invocation, for the record of one that raised nothing.</summary>
+    /// <summary>Reads back why an invocation failed, for the record of one that raised nothing.</summary>
     /// <remarks>
-    /// A parse error is reported by the library and returns a code rather than raising, so it reaches neither of the
-    /// paths that carry a message. Without this a refused invocation would be recorded as a failure with nothing said
-    /// about it, which is the one shape the log's own table promises never to have.
+    /// <para>
+    /// Two kinds end that way and neither reaches the paths that carry a message. A parse error is reported by the
+    /// library and returns a code; and a command whose refusal is an ordinary outcome rather than a defect — a contact
+    /// the book does not hold, a confirmation declined — writes its own sentence and returns one. Without both, those
+    /// invocations would be recorded as failures with nothing said about them, which is the one shape the log's own
+    /// table promises never to have.
+    /// </para>
+    /// <para>
+    /// The parser's answer is preferred where there is one, because it names what it refused and the command never ran
+    /// to write anything. Nothing is read at all for an invocation that succeeded, so a command that reported something
+    /// on its way to doing what it was asked cannot leave a failure on the record of it.
+    /// </para>
     /// </remarks>
-    private static string? RefusalOf(ParseResult parseResult, int exitCode) =>
-        exitCode != CliExitCode.Success && parseResult.Errors.Count > 0
-            ? string.Join(' ', parseResult.Errors.Select(error => error.Message))
-            : null;
+    private static string? RefusalOf(ParseResult parseResult, RefusalWatchingConsole refusals, int exitCode) =>
+        exitCode == CliExitCode.Success
+            ? null
+            : parseResult.Errors.Count > 0
+                ? string.Join(' ', parseResult.Errors.Select(error => error.Message))
+                : refusals.LastRefusal;
 
     /// <summary>Names the command that was invoked, as the path of declared names from the root down.</summary>
     /// <remarks>

--- a/src/Cli/CliRunner.cs
+++ b/src/Cli/CliRunner.cs
@@ -82,7 +82,8 @@ internal static class CliRunner
     /// </remarks>
     private static void Record(CliContext context, ParseResult parseResult, CliInvocationEntry entry)
     {
-        if (context.Log is not { } log || !CliOptions.RecordsInvocation(parseResult))
+        if (context.Log is not { } log
+            || !CliOptions.RecordsInvocation(parseResult, context.Variable(CliOptions.LogVariable)))
         {
             return;
         }

--- a/src/Cli/CliRunner.cs
+++ b/src/Cli/CliRunner.cs
@@ -56,7 +56,7 @@ internal static class CliRunner
         {
             var exitCode = await parseResult.InvokeAsync(invocation, cancellationToken);
 
-            entry = context.Invocation.Ended(command, exitCode, failure: null);
+            entry = context.Invocation.Ended(command, exitCode, RefusalOf(parseResult, exitCode));
 
             return exitCode;
         }
@@ -105,11 +105,33 @@ internal static class CliRunner
             return;
         }
 
-        if (!log.TryAppend(entry))
+        if (log.TryAppend(entry))
+        {
+            return;
+        }
+
+        try
         {
             context.Console.WriteError($"This invocation could not be recorded in {log.Location}.");
         }
+        catch (IOException)
+        {
+            // The terminal this would have gone to has gone away. This method runs in the runner's finally, so raising
+            // here would replace the exit code or the exception the invocation was already reporting with a complaint
+            // about a log — which is the failure the whole seam is written to make impossible.
+        }
     }
+
+    /// <summary>Reads back why the parser refused an invocation, for the record of one that raised nothing.</summary>
+    /// <remarks>
+    /// A parse error is reported by the library and returns a code rather than raising, so it reaches neither of the
+    /// paths that carry a message. Without this a refused invocation would be recorded as a failure with nothing said
+    /// about it, which is the one shape the log's own table promises never to have.
+    /// </remarks>
+    private static string? RefusalOf(ParseResult parseResult, int exitCode) =>
+        exitCode != CliExitCode.Success && parseResult.Errors.Count > 0
+            ? string.Join(' ', parseResult.Errors.Select(error => error.Message))
+            : null;
 
     /// <summary>Names the command that was invoked, as the path of declared names from the root down.</summary>
     /// <remarks>

--- a/src/Cli/Commands/CliRootCommand.cs
+++ b/src/Cli/Commands/CliRootCommand.cs
@@ -121,8 +121,11 @@ internal static class CliRootCommand
             ExportContactCommand.Create(context),
         };
 
+        // The only option the root owns. It governs what the runner does once a command has finished rather than
+        // anything a command does, so it is declared once and made recursive rather than added to each of them.
         return new RootCommand($"MailFathom administration tool ({version.Version}).")
         {
+            CliOptions.NoLog(),
             LoginCommand.Create(context),
             LogoutCommand.Create(context),
             SwitchCommand.Create(context),

--- a/src/Cli/Commands/LoginCommand.cs
+++ b/src/Cli/Commands/LoginCommand.cs
@@ -181,6 +181,11 @@ internal static class LoginCommand
             keyPair,
             connection.Trust);
 
+        // Named here rather than by the access seam every other command goes through, because a sign-in establishes a
+        // profile instead of resolving one — so without this the command that gives a deployment its name is the one
+        // whose own record does not carry it.
+        context.Invocation.ReachedDeployment(profileName);
+
         context.Console.WriteLine(
             $"Signed in to {endpoint.GetLeftPart(UriPartial.Authority)} as '{credentialName}' (MailFathom {deploymentSession.Version}), saved as profile '{profileName}' and selected.{DescribeTransport(connection.Trust)}");
 

--- a/src/Cli/Credentials/CredentialStore.cs
+++ b/src/Cli/Credentials/CredentialStore.cs
@@ -44,17 +44,13 @@ internal sealed class CredentialStore
 
     /// <summary>Reports where the store lives for the operator running the command.</summary>
     /// <returns>The absolute path of the credentials file.</returns>
-    /// <remarks>
-    /// <see cref="Environment.SpecialFolder.ApplicationData" /> resolves to <c>$XDG_CONFIG_HOME</c> or
-    /// <c>~/.config</c> on Linux and to <c>%APPDATA%</c> on Windows, so one call gives the right per-user location on
-    /// both without a platform branch here.
-    /// </remarks>
-    internal static string DefaultPath() => Path.Combine(DefaultDirectory(), "credentials.json");
+    /// <remarks><see cref="OperatorDirectory" /> holds where that is on each platform, and why everything the command owns on a machine lives in one directory.</remarks>
+    internal static string DefaultPath() => Path.Combine(OperatorDirectory.Resolve(), "credentials.json");
 
     /// <summary>Reports where the key sealing the stored tokens lives.</summary>
     /// <returns>The absolute path of the key file.</returns>
     /// <remarks>Beside the store rather than inside it, so the file an operator might copy or paste into a support bundle is not the file that opens it.</remarks>
-    internal static string DefaultKeyPath() => Path.Combine(DefaultDirectory(), "credentials.key");
+    internal static string DefaultKeyPath() => Path.Combine(OperatorDirectory.Resolve(), "credentials.key");
 
     /// <summary>Reads every profile and which one is the default.</summary>
     /// <returns>The stored state, empty when the operator has never signed in.</returns>
@@ -350,10 +346,6 @@ internal sealed class CredentialStore
                 session.Resource,
                 session.Scope)
             : null;
-
-    private static string DefaultDirectory() => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify),
-        "MailFathom");
 
     /// <summary>Replaces the store with a new one, in a way an interrupted process cannot leave half written.</summary>
     /// <remarks>

--- a/src/Cli/Credentials/OwnerOnlyStorage.cs
+++ b/src/Cli/Credentials/OwnerOnlyStorage.cs
@@ -59,6 +59,32 @@ internal static class OwnerOnlyStorage
         return new FileStream(path, options);
     }
 
+    /// <summary>Opens a file for appending, creating it readable by its owner alone when it does not exist yet.</summary>
+    /// <param name="path">The file path.</param>
+    /// <returns>The stream, which the caller disposes.</returns>
+    /// <remarks>
+    /// Shared for reading and writing, unlike <see cref="OpenForWriting" />: two invocations of the command can end at
+    /// the same moment, and a lock that made the second one fail would lose a record to protect a file that appends
+    /// rather than rewrites. The mode is applied on creation only, so a file an operator deliberately widened stays
+    /// widened rather than being tightened under them on the next command.
+    /// </remarks>
+    internal static FileStream OpenForAppending(string path)
+    {
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.Append,
+            Access = FileAccess.Write,
+            Share = FileShare.ReadWrite,
+        };
+
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            options.UnixCreateMode = OwnerOnlyFile;
+        }
+
+        return new FileStream(path, options);
+    }
+
     /// <summary>Creates the directory a file lives in, when it names one.</summary>
     /// <param name="path">The file path.</param>
     internal static void CreateDirectoryFor(string path)

--- a/src/Cli/Diagnostics/CliInvocationEntry.cs
+++ b/src/Cli/Diagnostics/CliInvocationEntry.cs
@@ -9,10 +9,10 @@ namespace MailFathom.Cli.Diagnostics;
 /// <para>
 /// <strong>No credential and no mail reaches this type.</strong> That is the line, and it holds by construction rather
 /// than by filtering: a credential is never in a <see cref="CliFailure" /> message, because the failure rules forbid it
-/// there for the terminal's sake already, and nothing a command prints <em>as its own answer</em> is offered to this
-/// type at all — a contact, an address, a subject, or a message is what was asked for rather than a fact about the
-/// asking. The one thing printed that does reach here is the failure line, which <see cref="Failure" /> carries and the
-/// paragraph below is about.
+/// there for the terminal's sake already, and what a command prints <em>as its own answer</em> — a contact, an address,
+/// a subject, or a message — goes to standard output, which nothing here reads. What <see cref="Failure" /> carries is
+/// a line from standard error, where a sentence written to be read beside a failing exit code goes, and the paragraph
+/// below is about what those can name.
 /// </para>
 /// <para>
 /// <strong>The operator's own deployment can be named here, and is.</strong> <see cref="Command" /> is the path of

--- a/src/Cli/Diagnostics/CliInvocationEntry.cs
+++ b/src/Cli/Diagnostics/CliInvocationEntry.cs
@@ -9,8 +9,10 @@ namespace MailFathom.Cli.Diagnostics;
 /// <para>
 /// <strong>No credential and no mail reaches this type.</strong> That is the line, and it holds by construction rather
 /// than by filtering: a credential is never in a <see cref="CliFailure" /> message, because the failure rules forbid it
-/// there for the terminal's sake already, and nothing a command printed is offered to this type at all — a contact, an
-/// address, a subject, or a message is the answer to the command rather than a fact about running it.
+/// there for the terminal's sake already, and nothing a command prints <em>as its own answer</em> is offered to this
+/// type at all — a contact, an address, a subject, or a message is what was asked for rather than a fact about the
+/// asking. The one thing printed that does reach here is the failure line, which <see cref="Failure" /> carries and the
+/// paragraph below is about.
 /// </para>
 /// <para>
 /// <strong>The operator's own deployment can be named here, and is.</strong> <see cref="Command" /> is the path of

--- a/src/Cli/Diagnostics/CliInvocationEntry.cs
+++ b/src/Cli/Diagnostics/CliInvocationEntry.cs
@@ -1,0 +1,40 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Cli.Diagnostics;
+
+/// <summary>One line of the invocation log: what was run, against which deployment, and how it ended.</summary>
+/// <remarks>
+/// <para>
+/// <strong>Nothing the operator typed beyond a declared command name is here.</strong> An argument list is where a
+/// deployment address, an account alias, a folder alias, a message identity and — for a sign-in — a credential are, so
+/// <see cref="Command" /> is the path of names <c>mfctl</c> itself declares and no argument value reaches this type at
+/// all. Neither does any row the command printed: a contact, an address, a subject, or a message is the answer to the
+/// command rather than a fact about running it, and this file is exactly the one that gets pasted into a support
+/// conversation.
+/// </para>
+/// <para>
+/// <see cref="Deployment" /> is the operator's own name for a profile rather than the address behind it, which is what
+/// distinguishes two deployments to the person reading the log and says nothing about where either one is.
+/// </para>
+/// </remarks>
+/// <param name="At">When the invocation started.</param>
+/// <param name="Command">The command that ran, as the declared names from <c>mfctl</c> down.</param>
+/// <param name="Outcome">How it ended.</param>
+/// <param name="DurationMilliseconds">How long it took, from the process composing its context to the exit code being decided.</param>
+internal sealed record CliInvocationEntry(
+    DateTimeOffset At,
+    string Command,
+    CliInvocationOutcome Outcome,
+    long DurationMilliseconds)
+{
+    /// <summary>Gets the code the invocation reported, and <see langword="null" /> when it faulted before reporting one.</summary>
+    public int? ExitCode { get; init; }
+
+    /// <summary>Gets the operator's name for the deployment the command reached, and <see langword="null" /> when it reached none.</summary>
+    public string? Deployment { get; init; }
+
+    /// <summary>Gets the operator-readable failure the command printed, and <see langword="null" /> when it printed none.</summary>
+    public string? Failure { get; init; }
+}

--- a/src/Cli/Diagnostics/CliInvocationEntry.cs
+++ b/src/Cli/Diagnostics/CliInvocationEntry.cs
@@ -41,4 +41,14 @@ internal sealed record CliInvocationEntry(
 
     /// <summary>Gets the operator-readable failure the command printed, and <see langword="null" /> when it printed none.</summary>
     public string? Failure { get; init; }
+
+    /// <summary>Gets the type of what the command raised, and <see langword="null" /> when it raised nothing of that kind.</summary>
+    /// <remarks>
+    /// The type's name and neither its message nor its stack. A defect's message is written for whoever will fix it and
+    /// quotes what the code was working on, which for this command is mail; a stack is frames rather than data but ends
+    /// the one-record-per-line shape the log is read by. A type name is a class in an assembly and says what went wrong
+    /// without either — which is the whole of what a log can honestly offer about a crash whose stack the operator
+    /// already saw.
+    /// </remarks>
+    public string? Fault { get; init; }
 }

--- a/src/Cli/Diagnostics/CliInvocationEntry.cs
+++ b/src/Cli/Diagnostics/CliInvocationEntry.cs
@@ -11,8 +11,8 @@ namespace MailFathom.Cli.Diagnostics;
 /// than by filtering: a credential is never in a <see cref="CliFailure" /> message, because the failure rules forbid it
 /// there for the terminal's sake already, and what a command prints <em>as its own answer</em> — a contact, an address,
 /// a subject, or a message — goes to standard output, which nothing here reads. What <see cref="Failure" /> carries is
-/// a line from standard error, where a sentence written to be read beside a failing exit code goes, and the paragraph
-/// below is about what those can name.
+/// a line the command reported as a failure, which is narrower still than the stream that carries it: guidance and a
+/// caution are their own kinds and are passed over. The paragraph below is about what a failure line can name.
 /// </para>
 /// <para>
 /// <strong>The operator's own deployment can be named here, and is.</strong> <see cref="Command" /> is the path of

--- a/src/Cli/Diagnostics/CliInvocationEntry.cs
+++ b/src/Cli/Diagnostics/CliInvocationEntry.cs
@@ -7,16 +7,20 @@ namespace MailFathom.Cli.Diagnostics;
 /// <summary>One line of the invocation log: what was run, against which deployment, and how it ended.</summary>
 /// <remarks>
 /// <para>
-/// <strong>Nothing the operator typed beyond a declared command name is here.</strong> An argument list is where a
-/// deployment address, an account alias, a folder alias, a message identity and — for a sign-in — a credential are, so
-/// <see cref="Command" /> is the path of names <c>mfctl</c> itself declares and no argument value reaches this type at
-/// all. Neither does any row the command printed: a contact, an address, a subject, or a message is the answer to the
-/// command rather than a fact about running it, and this file is exactly the one that gets pasted into a support
-/// conversation.
+/// <strong>No credential and no mail reaches this type.</strong> That is the line, and it holds by construction rather
+/// than by filtering: a credential is never in a <see cref="CliFailure" /> message, because the failure rules forbid it
+/// there for the terminal's sake already, and nothing a command printed is offered to this type at all — a contact, an
+/// address, a subject, or a message is the answer to the command rather than a fact about running it.
 /// </para>
 /// <para>
-/// <see cref="Deployment" /> is the operator's own name for a profile rather than the address behind it, which is what
-/// distinguishes two deployments to the person reading the log and says nothing about where either one is.
+/// <strong>The operator's own deployment can be named here, and is.</strong> <see cref="Command" /> is the path of
+/// names <c>mfctl</c> declares and carries no argument value, but the other two fields are not blind to where a
+/// deployment is: <see cref="Deployment" /> is the operator's name for a profile, which for a sign-in that passed no
+/// <c>--name</c> is the deployment's own host; and <see cref="Failure" /> is the line the command already printed to
+/// the terminal, which for several failures quotes the address or the alias that was typed. Scrubbing them was
+/// considered and rejected — the file sits beside a credential store that records every profile's endpoint in clear, so
+/// a log that named none of them would be protecting an address the directory it lives in already holds, at the cost of
+/// the field an operator reads the log for.
 /// </para>
 /// </remarks>
 /// <param name="At">When the invocation started.</param>

--- a/src/Cli/Diagnostics/CliInvocationLogJsonContext.cs
+++ b/src/Cli/Diagnostics/CliInvocationLogJsonContext.cs
@@ -1,0 +1,22 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text.Json.Serialization;
+
+namespace MailFathom.Cli.Diagnostics;
+
+/// <summary>The serialization contract the invocation log is written through.</summary>
+/// <remarks>
+/// Its own context rather than an entry in <see cref="CliJsonContext" />, because the two want opposite formatting.
+/// Everything that context serializes is read by a person or sent to a deployment and is indented for it; a log is one
+/// record per line, so that <c>tail</c>, <c>grep</c>, and <c>jq</c> each work on it without a parser that spans lines.
+/// Source-generated for the same reason every other contract here is: the published binary is trimmed.
+/// </remarks>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true,
+    WriteIndented = false)]
+[JsonSerializable(typeof(CliInvocationEntry))]
+internal sealed partial class CliInvocationLogJsonContext : JsonSerializerContext;

--- a/src/Cli/Diagnostics/CliInvocationOutcome.cs
+++ b/src/Cli/Diagnostics/CliInvocationOutcome.cs
@@ -18,6 +18,13 @@ internal enum CliInvocationOutcome
     /// <summary>The command ran and reported a failure the operator can act on.</summary>
     Failed = 1,
 
-    /// <summary>The command did not finish: it was cancelled, or it raised something that is a defect rather than an operator's mistake.</summary>
+    /// <summary>The command raised something that is a defect rather than an operator's mistake, and never reported a code.</summary>
     Faulted = 2,
+
+    /// <summary>The operator stopped the command before it finished.</summary>
+    /// <remarks>
+    /// Told apart from <see cref="Faulted" /> rather than folded into it, because the two read identically in a log and
+    /// mean opposite things: one is somebody pressing Ctrl+C and the other is this command being wrong.
+    /// </remarks>
+    Cancelled = 3,
 }

--- a/src/Cli/Diagnostics/CliInvocationOutcome.cs
+++ b/src/Cli/Diagnostics/CliInvocationOutcome.cs
@@ -1,0 +1,23 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Cli.Diagnostics;
+
+/// <summary>How one invocation of the command ended.</summary>
+/// <remarks>
+/// Recorded beside the exit code rather than derived from it, because the third value has no exit code to derive it
+/// from: an invocation that faulted never reported one, and a reader who saw only an absent number would have to guess
+/// whether the command failed or the record did.
+/// </remarks>
+internal enum CliInvocationOutcome
+{
+    /// <summary>The command ran and reported success.</summary>
+    Completed = 0,
+
+    /// <summary>The command ran and reported a failure the operator can act on.</summary>
+    Failed = 1,
+
+    /// <summary>The command did not finish: it was cancelled, or it raised something that is a defect rather than an operator's mistake.</summary>
+    Faulted = 2,
+}

--- a/src/Cli/Diagnostics/CliInvocationRecord.cs
+++ b/src/Cli/Diagnostics/CliInvocationRecord.cs
@@ -19,11 +19,13 @@ namespace MailFathom.Cli.Diagnostics;
 /// </remarks>
 internal sealed class CliInvocationRecord
 {
-    /// <summary>The greatest length a recorded failure may have, so one line of the log stays one line of it.</summary>
+    /// <summary>The greatest length any recorded text may have, so one line of the log stays one line of it.</summary>
     /// <remarks>
-    /// Every failure this records is a sentence written for an operator to read, so the ceiling is far above what any
-    /// of them reaches. It exists because a log is appended to on every invocation and nothing else bounds what a
-    /// message could grow into.
+    /// Every value this records is written for an operator to read — a failure sentence, a type's name, a profile name
+    /// they chose — so the ceiling is far above what any of them reaches. It exists because a log is appended to on
+    /// every invocation and nothing else bounds what a value could grow into: a message is composed rather than
+    /// declared, a closed generic type's name carries its arguments recursively, and a profile name is refused only for
+    /// being blank or for parsing as an address.
     /// </remarks>
     internal const int MaximumFailureLength = 512;
 
@@ -94,25 +96,25 @@ internal sealed class CliInvocationRecord
     /// <remarks>Its own ending rather than a fault, because Ctrl+C is the operator doing something deliberate and a log that read it as a crash would send somebody looking for one.</remarks>
     internal CliInvocationEntry Cancelled(string command) => this.Entry(command, CliInvocationOutcome.Cancelled);
 
-    /// <summary>Cuts a failure to the ceiling without splitting a character in half.</summary>
+    /// <summary>Cuts a recorded value to the ceiling without splitting a character in half.</summary>
     /// <remarks>
-    /// A message can carry an alias or a profile name an operator chose, so a character outside the basic plane can
+    /// A value can carry an alias or a profile name an operator chose, so a character outside the basic plane can
     /// straddle the ceiling — and cutting between the two halves of a surrogate pair leaves a string that is not valid
     /// UTF-16. The JSON writer refuses one outright, which would put an exception into the append that runs in the
     /// runner's <c>finally</c> and mask whatever the invocation was already reporting.
     /// </remarks>
-    private static string? Bounded(string? failure)
+    private static string? Bounded(string? value)
     {
-        if (failure is not { Length: > MaximumFailureLength })
+        if (value is not { Length: > MaximumFailureLength })
         {
-            return failure;
+            return value;
         }
 
-        var length = char.IsHighSurrogate(failure[MaximumFailureLength - 1])
+        var length = char.IsHighSurrogate(value[MaximumFailureLength - 1])
             ? MaximumFailureLength - 1
             : MaximumFailureLength;
 
-        return failure[..length];
+        return value[..length];
     }
 
     private CliInvocationEntry Entry(string command, CliInvocationOutcome outcome) => new(
@@ -121,6 +123,8 @@ internal sealed class CliInvocationRecord
         outcome,
         (long)this.clock.GetElapsedTime(this.startedTimestamp).TotalMilliseconds)
     {
-        Deployment = this.Deployment,
+        // Bounded like the other two, and for the reason neither of them shows: this one is the operator's own text
+        // rather than the command's, and a profile name is refused only for being blank or for parsing as an address.
+        Deployment = Bounded(this.Deployment),
     };
 }

--- a/src/Cli/Diagnostics/CliInvocationRecord.cs
+++ b/src/Cli/Diagnostics/CliInvocationRecord.cs
@@ -1,0 +1,90 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Cli.Diagnostics;
+
+/// <summary>Collects what one invocation turns out to have done, across the layers that each know part of it.</summary>
+/// <remarks>
+/// <para>
+/// Mutable, and deliberately so: the runner knows which command was named and what it exited with, and only the access
+/// seam knows which deployment was reached. Neither can produce the whole line, and threading a return value up through
+/// every command for the sake of one field would put the log into signatures that have nothing to do with it.
+/// </para>
+/// <para>
+/// It starts timing as the context is composed rather than as the parser finishes, so a slow invocation is slow by the
+/// measure the operator experienced. The elapsed time comes from <see cref="TimeProvider.GetTimestamp" /> rather than
+/// from subtracting two wall-clock readings, so a clock adjusted mid-command cannot produce a negative duration.
+/// </para>
+/// </remarks>
+internal sealed class CliInvocationRecord
+{
+    /// <summary>The greatest length a recorded failure may have, so one line of the log stays one line of it.</summary>
+    /// <remarks>
+    /// Every failure this records is a sentence written for an operator to read, so the ceiling is far above what any
+    /// of them reaches. It exists because a log is appended to on every invocation and nothing else bounds what a
+    /// message could grow into.
+    /// </remarks>
+    internal const int MaximumFailureLength = 512;
+
+    private readonly TimeProvider clock;
+    private readonly DateTimeOffset startedAt;
+    private readonly long startedTimestamp;
+
+    /// <summary>Starts a record, timing from now.</summary>
+    /// <param name="clock">What the start and the elapsed time are read from.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="clock" /> is <see langword="null" />.</exception>
+    internal CliInvocationRecord(TimeProvider clock)
+    {
+        ArgumentNullException.ThrowIfNull(clock);
+
+        this.clock = clock;
+        this.startedAt = clock.GetUtcNow();
+        this.startedTimestamp = clock.GetTimestamp();
+    }
+
+    private string? Deployment { get; set; }
+
+    /// <summary>Notes which deployment the command settled on, once it has one.</summary>
+    /// <param name="profileName">The operator's own name for the deployment.</param>
+    /// <remarks>
+    /// The last one wins, which is the right answer for the one command that reaches two: a sign-in talks to an
+    /// authorization server before it talks to the deployment, and the deployment is what the invocation was about.
+    /// </remarks>
+    internal void ReachedDeployment(string profileName) => this.Deployment = profileName;
+
+    /// <summary>Closes the record for an invocation that reported an exit code.</summary>
+    /// <param name="command">The command that ran, as the declared names from <c>mfctl</c> down.</param>
+    /// <param name="exitCode">What it reported.</param>
+    /// <param name="failure">The operator-readable failure it printed, or <see langword="null" />.</param>
+    /// <returns>The line to append.</returns>
+    internal CliInvocationEntry Ended(string command, int exitCode, string? failure) => this.Entry(
+        command,
+        exitCode == CliExitCode.Success ? CliInvocationOutcome.Completed : CliInvocationOutcome.Failed) with
+    {
+        ExitCode = exitCode,
+        Failure = Bounded(failure),
+    };
+
+    /// <summary>Closes the record for an invocation that never reported an exit code.</summary>
+    /// <param name="command">The command that ran, as the declared names from <c>mfctl</c> down.</param>
+    /// <returns>The line to append.</returns>
+    /// <remarks>
+    /// What the command raised is deliberately not read. A defect's message is written for a developer and quotes
+    /// whatever it was working on, which for this command is mail — so the fact that it faulted is recorded and the
+    /// text of it is left to the stack trace the operator already saw.
+    /// </remarks>
+    internal CliInvocationEntry Faulted(string command) => this.Entry(command, CliInvocationOutcome.Faulted);
+
+    private static string? Bounded(string? failure) =>
+        failure is { Length: > MaximumFailureLength } ? failure[..MaximumFailureLength] : failure;
+
+    private CliInvocationEntry Entry(string command, CliInvocationOutcome outcome) => new(
+        this.startedAt,
+        command,
+        outcome,
+        (long)this.clock.GetElapsedTime(this.startedTimestamp).TotalMilliseconds)
+    {
+        Deployment = this.Deployment,
+    };
+}

--- a/src/Cli/Diagnostics/CliInvocationRecord.cs
+++ b/src/Cli/Diagnostics/CliInvocationRecord.cs
@@ -48,8 +48,11 @@ internal sealed class CliInvocationRecord
     /// <summary>Notes which deployment the command settled on, once it has one.</summary>
     /// <param name="profileName">The operator's own name for the deployment.</param>
     /// <remarks>
-    /// The last one wins, which is the right answer for the one command that reaches two: a sign-in talks to an
-    /// authorization server before it talks to the deployment, and the deployment is what the invocation was about.
+    /// Two things call this and neither calls it twice. Every command that reaches a deployment goes through
+    /// <see cref="Administration.DeploymentAccess" />, which is where the option, the variable, and the stored default
+    /// are reconciled; and <c>login</c> calls it directly, because it establishes a profile rather than resolving one
+    /// and would otherwise be the command with no deployment on its record while being the command that names them.
+    /// The last one still wins, so a command that ever grew a second deployment would report the one it ended on.
     /// </remarks>
     internal void ReachedDeployment(string profileName) => this.Deployment = profileName;
 
@@ -80,7 +83,9 @@ internal sealed class CliInvocationRecord
     {
         ArgumentNullException.ThrowIfNull(fault);
 
-        return this.Entry(command, CliInvocationOutcome.Faulted) with { Fault = fault.GetType().FullName };
+        // Bounded like the failure and for the same reason: a closed generic type's full name carries every argument's
+        // name recursively, so the one field that looks too short to need a ceiling is the one that has no other.
+        return this.Entry(command, CliInvocationOutcome.Faulted) with { Fault = Bounded(fault.GetType().FullName) };
     }
 
     /// <summary>Closes the record for an invocation the operator stopped.</summary>

--- a/src/Cli/Diagnostics/CliInvocationRecord.cs
+++ b/src/Cli/Diagnostics/CliInvocationRecord.cs
@@ -66,18 +66,49 @@ internal sealed class CliInvocationRecord
         Failure = Bounded(failure),
     };
 
-    /// <summary>Closes the record for an invocation that never reported an exit code.</summary>
+    /// <summary>Closes the record for an invocation that raised something rather than reporting an exit code.</summary>
+    /// <param name="command">The command that ran, as the declared names from <c>mfctl</c> down.</param>
+    /// <param name="fault">What it raised, whose type is recorded and whose message and stack are not.</param>
+    /// <returns>The line to append.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fault" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// This is the invocation the log is most worth having for — a crash puts its stack on the terminal and nowhere
+    /// else, so once the scrollback is gone the log is all there is. <see cref="CliInvocationEntry.Fault" /> holds what
+    /// can be recorded of it safely.
+    /// </remarks>
+    internal CliInvocationEntry Faulted(string command, Exception fault)
+    {
+        ArgumentNullException.ThrowIfNull(fault);
+
+        return this.Entry(command, CliInvocationOutcome.Faulted) with { Fault = fault.GetType().FullName };
+    }
+
+    /// <summary>Closes the record for an invocation the operator stopped.</summary>
     /// <param name="command">The command that ran, as the declared names from <c>mfctl</c> down.</param>
     /// <returns>The line to append.</returns>
-    /// <remarks>
-    /// What the command raised is deliberately not read. A defect's message is written for a developer and quotes
-    /// whatever it was working on, which for this command is mail — so the fact that it faulted is recorded and the
-    /// text of it is left to the stack trace the operator already saw.
-    /// </remarks>
-    internal CliInvocationEntry Faulted(string command) => this.Entry(command, CliInvocationOutcome.Faulted);
+    /// <remarks>Its own ending rather than a fault, because Ctrl+C is the operator doing something deliberate and a log that read it as a crash would send somebody looking for one.</remarks>
+    internal CliInvocationEntry Cancelled(string command) => this.Entry(command, CliInvocationOutcome.Cancelled);
 
-    private static string? Bounded(string? failure) =>
-        failure is { Length: > MaximumFailureLength } ? failure[..MaximumFailureLength] : failure;
+    /// <summary>Cuts a failure to the ceiling without splitting a character in half.</summary>
+    /// <remarks>
+    /// A message can carry an alias or a profile name an operator chose, so a character outside the basic plane can
+    /// straddle the ceiling — and cutting between the two halves of a surrogate pair leaves a string that is not valid
+    /// UTF-16. The JSON writer refuses one outright, which would put an exception into the append that runs in the
+    /// runner's <c>finally</c> and mask whatever the invocation was already reporting.
+    /// </remarks>
+    private static string? Bounded(string? failure)
+    {
+        if (failure is not { Length: > MaximumFailureLength })
+        {
+            return failure;
+        }
+
+        var length = char.IsHighSurrogate(failure[MaximumFailureLength - 1])
+            ? MaximumFailureLength - 1
+            : MaximumFailureLength;
+
+        return failure[..length];
+    }
 
     private CliInvocationEntry Entry(string command, CliInvocationOutcome outcome) => new(
         this.startedAt,

--- a/src/Cli/Diagnostics/FileCliInvocationLog.cs
+++ b/src/Cli/Diagnostics/FileCliInvocationLog.cs
@@ -79,9 +79,17 @@ internal sealed class FileCliInvocationLog : ICliInvocationLog
 
     /// <summary>Moves the current file aside once it has reached its ceiling, so the next append starts a new one.</summary>
     /// <remarks>
+    /// <para>
     /// Measured before the append rather than after it, so the ceiling is what the file is allowed to reach rather than
-    /// what it is allowed to exceed by one record. A file that vanished between the two steps is not a failure: the
-    /// append that follows creates it.
+    /// what it is allowed to exceed by one record.
+    /// </para>
+    /// <para>
+    /// A move that fails is swallowed rather than reported, for the reason the append is shared rather than locked: two
+    /// invocations can end at the same moment, and both can see a full file. The one that loses the race finds nothing
+    /// left to move, and treating that as a failure would drop its record to protect a rollover the other run has
+    /// already performed. Anything else that stops the move leaves the file over its ceiling until the next invocation,
+    /// which is a log slightly too large rather than a record thrown away.
+    /// </para>
     /// </remarks>
     private void RollOverWhenFull()
     {
@@ -92,6 +100,12 @@ internal sealed class FileCliInvocationLog : ICliInvocationLog
             return;
         }
 
-        File.Move(this.Location, this.Location + RolledSuffix, overwrite: true);
+        try
+        {
+            File.Move(this.Location, this.Location + RolledSuffix, overwrite: true);
+        }
+        catch (Exception raced) when (raced is IOException or UnauthorizedAccessException)
+        {
+        }
     }
 }

--- a/src/Cli/Diagnostics/FileCliInvocationLog.cs
+++ b/src/Cli/Diagnostics/FileCliInvocationLog.cs
@@ -95,22 +95,41 @@ internal sealed class FileCliInvocationLog : ICliInvocationLog
     /// already performed. Anything else that stops the move leaves the file over its ceiling until the next invocation,
     /// which is a log slightly too large rather than a record thrown away.
     /// </para>
+    /// <para>
+    /// The size is read again immediately before the move, which is what stops the worse version of that race: a run
+    /// that decided to roll, was overtaken by one that rolled and appended, and would otherwise move the fresh file
+    /// over the rolled one — replacing a full history with a single record. Re-reading is not a lock and the window is
+    /// not zero; what it is worth is the ratio, since the decision is made after work that takes orders of magnitude
+    /// longer than the two calls now left between the check and the move. A lock file would close it and would put a
+    /// file this log has to create, contend for, and clean up beside one whose whole point is that it cannot fail the
+    /// command.
+    /// </para>
     /// </remarks>
     private void RollOverWhenFull()
     {
-        var current = new FileInfo(this.Location);
-
-        if (!current.Exists || current.Length < MaximumBytes)
+        if (!IsFull(this.Location))
         {
             return;
         }
 
         try
         {
+            if (!IsFull(this.Location))
+            {
+                return;
+            }
+
             File.Move(this.Location, this.Location + RolledSuffix, overwrite: true);
         }
         catch (Exception raced) when (raced is IOException or UnauthorizedAccessException)
         {
         }
+    }
+
+    private static bool IsFull(string location)
+    {
+        var current = new FileInfo(location);
+
+        return current.Exists && current.Length >= MaximumBytes;
     }
 }

--- a/src/Cli/Diagnostics/FileCliInvocationLog.cs
+++ b/src/Cli/Diagnostics/FileCliInvocationLog.cs
@@ -1,0 +1,97 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text;
+using System.Text.Json;
+using MailFathom.Cli.Credentials;
+
+namespace MailFathom.Cli.Diagnostics;
+
+/// <summary>Appends each invocation to a file in the operator's own directory, one record per line.</summary>
+/// <remarks>
+/// <para>
+/// The file is the only durable record of what the command did. <c>mfctl</c> holds no exporter and opens no span, so
+/// nothing else on the machine answers <em>what did I run against that deployment, and how did it end</em> once the
+/// terminal's scrollback is gone.
+/// </para>
+/// <para>
+/// It is created readable by its owner alone, beside the credential store, and it is bounded: past
+/// <see cref="MaximumBytes" /> the current file is moved aside and a new one started, so the log occupies at most twice
+/// that and never grows without limit on a machine somebody administers daily.
+/// </para>
+/// </remarks>
+internal sealed class FileCliInvocationLog : ICliInvocationLog
+{
+    /// <summary>The size at which the current file is moved aside and a new one started.</summary>
+    internal const long MaximumBytes = 1024 * 1024;
+
+    /// <summary>The name the file carries in the operator's directory.</summary>
+    internal const string FileName = "mfctl.log";
+
+    /// <summary>What is appended to the name of the file moved aside, which the next rollover overwrites.</summary>
+    /// <remarks>One rather than a numbered series, because a series is a retention policy and nothing here is in a position to decide one for somebody's machine.</remarks>
+    internal const string RolledSuffix = ".1";
+
+    /// <summary>Initializes the log over a file path.</summary>
+    /// <param name="location">Where the log is written; its directory is created when the first record is appended.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="location" /> is <see langword="null" />.</exception>
+    internal FileCliInvocationLog(string location)
+    {
+        ArgumentNullException.ThrowIfNull(location);
+
+        this.Location = location;
+    }
+
+    /// <inheritdoc />
+    public string Location { get; }
+
+    /// <summary>Reports where the log lives for the operator running the command.</summary>
+    /// <returns>The absolute path of the log file.</returns>
+    internal static string DefaultPath() => Path.Combine(OperatorDirectory.Resolve(), FileName);
+
+    /// <inheritdoc />
+    public bool TryAppend(CliInvocationEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        try
+        {
+            OwnerOnlyStorage.CreateDirectoryFor(this.Location);
+            this.RollOverWhenFull();
+
+            // Serialized to bytes and written in one call, because two invocations may end at the same moment and an
+            // append that reached the file in pieces would interleave them into lines neither run wrote.
+            var line = Encoding.UTF8.GetBytes(
+                JsonSerializer.Serialize(entry, CliInvocationLogJsonContext.Default.CliInvocationEntry) + '\n');
+
+            using var contents = OwnerOnlyStorage.OpenForAppending(this.Location);
+
+            contents.Write(line);
+
+            return true;
+        }
+        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>Moves the current file aside once it has reached its ceiling, so the next append starts a new one.</summary>
+    /// <remarks>
+    /// Measured before the append rather than after it, so the ceiling is what the file is allowed to reach rather than
+    /// what it is allowed to exceed by one record. A file that vanished between the two steps is not a failure: the
+    /// append that follows creates it.
+    /// </remarks>
+    private void RollOverWhenFull()
+    {
+        var current = new FileInfo(this.Location);
+
+        if (!current.Exists || current.Length < MaximumBytes)
+        {
+            return;
+        }
+
+        File.Move(this.Location, this.Location + RolledSuffix, overwrite: true);
+    }
+}

--- a/src/Cli/Diagnostics/FileCliInvocationLog.cs
+++ b/src/Cli/Diagnostics/FileCliInvocationLog.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.Json;
 using MailFathom.Cli.Credentials;
@@ -51,6 +52,10 @@ internal sealed class FileCliInvocationLog : ICliInvocationLog
     internal static string DefaultPath() => Path.Combine(OperatorDirectory.Resolve(), FileName);
 
     /// <inheritdoc />
+    [SuppressMessage(
+        "Design",
+        "CA1031:Do not catch general exception types",
+        Justification = "The append runs in the runner's finally, so anything escaping here would mask the exit code or the exception the invocation was already reporting — which is the one thing keeping a record must never do.")]
     public bool TryAppend(CliInvocationEntry entry)
     {
         ArgumentNullException.ThrowIfNull(entry);
@@ -71,7 +76,7 @@ internal sealed class FileCliInvocationLog : ICliInvocationLog
 
             return true;
         }
-        catch (Exception failure) when (failure is IOException or UnauthorizedAccessException)
+        catch (Exception)
         {
             return false;
         }

--- a/src/Cli/Diagnostics/ICliInvocationLog.cs
+++ b/src/Cli/Diagnostics/ICliInvocationLog.cs
@@ -1,0 +1,26 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Cli.Diagnostics;
+
+/// <summary>Where the record of an invocation is appended.</summary>
+/// <remarks>
+/// A seam so a test can assert what a command would have written without reaching the operator's own directory, and so
+/// the runner can be driven against a writer that refuses. It is deliberately not an asynchronous contract: the append
+/// happens as the process is about to exit, where starting work nobody will await buys nothing.
+/// </remarks>
+internal interface ICliInvocationLog
+{
+    /// <summary>Gets where the log is written, so a message about a record that could not be appended names the file.</summary>
+    string Location { get; }
+
+    /// <summary>Appends one record.</summary>
+    /// <param name="entry">What the invocation did.</param>
+    /// <returns><see langword="true" /> when the record was written, and <see langword="false" /> when it could not be.</returns>
+    /// <remarks>
+    /// Reports rather than raises, because the command's job is the command: a home directory that is read-only, a full
+    /// disk, or a log an operator deleted the directory of must not turn a successful invocation into a failed one.
+    /// </remarks>
+    bool TryAppend(CliInvocationEntry entry);
+}

--- a/src/Cli/Diagnostics/RefusalWatchingConsole.cs
+++ b/src/Cli/Diagnostics/RefusalWatchingConsole.cs
@@ -1,0 +1,69 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Cli.Diagnostics;
+
+/// <summary>The terminal, remembering the last line a command wrote to standard error.</summary>
+/// <remarks>
+/// <para>
+/// Most commands report a refusal by raising a <see cref="CliFailure" />, which carries its message to the runner. A
+/// dozen do not: a contact the book does not hold, a job no longer dead-lettered, a confirmation declined, an erasure
+/// interrupted — each is an ordinary outcome rather than a defect, so the command writes one sentence and returns a
+/// failing code. Nothing about that reaches the runner, which would record those invocations as failures with nothing
+/// said about them, and that is the one shape the log's own table promises never to have.
+/// </para>
+/// <para>
+/// Standard error and not standard output, which is what makes this safe to record rather than merely convenient. The
+/// split is the one the whole command already keeps: what was asked for goes to standard output, and a contact, an
+/// address, a subject, or a message is only ever that. What goes to standard error is written to be read beside a
+/// failing exit code, and every such sentence already avoids naming a person — <see cref="Commands.Contacts.ContactOutput" />
+/// states the rule for the commands that handle people, and the reason it gives is this one: a failure message ends up
+/// in a log wherever the command is run from a script.
+/// </para>
+/// </remarks>
+internal sealed class RefusalWatchingConsole : ICliConsole
+{
+    private readonly ICliConsole terminal;
+
+    /// <summary>Wraps the terminal a command actually reports to.</summary>
+    /// <param name="terminal">The terminal, which receives everything unchanged.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="terminal" /> is <see langword="null" />.</exception>
+    internal RefusalWatchingConsole(ICliConsole terminal)
+    {
+        ArgumentNullException.ThrowIfNull(terminal);
+
+        this.terminal = terminal;
+    }
+
+    /// <summary>Gets the last sentence written to standard error, and <see langword="null" /> when none was.</summary>
+    /// <remarks>
+    /// The last rather than the first, because a command that writes several ends on the one that says what to do next,
+    /// and the blank lines the interactive sign-in writes for spacing are skipped so a refusal cannot be displaced by
+    /// one.
+    /// </remarks>
+    internal string? LastRefusal { get; private set; }
+
+    /// <inheritdoc />
+    public void WriteLine(string message) => this.terminal.WriteLine(message);
+
+    /// <inheritdoc />
+    public void WriteError(string message)
+    {
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            this.LastRefusal = message;
+        }
+
+        this.terminal.WriteError(message);
+    }
+
+    /// <inheritdoc />
+    public string ReadSecret(string prompt) => this.terminal.ReadSecret(prompt);
+
+    /// <inheritdoc />
+    public bool CanConfirm => this.terminal.CanConfirm;
+
+    /// <inheritdoc />
+    public bool Confirm(string question) => this.terminal.Confirm(question);
+}

--- a/src/Cli/Diagnostics/RefusalWatchingConsole.cs
+++ b/src/Cli/Diagnostics/RefusalWatchingConsole.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Cli.Output;
+
 namespace MailFathom.Cli.Diagnostics;
 
-/// <summary>The terminal, remembering the last line a command wrote to standard error.</summary>
+/// <summary>The terminal, remembering the last line a command reported as a failure.</summary>
 /// <remarks>
 /// <para>
 /// Most commands report a refusal by raising a <see cref="CliFailure" />, which carries its message to the runner. A
@@ -14,12 +16,17 @@ namespace MailFathom.Cli.Diagnostics;
 /// said about them, and that is the one shape the log's own table promises never to have.
 /// </para>
 /// <para>
-/// Standard error and not standard output, which is what makes this safe to record rather than merely convenient. The
-/// split is the one the whole command already keeps: what was asked for goes to standard output, and a contact, an
-/// address, a subject, or a message is only ever that. What goes to standard error is written to be read beside a
-/// failing exit code, and every such sentence already avoids naming a person — <see cref="Commands.Contacts.ContactOutput" />
-/// states the rule for the commands that handle people, and the reason it gives is this one: a failure message ends up
-/// in a log wherever the command is run from a script.
+/// <see cref="WriteError" /> alone, which is narrower than the stream it goes to and is what makes this safe to record
+/// rather than merely convenient. Standard error carries three kinds of line and the console names each: guidance
+/// through <see cref="WriteNotice" />, something to weigh through <see cref="WriteWarning" />, and a failure here. Only
+/// the last is a refusal, so a device-code prompt and a version caution pass through untouched — and what a command was
+/// asked for never appears on any of the three, since a contact, an address, a subject, or a message is written to
+/// standard output as the command's result.
+/// </para>
+/// <para>
+/// Every such sentence is already written to be read beside a failing exit code, and already avoids naming a person:
+/// <see cref="Commands.Contacts.ContactOutput" /> states the rule for the commands that handle people, and the reason
+/// it gives is this one — a failure message ends up in a log wherever the command is run from a script.
 /// </para>
 /// </remarks>
 internal sealed class RefusalWatchingConsole : ICliConsole
@@ -36,16 +43,21 @@ internal sealed class RefusalWatchingConsole : ICliConsole
         this.terminal = terminal;
     }
 
-    /// <summary>Gets the last sentence written to standard error, and <see langword="null" /> when none was.</summary>
+    /// <summary>Gets the last sentence written as a failure, and <see langword="null" /> when none was.</summary>
     /// <remarks>
     /// The last rather than the first, because a command that writes several ends on the one that says what to do next,
-    /// and the blank lines the interactive sign-in writes for spacing are skipped so a refusal cannot be displaced by
-    /// one.
+    /// and a blank line written for spacing is skipped so a refusal cannot be displaced by one.
     /// </remarks>
     internal string? LastRefusal { get; private set; }
 
     /// <inheritdoc />
     public void WriteLine(string message) => this.terminal.WriteLine(message);
+
+    /// <inheritdoc />
+    public void WriteNotice(string message) => this.terminal.WriteNotice(message);
+
+    /// <inheritdoc />
+    public void WriteWarning(string message) => this.terminal.WriteWarning(message);
 
     /// <inheritdoc />
     public void WriteError(string message)
@@ -57,6 +69,12 @@ internal sealed class RefusalWatchingConsole : ICliConsole
 
         this.terminal.WriteError(message);
     }
+
+    /// <inheritdoc />
+    public void Write(CliTable table) => this.terminal.Write(table);
+
+    /// <inheritdoc />
+    public void Write(CliDetails details) => this.terminal.Write(details);
 
     /// <inheritdoc />
     public string ReadSecret(string prompt) => this.terminal.ReadSecret(prompt);

--- a/src/Cli/OperatorDirectory.cs
+++ b/src/Cli/OperatorDirectory.cs
@@ -1,0 +1,32 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Cli;
+
+/// <summary>Where the command keeps what belongs to the operator on the machine they run it from.</summary>
+/// <remarks>
+/// <para>
+/// One directory rather than one per kind of file, so the command's whole footprint on a machine is a single path an
+/// operator can find, back up, exclude from a backup, or delete. The credential store, the key that seals it, and the
+/// invocation log all live here.
+/// </para>
+/// <para>
+/// <see cref="Environment.SpecialFolder.ApplicationData" /> resolves to <c>$XDG_CONFIG_HOME</c> or <c>~/.config</c> on
+/// Linux and to <c>%APPDATA%</c> on Windows, so one call gives the right per-user location on both without a platform
+/// branch here. The log is state rather than configuration and would belong under <c>$XDG_STATE_HOME</c> if the
+/// specification were followed to the letter; keeping the three files together is worth more to the person looking for
+/// them than splitting them across two specifications to satisfy one platform's convention.
+/// </para>
+/// </remarks>
+internal static class OperatorDirectory
+{
+    /// <summary>The name the command's own directory carries inside the per-user location.</summary>
+    internal const string Name = "MailFathom";
+
+    /// <summary>Reports the directory for the operator running the command.</summary>
+    /// <returns>The absolute path, which may not exist yet.</returns>
+    internal static string Resolve() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.DoNotVerify),
+        Name);
+}

--- a/tests/Cli.UnitTests/CliInvocationLogLine.cs
+++ b/tests/Cli.UnitTests/CliInvocationLogLine.cs
@@ -1,0 +1,24 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Text;
+using System.Text.Json;
+using MailFathom.Cli.Diagnostics;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Reads a written line of the invocation log back as the record it was serialized from.</summary>
+/// <remarks>Through the command's own contract rather than a second one written here, so a test asserting a field is asserting what an operator's <c>jq</c> would find rather than what this file believes was written.</remarks>
+internal static class CliInvocationLogLine
+{
+    /// <summary>Reads one line of the log.</summary>
+    /// <param name="line">The line.</param>
+    /// <returns>The record it holds.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the line holds no record.</exception>
+    internal static CliInvocationEntry Read(this string line) =>
+        JsonSerializer.Deserialize(
+            Encoding.UTF8.GetBytes(line),
+            CliInvocationLogJsonContext.Default.CliInvocationEntry)
+        ?? throw new InvalidOperationException("The line held no record.");
+}

--- a/tests/Cli.UnitTests/CliInvocationLogSwitchTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationLogSwitchTests.cs
@@ -1,0 +1,85 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.CommandLine;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers the order that decides whether an invocation is recorded at all.</summary>
+/// <remarks>
+/// The same order every other input to this command follows — what the operator typed beats what their shell was told
+/// — asserted against a stated value of the variable rather than against the process environment, which every other
+/// test in this assembly shares and any of them could be reading while these run.
+/// </remarks>
+public sealed class CliInvocationLogSwitchTests
+{
+    /// <summary>An invocation that said nothing about the log is recorded.</summary>
+    [Fact]
+    public void RecordsInvocation_AnInvocationThatSaidNothing_IsRecorded()
+    {
+        // Arrange
+
+        // Act
+        var records = CliOptions.RecordsInvocation(Parse([]), logVariable: null);
+
+        // Assert
+        Assert.True(records);
+    }
+
+    /// <summary>The option turns the record off wherever in the command tree it was written.</summary>
+    [Theory]
+    [InlineData("--no-log")]
+    [InlineData("profiles", "--no-log")]
+    public void RecordsInvocation_AnInvocationThatPassedTheOption_IsNotRecorded(params string[] args)
+    {
+        // Arrange
+
+        // Act
+        var records = CliOptions.RecordsInvocation(Parse(args), logVariable: null);
+
+        // Assert
+        Assert.False(records);
+    }
+
+    /// <summary>The variable turns the record off for a shell session, whatever case it is spelled in.</summary>
+    [Theory]
+    [InlineData("off")]
+    [InlineData("OFF")]
+    [InlineData("Off")]
+    public void RecordsInvocation_AShellThatTurnedTheLogOff_IsNotRecorded(string variable)
+    {
+        // Arrange
+
+        // Act
+        var records = CliOptions.RecordsInvocation(Parse([]), variable);
+
+        // Assert
+        Assert.False(records);
+    }
+
+    /// <summary>Every other value of the variable leaves the log on rather than failing the command over a typo.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("on")]
+    [InlineData("0")]
+    [InlineData("false")]
+    [InlineData("no")]
+    public void RecordsInvocation_AVariableSpelledSomeOtherWay_IsStillRecorded(string variable)
+    {
+        // Arrange
+
+        // Act
+        var records = CliOptions.RecordsInvocation(Parse([]), variable);
+
+        // Assert
+        Assert.True(records);
+    }
+
+    private static ParseResult Parse(string[] args) => new RootCommand("test")
+    {
+        CliOptions.NoLog(),
+        new Command("profiles", "A subcommand, so the option's reach past the root is what is asserted."),
+    }.Parse(args);
+}

--- a/tests/Cli.UnitTests/CliInvocationRecordTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationRecordTests.cs
@@ -67,6 +67,43 @@ public sealed class CliInvocationRecordTests
         Assert.DoesNotContain(entry.Failure!, char.IsSurrogate);
     }
 
+    /// <summary>A profile name longer than the ceiling is cut to it, on the same terms as everything else recorded.</summary>
+    /// <remarks>
+    /// The one recorded value the operator writes rather than the command, and the one nothing else bounds: a profile
+    /// name is refused for being blank and for parsing as an address, and for nothing about its length. A sign-in that
+    /// passed a long <c>--name</c> would otherwise put the whole of it on every later invocation's record.
+    /// </remarks>
+    [Fact]
+    public void ReachedDeployment_ANameLongerThanTheCeiling_RecordsExactlyTheCeiling()
+    {
+        // Arrange
+        var record = new CliInvocationRecord(new FakeTimeProvider());
+
+        // Act
+        record.ReachedDeployment(new string('x', CliInvocationRecord.MaximumFailureLength + 100));
+
+        var entry = record.Ended("mfctl status", CliExitCode.Success, failure: null);
+
+        // Assert
+        Assert.Equal(CliInvocationRecord.MaximumFailureLength, entry.Deployment?.Length);
+    }
+
+    /// <summary>A profile name the ceiling does not reach is recorded whole, which is every name anybody chooses.</summary>
+    [Fact]
+    public void ReachedDeployment_AnOrdinaryName_RecordsAllOfIt()
+    {
+        // Arrange
+        var record = new CliInvocationRecord(new FakeTimeProvider());
+
+        // Act
+        record.ReachedDeployment("production");
+
+        var entry = record.Ended("mfctl status", CliExitCode.Success, failure: null);
+
+        // Assert
+        Assert.Equal("production", entry.Deployment);
+    }
+
     /// <summary>What the command raised is recorded as its type and as nothing else about it.</summary>
     [Fact]
     public void Faulted_AnInvocationThatRaised_RecordsTheTypeAndNoExitCode()

--- a/tests/Cli.UnitTests/CliInvocationRecordTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationRecordTests.cs
@@ -46,20 +46,74 @@ public sealed class CliInvocationRecordTests
         Assert.Equal(Failure, entry.Failure);
     }
 
-    /// <summary>An invocation that never reported an exit code says so rather than borrowing one.</summary>
+    /// <summary>A failure whose ceiling falls between the halves of one character is cut before it, not through it.</summary>
+    /// <remarks>
+    /// The consequence is worse than a mangled message: an unpaired surrogate is not valid UTF-16, the JSON writer
+    /// refuses one, and the append runs in the runner's <c>finally</c> — so the exception would replace whatever the
+    /// invocation was already reporting, which is the one thing keeping a record must never do.
+    /// </remarks>
     [Fact]
-    public void Faulted_AnInvocationThatReportedNothing_RecordsNoExitCodeAndNoFailure()
+    public void Ended_AFailureWhoseCeilingFallsInsideACharacter_CutsBeforeIt()
+    {
+        // Arrange
+        var record = new CliInvocationRecord(new FakeTimeProvider());
+        var failure = new string('x', CliInvocationRecord.MaximumFailureLength - 1) + "\U0001F600 and more";
+
+        // Act
+        var entry = record.Ended("mfctl status", CliExitCode.Failure, failure);
+
+        // Assert
+        Assert.Equal(CliInvocationRecord.MaximumFailureLength - 1, entry.Failure?.Length);
+        Assert.DoesNotContain(entry.Failure!, char.IsSurrogate);
+    }
+
+    /// <summary>What the command raised is recorded as its type and as nothing else about it.</summary>
+    [Fact]
+    public void Faulted_AnInvocationThatRaised_RecordsTheTypeAndNoExitCode()
     {
         // Arrange
         var record = new CliInvocationRecord(new FakeTimeProvider());
 
         // Act
-        var entry = record.Faulted("mfctl status");
+        var entry = record.Faulted("mfctl status", new InvalidOperationException("A message written for a developer."));
 
         // Assert
         Assert.Equal(CliInvocationOutcome.Faulted, entry.Outcome);
+        Assert.Equal(typeof(InvalidOperationException).FullName, entry.Fault);
         Assert.Null(entry.ExitCode);
         Assert.Null(entry.Failure);
+    }
+
+    /// <summary>The message of what was raised is left out, because a defect's message quotes what it was working on.</summary>
+    [Fact]
+    public void Faulted_AnInvocationWhoseFailureQuotedItsWork_RecordsNoneOfThatText()
+    {
+        // Arrange
+        var record = new CliInvocationRecord(new FakeTimeProvider());
+        const string Quoted = "subject: Q3 numbers, from: someone@example.invalid";
+
+        // Act
+        var entry = record.Faulted("mfctl status", new InvalidOperationException(Quoted));
+
+        // Assert
+        Assert.DoesNotContain(Quoted, entry.Fault ?? string.Empty, StringComparison.Ordinal);
+        Assert.Null(entry.Failure);
+    }
+
+    /// <summary>An invocation the operator stopped is told apart from one that crashed.</summary>
+    [Fact]
+    public void Cancelled_AnInvocationTheOperatorStopped_IsNotRecordedAsAFault()
+    {
+        // Arrange
+        var record = new CliInvocationRecord(new FakeTimeProvider());
+
+        // Act
+        var entry = record.Cancelled("mfctl status");
+
+        // Assert
+        Assert.Equal(CliInvocationOutcome.Cancelled, entry.Outcome);
+        Assert.Null(entry.Fault);
+        Assert.Null(entry.ExitCode);
     }
 
     /// <summary>The deployment a command settled on is carried onto whatever ends the invocation.</summary>
@@ -73,6 +127,6 @@ public sealed class CliInvocationRecordTests
         record.ReachedDeployment("production");
 
         // Assert
-        Assert.Equal("production", record.Faulted("mfctl status").Deployment);
+        Assert.Equal("production", record.Faulted("mfctl status", new InvalidOperationException()).Deployment);
     }
 }

--- a/tests/Cli.UnitTests/CliInvocationRecordTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationRecordTests.cs
@@ -1,0 +1,78 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Diagnostics;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers what the record itself decides, apart from when the runner asks it to.</summary>
+public sealed class CliInvocationRecordTests
+{
+    /// <summary>A failure longer than the ceiling is cut to it, so one record stays one line of the log.</summary>
+    /// <remarks>
+    /// The messages this command raises are sentences, so nothing reaches the ceiling today — which is exactly why it
+    /// needs a test. A message that grew, or a bound that stopped being applied, would otherwise be found as a log file
+    /// somebody could no longer read a line at a time.
+    /// </remarks>
+    [Fact]
+    public void Ended_AFailureLongerThanTheCeiling_RecordsExactlyTheCeiling()
+    {
+        // Arrange
+        var record = new CliInvocationRecord(new FakeTimeProvider());
+        var failure = new string('x', CliInvocationRecord.MaximumFailureLength + 100);
+
+        // Act
+        var entry = record.Ended("mfctl status", CliExitCode.Failure, failure);
+
+        // Assert
+        Assert.Equal(CliInvocationRecord.MaximumFailureLength, entry.Failure?.Length);
+    }
+
+    /// <summary>A failure the ceiling does not reach is recorded whole, which is what makes the bound a bound.</summary>
+    [Fact]
+    public void Ended_AFailureShorterThanTheCeiling_RecordsAllOfIt()
+    {
+        // Arrange
+        var record = new CliInvocationRecord(new FakeTimeProvider());
+        const string Failure = "The deployment answered 404 rather than a contact.";
+
+        // Act
+        var entry = record.Ended("mfctl contact delete", CliExitCode.Failure, Failure);
+
+        // Assert
+        Assert.Equal(Failure, entry.Failure);
+    }
+
+    /// <summary>An invocation that never reported an exit code says so rather than borrowing one.</summary>
+    [Fact]
+    public void Faulted_AnInvocationThatReportedNothing_RecordsNoExitCodeAndNoFailure()
+    {
+        // Arrange
+        var record = new CliInvocationRecord(new FakeTimeProvider());
+
+        // Act
+        var entry = record.Faulted("mfctl status");
+
+        // Assert
+        Assert.Equal(CliInvocationOutcome.Faulted, entry.Outcome);
+        Assert.Null(entry.ExitCode);
+        Assert.Null(entry.Failure);
+    }
+
+    /// <summary>The deployment a command settled on is carried onto whatever ends the invocation.</summary>
+    [Fact]
+    public void ReachedDeployment_AnInvocationThatFaultedAfterwards_StillNamesTheDeployment()
+    {
+        // Arrange
+        var record = new CliInvocationRecord(new FakeTimeProvider());
+
+        // Act
+        record.ReachedDeployment("production");
+
+        // Assert
+        Assert.Equal("production", record.Faulted("mfctl status").Deployment);
+    }
+}

--- a/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
@@ -23,8 +23,20 @@ namespace MailFathom.Cli.UnitTests;
 /// by hand would assert the shape of a type nobody had asked to write anything.
 /// </para>
 /// </remarks>
-public sealed class CliInvocationRecordingTests
+public sealed class CliInvocationRecordingTests : IDisposable
 {
+    private readonly string storeDirectory =
+        Path.Combine(Path.GetTempPath(), $"mailfathom-cli-recording-tests-{Guid.NewGuid():N}");
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Directory.Exists(this.storeDirectory))
+        {
+            Directory.Delete(this.storeDirectory, recursive: true);
+        }
+    }
+
     /// <summary>An invocation that succeeded is recorded under the command it named, with the code it reported.</summary>
     [Fact]
     public async Task RunAsync_AnInvocationThatSucceeded_RecordsTheCommandAndTheExitCode()
@@ -136,6 +148,47 @@ public sealed class CliInvocationRecordingTests
         var entry = Assert.Single(log.Appended);
 
         Assert.DoesNotContain(Address, entry.Command, StringComparison.Ordinal);
+    }
+
+    /// <summary>A command that reached a deployment names it, which is the field the whole seam through the access layer exists for.</summary>
+    /// <remarks>
+    /// Against a stored profile and a deployment that answers, because that is the only arrangement in which
+    /// <c>DeploymentAccess.ReachAsync</c> gets past resolving the profile. A test that stops at the failure — which the
+    /// two above deliberately do — never reaches the line that writes this field, so removing it would break every
+    /// successful invocation's record with nothing to say so.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_ACommandThatReachedADeployment_RecordsTheProfileItActedThrough()
+    {
+        // Arrange
+        using var deployment = FakeAdminEndpoint.Accepting("workstation");
+
+        var store = new CredentialStore(
+            Path.Combine(this.storeDirectory, "credentials.json"),
+            new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key")));
+
+        store.Save("production", new Uri("https://mail.example.test:8443"), "not-a-real-key", "workstation");
+
+        var log = new RecordingCliInvocationLog();
+
+        var context = new CliContext(
+            new RecordingCliConsole(),
+            store,
+            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
+            FakeMailboxRedirect.Silent(),
+            static _ => false,
+            TimeProvider.System,
+            log,
+            static _ => null);
+
+        // Act
+        var exitCode = await CliRunner.RunAsync(context, ["status"], TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Equal("production", entry.Deployment);
     }
 
     /// <summary>A shell that turned the log off is obeyed by an invocation that ran through the whole runner.</summary>

--- a/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Cli.Commands;
 using MailFathom.Cli.Credentials;
 using MailFathom.Cli.Diagnostics;
+using MailFathom.Cli.Transport;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
@@ -128,29 +129,97 @@ public sealed class CliInvocationRecordingTests : IDisposable
     /// <summary>What a command reported on its way to doing what it was asked is not a failure on the record of it.</summary>
     /// <remarks>
     /// The control for the test above: recording the last line written to standard error whatever the invocation
-    /// returned would put a failure on every record of a command that reports its progress there, and the sign-in is
-    /// the one that reports the most.
+    /// returned would put a failure on every record of a command that reports something there and then succeeds. A
+    /// deployment on another build of this release line is that arrangement — the version agreement permits the command
+    /// and warns about it — and the first assertion is what makes the second one mean something, since a test whose
+    /// terminal stayed silent would pass with the exit-code guard removed.
     /// </remarks>
     [Fact]
     public async Task RunAsync_ACommandThatReportedOnStandardErrorAndSucceeded_RecordsNoFailure()
     {
         // Arrange
-        using var deployment = FakeAdminEndpoint.Accepting("workstation");
+        using var deployment = FakeAdminEndpoint.Accepting("workstation", FakeAdminEndpoint.AnotherBuildOfThisLine);
 
-        var console = new RecordingCliConsole { SecretToSupply = "not-a-real-key" };
+        var console = new RecordingCliConsole();
         var log = new RecordingCliInvocationLog();
 
         // Act
         var exitCode = await CliRunner.RunAsync(
             this.ContextReaching(deployment, log, console),
-            ["login", "--endpoint", "https://mail.example.test:8443"],
+            ["status"],
             TestContext.Current.CancellationToken);
 
         // Assert
         var entry = Assert.Single(log.Appended);
 
+        Assert.NotEmpty(console.Errors);
         Assert.Equal(CliExitCode.Success, exitCode);
         Assert.Null(entry.Failure);
+    }
+
+    /// <summary>An invocation that raised something the command did not expect is recorded as a fault, by its type.</summary>
+    /// <remarks>
+    /// Driven through the runner rather than against the record, because what is under test is the <c>catch</c> that
+    /// reaches for <c>Faulted</c> and the <c>finally</c> that appends what it built. A crash puts its stack on the
+    /// terminal and nowhere else, so a change that reordered those blocks or broke the guard between them would leave
+    /// the invocation the log is most worth having for unrecorded.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_AnInvocationThatRaisedADefect_RecordsItAsAFaultOfThatType()
+    {
+        // Arrange
+        var log = new RecordingCliInvocationLog();
+
+        var context = this.ContextOpening(
+            static (_, _) => throw new InvalidOperationException("A defect rather than a refusal."),
+            log);
+
+        // Act
+        var fault = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => CliRunner.RunAsync(context, ["status"], TestContext.Current.CancellationToken));
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.Equal("A defect rather than a refusal.", fault.Message);
+        Assert.Equal(CliInvocationOutcome.Faulted, entry.Outcome);
+        Assert.Equal(typeof(InvalidOperationException).FullName, entry.Fault);
+        Assert.Null(entry.ExitCode);
+    }
+
+    /// <summary>An invocation the operator stopped is recorded as its own ending rather than as a fault.</summary>
+    /// <remarks>
+    /// The companion to the test above and the reason the two catch blocks are separate: a stopped command and a broken
+    /// one otherwise read identically in the log and mean opposite things. The cancellation is raised where a command's
+    /// own work would raise it, against the token the runner was given, because that is what the runner's guard reads.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_AnInvocationTheOperatorStopped_RecordsItAsCancelled()
+    {
+        // Arrange
+        using var stopping = new CancellationTokenSource();
+
+        var log = new RecordingCliInvocationLog();
+
+        var context = this.ContextOpening(
+            (_, _) =>
+            {
+                stopping.Cancel();
+
+                throw new OperationCanceledException(stopping.Token);
+            },
+            log);
+
+        // Act
+        _ = await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => CliRunner.RunAsync(context, ["status"], stopping.Token));
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.Equal(CliInvocationOutcome.Cancelled, entry.Outcome);
+        Assert.Null(entry.ExitCode);
+        Assert.Null(entry.Fault);
     }
 
     /// <summary>A subcommand is recorded by the path of names it was declared under, not by the one word at the end.</summary>
@@ -384,6 +453,20 @@ public sealed class CliInvocationRecordingTests : IDisposable
     private CliContext ContextReaching(
         FakeHttpMessageHandler deployment,
         RecordingCliInvocationLog log,
+        RecordingCliConsole? console = null) =>
+        this.ContextOpening(
+            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
+            log,
+            console);
+
+    /// <summary>Builds the same context over a transport that is opened however the test says.</summary>
+    /// <remarks>
+    /// What a command does when opening one raises is the runner's business rather than the deployment's, so the two
+    /// tests about a fault and a cancellation say it here instead of arranging a deployment that answers strangely.
+    /// </remarks>
+    private CliContext ContextOpening(
+        Func<Uri, StoredTransportTrust, DeploymentTransport> openTransport,
+        RecordingCliInvocationLog log,
         RecordingCliConsole? console = null)
     {
         var store = new CredentialStore(
@@ -395,7 +478,7 @@ public sealed class CliInvocationRecordingTests : IDisposable
         return new CliContext(
             console ?? new RecordingCliConsole(),
             store,
-            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
+            openTransport,
             FakeMailboxRedirect.Silent(),
             static _ => false,
             Stopped(),

--- a/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
@@ -76,6 +76,22 @@ public sealed class CliInvocationRecordingTests : IDisposable
         Assert.NotEqual(CliExitCode.Success, exitCode);
         Assert.Equal(CliInvocationOutcome.Failed, entry.Outcome);
         Assert.Equal(exitCode, entry.ExitCode);
+        Assert.Contains("--no-such-option", entry.Failure ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    /// <summary>An invocation that succeeded records no failure, which is what makes the field mean something.</summary>
+    /// <remarks>The control for the assertion above: reading the parser's errors unconditionally would put text on every record, and a refused invocation would look no different from one that worked.</remarks>
+    [Fact]
+    public async Task RunAsync_AnInvocationThatSucceeded_RecordsNoFailure()
+    {
+        // Arrange
+        var log = new RecordingCliInvocationLog();
+
+        // Act
+        _ = await CliRunner.RunAsync(ContextFor(log), ["--version"], TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(Assert.Single(log.Appended).Failure);
     }
 
     /// <summary>A subcommand is recorded by the path of names it was declared under, not by the one word at the end.</summary>
@@ -177,7 +193,7 @@ public sealed class CliInvocationRecordingTests : IDisposable
             (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
             FakeMailboxRedirect.Silent(),
             static _ => false,
-            TimeProvider.System,
+            Stopped(),
             log,
             static _ => null);
 
@@ -189,6 +205,47 @@ public sealed class CliInvocationRecordingTests : IDisposable
 
         Assert.Equal(CliExitCode.Success, exitCode);
         Assert.Equal("production", entry.Deployment);
+    }
+
+    /// <summary>A sign-in names the profile it established, which no other command's path would have recorded for it.</summary>
+    /// <remarks>
+    /// <c>login</c> is the one command that reaches a deployment without going through the access seam the test above
+    /// covers — it establishes a profile rather than resolving one — so the field it fills is filled by a line of its
+    /// own. Removing that line would leave the command that gives every deployment its name as the only one whose own
+    /// record does not carry one, and the test above would stay green.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_ASignIn_RecordsTheProfileItEstablished()
+    {
+        // Arrange
+        using var deployment = FakeAdminEndpoint.Accepting("workstation");
+
+        var console = new RecordingCliConsole { SecretToSupply = "not-a-real-key" };
+        var log = new RecordingCliInvocationLog();
+
+        var context = new CliContext(
+            console,
+            new CredentialStore(
+                Path.Combine(this.storeDirectory, "credentials.json"),
+                new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key"))),
+            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
+            FakeMailboxRedirect.Silent(),
+            static _ => false,
+            Stopped(),
+            log,
+            static _ => null);
+
+        // Act
+        var exitCode = await CliRunner.RunAsync(
+            context,
+            ["login", "--endpoint", "https://mail.example.test:8443"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Equal("mail.example.test", entry.Deployment);
     }
 
     /// <summary>A shell that turned the log off is obeyed by an invocation that ran through the whole runner.</summary>
@@ -284,6 +341,14 @@ public sealed class CliInvocationRecordingTests : IDisposable
         Assert.Equal(3000, entry.DurationMilliseconds);
     }
 
+    /// <summary>A clock that does not move, which is what a test asserting anything but a duration wants.</summary>
+    /// <remarks>
+    /// Every test here would otherwise take the wall clock, so a record's timestamp and duration would be whatever the
+    /// machine was doing while it ran. Nothing asserts either of those today, which makes the absence of a flake
+    /// incidental rather than intended — and the policy is about the dependency rather than about the flake.
+    /// </remarks>
+    private static FakeTimeProvider Stopped() => new(new DateTimeOffset(2026, 8, 17, 9, 0, 0, TimeSpan.Zero));
+
     /// <summary>Builds a context whose environment is stated rather than inherited.</summary>
     /// <remarks>
     /// Every test here drives the whole runner, which consults the shell for <see cref="CliOptions.LogVariable" />.
@@ -301,7 +366,7 @@ public sealed class CliInvocationRecordingTests : IDisposable
         static (_, _) => throw new InvalidOperationException("No command in this class opens a transport."),
         FakeMailboxRedirect.Silent(),
         static _ => false,
-        clock ?? TimeProvider.System,
+        clock ?? Stopped(),
         log,
         variables ?? (static _ => null));
 }

--- a/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Cli.Commands;
 using MailFathom.Cli.Credentials;
 using MailFathom.Cli.Diagnostics;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using Xunit;
 
@@ -94,6 +95,64 @@ public sealed class CliInvocationRecordingTests : IDisposable
         Assert.Null(Assert.Single(log.Appended).Failure);
     }
 
+    /// <summary>A command that refused by printing rather than raising still records what it printed.</summary>
+    /// <remarks>
+    /// A dozen commands treat a refusal as an ordinary outcome — a contact the book does not hold, a job no longer
+    /// dead-lettered, a confirmation declined — so they write one sentence and return a failing code without raising.
+    /// Nothing about that reaches the runner on its own, and those invocations were being recorded as failures with
+    /// nothing said about them.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_ACommandThatRefusedWithoutRaising_RecordsTheSentenceItPrinted()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding();
+
+        var log = new RecordingCliInvocationLog();
+
+        // Act
+        var exitCode = await CliRunner.RunAsync(
+            this.ContextReaching(deployment, log),
+            ["contact", "show", "--address", "nobody@example.test"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal(CliInvocationOutcome.Failed, entry.Outcome);
+        Assert.NotNull(entry.Failure);
+        Assert.DoesNotContain("nobody@example.test", entry.Failure, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>What a command reported on its way to doing what it was asked is not a failure on the record of it.</summary>
+    /// <remarks>
+    /// The control for the test above: recording the last line written to standard error whatever the invocation
+    /// returned would put a failure on every record of a command that reports its progress there, and the sign-in is
+    /// the one that reports the most.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_ACommandThatReportedOnStandardErrorAndSucceeded_RecordsNoFailure()
+    {
+        // Arrange
+        using var deployment = FakeAdminEndpoint.Accepting("workstation");
+
+        var console = new RecordingCliConsole { SecretToSupply = "not-a-real-key" };
+        var log = new RecordingCliInvocationLog();
+
+        // Act
+        var exitCode = await CliRunner.RunAsync(
+            this.ContextReaching(deployment, log, console),
+            ["login", "--endpoint", "https://mail.example.test:8443"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Null(entry.Failure);
+    }
+
     /// <summary>A subcommand is recorded by the path of names it was declared under, not by the one word at the end.</summary>
     [Fact]
     public async Task RunAsync_ASubcommand_RecordsThePathOfDeclaredNames()
@@ -179,26 +238,13 @@ public sealed class CliInvocationRecordingTests : IDisposable
         // Arrange
         using var deployment = FakeAdminEndpoint.Accepting("workstation");
 
-        var store = new CredentialStore(
-            Path.Combine(this.storeDirectory, "credentials.json"),
-            new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key")));
-
-        store.Save("production", new Uri("https://mail.example.test:8443"), "not-a-real-key", "workstation");
-
         var log = new RecordingCliInvocationLog();
 
-        var context = new CliContext(
-            new RecordingCliConsole(),
-            store,
-            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
-            FakeMailboxRedirect.Silent(),
-            static _ => false,
-            Stopped(),
-            log,
-            static _ => null);
-
         // Act
-        var exitCode = await CliRunner.RunAsync(context, ["status"], TestContext.Current.CancellationToken);
+        var exitCode = await CliRunner.RunAsync(
+            this.ContextReaching(deployment, log),
+            ["status"],
+            TestContext.Current.CancellationToken);
 
         // Assert
         var entry = Assert.Single(log.Appended);
@@ -223,21 +269,9 @@ public sealed class CliInvocationRecordingTests : IDisposable
         var console = new RecordingCliConsole { SecretToSupply = "not-a-real-key" };
         var log = new RecordingCliInvocationLog();
 
-        var context = new CliContext(
-            console,
-            new CredentialStore(
-                Path.Combine(this.storeDirectory, "credentials.json"),
-                new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key"))),
-            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
-            FakeMailboxRedirect.Silent(),
-            static _ => false,
-            Stopped(),
-            log,
-            static _ => null);
-
         // Act
         var exitCode = await CliRunner.RunAsync(
-            context,
+            this.ContextReaching(deployment, log, console),
             ["login", "--endpoint", "https://mail.example.test:8443"],
             TestContext.Current.CancellationToken);
 
@@ -339,6 +373,34 @@ public sealed class CliInvocationRecordingTests : IDisposable
 
         Assert.Equal(new DateTimeOffset(2026, 8, 17, 9, 0, 0, TimeSpan.Zero), entry.At);
         Assert.Equal(3000, entry.DurationMilliseconds);
+    }
+
+    /// <summary>Builds a context with a stored profile and a deployment that answers, which is what a command has to reach one.</summary>
+    /// <remarks>
+    /// The profile is saved up front because <c>DeploymentAccess.ReachAsync</c> resolves one before it opens anything,
+    /// so a command driven against a bare store stops before the deployment is involved at all. <c>login</c> is given
+    /// the same arrangement and simply establishes a second profile over it.
+    /// </remarks>
+    private CliContext ContextReaching(
+        FakeHttpMessageHandler deployment,
+        RecordingCliInvocationLog log,
+        RecordingCliConsole? console = null)
+    {
+        var store = new CredentialStore(
+            Path.Combine(this.storeDirectory, "credentials.json"),
+            new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key")));
+
+        store.Save("production", new Uri("https://mail.example.test:8443"), "not-a-real-key", "workstation");
+
+        return new CliContext(
+            console ?? new RecordingCliConsole(),
+            store,
+            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
+            FakeMailboxRedirect.Silent(),
+            static _ => false,
+            Stopped(),
+            log,
+            static _ => null);
     }
 
     /// <summary>A clock that does not move, which is what a test asserting anything but a duration wants.</summary>

--- a/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
@@ -1,0 +1,207 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Commands;
+using MailFathom.Cli.Credentials;
+using MailFathom.Cli.Diagnostics;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers what one invocation leaves behind in the local log, which is the only durable record of it.</summary>
+/// <remarks>
+/// <para>
+/// The command holds no exporter and opens no span, so once the terminal's scrollback is gone this file is the whole
+/// answer to what was run against a deployment and how it ended. What these assert is that the answer is there for
+/// every way an invocation can end, and that nothing the operator typed is in it.
+/// </para>
+/// <para>
+/// Driven through <see cref="CliRunner.RunAsync" /> against the real command tree rather than against the record
+/// directly, because what is under test is the runner's decision about when to append and with what — a record built
+/// by hand would assert the shape of a type nobody had asked to write anything.
+/// </para>
+/// </remarks>
+public sealed class CliInvocationRecordingTests
+{
+    /// <summary>An invocation that succeeded is recorded under the command it named, with the code it reported.</summary>
+    [Fact]
+    public async Task RunAsync_AnInvocationThatSucceeded_RecordsTheCommandAndTheExitCode()
+    {
+        // Arrange
+        var log = new RecordingCliInvocationLog();
+
+        // Act
+        var exitCode = await CliRunner.RunAsync(ContextFor(log), ["--version"], TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Equal(CliRootCommand.CommandName, entry.Command);
+        Assert.Equal(CliInvocationOutcome.Completed, entry.Outcome);
+        Assert.Equal(CliExitCode.Success, entry.ExitCode);
+        Assert.Null(entry.Failure);
+    }
+
+    /// <summary>An invocation the parser refused is recorded as a failure, under the command it got as far as.</summary>
+    [Fact]
+    public async Task RunAsync_AnInvocationTheParserRefused_RecordsItAsAFailure()
+    {
+        // Arrange
+        var log = new RecordingCliInvocationLog();
+
+        // Act
+        var exitCode = await CliRunner.RunAsync(
+            ContextFor(log),
+            ["--no-such-option"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.NotEqual(CliExitCode.Success, exitCode);
+        Assert.Equal(CliInvocationOutcome.Failed, entry.Outcome);
+        Assert.Equal(exitCode, entry.ExitCode);
+    }
+
+    /// <summary>A subcommand is recorded by the path of names it was declared under, not by the one word at the end.</summary>
+    [Fact]
+    public async Task RunAsync_ASubcommand_RecordsThePathOfDeclaredNames()
+    {
+        // Arrange
+        var log = new RecordingCliInvocationLog();
+
+        // Act
+        _ = await CliRunner.RunAsync(
+            ContextFor(log),
+            ["contact", "list", "--help"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.Equal($"{CliRootCommand.CommandName} contact list", entry.Command);
+    }
+
+    /// <summary>Nothing the operator typed beyond a declared command name reaches the record.</summary>
+    /// <remarks>
+    /// The assertion is over every value the record holds rather than over the command alone, because a field added
+    /// later would otherwise carry an argument unasserted. Both strings are this test's own, so a value that reached
+    /// the file could only have come from the argument list.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_AnInvocationCarryingAnAddressAndASecret_RecordsNeither()
+    {
+        // Arrange
+        var log = new RecordingCliInvocationLog();
+        const string Address = "https://mail.example.invalid:8443";
+        const string Secret = "sk-not-a-real-credential";
+
+        // Act
+        _ = await CliRunner.RunAsync(
+            ContextFor(log),
+            ["--endpoint", Address, "--token", Secret],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        var written = new[] { entry.Command, entry.Deployment, entry.Failure }
+            .Where(value => value is not null)
+            .ToArray();
+
+        Assert.NotEmpty(written);
+        Assert.DoesNotContain(written, value => value!.Contains(Address, StringComparison.Ordinal));
+        Assert.DoesNotContain(written, value => value!.Contains(Secret, StringComparison.Ordinal));
+    }
+
+    /// <summary>An invocation that asked for no record leaves none.</summary>
+    [Fact]
+    public async Task RunAsync_AnInvocationThatAskedForNoRecord_AppendsNothing()
+    {
+        // Arrange
+        var log = new RecordingCliInvocationLog();
+
+        // Act
+        _ = await CliRunner.RunAsync(
+            ContextFor(log),
+            ["--version", "--no-log"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(log.Appended);
+    }
+
+    /// <summary>A log that refused the record is said once and changes nothing about what the command reported.</summary>
+    /// <remarks>The case the whole seam exists for: a read-only home directory must not turn an invocation that did what it was asked into one that failed.</remarks>
+    [Fact]
+    public async Task RunAsync_ALogThatCouldNotBeWritten_ReportsItWithoutFailingTheCommand()
+    {
+        // Arrange
+        var console = new RecordingCliConsole();
+        var log = new RecordingCliInvocationLog { Accepts = false };
+
+        // Act
+        var exitCode = await CliRunner.RunAsync(
+            ContextFor(log, console),
+            ["--version"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Contains(console.Errors, line => line.Contains(log.Location, StringComparison.Ordinal));
+    }
+
+    /// <summary>A context given no log writes nowhere, which is what every test that is not about the log relies on.</summary>
+    [Fact]
+    public async Task RunAsync_AContextWithNoLog_RunsTheCommandAnyway()
+    {
+        // Arrange
+        var console = new RecordingCliConsole();
+
+        // Act
+        var exitCode = await CliRunner.RunAsync(
+            ContextFor(log: null, console),
+            ["--version"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Empty(console.Errors);
+    }
+
+    /// <summary>How long the invocation took is measured against the clock it was given, not against the wall.</summary>
+    [Fact]
+    public async Task RunAsync_AnInvocationThatTookTime_RecordsWhatTheClockMeasured()
+    {
+        // Arrange
+        var log = new RecordingCliInvocationLog();
+        var clock = new FakeTimeProvider(new DateTimeOffset(2026, 8, 17, 9, 0, 0, TimeSpan.Zero));
+        var context = ContextFor(log, new RecordingCliConsole(), clock);
+
+        clock.Advance(TimeSpan.FromSeconds(3));
+
+        // Act
+        _ = await CliRunner.RunAsync(context, ["--version"], TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.Equal(new DateTimeOffset(2026, 8, 17, 9, 0, 0, TimeSpan.Zero), entry.At);
+        Assert.Equal(3000, entry.DurationMilliseconds);
+    }
+
+    private static CliContext ContextFor(
+        RecordingCliInvocationLog? log,
+        RecordingCliConsole? console = null,
+        TimeProvider? clock = null) => new(
+        console ?? new RecordingCliConsole(),
+        new CredentialStore("credentials.json", new TokenProtector("credentials.key")),
+        static (_, _) => throw new InvalidOperationException("No command in this class opens a transport."),
+        FakeMailboxRedirect.Silent(),
+        static _ => false,
+        clock ?? TimeProvider.System,
+        log);
+}

--- a/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
@@ -85,36 +85,74 @@ public sealed class CliInvocationRecordingTests
         Assert.Equal($"{CliRootCommand.CommandName} contact list", entry.Command);
     }
 
-    /// <summary>Nothing the operator typed beyond a declared command name reaches the record.</summary>
+    /// <summary>A command that reached the deployment seam records the failure it printed, and names no command argument.</summary>
     /// <remarks>
-    /// The assertion is over every value the record holds rather than over the command alone, because a field added
-    /// later would otherwise carry an argument unasserted. Both strings are this test's own, so a value that reached
-    /// the file could only have come from the argument list.
+    /// Driven through <c>status</c> against an empty store, which is the shortest route to the one path that both
+    /// resolves a deployment and raises a <see cref="CliFailure" /> — a run that stops at the parser reaches neither,
+    /// so it would satisfy an assertion about what they write without ever having written anything.
     /// </remarks>
     [Fact]
-    public async Task RunAsync_AnInvocationCarryingAnAddressAndASecret_RecordsNeither()
+    public async Task RunAsync_ACommandThatFailedAgainstADeployment_RecordsTheLineItPrinted()
     {
         // Arrange
+        var console = new RecordingCliConsole();
         var log = new RecordingCliInvocationLog();
         const string Address = "https://mail.example.invalid:8443";
-        const string Secret = "sk-not-a-real-credential";
 
         // Act
-        _ = await CliRunner.RunAsync(
-            ContextFor(log),
-            ["--endpoint", Address, "--token", Secret],
+        var exitCode = await CliRunner.RunAsync(
+            ContextFor(log, console),
+            ["status", "--endpoint", Address],
             TestContext.Current.CancellationToken);
 
         // Assert
         var entry = Assert.Single(log.Appended);
 
-        var written = new[] { entry.Command, entry.Deployment, entry.Failure }
-            .Where(value => value is not null)
-            .ToArray();
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Equal($"{CliRootCommand.CommandName} status", entry.Command);
+        Assert.Equal(Assert.Single(console.Errors), entry.Failure);
+    }
 
-        Assert.NotEmpty(written);
-        Assert.DoesNotContain(written, value => value!.Contains(Address, StringComparison.Ordinal));
-        Assert.DoesNotContain(written, value => value!.Contains(Secret, StringComparison.Ordinal));
+    /// <summary>The command a record names is the declared one, whatever the operator typed after it.</summary>
+    /// <remarks>
+    /// The address is deliberately allowed to reach <see cref="CliInvocationEntry.Failure" /> and is asserted against
+    /// the command alone for that reason — what this holds is that the field naming the operation is derived from the
+    /// parser rather than from the argument list, which is where a credential would be.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_AnInvocationCarryingAnAddress_NamesTheCommandWithoutIt()
+    {
+        // Arrange
+        var log = new RecordingCliInvocationLog();
+        const string Address = "https://mail.example.invalid:8443";
+
+        // Act
+        _ = await CliRunner.RunAsync(
+            ContextFor(log),
+            ["status", "--endpoint", Address],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.DoesNotContain(Address, entry.Command, StringComparison.Ordinal);
+    }
+
+    /// <summary>A shell that turned the log off is obeyed by an invocation that ran through the whole runner.</summary>
+    [Fact]
+    public async Task RunAsync_AShellThatTurnedTheLogOff_AppendsNothing()
+    {
+        // Arrange
+        var log = new RecordingCliInvocationLog();
+
+        // Act
+        _ = await CliRunner.RunAsync(
+            ContextFor(log, variables: name => name == CliOptions.LogVariable ? CliOptions.LogOff : null),
+            ["--version"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Empty(log.Appended);
     }
 
     /// <summary>An invocation that asked for no record leaves none.</summary>
@@ -193,15 +231,24 @@ public sealed class CliInvocationRecordingTests
         Assert.Equal(3000, entry.DurationMilliseconds);
     }
 
+    /// <summary>Builds a context whose environment is stated rather than inherited.</summary>
+    /// <remarks>
+    /// Every test here drives the whole runner, which consults the shell for <see cref="CliOptions.LogVariable" />.
+    /// Reading the process's own environment would make each of these depend on whether whoever started the test run
+    /// had turned the log off — which the documentation tells operators to do — so the reader is supplied and answers
+    /// for nothing by default.
+    /// </remarks>
     private static CliContext ContextFor(
         RecordingCliInvocationLog? log,
         RecordingCliConsole? console = null,
-        TimeProvider? clock = null) => new(
+        TimeProvider? clock = null,
+        Func<string, string?>? variables = null) => new(
         console ?? new RecordingCliConsole(),
         new CredentialStore("credentials.json", new TokenProtector("credentials.key")),
         static (_, _) => throw new InvalidOperationException("No command in this class opens a transport."),
         FakeMailboxRedirect.Silent(),
         static _ => false,
         clock ?? TimeProvider.System,
-        log);
+        log,
+        variables ?? (static _ => null));
 }

--- a/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
+++ b/tests/Cli.UnitTests/CliInvocationRecordingTests.cs
@@ -126,16 +126,17 @@ public sealed class CliInvocationRecordingTests : IDisposable
         Assert.DoesNotContain("nobody@example.test", entry.Failure, StringComparison.OrdinalIgnoreCase);
     }
 
-    /// <summary>What a command reported on its way to doing what it was asked is not a failure on the record of it.</summary>
+    /// <summary>A caution a command raised on its way to doing what it was asked is not a failure on the record of it.</summary>
     /// <remarks>
-    /// The control for the test above: recording the last line written to standard error whatever the invocation
-    /// returned would put a failure on every record of a command that reports something there and then succeeds. A
-    /// deployment on another build of this release line is that arrangement — the version agreement permits the command
-    /// and warns about it — and the first assertion is what makes the second one mean something, since a test whose
-    /// terminal stayed silent would pass with the exit-code guard removed.
+    /// The control for the test above, and it holds twice over: reading every line standard error carried would put a
+    /// failure on the record of a command that only warned, and reading the failure lines whatever the invocation
+    /// returned would put one there too. A deployment on another build of this release line is the arrangement for both
+    /// — the version agreement permits the command and cautions about it — and the assertion on the terminal is what
+    /// makes the assertion on the record mean something, since a test whose terminal stayed silent would pass either
+    /// way.
     /// </remarks>
     [Fact]
-    public async Task RunAsync_ACommandThatReportedOnStandardErrorAndSucceeded_RecordsNoFailure()
+    public async Task RunAsync_ACommandThatCautionedAndSucceeded_RecordsNoFailure()
     {
         // Arrange
         using var deployment = FakeAdminEndpoint.Accepting("workstation", FakeAdminEndpoint.AnotherBuildOfThisLine);
@@ -152,9 +153,40 @@ public sealed class CliInvocationRecordingTests : IDisposable
         // Assert
         var entry = Assert.Single(log.Appended);
 
-        Assert.NotEmpty(console.Errors);
+        Assert.NotEmpty(console.Warnings);
         Assert.Equal(CliExitCode.Success, exitCode);
         Assert.Null(entry.Failure);
+    }
+
+    /// <summary>A caution raised before a refusal does not displace it, because only a failure line is a refusal.</summary>
+    /// <remarks>
+    /// Standard error carries three kinds of line and the last one written is not always the refusal: every command
+    /// settles the two versions before its own operation, so a deployment on another build cautions first and the
+    /// command refuses after. Reading the stream rather than the kind would record the caution and lose what actually
+    /// stopped the command.
+    /// </remarks>
+    [Fact]
+    public async Task RunAsync_ACommandThatCautionedAndThenRefused_RecordsTheRefusal()
+    {
+        // Arrange
+        using var deployment = FakeContactDeployment.Holding(version: FakeAdminEndpoint.AnotherBuildOfThisLine);
+
+        var console = new RecordingCliConsole();
+        var log = new RecordingCliInvocationLog();
+
+        // Act
+        var exitCode = await CliRunner.RunAsync(
+            this.ContextReaching(deployment, log, console),
+            ["contact", "show", "--address", "nobody@example.test"],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var entry = Assert.Single(log.Appended);
+
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.NotEmpty(console.Warnings);
+        Assert.Equal(console.Failures[^1], entry.Failure);
+        Assert.DoesNotContain(entry.Failure!, console.Warnings);
     }
 
     /// <summary>An invocation that raised something the command did not expect is recorded as a fault, by its type.</summary>

--- a/tests/Cli.UnitTests/FakeContactDeployment.cs
+++ b/tests/Cli.UnitTests/FakeContactDeployment.cs
@@ -27,19 +27,23 @@ internal static class FakeContactDeployment
     /// <param name="page">What a listing answers, or <see langword="null" /> where the test asks for none.</param>
     /// <param name="erasure">What an erasure answers, or <see langword="null" /> where the test asks for none.</param>
     /// <param name="export">What an export answers, or <see langword="null" /> where the test asks for none.</param>
+    /// <param name="version">The release this deployment reports, or <see langword="null" /> for the command's own.</param>
     /// <returns>The deployment.</returns>
     /// <remarks>
     /// The session route is answered unconditionally, because every command settles the two versions there before its
     /// own operation and a double serving the contact routes alone would report a deployment nothing can be
-    /// administered on.
+    /// administered on. That settling is also the one thing a contact command does before its own work, which is why
+    /// the version is stated here at all: a test about what a command writes before it refuses has no other way to make
+    /// it write anything.
     /// </remarks>
     internal static FakeHttpMessageHandler Holding(
         string? lookup = null,
         string? write = null,
         string? page = null,
         string? erasure = null,
-        string? export = null) =>
-        new((request, _) => Task.FromResult(Answer(request, lookup, write, page, erasure, export)));
+        string? export = null,
+        string? version = null) =>
+        new((request, _) => Task.FromResult(Answer(request, lookup, write, page, erasure, export, version)));
 
     /// <summary>Writes the body a read of one contact answers with.</summary>
     /// <param name="displayName">The name the contact carries.</param>
@@ -168,7 +172,8 @@ internal static class FakeContactDeployment
         string? write,
         string? page,
         string? erasure,
-        string? export)
+        string? export,
+        string? version)
     {
         var path = request.RequestUri?.AbsolutePath;
 
@@ -176,7 +181,7 @@ internal static class FakeContactDeployment
         {
             return Json(
                 HttpStatusCode.OK,
-                FakeAdminEndpoint.SessionBody("workstation", FakeAdminEndpoint.CommandVersion));
+                FakeAdminEndpoint.SessionBody("workstation", version ?? FakeAdminEndpoint.CommandVersion));
         }
 
         if (path == AdminEndpointRoutes.ContactsPath)

--- a/tests/Cli.UnitTests/FileCliInvocationLogTests.cs
+++ b/tests/Cli.UnitTests/FileCliInvocationLogTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Runtime.InteropServices;
 using MailFathom.Cli.Diagnostics;
 using Xunit;
 
@@ -143,6 +144,30 @@ public sealed class FileCliInvocationLogTests : IDisposable
         // Assert
         Assert.False(File.Exists(this.Location() + FileCliInvocationLog.RolledSuffix));
         Assert.True(new FileInfo(this.Location()).Length > FileCliInvocationLog.MaximumBytes - 1);
+    }
+
+    /// <summary>
+    /// The log names which deployments an operator administers and when, which is what makes it worth reading on a
+    /// shared machine, so it is created on the credential store's terms: readable by its owner and nobody else, and set
+    /// as the file is created rather than tightened afterwards. Windows carries no mode to read back, as
+    /// <see cref="CredentialStoreTests" /> says of the store itself.
+    /// </summary>
+    [Fact]
+    public void TryAppend_OnAPlatformWithFileModes_CreatesTheLogReadableByItsOwnerAlone()
+    {
+        // Arrange
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return;
+        }
+
+        var log = new FileCliInvocationLog(this.Location());
+
+        // Act
+        _ = log.TryAppend(Entry("mfctl status"));
+
+        // Assert
+        Assert.Equal(UnixFileMode.UserRead | UnixFileMode.UserWrite, File.GetUnixFileMode(this.Location()));
     }
 
     /// <summary>A path that cannot be written to is reported rather than raised, which is what keeps a command's own answer intact.</summary>

--- a/tests/Cli.UnitTests/FileCliInvocationLogTests.cs
+++ b/tests/Cli.UnitTests/FileCliInvocationLogTests.cs
@@ -1,0 +1,174 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Diagnostics;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers the file the record is appended to: its shape, its ceiling, and what it does when it cannot be written.</summary>
+/// <remarks>
+/// Against a real directory under the temporary path, as <see cref="CredentialStoreTests" /> is, because what is under
+/// test is file behaviour — appending, rolling over, and refusing — and a substitute for the file system would assert
+/// the substitute. Each instance owns a directory named after a fresh identifier and removes it, so nothing here is
+/// shared with another test.
+/// </remarks>
+public sealed class FileCliInvocationLogTests : IDisposable
+{
+    private readonly string directory =
+        Path.Combine(Path.GetTempPath(), $"mailfathom-cli-log-tests-{Guid.NewGuid():N}");
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Directory.Exists(this.directory))
+        {
+            Directory.Delete(this.directory, recursive: true);
+        }
+    }
+
+    /// <summary>A record is appended as one line of JSON, in a file created under a directory that did not exist.</summary>
+    [Fact]
+    public void TryAppend_TheFirstRecord_WritesOneLineAndCreatesTheDirectory()
+    {
+        // Arrange
+        var log = new FileCliInvocationLog(this.Location());
+
+        // Act
+        var written = log.TryAppend(Entry("mfctl status"));
+
+        // Assert
+        var lines = File.ReadAllLines(this.Location());
+
+        Assert.True(written);
+        Assert.Equal("mfctl status", Assert.Single(lines).Read().Command);
+    }
+
+    /// <summary>A second record joins the first rather than replacing it, which is what makes the file a history.</summary>
+    [Fact]
+    public void TryAppend_ASecondRecord_LeavesTheFirstInPlace()
+    {
+        // Arrange
+        var log = new FileCliInvocationLog(this.Location());
+
+        // Act
+        _ = log.TryAppend(Entry("mfctl status"));
+        _ = log.TryAppend(Entry("mfctl profiles"));
+
+        // Assert
+        var commands = File.ReadAllLines(this.Location()).Select(line => line.Read().Command).ToArray();
+
+        Assert.Equal(["mfctl status", "mfctl profiles"], commands);
+    }
+
+    /// <summary>Every field the record carries survives the round trip, including the ones that may be absent.</summary>
+    [Fact]
+    public void TryAppend_ARecordOfAFailedInvocation_WritesEveryFieldItCarries()
+    {
+        // Arrange
+        var log = new FileCliInvocationLog(this.Location());
+        var entry = Entry("mfctl contacts delete") with
+        {
+            Outcome = CliInvocationOutcome.Failed,
+            ExitCode = CliExitCode.Failure,
+            Deployment = "production",
+            Failure = "The deployment answered 404 rather than a contact.",
+        };
+
+        // Act
+        _ = log.TryAppend(entry);
+
+        // Assert
+        var written = Assert.Single(File.ReadAllLines(this.Location())).Read();
+
+        Assert.Equal(entry, written);
+    }
+
+    /// <summary>A field the record does not carry is left out rather than written as a null, so a line stays readable.</summary>
+    [Fact]
+    public void TryAppend_ARecordThatReachedNoDeployment_WritesNoDeploymentField()
+    {
+        // Arrange
+        var log = new FileCliInvocationLog(this.Location());
+
+        // Act
+        _ = log.TryAppend(Entry("mfctl status"));
+
+        // Assert
+        var line = Assert.Single(File.ReadAllLines(this.Location()));
+
+        Assert.DoesNotContain("deployment", line, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("failure", line, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Past its ceiling the file is moved aside and a new one started, so the log cannot grow without limit.</summary>
+    [Fact]
+    public void TryAppend_AFileThatReachedItsCeiling_StartsANewOneAndKeepsTheOld()
+    {
+        // Arrange
+        var log = new FileCliInvocationLog(this.Location());
+
+        Directory.CreateDirectory(this.directory);
+        File.WriteAllBytes(this.Location(), new byte[FileCliInvocationLog.MaximumBytes]);
+
+        // Act
+        var written = log.TryAppend(Entry("mfctl status"));
+
+        // Assert
+        var rolled = this.Location() + FileCliInvocationLog.RolledSuffix;
+
+        Assert.True(written);
+        Assert.Equal("mfctl status", Assert.Single(File.ReadAllLines(this.Location())).Read().Command);
+        Assert.Equal(FileCliInvocationLog.MaximumBytes, new FileInfo(rolled).Length);
+    }
+
+    /// <summary>A file still under its ceiling is appended to rather than rolled over.</summary>
+    /// <remarks>
+    /// The control for the test above: a rollover on every append would satisfy that assertion just as well and would
+    /// leave the log holding one record.
+    /// </remarks>
+    [Fact]
+    public void TryAppend_AFileUnderItsCeiling_KeepsWritingToIt()
+    {
+        // Arrange
+        var log = new FileCliInvocationLog(this.Location());
+
+        Directory.CreateDirectory(this.directory);
+        File.WriteAllBytes(this.Location(), new byte[FileCliInvocationLog.MaximumBytes - 1]);
+
+        // Act
+        _ = log.TryAppend(Entry("mfctl status"));
+
+        // Assert
+        Assert.False(File.Exists(this.Location() + FileCliInvocationLog.RolledSuffix));
+        Assert.True(new FileInfo(this.Location()).Length > FileCliInvocationLog.MaximumBytes - 1);
+    }
+
+    /// <summary>A path that cannot be written to is reported rather than raised, which is what keeps a command's own answer intact.</summary>
+    [Fact]
+    public void TryAppend_APathThatIsADirectory_ReportsThatItCouldNotBeWritten()
+    {
+        // Arrange
+        var log = new FileCliInvocationLog(this.Location());
+
+        Directory.CreateDirectory(this.Location());
+
+        // Act
+        var written = log.TryAppend(Entry("mfctl status"));
+
+        // Assert
+        Assert.False(written);
+    }
+
+    private static CliInvocationEntry Entry(string command) => new(
+        new DateTimeOffset(2026, 8, 17, 9, 0, 0, TimeSpan.Zero),
+        command,
+        CliInvocationOutcome.Completed,
+        DurationMilliseconds: 42)
+    {
+        ExitCode = CliExitCode.Success,
+    };
+
+    private string Location() => Path.Combine(this.directory, FileCliInvocationLog.FileName);
+}

--- a/tests/Cli.UnitTests/RecordingCliInvocationLog.cs
+++ b/tests/Cli.UnitTests/RecordingCliInvocationLog.cs
@@ -1,0 +1,34 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Diagnostics;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>A log that keeps what was appended, and refuses when a test asks it to.</summary>
+/// <remarks>Refusal is part of the contract rather than a convenience: an invocation whose record could not be written must still report what the command did, and only a writer that fails proves it.</remarks>
+internal sealed class RecordingCliInvocationLog : ICliInvocationLog
+{
+    /// <summary>Gets the records appended, in order.</summary>
+    internal List<CliInvocationEntry> Appended { get; } = [];
+
+    /// <summary>Gets or sets a value indicating whether this log accepts what it is given.</summary>
+    internal bool Accepts { get; set; } = true;
+
+    /// <inheritdoc />
+    public string Location => "/dev/null/mfctl.log";
+
+    /// <inheritdoc />
+    public bool TryAppend(CliInvocationEntry entry)
+    {
+        if (!this.Accepts)
+        {
+            return false;
+        }
+
+        this.Appended.Add(entry);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Closes #908.

`mfctl` left no durable record of anything it did. It holds no exporter and opens no span — #902 settled that and
`docs/operations/telemetry.md` says why — so once a terminal's scrollback was gone, nothing on the machine answered
*what did I run against that deployment, when, and how did it end*.

That is worst exactly where the terminal is least useful. A command that failed prints one operator-readable line by
design, because a stack trace is the wrong answer to a refused credential or a `409`. The line is enough to act on and
not enough to reconstruct a sequence afterwards.

## What it writes

One JSON line per invocation, appended to `mfctl.log` in the directory the credential store already owns —
`$XDG_CONFIG_HOME/MailFathom` or `~/.config/MailFathom` on Linux, `%APPDATA%\MailFathom` on Windows:

```json
{"at":"2026-08-17T09:41:22.184+00:00","command":"mfctl contact delete","outcome":"Failed","durationMilliseconds":412,"exitCode":1,"deployment":"production","failure":"The deployment answered 404 rather than a contact."}
```

JSON Lines rather than the indented shape the rest of the command serializes, so `tail`, `grep`, and `jq` each work on
it without a parser that spans lines. It gets a source-generated context of its own for that reason and no other; the
binary is trimmed, so reflection is not available to either.

`outcome` is one of four, and the append is in a `finally` rather than beside each `return` so that the last two are
reached at all: `Completed`, `Failed` with the line the command printed, `Faulted` with the *type* of what was raised,
and `Cancelled`. A crash puts its stack on the terminal and nowhere else, so the invocation the log is most worth
having for is the one it must not be silent about — but neither the exception's message nor its stack is recorded, the
first because a defect's message is written for whoever will fix it and quotes what the code was working on, the second
because it ends the one-record-per-line shape. Cancellation is its own ending rather than a fault, since a stopped
command and a broken one otherwise read identically and mean opposite things.

## What is in it, and what may never be

**No credential and no mail.** A credential never reaches a failure message in the first place — the failure rules
forbid one in a line written for a terminal — and nothing a command printed is offered to the log at all, so a contact,
an address, or a subject a command showed is out by construction rather than by filtering.

**The operator's own deployment is named, and the first revision claimed otherwise.** Review found both routes:
`CredentialStore` embeds the typed authority in `Not signed in to https://…`, and a sign-in that passes no `--name` is
named after the deployment's host, which `deployment` then carries on every later invocation. Both are kept. Scrubbing
would have to reach the account-alias and folder-alias messages too, so it would leave a guarantee true of one message
and false of several; and the file sits beside `credentials.json`, which records every profile's endpoint in clear, so
a log naming none of them would protect an address the same directory already discloses at the cost of the field the
log is read for. The claim is narrowed instead, in the entry's own remarks and in all three pages, and `telemetry.md`
says why an exported signal is still held to more: it leaves the machine for a store somebody else may read.

`command` carries no argument value either way — it is the path of names `mfctl` declares — and `deployment` is noted
where the profile is actually settled, in `DeploymentAccess`, so an invocation relying on the stored default records
what it truly reached rather than the empty option it was passed.

## Bounds and failure

Owner-readable on creation, on the same terms as the credential store and through the same `OwnerOnlyStorage`, which
gains an appending mode shared for reading and writing — two invocations can end at once, and a lock that failed the
second would lose a record to protect a file that appends rather than rewrites. Bounded at one mebibyte with a single
rollover to `mfctl.log.1`, so the log occupies at most twice that however long a deployment is administered. A recorded
failure message is bounded too.

A record that cannot be written — a read-only home, a full disk, a directory somebody removed — is reported as one line
on standard error and changes nothing else. The command's exit code and its own output stay exactly what they would
have been.

## The switch

`--no-log` for one invocation, accepted after the subcommand as well; `MAILFATHOM_LOG=off` for a shell session. What the
operator typed beats what their shell was told, and the default is on — the same order `CliOptions` already applies to
`--endpoint`, and no settings file, because `mfctl` composes no configuration pipeline. Every other value of the
variable leaves the log on rather than failing a command over a typo in it.

The variable is read through a seam on `CliContext`, beside the delegates it already carries for the transport, the
redirect, and the browser. Reading the process environment directly made every test that drives the runner depend on
whether the shell running them had set `MAILFATHOM_LOG=off` — which these very docs tell operators to do.

## Also here

`CredentialStore`'s private per-user directory resolution moved to `OperatorDirectory`, because two things now need it
and the reasoning about where a per-user directory is — and why the log lives beside configuration rather than under
`$XDG_STATE_HOME` — belongs in one place.

## Breaking changes

None. `CliContext` gains an optional parameter and `DeploymentAccess` a defaulted one, so nothing that constructs either
had to change; a context given no log writes nowhere, which is what every test not about the log relies on.

## Verification

`scripts/verify-full.sh`. The tests drive `CliRunner.RunAsync` against the real command tree for what is recorded and
when, assert the file's shape, its ceiling with the control that a file under it is not rolled, and its refusal; the
record's own decisions — the failure ceiling with its control, a faulted invocation borrowing no exit code — are
asserted directly; and the switch's precedence is asserted against a stated value of the variable.

Review found two of them proving nothing and both are fixed. The redaction test passed `--token`, which is no option,
and `--endpoint`, which is not on the root, so the run stopped at the parser and asserted over a parse failure — it
would have passed with any leak at all. It drives `status` against an empty store now. Rollover also gained one fix
found in review: a `File.Move` that lost a race to a concurrent invocation dropped the record it was making room for,
and is now tolerated the same way the shared append already is.


A third round found two more gaps in what is recorded, and both are behaviour rather than wording. A parse error is
reported by System.CommandLine and returns a code rather than raising, so a refused invocation was written as a failure
with nothing said about it; the parser's own errors are read back for that case, with a control asserting a successful
invocation still records none. And `login` establishes a profile instead of resolving one, so it never passed the seam
that notes which deployment was reached — the command that gives every deployment its name was the only one whose own
record carried none.

A fourth round found the largest gap of all: eleven commands treat a refusal as an ordinary outcome rather than a
defect — a contact the book does not hold, a job no longer dead-lettered, a confirmation declined, an erasure
interrupted — so each writes one sentence to standard error and returns a failing code without raising, and none of it
reached the runner. The commands now run against a console that forwards everything and remembers the last line written
to standard error, read only when the invocation failed and the parser had nothing of its own. Routing those refusals
through `CliFailure` was the alternative and is refused: they return a code because they are not defects.

That is also what makes the privacy claim precise rather than absolute, and the earlier wording was wrong the other
way. What a command was asked for goes to standard output, so mail is out by the split the command already keeps, and
every refusal sentence is already written to avoid naming a person — `ContactOutput` states the rule and
`ShowContactCommand.DescribeAbsence` demonstrates it. Both the entry's remarks and `admin-endpoint.md` now say that
instead of saying nothing printed is read.