### PR TITLE
[#918] Strip the byte-order mark from the schema artifact a release publishes

### DIFF
--- a/docs/operations/database-schema.md
+++ b/docs/operations/database-schema.md
@@ -31,6 +31,11 @@ once.
 It is also **only forward**. The script carries no reverse migrations, so it cannot undo anything, and nothing in
 MailFathom can. [Rolling back](#rolling-back) is what that leaves.
 
+And it is **UTF-8 with no byte-order mark**. `psql` does not skip one, so a marked file fails on its first statement
+with a syntax error naming a character nothing displays, which is a confusing way to be told the file is fine and the
+encoding is not. What EF Core generates does carry the mark; `scripts/build-schema-artifact.sh` removes it and refuses
+to publish a file that still has one, so an artifact attached to a release is one `psql -f` accepts.
+
 Read it before you run it. That is the whole reason the artifact is a SQL file rather than something that runs itself:
 
 ```bash

--- a/scripts/build-schema-artifact.sh
+++ b/scripts/build-schema-artifact.sh
@@ -97,10 +97,24 @@ mkdir --parents "$output_directory"
 artifact_path="$output_directory/mailfathom-schema-$artifact_version.sql"
 checksum_path="$artifact_path.sha256"
 
-cp "$published_script" "$artifact_path"
+# Copied without its byte-order mark, which is the one edit this makes to what the publish produced. EF Core writes the
+# script as UTF-8 with one, and psql does not skip it: the mark arrives as part of the first token, the apply stops on a
+# syntax error at the first CREATE, and nothing in that message names a character nobody can see. That command is what
+# docs/operations/database-schema.md gives an operator, so the mark makes the documented path from a downloaded release
+# to a schema fail on its first statement. Only the first line is touched, so the SQL itself is byte-identical.
+sed '1s/^\xef\xbb\xbf//' "$published_script" > "$artifact_path"
+
+# Asserted rather than trusted, because the failure it guards against is silent at this end and fatal at the operator's:
+# a build that ships a marked artifact again would look exactly like this one until somebody ran psql against it.
+if [[ "$(head --bytes=3 "$artifact_path" | od --address-radix=n --format=x1 | tr --delete ' ')" == 'efbbbf' ]]; then
+  printf 'The artifact still begins with a byte-order mark, which psql does not skip. Check that this\n' >&2
+  printf 'script strips it from %s.\n' "$published_script" >&2
+  exit 1
+fi
 
 # Written in sha256sum's own format and with the bare file name, so an operator verifies it from the directory the two
-# files were downloaded into: `sha256sum --check mailfathom-schema-<version>.sql.sha256`.
+# files were downloaded into: `sha256sum --check mailfathom-schema-<version>.sql.sha256`. It covers the file above, so
+# what an operator checksums is what they apply.
 (cd "$output_directory" && sha256sum "$(basename "$artifact_path")" > "$(basename "$checksum_path")")
 
 artifact_checksum="$(cut --delimiter=' ' --fields=1 < "$checksum_path")"

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -5203,6 +5203,142 @@ changelog_section_reading_returns_only_the_requested_release() {
   assert_excludes 'The first release.' "$output_file"
 }
 
+# The schema artifact is the one release asset an operator runs by hand, against their own database, from a command a
+# page here gives them. Nothing downstream of the build applies the published file — the integration suite generates the
+# same SQL through EF Core and applies it over ADO.NET, where a reader consumes a byte-order mark that psql would send
+# to the server — so what the file's first bytes are is asserted here or nowhere, and a marked artifact reaches whoever
+# downloads it next as a syntax error naming a character that cannot be seen.
+#
+# The fixture stands in for `aspire publish` rather than running it: what these contracts are about is the file the
+# script writes from the publish output, and a real publish would need the SDK, the tool manifest, and a minute of build
+# time to produce a fixture this one writes in three lines.
+create_schema_artifact_fixture() {
+  local fixture_root="$1"
+  local published_sql="$2"
+
+  mkdir -p "$fixture_root/scripts" "$fixture_root/stubs"
+  cp "$source_repository_root/scripts/build-schema-artifact.sh" "$fixture_root/scripts/"
+
+  git -C "$fixture_root" init --initial-branch=main --quiet
+
+  # `aspire publish` writes one SQL script under `efmigrations/`, and the guard the script asserts on is the migration
+  # history check that makes the artifact idempotent. Both are what the stub reproduces; the SQL itself is a stand-in.
+  cat > "$fixture_root/stubs/aspire" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_path=''
+previous=''
+for argument in "$@"; do
+  if [[ "$previous" == '--output-path' ]]; then
+    output_path="$argument"
+  fi
+  previous="$argument"
+done
+
+if [[ "${1:-}" == '--version' ]]; then
+  printf 'stub\n'
+  exit 0
+fi
+
+mkdir -p "$output_path/efmigrations"
+cp "$PUBLISHED_SQL" "$output_path/efmigrations/mailfathom.sql"
+STUB
+
+  # The manifest-local EF Core tooling is restored before the publish, and nothing in these contracts depends on it.
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$fixture_root/stubs/dotnet"
+
+  chmod +x "$fixture_root/stubs/aspire" "$fixture_root/stubs/dotnet"
+
+  cp "$published_sql" "$fixture_root/published.sql"
+}
+
+write_published_schema_script() {
+  local target_file="$1"
+  local leading_bytes="$2"
+
+  {
+    printf '%b' "$leading_bytes"
+    printf 'CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (\n'
+    printf '    "MigrationId" character varying(150) NOT NULL\n);\n\n'
+    printf 'DO $EF$\nBEGIN\n'
+    printf '    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = %s20260101000000_First%s) THEN\n' \
+      "'" "'"
+    printf '    CREATE TABLE "Emails" ("Id" uuid NOT NULL);\n    END IF;\nEND $EF$;\n'
+  } > "$target_file"
+}
+
+build_schema_artifact() {
+  local fixture_root="$1"
+  local output_directory="$2"
+  local output_file="$3"
+
+  (
+    cd "$fixture_root"
+    PATH="$fixture_root/stubs:$PATH" PUBLISHED_SQL="$fixture_root/published.sql" \
+      bash scripts/build-schema-artifact.sh "$output_directory" '9.9.9'
+  ) > "$output_file" 2>&1
+}
+
+schema_artifact_carries_no_byte_order_mark() {
+  local fixture_root="$test_directory/schema-artifact-marked"
+  local output_directory="$fixture_root/artifacts"
+  local output_file="$test_directory/schema-artifact-marked-output"
+  local artifact_path="$output_directory/mailfathom-schema-9.9.9.sql"
+
+  write_published_schema_script "$test_directory/published-marked.sql" '\xef\xbb\xbf'
+  create_schema_artifact_fixture "$fixture_root" "$test_directory/published-marked.sql"
+
+  build_schema_artifact "$fixture_root" "$output_directory" "$output_file"
+
+  if [[ "$(head --bytes=6 "$artifact_path")" != 'CREATE' ]]; then
+    printf 'Expected the artifact to begin with CREATE, and it begins with: %s\n' \
+      "$(head --bytes=6 "$artifact_path" | od --address-radix=n --format=x1)" >&2
+    return 1
+  fi
+
+  # The mark is the only difference the script may make to the publish output, so the rest is compared byte for byte.
+  if ! tail --bytes=+4 "$test_directory/published-marked.sql" | cmp --quiet - "$artifact_path"; then
+    printf 'The artifact differs from the published script by more than its byte-order mark.\n' >&2
+    return 1
+  fi
+
+  assert_contains '20260101000000_First' "$output_file"
+}
+
+schema_artifact_checksum_covers_the_file_an_operator_applies() {
+  local fixture_root="$test_directory/schema-artifact-checksum"
+  local output_directory="$fixture_root/artifacts"
+  local output_file="$test_directory/schema-artifact-checksum-output"
+
+  write_published_schema_script "$test_directory/published-checksum.sql" '\xef\xbb\xbf'
+  create_schema_artifact_fixture "$fixture_root" "$test_directory/published-checksum.sql"
+
+  build_schema_artifact "$fixture_root" "$output_directory" "$output_file"
+
+  # Exactly what the documentation asks an operator to run before applying the file.
+  if ! (cd "$output_directory" && sha256sum --check --status 'mailfathom-schema-9.9.9.sql.sha256'); then
+    printf 'The published checksum does not identify the artifact beside it.\n' >&2
+    return 1
+  fi
+}
+
+schema_artifact_leaves_an_unmarked_publish_untouched() {
+  local fixture_root="$test_directory/schema-artifact-unmarked"
+  local output_directory="$fixture_root/artifacts"
+  local output_file="$test_directory/schema-artifact-unmarked-output"
+
+  write_published_schema_script "$test_directory/published-unmarked.sql" ''
+  create_schema_artifact_fixture "$fixture_root" "$test_directory/published-unmarked.sql"
+
+  build_schema_artifact "$fixture_root" "$output_directory" "$output_file"
+
+  if ! cmp --quiet "$test_directory/published-unmarked.sql" "$output_directory/mailfathom-schema-9.9.9.sql"; then
+    printf 'A publish that carried no byte-order mark was rewritten anyway.\n' >&2
+    return 1
+  fi
+}
+
 # The winget manifest is the one thing this repository produces whose correctness is judged in somebody else's pull
 # request, days after the release that submitted it. What is asserted here is what a Windows install actually depends
 # on: that `portable` with `Commands` is what makes the binary reachable as `mfctl` rather than under the versioned
@@ -6282,6 +6418,9 @@ run_test release_tag_assertion_accepts_a_patch_from_a_release_branch
 run_test release_tag_assertion_refuses_a_version_already_released_on_its_line
 run_test release_tag_assertion_refuses_an_empty_changelog_section
 run_test changelog_section_reading_returns_only_the_requested_release
+run_test schema_artifact_carries_no_byte_order_mark
+run_test schema_artifact_checksum_covers_the_file_an_operator_applies
+run_test schema_artifact_leaves_an_unmarked_publish_untouched
 run_test winget_manifests_name_the_release_assets_they_hash
 run_test winget_manifest_names_the_product_and_the_command
 run_test winget_manifests_refuse_a_missing_windows_binary


### PR DESCRIPTION
`scripts/build-schema-artifact.sh` copied the SQL `aspire publish` writes straight to
`mailfathom-schema-<version>.sql`, and EF Core writes that script as UTF-8 with a byte-order mark. `psql` does not skip
one, so the apply command `docs/operations/database-schema.md` gives an operator stopped on its first statement with a
syntax error naming a character nothing displays. Every published artifact from `v0.2.0` to `v0.6.0` begins `ef bb bf`,
so the documented path from a downloaded release to a schema has never worked.

Nothing caught it because nothing applies the published file: `OrchestratedSchemaArtifactTests` generates the same SQL
through EF Core and applies it over ADO.NET, where a reader consumes the mark instead of sending it to the server, and
the workflow that builds the artifact deliberately reaches no database.

## What changed

- **The artifact is written without the mark.** Only the first line is touched, so the SQL is byte-identical to what
  the publish produced, and the checksum is taken over the corrected file — what an operator verifies is what they
  apply.
- **The build refuses a marked artifact.** The failure this guards against is silent at the build's end and fatal at
  the operator's, so it is asserted rather than trusted.
- **Three contracts in `scripts/test-agent-workflow.sh`** hold the artifact's first bytes and its equality with the
  publish output, the checksum over the published pair, and that a publish carrying no mark is left byte for byte
  alone. The fixture stands in for `aspire publish`, because what is under test is the file the script writes from the
  publish output.
- **`docs/operations/database-schema.md`** states the artifact's encoding where it says what the file is.

No behavior of the service changes, and no released artifact is corrected retroactively: `v0.6.0`'s asset still carries
the mark, and an operator applying it today strips it themselves or waits for the next release.

Closes #918

---

Issue: https://github.com/Krzysztof318/MailFathom/issues/918
