### PR TITLE
[#928] Allocate the developer topology's ports, and pin one only when a user secret states it

### DIFF
--- a/docs/operations/local-development.md
+++ b/docs/operations/local-development.md
@@ -153,14 +153,14 @@ Three resources come up, in dependency order. The `postgres` container starts fi
 `mailfathom-migrations` resource then applies every pending migration to it; and `mailfathom-host` waits for that run
 to complete before starting, which is why the schema gate that fails a fresh deployment on purpose never fires on a
 local run — the explicit schema step the deployments require is performed here by the orchestration, before the host
-looks. The host runs in the `Development` environment on ports the app model states rather than allocates, so the MCP endpoint
-answers at `http://localhost:8080` and the probes at `http://127.0.0.1:8081`. There is no local TLS listener: MailFathom
+looks. The host runs in the `Development` environment on two sockets, the MCP endpoint's on `localhost` and the probes'
+on `127.0.0.1`, each on a free port the run takes unless this checkout [pinned one](#pinning-a-port); the
+dashboard reports the numbers it took. There is no local TLS listener: MailFathom
 never serves one out of an ASP.NET Core development certificate, so a developer who wants TLS configures
-`McpEndpoint:Https` the way a deployment does, which is also the shape they will ship. An MCP client's configuration therefore names an address once instead of following whatever a
-launch profile or the orchestrator's port allocation produced that run. Neither is proxied either: the socket
-a client connects to is the socket Kestrel opened, which is what keeps a TLS handshake — and a client certificate — a
-conversation with the host itself. The probe listener is pinned to loopback deliberately, because the probes answer
-without a credential and nothing on a local network has any business asking them — which is also why it is a socket of
+`McpEndpoint:Https` the way a deployment does, which is also the shape they will ship. Neither socket is proxied: the
+socket a client connects to is the socket Kestrel opened, which is what keeps a TLS handshake — and a client
+certificate — a conversation with the host itself. The probe listener is pinned to loopback deliberately, because the
+probes answer without a credential and nothing on a local network has any business asking them — which is also why it is a socket of
 its own here rather than the MCP endpoint's. A shared socket is one socket, so the probes would answer wherever the MCP
 endpoint does. The integration topology shares one deliberately, and [what that couples](configuration-reference.md#which-settings-a-shared-socket-couples)
 is the same list a deployment reads.
@@ -172,17 +172,45 @@ and MailFathom refuses that variable outright, because each surface states where
 endpoint is published without ever reaching it. That is also why the resource carries no `WithHttpHealthCheck`, which
 derives its address from an HTTP endpoint this app model declares none of.
 
-`8080` and `8081` are the ports [the container image](container-image.md) publishes, so a local run and a deployed one
-answer on the same numbers. `8443` belongs to this topology alone: the image serves no TLS listener, and `443` is a
-privileged port a developer's process cannot bind without a capability nothing here should require.
+### Pinning a port
 
-A fixed port is one port, so two ordinary orchestrations cannot run at once on one machine — a second one fails to bind
-and says so. The integration-test topology is left on allocated ports for exactly that reason, which is what keeps a
-suite run and a developer's run able to coexist.
+Every port this topology publishes is taken free per run, which is what lets several checkouts of this repository run
+their orchestrations at the same time: a fixed port is one port, and the second run to ask for it fails to bind and
+exits. The integration-test topology has never used a fixed one, for that same reason.
 
-That TLS listener presents the ASP.NET Core development certificate, which Kestrel uses for an address no endpoint
-configuration claims. Create and trust it once per machine — without a certificate at all the host fails to start with
-nothing to present, and with an untrusted one it starts while every client refuses the handshake:
+A port taken per run moves between runs, and an address written once into an MCP client's configuration or a database
+tool should not have to. So each socket is pinned on its own, in the app host's own user secrets — where a decision
+about one machine belongs, out of every checkout:
+
+```bash
+dotnet user-secrets --project src/AppHost/AppHost.csproj set "Ports:McpEndpoint" "8080"
+dotnet user-secrets --project src/AppHost/AppHost.csproj set "Ports:HealthEndpoints" "8081"
+dotnet user-secrets --project src/AppHost/AppHost.csproj set "Ports:Postgres" "5432"
+```
+
+`8080` and `8081` are the ports [the container image](container-image.md) publishes and `5432` is PostgreSQL's own, so
+those three values are what makes a local run answer where a deployment does. Each key is read on its own, so pinning
+the MCP endpoint leaves the probes and the database on whatever the run takes. A value that is not a port number
+between `1` and `65535` fails the app host at startup naming the key, rather than being ignored and leaving the address
+to move anyway.
+
+That store is keyed by the `UserSecretsId` in `src/AppHost/AppHost.csproj`, which is one fixed identifier, so a port
+pinned there is pinned for **every checkout on the machine** — which is the collision above, taken deliberately for the
+address it buys. It is also loaded in the `Development` environment only, which is what the app host's only launch
+profile runs it in. The environment form of each key is what pins a port for one run: `Ports__McpEndpoint`,
+`Ports__HealthEndpoints`, and `Ports__Postgres` are read after the store and therefore win over it.
+
+```bash
+Ports__McpEndpoint=8080 dotnet run --project src/AppHost/AppHost.csproj
+```
+
+A port nothing pinned is read from the dashboard, which lists each resource's endpoints, and from the host's own
+startup log, which reports the socket every surface bound.
+
+The Aspire dashboard is served over TLS and presents the ASP.NET Core development certificate, which Kestrel uses for
+an address no endpoint configuration claims. Create and trust it once per machine — without a certificate at all the app
+host fails to start with nothing to present, and with an untrusted one it starts while the browser refuses the
+handshake:
 
 ```bash
 dotnet dev-certs https --trust
@@ -216,7 +244,7 @@ what it costs, and how to confirm the handshake is what failed. The AppHost pass
 sets one, so a checkout that exports nothing runs under the platform default; the integration-test topology receives it
 under no circumstances, because a suite whose handshakes depended on the machine that ran it would prove nothing.
 
-An MCP client then connects to `http://localhost:8080/mcp`, or to `https://localhost:8443/mcp`, with
+An MCP client then connects to `http://localhost:<the port the MCP endpoint took>/mcp` with
 `Authorization: Bearer dev-key`. Stopping the orchestration with `Ctrl+C` — or
 `aspire stop --apphost src/AppHost/AppHost.csproj --non-interactive` — leaves the synchronized mail in place, because
 the database volume outlives the container and the container outlives the run. The container is stopped rather than
@@ -252,12 +280,12 @@ rather than a PostgreSQL process and the port it holds. A shutdown that runs —
 termination — stops it; a process killed outright runs nothing and leaves the container up, which is then stopped with
 `docker stop` like any other.
 
-The server is reached on the conventional port with conventional credentials, so a database tool needs nothing this
-repository has to tell it:
+The server is reached with conventional credentials, so a database tool needs nothing this repository has to tell it
+beyond the port this run published:
 
 | | |
 | --- | --- |
-| Host and port | `localhost:5432` |
+| Host and port | `localhost` and the port the dashboard reports — `5432` where it is [pinned](#pinning-a-port) |
 | Database | `mailfathom` |
 | User and password | `postgres` / `postgres` |
 
@@ -268,13 +296,14 @@ that never changes cannot drift from itself. It authenticates one local developm
 publishes on the loopback address alone, and no deployment is reached this way: a deployed MailFathom takes its
 connection string from [secret provisioning](secret-provisioning.md), which this app model has no part in.
 
-The fixed port is a convenience with one consequence worth knowing: a PostgreSQL already listening on `5432`, whether a
-system service or another orchestration, takes the port first and the container then fails to start with an
-address-in-use error naming it.
+Pinning that port has one consequence worth knowing: a PostgreSQL already listening on the number pinned, whether a
+system service or another orchestration, takes it first and the container then fails to start with an address-in-use
+error naming it.
 
 `src/AppHost/AppHost.csproj` still declares a `UserSecretsId`, and `src/AppHost/Properties/launchSettings.json` still
 sets `DOTNET_ENVIRONMENT=Development`, because that is where Aspire persists what it generates for the app model
-itself — the dashboard and OTLP API keys — and user secrets are loaded in the `Development` environment only.
+itself — the dashboard and OTLP API keys — and where [a pinned port](#pinning-a-port) is stated; user secrets are loaded
+in the `Development` environment only.
 
 To discard the local database and start from an empty one, remove the container and its volume:
 

--- a/src/AppHost/OrchestrationContract.cs
+++ b/src/AppHost/OrchestrationContract.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
 using System.Security.Cryptography;
 
 namespace MailFathom.AppHost;
@@ -419,6 +422,38 @@ public static class OrchestrationContract
     /// </remarks>
     public const string EphemeralRunIdentifierVariable = "MAILFATHOM_INTEGRATIONTESTS_RUN_ID";
 
+    /// <summary>The configuration key a developer states the MCP endpoint's port under to pin it.</summary>
+    /// <remarks>
+    /// <para>
+    /// The ordinary topology takes a free port for each socket it publishes, because a fixed port is one port and several checkouts
+    /// of this repository run their orchestrations at the same time: the second to start cannot bind what the first is
+    /// holding, and it exits rather than falling back. What a fixed port buys is an address written once into an MCP
+    /// client's configuration and never revisited, so it stays available as something a developer asks for — state the
+    /// number here and the run binds it.
+    /// </para>
+    /// <para>
+    /// Read from the app host's own configuration, which is what makes user secrets its natural home: pinning a port is
+    /// a decision about one machine and belongs in nobody's checkout. That store is keyed by the app host's fixed
+    /// <c>UserSecretsId</c>, so a value put in it holds for every checkout on the machine rather than for the one it was
+    /// set from; its environment form, <c>Ports__McpEndpoint</c>, is what pins a port for a single run.
+    /// </para>
+    /// </remarks>
+    public const string PinnedMcpEndpointPortKey = "Ports:McpEndpoint";
+
+    /// <summary>The configuration key a developer states the probe listener's port under to pin it.</summary>
+    /// <remarks>Read the way <see cref="PinnedMcpEndpointPortKey" /> is, and read on its own, so pinning one socket leaves the other free to move.</remarks>
+    public const string PinnedHealthEndpointsPortKey = "Ports:HealthEndpoints";
+
+    /// <summary>The configuration key a developer states the PostgreSQL server's host port under to pin it.</summary>
+    /// <remarks>Read the way <see cref="PinnedMcpEndpointPortKey" /> is. Pinning it is what a database tool configured once wants; leaving it unset is what lets a second checkout start a server of its own.</remarks>
+    public const string PinnedPostgresPortKey = "Ports:Postgres";
+
+    /// <summary>The lowest number a pinned port may state.</summary>
+    private const int MinimumPortNumber = 1;
+
+    /// <summary>The highest number a pinned port may state.</summary>
+    private const int MaximumPortNumber = 65535;
+
     /// <summary>How many characters a generated run identifier has.</summary>
     /// <remarks>Four bytes of randomness, which is short enough to read in a container listing and long enough that two runs starting in the same minute do not collide.</remarks>
     private const int GeneratedRunIdentifierLength = 8;
@@ -452,6 +487,85 @@ public static class OrchestrationContract
         }
 
         return $"{EphemeralResourceNamePrefix}-{statedIdentifier}";
+    }
+
+    /// <summary>Reads the port a developer pinned under <paramref name="configurationKey" />.</summary>
+    /// <param name="configurationKey">The key the value was read from, which is what a refusal names.</param>
+    /// <param name="statedPort">The value configuration holds under that key, or <see langword="null" /> when it holds none.</param>
+    /// <returns>The stated port, or <see langword="null" /> when nothing states one, which is what leaves the caller to take a free one.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when a stated value is not a TCP port number.</exception>
+    /// <remarks>
+    /// A stated value that is not a port is refused rather than ignored, for the reason an unusable run identifier is:
+    /// falling back to a free port would answer a request for one fixed address with a different address every run, and
+    /// nothing would say why.
+    /// </remarks>
+    public static int? ResolvePinnedPort(string configurationKey, string? statedPort)
+    {
+        if (string.IsNullOrWhiteSpace(statedPort))
+        {
+            return null;
+        }
+
+        var statedNumber = statedPort.Trim();
+
+        if (!int.TryParse(statedNumber, NumberStyles.None, CultureInfo.InvariantCulture, out var port)
+            || port is < MinimumPortNumber or > MaximumPortNumber)
+        {
+            throw new InvalidOperationException(
+                $"{configurationKey} is '{statedNumber}', which is not a TCP port number. State a number between {MinimumPortNumber} and {MaximumPortNumber}, or leave it unset to have a free one taken per run.");
+        }
+
+        return port;
+    }
+
+    /// <summary>Finds free TCP ports for the sockets the orchestration publishes without a proxy in front of them.</summary>
+    /// <param name="count">How many ports the caller needs, which is how many sockets it declares.</param>
+    /// <returns>That many ports, each free when it was asked for and none equal to another.</returns>
+    /// <remarks>
+    /// <para>
+    /// An unproxied endpoint has to state its number: the orchestrator allocates a port for the proxy it would put in
+    /// front of the resource, and there is no proxy here, so it refuses the endpoint rather than choosing for it. What
+    /// keeps a run off another run's port is therefore this — the operating system's own answer to which port is free,
+    /// which is the same answer it gives a proxy.
+    /// </para>
+    /// <para>
+    /// Every port is asked for before any is released, which is what makes them different from one another. Asking one
+    /// at a time would release each before the next was chosen, and two sockets handed the same number would leave the
+    /// host refusing to open the second listener over a collision within one run.
+    /// </para>
+    /// <para>
+    /// They are all released before the host binds them, so a process that asks in the same instant can take one first
+    /// and the host then fails to start on an address already in use. That is a race a few milliseconds wide against a
+    /// range of sixteen thousand ephemeral ports, and it fails loudly on the run that loses rather than silently on the
+    /// one that wins; holding the sockets open until the host binds them is not available, because the host is a
+    /// separate process.
+    /// </para>
+    /// </remarks>
+    public static int[] FindFreePorts(int count)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        List<TcpListener> probes = [];
+
+        try
+        {
+            for (var index = 0; index < count; index++)
+            {
+                var probe = new TcpListener(IPAddress.Any, 0);
+
+                probes.Add(probe);
+                probe.Start();
+            }
+
+            return [.. probes.Select(static probe => ((IPEndPoint)probe.LocalEndpoint).Port)];
+        }
+        finally
+        {
+            foreach (var probe in probes)
+            {
+                probe.Dispose();
+            }
+        }
     }
 
     private static bool IsUsableInAContainerName(string identifier) =>

--- a/src/AppHost/Program.cs
+++ b/src/AppHost/Program.cs
@@ -17,6 +17,13 @@ var builder = DistributedApplication.CreateBuilder(args);
 // ephemeral database and leave its volume under the prefix the test script deletes.
 var runsIntegrationTests = args.Contains(OrchestrationContract.IntegrationTestingArgument, StringComparer.Ordinal);
 
+// The port this checkout pinned for a socket, or null where it pinned none — which is what leaves the number to be
+// found per run and lets a second checkout start while the first is running. Read from the app host's own
+// configuration, so `dotnet user-secrets --project src/AppHost/AppHost.csproj` is where a developer states one; unlike
+// the topology switch above, an ambient value here can only move a port the run publishes, never select a topology.
+int? PinnedPort(string configurationKey) =>
+    OrchestrationContract.ResolvePinnedPort(configurationKey, builder.Configuration[configurationKey]);
+
 // One identifier per run, so two suites started on one machine name different containers and volumes instead of racing
 // for one name — and so the caller that started a run can remove exactly what it created. The ordinary topology names
 // nothing with it and leaves it empty.
@@ -82,9 +89,12 @@ else
     // below stops it during shutdown. What outlives the orchestration is then the container and its data rather than a
     // PostgreSQL process and the port it holds.
     //
-    // The host port is fixed for the same reason the host's own ports are: a connection string typed into a database
-    // tool once should keep working. PostgreSQL's own port is the convenient one, and Aspire publishes it on the
-    // loopback address, so the server a developer reaches is not one anything else on their network can.
+    // The host port is allocated for the same reason the host's own ports are: a fixed one is a single port, and a
+    // second checkout running its own orchestration cannot have it. A connection string typed into a database tool once
+    // should still be able to keep working, so a developer who wants that pins the conventional 5432 under
+    // OrchestrationContract.PinnedPostgresPortKey and gets it on every run that reads it. Whatever the number is,
+    // Aspire publishes it on the loopback address, so the server a developer reaches is not one anything else on their
+    // network can.
     //
     // The volume keeps the name WithDataVolume would have given it, which is what makes it still one volume per
     // checkout: the generated name carries a hash of the app host's path, so a clone and a worktree own different
@@ -92,7 +102,7 @@ else
     postgres
         .WithVolume(VolumeNameGenerator.Generate(postgres, "data"), postgresDataDirectory)
         .WithLifetime(ContainerLifetime.Persistent)
-        .WithHostPort(5432);
+        .WithHostPort(PinnedPort(OrchestrationContract.PinnedPostgresPortKey));
 
     // Registered last, which is what makes its shutdown run first: a hosted service stops in reverse registration
     // order, and the orchestrator that carries out the stop is registered while the builder is created.
@@ -349,7 +359,17 @@ if (runsIntegrationTests)
 }
 else
 {
-    // The two sockets a developer's run serves, each stated by the section that owns it.
+    // The two sockets a developer's run serves, each stated by the section that owns it, and each on a free port this
+    // run found unless this checkout pinned one. Found here rather than left to the orchestrator, which allocates a
+    // port for the proxy it would put in front of a resource and refuses an endpoint that declares none while asking
+    // for no proxy — and no proxy is what keeps the socket a client reaches the socket Kestrel opened.
+    //
+    // Both are found in one call whether or not either is pinned, because that is what makes them different from each
+    // other; a pinned value then replaces the one it was found for and the other stays where it was put.
+    var foundPorts = OrchestrationContract.FindFreePorts(2);
+    var mcpEndpointPort = PinnedPort(OrchestrationContract.PinnedMcpEndpointPortKey) ?? foundPorts[0];
+    var healthEndpointsPort = PinnedPort(OrchestrationContract.PinnedHealthEndpointsPortKey) ?? foundPorts[1];
+
     mailFathomHost
         // The MCP endpoint's own socket, stated to the app model and injected into the host's own configuration key, so
         // the number is written once rather than declared here and configured again beside it. Its scheme is tcp rather
@@ -358,15 +378,16 @@ else
         // section. A tcp endpoint is recorded and published without reaching it; what a client connects with is still
         // HTTP.
         //
-        // Fixed rather than allocated, and bound by the host itself rather than by a proxy in front of it. An MCP
-        // client's configuration names an address once, so a port that moved with a launch profile or with the
-        // orchestrator's own allocation would make that address a per-run detail; unproxied also means the socket a
-        // client connects to is the socket Kestrel opened, which is what keeps a TLS handshake and a client certificate
-        // a conversation with the host. 8080 and 8081 are the numbers the container image already publishes, so a local
-        // run and a deployed one answer on the same ports.
+        // Bound by the host itself rather than by a proxy in front of it: the socket a client connects to is then the
+        // socket Kestrel opened, which is what keeps a TLS handshake and a client certificate a conversation with the
+        // host.
         //
-        // Only the ordinary topology pins them. The integration suite starts this same app model, and a fixed port
-        // there would let one run refuse to bind because another still holds it.
+        // Its number is a free one this run found, unless this checkout stated the number it wants. An MCP client's
+        // configuration names an address once, which is what a fixed port was here for, but a fixed port is one port
+        // and several checkouts of this repository run their orchestrations at the same time — every run after the
+        // first then failed to bind and exited. So the stable address is what a developer asks for rather than what
+        // every run imposes on every other: 8080 and 8081 are the numbers the container image publishes, and pinning
+        // them is what makes a local run and a deployed one answer on the same ports.
         //
         // No HTTPS endpoint accompanies this one. Kestrel serves an https:// address it was handed with no endpoint
         // configuration out of the ASP.NET Core development certificate, and MailFathom never serves a listener out of
@@ -375,8 +396,8 @@ else
         .WithEndpoint(
             name: OrchestrationContract.HostHttpEndpointName,
             scheme: "tcp",
-            port: 8080,
-            targetPort: 8080,
+            port: mcpEndpointPort,
+            targetPort: mcpEndpointPort,
             isProxied: false,
             env: "McpEndpoint__Port")
         // The probe listener, on a socket of its own here rather than beside the MCP endpoint the way the integration
@@ -393,8 +414,8 @@ else
         .WithEndpoint(
             name: "health",
             scheme: "tcp",
-            port: 8081,
-            targetPort: 8081,
+            port: healthEndpointsPort,
+            targetPort: healthEndpointsPort,
             isProxied: false,
             env: "HealthEndpoints__Port");
 }

--- a/tests/AppHost.UnitTests/OrchestrationContractTests.cs
+++ b/tests/AppHost.UnitTests/OrchestrationContractTests.cs
@@ -2,15 +2,23 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Net;
+using System.Net.Sockets;
 using Xunit;
 
 namespace MailFathom.AppHost.UnitTests;
 
-/// <summary>Covers the two values the app model states rather than derives: the ephemeral resource name, and the development data-encryption key.</summary>
+/// <summary>Covers the values the app model resolves rather than states outright: the ephemeral resource name, a pinned port, and the development data-encryption key.</summary>
 /// <remarks>
 /// What the naming assertions establish is what the removal at the end of a run depends on. A prefix that did not start
 /// with the shared part would leave a run's resources outside every filter that finds them, and an identifier a
 /// container runtime refuses would fail the run at a point that says nothing about why.
+/// <para>
+/// What the port assertions establish is that the opt-in behaves the way the app model's default depends on. An unset
+/// key has to resolve to nothing, because that is what leaves Aspire to allocate and lets a second checkout run at the
+/// same time; a stated one has to reach the endpoint unchanged, because a developer pins a port to stop having to look
+/// it up.
+/// </para>
 /// <para>
 /// The key assertion establishes something the compiler cannot: the constant is written into a <c>plaintext:</c> secret
 /// reference, so a mistyped character or a change to the text behind it would first be reported by a developer's own
@@ -23,6 +31,9 @@ public sealed class OrchestrationContractTests
 
     /// <summary>The key length AES-256 takes, stated here because this project compiles one source file and reaches no shared constant.</summary>
     private const int DataEncryptionKeySizeInBytes = 32;
+
+    /// <summary>The configuration section every pinned port is stated under, restated here for the reason above.</summary>
+    private const string PinnedPortSection = "Ports:";
 
     /// <summary>A run that states no identifier still names its resources apart from every other run's.</summary>
     [Theory]
@@ -129,6 +140,124 @@ public sealed class OrchestrationContractTests
         // Assert — the accepted shape is an alphanumeric first character followed by up to 63 more of the same plus
         // `.`, `_`, and `-`. It is restated rather than shared because this project compiles one source file.
         Assert.Matches("^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$", OrchestrationContract.DataEncryptionKeyId);
+    }
+
+    /// <summary>Nothing stated leaves the port to the orchestration, which is what lets two checkouts run at once.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ResolvePinnedPort_NothingStated_LeavesThePortUnpinned(string? statedPort)
+    {
+        // Act
+        var port = OrchestrationContract.ResolvePinnedPort(OrchestrationContract.PinnedMcpEndpointPortKey, statedPort);
+
+        // Assert
+        Assert.Null(port);
+    }
+
+    /// <summary>A stated port reaches the endpoint as the number it states, which is the whole of what pinning buys.</summary>
+    [Theory]
+    [InlineData("8080", 8080)]
+    [InlineData("  8081  ", 8081)]
+    [InlineData("1", 1)]
+    [InlineData("65535", 65535)]
+    public void ResolvePinnedPort_PortStated_ReturnsThatNumber(string statedPort, int expectedPort)
+    {
+        // Act
+        var port = OrchestrationContract.ResolvePinnedPort(OrchestrationContract.PinnedMcpEndpointPortKey, statedPort);
+
+        // Assert
+        Assert.Equal(expectedPort, port);
+    }
+
+    /// <summary>A value that is not a port fails the run naming the key, rather than allocating one and saying nothing.</summary>
+    /// <remarks>
+    /// Falling back would answer a developer's request for one fixed address with a different address every run, and the
+    /// key they mistyped is the only thing that says where to look.
+    /// </remarks>
+    [Theory]
+    [InlineData("0")]
+    [InlineData("65536")]
+    [InlineData("-1")]
+    [InlineData("+8080")]
+    [InlineData("8080.0")]
+    [InlineData("8080 8081")]
+    [InlineData("eighty-eighty")]
+    [InlineData("0x1F90")]
+    public void ResolvePinnedPort_ValueIsNotAPort_FailsNamingTheKey(string statedPort)
+    {
+        // Act
+        var failure = Assert.Throws<InvalidOperationException>(
+            () => OrchestrationContract.ResolvePinnedPort(OrchestrationContract.PinnedPostgresPortKey, statedPort));
+
+        // Assert
+        Assert.Contains(OrchestrationContract.PinnedPostgresPortKey, failure.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>Each socket is pinned under a key of its own, which is what lets one be pinned while the others stay allocated.</summary>
+    [Fact]
+    public void PinnedPortKeys_TheThreeSocketsTheOrdinaryTopologyPublishes_AreStatedSeparately()
+    {
+        // Act
+        string[] keys =
+        [
+            OrchestrationContract.PinnedMcpEndpointPortKey,
+            OrchestrationContract.PinnedHealthEndpointsPortKey,
+            OrchestrationContract.PinnedPostgresPortKey,
+        ];
+
+        // Assert
+        Assert.Equal(keys.Length, keys.Distinct(StringComparer.Ordinal).Count());
+        Assert.All(keys, key => Assert.StartsWith(PinnedPortSection, key, StringComparison.Ordinal));
+    }
+
+    /// <summary>A port nothing pinned is one the host can actually bind, which is the whole of what the run needs from it.</summary>
+    /// <remarks>
+    /// The orchestrator refuses an unproxied endpoint that states no port, so this is what stands in for its allocation.
+    /// A value the operating system reported free and immediately refuses to bind would be no allocation at all.
+    /// </remarks>
+    [Fact]
+    public void FindFreePorts_APortNothingPinned_IsOneAListenerCanBind()
+    {
+        // Act
+        var ports = OrchestrationContract.FindFreePorts(1);
+
+        // Assert
+        var port = Assert.Single(ports);
+
+        Assert.InRange(port, 1, 65535);
+
+        using var listener = new TcpListener(IPAddress.Any, port);
+
+        listener.Start();
+    }
+
+    /// <summary>The sockets one run serves get different ports, or the second listener would collide with the first.</summary>
+    /// <remarks>
+    /// The reason the count is a parameter rather than something the caller loops over: a port asked for on its own is
+    /// released before the next is chosen, so nothing would stop the operating system offering the same one twice.
+    /// </remarks>
+    [Fact]
+    public void FindFreePorts_TheSocketsOneRunServes_AreEachGivenADifferentPort()
+    {
+        // Act
+        var ports = OrchestrationContract.FindFreePorts(16);
+
+        // Assert
+        Assert.Equal(16, ports.Length);
+        Assert.Equal(ports.Length, ports.Distinct().Count());
+    }
+
+    /// <summary>A run pinning every socket it serves asks for nothing, which is a request rather than a mistake.</summary>
+    [Fact]
+    public void FindFreePorts_NoneNeeded_ReturnsNone()
+    {
+        // Act
+        var ports = OrchestrationContract.FindFreePorts(0);
+
+        // Assert
+        Assert.Empty(ports);
     }
 
     private static string IdentifierOf(string prefix) =>


### PR DESCRIPTION
Closes #928

## What changes

The developer topology took three fixed ports — PostgreSQL on `5432`, the MCP endpoint on `8080`, the probe listener on `8081`. A fixed port is one port, and several checkouts of this repository run their orchestrations at the same time, so every run after the first failed to bind and exited. Each socket now takes a free port per run, and a developer who wants a stable address pins it themselves under `Ports:McpEndpoint`, `Ports:HealthEndpoints`, or `Ports:Postgres` in the app host's own configuration. The integration-test topology is untouched — it never used a fixed port, for the same reason.

Two things were decided rather than derived.

**The two host sockets stay unproxied, so their ports are found here rather than left to the orchestrator.** DCP allocates a port for the proxy it would put in front of a resource, and it refuses an unproxied endpoint that declares none — verified by running it: `Service 'mailfathom-host-health' needs to specify a port for endpoint 'health' since it isn't using a proxy`. Making the endpoints proxied would have been the smaller diff and would have cost the property those three paragraphs in `Program.cs` defend: that the socket a client connects to is the socket Kestrel opened. So `OrchestrationContract.FindFreePorts` asks the operating system, which is the same answer a proxy would have got. It takes a count rather than being called twice on purpose — a port asked for alone is released before the next is chosen, so two sockets could be handed the same number within one run.

**PostgreSQL's endpoint is proxied and takes no number at all**, so `WithHostPort(null)` leaves the choice where it already belonged.

A value that is not a port number between `1` and `65535` fails the app host at startup naming the key, rather than being ignored — falling back to a free port would answer a request for one fixed address with a different address every run, and nothing would say why.

Two stale claims in `docs/operations/local-development.md` are corrected while that section is being rewritten: it described a local TLS listener on `8443` that the app model declares nowhere, and attributed the ASP.NET Core development certificate to a MailFathom listener rather than to the Aspire dashboard, which is what actually serves HTTPS locally.

### The break, and what to do about it

**Local development contract.** A checkout that relied on `http://localhost:8080/mcp`, `http://127.0.0.1:8081`, or `localhost:5432` no longer gets those numbers by default. The action is one command per socket, and it is in the documentation:

```bash
dotnet user-secrets --project src/AppHost/AppHost.csproj set "Ports:McpEndpoint" "8080"
```

That store is keyed by one fixed `UserSecretsId`, so a pin there holds for every checkout on the machine — which is the collision above, taken deliberately for the address it buys. `Ports__McpEndpoint` in the environment pins a port for a single run instead. No configuration key, database column, MCP tool argument, or deployment contract moves; the container image still publishes `8080` and `8081`.

## How it was verified

`scripts/verify-full.sh`: 8524 tests passed, 215 workflow assertions passed, exit `0`, on this branch rebased onto current `main`.

Six unit tests in `tests/AppHost.UnitTests/OrchestrationContractTests.cs` cover the resolution: an unset key leaves the port unpinned, a stated one comes back as that number, eight malformed values each fail naming the key, the three keys are distinct, a found port is one a listener can actually bind, and sixteen found at once are all different.

The orchestration was started for real, four times, because none of the above proves what DCP accepts:

- the first run failed exactly as described above, which is how the unproxied constraint was found rather than assumed;
- after the fix it reached `Distributed application started`, with the host bound to `127.0.0.1:39149` **while another checkout's orchestration was holding `127.0.0.1:8081` and `127.0.0.1:5432`** — the collision this change exists to remove, observed not colliding;
- a run with `Ports__HealthEndpoints=18099` bound `127.0.0.1:18099`, which is the opt-in end to end;
- every container and volume those runs created was removed afterwards.

Not verified: the pinned MCP port binding a listener, because the MCP endpoint is disabled by default locally and enabling it was outside this change. The endpoint declaration is the same code path the probe listener's pin exercised.

## Checklist

- [x] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [x] Behavior changes are covered by unit tests, and the coverage gate passes.
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail.
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.
