### PR TITLE
[#921] Claim the Glama directory listing with a maintainer record

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["Krzysztof318"]
+}


### PR DESCRIPTION
Adds a root `glama.json` naming the maintainer of MailFathom's entry in the Glama MCP directory.

The directory builds the server from a specification held in its own admin panel and inspects it over `tools/list`. Against the listing it reports one gap that belongs to this repository: no `glama.json`. The file's schema (`https://glama.ai/mcp/schemas/server.json`) has exactly one property — `maintainers`, the GitHub accounts permitted to maintain the listing — so the file states who owns the entry and nothing else. Without it the entry is unclaimed.

It joins `server.json` and `context7.json` in the repository root, which are the same kind of file: metadata a third-party registry reads about this project, rather than anything the build, the host, or an operator consumes. Nothing here reads it, no gate asserts it, and no public surface moves.

The other two gaps the directory reports are not repository work: usage data comes from running the listed server, and related-server links are set on the directory itself.

## Verification

No verification was run, at the owner's explicit request: the change is one JSON file that no build, test, script, or documentation page reads. No C# moved, so the solution's Release build and unit suite cover the same tree they covered on `main`.

Closes #921

- Issue: https://github.com/Krzysztof318/MailFathom/issues/921
- Pull request: https://github.com/Krzysztof318/MailFathom/pull/922