### PR TITLE
[#914] Zoom a diagram by its own width so the enlargement redraws it rather than stretching a bitmap

### DIFF
--- a/docfx/template/public/main.css
+++ b/docfx/template/public/main.css
@@ -88,7 +88,14 @@ article pre.mermaid {
 
 .mf-viewer-stage {
   cursor: grab;
+
+  /* A figure zoomed past the viewport is panned around, so the stage keeps the width its contents ask
+     for instead of being shrunk back into the space a flex item is offered. */
+  flex: 0 0 auto;
   transform-origin: center center;
+
+  /* The transform this promotes a layer for carries the panning alone. The zoom is a width `main.js`
+     sets, which is what stops the enlargement from being a stretch of the bitmap this layer holds. */
   will-change: transform;
 }
 
@@ -96,25 +103,32 @@ article pre.mermaid {
   cursor: grabbing;
 }
 
-/* The copy the viewer shows starts at the size the page would have given it and is scaled from
-   there, so opening a diagram never reflows it into a different layout than the one being read. */
-.mf-viewer-stage > * {
-  max-width: 92vw;
-  max-height: 88vh;
-  margin: 0;
+/* The frame the figure sits in, sized to whatever the figure currently is. The padding is a constant
+   border around the drawing rather than part of it, which is why the zoom is carried by the figure
+   inside the frame and not by the frame itself. */
+.mf-viewer-frame {
+  width: fit-content;
   background: var(--bs-body-bg);
   border-radius: 0.5rem;
   padding: 1rem;
 }
 
-.mf-viewer-stage img {
-  display: block;
-  object-fit: contain;
+.mf-viewer-frame > * {
+  margin: 0;
 }
 
-.mf-viewer-stage svg {
-  max-width: 100%;
-  height: auto;
+/* The `<pre>` a Mermaid diagram arrives in carries the article's width and the article's answer to a
+   drawing wider than it. Both belong to the page rather than to the viewer, and left in place they
+   would hold the SVG at the width the reader opened the viewer to get past. */
+.mf-viewer-frame > pre {
+  width: max-content;
+  max-width: none;
+  padding: 0;
+  overflow: visible;
+}
+
+.mf-viewer-frame img {
+  display: block;
 }
 
 .mf-viewer-controls {

--- a/docfx/template/public/main.js
+++ b/docfx/template/public/main.js
@@ -18,6 +18,11 @@ const zoomStep = 1.2
 const minimumScale = 0.2
 const maximumScale = 40
 
+// The share of the viewport a figure larger than it opens into. The frame around it sits outside that
+// share, which is what the remainder leaves room for.
+const openWidthShare = 0.92
+const openHeightShare = 0.88
+
 export default {
   iconLinks: [
     {
@@ -218,8 +223,8 @@ function renderVersionNotice(layout, manifest, current) {
 
 // A diagram is drawn at the width of the article, which is the one measurement that has nothing to
 // do with how much detail it holds. The viewer opens it over the page at whatever size the reader
-// needs, and every gesture below moves one transform on one element: the wheel and the buttons
-// scale it about the pointer, a drag translates it, and Escape or the backdrop puts the page back.
+// needs: the wheel and the buttons scale it about the pointer, a drag translates it, and Escape or
+// the backdrop puts the page back.
 function installFigureViewer() {
   let viewer = null
 
@@ -265,15 +270,31 @@ function createViewer() {
   const pointers = new Map()
   let lastPointerSpread = 0
 
-  const applyTransform = () => {
-    stage.style.transform = `translate(${offsetX}px, ${offsetY}px) scale(${scale})`
+  // The figure the zoom resizes, the width it was drawn at on the page, and the scale it opens at.
+  // Carrying the zoom in a width rather than in the transform is what keeps an enlarged diagram sharp:
+  // the stage is a compositor layer, a layer is rasterized once at the size it is given, and a `scale()`
+  // over one stretches that bitmap however much vector art is inside it. A width is laid out instead, so
+  // the SVG is drawn again at every step and an image is resampled from its own pixels rather than from
+  // the copy the layer kept. The transform is left to carry the panning, which changes no raster size.
+  let zoomedFigure = null
+  let drawnSize = null
+  let openScale = 1
+
+  const applyView = () => {
+    stage.style.transform = zoomedFigure
+      ? `translate(${offsetX}px, ${offsetY}px)`
+      : `translate(${offsetX}px, ${offsetY}px) scale(${scale})`
+
+    if (zoomedFigure) {
+      zoomedFigure.style.width = `${drawnSize.width * scale}px`
+    }
   }
 
   const reset = () => {
-    scale = 1
+    scale = openScale
     offsetX = 0
     offsetY = 0
-    applyTransform()
+    applyView()
   }
 
   // Zooming about a point keeps whatever is under it still, which is what makes a wheel over the
@@ -288,7 +309,7 @@ function createViewer() {
     offsetX = clientX - centreX - (clientX - centreX - offsetX) * applied
     offsetY = clientY - centreY - (clientY - centreY - offsetY) * applied
     scale = next
-    applyTransform()
+    applyView()
   }
 
   const zoomAtCentre = factor => {
@@ -299,6 +320,7 @@ function createViewer() {
   const close = () => {
     root.hidden = true
     stage.replaceChildren()
+    zoomedFigure = null
     pointers.clear()
     document.body.classList.remove('mf-viewer-open')
   }
@@ -343,7 +365,7 @@ function createViewer() {
     if (pointers.size === 1) {
       offsetX += event.clientX - previous.clientX
       offsetY += event.clientY - previous.clientY
-      applyTransform()
+      applyView()
       return
     }
 
@@ -372,6 +394,22 @@ function createViewer() {
   root.addEventListener('pointercancel', releasePointer)
   root.addEventListener('dblclick', reset)
 
+  // The size a figure fits into is the viewport's, so a window that changes size changes it. A reader
+  // who has zoomed is left where they are and reaches the new fit through the reset they already have;
+  // one who has not is following the fit, and a rotated phone is exactly when they need it followed.
+  window.addEventListener('resize', () => {
+    if (root.hidden || !zoomedFigure) {
+      return
+    }
+
+    const wasAtOpenScale = scale === openScale
+    openScale = openingScaleFor(drawnSize)
+
+    if (wasAtOpenScale) {
+      reset()
+    }
+  })
+
   document.addEventListener('keydown', event => {
     if (root.hidden) {
       return
@@ -390,14 +428,51 @@ function createViewer() {
 
   return {
     open(figure) {
+      const frame = document.createElement('div')
+      frame.className = 'mf-viewer-frame'
+
       const copy = figure.cloneNode(true)
       copy.removeAttribute('id')
-      stage.replaceChildren(copy)
+      frame.appendChild(copy)
+      stage.replaceChildren(frame)
+
+      // A Mermaid diagram is an `<svg>` inside the `<pre>` that was clicked, and it is the SVG rather than
+      // the `<pre>` that has a size worth stating. Either it or an image carries an aspect ratio, so a
+      // width is the whole of the instruction and the height follows from it — and both the article's cap
+      // on that width and Mermaid's own are withdrawn, since each holds the drawing at the one size the
+      // viewer exists to leave behind. A `<pre>` Mermaid has not drawn into yet has neither, and keeps the
+      // transform below so that its gestures still do something.
+      zoomedFigure = copy.matches('img') ? copy : copy.querySelector('svg')
+      const asDrawn = (figure.matches('img') ? figure : figure.querySelector('svg'))?.getBoundingClientRect()
+
+      if (zoomedFigure && asDrawn?.width > 0) {
+        zoomedFigure.style.maxWidth = 'none'
+        zoomedFigure.style.maxHeight = 'none'
+        zoomedFigure.style.height = 'auto'
+        drawnSize = asDrawn
+        openScale = openingScaleFor(asDrawn)
+      } else {
+        zoomedFigure = null
+        drawnSize = null
+        openScale = 1
+      }
+
       reset()
       root.hidden = false
       document.body.classList.add('mf-viewer-open')
     }
   }
+}
+
+// A figure opens at the size the page drew it at, reduced only where that size does not fit over the page.
+// Opening it larger than the page had it would be a second layout of the drawing the reader is looking at,
+// and opening a tall one unreduced would put its head and its foot outside the viewer before a gesture has
+// been made.
+function openingScaleFor(asDrawn) {
+  return Math.min(
+    1,
+    openWidthShare * window.innerWidth / asDrawn.width,
+    openHeightShare * window.innerHeight / asDrawn.height)
 }
 
 function controlButton(icon, title, onClick) {

--- a/docfx/template/public/main.js
+++ b/docfx/template/public/main.js
@@ -467,12 +467,16 @@ function createViewer() {
 // A figure opens at the size the page drew it at, reduced only where that size does not fit over the page.
 // Opening it larger than the page had it would be a second layout of the drawing the reader is looking at,
 // and opening a tall one unreduced would put its head and its foot outside the viewer before a gesture has
-// been made.
+// been made. The floor is the one every zoom already stops at: a drawing several times the height of the
+// viewport — a long diagram on a phone held sideways — would otherwise open below it, and the first zoom
+// out would then raise the scale to the floor and enlarge the figure it was asked to shrink.
 function openingScaleFor(asDrawn) {
-  return Math.min(
+  const fitted = Math.min(
     1,
     openWidthShare * window.innerWidth / asDrawn.width,
     openHeightShare * window.innerHeight / asDrawn.height)
+
+  return Math.max(minimumScale, fitted)
 }
 
 function controlButton(icon, title, onClick) {

--- a/docs/operations/documentation-site.md
+++ b/docs/operations/documentation-site.md
@@ -266,8 +266,9 @@ build has finished and against files the build never reads, so a page that rende
 does not are the same output as far as every gate here is concerned. **The site's appearance and its run-time
 behaviour are the parts of it verified by looking at the deployed site**, and every defect found that way so far — a
 logo at its natural size, a selector missing from the two pages served from a version's own directory, the same
-selector missing again when that directory was addressed without its trailing slash, and a selector that reached the
-header but stopped halfway across it — was invisible to a green build.
+selector missing again when that directory was addressed without its trailing slash, a selector that reached the
+header but stopped halfway across it, and a diagram whose viewer enlarged a bitmap of it rather than drawing it
+again — was invisible to a green build.
 
 What the template adds beyond that:
 
@@ -278,6 +279,13 @@ What the template adds beyond that:
   and the buttons zoom about the pointer, a drag pans, a double click resets, and <kbd>Esc</kbd> closes. Pinch-zoom
   works the same way on a touch screen. A diagram is drawn at the width of the article, which has nothing to do with
   how much detail it holds, and this is what makes the detail reachable.
+
+  **The zoom is the figure's own width, and the panning is the transform.** That split is what makes the enlargement
+  a redrawing of the diagram rather than a magnification of the picture the page had: the element a transform is
+  animated on is a compositor layer, a layer is rasterized once at the size it was given, and scaling one therefore
+  stretches that bitmap however much vector art is inside it. A width is laid out instead, so Mermaid draws its SVG
+  again at every step and an image is resampled from its own pixels. The figure opens at the size the page drew it
+  at, reduced only where that size would not fit over the page.
 
 Both are written against the DOM the `modern` template produces, which re-renders the navigation bar and every Mermaid
 diagram after the page loads. The selector is therefore re-placed by an observer whenever the navigation bar is written


### PR DESCRIPTION
Closes #914

The documentation site's figure viewer scaled a diagram with a CSS transform on `.mf-viewer-stage`, an element
carrying `will-change: transform`. That promotes it to a compositor layer, a layer is rasterized once at the size it
was given, and every `scale()` after that stretched the bitmap rather than redrawing what was inside it — so a Mermaid
diagram, which is vector art and should stay sharp at any magnification, blurred like a low-resolution screenshot the
moment it was enlarged. The same stylesheet capped the copy at `max-width: 100%` of a stage that shrank as a flex item,
so opening the diagram *also* reduced it: measured in a headless Chromium, a diagram drawn at 915 px on the page was
laid out at 300 px in the viewer and every zoom stretched that.

The zoom is now the figure's own width and the transform carries the panning alone. `open()` measures the SVG (or the
image) as the page drew it, withdraws the caps the article and Mermaid put on it, and each step of the zoom writes
`width` in pixels; the browser lays that out, so Mermaid draws its SVG again at the new size and an image is resampled
from its own pixels. A frame element now holds the padding and the background, which is why the border around the
drawing stays one rem wide at every scale instead of growing with it.

Three smaller things follow from the split:

- The figure opens at the size the page drew it at, reduced only where that size would not fit over the page, and
  never below `minimumScale` — a drawing several times the height of the viewport fits under the floor every zoom
  stops at, and opening it there would make the first zoom out enlarge it. The viewport share that decides the
  reduction moved from `92vw`/`88vh` in the stylesheet into `main.js`, because it is now an opening scale rather than
  a live cap — and a live cap is what the resize listener replaces: a reader who has not zoomed follows the new fit,
  one who has is left where they are and reaches it through the reset they already have.
- A `<pre class="mermaid">` that Mermaid has not drawn into yet has no SVG and therefore no width to state. It keeps
  the transform, so its gestures still do something.
- `.mf-viewer-stage` takes `flex: 0 0 auto`, so a figure zoomed past the viewport is panned around rather than shrunk
  back into the space a flex item is offered.

## Verification

No gate here can see any of this — everything the template adds happens in the browser, after the build has finished,
which `docs/operations/documentation-site.md` states and this change adds itself to the list of defects that proves.
So it was verified by driving the built site in a headless Chromium over CDP:

| What | Before | After |
| --- | --- | --- |
| A diagram drawn at 915×653 on the page, opened | laid out at 300 px wide | 915×653, transform identity |
| Zoomed 4.3× | one `scale(4.3)` over that 300 px raster | SVG laid out at 3934×2809, transform identity |
| Zoomed to the 40× ceiling | — | SVG laid out at 36593×26134, text still vector-sharp |
| An image drawn at 1089 px, zoomed 1.44× | — | laid out at 1568 px, transform identity |
| A 700×500 viewport | — | opens at 616×440, inside the viewport both ways |
| Dragging 150×120 px | — | `translate(150px, 120px)`, the figure's width unchanged |
| Resized to 640×480 while open | — | follows the fit unzoomed, stays put when zoomed |

Pointer-anchored wheel zoom, the buttons, pinch, double-click reset, <kbd>Esc</kbd>, and the `+`/`-`/`0` keys were all
exercised through the same session. Firefox was not: this host has no browser of its own and the container image is
Chromium, so the engine-independent part of the claim is the mechanism — a laid-out width rather than a compositor
behaviour — rather than a second measurement.

`scripts/verify-full.sh`, `scripts/test-agent-workflow.sh` (212 passed), and `scripts/build-docs-site.sh` are green.