### PR TITLE
[#587] Enforce a caller's grant on every administrative route, and separate the write from the reads

### DIFF
--- a/docs/architecture/authorized-principal.md
+++ b/docs/architecture/authorized-principal.md
@@ -104,8 +104,19 @@ does not exist: the same error, the same code, and nothing about the caller, the
 refusal never reaches a client in a form it could read;
 [the MCP tools page](../features/mcp-tools.md#what-a-caller-is-offered) states which tool requires which permission.
 
-**The administrative surface has no mapping yet**, so no route there requires a permission and none can produce this
-refusal. The other requirement in force is the download route's, which admits a signed capability and nothing else.
+**The administrative surface answers it by naming the permission and nothing else.** Every route there publishes the one
+permission it requires as endpoint metadata, decided beside the route rather than in a list a new route could be added
+without joining, and a group filter reads that metadata ahead of the handler: a caller the grant does not admit is
+refused `403` in the endpoint's ordinary problem shape, stating the permission that would have sufficed and carrying it
+as a `permission` member so `mfctl` can say what to grant. A route publishing no decision is refused to everyone, which
+is what makes the omission a visible failure rather than an open route. The use case behind the route asks the same
+question again and raises this refusal on its own, and the filter answers that exception in the same shape — so the
+transport is a cheap first reading rather than the authority. `GET /session` is the one route that requires no
+permission, because reporting what the credential is and what it may do is what a caller holding nothing needs in order
+to learn that it holds nothing.
+[The administrative endpoint page](../operations/admin-endpoint.md#what-the-endpoint-serves) carries the whole mapping.
+
+The other requirement in force is the download route's, which admits a signed capability and nothing else.
 
 The transport's own reading of the grant goes through the same `AccessAuthorization` the use cases ask, which reports a
 verdict instead of raising where a boundary has to compose an answer rather than perform an operation. One definition of

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -1,6 +1,6 @@
 # Administering a deployment
 
-<!-- describes: src/Host/Configuration/Endpoints/AdminEndpointOptions.cs, src/Host/Api/Admin*.cs, src/Host/Api/Contact*.cs, src/Host/Api/Embedding*.cs, src/Host/Api/Job*.cs, src/Host/Api/Mail*.cs, src/Host/Api/Spam*.cs, src/Host/Hosting/Startup/SurfaceIsolation.cs, src/Host/Hosting/Warnings/AdminTransportSecurityWarning.cs, src/Host/Hosting/Warnings/TransportGrantStartupReport.cs, src/Domain/Access/MailFathomPermission.cs, src/Host/Security/Endpoints/TransportListenerBinder.cs, src/Host/Security/Transport/TransportRateLimiting.cs, src/Cli/**, scripts/install-mfctl.sh -->
+<!-- describes: src/Host/Configuration/Endpoints/AdminEndpointOptions.cs, src/Host/Api/Admin*.cs, src/Host/Api/Contact*.cs, src/Host/Api/Embedding*.cs, src/Host/Api/Job*.cs, src/Host/Api/Mail*.cs, src/Host/Api/Spam*.cs, src/Host/Hosting/Startup/SurfaceIsolation.cs, src/Host/Hosting/Warnings/AdminTransportSecurityWarning.cs, src/Host/Hosting/Warnings/TransportGrantStartupReport.cs, src/Domain/Access/MailFathomPermission.cs, src/Host/Security/Endpoints/AdminRouteAuthorization.cs, src/Host/Security/Endpoints/AdminRoutePermission.cs, src/Host/Security/Endpoints/TransportListenerBinder.cs, src/Host/Security/Transport/TransportRateLimiting.cs, src/Cli/**, scripts/install-mfctl.sh -->
 
 How the `mfctl` command reaches a running deployment, and what that deployment has to have enabled before it will
 answer.
@@ -87,14 +87,19 @@ nothing publishes fails startup, naming the entry and the position in the list, 
 read as a narrower grant than you meant; so is a name the same grant already carries. A `mailfathom.mail.*` name is
 refused for a second reason as well — it belongs to the MCP surface and would grant nothing on this one.
 
-**Three `mfctl` commands make two requests and therefore need two permissions.** The table below publishes one
-permission per route, and a command that reads before it writes reaches two routes: `mfctl contact delete` reads the
-person before erasing them, so it needs `mailfathom.admin.audit.read` beside `mailfathom.admin.erase`;
-`mfctl contact edit` reads the record it is about to amend, so it needs the same read beside
-`mailfathom.admin.operate`; and `mfctl mailbox rewind` always reads what a rewind would cost, including under `--yes`,
-so it needs `mailfathom.admin.read` beside `mailfathom.admin.operate`. A credential granted only the permission the operation is published under meets the
-refusal at the first request and nothing is done — which is the safe half of it, and still not what the operator
-intended.
+**Six `mfctl` commands make two requests and therefore need two permissions.** The table below publishes one permission
+per route, and a command that reads before it writes reaches two routes — because what it read is what it puts in front
+of you, or what it amends from:
+
+| Command | Needs |
+| --- | --- |
+| `mfctl contact update`, `mfctl contact add-address`, `mfctl contact remove-address` | `mailfathom.admin.audit.read` beside `mailfathom.admin.operate`, because each reads the record it is about to amend from |
+| `mfctl contact delete` | `mailfathom.admin.audit.read` beside `mailfathom.admin.erase`, because it shows you the person before erasing them |
+| `mfctl mailbox rewind` | `mailfathom.admin.read` beside `mailfathom.admin.operate`, because it always reads what the rewind would cost, including under `--yes` |
+| `mfctl embedding activate` | `mailfathom.admin.read` beside `mailfathom.admin.spend`, because it always reads what activating would spend before it spends it |
+
+A credential granted only the permission the operation itself is published under meets the refusal at the first request
+and nothing is done — which is the safe half of it, and still not what the operator intended.
 
 `GET /api/admin/session` sits outside the model and needs no permission. It reports the credential the caller already
 presented, the version this deployment already publishes, and the permissions that credential holds — all of which it
@@ -773,7 +778,7 @@ Amended:    2026-08-16 09:00:00Z
 | `contact update` | Corrects `--name`, `--note`, `--preferred`, or the whole `--address` set. What you do not name is kept; `--clear-note` holds no note afterwards |
 | `contact add-address` | Adds one address, keeping the rest. `--preferred` names which address to use by default afterwards |
 | `contact remove-address` | Takes one address off. `--preferred` is required when the one being removed is the default |
-| `contact promote` | Takes on a contact the deployment collected, so it becomes one you asserted |
+| `contact promote` | Takes on a contact the deployment collected, so it becomes one you asserted. It reports that the promotion happened rather than the record, because it sent none and reading the book is a permission of its own; `contact show` is how you look at the person afterwards |
 | `contact delete` | Erases the person. **This cannot be undone**; see below |
 | `contact export` | Writes everything held about the person to standard output, as JSON |
 

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -87,6 +87,15 @@ nothing publishes fails startup, naming the entry and the position in the list, 
 read as a narrower grant than you meant; so is a name the same grant already carries. A `mailfathom.mail.*` name is
 refused for a second reason as well — it belongs to the MCP surface and would grant nothing on this one.
 
+**Three `mfctl` commands make two requests and therefore need two permissions.** The table below publishes one
+permission per route, and a command that reads before it writes reaches two routes: `mfctl contact delete` reads the
+person before erasing them, so it needs `mailfathom.admin.audit.read` beside `mailfathom.admin.erase`;
+`mfctl contact edit` reads the record it is about to amend, so it needs the same read beside
+`mailfathom.admin.operate`; and `mfctl mailbox rewind` always reads what a rewind would cost, including under `--yes`,
+so it needs `mailfathom.admin.read` beside `mailfathom.admin.operate`. A credential granted only the permission the operation is published under meets the
+refusal at the first request and nothing is done — which is the safe half of it, and still not what the operator
+intended.
+
 `GET /api/admin/session` sits outside the model and needs no permission. It reports the credential the caller already
 presented, the version this deployment already publishes, and the permissions that credential holds — all of which it
 brought or could ask about itself — and it is what every command reads first, `mfctl login` included. Requiring a

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -57,16 +57,16 @@ location exactly when the resource names the same one. A deployment whose resour
 document nothing could find, and OAuth sign-in would be unreachable for a reason no refusal would explain. Behind a
 reverse proxy, write the public URL and keep the path: `https://mail.example.test/api/admin`.
 
-> **Every authenticated caller may still perform every administrative operation.** A grant can now be written on an
-> entry — see below — and nothing on this surface varies by it yet, so the credential remains what bounds access.
-> Provision one per client and rotate it like any other secret.
+> **An entry that writes no grant reaches every administrative operation.** The grant is what bounds a credential here,
+> and an entry that never narrowed one holds the whole surface — so provision one per client, narrow it to what that
+> client does, and rotate it like any other secret.
 >
 > Weigh that against what the operations are. The endpoint serves reads — who a credential makes the caller, two
 > records of what a mailbox has had done to it and what has been read from it, where semantic search stands, and what
 > synchronization is doing — and
-> writes that store a mailbox refresh token, start a provider bill, and erase what a folder has stored. Any credential
-> that can do the first can therefore do all of them, so an administrative key is as sensitive as the mailbox
-> credentials it can place, the histories it can read, the spend it can begin, and the mail it can dispose of.
+> writes that store a mailbox refresh token, start a provider bill, and erase what a folder has stored. An unnarrowed
+> credential can do all of them, so it is as sensitive as the mailbox credentials it can place, the histories it can
+> read, the spend it can begin, and the mail it can dispose of.
 
 ## What a credential may do
 
@@ -75,12 +75,12 @@ six names, allocated so that the separations an operator would plausibly want to
 
 | Permission | What it covers |
 | --- | --- |
-| `mailfathom.admin.read` | The reads reporting the deployment's own state and no mail: what synchronization is doing per account and per folder, embedding status and the activation preview, the loaded rules, a run's progress, the stopped-job list |
-| `mailfathom.admin.audit.read` | The per-account records derived from mail: the mailbox-mutation audit, the answering audit, the rules history, the spam classifications |
-| `mailfathom.admin.operate` | Asking the deployment to do work it can already do: running rules over an account, classifying an account, retrying or dropping a stopped job, cancelling a reindex |
+| `mailfathom.admin.read` | The reads reporting the deployment's own state and no mail: what synchronization is doing per account and per folder, embedding status and the activation preview, the loaded rules, a run's progress, what a rewind would cost, the stopped-job list |
+| `mailfathom.admin.audit.read` | Everything derived from somebody's mail: the mailbox-mutation audit, the answering audit, the rules history, the spam classifications, and reading the contact book — a listing, one person, or their export |
+| `mailfathom.admin.operate` | Asking the deployment to do work it can already do: running rules over an account, classifying an account, retrying or dropping a stopped job, cancelling a reindex, rewinding synchronization, re-deriving stored mail, and writing to the contact book |
 | `mailfathom.admin.credentials.write` | Storing a mailbox refresh token |
 | `mailfathom.admin.spend` | Activating the declared embedding model, which is the one operation that starts a provider bill |
-| `mailfathom.admin.erase` | Erasing the mail stored for a folder an account no longer mirrors |
+| `mailfathom.admin.erase` | Disposing of what this deployment holds: the mail stored for a folder an account no longer mirrors, and one person and everything the contact book derived from them |
 
 No permission implies another, so a credential that needs to read state and to run rules is granted both names. A name
 nothing publishes fails startup, naming the entry and the position in the list, so a misspelling is refused rather than
@@ -88,9 +88,18 @@ read as a narrower grant than you meant; so is a name the same grant already car
 refused for a second reason as well — it belongs to the MCP surface and would grant nothing on this one.
 
 `GET /api/admin/session` sits outside the model and needs no permission. It reports the credential the caller already
-presented and the version this deployment already publishes, so it discloses nothing a caller did not bring — and it is
-what every command reads first, `mfctl login` included. Requiring a permission for it would make that permission a
-component of every administrative grant.
+presented, the version this deployment already publishes, and the permissions that credential holds — all of which it
+brought or could ask about itself — and it is what every command reads first, `mfctl login` included. Requiring a
+permission for it would make that permission a component of every administrative grant, so a credential granted only
+the spend permission could not sign in to use it. **A credential granted nothing therefore still answers here and
+nowhere else**; an operator who wants nothing answered at all removes the entry.
+
+`mfctl status` prints what that route reports, which is how an operator reads their own grant back:
+
+```text
+'production' (https://mail.example.test:8443) accepts the stored credential as 'workstation' (MailFathom 0.2.0).
+It holds mailfathom.admin.read, mailfathom.admin.operate.
+```
 
 The rest of the reading is the same on both surfaces and is written once, under
 [what a credential may do](mcp-endpoint.md#what-a-credential-may-do): the grant belongs to the entry rather than to the
@@ -103,59 +112,89 @@ Startup records what every entry resolved to, one line per entry, and names the 
 ```text
 info: MailFathom.Host.Hosting.Warnings.TransportGrantStartupReport
       The administrative endpoint entry AdminEndpoint:Authentication:0 grants mailfathom.admin.read,
-      mailfathom.admin.operate to every credential it admits. No route here consults a permission yet, so a grant on
-      this surface states what a credential is meant to reach rather than what it currently reaches.
+      mailfathom.admin.operate to every credential it admits. A route here is served only to a caller whose grant holds
+      the one permission that route publishes, and every other caller is refused with that permission named.
 ```
 
-Every line closes with what a grant on that surface does, which is not the same on both: the MCP endpoint's lines say
-that a caller is served only the tools its grant permits, because there it is enforced. Nothing in those lines names a
-key, a public key, a token, an authorization server, or a subject: a grant is what the deployment wrote, never who
-presented something.
+Every line closes with what a grant on that surface does, which differs in what a refusal looks like rather than in
+whether the grant is enforced: the MCP endpoint answers a call naming a tool the grant omits as a tool that does not
+exist, and this one names the permission. Nothing in those lines names a key, a public key, a token, an authorization
+server, or a subject: a grant is what the deployment wrote, never who presented something.
 
-**No name covers the contact book.** The six above were allocated against the routes that existed when they were, and
-the book's own routes — reading it, writing to it, exporting a person, erasing one — fall under none of them. Nothing
-follows from that today, because of the paragraph below; what it means is that a grant narrowing this surface does not
-narrow the book, and allocating names for it is a decision about the published permission set rather than about these
-routes.
+**The contact book falls under the six above rather than under names of its own.** Reading the book, reading one person
+and exporting them are `mailfathom.admin.audit.read`, because what the book holds is derived from mail; recording,
+amending and promoting are `mailfathom.admin.operate`; erasing somebody is `mailfathom.admin.erase`. Nothing about the
+book needed a seventh name — what it needed was for each of its routes to be placed against the separations the six
+already draw.
 
-**Nothing on this surface varies by the grant today.** The permissions are read, validated, carried on the authenticated
-caller, and reported at startup; every route still serves any authenticated caller, which is what the note above says.
+### What a refusal says
+
+A caller the endpoint admitted and a route then refuses is answered `403` with a problem document, and that document
+names **the one permission that would have sufficed and nothing else**: no inventory of the other routes, nothing about
+which credential would have worked, and nothing about how this deployment is configured.
+
+```json
+{
+  "status": 403,
+  "detail": "The credential is not granted 'mailfathom.admin.read'.",
+  "permission": "mailfathom.admin.read"
+}
+```
+
+The `permission` member carries the same name on its own, so a client reads what to grant instead of parsing the
+sentence. `mfctl` does exactly that, and reports it as the operator's next action rather than as a credential to
+replace:
+
+```text
+The deployment refused the operation: this credential does not hold 'mailfathom.admin.read'. Add that permission to the
+credential's entry under AdminEndpoint:Authentication, or sign in with one that already holds it.
+```
+
+Naming the permission is a deliberate difference from the MCP surface, which discloses nothing to a refused caller.
+[ADR 0012](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0012-authorization-model-named-permissions-and-where-they-are-enforced.md)
+records why: the caller here is an operator at their own terminal, and a refusal they can act on is worth more than a
+refusal that says nothing.
+
+The transport is not the authority. Each route's use case asks for the same permission itself, so an entrypoint added
+later cannot widen the surface by forgetting a filter, and a use case's own refusal is answered in the shape above
+rather than reaching the caller as a fault in the deployment. A route mapped without deciding a permission is refused
+outright — nobody reaches it — so forgetting to decide costs a route rather than opening one.
 
 ## What the endpoint serves
 
-| Route | What it does |
-| --- | --- |
-| `GET /api/admin/session` | Reports the credential that authenticated and the running version. `login` and `status` report what it answers; every other command reads it first to [check the two versions against each other](#take-the-command-from-the-deployments-own-release-line). |
-| `POST /api/admin/mailbox/refresh-token` | Stores a mailbox refresh token for one configured account, sealed under the deployment's data-encryption key. This is what [`mfctl mailbox authorize --account`](mailbox-oauth.md#sending-the-token-to-the-deployment) sends. |
-| `GET /api/admin/mailbox/synchronization` | Reports what synchronization is doing, per account and per mapped folder. This is what [`mfctl mailbox status`](#reading-what-synchronization-is-doing) asks. |
-| `GET /api/admin/mailbox/rewind` | Reports how much mail discarding an account's synchronization progress would have fetched again, discarding nothing. |
-| `POST /api/admin/mailbox/rewind` | Discards it, so the next runs read the scope's folders from the start of the account's window. **This is the one route that makes a deployment pull a mailbox over IMAP again.** |
-| `POST /api/admin/mailbox/rederivation` | Re-reads one bounded pass of the raw MIME already stored, into the properties a newer release records from it. Opens no mailbox session. |
-| `GET /api/admin/mailbox/mutations/audit` | Reads one account's record of the changes MailFathom made to its mailbox, where that account [keeps one](../features/imap-synchronization.md#an-account-can-keep-a-record-of-what-was-done-to-it-and-none-does-by-default). |
-| `GET /api/admin/answering/audit` | Reads one account's record of the questions answered from its mailbox, where that account [keeps one](../features/mail-answering.md#an-account-can-keep-a-record-of-what-a-question-read-and-none-does-by-default). |
-| `GET /api/admin/embeddings` | Reports whether semantic search is working and how far behind it is. This is what [`mfctl embedding status`](#administering-the-embedding-profile) asks. |
-| `GET /api/admin/embeddings/activation` | Reports what activating the declared model would do and what it would cost, writing nothing. |
-| `POST /api/admin/embeddings/activation` | Takes up the declared model and begins embedding under it. **This is the one route that starts a provider bill.** |
-| `POST /api/admin/embeddings/reindex/cancellation` | Stops the reindex under way, leaving the generation that is serving where it is. |
-| `GET /api/admin/rules` | Reports the [mail rules](../features/mail-rules.md) this deployment has loaded, in the order they run, and whether the configuration as it now stands is the one they were read from. |
-| `POST /api/admin/rules/runs` | Asks for one account's rules to be run over every message already stored for it, and answers with the run already under way where there is one. |
-| `GET /api/admin/rules/runs` | Reports where that run has got to, or how the last one ended. |
-| `GET /api/admin/rules/history` | Reads one account's record of what its rules concluded and what those conclusions asked for. |
-| `POST /api/admin/spam/runs` | Asks for every message already stored for one account to be [classified](../features/spam-classification.md), and answers with the run already under way where there is one. It is a dry run unless the body asks to apply. |
-| `GET /api/admin/spam/runs` | Reports where that run has got to, or how the last one ended. |
-| `GET /api/admin/spam/classifications` | Reads one account's classifications, newest first, and the changes each verdict asked the mailbox for. |
-| `GET /api/admin/jobs/dead-letters` | Reads the background work that stopped and will not be attempted again, newest first, with what ended each piece of it. |
-| `POST /api/admin/jobs/dead-letters/retry` | Returns one stopped job to the queue under the identity it was enqueued with. |
-| `POST /api/admin/jobs/dead-letters/drop` | Decides one stopped job will never run, keeping the record of it. |
-| `POST /api/admin/folders/erasure` | Erases one bounded pass of the mail stored for a folder the account no longer mirrors. **This is the one route that disposes of mail.** |
-| `GET /api/admin/contacts` | Reads one bounded, keyset-paginated page of the [contact book](../features/contacts.md), optionally narrowed to one origin. |
-| `POST /api/admin/contacts` | Records a person the book does not yet hold, as a contact this deployment's owner asserted. |
-| `GET /api/admin/contacts/by-address` | Reads whoever uses one address, in whichever casing the book recorded it. |
-| `GET /api/admin/contacts/{id}` | Reads one contact by the identity the book gave it. |
-| `PUT /api/admin/contacts/{id}` | Amends one contact to the whole record the body states. |
-| `POST /api/admin/contacts/{id}/promotion` | Takes on a contact the deployment collected, so it becomes one the owner asserted. |
-| `DELETE /api/admin/contacts/{id}` | Erases one person and everything the book derived from them. **This is the one route that disposes of a contact, and it cannot be undone.** |
-| `GET /api/admin/contacts/{id}/export` | Produces everything the book holds about one person, as of the instant it was taken. |
+| Route | Permission | What it does |
+| --- | --- | --- |
+| `GET /api/admin/session` | none | Reports the credential that authenticated and the running version. `login` and `status` report what it answers; every other command reads it first to [check the two versions against each other](#take-the-command-from-the-deployments-own-release-line). |
+| `POST /api/admin/mailbox/refresh-token` | `mailfathom.admin.credentials.write` | Stores a mailbox refresh token for one configured account, sealed under the deployment's data-encryption key. This is what [`mfctl mailbox authorize --account`](mailbox-oauth.md#sending-the-token-to-the-deployment) sends. |
+| `GET /api/admin/mailbox/synchronization` | `mailfathom.admin.read` | Reports what synchronization is doing, per account and per mapped folder. This is what [`mfctl mailbox status`](#reading-what-synchronization-is-doing) asks. |
+| `GET /api/admin/mailbox/rewind` | `mailfathom.admin.read` | Reports how much mail discarding an account's synchronization progress would have fetched again, discarding nothing. |
+| `POST /api/admin/mailbox/rewind` | `mailfathom.admin.operate` | Discards it, so the next runs read the scope's folders from the start of the account's window. **This is the one route that makes a deployment pull a mailbox over IMAP again.** |
+| `POST /api/admin/mailbox/rederivation` | `mailfathom.admin.operate` | Re-reads one bounded pass of the raw MIME already stored, into the properties a newer release records from it. Opens no mailbox session. |
+| `GET /api/admin/mailbox/mutations/audit` | `mailfathom.admin.audit.read` | Reads one account's record of the changes MailFathom made to its mailbox, where that account [keeps one](../features/imap-synchronization.md#an-account-can-keep-a-record-of-what-was-done-to-it-and-none-does-by-default). |
+| `GET /api/admin/answering/audit` | `mailfathom.admin.audit.read` | Reads one account's record of the questions answered from its mailbox, where that account [keeps one](../features/mail-answering.md#an-account-can-keep-a-record-of-what-a-question-read-and-none-does-by-default). |
+| `GET /api/admin/embeddings` | `mailfathom.admin.read` | Reports whether semantic search is working and how far behind it is. This is what [`mfctl embedding status`](#administering-the-embedding-profile) asks. |
+| `GET /api/admin/embeddings/activation` | `mailfathom.admin.read` | Reports what activating the declared model would do and what it would cost, writing nothing. |
+| `POST /api/admin/embeddings/activation` | `mailfathom.admin.spend` | Takes up the declared model and begins embedding under it. **This is the one route that starts a provider bill.** |
+| `POST /api/admin/embeddings/reindex/cancellation` | `mailfathom.admin.operate` | Stops the reindex under way, leaving the generation that is serving where it is. |
+| `GET /api/admin/rules` | `mailfathom.admin.read` | Reports the [mail rules](../features/mail-rules.md) this deployment has loaded, in the order they run, and whether the configuration as it now stands is the one they were read from. |
+| `POST /api/admin/rules/runs` | `mailfathom.admin.operate` | Asks for one account's rules to be run over every message already stored for it, and answers with the run already under way where there is one. |
+| `GET /api/admin/rules/runs` | `mailfathom.admin.read` | Reports where that run has got to, or how the last one ended. |
+| `GET /api/admin/rules/history` | `mailfathom.admin.audit.read` | Reads one account's record of what its rules concluded and what those conclusions asked for. |
+| `POST /api/admin/spam/runs` | `mailfathom.admin.operate` | Asks for every message already stored for one account to be [classified](../features/spam-classification.md), and answers with the run already under way where there is one. It is a dry run unless the body asks to apply. |
+| `GET /api/admin/spam/runs` | `mailfathom.admin.read` | Reports where that run has got to, or how the last one ended. |
+| `GET /api/admin/spam/classifications` | `mailfathom.admin.audit.read` | Reads one account's classifications, newest first, and the changes each verdict asked the mailbox for. |
+| `GET /api/admin/jobs/dead-letters` | `mailfathom.admin.read` | Reads the background work that stopped and will not be attempted again, newest first, with what ended each piece of it. |
+| `POST /api/admin/jobs/dead-letters/retry` | `mailfathom.admin.operate` | Returns one stopped job to the queue under the identity it was enqueued with. |
+| `POST /api/admin/jobs/dead-letters/drop` | `mailfathom.admin.operate` | Decides one stopped job will never run, keeping the record of it. |
+| `POST /api/admin/folders/erasure` | `mailfathom.admin.erase` | Erases one bounded pass of the mail stored for a folder the account no longer mirrors. **This is the one route that disposes of mail.** |
+| `GET /api/admin/contacts` | `mailfathom.admin.audit.read` | Reads one bounded, keyset-paginated page of the [contact book](../features/contacts.md), optionally narrowed to one origin. |
+| `POST /api/admin/contacts` | `mailfathom.admin.operate` | Records a person the book does not yet hold, as a contact this deployment's owner asserted. |
+| `GET /api/admin/contacts/by-address` | `mailfathom.admin.audit.read` | Reads whoever uses one address, in whichever casing the book recorded it. |
+| `GET /api/admin/contacts/{id}` | `mailfathom.admin.audit.read` | Reads one contact by the identity the book gave it. |
+| `PUT /api/admin/contacts/{id}` | `mailfathom.admin.operate` | Amends one contact to the whole record the body states. |
+| `POST /api/admin/contacts/{id}/promotion` | `mailfathom.admin.operate` | Takes on a contact the deployment collected, so it becomes one the owner asserted. |
+| `DELETE /api/admin/contacts/{id}` | `mailfathom.admin.erase` | Erases one person and everything the book derived from them. **This is the one route that disposes of a contact, and it cannot be undone.** |
+| `GET /api/admin/contacts/{id}/export` | `mailfathom.admin.audit.read` | Produces everything the book holds about one person, as of the instant it was taken. |
 
 The write route's body carries a long-lived credential for a named mailbox owner, which is what makes the clear-text
 warning below matter more here than it does for a session probe. It refuses, with `400` and a sentence naming what was
@@ -1236,6 +1275,7 @@ address:
 ```console
 $ mfctl status --endpoint production
 'production' (https://mail.example.test:8443) accepts the stored credential as 'workstation' (MailFathom 0.2.0).
+It holds mailfathom.admin.read, mailfathom.admin.operate.
 Documentation for that version: https://krzysztof318.github.io/MailFathom/v0.2.0/
 ```
 
@@ -1386,6 +1426,8 @@ removing the log is a way to start a new one rather than a way to turn it off.
 | `There is no profile named …` | A typo, or a profile that was never created. The message lists the ones that exist. |
 | `Not signed in to https://…` | `--endpoint` named an address no profile serves. Sign in to it, or name a profile instead. |
 | `The deployment refused the credential.` | The key is not one this endpoint is configured with, or its lifetime has ended. Note that an MCP API key is not one of them. |
+| `this credential does not hold …` | The credential was accepted and the operation was not: its entry's `Permissions` omits the name the message states. Add that name to the entry, or run the command with a credential that already holds it. `mfctl status` prints what the one in use holds. |
+| `The deployment refused the operation: …` | The endpoint refused for a reason other than a missing permission, and the sentence is the deployment's own. A deployment publishing no permission for the route is a defect worth reporting, because no grant makes such a route reachable. |
 | `answered 429` | The endpoint refused the request for its rate limit rather than for its credential. `Retry-After` on the response says when capacity returns where the limiter can compute one. The whole endpoint shares one bucket, so another caller's burst — including somebody guessing keys — is enough to cause this. |
 | `serves no administrative endpoint at /api/admin/…` | The address answered, but on a listener that serves something else. Check the port, and check that `AdminEndpoint:Enabled` is true. |
 | `This deployment configures no mail account named …` | `mailbox authorize --account` named an identifier no `MailSynchronization:Accounts` entry carries, or you are signed in to the wrong deployment. Nothing was stored. |

--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -1174,12 +1174,12 @@ disjoint halves, and the name says which half it belongs to.
 | --- | --- | --- |
 | `mailfathom.mail.read` | MCP | The tools that read the local mailbox copy: `list_accounts`, `list_emails`, `get_email_content`, `search_emails`. Where semantic retrieval is configured, searching places the caller's own query text with the embedding provider, so this is not an egress-free grant |
 | `mailfathom.mail.ask` | MCP | `ask_mail`, which answers from mail content by sending it to a model provider. It does not imply `mailfathom.mail.read`, and granting it is granting access to mail |
-| `mailfathom.admin.read` | administrative | The reads reporting the deployment's own state and no mail: what synchronization is doing, embedding status and the activation preview, the loaded rules, a run's progress, the stopped-job list |
-| `mailfathom.admin.audit.read` | administrative | The per-account records derived from mail: the mailbox-mutation audit, the answering audit, the rules history, the spam classifications |
-| `mailfathom.admin.operate` | administrative | Asking the deployment to do work it can already do: running rules, classifying an account, retrying or dropping a stopped job, cancelling a reindex |
+| `mailfathom.admin.read` | administrative | The reads reporting the deployment's own state and no mail: what synchronization is doing, embedding status and the activation preview, the loaded rules, a run's progress, what a rewind would cost, the stopped-job list |
+| `mailfathom.admin.audit.read` | administrative | Everything derived from somebody's mail: the mailbox-mutation audit, the answering audit, the rules history, the spam classifications, and reading the contact book |
+| `mailfathom.admin.operate` | administrative | Asking the deployment to do work it can already do: running rules, classifying an account, retrying or dropping a stopped job, cancelling a reindex, rewinding synchronization, re-deriving stored mail, writing to the contact book |
 | `mailfathom.admin.credentials.write` | administrative | Storing a mailbox refresh token |
 | `mailfathom.admin.spend` | administrative | Activating the declared embedding model, which is the one operation that starts a provider bill |
-| `mailfathom.admin.erase` | administrative | Erasing the mail stored for a folder an account no longer mirrors |
+| `mailfathom.admin.erase` | administrative | Disposing of what the deployment holds: the mail stored for a folder an account no longer mirrors, and one person and everything the contact book derived from them |
 
 No permission implies another, so a credential that needs two is granted two.
 
@@ -1187,21 +1187,21 @@ No permission implies another, so a credential that needs two is granted two.
 block at once, and `Permissions` on it applies to every credential it admits. Two credentials to be granted differently
 are therefore two entries — which is what turns grouping, until now only a matter of tidiness, into a decision.
 
-**The two surfaces enforce a grant differently today.** On the MCP endpoint it is in force: a caller is listed only the
-tools its grant permits and a call naming any other is answered as a call naming a tool that does not exist, with
-nothing said about the permission that was missing — [MCP tools](../features/mcp-tools.md#what-a-caller-is-offered) has
-the tool-to-permission mapping. On the administrative endpoint the permissions are read, validated, carried on the
-authenticated caller and reported at startup, and no route consults them, so every admitted caller still reaches every
-administrative operation. Read a `mailfathom.admin.*` sentence below as what the setting says rather than as what it
-currently stops.
+**Both surfaces enforce a grant, and they refuse differently.** On the MCP endpoint a caller is listed only the tools
+its grant permits and a call naming any other is answered as a call naming a tool that does not exist, with nothing said
+about the permission that was missing — [MCP tools](../features/mcp-tools.md#what-a-caller-is-offered) has the
+tool-to-permission mapping. On the administrative endpoint a caller the grant does not admit is answered `403` naming
+the one permission that would have sufficed and nothing else, because the caller there is an operator at their own
+terminal — [what the endpoint serves](admin-endpoint.md#what-the-endpoint-serves) names the permission every route is
+published under.
 
 **An absent `Permissions` key and an empty list are opposites.** Writing no key at all leaves the entry holding
 everything its surface publishes, which is what makes a first deployment work before it is governed and what leaves an
-existing deployment unchanged on upgrade. Writing `Permissions: []` grants nothing, which is how a credential will be
-retired without deleting its entry: it still authenticates, and on the administrative surface it will still read
-`GET /api/admin/session`, which needs no permission because it reports only what the caller already presented. On the
-MCP endpoint that retirement is in force — an emptied grant is served an empty tool list — and on the administrative one
-it retires nothing yet, because no route there consults a permission.
+existing deployment unchanged on upgrade. Writing `Permissions: []` grants nothing, which is how a credential is retired
+without deleting its entry: it still authenticates, and on the administrative surface it still reads
+`GET /api/admin/session`, which needs no permission because it reports only what the caller already presented — and
+which is where an operator reads that the credential now holds nothing. Everything else is refused: an emptied grant is
+served an empty tool list on the MCP endpoint and reaches no administrative route at all.
 
 **A surface with no `Authentication` entry at all grants that surface's whole half**, because there is no entry for a
 grant to be written on. That is the unauthenticated posture the startup warning already reports.

--- a/docs/operations/mailbox-oauth.md
+++ b/docs/operations/mailbox-oauth.md
@@ -201,9 +201,11 @@ the same way it does for every other command. [Administering a deployment](admin
 the write needs the administrative endpoint enabled; a deployment without one still takes a token you provision
 yourself.
 
-> **The route this uses is behind the endpoint's authentication, and behind nothing else.** Every authenticated caller
-> may perform every administrative operation, so an administrative credential that can read a session can write a
-> mailbox credential. Provision one per client and treat it as what it now is.
+> **The route this uses requires `mailfathom.admin.credentials.write`, and being authenticated is not enough.** A
+> credential whose entry narrows its grant to anything else is refused and told which permission it lacked, and an entry
+> that writes no grant at all reaches this route like every other. Provision one per client, grant it that permission
+> and no more, and treat it as what it now is — [what a credential may
+> do](admin-endpoint.md#what-a-credential-may-do) is where the grant is written.
 
 Sending a grant does **not** change the account's configuration. `OAuth:RefreshToken` stays a secret reference and is
 still what an account is served from until something is stored for it; what changes is that something now is. The

--- a/docs/operations/mcp-client-oauth.md
+++ b/docs/operations/mcp-client-oauth.md
@@ -140,10 +140,10 @@ write the grant in configuration instead, which is the only form available where
 one that does not.** Where the entry opted in, a client that never received the scope is listed only the tools its
 remaining scopes permit and is answered about the rest as though they did not exist; where it did not, every token the
 entry admits holds the entry's whole grant whatever scopes it carries, because the deployment wrote that grant and the
-authorization server was never asked. A `mailfathom.admin.*` scope is in force nowhere yet: the administrative surface
-reads, validates, carries and reports the grant and no route there consults it, so such a scope states what a credential
-is *meant* to reach rather than what it currently reaches. Create those anyway — an entry that narrows by them publishes
-them in `scopes_supported`, and a client that never receives one holds nothing under it the moment enforcement arrives.
+authorization server was never asked. A `mailfathom.admin.*` scope narrows the administrative surface the same way, on an
+entry that opted in: a token that never received the scope is refused every route published under it, and told which
+permission that was. An entry that narrows by them publishes them in `scopes_supported`, which is what a client reads to
+know what it may ask for.
 
 **Decide here whether clients should hold a refresh token.** A client asks for one by naming `offline_access`, and it
 learns to ask by reading that scope in MailFathom's metadata document — so if you do not advertise it, a client asks

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -664,9 +664,9 @@ info: MailFathom.Host.Hosting.Warnings.TransportGrantStartupReport
 ```
 
 Every line closes with what a grant on that surface does, so an operator reading back the one entry they edited learns
-whether the narrowing bites without reading the rest of the report. On this endpoint it does. The administrative
-endpoint's lines say instead that no route there consults a permission yet, which is what makes a narrowed entry there a
-statement of intent rather than a bound.
+what the narrowing costs a caller without reading the rest of the report. The two surfaces differ in the refusal rather
+than in whether the grant bites: here a tool the grant omits is one that does not exist, and the administrative
+endpoint's lines say instead that a refused caller is told the permission that would have sufficed.
 
 An entry that narrowed its grant is reported as what it grants, an entry with `PermissionsFromTokenScopes` as what it
 grants *at most*, and an entry granted nothing as `nothing` rather than as a line that lost its argument. An endpoint

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -163,6 +163,23 @@ from a host that is simply down — the stored profile can only say what was tru
 forgets a local profile without revoking anything: the credential keeps working until the deployment stops accepting
 it, so a lost laptop is a reason to rotate the key on the server rather than to sign out.
 
+`status` also prints what your credential may do, which is what decides whether any other command here will work:
+
+```console
+$ mfctl status
+'production' (https://mail.example.test:8443) accepts the stored credential as 'workstation' (MailFathom 0.2.0).
+It holds mailfathom.admin.read, mailfathom.admin.operate.
+Documentation for that version: https://krzysztof318.github.io/MailFathom/v0.2.0/
+```
+
+A credential is granted a set of named permissions on the deployment, and each command needs one of them. Signing in
+needs none, so a key that reads `It holds no administrative permission` still signs in and is refused everywhere else —
+which is how a credential is retired without its entry being removed. When a command is refused for want of one, it
+names the permission to add and where it is written, so the answer is to widen that credential's grant rather than to
+replace the key.
+[What a credential may do](../operations/admin-endpoint.md#what-a-credential-may-do) lists the names, what each covers,
+and which permission every route is published under.
+
 When you work against one deployment for a whole session, `MAILFATHOM_ENDPOINT` states it once for the shell.
 `--endpoint` beats it, and both beat the profile you last switched to.
 

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -172,7 +172,8 @@ It holds mailfathom.admin.read, mailfathom.admin.operate.
 Documentation for that version: https://krzysztof318.github.io/MailFathom/v0.2.0/
 ```
 
-A credential is granted a set of named permissions on the deployment, and each command needs one of them. Signing in
+A credential is granted a set of named permissions on the deployment, and each command needs the one its operation is
+published under — two, for the three commands that read something before they change it. Signing in
 needs none, so a key that reads `It holds no administrative permission` still signs in and is refused everywhere else —
 which is how a credential is retired without its entry being removed. When a command is refused for want of one, it
 names the permission to add and where it is written, so the answer is to widen that credential's grant rather than to

--- a/docs/users/administering.md
+++ b/docs/users/administering.md
@@ -173,13 +173,13 @@ Documentation for that version: https://krzysztof318.github.io/MailFathom/v0.2.0
 ```
 
 A credential is granted a set of named permissions on the deployment, and each command needs the one its operation is
-published under — two, for the three commands that read something before they change it. Signing in
+published under — two, for the six commands that read something before they change it. Signing in
 needs none, so a key that reads `It holds no administrative permission` still signs in and is refused everywhere else —
 which is how a credential is retired without its entry being removed. When a command is refused for want of one, it
 names the permission to add and where it is written, so the answer is to widen that credential's grant rather than to
 replace the key.
 [What a credential may do](../operations/admin-endpoint.md#what-a-credential-may-do) lists the names, what each covers,
-and which permission every route is published under.
+which permission every route is published under, and which six commands need a second one.
 
 When you work against one deployment for a whole session, `MAILFATHOM_ENDPOINT` states it once for the shell.
 `--endpoint` beats it, and both beat the profile you last switched to.

--- a/src/AppHost/OrchestrationContract.cs
+++ b/src/AppHost/OrchestrationContract.cs
@@ -247,6 +247,17 @@ public static class OrchestrationContract
     /// </remarks>
     public const string AdminApiKey = "integration-tests-only-admin-api-key";
 
+    /// <summary>The name of a second administrative key, whose entry grants one permission rather than the surface.</summary>
+    /// <remarks>The key above writes no grant and therefore reaches everything administrative, so a suite holding only that one could never observe a route refusing a caller over what it holds.</remarks>
+    public const string AdminNarrowedApiKeyName = "integration-tests-admin-read-only";
+
+    /// <summary>A second administrative API key, admitted by an entry granting <see cref="AdminNarrowedPermission" /> and nothing else.</summary>
+    /// <remarks>A literal under the same restriction as <see cref="AdminApiKey" />, and deliberately a different value: what it exists to make observable is that two credentials on one surface reach different routes.</remarks>
+    public const string AdminNarrowedApiKey = "integration-tests-only-admin-read-only-api-key";
+
+    /// <summary>The one permission the entry above grants, which is what its key holds and the whole of what it reaches.</summary>
+    public const string AdminNarrowedPermission = "mailfathom.admin.read";
+
     /// <summary>The EF Core migration tool resource.</summary>
     public const string MigrationsResourceName = "mailfathom-migrations";
 

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -306,6 +306,18 @@ if (runsIntegrationTests)
         .WithEnvironment(
             "AdminEndpoint__Authentication__0__ApiKey__SecretReference",
             $"plaintext:{OrchestrationContract.AdminApiKey}")
+        // A second entry, narrowed to one permission. The entry above writes no grant and therefore reaches every
+        // administrative route, so it is the arrangement under which a route's published permission decides nothing a
+        // caller can observe; this one is what makes the enforcement visible from where an operator stands.
+        .WithEnvironment(
+            "AdminEndpoint__Authentication__1__ApiKey__Name",
+            OrchestrationContract.AdminNarrowedApiKeyName)
+        .WithEnvironment(
+            "AdminEndpoint__Authentication__1__ApiKey__SecretReference",
+            $"plaintext:{OrchestrationContract.AdminNarrowedApiKey}")
+        .WithEnvironment(
+            "AdminEndpoint__Authentication__1__Permissions__0",
+            OrchestrationContract.AdminNarrowedPermission)
         // Narrowed from the product defaults for the same reason the origins are: a burst small enough to exhaust
         // deliberately is what makes the difference between a limiter that is wired in and one that is not observable.
         // The replenishment period outlasts the run, so what a client spent stays spent and a refusal cannot depend on

--- a/src/Application/Accounts/MailboxRefreshTokenRecorder.cs
+++ b/src/Application/Accounts/MailboxRefreshTokenRecorder.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 
 namespace MailFathom.Application.Accounts;
@@ -28,20 +30,25 @@ public sealed class MailboxRefreshTokenRecorder
 {
     private readonly IMailAccountCatalog accountCatalog;
     private readonly IMailboxRefreshTokenStore refreshTokenStore;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes the use case over the accounts this deployment serves and the store that seals a token.</summary>
     /// <param name="accountCatalog">Names the accounts a grant may be recorded for.</param>
     /// <param name="refreshTokenStore">Where the token is written.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
     public MailboxRefreshTokenRecorder(
         IMailAccountCatalog accountCatalog,
-        IMailboxRefreshTokenStore refreshTokenStore)
+        IMailboxRefreshTokenStore refreshTokenStore,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(accountCatalog);
         ArgumentNullException.ThrowIfNull(refreshTokenStore);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.accountCatalog = accountCatalog;
         this.refreshTokenStore = refreshTokenStore;
+        this.authorization = authorization;
     }
 
     /// <summary>Records the refresh token for one served account, replacing whatever was stored for it before.</summary>
@@ -50,11 +57,16 @@ public sealed class MailboxRefreshTokenRecorder
     /// <param name="cancellationToken">Propagates caller cancellation.</param>
     /// <returns>A task that completes after durable storage.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="refreshToken" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminCredentialsWrite" />.</exception>
     /// <exception cref="MailAccountNotAccessibleException">Thrown when this deployment serves no account with that identifier.</exception>
     /// <remarks>
     /// Recording is idempotent in the account, because re-authorizing a mailbox is what an operator does after a
     /// revocation and a second grant beside the first would leave the account holding a credential nothing chose
     /// between. The store owns that guarantee; this use case adds only the account check in front of it.
+    /// <para>
+    /// The grant is asked for first, and before the account check, so that a caller who may not write a credential
+    /// cannot learn from the refusal which accounts this deployment serves.
+    /// </para>
     /// </remarks>
     public async Task RecordAsync(
         MailAccountId accountId,
@@ -62,6 +74,8 @@ public sealed class MailboxRefreshTokenRecorder
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(refreshToken);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminCredentialsWrite);
 
         if (!this.accountCatalog.ServedAccounts.Any(account => account.Id == accountId))
         {

--- a/src/Application/Contacts/ContactBook.cs
+++ b/src/Application/Contacts/ContactBook.cs
@@ -10,11 +10,11 @@ using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Contacts;
 
-/// <summary>The acts a contact book supports: read it, record a person, amend one, promote one, erase one, and export one.</summary>
+/// <summary>The acts a contact book supports: read it — a page of it, one person, or whoever holds an address — record a person, amend one, promote one, erase one, and export one.</summary>
 /// <remarks>
 /// <para>
 /// Every surface over the book — the administration tool, the MCP tools, and collection from arriving mail — performs
-/// these five acts and no others, which is what keeps the origin rule from being a convention each of them remembers.
+/// these six acts and no others, which is what keeps the origin rule from being a convention each of them remembers.
 /// A writer names the origin it acts under, and a contact is amendable only by a writer of its own: collection never
 /// touches what an owner wrote down, and an owner promotes a collected contact rather than editing it in place.
 /// Promotion names the writer for the same reason, so the act of taking a record on is the owner's rather than something

--- a/src/Application/Contacts/ContactBook.cs
+++ b/src/Application/Contacts/ContactBook.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Persistence;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Contacts;
+using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Contacts;
 
-/// <summary>The acts a contact book supports: record a person, amend one, promote one, erase one, and export one.</summary>
+/// <summary>The acts a contact book supports: read it, record a person, amend one, promote one, erase one, and export one.</summary>
 /// <remarks>
 /// <para>
 /// Every surface over the book — the administration tool, the MCP tools, and collection from arriving mail — performs
@@ -28,6 +31,16 @@ namespace MailFathom.Application.Contacts;
 /// produces are what a surface reports; a log line about a write would put the whole book into a log within a week of
 /// somebody using it.
 /// </para>
+/// <para>
+/// Every act states the grant it is reached under, because the administrative endpoint is the surface that performs them
+/// today and a check that lived only in its routes would be one a second entrypoint forgets. Reading the book is
+/// <see cref="MailFathomPermission.AdminAuditRead" />, since a collected contact is somebody this deployment learned
+/// about from correspondence rather than a report of its own state; writing one is
+/// <see cref="MailFathomPermission.AdminOperate" />; and erasing a person is
+/// <see cref="MailFathomPermission.AdminErase" />, beside the erasure of stored mail. Collection from arriving mail is
+/// work no caller requests, so when it reaches this book the act it uses states that kind of principal beside the grant;
+/// nothing here decides that in advance.
+/// </para>
 /// </remarks>
 public sealed class ContactBook
 {
@@ -35,28 +48,74 @@ public sealed class ContactBook
     private readonly IContactDirectory directory;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
     private readonly TimeProvider timeProvider;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes the book over the store it writes to and the directory it reads from.</summary>
     /// <param name="store">Keeps the records.</param>
     /// <param name="directory">Answers what the book already holds.</param>
     /// <param name="commitPolicy">Commits each write, retrying a lost race from a fresh read.</param>
     /// <param name="timeProvider">Stamps when a contact was recorded, amended, promoted, or exported.</param>
+    /// <param name="authorization">Answers which principal reached each act.</param>
     /// <exception cref="ArgumentNullException">Thrown when a required collaborator is <see langword="null" />.</exception>
     public ContactBook(
         IContactStore store,
         IContactDirectory directory,
         OptimisticConcurrencyRetryPolicy commitPolicy,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(store);
         ArgumentNullException.ThrowIfNull(directory);
         ArgumentNullException.ThrowIfNull(commitPolicy);
         ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.store = store;
         this.directory = directory;
         this.commitPolicy = commitPolicy;
         this.timeProvider = timeProvider;
+        this.authorization = authorization;
+    }
+
+    /// <summary>Reads one bounded page of the book.</summary>
+    /// <param name="query">Which part of the book, how large a page, and where to continue from.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The page, and the cursor the following one is asked with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="query" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the read was reached by anything but a caller granted <see cref="MailFathomPermission.AdminAuditRead" />.</exception>
+    /// <remarks>The page is bounded by the query the caller composed, which is where the ceiling on how much of a person's correspondents leaves the database at once already lives.</remarks>
+    public Task<ContactPage> ReadPageAsync(ContactQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminAuditRead);
+
+        return this.directory.ReadPageAsync(query, cancellationToken);
+    }
+
+    /// <summary>Reads one contact by the identity the book gave it.</summary>
+    /// <param name="contactId">The contact to read.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The contact, or <see langword="null" /> where the book holds no such person.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the read was reached by anything but a caller granted <see cref="MailFathomPermission.AdminAuditRead" />.</exception>
+    public Task<Contact?> FindAsync(ContactId contactId, CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.AdminAuditRead);
+
+        return this.directory.FindAsync(contactId, cancellationToken);
+    }
+
+    /// <summary>Reads the person who uses one address.</summary>
+    /// <param name="address">The address to resolve, in its comparison form.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The contact, or <see langword="null" /> where nobody in the book holds it.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the read was reached by anything but a caller granted <see cref="MailFathomPermission.AdminAuditRead" />.</exception>
+    /// <remarks>Resolving an address to a person is the most pointed read the book answers, which is why it asks for the same grant the listing does rather than a weaker one.</remarks>
+    public Task<Contact?> FindByAddressAsync(EmailAddress address, CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.AdminAuditRead);
+
+        return this.directory.FindByAddressAsync(address, cancellationToken);
     }
 
     /// <summary>Records a person the book does not yet hold.</summary>
@@ -66,6 +125,7 @@ public sealed class ContactBook
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="newContact" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException">Thrown when the supplied addresses do not form a contact the domain admits.</exception>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when every allowed attempt lost the race.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the write was reached by anything but a caller granted <see cref="MailFathomPermission.AdminOperate" />.</exception>
     /// <remarks>
     /// The identity is minted here, from a UUID version 7 over the instant of the write, so the book's own identifiers
     /// order the way the records were created without a caller being able to choose one.
@@ -73,6 +133,8 @@ public sealed class ContactBook
     public Task<ContactWriteResult> RecordAsync(NewContact newContact, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(newContact);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminOperate);
 
         var recordedAt = this.timeProvider.GetUtcNow();
         var contact = Contact.Create(
@@ -107,9 +169,13 @@ public sealed class ContactBook
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="amendment" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException">Thrown when the amendment does not form a contact the domain admits.</exception>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when every allowed attempt lost the race.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the write was reached by anything but a caller granted <see cref="MailFathomPermission.AdminOperate" />.</exception>
+    /// <remarks>The grant is asked for before the book is read, so a caller who may not write cannot learn from the refusal whether the book holds the person they named.</remarks>
     public Task<ContactWriteResult> AmendAsync(ContactAmendment amendment, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(amendment);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminOperate);
 
         return this.commitPolicy.CommitAsync(
             async (session, token) =>
@@ -151,17 +217,25 @@ public sealed class ContactBook
     /// <param name="cancellationToken">Cancels the write.</param>
     /// <returns>The promoted record, or the refusal naming what stopped it.</returns>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when every allowed attempt lost the race.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the write was reached by anything but a caller granted <see cref="MailFathomPermission.AdminOperate" />.</exception>
     /// <remarks>
     /// The one act that changes an origin, and it runs one way. It is gated on the writer for the reason an amendment is:
     /// promotion is the owner taking a record on, so collection asking for it is refused rather than granted the authority
     /// it was about to award itself. A contact that is already asserted is answered as such rather than written again, so
     /// an owner repeating the request learns that nothing was left to do.
+    /// <para>
+    /// The writer and the grant answer different questions and both are asked: the grant says whether this caller may
+    /// write to the book at all, and the writer says whether the record's own origin admits what it is about to do.
+    /// </para>
     /// </remarks>
     public Task<ContactWriteResult> PromoteAsync(
         ContactId contactId,
         ContactOrigin writer,
-        CancellationToken cancellationToken) =>
-        this.commitPolicy.CommitAsync(
+        CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.AdminOperate);
+
+        return this.commitPolicy.CommitAsync(
             async (session, token) =>
             {
                 var held = await this.directory.FindAsync(contactId, token);
@@ -188,26 +262,40 @@ public sealed class ContactBook
                     : ContactWriteResult.NotFound();
             },
             cancellationToken);
+    }
 
     /// <summary>Erases one person and everything the book derived from them.</summary>
     /// <param name="contactId">The contact to erase.</param>
     /// <param name="cancellationToken">Cancels the erasure.</param>
     /// <returns>What the erasure removed.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the erasure was reached by anything but a caller granted <see cref="MailFathomPermission.AdminErase" />.</exception>
     /// <remarks>
     /// Erasure is not a write a writer's origin gates. It is the data-subject path, and a person asking to be removed
     /// from somebody's contact book is not answered with which half of the book they happen to be in.
+    /// <para>
+    /// It asks for the erasing grant rather than the writing one, beside the erasure of stored mail, because what it
+    /// destroys cannot be written back and a credential provisioned to correct a record should not be able to remove one.
+    /// </para>
     /// </remarks>
-    public Task<ContactErasure> EraseAsync(ContactId contactId, CancellationToken cancellationToken) =>
-        this.commitPolicy.CommitAsync(
+    public Task<ContactErasure> EraseAsync(ContactId contactId, CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.AdminErase);
+
+        return this.commitPolicy.CommitAsync(
             (session, token) => this.store.EraseAsync(session, contactId, token),
             cancellationToken);
+    }
 
     /// <summary>Produces everything the book holds about one person.</summary>
     /// <param name="contactId">The contact to export.</param>
     /// <param name="cancellationToken">Cancels the read.</param>
     /// <returns>The export, or <see langword="null" /> when the book holds no such contact.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the export was reached by anything but a caller granted <see cref="MailFathomPermission.AdminAuditRead" />.</exception>
+    /// <remarks>It is what a data-subject access request is answered from, which is reading what this deployment derived about a person rather than a report of its own state.</remarks>
     public async Task<ContactExport?> ExportAsync(ContactId contactId, CancellationToken cancellationToken)
     {
+        this.authorization.RequirePermission(MailFathomPermission.AdminAuditRead);
+
         var held = await this.directory.FindAsync(contactId, cancellationToken);
 
         return held is null ? null : new ContactExport(held, this.timeProvider.GetUtcNow());

--- a/src/Application/Emails/Embeddings/Administration/CountedEmbeddingActivation.cs
+++ b/src/Application/Emails/Embeddings/Administration/CountedEmbeddingActivation.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Limits;
+using MailFathom.Domain.Access;
 
 namespace MailFathom.Application.Emails.Embeddings.Administration;
 
@@ -28,28 +30,33 @@ public sealed class CountedEmbeddingActivation
     private readonly IEmbeddingWorkloadReader workloadReader;
     private readonly EmbeddingSpendGate spendGate;
     private readonly EmbeddingProfileActivation activation;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes a new counted activation.</summary>
     /// <param name="generationStore">Reads which generations exist, which decides what an activation would do.</param>
     /// <param name="workloadReader">Counts the passages the run would send.</param>
     /// <param name="spendGate">Reads where the budget period stands.</param>
     /// <param name="activation">Performs the activation once it has been weighed.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public CountedEmbeddingActivation(
         IEmbeddingGenerationStore generationStore,
         IEmbeddingWorkloadReader workloadReader,
         EmbeddingSpendGate spendGate,
-        EmbeddingProfileActivation activation)
+        EmbeddingProfileActivation activation,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(generationStore);
         ArgumentNullException.ThrowIfNull(workloadReader);
         ArgumentNullException.ThrowIfNull(spendGate);
         ArgumentNullException.ThrowIfNull(activation);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.generationStore = generationStore;
         this.workloadReader = workloadReader;
         this.spendGate = spendGate;
         this.activation = activation;
+        this.authorization = authorization;
     }
 
     /// <summary>Reads what activating the declared geometry would do and what it would cost, writing nothing.</summary>
@@ -57,13 +64,30 @@ public sealed class CountedEmbeddingActivation
     /// <param name="cancellationToken">Cancels the reads.</param>
     /// <returns>The assessment an operator confirms against.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="declared" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminRead" />.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
-    public async Task<EmbeddingActivationAssessment> AssessAsync(
+    /// <remarks>Reading what an activation would cost is a report about this deployment, so it asks for the read permission and never for the one that starts a bill.</remarks>
+    public Task<EmbeddingActivationAssessment> AssessAsync(
         EmbeddingProfileIdentity declared,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(declared);
 
+        this.authorization.RequirePermission(MailFathomPermission.AdminRead);
+
+        return this.ReadAssessmentAsync(declared, cancellationToken);
+    }
+
+    /// <summary>Composes the assessment, having established that whoever asked may have it.</summary>
+    /// <remarks>
+    /// Separated from <see cref="AssessAsync" /> because the activation below weighs the same figures and is reached
+    /// under a different grant. No permission implies another here as anywhere else, so an activating caller reading
+    /// through the assessing method would be refused for lacking a permission its own operation never needed.
+    /// </remarks>
+    private async Task<EmbeddingActivationAssessment> ReadAssessmentAsync(
+        EmbeddingProfileIdentity declared,
+        CancellationToken cancellationToken)
+    {
         var declaredFingerprint = EmbeddingProfileFingerprint.Compute(declared);
         var generations = await this.generationStore.ReadGenerationsAsync(cancellationToken);
         var estimate = await this.workloadReader.ReadWorkloadAsync(declaredFingerprint, cancellationToken);
@@ -81,12 +105,18 @@ public sealed class CountedEmbeddingActivation
     /// <param name="cancellationToken">Cancels the reads and the registration.</param>
     /// <returns>What was weighed, and what the activation did where it ran.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="declared" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminSpend" />.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
     /// <remarks>
     /// The assessment is taken again here rather than accepted from the caller, so what refuses a spend is the state of
     /// the deployment at the moment it would happen rather than a figure a client read earlier and may have edited on
     /// the way back. Every other failure of the activation itself — a lost registration race, an index the database
     /// refused — is <see cref="EmbeddingProfileActivation" />'s and reaches the caller unchanged.
+    /// <para>
+    /// This is the one operation on the administrative surface that starts a provider bill, which is why it is the only
+    /// one asking for <see cref="MailFathomPermission.AdminSpend" /> and why holding the read permission does not reach
+    /// it.
+    /// </para>
     /// </remarks>
     public async Task<CountedEmbeddingActivationResult> ActivateAsync(
         EmbeddingProfileIdentity declared,
@@ -94,7 +124,9 @@ public sealed class CountedEmbeddingActivation
     {
         ArgumentNullException.ThrowIfNull(declared);
 
-        var assessment = await this.AssessAsync(declared, cancellationToken);
+        this.authorization.RequirePermission(MailFathomPermission.AdminSpend);
+
+        var assessment = await this.ReadAssessmentAsync(declared, cancellationToken);
 
         if (assessment.ExceedsSpendCeiling)
         {

--- a/src/Application/Emails/Embeddings/Administration/EmbeddingStatusReader.cs
+++ b/src/Application/Emails/Embeddings/Administration/EmbeddingStatusReader.cs
@@ -2,10 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Limits;
+using MailFathom.Domain.Access;
 
 namespace MailFathom.Application.Emails.Embeddings.Administration;
 
@@ -23,6 +25,7 @@ public sealed class EmbeddingStatusReader
     private readonly EmbeddingSpendGate spendGate;
     private readonly IAiProviderHealthReader providerHealth;
     private readonly EmbeddingBackfillSchedule backfillSchedule;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes a new reader over the state one status answer is composed from.</summary>
     /// <param name="generationStore">Reads which generations this instance holds.</param>
@@ -30,40 +33,52 @@ public sealed class EmbeddingStatusReader
     /// <param name="spendGate">Reads where the budget period stands.</param>
     /// <param name="providerHealth">Reports what the last call to the embedding provider established.</param>
     /// <param name="backfillSchedule">Reports when the walk's next pass is due.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public EmbeddingStatusReader(
         IEmbeddingGenerationStore generationStore,
         IEmbeddingWorkloadReader workloadReader,
         EmbeddingSpendGate spendGate,
         IAiProviderHealthReader providerHealth,
-        EmbeddingBackfillSchedule backfillSchedule)
+        EmbeddingBackfillSchedule backfillSchedule,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(generationStore);
         ArgumentNullException.ThrowIfNull(workloadReader);
         ArgumentNullException.ThrowIfNull(spendGate);
         ArgumentNullException.ThrowIfNull(providerHealth);
         ArgumentNullException.ThrowIfNull(backfillSchedule);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.generationStore = generationStore;
         this.workloadReader = workloadReader;
         this.spendGate = spendGate;
         this.providerHealth = providerHealth;
         this.backfillSchedule = backfillSchedule;
+        this.authorization = authorization;
     }
 
     /// <summary>Reads where semantic search stands on this instance.</summary>
     /// <param name="declared">The geometry configuration declares, or <see langword="null" /> where it declares none.</param>
     /// <param name="cancellationToken">Cancels the reads.</param>
     /// <returns>The status.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminRead" />.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
     /// <remarks>
     /// An instance that has activated nothing answers with both generations absent and the rest present, which is the
     /// supported deployment that serves lexical search rather than a failure to report on.
+    /// <para>
+    /// What it reports is this deployment's own state and no mail, which is the grant it asks for. It asks here rather
+    /// than only at the route, so a second entrypoint cannot publish what a provider costs this deployment by reaching
+    /// the use case without passing a filter.
+    /// </para>
     /// </remarks>
     public async Task<EmbeddingStatus> ReadAsync(
         EmbeddingProfileIdentity? declared,
         CancellationToken cancellationToken)
     {
+        this.authorization.RequirePermission(MailFathomPermission.AdminRead);
+
         var generations = await this.generationStore.ReadGenerationsAsync(cancellationToken);
 
         return new EmbeddingStatus(

--- a/src/Application/Emails/Embeddings/Generations/EmbeddingReindexCancellation.cs
+++ b/src/Application/Emails/Embeddings/Generations/EmbeddingReindexCancellation.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Persistence;
+using MailFathom.Domain.Access;
 
 namespace MailFathom.Application.Emails.Embeddings.Generations;
 
@@ -20,28 +22,33 @@ public sealed class EmbeddingReindexCancellation
     private readonly IEmbeddingProfileVectorIndex vectorIndex;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
     private readonly EmbeddingBackfillSchedule backfillSchedule;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes a new cancellation.</summary>
     /// <param name="generationStore">Reads which generation is being built and abandons it.</param>
     /// <param name="vectorIndex">Removes the approximate index the abandoned generation would have been searched through.</param>
     /// <param name="concurrencyRetryPolicy">Commits the transition, retrying a conflict with a competing writer.</param>
     /// <param name="backfillSchedule">Brings the next upkeep pass forward, which is the pass that removes what the abandoned generation holds.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public EmbeddingReindexCancellation(
         IEmbeddingGenerationStore generationStore,
         IEmbeddingProfileVectorIndex vectorIndex,
         OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
-        EmbeddingBackfillSchedule backfillSchedule)
+        EmbeddingBackfillSchedule backfillSchedule,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(generationStore);
         ArgumentNullException.ThrowIfNull(vectorIndex);
         ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
         ArgumentNullException.ThrowIfNull(backfillSchedule);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.generationStore = generationStore;
         this.vectorIndex = vectorIndex;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
         this.backfillSchedule = backfillSchedule;
+        this.authorization = authorization;
     }
 
     /// <summary>Abandons the generation being built, if one is.</summary>
@@ -53,9 +60,13 @@ public sealed class EmbeddingReindexCancellation
     /// removal of its vectors reaches the end and drops it.
     /// </exception>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when a competing writer wins a race the bounded retries could not resolve.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminOperate" />.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    /// <remarks>Stopping a run is asking the deployment to do something it can already do, which is the operating grant rather than the one that started the spend.</remarks>
     public async Task<EmbeddingReindexCancellationOutcome> CancelAsync(CancellationToken cancellationToken)
     {
+        this.authorization.RequirePermission(MailFathomPermission.AdminOperate);
+
         var generations = await this.generationStore.ReadGenerationsAsync(cancellationToken);
         if (generations.Building is not { } building)
         {

--- a/src/Application/Folders/UnmirroredMailFolderEraser.cs
+++ b/src/Application/Folders/UnmirroredMailFolderEraser.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
 
@@ -29,24 +31,29 @@ public sealed class UnmirroredMailFolderEraser
     private readonly IStoredMailFolderMirrorStore mirrorStore;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
     private readonly MailboxSynchronizationOptions options;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes the eraser.</summary>
     /// <param name="mirrorStore">Removes the stored mail of one folder and clears its checkpoint.</param>
     /// <param name="concurrencyRetryPolicy">Commits one pass, retrying a conflict with a competing writer.</param>
     /// <param name="options">Bounds one pass, reusing the bound the backward pass over stored mail already carries.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public UnmirroredMailFolderEraser(
         IStoredMailFolderMirrorStore mirrorStore,
         OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
-        MailboxSynchronizationOptions options)
+        MailboxSynchronizationOptions options,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(mirrorStore);
         ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
         ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.mirrorStore = mirrorStore;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
         this.options = options;
+        this.authorization = authorization;
     }
 
     /// <summary>Erases one bounded pass of what is stored for a folder nothing mirrors any more.</summary>
@@ -55,11 +62,19 @@ public sealed class UnmirroredMailFolderEraser
     /// <param name="cancellationToken">Cancels the pass before or during its single transaction.</param>
     /// <returns>What this pass erased, and whether the folder still holds stored mail.</returns>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when a competing writer wins a race the bounded retries could not resolve.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminErase" />.</exception>
+    /// <remarks>
+    /// This is the one operation that disposes of stored mail, so it asks for the grant allocated to exactly that and
+    /// nothing wider reaches it. The check is here rather than only at the route because an erasure is irreversible and
+    /// an entrypoint added later must not be able to perform one by omission.
+    /// </remarks>
     public async Task<MailFolderMirrorErasure> EraseAsync(
         MailAccountId accountId,
         MailFolderAlias folderAlias,
         CancellationToken cancellationToken)
     {
+        this.authorization.RequirePermission(MailFathomPermission.AdminErase);
+
         var erasure = MailFolderMirrorErasure.Nothing;
 
         await this.concurrencyRetryPolicy.CommitAsync(

--- a/src/Application/Jobs/DeadLetters/DeadLetteredJobs.cs
+++ b/src/Application/Jobs/DeadLetters/DeadLetteredJobs.cs
@@ -1,0 +1,86 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Jobs.DeadLetters;
+
+/// <summary>The three things an operator does about background work that stopped: read it, run one again, or drop one.</summary>
+/// <remarks>
+/// <para>
+/// The store keeps the rows and is written by the queue itself; this is what an operator reaches, and it exists so that
+/// the grant is asked where the decision is made rather than only at the routes serving it today. Reading what stopped
+/// reports the deployment's own state, while returning a job to the queue makes it run again — against somebody's
+/// mailbox, under the identity the row already carries — so the two are published under different grants and a
+/// credential provisioned to watch a queue cannot act on it.
+/// </para>
+/// <para>
+/// Neither decision performs the work. A retry writes the row back to a state the next worker claims from, and a drop
+/// records that nothing will, which is why both answer immediately whatever the job was about.
+/// </para>
+/// </remarks>
+public sealed class DeadLetteredJobs
+{
+    private readonly IDeadLetteredJobStore deadLetters;
+    private readonly AccessAuthorization authorization;
+
+    /// <summary>Initializes the operations over the dead-letter store.</summary>
+    /// <param name="deadLetters">Keeps the jobs nothing will attempt again, and performs a decision about one.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public DeadLetteredJobs(IDeadLetteredJobStore deadLetters, AccessAuthorization authorization)
+    {
+        ArgumentNullException.ThrowIfNull(deadLetters);
+        ArgumentNullException.ThrowIfNull(authorization);
+
+        this.deadLetters = deadLetters;
+        this.authorization = authorization;
+    }
+
+    /// <summary>Reads one page of the jobs nothing will attempt again.</summary>
+    /// <param name="query">The filters and where the page continues from.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The page, and the cursor the following one is asked with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="query" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminRead" />.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    public Task<DeadLetteredJobPage> ReadPageAsync(
+        DeadLetteredJobQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminRead);
+
+        return this.deadLetters.ReadPageAsync(query, cancellationToken);
+    }
+
+    /// <summary>Returns one dead letter to the queue, to be run again under the identity it already carries.</summary>
+    /// <param name="jobId">The job to attempt again.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>What became of the job, including that it was not one this deployment holds or had already moved on.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminOperate" />.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    public Task<JobRecoveryOutcome> RetryAsync(JobId jobId, CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.AdminOperate);
+
+        return this.deadLetters.RetryAsync(jobId, cancellationToken);
+    }
+
+    /// <summary>Records that one dead letter will never be run.</summary>
+    /// <param name="jobId">The job to drop.</param>
+    /// <param name="cancellationToken">Cancels the write.</param>
+    /// <returns>What became of the job, including that it was not one this deployment holds or had already moved on.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminOperate" />.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    /// <remarks>Dropping asks for the same grant retrying does rather than the erasing one, because the row and its failure stay where they are: what it records is a decision, not a removal.</remarks>
+    public Task<JobRecoveryOutcome> DropAsync(JobId jobId, CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.AdminOperate);
+
+        return this.deadLetters.DropAsync(jobId, cancellationToken);
+    }
+}

--- a/src/Application/Mail/Maintenance/MailSynchronizationRewind.cs
+++ b/src/Application/Mail/Maintenance/MailSynchronizationRewind.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization.Checkpoints;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Folders;
 
 namespace MailFathom.Application.Mail.Maintenance;
@@ -32,24 +34,29 @@ public sealed class MailSynchronizationRewind
     private readonly ISynchronizationCheckpointStore checkpointStore;
     private readonly IStoredMailCounter storedMailCounter;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes the rewind.</summary>
     /// <param name="checkpointStore">Reads and removes the durable progress of the account's bindings.</param>
     /// <param name="storedMailCounter">Counts what a rewound scope would have re-read.</param>
     /// <param name="concurrencyRetryPolicy">Commits the removal, retrying a conflict with a competing writer.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public MailSynchronizationRewind(
         ISynchronizationCheckpointStore checkpointStore,
         IStoredMailCounter storedMailCounter,
-        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy)
+        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(checkpointStore);
         ArgumentNullException.ThrowIfNull(storedMailCounter);
         ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.checkpointStore = checkpointStore;
         this.storedMailCounter = storedMailCounter;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
+        this.authorization = authorization;
     }
 
     /// <summary>Reports how much mail a rewind of one scope would have the next runs read again.</summary>
@@ -62,10 +69,17 @@ public sealed class MailSynchronizationRewind
     /// holds is not fetched again, and mail that arrived since is fetched without ever having been stored. Neither
     /// difference is knowable without a mailbox session, which this deliberately does not open, and the stored count is
     /// the figure of the right order for the decision an operator is making.
+    /// <para>
+    /// It counts rather than discards, so it asks for the permission a report of the deployment's own state is published
+    /// under and never for the one that performs the rewind.
+    /// </para>
     /// </remarks>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminRead" />.</exception>
     public Task<int> AssessAsync(StoredMailScope scope, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(scope);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminRead);
 
         return this.storedMailCounter.CountStoredEmailsAsync(scope, cancellationToken);
     }
@@ -76,16 +90,23 @@ public sealed class MailSynchronizationRewind
     /// <returns>The aliases whose bindings held progress, ordered and without repeats.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="scope" /> is <see langword="null" />.</exception>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when a competing writer wins a race the bounded retries could not resolve.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminOperate" />.</exception>
     /// <remarks>
     /// One transaction for the whole scope rather than a bounded pass per folder. What it removes is one row per
     /// binding, so an account's worth of it is a handful of rows however much mail those bindings cover, and a partial
     /// rewind would leave an account whose folders resume from different points for no benefit.
+    /// <para>
+    /// It makes the deployment pull a mailbox over IMAP again, which is asking it to do work it can already do, so the
+    /// operating grant is what reaches it and reading the assessment beforehand does not.
+    /// </para>
     /// </remarks>
     public async Task<IReadOnlyList<MailFolderAlias>> RewindAsync(
         StoredMailScope scope,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(scope);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminOperate);
 
         IReadOnlyList<MailFolderAlias> rewound = [];
 

--- a/src/Application/Mail/Maintenance/StoredMailRederivation.cs
+++ b/src/Application/Mail/Maintenance/StoredMailRederivation.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Persistence;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Mail.Maintenance;
@@ -70,28 +72,33 @@ public sealed class StoredMailRederivation
     private readonly IEmailContentStore contentStore;
     private readonly IEmailMimeReader mimeReader;
     private readonly OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes the re-derivation.</summary>
     /// <param name="rederivationStore">Reads what the walk has left and writes what one email's re-reading produced.</param>
     /// <param name="contentStore">Reads back the raw MIME an earlier run stored.</param>
     /// <param name="mimeReader">Turns that raw MIME into normalized metadata.</param>
     /// <param name="concurrencyRetryPolicy">Commits a batch, retrying a conflict with a competing writer.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public StoredMailRederivation(
         IStoredMailRederivationStore rederivationStore,
         IEmailContentStore contentStore,
         IEmailMimeReader mimeReader,
-        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy)
+        OptimisticConcurrencyRetryPolicy concurrencyRetryPolicy,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(rederivationStore);
         ArgumentNullException.ThrowIfNull(contentStore);
         ArgumentNullException.ThrowIfNull(mimeReader);
         ArgumentNullException.ThrowIfNull(concurrencyRetryPolicy);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.rederivationStore = rederivationStore;
         this.contentStore = contentStore;
         this.mimeReader = mimeReader;
         this.concurrencyRetryPolicy = concurrencyRetryPolicy;
+        this.authorization = authorization;
     }
 
     /// <summary>Runs one bounded pass over the scope's stored mail.</summary>
@@ -103,12 +110,16 @@ public sealed class StoredMailRederivation
     /// Thrown when a competing writer wins a race that the bounded retries could not resolve. Batches already committed
     /// stay durable, and the next pass resumes from the committed position.
     /// </exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminOperate" />.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels. Committed batches stay durable.</exception>
+    /// <remarks>A pass is work the deployment performs on the operator's asking, which is the grant it asks for.</remarks>
     public async Task<StoredMailRederivationPass> RunAsync(
         StoredMailScope scope,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(scope);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminOperate);
 
         var position = await this.rederivationStore.FindResumePositionAsync(scope, cancellationToken);
         var rederivedCount = 0;

--- a/src/Application/Mail/Mutations/Audit/MailboxMutationAuditTrailReader.cs
+++ b/src/Application/Mail/Mutations/Audit/MailboxMutationAuditTrailReader.cs
@@ -1,0 +1,59 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Mail.Mutations.Audit;
+
+/// <summary>Reads one account's record of the changes MailFathom made to its mailbox, for whoever may read it.</summary>
+/// <remarks>
+/// <para>
+/// The store keeps the trail and answers every writer of it, including the mutation paths that append to it while a run
+/// is under way. This is the use case reading it on somebody's behalf, and it exists so that the grant is asked where
+/// the reading is rather than only at the route that happens to serve it today: what the trail says is where a person's
+/// mail has been, when, and at whose instruction, so an entrypoint added later must not be able to publish it by
+/// forgetting a filter.
+/// </para>
+/// <para>
+/// It narrows nothing of its own. The query the caller composed already bounds the page and names the account, and a
+/// second opinion here would be a bound nobody could see from the caller's side.
+/// </para>
+/// </remarks>
+public sealed class MailboxMutationAuditTrailReader
+{
+    private readonly IMailboxMutationAuditEntryStore entries;
+    private readonly AccessAuthorization authorization;
+
+    /// <summary>Initializes the reading over the trail's store.</summary>
+    /// <param name="entries">Keeps the recorded changes.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public MailboxMutationAuditTrailReader(IMailboxMutationAuditEntryStore entries, AccessAuthorization authorization)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(authorization);
+
+        this.entries = entries;
+        this.authorization = authorization;
+    }
+
+    /// <summary>Reads one page of an account's audit trail.</summary>
+    /// <param name="query">The account, the filters, and where the page continues from.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The page, and the cursor the following one is asked with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="query" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminAuditRead" />.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    public Task<MailboxMutationAuditPage> ReadPageAsync(
+        MailboxMutationAuditQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminAuditRead);
+
+        return this.entries.ReadPageAsync(query, cancellationToken);
+    }
+}

--- a/src/Application/Retrieval/AskMail/Audit/MailAnsweringAuditTrailReader.cs
+++ b/src/Application/Retrieval/AskMail/Audit/MailAnsweringAuditTrailReader.cs
@@ -1,0 +1,58 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Retrieval.AskMail.Audit;
+
+/// <summary>Reads one account's record of the questions this deployment answered from its mailbox.</summary>
+/// <remarks>
+/// <para>
+/// The store is appended to by every answering run and read by whoever an operator provisioned to read it. Separating
+/// the reading into a use case is what lets the grant be asked where the record is served rather than only at the route
+/// serving it: the record says which of a person's messages a question reached and when, which is derived personal data
+/// however little of the mail itself it carries.
+/// </para>
+/// <para>
+/// It reads beside <see cref="Mail.Mutations.Audit.MailboxMutationAuditTrailReader" /> and asks for the same grant, because
+/// the two together are what an operator answers "why is this message here" and "why did it answer that" from.
+/// </para>
+/// </remarks>
+public sealed class MailAnsweringAuditTrailReader
+{
+    private readonly IMailAnsweringAuditEntryStore entries;
+    private readonly AccessAuthorization authorization;
+
+    /// <summary>Initializes the reading over the record's store.</summary>
+    /// <param name="entries">Keeps the answered questions.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public MailAnsweringAuditTrailReader(IMailAnsweringAuditEntryStore entries, AccessAuthorization authorization)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+        ArgumentNullException.ThrowIfNull(authorization);
+
+        this.entries = entries;
+        this.authorization = authorization;
+    }
+
+    /// <summary>Reads one page of an account's answering record.</summary>
+    /// <param name="query">The account, the filters, and where the page continues from.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The page, and the cursor the following one is asked with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="query" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminAuditRead" />.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    public Task<MailAnsweringAuditPage> ReadPageAsync(
+        MailAnsweringAuditQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminAuditRead);
+
+        return this.entries.ReadPageAsync(query, cancellationToken);
+    }
+}

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationRunReader.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationRunReader.cs
@@ -1,0 +1,50 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.Rules.Evaluation;
+
+/// <summary>Reports where one account's whole-mailbox rule run has got to.</summary>
+/// <remarks>
+/// Reading a run is separated from asking for one — <see cref="MailRuleEvaluationRunRequests" /> — because the two are
+/// reached under different grants and neither implies the other: watching a pass is a report of what this deployment is
+/// doing, while starting one changes mail on somebody's server. An operator can therefore provision a credential that
+/// watches a run it cannot start.
+/// </remarks>
+public sealed class MailRuleEvaluationRunReader
+{
+    private readonly IMailRuleEvaluationRunStore runs;
+    private readonly AccessAuthorization authorization;
+
+    /// <summary>Initializes the reading over the run store.</summary>
+    /// <param name="runs">Holds the one run an account may have outstanding, and the ending of the last one.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public MailRuleEvaluationRunReader(IMailRuleEvaluationRunStore runs, AccessAuthorization authorization)
+    {
+        ArgumentNullException.ThrowIfNull(runs);
+        ArgumentNullException.ThrowIfNull(authorization);
+
+        this.runs = runs;
+        this.authorization = authorization;
+    }
+
+    /// <summary>Reads the run one account has outstanding, or the last one it finished.</summary>
+    /// <param name="accountId">The account whose run is read.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The run, or <see langword="null" /> where the account has never been asked for one.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminRead" />.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    public Task<MailRuleEvaluationRun?> FindLatestAsync(
+        MailAccountId accountId,
+        CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.AdminRead);
+
+        return this.runs.FindLatestAsync(accountId, cancellationToken);
+    }
+}

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationRunRequests.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationRunRequests.cs
@@ -78,8 +78,9 @@ public sealed class MailRuleEvaluationRunRequests
     /// </para>
     /// <para>
     /// This is the operator's own request, so it asks for the grant that covers making the deployment do work — a pass
-    /// over a whole mailbox changes mail on the server. <see cref="SubmitScheduledAsync" /> asks for nothing, because
-    /// what reaches it is this process on a rule's own declared occasion rather than a caller.
+    /// over a whole mailbox changes mail on the server. <see cref="SubmitScheduledAsync" /> asks for no permission and
+    /// for the process itself instead, because what reaches it is this process on a rule's own declared occasion rather
+    /// than a caller.
     /// </para>
     /// </remarks>
     public Task<MailRuleEvaluationRunRequest> SubmitAsync(
@@ -115,15 +116,21 @@ public sealed class MailRuleEvaluationRunRequests
     /// mailbox work nobody needs — which is the guarantee the mechanism dispatching this occasion also makes about the
     /// job it enqueued.
     /// <para>
-    /// It asks for no permission, deliberately. What reaches it is a job this deployment enqueued from a rule's own
-    /// declared schedule, so there is no caller to hold one, and requiring an administrative grant here would mean the
-    /// schedule ran under a credential nobody presented.
+    /// It asks for no permission, deliberately, and requires the process itself instead. What reaches it is a job this
+    /// deployment enqueued from a rule's own declared schedule, so there is no caller to hold a grant, and requiring an
+    /// administrative one here would mean the schedule ran under a credential nobody presented. Requiring the process
+    /// identity is what makes that an admitted case rather than an unasked question: a caller reaching this method from
+    /// an entrypoint added later is refused instead of starting a mailbox-wide pass under no grant at all.
     /// </para>
     /// </remarks>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when anything but this deployment's own process reached the use case.</exception>
     public Task<MailRuleEvaluationRunRequest> SubmitScheduledAsync(
         MailAccountId accountId,
-        CancellationToken cancellationToken) =>
-        this.commitPolicy.CommitAsync(
+        CancellationToken cancellationToken)
+    {
+        this.authorization.RequireProcessIdentity();
+
+        return this.commitPolicy.CommitAsync(
             async (session, attemptCancellationToken) =>
             {
                 var scheduled = new MailRuleEvaluationRun
@@ -136,6 +143,7 @@ public sealed class MailRuleEvaluationRunRequests
                 return await this.StartAsync(session, scheduled, attemptCancellationToken);
             },
             cancellationToken);
+    }
 
     /// <summary>Starts the run unless the account's row already holds one this request must not replace.</summary>
     /// <param name="session">The session the write is staged in.</param>

--- a/src/Application/Rules/Evaluation/MailRuleEvaluationRunRequests.cs
+++ b/src/Application/Rules/Evaluation/MailRuleEvaluationRunRequests.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules.History;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 
 namespace MailFathom.Application.Rules.Evaluation;
@@ -34,24 +36,29 @@ public sealed class MailRuleEvaluationRunRequests
     private readonly IMailRuleEvaluationRunStore runStore;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
     private readonly TimeProvider timeProvider;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes the request intake.</summary>
     /// <param name="runStore">Reads whether a run is outstanding and records the one this request asks for.</param>
     /// <param name="commitPolicy">Makes the read and the write one decision, and resolves a race with a competing request.</param>
     /// <param name="timeProvider">Stamps the request.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
     public MailRuleEvaluationRunRequests(
         IMailRuleEvaluationRunStore runStore,
         OptimisticConcurrencyRetryPolicy commitPolicy,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(runStore);
         ArgumentNullException.ThrowIfNull(commitPolicy);
         ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.runStore = runStore;
         this.commitPolicy = commitPolicy;
         this.timeProvider = timeProvider;
+        this.authorization = authorization;
     }
 
     /// <summary>Asks for the account's rules to be run over every message stored for it.</summary>
@@ -59,6 +66,7 @@ public sealed class MailRuleEvaluationRunRequests
     /// <param name="cancellationToken">Cancels the write.</param>
     /// <returns>The run the account now has outstanding, and whether this request is what put it there.</returns>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when two requests raced past the bounded retries.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminOperate" />.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
     /// <remarks>
     /// Whether the account is free is decided at the write rather than by a check in front of it, because two requests
@@ -68,11 +76,19 @@ public sealed class MailRuleEvaluationRunRequests
     /// A scheduled run in front of the account is replaced rather than answered with, because this request reaches every
     /// rule and that one reaches only the rules declaring a schedule.
     /// </para>
+    /// <para>
+    /// This is the operator's own request, so it asks for the grant that covers making the deployment do work — a pass
+    /// over a whole mailbox changes mail on the server. <see cref="SubmitScheduledAsync" /> asks for nothing, because
+    /// what reaches it is this process on a rule's own declared occasion rather than a caller.
+    /// </para>
     /// </remarks>
     public Task<MailRuleEvaluationRunRequest> SubmitAsync(
         MailAccountId accountId,
-        CancellationToken cancellationToken) =>
-        this.commitPolicy.CommitAsync(
+        CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.AdminOperate);
+
+        return this.commitPolicy.CommitAsync(
             async (session, attemptCancellationToken) =>
             {
                 var requested = new MailRuleEvaluationRun
@@ -85,6 +101,7 @@ public sealed class MailRuleEvaluationRunRequests
                 return await this.StartAsync(session, requested, attemptCancellationToken);
             },
             cancellationToken);
+    }
 
     /// <summary>Asks, on a rule's own declared occasion, for the account's scheduled rules to be run over its mailbox.</summary>
     /// <param name="accountId">The account to run the scheduled rules over.</param>
@@ -97,6 +114,11 @@ public sealed class MailRuleEvaluationRunRequests
     /// occasion wanted and more, and a scheduled run is the same walk arriving early, so both make a second walk of one
     /// mailbox work nobody needs — which is the guarantee the mechanism dispatching this occasion also makes about the
     /// job it enqueued.
+    /// <para>
+    /// It asks for no permission, deliberately. What reaches it is a job this deployment enqueued from a rule's own
+    /// declared schedule, so there is no caller to hold one, and requiring an administrative grant here would mean the
+    /// schedule ran under a credential nobody presented.
+    /// </para>
     /// </remarks>
     public Task<MailRuleEvaluationRunRequest> SubmitScheduledAsync(
         MailAccountId accountId,

--- a/src/Application/Rules/History/MailRuleHistory.cs
+++ b/src/Application/Rules/History/MailRuleHistory.cs
@@ -1,0 +1,57 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Rules.History;
+
+/// <summary>Reads what this deployment's rules concluded about one account's mail.</summary>
+/// <remarks>
+/// <para>
+/// The store is written by every evaluation pass and aged by retention. This is the reading, separated so that the grant
+/// is asked where the history is served: what a rule concluded about a message is derived from that message, which is
+/// why it is published under the audit grant rather than under the one covering reports of the deployment's own state.
+/// </para>
+/// <para>
+/// Which rules are loaded is a different question and a different grant — <see cref="MailRuleSetReader" /> answers it —
+/// because a rule set says what this deployment will do and a history says what it did to somebody's mail.
+/// </para>
+/// </remarks>
+public sealed class MailRuleHistory
+{
+    private readonly IMailRuleExecutionStore executions;
+    private readonly AccessAuthorization authorization;
+
+    /// <summary>Initializes the reading over the recorded executions.</summary>
+    /// <param name="executions">Keeps what each evaluation concluded.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public MailRuleHistory(IMailRuleExecutionStore executions, AccessAuthorization authorization)
+    {
+        ArgumentNullException.ThrowIfNull(executions);
+        ArgumentNullException.ThrowIfNull(authorization);
+
+        this.executions = executions;
+        this.authorization = authorization;
+    }
+
+    /// <summary>Reads one page of an account's rule history.</summary>
+    /// <param name="query">The account, the filters, and where the page continues from.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The page, and the cursor the following one is asked with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="query" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminAuditRead" />.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    public Task<MailRuleExecutionPage> ReadPageAsync(
+        MailRuleExecutionQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminAuditRead);
+
+        return this.executions.ReadPageAsync(query, cancellationToken);
+    }
+}

--- a/src/Application/Rules/MailRuleSetReader.cs
+++ b/src/Application/Rules/MailRuleSetReader.cs
@@ -17,8 +17,9 @@ namespace MailFathom.Application.Rules;
 /// one.
 /// </para>
 /// <para>
-/// The reading is not asynchronous and does not fail, for the reason the source it reads gives: a candidate rule set that
-/// could not be proven usable never becomes the current one.
+/// The reading is not asynchronous, and the rule set itself cannot fail to be produced, for the reason the source it
+/// reads gives: a candidate rule set that could not be proven usable never becomes the current one. What the reading
+/// does refuse is a caller whose grant does not carry the permission, which it raises rather than reports.
 /// </para>
 /// </remarks>
 public sealed class MailRuleSetReader

--- a/src/Application/Rules/MailRuleSetReader.cs
+++ b/src/Application/Rules/MailRuleSetReader.cs
@@ -1,0 +1,51 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Rules;
+
+/// <summary>Reports the rule set in force to whoever may read it.</summary>
+/// <remarks>
+/// <para>
+/// A pass reads <see cref="IMailRuleSetSource" /> directly and holds what it was given, which is the reload contract and
+/// is not what this is for. This is the operator's reading: what a caller is being told is what this deployment will do
+/// to a mailbox, which is a report of the deployment's own state and carries no mail — so it asks for the read grant,
+/// while what the rules concluded about somebody's messages is <see cref="History.MailRuleHistory" /> and a different
+/// one.
+/// </para>
+/// <para>
+/// The reading is not asynchronous and does not fail, for the reason the source it reads gives: a candidate rule set that
+/// could not be proven usable never becomes the current one.
+/// </para>
+/// </remarks>
+public sealed class MailRuleSetReader
+{
+    private readonly IMailRuleSetSource ruleSets;
+    private readonly AccessAuthorization authorization;
+
+    /// <summary>Initializes the reading over the published rule set.</summary>
+    /// <param name="ruleSets">Hands out the rule set compiled from the published configuration.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public MailRuleSetReader(IMailRuleSetSource ruleSets, AccessAuthorization authorization)
+    {
+        ArgumentNullException.ThrowIfNull(ruleSets);
+        ArgumentNullException.ThrowIfNull(authorization);
+
+        this.ruleSets = ruleSets;
+        this.authorization = authorization;
+    }
+
+    /// <summary>Reads the rule set a pass starting now would run against.</summary>
+    /// <returns>The loaded rule set.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminRead" />.</exception>
+    public MailRuleSet Read()
+    {
+        this.authorization.RequirePermission(MailFathomPermission.AdminRead);
+
+        return this.ruleSets.Current;
+    }
+}

--- a/src/Application/Spam/History/SpamClassificationHistory.cs
+++ b/src/Application/Spam/History/SpamClassificationHistory.cs
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Spam.History;
+
+/// <summary>Reads what classification concluded about one account's mail.</summary>
+/// <remarks>
+/// A verdict, a score, and the signals behind them are derived from the message they are about, so this is published
+/// under the audit grant rather than the one covering reports of the deployment's own state. Where a run has got to is
+/// the other question and the other grant, which <see cref="Runs.SpamClassificationRunReader" /> answers.
+/// </remarks>
+public sealed class SpamClassificationHistory
+{
+    private readonly ISpamClassificationHistoryReader classifications;
+    private readonly AccessAuthorization authorization;
+
+    /// <summary>Initializes the reading over the recorded classifications.</summary>
+    /// <param name="classifications">Keeps what each classification concluded.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public SpamClassificationHistory(
+        ISpamClassificationHistoryReader classifications,
+        AccessAuthorization authorization)
+    {
+        ArgumentNullException.ThrowIfNull(classifications);
+        ArgumentNullException.ThrowIfNull(authorization);
+
+        this.classifications = classifications;
+        this.authorization = authorization;
+    }
+
+    /// <summary>Reads one page of an account's classifications.</summary>
+    /// <param name="query">The account, the filters, and where the page continues from.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The page, and the cursor the following one is asked with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="query" /> is <see langword="null" />.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminAuditRead" />.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    public Task<SpamClassificationHistoryPage> ReadPageAsync(
+        SpamClassificationHistoryQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminAuditRead);
+
+        return this.classifications.ReadPageAsync(query, cancellationToken);
+    }
+}

--- a/src/Application/Spam/Runs/SpamClassificationRunReader.cs
+++ b/src/Application/Spam/Runs/SpamClassificationRunReader.cs
@@ -1,0 +1,50 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Accounts;
+
+namespace MailFathom.Application.Spam.Runs;
+
+/// <summary>Reports where one account's whole-mailbox classification run has got to.</summary>
+/// <remarks>
+/// Reading a run is separated from asking for one — <see cref="SpamClassificationRunRequests" /> — because the two are
+/// reached under different grants: a run asked to act moves mail on somebody's server, while watching one is a report of
+/// what this deployment is doing. What each message was classified as is neither, and is
+/// <see cref="History.SpamClassificationHistory" /> under the audit grant.
+/// </remarks>
+public sealed class SpamClassificationRunReader
+{
+    private readonly ISpamClassificationRunStore runs;
+    private readonly AccessAuthorization authorization;
+
+    /// <summary>Initializes the reading over the run store.</summary>
+    /// <param name="runs">Holds the one run an account may have outstanding, and the ending of the last one.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
+    /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    public SpamClassificationRunReader(ISpamClassificationRunStore runs, AccessAuthorization authorization)
+    {
+        ArgumentNullException.ThrowIfNull(runs);
+        ArgumentNullException.ThrowIfNull(authorization);
+
+        this.runs = runs;
+        this.authorization = authorization;
+    }
+
+    /// <summary>Reads the run one account has outstanding, or the last one it finished.</summary>
+    /// <param name="accountId">The account whose run is read.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The run, or <see langword="null" /> where the account has never been asked for one.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminRead" />.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
+    public Task<SpamClassificationRun?> FindLatestAsync(
+        MailAccountId accountId,
+        CancellationToken cancellationToken)
+    {
+        this.authorization.RequirePermission(MailFathomPermission.AdminRead);
+
+        return this.runs.FindLatestAsync(accountId, cancellationToken);
+    }
+}

--- a/src/Application/Spam/Runs/SpamClassificationRunRequests.cs
+++ b/src/Application/Spam/Runs/SpamClassificationRunRequests.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Persistence;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 
 namespace MailFathom.Application.Spam.Runs;
@@ -26,24 +28,29 @@ public sealed class SpamClassificationRunRequests
     private readonly ISpamClassificationRunStore runStore;
     private readonly OptimisticConcurrencyRetryPolicy commitPolicy;
     private readonly TimeProvider timeProvider;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes the request intake.</summary>
     /// <param name="runStore">Reads whether a run is outstanding and records the one this request asks for.</param>
     /// <param name="commitPolicy">Makes the read and the write one decision, and resolves a race with a competing request.</param>
     /// <param name="timeProvider">Stamps the request.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when a collaborator is <see langword="null" />.</exception>
     public SpamClassificationRunRequests(
         ISpamClassificationRunStore runStore,
         OptimisticConcurrencyRetryPolicy commitPolicy,
-        TimeProvider timeProvider)
+        TimeProvider timeProvider,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(runStore);
         ArgumentNullException.ThrowIfNull(commitPolicy);
         ArgumentNullException.ThrowIfNull(timeProvider);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.runStore = runStore;
         this.commitPolicy = commitPolicy;
         this.timeProvider = timeProvider;
+        this.authorization = authorization;
     }
 
     /// <summary>Asks for every message stored for the account to be classified on the terms given.</summary>
@@ -53,11 +60,16 @@ public sealed class SpamClassificationRunRequests
     /// <returns>The run the account now has outstanding, and whether this request is what put it there.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="terms" /> is <see langword="null" />.</exception>
     /// <exception cref="PersistenceConcurrencyConflictException">Thrown when two requests raced past the bounded retries.</exception>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminOperate" />.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
     /// <remarks>
     /// The read and the write are one committed decision rather than a check followed by an insert, because two requests
     /// arriving together must resolve to one run. The loser of that race meets the account's own key, is retried from a
     /// fresh read, and is answered with the run the winner asked for.
+    /// <para>
+    /// A run asked to act moves mail on somebody's server, so the grant it asks for is the one covering work the
+    /// deployment performs on request — reading what a run concluded is a different grant and neither implies the other.
+    /// </para>
     /// </remarks>
     public Task<SpamClassificationRunRequest> SubmitAsync(
         MailAccountId accountId,
@@ -65,6 +77,8 @@ public sealed class SpamClassificationRunRequests
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(terms);
+
+        this.authorization.RequirePermission(MailFathomPermission.AdminOperate);
 
         return this.commitPolicy.CommitAsync(
             async (session, attemptCancellationToken) =>

--- a/src/Application/Synchronization/Administration/MailSynchronizationStatusReader.cs
+++ b/src/Application/Synchronization/Administration/MailSynchronizationStatusReader.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Folders;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Folders;
 
 namespace MailFathom.Application.Synchronization.Administration;
@@ -30,40 +32,50 @@ public sealed class MailSynchronizationStatusReader
     private readonly IMailFolderParticipationReader folders;
     private readonly MailSynchronizationRunLedger runLedger;
     private readonly IMailFolderSynchronizationProgressReader progressReader;
+    private readonly AccessAuthorization authorization;
 
     /// <summary>Initializes a reader over the four sources one status answer is composed from.</summary>
     /// <param name="accounts">Names the accounts this deployment serves, and whether it synchronizes at all.</param>
     /// <param name="folders">Names the folders configuration maps, and which of them are mirrored.</param>
     /// <param name="runLedger">Reports what the running process's supervisors are doing.</param>
     /// <param name="progressReader">Reports how far each folder's durable progress has come.</param>
+    /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
     public MailSynchronizationStatusReader(
         IMailAccountCatalog accounts,
         IMailFolderParticipationReader folders,
         MailSynchronizationRunLedger runLedger,
-        IMailFolderSynchronizationProgressReader progressReader)
+        IMailFolderSynchronizationProgressReader progressReader,
+        AccessAuthorization authorization)
     {
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(folders);
         ArgumentNullException.ThrowIfNull(runLedger);
         ArgumentNullException.ThrowIfNull(progressReader);
+        ArgumentNullException.ThrowIfNull(authorization);
 
         this.accounts = accounts;
         this.folders = folders;
         this.runLedger = runLedger;
         this.progressReader = progressReader;
+        this.authorization = authorization;
     }
 
     /// <summary>Reads what synchronization is doing across every configured account.</summary>
     /// <param name="cancellationToken">Cancels the durable read.</param>
     /// <returns>The status.</returns>
+    /// <exception cref="PrincipalNotAuthorizedException">Thrown when the use case was reached by anything but a caller granted <see cref="MailFathomPermission.AdminRead" />.</exception>
     /// <exception cref="OperationCanceledException">Thrown when the caller cancels.</exception>
     /// <remarks>
-    /// It never refuses. A deployment that configures no account, one that switched synchronization off, and one whose
-    /// process has only just started are all supported states an operator reads here rather than failures to report on.
+    /// It refuses nothing about the deployment's own state. A deployment that configures no account, one that switched
+    /// synchronization off, and one whose process has only just started are all supported states an operator reads here
+    /// rather than failures to report on — what it does refuse is a caller whose grant does not carry the permission
+    /// this report is published under.
     /// </remarks>
     public async Task<MailSynchronizationStatus> ReadAsync(CancellationToken cancellationToken)
     {
+        this.authorization.RequirePermission(MailFathomPermission.AdminRead);
+
         var progress = await this.progressReader.ReadAsync(cancellationToken);
         var progressByFolder = progress.ToDictionary(entry => entry.Folder);
         var mirrored = this.folders.FoldersSynchronized.ToHashSet();

--- a/src/Cli/Administration/AdminApiClient.cs
+++ b/src/Cli/Administration/AdminApiClient.cs
@@ -37,6 +37,14 @@ namespace MailFathom.Cli.Administration;
 /// </remarks>
 internal sealed class AdminApiClient
 {
+    /// <summary>What the operator is told when the deployment would not accept the credential at all.</summary>
+    /// <remarks>
+    /// Distinct from being admitted and then refused an operation, which names a permission instead. Conflating the two
+    /// would send an operator to rotate a key that is working when what they have to do is widen its grant.
+    /// </remarks>
+    private const string CredentialRefused =
+        "The deployment refused the credential. Check that it is one the administrative endpoint is configured with, and that it has not expired.";
+
     private static readonly string CommandVersion =
         StampedAssemblyVersion.ReadFrom(typeof(AdminApiClient).Assembly).Version;
 
@@ -79,8 +87,7 @@ internal sealed class AdminApiClient
 
         if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
         {
-            throw new CliFailure(
-                "The deployment refused the credential. Check that it is one the administrative endpoint is configured with, and that it has not expired.");
+            throw new CliFailure(CredentialRefused);
         }
 
         if (response.StatusCode is HttpStatusCode.NotFound)
@@ -136,10 +143,14 @@ internal sealed class AdminApiClient
 
         using var response = await this.SendAsync(request, cancellationToken);
 
-        if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        if (response.StatusCode is HttpStatusCode.Unauthorized)
         {
-            throw new CliFailure(
-                "The deployment refused the credential. Check that it is one the administrative endpoint is configured with, and that it has not expired.");
+            throw new CliFailure(CredentialRefused);
+        }
+
+        if (response.StatusCode is HttpStatusCode.Forbidden)
+        {
+            throw new CliFailure(await DescribeForbiddenAsync(response, cancellationToken));
         }
 
         if (response.StatusCode is HttpStatusCode.NotFound)
@@ -831,10 +842,14 @@ internal sealed class AdminApiClient
 
         using var response = await this.SendAsync(request, cancellationToken);
 
-        if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        if (response.StatusCode is HttpStatusCode.Unauthorized)
         {
-            throw new CliFailure(
-                "The deployment refused the credential. Check that it is one the administrative endpoint is configured with, and that it has not expired.");
+            throw new CliFailure(CredentialRefused);
+        }
+
+        if (response.StatusCode is HttpStatusCode.Forbidden)
+        {
+            throw new CliFailure(await DescribeForbiddenAsync(response, cancellationToken));
         }
 
         if (response.StatusCode is HttpStatusCode.NotFound)
@@ -935,21 +950,61 @@ internal sealed class AdminApiClient
     /// <summary>Reads the sentence a refusal carries, when it carries one.</summary>
     /// <remarks>
     /// A deployment states what was wrong with the request — an account it does not configure, a field the body omitted
-    /// — and repeating that is more use than any wording invented here. Anything that is not a problem document is read
-    /// as no reason rather than as a failure of its own, because the request was already refused and how the refusal
-    /// was phrased is not the operator's problem to solve.
+    /// — and repeating that is more use than any wording invented here.
     /// </remarks>
     private static async Task<string?> ReadRefusalAsync(
         HttpResponseMessage response,
         CancellationToken cancellationToken)
     {
+        var problem = await ReadProblemAsync(response, cancellationToken);
+
+        return problem?.Detail is { Length: > 0 } stated ? stated : null;
+    }
+
+    /// <summary>Turns a refusal for want of a grant into the sentence an operator acts on.</summary>
+    /// <remarks>
+    /// <para>
+    /// The deployment names the one permission that would have sufficed, and this is what turns that into an
+    /// instruction: which permission, where it is written, and what the alternative is. The command never says which
+    /// entry — it holds one credential and no view of the deployment's configuration — so it names the section and
+    /// leaves the entry to whoever edits it.
+    /// </para>
+    /// <para>
+    /// A refusal carrying no permission is repeated as it was written. That is the deployment saying something other
+    /// than "grant this", and inventing an instruction from it would send an operator to widen a grant that was never
+    /// what stopped them.
+    /// </para>
+    /// </remarks>
+    private static async Task<string> DescribeForbiddenAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
+        var problem = await ReadProblemAsync(response, cancellationToken);
+
+        if (problem?.Permission is { Length: > 0 } permission)
+        {
+            return $"The deployment refused the operation: this credential does not hold '{permission}'. Add that permission to the credential's entry under AdminEndpoint:Authentication, or sign in with one that already holds it.";
+        }
+
+        return problem?.Detail is { Length: > 0 } stated
+            ? $"The deployment refused the operation: {stated}"
+            : CredentialRefused;
+    }
+
+    /// <summary>Reads the problem document a refusal carries, treating anything else as none.</summary>
+    /// <remarks>
+    /// Anything that is not a problem document is read as no document rather than as a failure of its own, because the
+    /// request was already refused and how the refusal was phrased is not the operator's problem to solve.
+    /// </remarks>
+    private static async Task<AdminProblem?> ReadProblemAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken)
+    {
         try
         {
-            var problem = await response.Content.ReadFromJsonAsync(
+            return await response.Content.ReadFromJsonAsync(
                 CliJsonContext.Default.AdminProblem,
                 cancellationToken);
-
-            return problem?.Detail is { Length: > 0 } stated ? stated : null;
         }
         catch (Exception failure) when (failure is JsonException or NotSupportedException)
         {

--- a/src/Cli/Administration/AdminSession.cs
+++ b/src/Cli/Administration/AdminSession.cs
@@ -10,7 +10,14 @@ namespace MailFathom.Cli.Administration;
 /// <param name="Service">The product answering, which is what tells a successful sign-in from having reached something else that returns JSON.</param>
 /// <param name="Version">The running version.</param>
 /// <param name="Credential">The name the deployment knows the presented credential by.</param>
+/// <param name="Permissions">The administrative permissions the credential holds, which is what decides every other command.</param>
+/// <remarks>
+/// Every member is nullable because this describes what came off the wire rather than what a deployment sends: the body
+/// is read before anything has established that the address is MailFathom at all. An absent list is therefore "the body
+/// stated none" and an empty one is "the credential holds none", which are different answers and are reported as such.
+/// </remarks>
 internal sealed record AdminSession(
     [property: JsonPropertyName("service")] string? Service,
     [property: JsonPropertyName("version")] string? Version,
-    [property: JsonPropertyName("credential")] string? Credential);
+    [property: JsonPropertyName("credential")] string? Credential,
+    [property: JsonPropertyName("permissions")] IReadOnlyList<string>? Permissions);

--- a/src/Cli/Administration/Contacts/ContactWriteAnswer.cs
+++ b/src/Cli/Administration/Contacts/ContactWriteAnswer.cs
@@ -8,12 +8,19 @@ namespace MailFathom.Cli.Administration.Contacts;
 
 /// <summary>What one write to a deployment's contact book produced.</summary>
 /// <param name="Outcome">How the write ended, by the name the deployment's own outcome carries.</param>
-/// <param name="Contact">The record the outcome is about, or <see langword="null" /> where the book held none.</param>
+/// <param name="Contact">The record as the deployment settled it, present only where this command stated one and the write was performed.</param>
 /// <param name="AddressHolder">The contact already holding an address the write claimed, present exactly when that is what refused it.</param>
 /// <remarks>
+/// <para>
 /// A refusal arrives as a named outcome with a success status rather than as an error, because each one is something the
 /// operator acts on and continues from: correcting a record whose address somebody else holds, promoting a collected
 /// contact before amending it, or discovering the person was erased meanwhile.
+/// </para>
+/// <para>
+/// A promotion answers with no record, because the deployment's grant to write the book does not admit reading it and
+/// the command stated no record to read back. That is why one is absent rather than a deployment that failed to send
+/// one, and why the command reports the identity it was given instead.
+/// </para>
 /// </remarks>
 internal sealed record ContactWriteAnswer(
     [property: JsonPropertyName("outcome")] string? Outcome,

--- a/src/Cli/Administration/MailboxRefreshTokenRequest.cs
+++ b/src/Cli/Administration/MailboxRefreshTokenRequest.cs
@@ -25,9 +25,14 @@ internal sealed record MailboxRefreshTokenRequest(
 
 /// <summary>What a deployment says when it refuses a request, read from the problem document it answers with.</summary>
 /// <param name="Detail">The sentence written for the operator, which is the whole of what the command reports back.</param>
+/// <param name="Permission">The one permission that would have sufficed, which a refusal for want of a grant carries and no other refusal does.</param>
 /// <remarks>
-/// One field of RFC 9457, because one is what the command uses. The rest of the document — the type, the title, the
+/// Two fields of RFC 9457, because two are what the command uses. The rest of the document — the type, the title, the
 /// status — restates either the status line the command already read or a URI it would have nothing to do with, and a
-/// contract that named them would have to keep agreeing with a service that never sends anything else.
+/// contract that named them would have to keep agreeing with a service that never sends anything else. The permission
+/// is read as its own member rather than out of the sentence, so what the command tells an operator to grant does not
+/// depend on how the deployment happened to word the refusal.
 /// </remarks>
-internal sealed record AdminProblem([property: JsonPropertyName("detail")] string? Detail);
+internal sealed record AdminProblem(
+    [property: JsonPropertyName("detail")] string? Detail,
+    [property: JsonPropertyName("permission")] string? Permission);

--- a/src/Cli/Commands/Contacts/ContactOutput.cs
+++ b/src/Cli/Commands/Contacts/ContactOutput.cs
@@ -123,4 +123,34 @@ internal static class ContactOutput
 
         return CliExitCode.Success;
     }
+
+    /// <summary>Reports what one write the command stated no record for produced, which is that it happened or why it did not.</summary>
+    /// <param name="context">What the command needs from its surroundings.</param>
+    /// <param name="answer">What the deployment answered.</param>
+    /// <param name="contactId">The person the write named, which the answer does not repeat.</param>
+    /// <param name="performed">What the command did, as a sentence's opening, such as <c>Took on</c>.</param>
+    /// <returns>The exit code the command ends with.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when an argument is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The deployment answers such a write with the outcome alone, because the record would be its own contents rather
+    /// than anything the command sent — the grant that writes does not admit reading the book. So the identity printed
+    /// here is the one the command was given, and an operator who wants the record reads it with
+    /// <c>mfctl contact show</c>.
+    /// </remarks>
+    internal static int ReportOutcome(CliContext context, ContactWriteAnswer answer, Guid contactId, string performed)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(answer);
+
+        if (!answer.WasWritten())
+        {
+            context.Console.WriteError(answer.DescribeRefusal());
+
+            return CliExitCode.Failure;
+        }
+
+        context.Console.WriteLine($"{performed} contact {contactId:D}.");
+
+        return CliExitCode.Success;
+    }
 }

--- a/src/Cli/Commands/Contacts/PromoteContactCommand.cs
+++ b/src/Cli/Commands/Contacts/PromoteContactCommand.cs
@@ -53,6 +53,6 @@ internal static class PromoteContactCommand
         var promoted = await new AdminApiClient(transport, context.Console)
             .PromoteContactAsync(profile.Token, contactId, cancellationToken);
 
-        return ContactOutput.ReportWrite(context, promoted, "Took on");
+        return ContactOutput.ReportOutcome(context, promoted, contactId, "Took on");
     }
 }

--- a/src/Cli/Commands/StatusCommand.cs
+++ b/src/Cli/Commands/StatusCommand.cs
@@ -61,6 +61,8 @@ internal static class StatusCommand
         context.Console.WriteLine(
             $"'{profile.Name}' ({profile.Endpoint.GetLeftPart(UriPartial.Authority)}) accepts the stored credential as '{session.Credential}' (MailFathom {session.Version}).");
 
+        context.Console.WriteLine(DescribeGrant(session.Permissions));
+
         if (DocumentationAddress.ForVersion(session.Version) is { } documentation)
         {
             context.Console.WriteLine($"Documentation for that version: {documentation}");
@@ -68,4 +70,17 @@ internal static class StatusCommand
 
         return CliExitCode.Success;
     }
+
+    /// <summary>States what the credential may do, which is what decides whether any other command will work.</summary>
+    /// <remarks>
+    /// Reported here rather than left to be discovered one refusal at a time: an operator who has just signed in wants
+    /// to know which commands are theirs before they run one. A credential granted nothing is the case worth stating
+    /// plainly, because it is how one is retired without its entry being deleted and its sign-in still succeeds.
+    /// </remarks>
+    private static string DescribeGrant(IReadOnlyList<string>? permissions) => permissions switch
+    {
+        null => "The deployment did not state what the credential may do.",
+        { Count: 0 } => "It holds no administrative permission, so every operation but this one is refused.",
+        _ => $"It holds {string.Join(", ", permissions)}.",
+    };
 }

--- a/src/Host/Api/AdminApiEndpoints.cs
+++ b/src/Host/Api/AdminApiEndpoints.cs
@@ -3,7 +3,10 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Security.Claims;
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Security.Endpoints;
 using MailFathom.Host.Security.Transport;
 using MailFathom.Versioning;
 
@@ -82,11 +85,22 @@ namespace MailFathom.Host.Api;
 /// </para>
 /// <para>
 /// Every one of them is mapped into one group so a route cannot be added outside the requirement the endpoint attaches
-/// to it.
+/// to it, and so the one filter that reads each route's published permission covers every route the group holds.
 /// </para>
 /// </remarks>
 internal static class AdminApiEndpoints
 {
+    /// <summary>The route reporting what the deployment knows about the caller, relative to the administrative prefix.</summary>
+    /// <remarks>
+    /// The one administrative route published under no permission. It discloses nothing a caller did not bring — the
+    /// credential it presented, the version this deployment already publishes, and what its own grant carries — and it
+    /// is what every command reads first, <c>mfctl login</c> included. Putting it behind a permission would make that
+    /// permission a component of every administrative grant, so a credential granted only the spend permission could not
+    /// sign in to use it. A credential granted nothing therefore still answers here and nowhere else; an operator who
+    /// wants nothing answered at all removes the entry.
+    /// </remarks>
+    internal const string SessionRoute = "/session";
+
     /// <summary>Maps the administrative routes beneath the endpoint's route prefix.</summary>
     /// <param name="endpoints">The route builder.</param>
     /// <returns>The mapped group, so the caller can attach the requirement the endpoint carries.</returns>
@@ -97,7 +111,16 @@ internal static class AdminApiEndpoints
 
         var api = endpoints.MapGroup(AdminEndpointOptions.RoutePrefix);
 
-        api.MapGet("/session", (ClaimsPrincipal caller) => Results.Ok(AdminSessionResponse.For(caller)));
+        // On the group rather than on each route, because what a route supplies is its decision and what this supplies
+        // is the enforcement: a route mapped without stating a permission is refused by this rather than served, which
+        // is what makes forgetting to decide fail closed. Group filters reach every route the group holds, whenever it
+        // was added, so nothing here depends on this line staying first.
+        api.AddEndpointFilter(AdminRouteAuthorization.RefuseUnpermittedAsync);
+
+        api.MapGet(SessionRoute, (ClaimsPrincipal caller, IAuthorizedPrincipalSource principals) =>
+                Results.Ok(AdminSessionResponse.For(caller, principals.Current)))
+            .RequireNoPermission();
+
         api.MapMailboxRefreshToken();
         api.MapMailboxSynchronizationStatus();
         api.MapMailboxMaintenance();
@@ -118,26 +141,52 @@ internal static class AdminApiEndpoints
 /// <param name="Service">The product this is, so a client can tell it reached MailFathom rather than something else answering the port.</param>
 /// <param name="Version">The running version, which is what an operator checks before reporting behavior.</param>
 /// <param name="Credential">The name of the credential that authenticated, or <c>anonymous</c> where the endpoint requires none.</param>
+/// <param name="Permissions">The published names of what this caller's grant carries, in the order this repository publishes them, and empty for a credential granted nothing.</param>
 /// <remarks>
+/// <para>
 /// The credential's *name* is MailFathom's own configured identity for it — never the material, and never a claim an
 /// authorization server supplied beyond the subject the deployment already authorized. A response that echoed more
 /// would be a way to read a token's contents back out of the service.
+/// </para>
+/// <para>
+/// The grant is reported for the same reason the route requires none: it is the caller asking what it may do, which is
+/// the one question a caller may always ask about itself. It is also what an operator reads instead of their own
+/// configuration file — a grant nobody narrowed reaches the whole surface, and reading that back is how they meet the
+/// posture rather than infer it from what a credential turned out to be able to do.
+/// </para>
 /// </remarks>
-internal sealed record AdminSessionResponse(string Service, string Version, string Credential)
+internal sealed record AdminSessionResponse(
+    string Service,
+    string Version,
+    string Credential,
+    IReadOnlyList<string> Permissions)
 {
-    /// <summary>Describes the caller a validated credential produced.</summary>
+    /// <summary>Describes the caller a validated credential produced, and what it was granted.</summary>
     /// <param name="caller">The principal the authentication scheme produced.</param>
+    /// <param name="principal">What the application layer was told admitted this request, or nothing where the transport established none.</param>
     /// <returns>The response body.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="caller" /> is <see langword="null" />.</exception>
-    internal static AdminSessionResponse For(ClaimsPrincipal caller)
+    /// <remarks>
+    /// A request that established no principal reports an empty grant rather than failing. This route requires no
+    /// permission, so it answers a caller the rest of the surface refuses, and saying "nothing" is the accurate answer
+    /// to what such a caller may do.
+    /// </remarks>
+    internal static AdminSessionResponse For(ClaimsPrincipal caller, AuthorizedPrincipal? principal)
     {
         ArgumentNullException.ThrowIfNull(caller);
 
         return new AdminSessionResponse(
             "MailFathom",
             StampedAssemblyVersion.ReadFrom(typeof(AdminSessionResponse).Assembly).Version,
-            NameOf(caller));
+            NameOf(caller),
+            GrantOf(principal));
     }
+
+    /// <summary>Names what the caller holds, in the order this repository publishes the set.</summary>
+    /// <remarks>The published order rather than the grant's own, so two credentials granted the same permissions are reported identically whichever order an operator wrote them in.</remarks>
+    private static IReadOnlyList<string> GrantOf(AuthorizedPrincipal? principal) => principal is null
+        ? []
+        : [.. MailFathomPermission.All.Where(principal.Holds).Select(permission => permission.Name)];
 
     /// <summary>Reports the configured name of whatever authenticated, or that nothing did.</summary>
     /// <remarks>The naming rule is the transport's own, shared with what the application layer is told the work is running for, so this response and a record of a refusal cannot call one caller two things.</remarks>

--- a/src/Host/Api/AdminApiEndpoints.cs
+++ b/src/Host/Api/AdminApiEndpoints.cs
@@ -21,8 +21,11 @@ namespace MailFathom.Host.Api;
 /// </para>
 /// <para>
 /// It reports what the deployment knows about the caller and nothing else. There is no configuration, no account list,
-/// and no mailbox here: the response names the credential that authenticated and the product version, which is what a
-/// client needs to tell "signed in" from "reached something else that answers HTTP".
+/// and no mailbox here: the response names the credential that authenticated, the product version, and the permissions
+/// that credential's grant carries — which is what a client needs to tell "signed in" from "reached something else that
+/// answers HTTP", and what the caller needs to learn what the rest of this surface will serve it. Each of the three is
+/// something the caller brought or may ask about itself, which is why this is the one route published under no
+/// permission.
 /// </para>
 /// <para>
 /// The second is the surface's only write, and <see cref="MailboxRefreshTokenEndpoint" /> states what that costs.

--- a/src/Host/Api/ContactEndpoints.cs
+++ b/src/Host/Api/ContactEndpoints.cs
@@ -3,8 +3,10 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Contacts;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Emails;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -22,6 +24,15 @@ namespace MailFathom.Host.Api;
 /// They are here rather than on the MCP surface because the book is the most concentrated personal data this system
 /// holds, and what bounds administrative access is what should bound who may add to it, correct it, read it out, or
 /// erase somebody from it. The MCP tools over the book are a separate surface with separate reasoning.
+/// </para>
+/// <para>
+/// These routes postdate ADR 0012's table and are allocated under its rule, which separates reading what was derived
+/// from mail, causing work, and destroying. <strong>Reading the book — the listing, both lookups, and the export — is
+/// <c>mailfathom.admin.audit.read</c></strong>, because a collected contact is a person this deployment learned about
+/// from somebody's correspondence rather than a report of its own state, and the export is what a data-subject request
+/// is answered from. Writing one is <c>mailfathom.admin.operate</c>, and erasing somebody is
+/// <c>mailfathom.admin.erase</c> beside the mail erasure, because both destroy what this deployment holds about a
+/// person and an operator granting one is granting the other.
 /// </para>
 /// <para>
 /// <strong>Nothing a contact carries reaches a refusal.</strong> A name, an address, and a note travel in a request and
@@ -80,30 +91,41 @@ internal static class ContactEndpoints
     {
         ArgumentNullException.ThrowIfNull(api);
 
-        api.MapGet(ContactsRoute, ListAsync);
+        api.MapGet(ContactsRoute, ListAsync)
+            .RequirePermission(MailFathomPermission.AdminAuditRead);
 
         // The attribute is reached for its metadata rather than as an MVC filter: it implements
         // IRequestSizeLimitMetadata, which the routing pipeline applies to the request body feature, so a body over the
         // bound is answered 413 before the handler is reached.
         api.MapPost(ContactsRoute, RecordAsync)
-            .WithMetadata(new RequestSizeLimitAttribute(MaxRecordRequestBytes));
+            .WithMetadata(new RequestSizeLimitAttribute(MaxRecordRequestBytes))
+            .RequirePermission(MailFathomPermission.AdminOperate);
 
-        api.MapGet(ContactByAddressRoute, FindByAddressAsync);
-        api.MapGet(ContactRoute, FindAsync);
+        api.MapGet(ContactByAddressRoute, FindByAddressAsync)
+            .RequirePermission(MailFathomPermission.AdminAuditRead);
+
+        api.MapGet(ContactRoute, FindAsync)
+            .RequirePermission(MailFathomPermission.AdminAuditRead);
 
         api.MapPut(ContactRoute, AmendAsync)
-            .WithMetadata(new RequestSizeLimitAttribute(MaxRecordRequestBytes));
+            .WithMetadata(new RequestSizeLimitAttribute(MaxRecordRequestBytes))
+            .RequirePermission(MailFathomPermission.AdminOperate);
 
-        api.MapDelete(ContactRoute, EraseAsync);
-        api.MapPost(ContactPromotionRoute, PromoteAsync);
-        api.MapGet(ContactExportRoute, ExportAsync);
+        api.MapDelete(ContactRoute, EraseAsync)
+            .RequirePermission(MailFathomPermission.AdminErase);
+
+        api.MapPost(ContactPromotionRoute, PromoteAsync)
+            .RequirePermission(MailFathomPermission.AdminOperate);
+
+        api.MapGet(ContactExportRoute, ExportAsync)
+            .RequirePermission(MailFathomPermission.AdminAuditRead);
     }
 
     /// <summary>Serves one bounded page of the book, or reports what was wrong with the request.</summary>
     /// <param name="origin">The origin to narrow to, or <see langword="null" /> for the whole book.</param>
     /// <param name="pageSize">How many contacts the page may hold, or <see langword="null" /> for the default.</param>
     /// <param name="cursor">The cursor the previous page returned, or <see langword="null" /> for the first page.</param>
-    /// <param name="directory">Reads the page.</param>
+    /// <param name="book">Reads the page, for a caller the book's own grant admits.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
     /// <returns><c>200</c> with the page, or <c>400</c> naming what was wrong with the request.</returns>
     /// <remarks>
@@ -115,10 +137,10 @@ internal static class ContactEndpoints
         [FromQuery] string? origin,
         [FromQuery] int? pageSize,
         [FromQuery] string? cursor,
-        [FromServices] IContactDirectory directory,
+        [FromServices] ContactBook book,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(directory);
+        ArgumentNullException.ThrowIfNull(book);
 
         if (!TryReadOrigin(origin, out var narrowedOrigin))
         {
@@ -143,7 +165,7 @@ internal static class ContactEndpoints
             return Refused($"A contact page holds between 1 and {ContactQuery.MaximumPageSize} contacts.");
         }
 
-        var page = await directory.ReadPageAsync(query, cancellationToken);
+        var page = await book.ReadPageAsync(query, cancellationToken);
 
         return TypedResults.Ok(new ContactPageResponse(
             [.. page.Contacts.Select(ContactResponse.For)],
@@ -185,29 +207,29 @@ internal static class ContactEndpoints
 
     /// <summary>Reads one contact by the identity the book gave it.</summary>
     /// <param name="contactId">The contact to read.</param>
-    /// <param name="directory">Answers what the book holds.</param>
+    /// <param name="book">Answers what the book holds, for a caller the book's own grant admits.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
     /// <returns><c>200</c> with the contact, or <c>200</c> with none where the book holds no such person.</returns>
     internal static async Task<Results<Ok<ContactLookupResponse>, ProblemHttpResult>> FindAsync(
         Guid contactId,
-        [FromServices] IContactDirectory directory,
+        [FromServices] ContactBook book,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(directory);
+        ArgumentNullException.ThrowIfNull(book);
 
         if (!TryReadContactId(contactId, out var identity))
         {
             return EmptyIdentity();
         }
 
-        var held = await directory.FindAsync(identity, cancellationToken);
+        var held = await book.FindAsync(identity, cancellationToken);
 
         return TypedResults.Ok(new ContactLookupResponse(held is null ? null : ContactResponse.For(held)));
     }
 
     /// <summary>Reads the person who uses one address.</summary>
     /// <param name="address">The address to resolve.</param>
-    /// <param name="directory">Answers what the book holds.</param>
+    /// <param name="book">Answers what the book holds, for a caller the book's own grant admits.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
     /// <returns><c>200</c> with the contact, <c>200</c> with none where nobody holds it, or <c>400</c> where the address is not one.</returns>
     /// <remarks>
@@ -217,17 +239,17 @@ internal static class ContactEndpoints
     /// </remarks>
     internal static async Task<Results<Ok<ContactLookupResponse>, ProblemHttpResult>> FindByAddressAsync(
         [FromQuery] string? address,
-        [FromServices] IContactDirectory directory,
+        [FromServices] ContactBook book,
         CancellationToken cancellationToken)
     {
-        ArgumentNullException.ThrowIfNull(directory);
+        ArgumentNullException.ThrowIfNull(book);
 
         if (!TryReadAddress(address, out var resolved))
         {
             return Refused("The lookup names no usable address.");
         }
 
-        var held = await directory.FindByAddressAsync(resolved, cancellationToken);
+        var held = await book.FindByAddressAsync(resolved, cancellationToken);
 
         return TypedResults.Ok(new ContactLookupResponse(held is null ? null : ContactResponse.For(held)));
     }

--- a/src/Host/Api/ContactEndpoints.cs
+++ b/src/Host/Api/ContactEndpoints.cs
@@ -304,7 +304,13 @@ internal static class ContactEndpoints
     /// <param name="contactId">The contact to promote.</param>
     /// <param name="book">Performs the write.</param>
     /// <param name="cancellationToken">Cancels the write when the client disconnects.</param>
-    /// <returns><c>200</c> with the outcome, including a contact that was already asserted.</returns>
+    /// <returns><c>200</c> with the outcome and no record, including for a contact that was already asserted.</returns>
+    /// <remarks>
+    /// The only route here whose caller states no record, and therefore the only one whose answer would be the book's
+    /// own contents rather than the request's. It is published under <c>mailfathom.admin.operate</c> while reading the
+    /// book is <c>mailfathom.admin.audit.read</c>, so it answers what happened and leaves reading the person to the
+    /// route that publishes reading one.
+    /// </remarks>
     internal static async Task<Results<Ok<ContactWriteResponse>, ProblemHttpResult>> PromoteAsync(
         Guid contactId,
         [FromServices] ContactBook book,
@@ -319,7 +325,7 @@ internal static class ContactEndpoints
 
         var promoted = await book.PromoteAsync(identity, AdministrativeWriter, cancellationToken);
 
-        return TypedResults.Ok(ContactWriteResponse.For(promoted));
+        return TypedResults.Ok(ContactWriteResponse.OutcomeOf(promoted));
     }
 
     /// <summary>Erases one person and everything the book derived from them.</summary>

--- a/src/Host/Api/ContactResponses.cs
+++ b/src/Host/Api/ContactResponses.cs
@@ -88,7 +88,7 @@ internal sealed record ContactPageResponse(IReadOnlyList<ContactResponse> Contac
 
 /// <summary>What one write to the book produced.</summary>
 /// <param name="Outcome">How the write ended, by the name the application's own outcome carries.</param>
-/// <param name="Contact">The record as written, present exactly when the write was performed.</param>
+/// <param name="Contact">The record the caller itself stated, present exactly when that write was performed.</param>
 /// <param name="AddressHolder">The contact already holding an address the write claimed, present exactly when that is what refused it.</param>
 /// <remarks>
 /// <para>
@@ -98,19 +98,22 @@ internal sealed record ContactPageResponse(IReadOnlyList<ContactResponse> Contac
 /// write.
 /// </para>
 /// <para>
-/// A refusal carries no record for the same reason, including the two the book can only reach by reading one — a write
-/// the contact's origin refuses, and a promotion of somebody already asserted. The routes that write are published
-/// under <c>mailfathom.admin.operate</c> and reading the book is <c>mailfathom.admin.audit.read</c>, so echoing the
-/// held record back would serve a read to a grant that does not admit it, and a refused write is where that would be
-/// least visible. What the caller is told is what it has to act on: which outcome refused the write.
+/// What decides whether a record comes back is whether the caller stated one. The routes that write are published under
+/// <c>mailfathom.admin.operate</c> and reading the book is <c>mailfathom.admin.audit.read</c>, so a body carrying a
+/// record the caller never sent is a read served to a grant that does not admit one. Recording and amending state the
+/// whole record, so <see cref="For" /> hands the written form of it back; a promotion states an identity and nothing
+/// else, so <see cref="OutcomeOf" /> is what answers it. A refusal carries no record on either path, including the two
+/// the book could only reach by reading one — a write the contact's origin refuses, and a promotion of somebody already
+/// asserted — because a refused write is where that read would be least visible.
 /// </para>
 /// </remarks>
 internal sealed record ContactWriteResponse(string Outcome, ContactResponse? Contact, Guid? AddressHolder)
 {
-    /// <summary>Describes what a write to the book produced.</summary>
+    /// <summary>Describes what a write whose record the caller stated produced.</summary>
     /// <param name="result">The outcome the book answered with.</param>
     /// <returns>The response body.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="result" /> is <see langword="null" />.</exception>
+    /// <remarks>The written record is the caller's own request as the book settled it, which is what makes reading it back an answer about the request rather than about the book.</remarks>
     internal static ContactWriteResponse For(ContactWriteResult result)
     {
         ArgumentNullException.ThrowIfNull(result);
@@ -119,6 +122,23 @@ internal sealed record ContactWriteResponse(string Outcome, ContactResponse? Con
             result.Outcome.ToString(),
             result is { Outcome: ContactWriteOutcome.Written, Contact: { } written } ? ContactResponse.For(written) : null,
             result.AddressHolder?.Value);
+    }
+
+    /// <summary>Describes what a write the caller stated no record for produced, which is the outcome and nothing else.</summary>
+    /// <param name="result">The outcome the book answered with.</param>
+    /// <returns>The response body.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="result" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// A promotion names one person and changes their origin, so a record in the answer would be the book's own
+    /// contents rather than the caller's request — the whole of what <c>mailfathom.admin.audit.read</c> publishes,
+    /// obtained under the operating grant from an identity alone. The caller learns that the promotion happened and
+    /// reads the person through the route that is published for reading them.
+    /// </remarks>
+    internal static ContactWriteResponse OutcomeOf(ContactWriteResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        return new ContactWriteResponse(result.Outcome.ToString(), Contact: null, AddressHolder: null);
     }
 }
 

--- a/src/Host/Api/ContactResponses.cs
+++ b/src/Host/Api/ContactResponses.cs
@@ -88,13 +88,22 @@ internal sealed record ContactPageResponse(IReadOnlyList<ContactResponse> Contac
 
 /// <summary>What one write to the book produced.</summary>
 /// <param name="Outcome">How the write ended, by the name the application's own outcome carries.</param>
-/// <param name="Contact">The record the outcome is about, or nothing where the book held none.</param>
+/// <param name="Contact">The record as written, present exactly when the write was performed.</param>
 /// <param name="AddressHolder">The contact already holding an address the write claimed, present exactly when that is what refused it.</param>
 /// <remarks>
+/// <para>
 /// A refusal is answered with <c>200</c> and a named outcome rather than a status code, because each one is something
 /// the caller reports to its owner and continues from rather than a request that was malformed. Only the holder's
 /// identity is named: answering with somebody else's record would hand a third party out as a side effect of a refused
 /// write.
+/// </para>
+/// <para>
+/// A refusal carries no record for the same reason, including the two the book can only reach by reading one — a write
+/// the contact's origin refuses, and a promotion of somebody already asserted. The routes that write are published
+/// under <c>mailfathom.admin.operate</c> and reading the book is <c>mailfathom.admin.audit.read</c>, so echoing the
+/// held record back would serve a read to a grant that does not admit it, and a refused write is where that would be
+/// least visible. What the caller is told is what it has to act on: which outcome refused the write.
+/// </para>
 /// </remarks>
 internal sealed record ContactWriteResponse(string Outcome, ContactResponse? Contact, Guid? AddressHolder)
 {
@@ -108,7 +117,7 @@ internal sealed record ContactWriteResponse(string Outcome, ContactResponse? Con
 
         return new ContactWriteResponse(
             result.Outcome.ToString(),
-            result.Contact is null ? null : ContactResponse.For(result.Contact),
+            result is { Outcome: ContactWriteOutcome.Written, Contact: { } written } ? ContactResponse.For(written) : null,
             result.AddressHolder?.Value);
     }
 }

--- a/src/Host/Api/EmbeddingProfileEndpoints.cs
+++ b/src/Host/Api/EmbeddingProfileEndpoints.cs
@@ -4,7 +4,9 @@
 
 using MailFathom.Application.Emails.Embeddings.Administration;
 using MailFathom.Application.Emails.Embeddings.Generations;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Configuration.Embeddings;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -21,9 +23,11 @@ namespace MailFathom.Host.Api;
 /// </para>
 /// <para>
 /// They are here rather than on the MCP surface because none of them is anything a model reasons over, and because what
-/// bounds administrative access is what should bound the ability to start a provider bill.
-/// <strong>Every authenticated caller may perform every administrative operation</strong>, which
-/// <see cref="MailboxRefreshTokenEndpoint" /> states in full; a credential that can read a session can activate.
+/// bounds administrative access is what should bound the ability to start a provider bill. <strong>Activating is
+/// published under <c>mailfathom.admin.spend</c> and nothing else is</strong>, because it is the one operation on this
+/// surface that begins spending somebody's money: reading the same assessment requires only
+/// <c>mailfathom.admin.read</c>, so an operator can provision a credential that reports what an activation would cost
+/// and cannot perform one.
 /// </para>
 /// <para>
 /// Nothing any of them answers with is mail. Model names, counts, character totals, timestamps, and a profile
@@ -48,15 +52,21 @@ internal static class EmbeddingProfileEndpoints
     {
         ArgumentNullException.ThrowIfNull(api);
 
-        api.MapGet(StatusRoute, ReadStatusAsync);
+        api.MapGet(StatusRoute, ReadStatusAsync)
+            .RequirePermission(MailFathomPermission.AdminRead);
 
         // One path and two verbs, because they are one operation read and then performed: what the reading answers is
         // exactly what the write will weigh, so an operator confirming a figure and a deployment refusing one are
-        // talking about the same thing rather than about two endpoints that happen to count alike.
-        api.MapGet(ActivationRoute, ReadActivationAsync);
-        api.MapPost(ActivationRoute, ActivateAsync);
+        // talking about the same thing rather than about two endpoints that happen to count alike. The two grants
+        // differ for the same reason, since only one of them starts a bill.
+        api.MapGet(ActivationRoute, ReadActivationAsync)
+            .RequirePermission(MailFathomPermission.AdminRead);
 
-        api.MapPost(ReindexCancellationRoute, CancelReindexAsync);
+        api.MapPost(ActivationRoute, ActivateAsync)
+            .RequirePermission(MailFathomPermission.AdminSpend);
+
+        api.MapPost(ReindexCancellationRoute, CancelReindexAsync)
+            .RequirePermission(MailFathomPermission.AdminOperate);
     }
 
     /// <summary>Reports whether semantic search is working on this instance, and how far behind it is.</summary>

--- a/src/Host/Api/EmbeddingProfileEndpoints.cs
+++ b/src/Host/Api/EmbeddingProfileEndpoints.cs
@@ -73,11 +73,11 @@ internal static class EmbeddingProfileEndpoints
     /// <param name="declared">What this deployment declares it embeds with, which may be nothing.</param>
     /// <param name="reader">Composes the answer from the generations, the counts, the provider, and the budget.</param>
     /// <param name="cancellationToken">Cancels the reads when the client disconnects.</param>
-    /// <returns><c>200</c> with the state, on every instance including one that declared no provider.</returns>
+    /// <returns><c>200</c> with the state on every instance including one that declared no provider, or <c>403</c> for a caller whose grant does not carry <c>mailfathom.admin.read</c>.</returns>
     /// <remarks>
-    /// It never refuses. An instance with no declaration, no activation, and no provider is a supported deployment
-    /// serving lexical search, and it is also the instance whose operator is most likely to be asking this question —
-    /// so the absence of every part is the answer rather than an error.
+    /// The grant is the only thing it refuses over. An instance with no declaration, no activation, and no provider is a
+    /// supported deployment serving lexical search, and it is also the instance whose operator is most likely to be
+    /// asking this question — so the absence of every part is the answer rather than an error.
     /// </remarks>
     internal static async Task<Ok<EmbeddingStatusResponse>> ReadStatusAsync(
         [FromServices] DeclaredEmbeddingGeometry declared,

--- a/src/Host/Api/JobDeadLetterEndpoints.cs
+++ b/src/Host/Api/JobDeadLetterEndpoints.cs
@@ -5,7 +5,9 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Jobs;
 using MailFathom.Application.Jobs.DeadLetters;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -21,8 +23,8 @@ namespace MailFathom.Host.Api;
 /// <para>
 /// They are here rather than on the MCP surface because none of them is anything a model reasons over, and because
 /// re-running work that changes somebody's mailbox should be bounded by the credential that bounds everything else
-/// administrative. <strong>Every authenticated caller may perform every administrative operation</strong>, which
-/// <see cref="MailboxRefreshTokenEndpoint" /> states in full.
+/// administrative. Reading what stopped is <c>mailfathom.admin.read</c> and both decisions are
+/// <c>mailfathom.admin.operate</c>, so a monitoring credential can report a queue it cannot act on.
 /// </para>
 /// <para>
 /// Nothing any of them answers with is mail. A job type's name, an idempotency key composed of MailFathom's own
@@ -57,16 +59,19 @@ internal static class JobDeadLetterEndpoints
     {
         ArgumentNullException.ThrowIfNull(api);
 
-        api.MapGet(DeadLettersRoute, ReadDeadLettersAsync);
+        api.MapGet(DeadLettersRoute, ReadDeadLettersAsync)
+            .RequirePermission(MailFathomPermission.AdminRead);
 
         // The attribute is reached for its metadata rather than as an MVC filter, exactly as the erasure route reaches
         // it: it implements IRequestSizeLimitMetadata, which the routing pipeline applies to the request body feature,
         // so a body over the bound is answered 413 before the handler is reached.
         api.MapPost(RetryRoute, RetryAsync)
-            .WithMetadata(new RequestSizeLimitAttribute(MaxDecisionRequestBytes));
+            .WithMetadata(new RequestSizeLimitAttribute(MaxDecisionRequestBytes))
+            .RequirePermission(MailFathomPermission.AdminOperate);
 
         api.MapPost(DropRoute, DropAsync)
-            .WithMetadata(new RequestSizeLimitAttribute(MaxDecisionRequestBytes));
+            .WithMetadata(new RequestSizeLimitAttribute(MaxDecisionRequestBytes))
+            .RequirePermission(MailFathomPermission.AdminOperate);
     }
 
     /// <summary>Serves one page of the jobs nothing will attempt again, newest first.</summary>
@@ -89,7 +94,7 @@ internal static class JobDeadLetterEndpoints
         [FromQuery] int? pageSize,
         [FromQuery] string? cursor,
         [FromServices] IMailAccountCatalog accounts,
-        [FromServices] IDeadLetteredJobStore deadLetters,
+        [FromServices] DeadLetteredJobs deadLetters,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(accounts);
@@ -162,7 +167,7 @@ internal static class JobDeadLetterEndpoints
     /// </remarks>
     internal static async Task<Results<Ok<JobRecoveryResponse>, ProblemHttpResult>> RetryAsync(
         [FromBody] JobRecoveryRequest? request,
-        [FromServices] IDeadLetteredJobStore deadLetters,
+        [FromServices] DeadLetteredJobs deadLetters,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(deadLetters);
@@ -185,7 +190,7 @@ internal static class JobDeadLetterEndpoints
     /// <remarks>The record is kept rather than removed, for the reason <see cref="JobState.Dropped" /> gives: what an operator decided about a job is itself worth keeping.</remarks>
     internal static async Task<Results<Ok<JobRecoveryResponse>, ProblemHttpResult>> DropAsync(
         [FromBody] JobRecoveryRequest? request,
-        [FromServices] IDeadLetteredJobStore deadLetters,
+        [FromServices] DeadLetteredJobs deadLetters,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(deadLetters);

--- a/src/Host/Api/MailAnsweringAuditEndpoint.cs
+++ b/src/Host/Api/MailAnsweringAuditEndpoint.cs
@@ -4,8 +4,10 @@
 
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Retrieval.AskMail.Audit;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Answering.Audit;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -20,9 +22,9 @@ namespace MailFathom.Host.Api;
 /// are MailFathom's own names for things, and the messages are named rather than quoted.
 /// </para>
 /// <para>
-/// <strong>Every authenticated caller may perform every administrative operation.</strong> The endpoint has no
-/// permission model, which <see cref="MailboxRefreshTokenEndpoint" /> states in full and which an operator provisions
-/// keys against; a credential that can read a session can read this.
+/// <strong>The route is published under <c>mailfathom.admin.audit.read</c></strong>, beside the mutation trail and for
+/// the same reason: the two together are what an operator answers "why is this message here" and "why did it answer
+/// that" from, so one grant provisions and revokes both.
 /// </para>
 /// <para>
 /// The page is bounded and keyset-paginated. A caller walks the record by presenting the cursor the previous page
@@ -42,7 +44,8 @@ internal static class MailAnsweringAuditEndpoint
     {
         ArgumentNullException.ThrowIfNull(api);
 
-        api.MapGet(Route, ReadAsync);
+        api.MapGet(Route, ReadAsync)
+            .RequirePermission(MailFathomPermission.AdminAuditRead);
     }
 
     /// <summary>Serves one page of an account's answering record, or reports what was wrong with the request.</summary>
@@ -52,7 +55,7 @@ internal static class MailAnsweringAuditEndpoint
     /// <param name="pageSize">How many entries the page may hold, or <see langword="null" /> for the default.</param>
     /// <param name="cursor">The cursor the previous page returned, or <see langword="null" /> for the first page.</param>
     /// <param name="accounts">Reports whether this deployment serves the named account.</param>
-    /// <param name="store">Reads the page.</param>
+    /// <param name="trail">Reads the page, for a caller the record's own grant admits.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
     /// <returns><c>200</c> with the page, or <c>400</c> naming what was wrong with the request.</returns>
     /// <remarks>
@@ -68,11 +71,11 @@ internal static class MailAnsweringAuditEndpoint
         [FromQuery] int? pageSize,
         [FromQuery] string? cursor,
         [FromServices] IMailAccountCatalog accounts,
-        [FromServices] IMailAnsweringAuditEntryStore store,
+        [FromServices] MailAnsweringAuditTrailReader trail,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(accounts);
-        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(trail);
 
         if (string.IsNullOrWhiteSpace(account))
         {
@@ -111,7 +114,7 @@ internal static class MailAnsweringAuditEndpoint
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
-        var page = await store.ReadPageAsync(query, cancellationToken);
+        var page = await trail.ReadPageAsync(query, cancellationToken);
 
         return TypedResults.Ok(MailAnsweringAuditPageResponse.For(page));
     }

--- a/src/Host/Api/MailFolderErasureEndpoint.cs
+++ b/src/Host/Api/MailFolderErasureEndpoint.cs
@@ -4,8 +4,10 @@
 
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Folders;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -21,8 +23,8 @@ namespace MailFathom.Host.Api;
 /// <para>
 /// It is here rather than on the MCP surface for the reason every administrative route is: erasing a mailbox's worth of
 /// mail is not something a model reasons over, and what bounds administrative access is what should bound it.
-/// <strong>Every authenticated caller may perform every administrative operation</strong>, which
-/// <see cref="MailboxRefreshTokenEndpoint" /> states in full.
+/// <strong>It is published under <c>mailfathom.admin.erase</c>, which nothing else asks for</strong>, so the one
+/// operation that disposes of stored mail is reachable by a credential provisioned for it and by no other.
 /// </para>
 /// <para>
 /// One request is one bounded pass, and the command repeats it. The bound is the one the backward pass over stored mail
@@ -55,7 +57,8 @@ internal static class MailFolderErasureEndpoint
         // it: it implements IRequestSizeLimitMetadata, which the routing pipeline applies to the request body feature,
         // so a body over the bound is answered 413 before the handler is reached.
         api.MapPost(ErasureRoute, EraseAsync)
-            .WithMetadata(new RequestSizeLimitAttribute(MaxErasureRequestBytes));
+            .WithMetadata(new RequestSizeLimitAttribute(MaxErasureRequestBytes))
+            .RequirePermission(MailFathomPermission.AdminErase);
     }
 
     /// <summary>Erases one bounded pass of what is stored for a folder this deployment no longer mirrors.</summary>

--- a/src/Host/Api/MailFolderErasureEndpoint.cs
+++ b/src/Host/Api/MailFolderErasureEndpoint.cs
@@ -23,8 +23,9 @@ namespace MailFathom.Host.Api;
 /// <para>
 /// It is here rather than on the MCP surface for the reason every administrative route is: erasing a mailbox's worth of
 /// mail is not something a model reasons over, and what bounds administrative access is what should bound it.
-/// <strong>It is published under <c>mailfathom.admin.erase</c>, which nothing else asks for</strong>, so the one
-/// operation that disposes of stored mail is reachable by a credential provisioned for it and by no other.
+/// <strong>It is published under <c>mailfathom.admin.erase</c></strong>, the grant this deployment allocates to
+/// disposing of what it holds — this route and the erasure of one person from the contact book — so a credential that
+/// reads, operates, or spends does not reach it.
 /// </para>
 /// <para>
 /// One request is one bounded pass, and the command repeats it. The bound is the one the backward pass over stored mail

--- a/src/Host/Api/MailRuleEndpoints.cs
+++ b/src/Host/Api/MailRuleEndpoints.cs
@@ -6,10 +6,12 @@ using MailFathom.Application.Accounts;
 using MailFathom.Application.Rules;
 using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Rules.History;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Rules;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -26,9 +28,10 @@ namespace MailFathom.Host.Api;
 /// </para>
 /// <para>
 /// They are here rather than on the MCP surface because none of them is anything a model reasons over, and because what
-/// bounds administrative access is what should bound the ability to start a pass over a whole mailbox.
-/// <strong>Every authenticated caller may perform every administrative operation</strong>, which
-/// <see cref="MailboxRefreshTokenEndpoint" /> states in full.
+/// bounds administrative access is what should bound the ability to start a pass over a whole mailbox. The three grants
+/// differ accordingly: reading the loaded set and a run's progress is <c>mailfathom.admin.read</c>, asking for a pass is
+/// <c>mailfathom.admin.operate</c>, and the history is <c>mailfathom.admin.audit.read</c>, because what a rule concluded
+/// about somebody's mail is derived from that mail rather than a report of this deployment's own state.
 /// </para>
 /// <para>
 /// Nothing any of them answers with is mail. Rule names, folder aliases, mutation names, fact names, counts, instants,
@@ -67,17 +70,21 @@ internal static class MailRuleEndpoints
     {
         ArgumentNullException.ThrowIfNull(api);
 
-        api.MapGet(RulesRoute, ReadRules);
+        api.MapGet(RulesRoute, ReadRules)
+            .RequirePermission(MailFathomPermission.AdminRead);
 
         // The attribute is reached for its metadata rather than as an MVC filter, exactly as the write route beside it
         // reaches it: it implements IRequestSizeLimitMetadata, which the routing pipeline applies to the request body
         // feature, so a body over the bound is answered 413 before the handler is reached.
         api.MapPost(RunsRoute, StartRunAsync)
-            .WithMetadata(new RequestSizeLimitAttribute(MaxRunRequestBytes));
+            .WithMetadata(new RequestSizeLimitAttribute(MaxRunRequestBytes))
+            .RequirePermission(MailFathomPermission.AdminOperate);
 
-        api.MapGet(RunsRoute, ReadRunAsync);
+        api.MapGet(RunsRoute, ReadRunAsync)
+            .RequirePermission(MailFathomPermission.AdminRead);
 
-        api.MapGet(HistoryRoute, ReadHistoryAsync);
+        api.MapGet(HistoryRoute, ReadHistoryAsync)
+            .RequirePermission(MailFathomPermission.AdminAuditRead);
     }
 
     /// <summary>Reports the rule set in force, and whether the configuration on disk is the one it was read from.</summary>
@@ -98,14 +105,14 @@ internal static class MailRuleEndpoints
     /// </para>
     /// </remarks>
     internal static Ok<MailRuleSetResponse> ReadRules(
-        [FromServices] IMailRuleSetSource ruleSets,
+        [FromServices] MailRuleSetReader ruleSets,
         [FromServices] ValidatedSettingsSnapshot<MailRulesOptions> settings)
     {
         ArgumentNullException.ThrowIfNull(ruleSets);
         ArgumentNullException.ThrowIfNull(settings);
 
         return TypedResults.Ok(MailRuleSetResponse.For(
-            ruleSets.Current,
+            ruleSets.Read(),
             settings.LatestReloadRefused,
             settings.RefusedSettingCount));
     }
@@ -150,7 +157,7 @@ internal static class MailRuleEndpoints
     /// <summary>Reports where one account's whole-mailbox run has got to, or how the last one ended.</summary>
     /// <param name="account">The configured identifier of the account whose run is read.</param>
     /// <param name="accounts">Reports whether this deployment serves the named account.</param>
-    /// <param name="runs">Holds the one run an account may have outstanding, and the ending of the last one.</param>
+    /// <param name="runs">Reads the one run an account may have outstanding, or the ending of the last one.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
     /// <returns><c>200</c> with the run, <c>200</c> with none where the account has never been asked for one, or <c>400</c>.</returns>
     /// <remarks>
@@ -161,7 +168,7 @@ internal static class MailRuleEndpoints
     internal static async Task<Results<Ok<MailRuleRunStateResponse>, ProblemHttpResult>> ReadRunAsync(
         [FromQuery] string? account,
         [FromServices] IMailAccountCatalog accounts,
-        [FromServices] IMailRuleEvaluationRunStore runs,
+        [FromServices] MailRuleEvaluationRunReader runs,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(accounts);
@@ -205,7 +212,7 @@ internal static class MailRuleEndpoints
         [FromQuery] int? pageSize,
         [FromQuery] string? cursor,
         [FromServices] IMailAccountCatalog accounts,
-        [FromServices] IMailRuleExecutionStore history,
+        [FromServices] MailRuleHistory history,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(accounts);

--- a/src/Host/Api/MailboxMaintenanceEndpoints.cs
+++ b/src/Host/Api/MailboxMaintenanceEndpoints.cs
@@ -4,8 +4,10 @@
 
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Mail.Maintenance;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -40,9 +42,10 @@ namespace MailFathom.Host.Api;
 /// </para>
 /// <para>
 /// Both are here rather than on the MCP surface for the reason every administrative route is: re-reading a mailbox is
-/// not something a model reasons over, and what bounds administrative access is what should bound it.
-/// <strong>Every authenticated caller may perform every administrative operation</strong>, which
-/// <see cref="MailboxRefreshTokenEndpoint" /> states in full.
+/// not something a model reasons over, and what bounds administrative access is what should bound it. These routes
+/// postdate ADR 0012's table and are allocated under its rule: assessing a rewind reports what the deployment holds and
+/// is <c>mailfathom.admin.read</c>, while performing either of them asks the deployment to do work it can already do and
+/// is <c>mailfathom.admin.operate</c>.
 /// </para>
 /// </remarks>
 internal static class MailboxMaintenanceEndpoints
@@ -69,16 +72,19 @@ internal static class MailboxMaintenanceEndpoints
     {
         ArgumentNullException.ThrowIfNull(api);
 
-        api.MapGet(RewindRoute, AssessRewindAsync);
+        api.MapGet(RewindRoute, AssessRewindAsync)
+            .RequirePermission(MailFathomPermission.AdminRead);
 
         // The attribute is reached for its metadata rather than as an MVC filter, exactly as the erasure route reaches
         // it: it implements IRequestSizeLimitMetadata, which the routing pipeline applies to the request body feature,
         // so a body over the bound is answered 413 before the handler is reached.
         api.MapPost(RewindRoute, RewindAsync)
-            .WithMetadata(new RequestSizeLimitAttribute(MaxMaintenanceRequestBytes));
+            .WithMetadata(new RequestSizeLimitAttribute(MaxMaintenanceRequestBytes))
+            .RequirePermission(MailFathomPermission.AdminOperate);
 
         api.MapPost(RederivationRoute, RederiveAsync)
-            .WithMetadata(new RequestSizeLimitAttribute(MaxMaintenanceRequestBytes));
+            .WithMetadata(new RequestSizeLimitAttribute(MaxMaintenanceRequestBytes))
+            .RequirePermission(MailFathomPermission.AdminOperate);
     }
 
     /// <summary>Reports what a rewind of one scope would have the next runs read again, without discarding anything.</summary>

--- a/src/Host/Api/MailboxMutationAuditEndpoint.cs
+++ b/src/Host/Api/MailboxMutationAuditEndpoint.cs
@@ -4,9 +4,11 @@
 
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Mutations.Audit;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -21,9 +23,10 @@ namespace MailFathom.Host.Api;
 /// own or MailFathom's own names for things.
 /// </para>
 /// <para>
-/// <strong>Every authenticated caller may perform every administrative operation.</strong> The endpoint has no
-/// permission model, which <see cref="MailboxRefreshTokenEndpoint" /> states in full and which an operator provisions
-/// keys against; a credential that can read a session can read this.
+/// <strong>The route is published under <c>mailfathom.admin.audit.read</c></strong>, which is the grant covering what
+/// this deployment derived from somebody's mail rather than what it knows about itself. Somebody answering a
+/// data-subject request holds it; a credential provisioned to retry a job or to place a mailbox token does not, unless
+/// its entry was never narrowed.
 /// </para>
 /// <para>
 /// The page is bounded and keyset-paginated. A caller walks the trail by presenting the cursor the previous page
@@ -43,7 +46,8 @@ internal static class MailboxMutationAuditEndpoint
     {
         ArgumentNullException.ThrowIfNull(api);
 
-        api.MapGet(Route, ReadAsync);
+        api.MapGet(Route, ReadAsync)
+            .RequirePermission(MailFathomPermission.AdminAuditRead);
     }
 
     /// <summary>Serves one page of an account's audit trail, or reports what was wrong with the request.</summary>
@@ -54,7 +58,7 @@ internal static class MailboxMutationAuditEndpoint
     /// <param name="pageSize">How many entries the page may hold, or <see langword="null" /> for the default.</param>
     /// <param name="cursor">The cursor the previous page returned, or <see langword="null" /> for the first page.</param>
     /// <param name="accounts">Reports whether this deployment serves the named account.</param>
-    /// <param name="store">Reads the page.</param>
+    /// <param name="trail">Reads the page, for a caller the trail's own grant admits.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
     /// <returns><c>200</c> with the page, or <c>400</c> naming what was wrong with the request.</returns>
     /// <remarks>
@@ -71,11 +75,11 @@ internal static class MailboxMutationAuditEndpoint
         [FromQuery] int? pageSize,
         [FromQuery] string? cursor,
         [FromServices] IMailAccountCatalog accounts,
-        [FromServices] IMailboxMutationAuditEntryStore store,
+        [FromServices] MailboxMutationAuditTrailReader trail,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(accounts);
-        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(trail);
 
         if (string.IsNullOrWhiteSpace(account))
         {
@@ -131,7 +135,7 @@ internal static class MailboxMutationAuditEndpoint
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
-        var page = await store.ReadPageAsync(query, cancellationToken);
+        var page = await trail.ReadPageAsync(query, cancellationToken);
 
         return TypedResults.Ok(MailboxMutationAuditPageResponse.For(page));
     }

--- a/src/Host/Api/MailboxRefreshTokenEndpoint.cs
+++ b/src/Host/Api/MailboxRefreshTokenEndpoint.cs
@@ -3,7 +3,9 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Accounts;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,11 +20,11 @@ namespace MailFathom.Host.Api;
 /// authentication method turned on accepts it from anybody who can reach the address.
 /// </para>
 /// <para>
-/// <strong>Every authenticated caller may perform every administrative operation.</strong> The endpoint has no
-/// permission model, so a credential that could previously read a session can now write a mailbox credential. That is
-/// accepted for this route rather than overlooked: the alternative is a permission model invented for one route, and
-/// the credential is already the thing that bounds administrative access. It is stated in the operations documentation
-/// beside the warnings, because it is a fact an operator provisions keys against.
+/// <strong>The route is published under <c>mailfathom.admin.credentials.write</c>, and nothing else on this surface
+/// is.</strong> Placing a mailbox owner's long-lived credential is nothing like reading the deployment's state or
+/// retrying a job, so an operator who provisioned a credential for either of those has not thereby provisioned one that
+/// can do this. A caller whose grant omits the permission is refused with it named, and a caller whose entry narrows
+/// nothing holds it like every other permission the surface publishes.
 /// </para>
 /// <para>
 /// Answered with no body at all. There is nothing to report that the caller did not send, and a response echoing any
@@ -55,7 +57,8 @@ internal static class MailboxRefreshTokenEndpoint
         // reads and applies to the request body feature, so the bound holds on a minimal API route with no MVC in the
         // process. A body over the limit is answered 413 before the handler is reached.
         api.MapPost(Route, StoreAsync)
-            .WithMetadata(new RequestSizeLimitAttribute(MaxRequestBytes));
+            .WithMetadata(new RequestSizeLimitAttribute(MaxRequestBytes))
+            .RequirePermission(MailFathomPermission.AdminCredentialsWrite);
     }
 
     /// <summary>Stores one account's refresh token, or reports why it was not stored.</summary>

--- a/src/Host/Api/MailboxSynchronizationStatusEndpoint.cs
+++ b/src/Host/Api/MailboxSynchronizationStatusEndpoint.cs
@@ -50,11 +50,11 @@ internal static class MailboxSynchronizationStatusEndpoint
     /// <summary>Reports where each configured account's synchronization stands.</summary>
     /// <param name="reader">Composes the answer from configuration, the running process, and the durable checkpoints.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
-    /// <returns><c>200</c> with the state, on every deployment including one that synchronizes nothing.</returns>
+    /// <returns><c>200</c> with the state on every deployment including one that synchronizes nothing, or <c>403</c> for a caller whose grant does not carry <c>mailfathom.admin.read</c>.</returns>
     /// <remarks>
-    /// It never refuses. A deployment configuring no account, one that has switched synchronization off, and one whose
-    /// process has only just started are supported states rather than errors, and the last of them is the reading an
-    /// operator most needs to be given rather than left to infer from an empty answer.
+    /// The grant is the only thing it refuses over. A deployment configuring no account, one that has switched
+    /// synchronization off, and one whose process has only just started are supported states rather than errors, and the
+    /// last of them is the reading an operator most needs to be given rather than left to infer from an empty answer.
     /// </remarks>
     internal static async Task<Ok<MailSynchronizationStatusResponse>> ReadStatusAsync(
         [FromServices] MailSynchronizationStatusReader reader,

--- a/src/Host/Api/MailboxSynchronizationStatusEndpoint.cs
+++ b/src/Host/Api/MailboxSynchronizationStatusEndpoint.cs
@@ -3,6 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Synchronization.Administration;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -19,9 +21,10 @@ namespace MailFathom.Host.Api;
 /// <para>
 /// It is here rather than on the MCP surface for the reason every administrative route is: what it reports is the state
 /// of the service rather than anything a model reasons over, and the credential that bounds administrative access is
-/// what should bound reading how a deployment's workers are faring.
-/// <strong>Every authenticated caller may perform every administrative operation</strong>, which
-/// <see cref="MailboxRefreshTokenEndpoint" /> states in full.
+/// what should bound reading how a deployment's workers are faring. It is published under
+/// <c>mailfathom.admin.read</c>, which is the grant for what a deployment reports about itself: this route postdates
+/// ADR 0012's table and is allocated there by that rule, because what it answers with is the deployment's own state and
+/// no mail.
 /// </para>
 /// <para>
 /// Nothing it answers with is mail. Configured account identifiers and folder aliases, a phase, counts, UIDs, and
@@ -40,7 +43,8 @@ internal static class MailboxSynchronizationStatusEndpoint
     {
         ArgumentNullException.ThrowIfNull(api);
 
-        api.MapGet(StatusRoute, ReadStatusAsync);
+        api.MapGet(StatusRoute, ReadStatusAsync)
+            .RequirePermission(MailFathomPermission.AdminRead);
     }
 
     /// <summary>Reports where each configured account's synchronization stands.</summary>

--- a/src/Host/Api/SpamClassificationEndpoints.cs
+++ b/src/Host/Api/SpamClassificationEndpoints.cs
@@ -7,10 +7,12 @@ using MailFathom.Application.Spam;
 using MailFathom.Application.Spam.Actions;
 using MailFathom.Application.Spam.History;
 using MailFathom.Application.Spam.Runs;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Spam;
+using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 
@@ -27,8 +29,9 @@ namespace MailFathom.Host.Api;
 /// <para>
 /// They are here rather than on the MCP surface because neither is anything a model reasons over, and because what bounds
 /// administrative access is what should bound the ability to start a pass over a whole mailbox — and, with acting asked
-/// for, to move a thousand messages. <strong>Every authenticated caller may perform every administrative
-/// operation</strong>, which <see cref="MailboxRefreshTokenEndpoint" /> states in full.
+/// for, to move a thousand messages. Asking for a run is therefore <c>mailfathom.admin.operate</c> and reading where one
+/// got to is <c>mailfathom.admin.read</c>, while the classifications themselves are <c>mailfathom.admin.audit.read</c>:
+/// a verdict about a message is derived from that message rather than a report of the deployment's own state.
 /// </para>
 /// <para>
 /// Nothing either of them answers with is mail. Counts, verdicts, scores, signal names, folder aliases, mutation names,
@@ -69,11 +72,14 @@ internal static class SpamClassificationEndpoints
         // implements IRequestSizeLimitMetadata, which the routing pipeline applies to the request body feature, so a body
         // over the bound is answered 413 before the handler is reached.
         api.MapPost(RunsRoute, StartRunAsync)
-            .WithMetadata(new RequestSizeLimitAttribute(MaxRunRequestBytes));
+            .WithMetadata(new RequestSizeLimitAttribute(MaxRunRequestBytes))
+            .RequirePermission(MailFathomPermission.AdminOperate);
 
-        api.MapGet(RunsRoute, ReadRunAsync);
+        api.MapGet(RunsRoute, ReadRunAsync)
+            .RequirePermission(MailFathomPermission.AdminRead);
 
-        api.MapGet(ClassificationsRoute, ReadClassificationsAsync);
+        api.MapGet(ClassificationsRoute, ReadClassificationsAsync)
+            .RequirePermission(MailFathomPermission.AdminAuditRead);
     }
 
     /// <summary>Asks for every message stored for one account to be classified on the terms the caller named.</summary>
@@ -133,7 +139,7 @@ internal static class SpamClassificationEndpoints
     /// <summary>Reports where one account's whole-mailbox classification run has got to, or how the last one ended.</summary>
     /// <param name="account">The configured identifier of the account whose run is read.</param>
     /// <param name="accounts">Reports whether this deployment serves the named account.</param>
-    /// <param name="runs">Holds the one run an account may have outstanding, and the ending of the last one.</param>
+    /// <param name="runs">Reads the one run an account may have outstanding, for a caller the read's own grant admits.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
     /// <returns><c>200</c> with the run, <c>200</c> with none where the account has never been asked for one, or <c>400</c>.</returns>
     /// <remarks>
@@ -144,7 +150,7 @@ internal static class SpamClassificationEndpoints
     internal static async Task<Results<Ok<SpamClassificationRunStateResponse>, ProblemHttpResult>> ReadRunAsync(
         [FromQuery] string? account,
         [FromServices] IMailAccountCatalog accounts,
-        [FromServices] ISpamClassificationRunStore runs,
+        [FromServices] SpamClassificationRunReader runs,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(accounts);
@@ -171,7 +177,7 @@ internal static class SpamClassificationEndpoints
     /// <param name="pageSize">How many classifications the page may hold, or <see langword="null" /> for the default.</param>
     /// <param name="cursor">The cursor the previous page returned, or <see langword="null" /> for the first page.</param>
     /// <param name="accounts">Reports whether this deployment serves the named account.</param>
-    /// <param name="classifications">Reads the page.</param>
+    /// <param name="classifications">Reads the page, for a caller the record's own grant admits.</param>
     /// <param name="cancellationToken">Cancels the read when the client disconnects.</param>
     /// <returns><c>200</c> with the page, or <c>400</c> naming what was wrong with the request.</returns>
     /// <remarks>
@@ -189,7 +195,7 @@ internal static class SpamClassificationEndpoints
         [FromQuery] int? pageSize,
         [FromQuery] string? cursor,
         [FromServices] IMailAccountCatalog accounts,
-        [FromServices] ISpamClassificationHistoryReader classifications,
+        [FromServices] SpamClassificationHistory classifications,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(accounts);

--- a/src/Host/HostComposition.cs
+++ b/src/Host/HostComposition.cs
@@ -436,6 +436,9 @@ internal static class HostComposition
         builder.Services.AddSingleton<IMailRuleConditionCompiler>(mailRuleConditionCompiler);
         builder.Services.AddSingleton<MailRuleSetEvaluator>();
         builder.Services.AddSingleton<IMailRuleSetSource, ConfiguredMailRuleSetSource>();
+        // The reading the administrative surface performs over that source. Scoped rather than singleton like the source
+        // itself, because what it asks before it reads is which principal reached it, and that is a fact about one request.
+        builder.Services.AddScoped<MailRuleSetReader>();
         // The rule section validates itself on reload instead of letting the options framework drop an invalid candidate in
         // silence. That default is the wrong behavior here above everywhere else: an owner who mistypes a fact name would
         // get an instance that goes on acting on mail under the previous rules while their file says otherwise. A refused

--- a/src/Host/Hosting/Warnings/TransportGrantStartupReport.cs
+++ b/src/Host/Hosting/Warnings/TransportGrantStartupReport.cs
@@ -150,8 +150,8 @@ internal sealed partial class TransportGrantStartupReport : IHostedService
     /// <remarks>
     /// Carried on every line rather than reported once per endpoint, because these lines are read by searching for the
     /// entry path somebody edited: a posture stated on a line of its own is one a filtered log leaves out, which costs
-    /// the operator the same thing as not stating it. The two surfaces differ because the MCP one enforces a grant and
-    /// the administrative one does not yet, so a single wording would be wrong about one of them.
+    /// the operator the same thing as not stating it. The two surfaces differ in what a refusal looks like rather than
+    /// in whether the grant is enforced, so a single wording would be wrong about one of them.
     /// </remarks>
     private static string EnforcementOn(ProtectedSurface surface) => surface switch
     {
@@ -159,8 +159,8 @@ internal sealed partial class TransportGrantStartupReport : IHostedService
             "A caller here is served only the tools its grant permits, and a call naming any other is answered as a "
             + "tool that does not exist.",
         ProtectedSurface.Administration =>
-            "No route here consults a permission yet, so a grant on this surface states what a credential is meant to "
-            + "reach rather than what it currently reaches.",
+            "A route here is served only to a caller whose grant holds the one permission that route publishes, and "
+            + "every other caller is refused with that permission named.",
         _ => throw new ArgumentOutOfRangeException(nameof(surface)),
     };
 

--- a/src/Host/Security/Endpoints/AdminRouteAuthorization.cs
+++ b/src/Host/Security/Endpoints/AdminRouteAuthorization.cs
@@ -1,0 +1,133 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace MailFathom.Host.Security.Endpoints;
+
+/// <summary>Serves each administrative route only to a caller whose grant carries the permission that route is published under.</summary>
+/// <remarks>
+/// <para>
+/// Two halves, and they belong together because one is meaningless without the other.
+/// <see cref="RequirePermission" /> is how a route states its decision, next to the mapping that creates it, and
+/// <see cref="RefuseUnpermittedAsync" /> is the one filter the whole group carries, which reads that decision back per
+/// request. A route mapped into the group without stating anything is refused rather than served, so a route added
+/// later fails closed instead of inheriting whatever the group happened to allow.
+/// </para>
+/// <para>
+/// The refusal names the one permission that would have sufficed, and nothing else: no route inventory, no other
+/// credential, and nothing about how this deployment is configured. That is the opposite of what the MCP surface tells a
+/// refused caller, and ADR 0012 records why — the caller here is <c>mfctl</c> in the operator's own hands, so a refusal
+/// they can act on is worth more than a refusal that discloses nothing.
+/// </para>
+/// <para>
+/// This refuses cheaply and is not the authority. The use case behind each route asks for the same permission on its
+/// own, with the transport absent, so an entrypoint added later cannot widen the surface by forgetting a filter. Where
+/// the two disagree the use case wins: a refusal it raises is answered here in the same shape rather than reaching the
+/// caller as a fault in the deployment.
+/// </para>
+/// </remarks>
+internal static class AdminRouteAuthorization
+{
+    /// <summary>The member of the problem document that carries the permission on its own, beside the sentence.</summary>
+    /// <remarks>
+    /// Written for <c>mfctl</c>, which turns a refusal into what an operator has to grant. Reading the name back out of
+    /// the sentence would make the wording a contract, and the sentence is written for a person.
+    /// </remarks>
+    internal const string PermissionExtension = "permission";
+
+    /// <summary>States the one permission a route is published under.</summary>
+    /// <param name="route">The route being mapped.</param>
+    /// <param name="permission">The capability a caller must hold to reach it.</param>
+    /// <returns>The route, so a mapping reads as one expression.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="route" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when the permission names nothing published, or belongs to another surface.</exception>
+    internal static RouteHandlerBuilder RequirePermission(
+        this RouteHandlerBuilder route,
+        MailFathomPermission permission)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+
+        return route.WithMetadata(AdminRoutePermission.Requiring(permission));
+    }
+
+    /// <summary>States that a route requires no permission, which on this surface is the session read and nothing else.</summary>
+    /// <param name="route">The route being mapped.</param>
+    /// <returns>The route, so a mapping reads as one expression.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="route" /> is <see langword="null" />.</exception>
+    /// <remarks>Written rather than left out, because leaving it out is what a route whose grant nobody decided looks like, and that is refused.</remarks>
+    internal static RouteHandlerBuilder RequireNoPermission(this RouteHandlerBuilder route)
+    {
+        ArgumentNullException.ThrowIfNull(route);
+
+        return route.WithMetadata(AdminRoutePermission.None);
+    }
+
+    /// <summary>Refuses a request whose caller does not hold what the route it reached is published under.</summary>
+    /// <param name="context">The request being served.</param>
+    /// <param name="next">The rest of the route's pipeline.</param>
+    /// <returns>What the route answered, or the refusal that stopped it.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> or <paramref name="next" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// It runs as one filter over the whole group rather than as a filter per route, so the enforcement cannot be the
+    /// half of the arrangement a new route forgets — what a route supplies is the decision, and this reads it. The
+    /// grant is asked of <see cref="AccessAuthorization" /> rather than of the claims on the request, so the transport
+    /// and the use case behind it cannot come to disagree about what holding a permission means.
+    /// </remarks>
+    internal static async ValueTask<object?> RefuseUnpermittedAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(next);
+
+        if (context.HttpContext.GetEndpoint()?.Metadata.GetMetadata<AdminRoutePermission>() is not { } published)
+        {
+            return Undeclared();
+        }
+
+        if (published.Permission.IsSpecified
+            && !context.HttpContext.RequestServices.GetRequiredService<AccessAuthorization>().Permits(published.Permission))
+        {
+            return Refused(published.Permission);
+        }
+
+        try
+        {
+            return await next(context);
+        }
+        catch (PrincipalNotAuthorizedException refusal)
+        {
+            return Refused(refusal.RequiredPermission);
+        }
+    }
+
+    /// <summary>Writes the refusal a caller reads, which names the permission and nothing beside it.</summary>
+    /// <remarks>
+    /// A refusal that named no permission would leave an operator with nothing to grant, so the one case that produces
+    /// one — a use case refusing over the kind of principal that reached it rather than over a grant — says that instead
+    /// of naming something that would not have helped, and carries no <see cref="PermissionExtension" /> member either.
+    /// </remarks>
+    private static ProblemHttpResult Refused(MailFathomPermission required) => TypedResults.Problem(
+        required.IsSpecified
+            ? $"The credential is not granted '{required.Name}'."
+            : "The credential was not admitted to this operation.",
+        statusCode: StatusCodes.Status403Forbidden,
+        extensions: required.IsSpecified
+            ? new Dictionary<string, object?>(StringComparer.Ordinal) { [PermissionExtension] = required.Name }
+            : null);
+
+    /// <summary>Writes the answer a route that decided no permission is refused with.</summary>
+    /// <remarks>
+    /// It names none, because there is none: nobody decided what reaching this route requires, so no grant an operator
+    /// could write would make it reachable. Refusing rather than serving is what makes a route added without a decision
+    /// a route that answers nobody instead of one that answers everybody, and it is stated plainly because the remedy is
+    /// a defect report rather than a wider grant.
+    /// </remarks>
+    private static ProblemHttpResult Undeclared() => TypedResults.Problem(
+        "This deployment publishes no permission for that operation, so no credential reaches it.",
+        statusCode: StatusCodes.Status403Forbidden);
+}

--- a/src/Host/Security/Endpoints/AdminRouteAuthorization.cs
+++ b/src/Host/Security/Endpoints/AdminRouteAuthorization.cs
@@ -72,10 +72,18 @@ internal static class AdminRouteAuthorization
     /// <returns>What the route answered, or the refusal that stopped it.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> or <paramref name="next" /> is <see langword="null" />.</exception>
     /// <remarks>
+    /// <para>
     /// It runs as one filter over the whole group rather than as a filter per route, so the enforcement cannot be the
     /// half of the arrangement a new route forgets — what a route supplies is the decision, and this reads it. The
     /// grant is asked of <see cref="AccessAuthorization" /> rather than of the claims on the request, so the transport
     /// and the use case behind it cannot come to disagree about what holding a permission means.
+    /// </para>
+    /// <para>
+    /// A route is served only where it published exactly one decision. Reading the last of several would make a route
+    /// that decided twice take whichever declaration came last — which may be the one requiring nothing — so a route
+    /// deciding twice is refused for the same reason as one that decided not at all: nobody can say what reaching it
+    /// requires, and that is a defect in this repository rather than something a grant could resolve.
+    /// </para>
     /// </remarks>
     internal static async ValueTask<object?> RefuseUnpermittedAsync(
         EndpointFilterInvocationContext context,
@@ -84,7 +92,7 @@ internal static class AdminRouteAuthorization
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(next);
 
-        if (context.HttpContext.GetEndpoint()?.Metadata.GetMetadata<AdminRoutePermission>() is not { } published)
+        if (context.HttpContext.GetEndpoint()?.Metadata.GetOrderedMetadata<AdminRoutePermission>() is not [{ } published])
         {
             return Undeclared();
         }
@@ -120,12 +128,12 @@ internal static class AdminRouteAuthorization
             ? new Dictionary<string, object?>(StringComparer.Ordinal) { [PermissionExtension] = required.Name }
             : null);
 
-    /// <summary>Writes the answer a route that decided no permission is refused with.</summary>
+    /// <summary>Writes the answer a route that published no single decision is refused with.</summary>
     /// <remarks>
-    /// It names none, because there is none: nobody decided what reaching this route requires, so no grant an operator
-    /// could write would make it reachable. Refusing rather than serving is what makes a route added without a decision
-    /// a route that answers nobody instead of one that answers everybody, and it is stated plainly because the remedy is
-    /// a defect report rather than a wider grant.
+    /// It names no permission, because there is none to name: either nobody decided what reaching this route requires or
+    /// two decisions were published and neither is the route's, so no grant an operator could write would make it
+    /// reachable. Refusing rather than serving is what makes such a route one that answers nobody instead of one that
+    /// answers everybody, and it is stated plainly because the remedy is a defect report rather than a wider grant.
     /// </remarks>
     private static ProblemHttpResult Undeclared() => TypedResults.Problem(
         "This deployment publishes no permission for that operation, so no credential reaches it.",

--- a/src/Host/Security/Endpoints/AdminRoutePermission.cs
+++ b/src/Host/Security/Endpoints/AdminRoutePermission.cs
@@ -1,0 +1,61 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Host.Security.Endpoints;
+
+/// <summary>What one administrative route decided a caller must hold before it is served.</summary>
+/// <remarks>
+/// <para>
+/// The decision travels as endpoint metadata so that it is written beside the route it governs rather than in a list a
+/// route added later can be left out of. What makes the omission safe is that the absence of this metadata is itself an
+/// answer: <see cref="AdminRouteAuthorization" /> refuses a route carrying none, so forgetting to decide is a route
+/// nobody reaches instead of a route everybody does.
+/// </para>
+/// <para>
+/// <see cref="None" /> is the one route that requires no permission, and it is a stated value rather than the absence of
+/// one for exactly that reason. ADR 0012 allocates it to the session read alone: that route reports the credential the
+/// caller already presented and the version the deployment already publishes, and putting it behind a permission would
+/// make that permission a component of every administrative grant.
+/// </para>
+/// </remarks>
+internal sealed class AdminRoutePermission
+{
+    private AdminRoutePermission(MailFathomPermission permission) => this.Permission = permission;
+
+    /// <summary>Gets the decision of a route that requires no permission at all.</summary>
+    internal static AdminRoutePermission None { get; } = new(default);
+
+    /// <summary>Gets the permission a caller must hold, unspecified where the route requires none.</summary>
+    internal MailFathomPermission Permission { get; }
+
+    /// <summary>States the one permission a route is published under.</summary>
+    /// <param name="permission">The capability the route is reached with.</param>
+    /// <returns>The metadata the route carries.</returns>
+    /// <exception cref="ArgumentException">Thrown when the value names no published permission, or names one belonging to another surface.</exception>
+    /// <remarks>
+    /// Both refusals happen while the routes are mapped, which is startup, because either is a defect in this repository
+    /// rather than in anything an operator wrote: a route bounded by a permission an administrative grant can never carry
+    /// is a route no credential reaches, and one bounded by the struct default is a route bounded by nothing.
+    /// </remarks>
+    internal static AdminRoutePermission Requiring(MailFathomPermission permission)
+    {
+        if (!permission.IsSpecified)
+        {
+            throw new ArgumentException(
+                "An administrative route must be published under a permission rather than the unspecified default.",
+                nameof(permission));
+        }
+
+        if (permission.Surface != ProtectedSurface.Administration)
+        {
+            throw new ArgumentException(
+                $"'{permission.Name}' belongs to another surface, so no administrative grant can carry it.",
+                nameof(permission));
+        }
+
+        return new AdminRoutePermission(permission);
+    }
+}

--- a/src/Host/Security/Transport/TransportAccessPolicy.cs
+++ b/src/Host/Security/Transport/TransportAccessPolicy.cs
@@ -36,9 +36,9 @@ namespace MailFathom.Host.Security.Transport;
 /// credential's configuration entry granted travel on the principal this judges, written by whichever scheme
 /// authenticated it, so that admission stays one shared judgement while each surface comes to enforce the grant in the
 /// terms its own callers are answered in. <see cref="TransportGrant" /> is how one is read back, through the caller the
-/// application layer is handed. The MCP surface is the one doing so today: it serves each caller the tools its grant
-/// permits and answers a call for any other as a tool that does not exist. No administrative route consults a
-/// permission yet, so a grant reaches that surface carried and reported rather than enforced.
+/// application layer is handed. The MCP surface serves each caller the tools its grant permits and answers a call for
+/// any other as a tool that does not exist; the administrative surface refuses a route the grant does not admit and
+/// names the one permission that would have sufficed, because the caller there is an operator at their own terminal.
 /// </para>
 /// </remarks>
 internal static class TransportAccessPolicy

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -369,8 +369,12 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IStoredEmailReconciliationStore, StoredEmailReconciliationStore>();
         services.AddScoped<IMailRuleEvaluationStore, MailRuleEvaluationStore>();
         services.AddScoped<IMailRuleEvaluationRunStore, MailRuleEvaluationRunStore>();
+        // What the administrative surface asks of the two rule stores. Each is a use case rather than a second port,
+        // because the grant a reader has to hold is decided where the reading happens rather than at the route.
+        services.AddScoped<MailRuleEvaluationRunReader>();
         services.AddSingleton<MailRuleHistoryTelemetry>();
         services.AddScoped<IMailRuleExecutionStore, MailRuleExecutionStore>();
+        services.AddScoped<MailRuleHistory>();
         // Scoped like every other store, and deliberately not registered beside a worker: nothing here runs a job. It
         // takes no persistence session either, so a caller cannot enlist an enqueue in the transaction that stored the
         // message the work is about.
@@ -379,6 +383,7 @@ public static class ServiceCollectionExtensions
         // acts under a lease it holds, and these two answer an operator who holds none.
         services.AddScoped<IJobQueueDepthReader, JobQueueDepthReader>();
         services.AddScoped<IDeadLetteredJobStore, DeadLetteredJobStore>();
+        services.AddScoped<DeadLetteredJobs>();
         // What each recurring dispatch has already done. Scoped and sessionless like the queue itself, because a
         // schedule is advanced against work that is already enqueued.
         services.AddScoped<IJobScheduleStore, JobScheduleStore>();
@@ -394,6 +399,8 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ISpamActionOccurrenceReader, SpamActionOccurrenceReader>();
         services.AddScoped<ISpamClassificationRunStore, SpamClassificationRunStore>();
         services.AddScoped<ISpamClassificationHistoryReader, SpamClassificationHistoryReader>();
+        services.AddScoped<SpamClassificationRunReader>();
+        services.AddScoped<SpamClassificationHistory>();
 
         // The read side takes no persistence session and joins no transaction, so its ports are registered beside the
         // write repositories rather than through one of them.
@@ -581,6 +588,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<MailAnsweringAuditTelemetry>();
         services.AddSingleton<IMailAnsweringRunTelemetry, MailAnsweringRunTelemetry>();
         services.AddScoped<IMailAnsweringAuditEntryStore, MailAnsweringAuditEntryStore>();
+        services.AddScoped<MailAnsweringAuditTrailReader>();
         services.AddScoped<IMailAnsweringAuditTrail, MailAnsweringAuditTrail>();
         services.AddScoped<MailAnsweringAuditTrailRetention>();
         // Beside the retrieval bounds above and registered for every deployment for the same reason: what they bound is
@@ -679,6 +687,7 @@ public static class ServiceCollectionExtensions
         // the operational record above: that one ends with the mutation, and this one is kept for as long as the
         // account's retention says and is erased by the pass beside it.
         services.AddScoped<IMailboxMutationAuditEntryStore, MailboxMutationAuditEntryStore>();
+        services.AddScoped<MailboxMutationAuditTrailReader>();
         services.AddSingleton<MailboxMutationAuditTelemetry>();
         services.AddScoped<IMailboxMutationAuditTrail, MailboxMutationAuditTrail>();
         services.AddScoped<MailboxMutationAuditTrailRetention>();

--- a/tests/Application.UnitTests/Accounts/MailboxRefreshTokenRecorderTests.cs
+++ b/tests/Application.UnitTests/Accounts/MailboxRefreshTokenRecorderTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.TestSupport;
 using NSubstitute;
@@ -103,11 +105,56 @@ public sealed class MailboxRefreshTokenRecorderTests
             () => recorder.RecordAsync(Workspace, refreshToken: null!, TestContext.Current.CancellationToken));
     }
 
-    private MailboxRefreshTokenRecorder RecorderServing(params MailAccountId[] servedAccountIds)
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task RecordAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var recorder = this.RecorderServing(
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead),
+            Workspace);
+        using var refreshToken = MailboxRefreshToken.FromText("a-refresh-token");
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            recorder.RecordAsync(Workspace, refreshToken, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminCredentialsWrite, refusal.RequiredPermission);
+        await this.store.DidNotReceive().SaveTokenAsync(
+            Arg.Any<MailAccountId>(),
+            Arg.Any<MailboxRefreshToken>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>The grant is asked before the account is, so a refused caller learns nothing about which accounts this deployment serves.</summary>
+    [Fact]
+    public async Task RecordAsync_ACallerHoldingNothing_IsRefusedBeforeTheAccountIsResolved()
+    {
+        // Arrange
+        var recorder = this.RecorderServing(AccessAuthorizations.ForCallerGranted());
+        using var refreshToken = MailboxRefreshToken.FromText("a-refresh-token");
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            recorder.RecordAsync(Workspace, refreshToken, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminCredentialsWrite, refusal.RequiredPermission);
+    }
+
+    private MailboxRefreshTokenRecorder RecorderServing(params MailAccountId[] servedAccountIds) =>
+        this.RecorderServing(
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminCredentialsWrite),
+            servedAccountIds);
+
+    private MailboxRefreshTokenRecorder RecorderServing(
+        AccessAuthorization authorization,
+        params MailAccountId[] servedAccountIds)
     {
         var catalog = Substitute.For<IMailAccountCatalog>();
         catalog.ServedAccounts.Returns([.. servedAccountIds.Select(SyntheticServedAccount.Of)]);
 
-        return new MailboxRefreshTokenRecorder(catalog, this.store);
+        return new MailboxRefreshTokenRecorder(catalog, this.store, authorization);
     }
 }

--- a/tests/Application.UnitTests/Contacts/ContactBookTests.cs
+++ b/tests/Application.UnitTests/Contacts/ContactBookTests.cs
@@ -2,11 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Contacts;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Emails;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -305,7 +308,63 @@ public sealed class ContactBookTests
         Assert.Null(export);
     }
 
-    private static ContactBook BookOver(InMemoryContactBookStore book, FakeTimeProvider? clock = null)
+    /// <summary>Reading the book is reading what was derived from somebody's mail, so it asks for the audit grant rather than the administrative read.</summary>
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var book = BookOver(
+            new InMemoryContactBookStore(),
+            authorization: AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            book.ReadPageAsync(ContactQuery.Create(origin: null, pageSize: null, cursor: null), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminAuditRead, refusal.RequiredPermission);
+    }
+
+    /// <summary>Writing to the book is causing work rather than reading it, so reading grants nothing towards it.</summary>
+    [Fact]
+    public async Task RecordAsync_ACallerGrantedOnlyTheAuditRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var store = new InMemoryContactBookStore();
+        var book = BookOver(
+            store,
+            authorization: AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminAuditRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() => book.RecordAsync(
+            NewContactOf("Ada Lovelace", ["ada@example.test"]),
+            TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminOperate, refusal.RequiredPermission);
+    }
+
+    /// <summary>Taking somebody out of the book is destroying, which is the one grant allocated to that.</summary>
+    [Fact]
+    public async Task EraseAsync_ACallerGrantedOnlyTheAdministrativeOperate_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var book = BookOver(
+            new InMemoryContactBookStore(),
+            authorization: AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            book.EraseAsync(ContactId.Create(Guid.CreateVersion7(Now)), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminErase, refusal.RequiredPermission);
+    }
+
+    private static ContactBook BookOver(
+        InMemoryContactBookStore book,
+        FakeTimeProvider? clock = null,
+        AccessAuthorization? authorization = null)
     {
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
@@ -316,7 +375,11 @@ public sealed class ContactBookTests
             book,
             book,
             new OptimisticConcurrencyRetryPolicy(sessionFactory, new PersistenceConcurrencyOptions(), timeProvider),
-            timeProvider);
+            timeProvider,
+            authorization ?? AccessAuthorizations.ForCallerGranted(
+                MailFathomPermission.AdminAuditRead,
+                MailFathomPermission.AdminOperate,
+                MailFathomPermission.AdminErase));
     }
 
     private static NewContact NewContactOf(string displayName, IReadOnlyList<string> addresses) =>

--- a/tests/Application.UnitTests/Emails/Embeddings/Administration/CountedEmbeddingActivationTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Administration/CountedEmbeddingActivationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Administration;
 using MailFathom.Application.Emails.Embeddings.Backfill;
@@ -10,6 +11,8 @@ using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Access;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -210,7 +213,55 @@ public sealed class CountedEmbeddingActivationTests
             EmbeddingDistanceMetric.Cosine,
             EmbeddingInputPreparation.Create(2_000, passageInstruction: null, normalizesVector: true));
 
-    private static ActivationWorld CreateWorld(long maxInputCharactersPerPeriod = 1_000_000)
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task AssessAsync_ACallerGrantedOnlyTheSpend_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var world = CreateWorld(authorization: AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminSpend));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            world.Activation.AssessAsync(CreateIdentity("a-model"), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminRead, refusal.RequiredPermission);
+    }
+
+    /// <summary>The read in front of the activation is the activating caller's own, so holding the spend alone is enough to activate.</summary>
+    [Fact]
+    public async Task ActivateAsync_ACallerGrantedOnlyTheSpend_ActivatesWithoutAlsoHoldingTheRead()
+    {
+        // Arrange
+        var world = CreateWorld(authorization: AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminSpend));
+        var declared = CreateIdentity("a-model");
+
+        // Act
+        var result = await world.Activation.ActivateAsync(declared, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.RefusedBySpendCeiling);
+        Assert.Equal(EmbeddingProfileActivationOutcome.ReindexStarted, result.Activation?.Outcome);
+    }
+
+    /// <summary>Starting a provider bill asks for the one permission allocated to spending, and the administrative read does not carry it.</summary>
+    [Fact]
+    public async Task ActivateAsync_ACallerGrantedOnlyTheRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var world = CreateWorld(authorization: AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            world.Activation.ActivateAsync(CreateIdentity("a-model"), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminSpend, refusal.RequiredPermission);
+    }
+
+    private static ActivationWorld CreateWorld(
+        long maxInputCharactersPerPeriod = 1_000_000,
+        AccessAuthorization? authorization = null)
     {
         var generationStore = new InMemoryEmbeddingGenerationStore(new InMemoryEmailEmbeddingStore());
         var workloadReader = new InMemoryEmbeddingWorkloadReader();
@@ -235,7 +286,10 @@ public sealed class CountedEmbeddingActivationTests
                     sessionFactory,
                     new PersistenceConcurrencyOptions(),
                     timeProvider),
-                new EmbeddingBackfillSchedule(timeProvider)));
+                new EmbeddingBackfillSchedule(timeProvider)),
+            authorization ?? AccessAuthorizations.ForCallerGranted(
+                MailFathomPermission.AdminRead,
+                MailFathomPermission.AdminSpend));
 
         return new ActivationWorld(generationStore, workloadReader, ledger, activation);
     }

--- a/tests/Application.UnitTests/Emails/Embeddings/Administration/EmbeddingStatusReaderTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Administration/EmbeddingStatusReaderTests.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Administration;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Access;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -160,7 +163,24 @@ public sealed class EmbeddingStatusReaderTests
             EmbeddingDistanceMetric.Cosine,
             EmbeddingInputPreparation.Create(2_000, passageInstruction: null, normalizesVector: true));
 
-    private static StatusWorld CreateWorld(long maxInputCharactersPerPeriod = 1_000_000)
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task ReadAsync_ACallerGrantedOnlyTheSpend_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var world = CreateWorld(authorization: AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminSpend));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            world.Reader.ReadAsync(CreateIdentity("a-model"), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminRead, refusal.RequiredPermission);
+    }
+
+    private static StatusWorld CreateWorld(
+        long maxInputCharactersPerPeriod = 1_000_000,
+        AccessAuthorization? authorization = null)
     {
         var generationStore = new InMemoryEmbeddingGenerationStore(new InMemoryEmailEmbeddingStore());
         var workloadReader = new InMemoryEmbeddingWorkloadReader();
@@ -178,7 +198,8 @@ public sealed class EmbeddingStatusReaderTests
                 EmbeddingSpendBudget.Create(maxInputCharactersPerPeriod, TimeSpan.FromDays(1)),
                 new FakeTimeProvider(Now)),
             providerHealth,
-            backfillSchedule);
+            backfillSchedule,
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
 
         return new StatusWorld(generationStore, workloadReader, ledger, providerHealth, backfillSchedule, reader);
     }

--- a/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingReindexCancellationTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/Generations/EmbeddingReindexCancellationTests.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Access;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -134,7 +137,8 @@ public sealed class EmbeddingReindexCancellationTests
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
                 new FakeTimeProvider()),
-            new EmbeddingBackfillSchedule(new FakeTimeProvider(Now)));
+            new EmbeddingBackfillSchedule(new FakeTimeProvider(Now)),
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
 
         // Act
         var outcome = await cancellation.CancelAsync(TestContext.Current.CancellationToken);
@@ -153,7 +157,22 @@ public sealed class EmbeddingReindexCancellationTests
             EmbeddingDistanceMetric.Cosine,
             EmbeddingInputPreparation.Create(2_000, passageInstruction: null, normalizesVector: true));
 
-    private static CancellationWorld CreateWorld()
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task CancelAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var world = CreateWorld(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            world.Cancellation.CancelAsync(TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminOperate, refusal.RequiredPermission);
+    }
+
+    private static CancellationWorld CreateWorld(AccessAuthorization? authorization = null)
     {
         var generationStore = new InMemoryEmbeddingGenerationStore(new InMemoryEmailEmbeddingStore());
         var vectorIndex = Substitute.For<IEmbeddingProfileVectorIndex>();
@@ -170,7 +189,8 @@ public sealed class EmbeddingReindexCancellationTests
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
                 new FakeTimeProvider()),
-            backfillSchedule);
+            backfillSchedule,
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
 
         return new CancellationWorld(generationStore, vectorIndex, backfillSchedule, cancellation);
     }

--- a/tests/Application.UnitTests/Folders/UnmirroredMailFolderEraserTests.cs
+++ b/tests/Application.UnitTests/Folders/UnmirroredMailFolderEraserTests.cs
@@ -2,11 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Folders;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -82,7 +85,30 @@ public sealed class UnmirroredMailFolderEraserTests
         Assert.Equal([(Account, Junk, 25)], store.Passes);
     }
 
-    private static UnmirroredMailFolderEraser EraserOver(IStoredMailFolderMirrorStore store, int maxEmailsPerPass)
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task EraseAsync_ACallerGrantedOnlyTheAdministrativeOperate_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var store = new RecordingMirrorStore(new MailFolderMirrorErasure(ErasedEmailCount: 0, EmailsRemain: false));
+        var eraser = EraserOver(
+            store,
+            maxEmailsPerPass: 500,
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            eraser.EraseAsync(Account, Junk, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminErase, refusal.RequiredPermission);
+        Assert.Empty(store.Passes);
+    }
+
+    private static UnmirroredMailFolderEraser EraserOver(
+        IStoredMailFolderMirrorStore store,
+        int maxEmailsPerPass,
+        AccessAuthorization? authorization = null)
     {
         var clock = new FakeTimeProvider();
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
@@ -91,7 +117,8 @@ public sealed class UnmirroredMailFolderEraserTests
         return new UnmirroredMailFolderEraser(
             store,
             new OptimisticConcurrencyRetryPolicy(sessionFactory, new PersistenceConcurrencyOptions(), clock),
-            new MailboxSynchronizationOptions { MaxReconciledEmailsPerRun = maxEmailsPerPass });
+            new MailboxSynchronizationOptions { MaxReconciledEmailsPerRun = maxEmailsPerPass },
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminErase));
     }
 
     /// <summary>Records what each pass was asked to erase, and answers with the erasure the test arranged.</summary>

--- a/tests/Application.UnitTests/Jobs/DeadLetters/DeadLetteredJobsTests.cs
+++ b/tests/Application.UnitTests/Jobs/DeadLetters/DeadLetteredJobsTests.cs
@@ -1,0 +1,94 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Application.Jobs;
+using MailFathom.Application.Jobs.DeadLetters;
+using MailFathom.Domain.Access;
+using MailFathom.TestSupport;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Jobs.DeadLetters;
+
+/// <summary>Covers what an operator may do about background work that stopped, which is not one decision but two.</summary>
+/// <remarks>
+/// Watching a queue and acting on it are published under different grants, so the tests here are about which grant each
+/// operation asks for and about the store never being reached without it. What the store then does with a retry or a
+/// drop is the store's own contract and is covered where the store is.
+/// </remarks>
+public sealed class DeadLetteredJobsTests
+{
+    private static readonly JobId Job = JobId.Create(Guid.CreateVersion7(new DateTimeOffset(2026, 8, 17, 9, 0, 0, TimeSpan.Zero)));
+
+    private readonly IDeadLetteredJobStore store = Substitute.For<IDeadLetteredJobStore>();
+
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedTheAdministrativeRead_IsServedThePageTheStoreHolds()
+    {
+        // Arrange
+        var page = new DeadLetteredJobPage([], NextCursor: null);
+        this.store.ReadPageAsync(Arg.Any<DeadLetteredJobQuery>(), Arg.Any<CancellationToken>()).Returns(page);
+        var deadLetters = this.JobsFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var read = await deadLetters.ReadPageAsync(EveryDeadLetter(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(page, read);
+    }
+
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedOnlyTheAdministrativeOperate_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var deadLetters = this.JobsFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            deadLetters.ReadPageAsync(EveryDeadLetter(), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminRead, refusal.RequiredPermission);
+        await this.store.DidNotReceive().ReadPageAsync(Arg.Any<DeadLetteredJobQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Returning a job to the queue makes it run against somebody's mailbox again, so watching the queue grants nothing towards it.</summary>
+    [Fact]
+    public async Task RetryAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var deadLetters = this.JobsFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            deadLetters.RetryAsync(Job, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminOperate, refusal.RequiredPermission);
+        await this.store.DidNotReceive().RetryAsync(Arg.Any<JobId>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Dropping records a decision rather than removing anything, so it asks for the operating grant and not the erasing one.</summary>
+    [Fact]
+    public async Task DropAsync_ACallerGrantedOnlyTheErasure_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var deadLetters = this.JobsFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminErase));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            deadLetters.DropAsync(Job, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminOperate, refusal.RequiredPermission);
+        await this.store.DidNotReceive().DropAsync(Arg.Any<JobId>(), Arg.Any<CancellationToken>());
+    }
+
+    private static DeadLetteredJobQuery EveryDeadLetter() =>
+        DeadLetteredJobQuery.Create(jobType: null, accountId: null, pageSize: null, cursor: null).Query!;
+
+    private DeadLetteredJobs JobsFor(AccessAuthorization authorization) => new(this.store, authorization);
+}

--- a/tests/Application.UnitTests/Mail/Maintenance/MailSynchronizationRewindTests.cs
+++ b/tests/Application.UnitTests/Mail/Maintenance/MailSynchronizationRewindTests.cs
@@ -2,13 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Mail.Maintenance;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Synchronization.Checkpoints;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Synchronization;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -142,9 +145,48 @@ public sealed class MailSynchronizationRewindTests
             TestContext.Current.CancellationToken));
     }
 
+    /// <summary>Reading what a rewind would cost is the administrative read, and a caller granted only the operating permission does not hold it.</summary>
+    [Fact]
+    public async Task AssessAsync_ACallerGrantedOnlyTheAdministrativeOperate_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var rewind = RewindOver(
+            new RecordingCheckpointStore([Inbox]),
+            new RecordingCounter(storedEmailCount: 4),
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            rewind.AssessAsync(new StoredMailScope(Account, null), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminRead, refusal.RequiredPermission);
+    }
+
+    /// <summary>The one route that makes a deployment pull a mailbox again asks to operate, which the administrative read does not carry.</summary>
+    [Fact]
+    public async Task RewindAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var checkpoints = new RecordingCheckpointStore([Inbox]);
+        var rewind = RewindOver(
+            checkpoints,
+            new RecordingCounter(storedEmailCount: 4),
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            rewind.RewindAsync(new StoredMailScope(Account, null), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminOperate, refusal.RequiredPermission);
+        Assert.Empty(checkpoints.Discards);
+    }
+
     private static MailSynchronizationRewind RewindOver(
         ISynchronizationCheckpointStore checkpoints,
-        IStoredMailCounter counter)
+        IStoredMailCounter counter,
+        AccessAuthorization? authorization = null)
     {
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
@@ -155,7 +197,10 @@ public sealed class MailSynchronizationRewindTests
             new OptimisticConcurrencyRetryPolicy(
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
-                new FakeTimeProvider()));
+                new FakeTimeProvider()),
+            authorization ?? AccessAuthorizations.ForCallerGranted(
+                MailFathomPermission.AdminRead,
+                MailFathomPermission.AdminOperate));
     }
 
     /// <summary>Records which scopes were counted, and answers with the figure the test arranged.</summary>

--- a/tests/Application.UnitTests/Mail/Maintenance/StoredMailRederivationTests.cs
+++ b/tests/Application.UnitTests/Mail/Maintenance/StoredMailRederivationTests.cs
@@ -3,15 +3,18 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Security.Cryptography;
+using MailFathom.Application.Access;
 using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Mail.Maintenance;
 using MailFathom.Application.Persistence;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Emails.Authentication;
 using MailFathom.Domain.Folders;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -296,10 +299,32 @@ public sealed class StoredMailRederivationTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => rederivation.RunAsync(WholeAccount, cancellation.Token));
     }
 
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task RunAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var store = new FakeRederivationStore(StoredMail(1));
+        var rederivation = RederivationOver(
+            store,
+            ContentStoreWithReadableMime(),
+            ReaderThatReadsEverything(),
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            rederivation.RunAsync(WholeAccount, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminOperate, refusal.RequiredPermission);
+        Assert.Empty(store.Applied);
+    }
+
     private static StoredMailRederivation RederivationOver(
         IStoredMailRederivationStore store,
         IEmailContentStore contentStore,
-        IEmailMimeReader mimeReader)
+        IEmailMimeReader mimeReader,
+        AccessAuthorization? authorization = null)
     {
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
@@ -311,7 +336,8 @@ public sealed class StoredMailRederivationTests
             new OptimisticConcurrencyRetryPolicy(
                 sessionFactory,
                 new PersistenceConcurrencyOptions { MaximumCommitAttempts = 2 },
-                new FakeTimeProvider(new DateTimeOffset(2026, 8, 16, 12, 0, 0, TimeSpan.Zero))));
+                new FakeTimeProvider(new DateTimeOffset(2026, 8, 16, 12, 0, 0, TimeSpan.Zero))),
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
     }
 
     /// <summary>Builds stored mail whose identifiers increase in the order the walk visits it.</summary>

--- a/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditTrailReaderTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditTrailReaderTests.cs
@@ -1,0 +1,63 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Accounts;
+using MailFathom.TestSupport;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Mail.Mutations.Audit;
+
+/// <summary>Covers reading one account's record of what MailFathom did to its mailbox, which is derived from that mailbox.</summary>
+public sealed class MailboxMutationAuditTrailReaderTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+
+    private readonly IMailboxMutationAuditEntryStore entries = Substitute.For<IMailboxMutationAuditEntryStore>();
+
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedTheAuditRead_IsServedThePageTheStoreHolds()
+    {
+        // Arrange
+        var page = new MailboxMutationAuditPage([], NextCursor: null);
+        this.entries.ReadPageAsync(Arg.Any<MailboxMutationAuditQuery>(), Arg.Any<CancellationToken>()).Returns(page);
+        var trail = this.TrailFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminAuditRead));
+
+        // Act
+        var read = await trail.ReadPageAsync(WholeAccount(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(page, read);
+    }
+
+    /// <summary>Where a person's mail has been is derived personal data, so the state read grants nothing towards it.</summary>
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var trail = this.TrailFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            trail.ReadPageAsync(WholeAccount(), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminAuditRead, refusal.RequiredPermission);
+        await this.entries.DidNotReceive().ReadPageAsync(Arg.Any<MailboxMutationAuditQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    private static MailboxMutationAuditQuery WholeAccount() => MailboxMutationAuditQuery.Create(
+        Account,
+        default,
+        completedFrom: null,
+        completedBefore: null,
+        pageSize: null,
+        cursor: null).Query!;
+
+    private MailboxMutationAuditTrailReader TrailFor(AccessAuthorization authorization) =>
+        new(this.entries, authorization);
+}

--- a/tests/Application.UnitTests/Retrieval/AskMail/Audit/MailAnsweringAuditTrailReaderTests.cs
+++ b/tests/Application.UnitTests/Retrieval/AskMail/Audit/MailAnsweringAuditTrailReaderTests.cs
@@ -1,0 +1,62 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Application.Retrieval.AskMail.Audit;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Accounts;
+using MailFathom.TestSupport;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Retrieval.AskMail.Audit;
+
+/// <summary>Covers reading one account's record of the questions answered from its mailbox.</summary>
+public sealed class MailAnsweringAuditTrailReaderTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+
+    private readonly IMailAnsweringAuditEntryStore entries = Substitute.For<IMailAnsweringAuditEntryStore>();
+
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedTheAuditRead_IsServedThePageTheStoreHolds()
+    {
+        // Arrange
+        var page = new MailAnsweringAuditPage([], NextCursor: null);
+        this.entries.ReadPageAsync(Arg.Any<MailAnsweringAuditQuery>(), Arg.Any<CancellationToken>()).Returns(page);
+        var trail = this.TrailFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminAuditRead));
+
+        // Act
+        var read = await trail.ReadPageAsync(WholeAccount(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(page, read);
+    }
+
+    /// <summary>Which of a person's messages a question reached is derived personal data, so the state read grants nothing towards it.</summary>
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var trail = this.TrailFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            trail.ReadPageAsync(WholeAccount(), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminAuditRead, refusal.RequiredPermission);
+        await this.entries.DidNotReceive().ReadPageAsync(Arg.Any<MailAnsweringAuditQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    private static MailAnsweringAuditQuery WholeAccount() => MailAnsweringAuditQuery.Create(
+        Account,
+        completedFrom: null,
+        completedBefore: null,
+        pageSize: null,
+        cursor: null).Query!;
+
+    private MailAnsweringAuditTrailReader TrailFor(AccessAuthorization authorization) =>
+        new(this.entries, authorization);
+}

--- a/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationRunReaderTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationRunReaderTests.cs
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Application.Rules.Evaluation;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Accounts;
+using MailFathom.TestSupport;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Rules.Evaluation;
+
+/// <summary>Covers watching a whole-mailbox rule run, which is a grant of its own and not the one that starts one.</summary>
+public sealed class MailRuleEvaluationRunReaderTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+
+    private readonly IMailRuleEvaluationRunStore runs = Substitute.For<IMailRuleEvaluationRunStore>();
+
+    [Fact]
+    public async Task FindLatestAsync_AnAccountNeverAskedForARun_IsServedNone()
+    {
+        // Arrange
+        this.runs.FindLatestAsync(Account, Arg.Any<CancellationToken>()).Returns((MailRuleEvaluationRun?)null);
+        var reader = this.ReaderFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var run = await reader.FindLatestAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(run);
+    }
+
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task FindLatestAsync_ACallerGrantedOnlyTheAdministrativeOperate_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var reader = this.ReaderFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            reader.FindLatestAsync(Account, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminRead, refusal.RequiredPermission);
+        await this.runs.DidNotReceive().FindLatestAsync(Arg.Any<MailAccountId>(), Arg.Any<CancellationToken>());
+    }
+
+    private MailRuleEvaluationRunReader ReaderFor(AccessAuthorization authorization) => new(this.runs, authorization);
+}

--- a/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationRunRequestsTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationRunRequestsTests.cs
@@ -2,11 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Rules.History;
 using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -181,7 +184,37 @@ public sealed class MailRuleEvaluationRunRequestsTests
         Assert.Empty(this.runStore.Saves);
     }
 
-    private MailRuleEvaluationRunRequests CreateRequests()
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task SubmitAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var requests = this.CreateRequests(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            requests.SubmitAsync(Account, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminOperate, refusal.RequiredPermission);
+        Assert.Null(this.runStore.Find(Account));
+    }
+
+    /// <summary>The scheduled path is the process's own dispatch rather than a caller's request, so it asks for no grant and holds none.</summary>
+    [Fact]
+    public async Task SubmitScheduledAsync_TheProcessItself_RecordsARunWithoutHoldingAnyPermission()
+    {
+        // Arrange
+        var requests = this.CreateRequests(AccessAuthorizations.ForPrincipal(principal: null));
+
+        // Act
+        var request = await requests.SubmitScheduledAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(request.Accepted);
+    }
+
+    private MailRuleEvaluationRunRequests CreateRequests(AccessAuthorization? authorization = null)
     {
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
@@ -192,7 +225,8 @@ public sealed class MailRuleEvaluationRunRequestsTests
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
                 this.timeProvider),
-            this.timeProvider);
+            this.timeProvider,
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
     }
 
     private sealed class CommittingSession : IPersistenceSession

--- a/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationRunRequestsTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/MailRuleEvaluationRunRequestsTests.cs
@@ -22,6 +22,10 @@ public sealed class MailRuleEvaluationRunRequestsTests
     private static readonly DateTimeOffset RequestedAt = new(2026, 4, 2, 11, 0, 0, TimeSpan.Zero);
     private static readonly MailAccountId Account = MailAccountId.Create("work");
 
+    /// <summary>What a scheduled occasion is dispatched under, which is what the deployment's own process reaches this with.</summary>
+    private static readonly AccessAuthorization ProcessItself =
+        AccessAuthorizations.ForPrincipal(AuthorizedPrincipal.Process);
+
     private readonly InMemoryMailRuleEvaluationRunStore runStore = new();
     private readonly FakeTimeProvider timeProvider = new(RequestedAt);
 
@@ -84,7 +88,8 @@ public sealed class MailRuleEvaluationRunRequestsTests
     public async Task SubmitScheduledAsync_AccountWithNoRunOutstanding_RecordsAScheduledRun()
     {
         // Act
-        var request = await this.CreateRequests().SubmitScheduledAsync(Account, TestContext.Current.CancellationToken);
+        var request = await this.CreateRequests(ProcessItself)
+            .SubmitScheduledAsync(Account, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(request.Accepted);
@@ -108,7 +113,8 @@ public sealed class MailRuleEvaluationRunRequestsTests
         });
 
         // Act
-        var request = await this.CreateRequests().SubmitScheduledAsync(Account, TestContext.Current.CancellationToken);
+        var request = await this.CreateRequests(ProcessItself)
+            .SubmitScheduledAsync(Account, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(request.Accepted);
@@ -152,7 +158,8 @@ public sealed class MailRuleEvaluationRunRequestsTests
         });
 
         // Act
-        var request = await this.CreateRequests().SubmitScheduledAsync(Account, TestContext.Current.CancellationToken);
+        var request = await this.CreateRequests(ProcessItself)
+            .SubmitScheduledAsync(Account, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.False(request.Accepted);
@@ -205,13 +212,50 @@ public sealed class MailRuleEvaluationRunRequestsTests
     public async Task SubmitScheduledAsync_TheProcessItself_RecordsARunWithoutHoldingAnyPermission()
     {
         // Arrange
-        var requests = this.CreateRequests(AccessAuthorizations.ForPrincipal(principal: null));
+        var requests = this.CreateRequests(ProcessItself);
 
         // Act
         var request = await requests.SubmitScheduledAsync(Account, TestContext.Current.CancellationToken);
 
         // Assert
         Assert.True(request.Accepted);
+        Assert.Empty(AuthorizedPrincipal.Process.Permissions);
+    }
+
+    /// <summary>Holding no grant is not what admits the scheduled path, so a caller reaching it is refused rather than starting a mailbox-wide walk.</summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SubmitScheduledAsync_ACallerRatherThanTheProcess_IsRefusedWhateverItWasGranted(bool grantedEverything)
+    {
+        // Arrange
+        MailFathomPermission[] granted = grantedEverything
+            ? [.. MailFathomPermission.All.Where(permission => permission.Surface == ProtectedSurface.Administration)]
+            : [];
+        var requests = this.CreateRequests(AccessAuthorizations.ForCallerGranted(granted));
+
+        // Act
+        await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            requests.SubmitScheduledAsync(Account, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Null(this.runStore.Find(Account));
+        Assert.Empty(this.runStore.Saves);
+    }
+
+    /// <summary>An entrypoint that stated nothing about what admitted the work is the case the check exists to fail on.</summary>
+    [Fact]
+    public async Task SubmitScheduledAsync_AnEntrypointThatStatedNoPrincipal_IsRefusedRatherThanTreatedAsTheProcess()
+    {
+        // Arrange
+        var requests = this.CreateRequests(AccessAuthorizations.ForPrincipal(principal: null));
+
+        // Act
+        await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            requests.SubmitScheduledAsync(Account, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Null(this.runStore.Find(Account));
     }
 
     private MailRuleEvaluationRunRequests CreateRequests(AccessAuthorization? authorization = null)

--- a/tests/Application.UnitTests/Rules/Evaluation/ScheduledMailRuleRunHandlerTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/ScheduledMailRuleRunHandlerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Jobs;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules.Evaluation;
@@ -91,8 +92,9 @@ public sealed class ScheduledMailRuleRunHandlerTests
             new OptimisticConcurrencyRetryPolicy(sessionFactory, new PersistenceConcurrencyOptions(), timeProvider),
             timeProvider,
             // The occasion runs under the process rather than a caller, which is the arrangement the scheduled path is
-            // written for: it asks for no permission, so a principal that holds none still reaches it.
-            AccessAuthorizations.ForPrincipal(principal: null)));
+            // written for and requires: it asks for no permission and for the process itself, which is what the host
+            // reports outside a request.
+            AccessAuthorizations.ForPrincipal(AuthorizedPrincipal.Process)));
     }
 
     private sealed class CommittingSession : IPersistenceSession

--- a/tests/Application.UnitTests/Rules/Evaluation/ScheduledMailRuleRunHandlerTests.cs
+++ b/tests/Application.UnitTests/Rules/Evaluation/ScheduledMailRuleRunHandlerTests.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Rules.History;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Accounts;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -88,7 +89,10 @@ public sealed class ScheduledMailRuleRunHandlerTests
         return new ScheduledMailRuleRunHandler(new MailRuleEvaluationRunRequests(
             this.runStore,
             new OptimisticConcurrencyRetryPolicy(sessionFactory, new PersistenceConcurrencyOptions(), timeProvider),
-            timeProvider));
+            timeProvider,
+            // The occasion runs under the process rather than a caller, which is the arrangement the scheduled path is
+            // written for: it asks for no permission, so a principal that holds none still reaches it.
+            AccessAuthorizations.ForPrincipal(principal: null)));
     }
 
     private sealed class CommittingSession : IPersistenceSession

--- a/tests/Application.UnitTests/Rules/History/MailRuleHistoryTests.cs
+++ b/tests/Application.UnitTests/Rules/History/MailRuleHistoryTests.cs
@@ -1,0 +1,63 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Application.Rules.History;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Accounts;
+using MailFathom.TestSupport;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Rules.History;
+
+/// <summary>Covers reading what the rules concluded about an account's mail, which is derived from that mail.</summary>
+public sealed class MailRuleHistoryTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("work");
+
+    private readonly IMailRuleExecutionStore executions = Substitute.For<IMailRuleExecutionStore>();
+
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedTheAuditRead_IsServedThePageTheStoreHolds()
+    {
+        // Arrange
+        var page = new MailRuleExecutionPage([], NextCursor: null);
+        this.executions.ReadPageAsync(Arg.Any<MailRuleExecutionQuery>(), Arg.Any<CancellationToken>()).Returns(page);
+        var history = this.HistoryFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminAuditRead));
+
+        // Act
+        var read = await history.ReadPageAsync(WholeAccount(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(page, read);
+    }
+
+    /// <summary>What the rules concluded about somebody's messages is derived personal data, so the state read grants nothing towards it.</summary>
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var history = this.HistoryFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            history.ReadPageAsync(WholeAccount(), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminAuditRead, refusal.RequiredPermission);
+        await this.executions.DidNotReceive().ReadPageAsync(Arg.Any<MailRuleExecutionQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    private static MailRuleExecutionQuery WholeAccount() => MailRuleExecutionQuery.Create(
+        Account,
+        ruleName: null,
+        storedEmailId: null,
+        evaluatedFrom: null,
+        evaluatedBefore: null,
+        pageSize: null,
+        cursor: null).Query!;
+
+    private MailRuleHistory HistoryFor(AccessAuthorization authorization) => new(this.executions, authorization);
+}

--- a/tests/Application.UnitTests/Rules/MailRuleSetReaderTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleSetReaderTests.cs
@@ -1,0 +1,56 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Application.Rules;
+using MailFathom.Application.Rules.Conditions;
+using MailFathom.Domain.Access;
+using MailFathom.TestSupport;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Rules;
+
+/// <summary>Covers the operator's reading of the rule set, which is a report of the deployment's own state.</summary>
+public sealed class MailRuleSetReaderTests
+{
+    private readonly IMailRuleSetSource ruleSets = Substitute.For<IMailRuleSetSource>();
+
+    [Fact]
+    public void Read_ACallerGrantedTheAdministrativeRead_IsServedTheSetInForce()
+    {
+        // Arrange
+        var inForce = EmptyRuleSet();
+        this.ruleSets.Current.Returns(inForce);
+        var reader = this.ReaderFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var read = reader.Read();
+
+        // Assert
+        Assert.Same(inForce, read);
+    }
+
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public void Read_ACallerGrantedOnlyTheAuditRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var reader = this.ReaderFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminAuditRead));
+
+        // Act
+        var refusal = Assert.Throws<PrincipalNotAuthorizedException>(reader.Read);
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminRead, refusal.RequiredPermission);
+        _ = this.ruleSets.DidNotReceive().Current;
+    }
+
+    private static MailRuleSet EmptyRuleSet() => MailRuleSet.Create(
+        [],
+        MailRuleSetRevision.Create([]),
+        MailRuleConditionBounds.Default);
+
+    private MailRuleSetReader ReaderFor(AccessAuthorization authorization) => new(this.ruleSets, authorization);
+}

--- a/tests/Application.UnitTests/Spam/History/SpamClassificationHistoryTests.cs
+++ b/tests/Application.UnitTests/Spam/History/SpamClassificationHistoryTests.cs
@@ -1,0 +1,68 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Application.Spam.History;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Accounts;
+using MailFathom.TestSupport;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Spam.History;
+
+/// <summary>Covers reading what classification concluded about an account's mail, which is derived from that mail.</summary>
+public sealed class SpamClassificationHistoryTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("acct-1");
+
+    private readonly ISpamClassificationHistoryReader classifications =
+        Substitute.For<ISpamClassificationHistoryReader>();
+
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedTheAuditRead_IsServedThePageTheReaderHolds()
+    {
+        // Arrange
+        var page = new SpamClassificationHistoryPage([], NextCursor: null);
+        this.classifications
+            .ReadPageAsync(Arg.Any<SpamClassificationHistoryQuery>(), Arg.Any<CancellationToken>())
+            .Returns(page);
+        var history = this.HistoryFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminAuditRead));
+
+        // Act
+        var read = await history.ReadPageAsync(WholeAccount(), TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Same(page, read);
+    }
+
+    /// <summary>A verdict about a message is derived from that message, so the state read grants nothing towards it.</summary>
+    [Fact]
+    public async Task ReadPageAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var history = this.HistoryFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            history.ReadPageAsync(WholeAccount(), TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminAuditRead, refusal.RequiredPermission);
+        await this.classifications.DidNotReceive()
+            .ReadPageAsync(Arg.Any<SpamClassificationHistoryQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    private static SpamClassificationHistoryQuery WholeAccount() => SpamClassificationHistoryQuery.Create(
+        Account,
+        storedEmailId: null,
+        verdict: null,
+        evaluatedFrom: null,
+        evaluatedBefore: null,
+        pageSize: null,
+        cursor: null).Query!;
+
+    private SpamClassificationHistory HistoryFor(AccessAuthorization authorization) =>
+        new(this.classifications, authorization);
+}

--- a/tests/Application.UnitTests/Spam/Runs/SpamClassificationRunReaderTests.cs
+++ b/tests/Application.UnitTests/Spam/Runs/SpamClassificationRunReaderTests.cs
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Application.Spam.Runs;
+using MailFathom.Domain.Access;
+using MailFathom.Domain.Accounts;
+using MailFathom.TestSupport;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Spam.Runs;
+
+/// <summary>Covers watching a whole-mailbox classification run, which is a grant of its own and not the one that starts one.</summary>
+public sealed class SpamClassificationRunReaderTests
+{
+    private static readonly MailAccountId Account = MailAccountId.Create("acct-1");
+
+    private readonly ISpamClassificationRunStore runs = Substitute.For<ISpamClassificationRunStore>();
+
+    [Fact]
+    public async Task FindLatestAsync_AnAccountNeverAskedForARun_IsServedNone()
+    {
+        // Arrange
+        this.runs.FindLatestAsync(Account, Arg.Any<CancellationToken>()).Returns((SpamClassificationRun?)null);
+        var reader = this.ReaderFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var run = await reader.FindLatestAsync(Account, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(run);
+    }
+
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task FindLatestAsync_ACallerGrantedOnlyTheAdministrativeOperate_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var reader = this.ReaderFor(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            reader.FindLatestAsync(Account, TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminRead, refusal.RequiredPermission);
+        await this.runs.DidNotReceive().FindLatestAsync(Arg.Any<MailAccountId>(), Arg.Any<CancellationToken>());
+    }
+
+    private SpamClassificationRunReader ReaderFor(AccessAuthorization authorization) => new(this.runs, authorization);
+}

--- a/tests/Application.UnitTests/Spam/Runs/SpamClassificationRunRequestsTests.cs
+++ b/tests/Application.UnitTests/Spam/Runs/SpamClassificationRunRequestsTests.cs
@@ -2,12 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Spam.Actions;
 using MailFathom.Application.Spam.Runs;
 using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
+using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
 using Xunit;
@@ -97,7 +100,25 @@ public sealed class SpamClassificationRunRequestsTests
     private static SpamClassificationRunTerms TermsOf(SpamActionPosture posture) =>
         SpamClassificationRunTerms.Create([Inbox], posture, rescores: false);
 
-    private SpamClassificationRunRequests CreateRequests()
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task SubmitAsync_ACallerGrantedOnlyTheAdministrativeRead_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var requests = this.CreateRequests(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() => requests.SubmitAsync(
+            Account,
+            TermsOf(SpamActionPosture.DryRun),
+            TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminOperate, refusal.RequiredPermission);
+        Assert.Null(this.runStore.Find(Account));
+    }
+
+    private SpamClassificationRunRequests CreateRequests(AccessAuthorization? authorization = null)
     {
         var sessionFactory = Substitute.For<IPersistenceSessionFactory>();
         sessionFactory.BeginSessionAsync(Arg.Any<CancellationToken>()).Returns(_ => new CommittingSession());
@@ -108,7 +129,8 @@ public sealed class SpamClassificationRunRequestsTests
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
                 this.timeProvider),
-            this.timeProvider);
+            this.timeProvider,
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
     }
 
     private sealed class CommittingSession : IPersistenceSession

--- a/tests/Application.UnitTests/Synchronization/Administration/MailSynchronizationStatusReaderTests.cs
+++ b/tests/Application.UnitTests/Synchronization/Administration/MailSynchronizationStatusReaderTests.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Synchronization.Administration;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
@@ -167,11 +169,29 @@ public sealed class MailSynchronizationStatusReaderTests
         new(folder, ImapUidValidity.Create(1), ImapUid.Create(lastSeenUid), Start);
 
     /// <summary>Builds the reader over one account mapping two folders, which is the arrangement every test above narrows.</summary>
+    /// <summary>The grant is the authority here rather than at the transport, so an entrypoint that passed no filter meets the same refusal.</summary>
+    [Fact]
+    public async Task ReadAsync_ACallerGrantedOnlyTheAdministrativeOperate_IsRefusedWithTheTransportAbsent()
+    {
+        // Arrange
+        var reader = Reader(
+            new MailSynchronizationRunLedger(new FakeTimeProvider(Start)),
+            authorization: AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
+
+        // Act
+        var refusal = await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() =>
+            reader.ReadAsync(TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminRead, refusal.RequiredPermission);
+    }
+
     private static MailSynchronizationStatusReader Reader(
         MailSynchronizationRunLedger ledger,
         bool enabled = true,
         StubMailFolderParticipation? participation = null,
-        IReadOnlyList<MailFolderSynchronizationProgress>? progress = null)
+        IReadOnlyList<MailFolderSynchronizationProgress>? progress = null,
+        AccessAuthorization? authorization = null)
     {
         var accounts = Substitute.For<IMailAccountCatalog>();
         accounts.SynchronizationEnabled.Returns(enabled);
@@ -184,6 +204,7 @@ public sealed class MailSynchronizationStatusReaderTests
             accounts,
             participation ?? StubMailFolderParticipation.Mapping(Inbox, Archive),
             ledger,
-            progressReader);
+            progressReader,
+            authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
     }
 }

--- a/tests/Cli.UnitTests/ContactCommandTests.cs
+++ b/tests/Cli.UnitTests/ContactCommandTests.cs
@@ -558,11 +558,16 @@ public sealed class ContactCommandTests : IDisposable
     }
 
     /// <summary>Promoting is a write of its own, sent to a path of its own rather than carried as a field.</summary>
+    /// <remarks>
+    /// It is also the one write the deployment answers without a record, because the command stated none and the grant
+    /// that writes the book does not admit reading it. So what the command reports is the identity it was given, and an
+    /// operator who wants the record reads it with <c>contact show</c>.
+    /// </remarks>
     [Fact]
-    public async Task Promote_ACollectedContact_AsksThePromotionPathAndPrintsTheRecordItTookOn()
+    public async Task Promote_ACollectedContact_AsksThePromotionPathAndReportsItWithoutTheRecord()
     {
         // Arrange
-        using var deployment = FakeContactDeployment.Holding(write: FakeContactDeployment.Written());
+        using var deployment = FakeContactDeployment.Holding(write: FakeContactDeployment.Promoted());
 
         // Act
         var exitCode = await this.RunAsync(deployment, "contact", "promote", "--id", Identity, "--endpoint", Endpoint);
@@ -572,6 +577,8 @@ public sealed class ContactCommandTests : IDisposable
         Assert.Contains(
             deployment.RecordedRequests,
             request => request.RequestUri?.AbsolutePath.EndsWith("/promotion", StringComparison.Ordinal) == true);
+        Assert.Contains(this.console.Lines, line => line.Contains($"Took on contact {Identity}", StringComparison.Ordinal));
+        Assert.DoesNotContain(this.console.Lines, line => line.Contains("Anna Kowalska", StringComparison.Ordinal));
     }
 
     /// <summary>Erasing cannot be undone, so the record is shown and the question asked before anything is removed.</summary>

--- a/tests/Cli.UnitTests/FakeAdminEndpoint.cs
+++ b/tests/Cli.UnitTests/FakeAdminEndpoint.cs
@@ -49,13 +49,46 @@ internal static class FakeAdminEndpoint
         HttpStatusCode.OK,
         SessionBody(credentialName, version));
 
-    /// <summary>Builds the body the session route answers with.</summary>
+    /// <summary>Builds an endpoint that accepts the credential and reports the grant it holds.</summary>
+    /// <param name="credentialName">The name it reports for the credential.</param>
+    /// <param name="permissions">The permissions it reports the credential holding, which is empty for one granted nothing.</param>
+    /// <returns>The endpoint.</returns>
+    internal static FakeHttpMessageHandler AcceptingWithGrant(
+        string credentialName,
+        params string[] permissions) =>
+        AnsweringBody(HttpStatusCode.OK, SessionBody(credentialName, CommandVersion, permissions));
+
+    /// <summary>Builds the body the session route answers with, stating no grant.</summary>
     /// <param name="credentialName">The name it reports for the credential.</param>
     /// <param name="version">The version it reports.</param>
     /// <returns>The JSON body.</returns>
-    /// <remarks>Shared with the doubles that route by path, so every one of them reports a session the same way and a change to that shape lands in one place.</remarks>
+    /// <remarks>
+    /// Shared with the doubles that route by path, so every one of them reports a session the same way and a change to
+    /// that shape lands in one place. The grant is left out rather than stated, because most of these scenarios are
+    /// about something else and a body carrying one would put a permission list into every assertion about output; a
+    /// test whose subject is the grant states it with <see cref="AcceptingWithGrant" />.
+    /// </remarks>
     internal static string SessionBody(string credentialName, string version) =>
         $$"""{"service":"MailFathom","version":"{{version}}","credential":"{{credentialName}}"}""";
+
+    /// <summary>Builds the body the session route answers with, stating the grant the credential holds.</summary>
+    /// <param name="credentialName">The name it reports for the credential.</param>
+    /// <param name="version">The version it reports.</param>
+    /// <param name="permissions">The permissions it reports, which is empty for a credential granted nothing.</param>
+    /// <returns>The JSON body.</returns>
+    internal static string SessionBody(
+        string credentialName,
+        string version,
+        IReadOnlyList<string> permissions)
+    {
+        ArgumentNullException.ThrowIfNull(permissions);
+
+        var stated = string.Join(',', permissions.Select(permission => $"\"{permission}\""));
+
+        return $$"""
+            {"service":"MailFathom","version":"{{version}}","credential":"{{credentialName}}","permissions":[{{stated}}]}
+            """;
+    }
 
     /// <summary>Builds an endpoint that answers with a status and no usable body.</summary>
     /// <param name="status">The status it answers with.</param>

--- a/tests/Cli.UnitTests/FakeContactDeployment.cs
+++ b/tests/Cli.UnitTests/FakeContactDeployment.cs
@@ -69,6 +69,14 @@ internal static class FakeContactDeployment
         string origin = "Asserted") =>
         $$"""{"outcome":"Written","contact":{{Contact(displayName, addresses, origin, note: null)}}}""";
 
+    /// <summary>Writes the body a promotion answers with, which names the outcome and carries no record.</summary>
+    /// <returns>The response body.</returns>
+    /// <remarks>
+    /// The deployment's answer to a write whose caller stated no record: writing the book and reading it are different
+    /// permissions, so a promotion is told that it happened rather than handed the person it happened to.
+    /// </remarks>
+    internal static string Promoted() => """{"outcome":"Written","contact":null,"addressHolder":null}""";
+
     /// <summary>Writes the body a write answers with when an outcome refused it.</summary>
     /// <param name="outcome">The outcome that refused the write.</param>
     /// <param name="addressHolder">The contact holding a claimed address, where that is what refused it.</param>

--- a/tests/Cli.UnitTests/JobCommandTests.cs
+++ b/tests/Cli.UnitTests/JobCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Net;
 using MailFathom.Cli.Administration;
 using MailFathom.Cli.Credentials;
 using MailFathom.TestSupport;
@@ -213,6 +214,51 @@ public sealed class JobCommandTests : IDisposable
         Assert.Contains(
             this.console.Errors,
             line => line.Contains("holds no job", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A credential the deployment admitted and then refused the operation to is a grant to widen rather than a key to
+    /// rotate, so the refusal names the permission and where it is written instead of saying the credential was refused.
+    /// </summary>
+    [Fact]
+    public async Task DeadLetters_ADeploymentRefusingTheOperationForWantOfAGrant_SaysWhatToGrant()
+    {
+        // Arrange
+        using var deployment = FakeJobDeployment.Serving(
+            deadLetters: (
+                HttpStatusCode.Forbidden,
+                """{"detail":"The credential is not granted 'mailfathom.admin.read'.","permission":"mailfathom.admin.read"}"""));
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "jobs", "dead-letters", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains("mailfathom.admin.read", StringComparison.Ordinal)
+                && line.Contains("AdminEndpoint:Authentication", StringComparison.Ordinal));
+    }
+
+    /// <summary>A refusal naming no permission is repeated as it was written, because widening a grant would not have helped.</summary>
+    [Fact]
+    public async Task DeadLetters_ADeploymentRefusingWithoutNamingAPermission_RepeatsWhatItSaid()
+    {
+        // Arrange
+        using var deployment = FakeJobDeployment.Serving(
+            deadLetters: (
+                HttpStatusCode.Forbidden,
+                """{"detail":"The credential was not admitted to this operation."}"""));
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, "jobs", "dead-letters", "--endpoint", Endpoint);
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(
+            this.console.Errors,
+            line => line.Contains("was not admitted to this operation", StringComparison.Ordinal)
+                && !line.Contains("AdminEndpoint:Authentication", StringComparison.Ordinal));
     }
 
     /// <summary>A job something else already dealt with is named as that rather than as a job nobody has.</summary>

--- a/tests/Cli.UnitTests/LoginCommandTests.cs
+++ b/tests/Cli.UnitTests/LoginCommandTests.cs
@@ -360,6 +360,54 @@ public sealed class LoginCommandTests : IDisposable
     }
 
     /// <summary>
+    /// What the credential may do decides whether any other command will work, so it is reported here rather than
+    /// discovered one refusal at a time.
+    /// </summary>
+    [Fact]
+    public async Task Status_ADeploymentReportingAGrant_NamesEveryPermissionTheCredentialHolds()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        store.Save("production", EndpointAddress, "not-a-real-key", "workstation");
+        using var handler = FakeAdminEndpoint.AcceptingWithGrant(
+            "workstation",
+            "mailfathom.admin.read",
+            "mailfathom.admin.operate");
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "status");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("mailfathom.admin.read", StringComparison.Ordinal)
+                && line.Contains("mailfathom.admin.operate", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A credential granted nothing signs in exactly as one granted everything does, so saying so is the difference
+    /// between an operator understanding what they hold and meeting a refusal on the next command.
+    /// </summary>
+    [Fact]
+    public async Task Status_ACredentialGrantedNothing_SaysSoRatherThanReportingAnEmptyLine()
+    {
+        // Arrange
+        var store = this.CreateStore();
+        store.Save("production", EndpointAddress, "not-a-real-key", "workstation");
+        using var handler = FakeAdminEndpoint.AcceptingWithGrant("workstation");
+
+        // Act
+        var exitCode = await RunAsync(this.Context(store, handler), "status");
+
+        // Assert
+        Assert.Equal(0, exitCode);
+        Assert.Contains(
+            this.console.Lines,
+            line => line.Contains("no administrative permission", StringComparison.Ordinal));
+    }
+
+    /// <summary>
     /// The command that tells an operator what they are administering is also where they learn where to read about it,
     /// and the version that decides which pages those are is the deployment's rather than this command's.
     /// </summary>

--- a/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
@@ -289,6 +289,33 @@ public sealed class AdminApiEndpointsTests
             writeRoute.Metadata.GetMetadata<Microsoft.AspNetCore.Http.Metadata.IRequestSizeLimitMetadata>()!.MaxRequestBodySize);
     }
 
+    /// <summary>
+    /// The other half of the arrangement, and the one no metadata records: a route publishing its permission decides
+    /// nothing unless the group carries the filter that reads it. Deleting that one line leaves every assertion above
+    /// green while serving all 31 routes to any admitted credential, so this exercises the endpoint the mapping built —
+    /// its request delegate, filters included — rather than reading metadata off it.
+    /// </summary>
+    [Fact]
+    public async Task MapAdminApi_ARouteReachedByACallerItsPermissionDoesNotAdmit_IsRefusedByTheGroupsFilter()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder(AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
+        endpoints.MapAdminApi();
+
+        var statusRoute = endpoints.Materialize()
+            .OfType<RouteEndpoint>()
+            .Single(endpoint => endpoint.RoutePattern.RawText?.EndsWith(EmbeddingProfileEndpoints.StatusRoute, StringComparison.Ordinal) == true);
+
+        var request = new DefaultHttpContext { RequestServices = endpoints.ServiceProvider };
+        request.SetEndpoint(statusRoute);
+
+        // Act
+        await statusRoute.RequestDelegate!(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, request.Response.StatusCode);
+    }
+
     /// <summary>Reads back what each mapped route decided, as one line per verb and path.</summary>
     /// <remarks>
     /// Per verb rather than per path, because two verbs on one path are two operations and are deliberately published
@@ -308,16 +335,19 @@ public sealed class AdminApiEndpointsTests
             : "none";
 
     /// <summary>Builds the routing seam the mapping extends, with the routing services the group needs and nothing else.</summary>
+    /// <param name="authorization">What the group's filter asks about the caller, defaulting to the one no test issues a request under.</param>
     /// <remarks>
     /// The recorder is registered because minimal API parameter inference resolves a handler's non-primitive parameters
     /// against the container while the endpoint is built, and refuses to build one it cannot place. It is never invoked
-    /// here — no request is made — so a substitute with no behavior configured is the whole of what this needs.
+    /// by the tests that read metadata — those make no request — so a substitute with no behavior configured is the
+    /// whole of what those need; the one test that does issue a request states the grant it issues it under.
     /// </remarks>
-    private static TestEndpointRouteBuilder BuildRouteBuilder()
+    private static TestEndpointRouteBuilder BuildRouteBuilder(AccessAuthorization? authorization = null)
     {
         var services = new ServiceCollection();
         services.AddRouting();
         services.AddLogging();
+        services.AddScoped(_ => authorization ?? Authorization);
         services.AddScoped(_ => new MailboxRefreshTokenRecorder(
             Substitute.For<IMailAccountCatalog>(),
             Substitute.For<IMailboxRefreshTokenStore>(),

--- a/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
 using MailFathom.Application.AiProviders;
 using MailFathom.Application.Contacts;
@@ -12,13 +13,17 @@ using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Application.Persistence;
+using MailFathom.Domain.Access;
 using MailFathom.Host.Api;
 using MailFathom.Host.Configuration.Embeddings;
 using MailFathom.Host.Configuration.Endpoints;
+using MailFathom.Host.Security.Endpoints;
 using MailFathom.Host.Security.Transport;
 using MailFathom.Host.UnitTests.TestDoubles;
+using MailFathom.TestSupport;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Time.Testing;
@@ -45,6 +50,9 @@ namespace MailFathom.Host.UnitTests.Api;
 /// </remarks>
 public sealed class AdminApiEndpointsTests
 {
+    /// <summary>What the use cases behind the routes consult. Nothing here issues a request, so it is never asked.</summary>
+    private static readonly AccessAuthorization Authorization = AccessAuthorizations.ForPrincipal(principal: null);
+
     /// <summary>
     /// The regression this exists for: a route added to the file but mapped outside the group would compile, answer,
     /// and be unauthenticated, and every other test here would still pass.
@@ -145,6 +153,102 @@ public sealed class AdminApiEndpointsTests
             routes);
     }
 
+    /// <summary>
+    /// The regression this exists for: a route added without deciding what reaching it requires. The decision is
+    /// metadata the route carries, so forgetting it compiles and answers — and the filter over the group refuses such a
+    /// route rather than serving it, which is what this asserts is never something an operator has to discover.
+    /// </summary>
+    [Fact]
+    public void MapAdminApi_Always_LeavesNoRouteWithoutAPublishedDecision()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+
+        // Act
+        endpoints.MapAdminApi();
+
+        // Assert
+        var mapped = endpoints.Materialize();
+        Assert.NotEmpty(mapped);
+        Assert.All(mapped, endpoint => Assert.NotNull(endpoint.Metadata.GetMetadata<AdminRoutePermission>()));
+    }
+
+    /// <summary>
+    /// The allocation itself, pinned. Which permission a route is published under is a decision about what an operator
+    /// can provision separately, so moving one is a change to the deployment contract rather than a refactoring, and
+    /// this is what makes it one somebody has to write down.
+    /// </summary>
+    [Fact]
+    public void MapAdminApi_Always_PublishesEachRouteUnderThePermissionItWasAllocated()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+        var prefix = AdminEndpointOptions.RoutePrefix;
+
+        // Act
+        endpoints.MapAdminApi();
+
+        // Assert
+        Assert.Equal(
+            new[]
+            {
+                $"GET {prefix}{AdminApiEndpoints.SessionRoute} -> none",
+                $"POST {prefix}{MailboxRefreshTokenEndpoint.Route} -> {MailFathomPermission.AdminCredentialsWrite.Name}",
+                $"GET {prefix}{MailboxSynchronizationStatusEndpoint.StatusRoute} -> {MailFathomPermission.AdminRead.Name}",
+                $"GET {prefix}{MailboxMaintenanceEndpoints.RewindRoute} -> {MailFathomPermission.AdminRead.Name}",
+                $"POST {prefix}{MailboxMaintenanceEndpoints.RewindRoute} -> {MailFathomPermission.AdminOperate.Name}",
+                $"POST {prefix}{MailboxMaintenanceEndpoints.RederivationRoute} -> {MailFathomPermission.AdminOperate.Name}",
+                $"GET {prefix}{MailboxMutationAuditEndpoint.Route} -> {MailFathomPermission.AdminAuditRead.Name}",
+                $"GET {prefix}{MailAnsweringAuditEndpoint.Route} -> {MailFathomPermission.AdminAuditRead.Name}",
+                $"GET {prefix}{EmbeddingProfileEndpoints.StatusRoute} -> {MailFathomPermission.AdminRead.Name}",
+                $"GET {prefix}{EmbeddingProfileEndpoints.ActivationRoute} -> {MailFathomPermission.AdminRead.Name}",
+                $"POST {prefix}{EmbeddingProfileEndpoints.ActivationRoute} -> {MailFathomPermission.AdminSpend.Name}",
+                $"POST {prefix}{EmbeddingProfileEndpoints.ReindexCancellationRoute} -> {MailFathomPermission.AdminOperate.Name}",
+                $"GET {prefix}{MailRuleEndpoints.RulesRoute} -> {MailFathomPermission.AdminRead.Name}",
+                $"GET {prefix}{MailRuleEndpoints.RunsRoute} -> {MailFathomPermission.AdminRead.Name}",
+                $"POST {prefix}{MailRuleEndpoints.RunsRoute} -> {MailFathomPermission.AdminOperate.Name}",
+                $"GET {prefix}{MailRuleEndpoints.HistoryRoute} -> {MailFathomPermission.AdminAuditRead.Name}",
+                $"GET {prefix}{SpamClassificationEndpoints.RunsRoute} -> {MailFathomPermission.AdminRead.Name}",
+                $"POST {prefix}{SpamClassificationEndpoints.RunsRoute} -> {MailFathomPermission.AdminOperate.Name}",
+                $"GET {prefix}{SpamClassificationEndpoints.ClassificationsRoute} -> {MailFathomPermission.AdminAuditRead.Name}",
+                $"GET {prefix}{JobDeadLetterEndpoints.DeadLettersRoute} -> {MailFathomPermission.AdminRead.Name}",
+                $"POST {prefix}{JobDeadLetterEndpoints.RetryRoute} -> {MailFathomPermission.AdminOperate.Name}",
+                $"POST {prefix}{JobDeadLetterEndpoints.DropRoute} -> {MailFathomPermission.AdminOperate.Name}",
+                $"POST {prefix}{MailFolderErasureEndpoint.ErasureRoute} -> {MailFathomPermission.AdminErase.Name}",
+                $"GET {prefix}{ContactEndpoints.ContactsRoute} -> {MailFathomPermission.AdminAuditRead.Name}",
+                $"POST {prefix}{ContactEndpoints.ContactsRoute} -> {MailFathomPermission.AdminOperate.Name}",
+                $"GET {prefix}{ContactEndpoints.ContactByAddressRoute} -> {MailFathomPermission.AdminAuditRead.Name}",
+                $"GET {prefix}{ContactEndpoints.ContactRoute} -> {MailFathomPermission.AdminAuditRead.Name}",
+                $"PUT {prefix}{ContactEndpoints.ContactRoute} -> {MailFathomPermission.AdminOperate.Name}",
+                $"DELETE {prefix}{ContactEndpoints.ContactRoute} -> {MailFathomPermission.AdminErase.Name}",
+                $"GET {prefix}{ContactEndpoints.ContactExportRoute} -> {MailFathomPermission.AdminAuditRead.Name}",
+                $"POST {prefix}{ContactEndpoints.ContactPromotionRoute} -> {MailFathomPermission.AdminOperate.Name}",
+            }.Order(StringComparer.Ordinal),
+            PublishedAllocation(endpoints).Order(StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// The one route outside the model, and it is a stated decision rather than a route nobody decided about. A
+    /// credential granted nothing reaches it, which is what lets <c>mfctl login</c> confirm a key before any grant is
+    /// written and what keeps the session read out of every administrative grant.
+    /// </summary>
+    [Fact]
+    public void MapAdminApi_TheSessionRoute_RequiresNoPermission()
+    {
+        // Arrange
+        var endpoints = BuildRouteBuilder();
+
+        // Act
+        endpoints.MapAdminApi();
+
+        // Assert
+        var sessionRoute = endpoints.Materialize()
+            .OfType<RouteEndpoint>()
+            .Single(endpoint => endpoint.RoutePattern.RawText?.EndsWith(AdminApiEndpoints.SessionRoute, StringComparison.Ordinal) == true);
+
+        Assert.False(sessionRoute.Metadata.GetMetadata<AdminRoutePermission>()!.Permission.IsSpecified);
+    }
+
     /// <summary>The write route is a post, because a get carrying a credential reaches every access log on the path.</summary>
     [Fact]
     public void MapAdminApi_TheMailboxRefreshTokenRoute_AcceptsOnlyAPost()
@@ -185,6 +289,24 @@ public sealed class AdminApiEndpointsTests
             writeRoute.Metadata.GetMetadata<Microsoft.AspNetCore.Http.Metadata.IRequestSizeLimitMetadata>()!.MaxRequestBodySize);
     }
 
+    /// <summary>Reads back what each mapped route decided, as one line per verb and path.</summary>
+    /// <remarks>
+    /// Per verb rather than per path, because two verbs on one path are two operations and are deliberately published
+    /// under different permissions: reading what a rewind would cost is not asking for one.
+    /// </remarks>
+    private static IEnumerable<string> PublishedAllocation(TestEndpointRouteBuilder endpoints) => endpoints
+        .Materialize()
+        .OfType<RouteEndpoint>()
+        .SelectMany(
+            endpoint => endpoint.Metadata.GetMetadata<HttpMethodMetadata>()!.HttpMethods,
+            (endpoint, method) => $"{method} /{endpoint.RoutePattern.RawText?.TrimStart('/')} -> {Describe(endpoint)}");
+
+    /// <summary>Names what a route decided, with the route that decided on none saying so.</summary>
+    private static string Describe(Endpoint endpoint) =>
+        endpoint.Metadata.GetMetadata<AdminRoutePermission>() is { Permission.IsSpecified: true } published
+            ? published.Permission.Name
+            : "none";
+
     /// <summary>Builds the routing seam the mapping extends, with the routing services the group needs and nothing else.</summary>
     /// <remarks>
     /// The recorder is registered because minimal API parameter inference resolves a handler's non-primitive parameters
@@ -198,9 +320,11 @@ public sealed class AdminApiEndpointsTests
         services.AddLogging();
         services.AddScoped(_ => new MailboxRefreshTokenRecorder(
             Substitute.For<IMailAccountCatalog>(),
-            Substitute.For<IMailboxRefreshTokenStore>()));
+            Substitute.For<IMailboxRefreshTokenStore>(),
+            Authorization));
         services.AddScoped(_ => Substitute.For<IMailAccountCatalog>());
         services.AddScoped(_ => Substitute.For<IMailboxMutationAuditEntryStore>());
+        services.AddScoped(_ => Substitute.For<IAuthorizedPrincipalSource>());
         RegisterEmbeddingAdministration(services);
         RegisterContactBook(services);
 
@@ -236,17 +360,20 @@ public sealed class AdminApiEndpointsTests
             workloadReader,
             spendGate,
             Substitute.For<IAiProviderHealthReader>(),
-            backfillSchedule));
+            backfillSchedule,
+            Authorization));
         services.AddScoped(_ => new CountedEmbeddingActivation(
             generationStore,
             workloadReader,
             spendGate,
-            new EmbeddingProfileActivation(generationStore, vectorIndex, retryPolicy, backfillSchedule)));
+            new EmbeddingProfileActivation(generationStore, vectorIndex, retryPolicy, backfillSchedule),
+            Authorization));
         services.AddScoped(_ => new EmbeddingReindexCancellation(
             generationStore,
             vectorIndex,
             retryPolicy,
-            backfillSchedule));
+            backfillSchedule,
+            Authorization));
     }
 
     /// <summary>Places what the contact routes resolve, for the reason the embedding registrations exist.</summary>
@@ -268,6 +395,7 @@ public sealed class AdminApiEndpointsTests
                 Substitute.For<IPersistenceSessionFactory>(),
                 new PersistenceConcurrencyOptions(),
                 timeProvider),
-            timeProvider));
+            timeProvider,
+            Authorization));
     }
 }

--- a/tests/Host.UnitTests/Api/AdminSessionResponseTests.cs
+++ b/tests/Host.UnitTests/Api/AdminSessionResponseTests.cs
@@ -1,0 +1,83 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Claims;
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Api;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Api;
+
+/// <summary>Covers what the session read tells a caller about itself, which is the one question every caller may ask.</summary>
+/// <remarks>
+/// The route requires no permission, so what it answers is what a credential granted nothing sees. Reporting the grant
+/// there is what lets an operator read what they hold instead of discovering it one refusal at a time, and what makes a
+/// credential retired by narrowing its entry to nothing distinguishable from one that still works.
+/// </remarks>
+public sealed class AdminSessionResponseTests
+{
+    [Fact]
+    public void For_ACallerWithAGrant_ReportsEveryPermissionItHolds()
+    {
+        // Arrange
+        var principal = AuthorizedPrincipal.Caller(
+            "workstation",
+            [MailFathomPermission.AdminOperate, MailFathomPermission.AdminRead]);
+
+        // Act
+        var session = AdminSessionResponse.For(new ClaimsPrincipal(new ClaimsIdentity()), principal);
+
+        // Assert
+        Assert.Equal(
+            [MailFathomPermission.AdminRead.Name, MailFathomPermission.AdminOperate.Name],
+            session.Permissions);
+    }
+
+    /// <summary>
+    /// The published order rather than the grant's own, so two credentials granted the same permissions read
+    /// identically whichever order an operator happened to write them in.
+    /// </summary>
+    [Fact]
+    public void For_TwoGrantsWrittenInDifferentOrders_ReportsThemIdentically()
+    {
+        // Arrange
+        var caller = new ClaimsPrincipal(new ClaimsIdentity());
+
+        // Act
+        var first = AdminSessionResponse.For(
+            caller,
+            AuthorizedPrincipal.Caller("one", [MailFathomPermission.AdminRead, MailFathomPermission.AdminErase]));
+        var second = AdminSessionResponse.For(
+            caller,
+            AuthorizedPrincipal.Caller("two", [MailFathomPermission.AdminErase, MailFathomPermission.AdminRead]));
+
+        // Assert
+        Assert.Equal(first.Permissions, second.Permissions);
+    }
+
+    /// <summary>A credential granted nothing reaches this route and nowhere else, and "nothing" is the accurate answer.</summary>
+    [Fact]
+    public void For_ACallerGrantedNothing_ReportsAnEmptyGrantRatherThanFailing()
+    {
+        // Act
+        var session = AdminSessionResponse.For(
+            new ClaimsPrincipal(new ClaimsIdentity()),
+            AuthorizedPrincipal.Caller("retired", []));
+
+        // Assert
+        Assert.Empty(session.Permissions);
+    }
+
+    /// <summary>A request that established no principal is answered rather than faulted, for the same reason.</summary>
+    [Fact]
+    public void For_ARequestThatEstablishedNoPrincipal_ReportsAnEmptyGrant()
+    {
+        // Act
+        var session = AdminSessionResponse.For(new ClaimsPrincipal(new ClaimsIdentity()), principal: null);
+
+        // Assert
+        Assert.Empty(session.Permissions);
+    }
+}

--- a/tests/Host.UnitTests/Api/ContactEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/ContactEndpointsTests.cs
@@ -101,6 +101,50 @@ public sealed class ContactEndpointsTests
             Arg.Any<CancellationToken>());
     }
 
+    /// <summary>Writing is published under the operating grant and reading the book under the audit one, so a refused write hands back no record.</summary>
+    /// <remarks>
+    /// The record the book had to read in order to refuse the write is the whole of what the answer could leak here: a
+    /// caller granted only <c>mailfathom.admin.operate</c> would otherwise read any collected contact in full by asking
+    /// to amend it, which is a read of somebody's correspondents through the one route nobody watches for one.
+    /// </remarks>
+    [Fact]
+    public async Task AmendAsync_AWriteAnOriginRefuses_AnswersWithTheOutcomeAndNoRecord()
+    {
+        // Arrange
+        this.Holds(Collected("Anna Kowalska", "anna@example.test"));
+
+        // Act
+        var result = await ContactEndpoints.AmendAsync(
+            Identity,
+            new ContactRecordRequest("Anna Nowak", ["anna@example.test"], "anna@example.test", Note: null),
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var amended = Assert.IsType<Ok<ContactWriteResponse>>(result.Result);
+        Assert.Null(amended.Value!.Contact);
+        Assert.Null(amended.Value.AddressHolder);
+    }
+
+    /// <summary>A promotion of somebody already asserted wrote nothing either, so it echoes nothing back.</summary>
+    [Fact]
+    public async Task PromoteAsync_AContactAlreadyAsserted_AnswersWithTheOutcomeAndNoRecord()
+    {
+        // Arrange
+        this.Holds(Asserted("Anna Kowalska", "anna@example.test"));
+
+        // Act
+        var result = await ContactEndpoints.PromoteAsync(
+            Identity,
+            this.Book(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var promoted = Assert.IsType<Ok<ContactWriteResponse>>(result.Result);
+        Assert.Equal(nameof(ContactWriteOutcome.AlreadyAsserted), promoted.Value!.Outcome);
+        Assert.Null(promoted.Value.Contact);
+    }
+
     /// <summary>Each rule a record can break is named, and none of the answers repeats what broke it.</summary>
     /// <remarks>
     /// The cases are written as the wire's own values rather than as request objects, because the request type is

--- a/tests/Host.UnitTests/Api/ContactEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/ContactEndpointsTests.cs
@@ -7,6 +7,7 @@ using MailFathom.Application.Persistence;
 using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Emails;
 using MailFathom.Host.Api;
+using MailFathom.Host.UnitTests.TestDoubles;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Time.Testing;
@@ -221,7 +222,7 @@ public sealed class ContactEndpointsTests
         // Act
         var result = await ContactEndpoints.FindAsync(
             Identity,
-            this.directory,
+            this.Book(),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -236,7 +237,7 @@ public sealed class ContactEndpointsTests
         // Act
         var result = await ContactEndpoints.FindAsync(
             Guid.Empty,
-            this.directory,
+            this.Book(),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -256,7 +257,7 @@ public sealed class ContactEndpointsTests
         // Act
         var result = await ContactEndpoints.FindByAddressAsync(
             address,
-            this.directory,
+            this.Book(),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -280,7 +281,7 @@ public sealed class ContactEndpointsTests
             origin: null,
             pageSize: null,
             cursor: null,
-            this.directory,
+            this.Book(),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -302,7 +303,7 @@ public sealed class ContactEndpointsTests
             "collected",
             pageSize: null,
             cursor: null,
-            this.directory,
+            this.Book(),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -328,7 +329,7 @@ public sealed class ContactEndpointsTests
             origin,
             pageSize,
             cursor,
-            this.directory,
+            this.Book(),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -466,7 +467,8 @@ public sealed class ContactEndpointsTests
             this.store,
             this.directory,
             new OptimisticConcurrencyRetryPolicy(sessionFactory, new PersistenceConcurrencyOptions(), this.clock),
-            this.clock);
+            this.clock,
+            AdministrativeGrant.WholeSurface);
     }
 
     /// <summary>A session that commits whatever was staged in it, which is what a write's ordinary path needs.</summary>

--- a/tests/Host.UnitTests/Api/EmbeddingProfileEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/EmbeddingProfileEndpointsTests.cs
@@ -12,6 +12,7 @@ using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Persistence;
 using MailFathom.Host.Api;
 using MailFathom.Host.Configuration.Embeddings;
+using MailFathom.Host.UnitTests.TestDoubles;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Time.Testing;
@@ -291,9 +292,21 @@ public sealed class EmbeddingProfileEndpointsTests
                 generationStore,
                 workloadReader,
                 spendGate,
-                new EmbeddingProfileActivation(generationStore, vectorIndex, retryPolicy, backfillSchedule)),
-            new EmbeddingStatusReader(generationStore, workloadReader, spendGate, providerHealth, backfillSchedule),
-            new EmbeddingReindexCancellation(generationStore, vectorIndex, retryPolicy, backfillSchedule));
+                new EmbeddingProfileActivation(generationStore, vectorIndex, retryPolicy, backfillSchedule),
+                AdministrativeGrant.WholeSurface),
+            new EmbeddingStatusReader(
+                generationStore,
+                workloadReader,
+                spendGate,
+                providerHealth,
+                backfillSchedule,
+                AdministrativeGrant.WholeSurface),
+            new EmbeddingReindexCancellation(
+                generationStore,
+                vectorIndex,
+                retryPolicy,
+                backfillSchedule,
+                AdministrativeGrant.WholeSurface));
     }
 
     /// <summary>The ports one request runs against, and the three services the routes resolve.</summary>

--- a/tests/Host.UnitTests/Api/JobDeadLetterEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/JobDeadLetterEndpointsTests.cs
@@ -184,7 +184,7 @@ public sealed class JobDeadLetterEndpointsTests
         // Act
         var result = await JobDeadLetterEndpoints.RetryAsync(
             new JobRecoveryRequest(job.Value),
-            this.deadLetters,
+            this.DeadLetterOperations(),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -210,7 +210,7 @@ public sealed class JobDeadLetterEndpointsTests
         // Act
         var result = await JobDeadLetterEndpoints.DropAsync(
             new JobRecoveryRequest(job.Value),
-            this.deadLetters,
+            this.DeadLetterOperations(),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -230,7 +230,7 @@ public sealed class JobDeadLetterEndpointsTests
         // Act
         var result = await JobDeadLetterEndpoints.RetryAsync(
             request,
-            this.deadLetters,
+            this.DeadLetterOperations(),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -266,8 +266,11 @@ public sealed class JobDeadLetterEndpointsTests
             pageSize,
             cursor,
             CatalogServing(Account),
-            this.deadLetters,
+            this.DeadLetterOperations(),
             TestContext.Current.CancellationToken);
+
+    /// <summary>The use case the routes reach, over the store this suite arranges and with the grant granted.</summary>
+    private DeadLetteredJobs DeadLetterOperations() => new(this.deadLetters, AdministrativeGrant.WholeSurface);
 
     private static IMailAccountCatalog CatalogServing(params MailAccountId[] accounts)
     {

--- a/tests/Host.UnitTests/Api/MailFolderErasureEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/MailFolderErasureEndpointTests.cs
@@ -224,7 +224,8 @@ public sealed class MailFolderErasureEndpointTests
                 sessionFactory,
                 new PersistenceConcurrencyOptions(),
                 new FakeTimeProvider()),
-            new MailboxSynchronizationOptions());
+            new MailboxSynchronizationOptions(),
+            AdministrativeGrant.WholeSurface);
     }
 
     private static IMailAccountCatalog CatalogServing(params MailAccountId[] accounts)

--- a/tests/Host.UnitTests/Api/MailRuleEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/MailRuleEndpointsTests.cs
@@ -270,7 +270,7 @@ public sealed class MailRuleEndpointsTests
         var result = await MailRuleEndpoints.ReadRunAsync(
             Account.Value,
             CatalogServing(Account),
-            this.runs,
+            new MailRuleEvaluationRunReader(this.runs, AdministrativeGrant.WholeSurface),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -300,7 +300,7 @@ public sealed class MailRuleEndpointsTests
         var result = await MailRuleEndpoints.ReadRunAsync(
             Account.Value,
             CatalogServing(Account),
-            this.runs,
+            new MailRuleEvaluationRunReader(this.runs, AdministrativeGrant.WholeSurface),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -316,7 +316,7 @@ public sealed class MailRuleEndpointsTests
         var result = await MailRuleEndpoints.ReadRunAsync(
             "nowhere",
             CatalogServing(Account),
-            this.runs,
+            new MailRuleEvaluationRunReader(this.runs, AdministrativeGrant.WholeSurface),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -519,12 +519,12 @@ public sealed class MailRuleEndpointsTests
         return catalog;
     }
 
-    private static IMailRuleSetSource SourceOf(MailRuleSet ruleSet)
+    private static MailRuleSetReader SourceOf(MailRuleSet ruleSet)
     {
         var source = Substitute.For<IMailRuleSetSource>();
         source.Current.Returns(ruleSet);
 
-        return source;
+        return new MailRuleSetReader(source, AdministrativeGrant.WholeSurface);
     }
 
     private static MailRuleSet RuleSetOf(params MailRule[] rules) => MailRuleSet.Create(
@@ -575,7 +575,8 @@ public sealed class MailRuleEndpointsTests
                     sessionFactory,
                     new PersistenceConcurrencyOptions(),
                     this.timeProvider),
-                this.timeProvider),
+                this.timeProvider,
+                AdministrativeGrant.WholeSurface),
             TestContext.Current.CancellationToken);
     }
 
@@ -596,7 +597,7 @@ public sealed class MailRuleEndpointsTests
             pageSize,
             cursor,
             CatalogServing(Account),
-            this.history,
+            new MailRuleHistory(this.history, AdministrativeGrant.WholeSurface),
             TestContext.Current.CancellationToken);
 
     private sealed class CommittingSession : IPersistenceSession

--- a/tests/Host.UnitTests/Api/MailboxMaintenanceEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/MailboxMaintenanceEndpointsTests.cs
@@ -258,7 +258,7 @@ public sealed class MailboxMaintenanceEndpointsTests
     private static MailSynchronizationRewind RewindOver(
         ISynchronizationCheckpointStore checkpoints,
         int storedEmailCount) =>
-        new(checkpoints, new FixedCounter(storedEmailCount), RetryPolicy());
+        new(checkpoints, new FixedCounter(storedEmailCount), RetryPolicy(), AdministrativeGrant.WholeSurface);
 
     private static StoredMailRederivation RederivationOver(IStoredMailRederivationStore store)
     {
@@ -282,7 +282,7 @@ public sealed class MailboxMaintenanceEndpointsTests
                 ExtractedEmailText.FromPlainTextBody("Body", "Body"),
                 SenderAuthentication.NotEstablished()))));
 
-        return new StoredMailRederivation(store, contentStore, mimeReader, RetryPolicy());
+        return new StoredMailRederivation(store, contentStore, mimeReader, RetryPolicy(), AdministrativeGrant.WholeSurface);
     }
 
     private static OptimisticConcurrencyRetryPolicy RetryPolicy()

--- a/tests/Host.UnitTests/Api/MailboxRefreshTokenEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/MailboxRefreshTokenEndpointTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using MailFathom.Application.Accounts;
 using MailFathom.Domain.Accounts;
 using MailFathom.Host.Api;
+using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -180,6 +181,6 @@ public sealed class MailboxRefreshTokenEndpointTests
         var catalog = Substitute.For<IMailAccountCatalog>();
         catalog.ServedAccounts.Returns([.. servedAccountIds.Select(SyntheticServedAccount.Of)]);
 
-        return new MailboxRefreshTokenRecorder(catalog, this.store);
+        return new MailboxRefreshTokenRecorder(catalog, this.store, AdministrativeGrant.WholeSurface);
     }
 }

--- a/tests/Host.UnitTests/Api/MailboxSynchronizationStatusEndpointTests.cs
+++ b/tests/Host.UnitTests/Api/MailboxSynchronizationStatusEndpointTests.cs
@@ -8,6 +8,7 @@ using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Host.Api;
+using MailFathom.Host.UnitTests.TestDoubles;
 using MailFathom.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using NSubstitute;
@@ -124,6 +125,7 @@ public sealed class MailboxSynchronizationStatusEndpointTests
             accounts,
             StubMailFolderParticipation.Mapping(Inbox),
             ledger,
-            progressReader);
+            progressReader,
+            AdministrativeGrant.WholeSurface);
     }
 }

--- a/tests/Host.UnitTests/Api/SpamClassificationEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/SpamClassificationEndpointsTests.cs
@@ -258,7 +258,7 @@ public sealed class SpamClassificationEndpointsTests
         var result = await SpamClassificationEndpoints.ReadRunAsync(
             Account.Value,
             CatalogServing(Account),
-            this.runs,
+            new SpamClassificationRunReader(this.runs, AdministrativeGrant.WholeSurface),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -289,7 +289,7 @@ public sealed class SpamClassificationEndpointsTests
         var result = await SpamClassificationEndpoints.ReadRunAsync(
             Account.Value,
             CatalogServing(Account),
-            this.runs,
+            new SpamClassificationRunReader(this.runs, AdministrativeGrant.WholeSurface),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -310,7 +310,7 @@ public sealed class SpamClassificationEndpointsTests
         var result = await SpamClassificationEndpoints.ReadRunAsync(
             "nowhere",
             CatalogServing(Account),
-            this.runs,
+            new SpamClassificationRunReader(this.runs, AdministrativeGrant.WholeSurface),
             TestContext.Current.CancellationToken);
 
         // Assert
@@ -461,7 +461,8 @@ public sealed class SpamClassificationEndpointsTests
                     sessionFactory,
                     new PersistenceConcurrencyOptions(),
                     this.timeProvider),
-                this.timeProvider),
+                this.timeProvider,
+                AdministrativeGrant.WholeSurface),
             TestContext.Current.CancellationToken);
     }
 
@@ -482,7 +483,7 @@ public sealed class SpamClassificationEndpointsTests
             pageSize,
             cursor,
             CatalogServing(Account),
-            this.classifications,
+            new SpamClassificationHistory(this.classifications, AdministrativeGrant.WholeSurface),
             TestContext.Current.CancellationToken);
 
     private sealed class CommittingSession : IPersistenceSession

--- a/tests/Host.UnitTests/Host.UnitTests.csproj
+++ b/tests/Host.UnitTests/Host.UnitTests.csproj
@@ -12,6 +12,8 @@
     <Compile Include="..\shared\RecordingLoggerFactory.cs" Link="RecordingLoggerFactory.cs" />
     <Compile Include="..\shared\ExceptionHierarchyAssertion.cs" Link="ExceptionHierarchyAssertion.cs" />
     <Compile Include="..\shared\TestCertificates.cs" Link="TestCertificates.cs" />
+    <!-- Every administrative route builds the use case behind it, and every one of those asks who reached it. -->
+    <Compile Include="..\shared\AccessAuthorizations.cs" Link="AccessAuthorizations.cs" />
     <Compile Include="..\shared\StubMailFolderParticipation.cs" Link="StubMailFolderParticipation.cs" />
     <Compile Include="..\shared\StubJunkMailFolderCatalog.cs" Link="StubJunkMailFolderCatalog.cs" />
     <!-- The synchronization harness composes the classification gate, which reports through this. -->

--- a/tests/Host.UnitTests/Hosting/Warnings/TransportGrantStartupReportTests.cs
+++ b/tests/Host.UnitTests/Hosting/Warnings/TransportGrantStartupReportTests.cs
@@ -213,9 +213,9 @@ public sealed class TransportGrantStartupReportTests
             StringComparison.Ordinal);
     }
 
-    /// <summary>Saying the same of both surfaces would tell an operator narrowing an administrative entry that it bites, which it does not.</summary>
+    /// <summary>The two surfaces refuse differently, so a line that said the same of both would be wrong about one of them.</summary>
     [Fact]
-    public async Task StartAsync_AnEntryOnTheAdministrativeSurface_SaysNoRouteConsultsAPermissionYet()
+    public async Task StartAsync_AnEntryOnTheAdministrativeSurface_SaysARefusalNamesThePermissionThatWouldSuffice()
     {
         // Arrange
         using var logs = new RecordingLoggerProvider();
@@ -233,7 +233,7 @@ public sealed class TransportGrantStartupReportTests
         // Assert
         var record = Assert.Single(logs.Records);
         Assert.Contains(
-            "No route here consults a permission yet",
+            "refused with that permission named",
             Assert.Contains("GrantEnforcement", record.Properties)?.ToString(),
             StringComparison.Ordinal);
     }

--- a/tests/Host.UnitTests/Security/Endpoints/AdminRouteAuthorizationTests.cs
+++ b/tests/Host.UnitTests/Security/Endpoints/AdminRouteAuthorizationTests.cs
@@ -1,0 +1,179 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using MailFathom.Host.Security.Endpoints;
+using MailFathom.TestSupport;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Security.Endpoints;
+
+/// <summary>Covers the one filter the administrative group carries, which is what a published decision costs a caller.</summary>
+/// <remarks>
+/// Three behaviors, and the third is the one that makes the arrangement fail closed. A route that decided a permission
+/// admits the callers holding it and refuses the rest; a route that decided none admits everybody, including a
+/// credential granted nothing; and a route that decided nothing at all is refused rather than served, so forgetting to
+/// decide produces a route nobody reaches instead of a route everybody does.
+/// </remarks>
+public sealed class AdminRouteAuthorizationTests
+{
+    /// <summary>The ordinary path: a caller holding what the route publishes reaches the handler and gets its answer.</summary>
+    [Fact]
+    public async Task RefuseUnpermittedAsync_ACallerHoldingWhatTheRoutePublishes_ReachesTheHandler()
+    {
+        // Arrange
+        var context = ContextFor(
+            AdminRoutePermission.Requiring(MailFathomPermission.AdminRead),
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var answer = await AdminRouteAuthorization.RefuseUnpermittedAsync(context, _ => ValueTask.FromResult<object?>("served"));
+
+        // Assert
+        Assert.Equal("served", answer);
+    }
+
+    /// <summary>The refusal names the one permission that would have sufficed, and the caller never reaches the handler.</summary>
+    [Fact]
+    public async Task RefuseUnpermittedAsync_ACallerWithoutIt_RefusesNamingThatPermissionAlone()
+    {
+        // Arrange
+        var reached = false;
+        var context = ContextFor(
+            AdminRoutePermission.Requiring(MailFathomPermission.AdminRead),
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate));
+
+        // Act
+        var answer = await AdminRouteAuthorization.RefuseUnpermittedAsync(
+            context,
+            _ =>
+            {
+                reached = true;
+
+                return ValueTask.FromResult<object?>("served");
+            });
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(answer);
+        Assert.Equal(StatusCodes.Status403Forbidden, refusal.StatusCode);
+        Assert.Contains(MailFathomPermission.AdminRead.Name, refusal.ProblemDetails.Detail, StringComparison.Ordinal);
+        Assert.DoesNotContain(MailFathomPermission.AdminOperate.Name, refusal.ProblemDetails.Detail, StringComparison.Ordinal);
+        Assert.False(reached);
+    }
+
+    /// <summary>The permission travels as its own member as well, so <c>mfctl</c> reads what to grant rather than parsing the sentence.</summary>
+    [Fact]
+    public async Task RefuseUnpermittedAsync_ACallerWithoutIt_CarriesThePermissionAsItsOwnMember()
+    {
+        // Arrange
+        var context = ContextFor(
+            AdminRoutePermission.Requiring(MailFathomPermission.AdminErase),
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var answer = await AdminRouteAuthorization.RefuseUnpermittedAsync(context, _ => ValueTask.FromResult<object?>("served"));
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(answer);
+        Assert.Equal(
+            MailFathomPermission.AdminErase.Name,
+            Assert.Contains(AdminRouteAuthorization.PermissionExtension, refusal.ProblemDetails.Extensions));
+    }
+
+    /// <summary>The session route's case: a credential granted nothing still reaches a route published under no permission.</summary>
+    [Fact]
+    public async Task RefuseUnpermittedAsync_ARouteRequiringNoPermission_ServesACallerGrantedNothing()
+    {
+        // Arrange
+        var context = ContextFor(AdminRoutePermission.None, AccessAuthorizations.ForCallerGranted());
+
+        // Act
+        var answer = await AdminRouteAuthorization.RefuseUnpermittedAsync(context, _ => ValueTask.FromResult<object?>("served"));
+
+        // Assert
+        Assert.Equal("served", answer);
+    }
+
+    /// <summary>
+    /// The regression the whole arrangement exists for. A route mapped into the group without deciding anything is
+    /// refused rather than served, so a permission nobody remembered to write is a route nobody reaches.
+    /// </summary>
+    [Fact]
+    public async Task RefuseUnpermittedAsync_ARouteThatDecidedNothing_RefusesEveryCaller()
+    {
+        // Arrange
+        var reached = false;
+        var context = ContextFor(
+            publishedPermission: null,
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var answer = await AdminRouteAuthorization.RefuseUnpermittedAsync(
+            context,
+            _ =>
+            {
+                reached = true;
+
+                return ValueTask.FromResult<object?>("served");
+            });
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(answer);
+        Assert.Equal(StatusCodes.Status403Forbidden, refusal.StatusCode);
+        Assert.False(reached);
+        Assert.DoesNotContain(AdminRouteAuthorization.PermissionExtension, refusal.ProblemDetails.Extensions);
+    }
+
+    /// <summary>
+    /// The use case is the authority, and this is what its refusal looks like to a caller: the same shape as the
+    /// transport's own, rather than an unhandled fault reported as a deployment that broke.
+    /// </summary>
+    [Fact]
+    public async Task RefuseUnpermittedAsync_AUseCaseRefusingBehindAPermittedRoute_AnswersInTheSameShape()
+    {
+        // Arrange
+        var authorization = AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead);
+        var context = ContextFor(AdminRoutePermission.Requiring(MailFathomPermission.AdminRead), authorization);
+
+        // Act
+        var answer = await AdminRouteAuthorization.RefuseUnpermittedAsync(
+            context,
+            _ =>
+            {
+                authorization.RequirePermission(MailFathomPermission.AdminErase);
+
+                return ValueTask.FromResult<object?>("served");
+            });
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(answer);
+        Assert.Equal(StatusCodes.Status403Forbidden, refusal.StatusCode);
+        Assert.Equal(
+            MailFathomPermission.AdminErase.Name,
+            Assert.Contains(AdminRouteAuthorization.PermissionExtension, refusal.ProblemDetails.Extensions));
+    }
+
+    /// <summary>Builds one request against a route carrying the decision named, or carrying none at all.</summary>
+    private static EndpointFilterInvocationContext ContextFor(
+        AdminRoutePermission? publishedPermission,
+        AccessAuthorization authorization)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(authorization);
+
+        var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+        httpContext.SetEndpoint(new Endpoint(
+            requestDelegate: null,
+            publishedPermission is null
+                ? EndpointMetadataCollection.Empty
+                : new EndpointMetadataCollection(publishedPermission),
+            "an administrative route"));
+
+        return EndpointFilterInvocationContext.Create(httpContext);
+    }
+}

--- a/tests/Host.UnitTests/Security/Endpoints/AdminRouteAuthorizationTests.cs
+++ b/tests/Host.UnitTests/Security/Endpoints/AdminRouteAuthorizationTests.cs
@@ -158,21 +158,64 @@ public sealed class AdminRouteAuthorizationTests
             Assert.Contains(AdminRouteAuthorization.PermissionExtension, refusal.ProblemDetails.Extensions));
     }
 
+    /// <summary>
+    /// The neighbour of the case above, and the one that would fail open rather than closed: a route stating two
+    /// decisions has no decision, and reading the last of them would let a second declaration — possibly the one
+    /// requiring nothing — quietly replace what the route was published under.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task RefuseUnpermittedAsync_ARouteThatDecidedTwice_RefusesEveryCallerWhicheverCameLast(
+        bool lastRequiresNothing)
+    {
+        // Arrange
+        var reached = false;
+        var decisions = lastRequiresNothing
+            ? new object[] { AdminRoutePermission.Requiring(MailFathomPermission.AdminRead), AdminRoutePermission.None }
+            : [AdminRoutePermission.None, AdminRoutePermission.Requiring(MailFathomPermission.AdminRead)];
+
+        var context = ContextFor(
+            new EndpointMetadataCollection(decisions),
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead));
+
+        // Act
+        var answer = await AdminRouteAuthorization.RefuseUnpermittedAsync(
+            context,
+            _ =>
+            {
+                reached = true;
+
+                return ValueTask.FromResult<object?>("served");
+            });
+
+        // Assert
+        var refusal = Assert.IsType<ProblemHttpResult>(answer);
+        Assert.Equal(StatusCodes.Status403Forbidden, refusal.StatusCode);
+        Assert.False(reached);
+        Assert.DoesNotContain(AdminRouteAuthorization.PermissionExtension, refusal.ProblemDetails.Extensions);
+    }
+
     /// <summary>Builds one request against a route carrying the decision named, or carrying none at all.</summary>
     private static EndpointFilterInvocationContext ContextFor(
         AdminRoutePermission? publishedPermission,
+        AccessAuthorization authorization) =>
+        ContextFor(
+            publishedPermission is null
+                ? EndpointMetadataCollection.Empty
+                : new EndpointMetadataCollection(publishedPermission),
+            authorization);
+
+    /// <summary>Builds one request against a route carrying exactly the metadata named.</summary>
+    private static EndpointFilterInvocationContext ContextFor(
+        EndpointMetadataCollection metadata,
         AccessAuthorization authorization)
     {
         var services = new ServiceCollection();
         services.AddSingleton(authorization);
 
         var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
-        httpContext.SetEndpoint(new Endpoint(
-            requestDelegate: null,
-            publishedPermission is null
-                ? EndpointMetadataCollection.Empty
-                : new EndpointMetadataCollection(publishedPermission),
-            "an administrative route"));
+        httpContext.SetEndpoint(new Endpoint(requestDelegate: null, metadata, "an administrative route"));
 
         return EndpointFilterInvocationContext.Create(httpContext);
     }

--- a/tests/Host.UnitTests/Security/Endpoints/AdminRoutePermissionTests.cs
+++ b/tests/Host.UnitTests/Security/Endpoints/AdminRoutePermissionTests.cs
@@ -1,0 +1,52 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+using MailFathom.Host.Security.Endpoints;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Security.Endpoints;
+
+/// <summary>Covers what a route may decide, which is refused while the routes are mapped rather than at a request.</summary>
+/// <remarks>
+/// Both refusals are defects in this repository rather than in anything an operator wrote, and both produce a route no
+/// credential could ever reach. Startup is therefore where they are found: a deployment that would answer nobody on one
+/// of its routes should not start at all.
+/// </remarks>
+public sealed class AdminRoutePermissionTests
+{
+    [Fact]
+    public void Requiring_APublishedAdministrativePermission_CarriesIt()
+    {
+        // Act
+        var published = AdminRoutePermission.Requiring(MailFathomPermission.AdminOperate);
+
+        // Assert
+        Assert.Equal(MailFathomPermission.AdminOperate, published.Permission);
+    }
+
+    /// <summary>The struct default names nothing, so a route published under it would be a route bounded by nothing.</summary>
+    [Fact]
+    public void Requiring_TheUnspecifiedDefault_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() => AdminRoutePermission.Requiring(default));
+    }
+
+    /// <summary>A name from the other surface is one no administrative grant can carry, so the route would answer nobody.</summary>
+    [Fact]
+    public void Requiring_APermissionOfTheMailSurface_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() => AdminRoutePermission.Requiring(MailFathomPermission.MailRead));
+    }
+
+    /// <summary>The route that requires none says so, rather than being a route whose decision is missing.</summary>
+    [Fact]
+    public void None_Always_NamesNoPermission()
+    {
+        // Act, Assert
+        Assert.False(AdminRoutePermission.None.Permission.IsSpecified);
+    }
+}

--- a/tests/Host.UnitTests/TestDoubles/AdministrativeGrant.cs
+++ b/tests/Host.UnitTests/TestDoubles/AdministrativeGrant.cs
@@ -1,0 +1,24 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Access;
+using MailFathom.Domain.Access;
+using MailFathom.TestSupport;
+
+namespace MailFathom.Host.UnitTests.TestDoubles;
+
+/// <summary>The grant an endpoint test arranges when the grant is not what that test is about.</summary>
+/// <remarks>
+/// An endpoint test's subject is what the route decides about a request — an account it does not serve, a page size out
+/// of range, a cursor issued for other filters — and every one of those is reached through a use case that now asks what
+/// the caller holds. Granting the whole surface keeps those tests about the shapes they were written for. Which
+/// permission each route is published under is asserted in <c>AdminApiEndpointsTests</c>, and what each use case refuses
+/// without is asserted where that use case lives, so nothing is left unproven by arranging a caller who holds all of it.
+/// </remarks>
+internal static class AdministrativeGrant
+{
+    /// <summary>Gets the authorization of a caller granted every permission this surface publishes.</summary>
+    internal static AccessAuthorization WholeSurface { get; } = AccessAuthorizations.ForCallerGranted(
+        [.. MailFathomPermission.All.Where(permission => permission.Surface == ProtectedSurface.Administration)]);
+}

--- a/tests/IntegrationTests/Hosting/ComposedAdminEndpointSecurityTests.cs
+++ b/tests/IntegrationTests/Hosting/ComposedAdminEndpointSecurityTests.cs
@@ -164,6 +164,75 @@ public sealed class ComposedAdminEndpointSecurityTests
         Assert.Equal("Bearer", Assert.Single(protocolRefusal.Headers.WwwAuthenticate).Scheme);
     }
 
+    /// <summary>
+    /// What no unit test can reach: that the filter reading each route's published permission is attached to the group
+    /// the mapping builds, rather than merely written. An endpoint filter is not endpoint metadata, so nothing about it
+    /// is readable off a built endpoint — deleting the line that attaches it leaves every route serving any admitted
+    /// credential. Both directions are one claim and are asserted together: the same credential reaches the route its
+    /// one permission publishes and is refused the route another does.
+    /// </summary>
+    [Fact]
+    public async Task AdminEndpoint_ACredentialGrantedOneAdministrativePermission_ReachesThatRouteAndIsRefusedAnother()
+    {
+        // Arrange
+        using var client = await this.orchestration.OpenAdminEndpointClientAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        using var permittedRequest = AuthenticatedGet("/api/admin/rules", OrchestrationContract.AdminNarrowedApiKey);
+        using var permitted = await client.SendAsync(permittedRequest, TestContext.Current.CancellationToken);
+
+        using var refusedRequest = AuthenticatedGet("/api/admin/contacts", OrchestrationContract.AdminNarrowedApiKey);
+        using var refused = await client.SendAsync(refusedRequest, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, permitted.StatusCode);
+        Assert.Equal(HttpStatusCode.Forbidden, refused.StatusCode);
+
+        using var problem = JsonDocument.Parse(
+            await refused.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal("mailfathom.admin.audit.read", problem.RootElement.GetProperty("permission").GetString());
+        Assert.False(problem.RootElement.TryGetProperty("contacts", out _));
+    }
+
+    /// <summary>
+    /// The one route published under no permission, reached by a credential the rest of the surface refuses, reporting
+    /// back exactly what that credential holds. It is what <c>mfctl status</c> prints, and the only way an operator
+    /// learns a grant without reading the deployment's own configuration.
+    /// </summary>
+    [Fact]
+    public async Task AdminEndpoint_TheSessionRoute_ReportsTheGrantTheCredentialWasAdmittedUnder()
+    {
+        // Arrange
+        using var client = await this.orchestration.OpenAdminEndpointClientAsync(TestContext.Current.CancellationToken);
+        using var request = SessionRequest(OrchestrationContract.AdminNarrowedApiKey);
+
+        // Act
+        using var response = await client.SendAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var session = JsonDocument.Parse(
+            await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(
+            OrchestrationContract.AdminNarrowedApiKeyName,
+            session.RootElement.GetProperty("credential").GetString());
+        Assert.Equal(
+            [OrchestrationContract.AdminNarrowedPermission],
+            session.RootElement.GetProperty("permissions").EnumerateArray().Select(name => name.GetString()));
+    }
+
+    /// <summary>Builds a bearer-authenticated read of one administrative route.</summary>
+    private static HttpRequestMessage AuthenticatedGet(string route, string apiKey)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, new Uri(route, UriKind.Relative));
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+        return request;
+    }
+
     /// <summary>Builds a request for the session route, optionally presenting a bearer credential.</summary>
     private static HttpRequestMessage SessionRequest(string? apiKey)
     {


### PR DESCRIPTION
Every route beneath `/api/admin` now publishes the one permission it requires as endpoint metadata, written beside the mapping that creates it, and one group filter reads that decision back per request. A route mapped into the group without stating a permission is refused rather than served, so forgetting to decide costs a route instead of opening one — the arrangement fails closed by construction rather than by a central list somebody has to remember to extend.

## What a caller meets

A caller the endpoint admitted and a route then refuses is answered `403` with a problem document naming **the one permission that would have sufficed and nothing else**: no route inventory, no other credential, nothing about how the deployment is configured.

```json
{
  "status": 403,
  "detail": "The credential is not granted 'mailfathom.admin.read'.",
  "permission": "mailfathom.admin.read"
}
```

The `permission` member carries the name on its own so `mfctl` reports what to grant without parsing the sentence:

```text
The deployment refused the operation: this credential does not hold 'mailfathom.admin.read'. Add that
permission to the credential's entry under AdminEndpoint:Authentication, or sign in with one that already
holds it.
```

`mfctl` now also tells that apart from a credential the deployment would not accept at all, which used to be one message for both — an operator was sent to rotate a working key when what they had to do was widen its grant.

## The session route

`GET /api/admin/session` requires no permission, and says so as a stated value rather than by omission. It reports the credential the caller already presented, the version the deployment already publishes, and now the permissions that credential holds. A credential granted nothing therefore still signs in and is refused everywhere else, which is how one is retired without deleting its entry; `mfctl status` prints the grant back:

```text
'production' (https://mail.example.test:8443) accepts the stored credential as 'workstation' (MailFathom 0.2.0).
It holds mailfathom.admin.read, mailfathom.admin.operate.
```

## The transport is not the authority

The use case behind each route asks for the same permission itself, and every one of those is proved with the transport absent. Several reads previously lived only inside an endpoint handler and had no use case to ask in — `MailRuleSetReader`, `MailRuleEvaluationRunReader`, `MailRuleHistory`, `SpamClassificationRunReader`, `SpamClassificationHistory`, `DeadLetteredJobs`, `MailboxMutationAuditTrailReader`, and `MailAnsweringAuditTrailReader` are those reads, now application use cases requiring their permission and covered by tests of their own.

Where the two disagree the use case wins: the filter answers a `PrincipalNotAuthorizedException` in the same shape rather than letting it reach the caller as a fault in the deployment.

## Where each route landed

`mailfathom.admin.read` covers the deployment's own state, `mailfathom.admin.audit.read` everything derived from somebody's mail, `mailfathom.admin.operate` asking the deployment to do work it can already do, `mailfathom.admin.credentials.write` the mailbox refresh token, `mailfathom.admin.spend` the one operation that starts a provider bill, and `mailfathom.admin.erase` disposing of what the deployment holds. The contact book needed no seventh name — its routes divide across the audit-read, operate and erase separations the six already draw. `docs/operations/admin-endpoint.md` carries the full route-to-permission table, and `AdminApiEndpointsTests` pins the same allocation route by route.

## No public surface breaks

No configuration key, database column, MCP tool contract, or deployment contract changes, so nothing here is a break under [ADR 0012](https://github.com/Krzysztof318/MailFathom/blob/main/docs/decisions/0012-authorization-model-named-permissions-and-where-they-are-enforced.md) or the versioning rule in `AGENTS.md`. A credential whose entry writes no `Permissions` still reaches the whole administrative surface, so an existing deployment behaves exactly as it did. What changes for an operator who *had* narrowed an administrative entry is that the narrowing now bites: until this change it was validated, carried and reported rather than enforced.

## Documentation

`docs/operations/admin-endpoint.md` loses the blockquote saying every authenticated caller may perform every administrative operation and carries the table, a *What a refusal says* section, the updated startup-log sample and two troubleshooting rows instead. `docs/users/administering.md`, `docs/architecture/authorized-principal.md`, `docs/operations/configuration-reference.md`, `docs/operations/mcp-endpoint.md`, `docs/operations/mcp-client-oauth.md` and `docs/operations/mailbox-oauth.md` follow, each losing the sentence that said this surface enforced nothing.

## Verification

- `scripts/verify-full.sh` — passed over exactly this tree.
- `dotnet msbuild .config/CodeCoverage.proj -t:Collect` — 8288 tests, 0 failed, aggregate line coverage 96.00% against the 85% gate.
- `scripts/review-obligations.sh` — every row read; no page it named still says anything untrue about the part that moved.

Closes #587

---

- Issue: https://github.com/Krzysztof318/MailFathom/issues/587
- Pull request: https://github.com/Krzysztof318/MailFathom/pull/925
