### PR TITLE
[#934][#935] Say the trust list has one half, and draw the derivations the arrival pipeline gained

### DIFF
--- a/docs/architecture/arrival-pipeline.md
+++ b/docs/architecture/arrival-pipeline.md
@@ -1,10 +1,10 @@
 # The arrival pipeline
 
-<!-- describes: src/Application/Synchronization/MailboxSynchronizer.cs, src/Application/Emails/Chunking/MailChunkingPass.cs, src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs, src/Application/Emails/Extraction/RedactingEmailMimeReader.cs, src/Application/Spam/Gating/**, src/Application/Spam/Runs/SpamClassificationPass.cs, src/Application/Spam/SpamClassificationArrivals.cs, src/Application/Spam/EmailSpamClassificationHandler.cs, src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs, src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs, src/Host/Hosting/Workers/MailEmbeddingWorker.cs -->
+<!-- describes: src/Application/Synchronization/MailboxSynchronizer.cs, src/Application/Emails/Chunking/MailChunkingPass.cs, src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs, src/Application/Emails/Extraction/RedactingEmailMimeReader.cs, src/Application/Emails/Extraction/SenderTrustEvaluatingEmailMimeReader.cs, src/Application/Emails/Extraction/MachineAuthorshipEvaluatingEmailMimeReader.cs, src/Application/Emails/Threads/EmailThreadAssembly.cs, src/Application/Spam/Gating/**, src/Application/Spam/Runs/SpamClassificationPass.cs, src/Application/Spam/SpamClassificationArrivals.cs, src/Application/Spam/EmailSpamClassificationHandler.cs, src/Application/Rules/Evaluation/MailRuleEvaluationPass.cs, src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs, src/Host/Hosting/Workers/MailEmbeddingWorker.cs -->
 
-Six features decide what happens to a message between the moment synchronization commits it and the moment everything
-derived from it exists. Each of them documents its own half, and none of them can state the order, because the order is
-what they have between them. This page is that order, drawn once.
+Eight features decide what happens to a message between the moment synchronization fetches it and the moment
+everything derived from it exists. Each of them documents its own half, and none of them can state the order, because
+the order is what they have between them. This page is that order, drawn once.
 
 It is a graph rather than a list. A message branches at its classification verdict, two of the stages are calls into
 sidecars, and one of them — redaction — is a guard on the way into a derived store rather than a stage every message
@@ -20,7 +20,8 @@ flowchart TD
         converge["Converge the previous run's mutations"]
         fetch["Fetch raw MIME, without setting the remote Seen flag"]
         extract["Extract the body text"]
-        commit[("Commit: metadata, raw MIME, search document")]
+        judge["Judge the author, and read how machine written the message's own text is"]
+        commit[("Commit: metadata, the conversation it joins, raw MIME, search document")]
         ask(["Ask for the message to be classified"])
         classify["Classification pass — only when somebody asked for a run over the whole mailbox"]
         rules["Rule evaluation pass"]
@@ -40,10 +41,10 @@ flowchart TD
         sweeps["Extraction and embedding backfills"]
     end
 
-    converge --> fetch --> extract
-    extract -. "redaction, fails closed" .-> presidio
-    presidio -. "placeholders replace every finding" .-> extract
-    extract --> commit
+    converge --> fetch --> extract --> judge
+    judge -. "redaction, fails closed" .-> presidio
+    presidio -. "placeholders replace every finding" .-> judge
+    judge --> commit
     commit --> ask
     ask -. "one job per occurrence; a full queue refuses rather than waits" .-> job
     ask --> classify
@@ -61,6 +62,15 @@ flowchart TD
     sweeps --> cut
     sweeps --> worker
 ```
+
+**Two judgements sit between the parse and the commit.** Whether the author a receiving server established is one the
+account recognizes, and how much the message's own text reads as machine written, are decisions this deployment makes
+rather than facts read out of the message's bytes — so each is a decorator over the reader that parses raw MIME rather
+than a step inside it, which is what puts them on every path that produces a reading rather than only on this one. Both
+run *before* redaction, deliberately: redaction replaces the words a scanner recognized, and a reading taken afterwards
+would judge a message partly by what the scanner rewrote in it. Neither carries any of the text out — what each writes
+is a verdict, a set of signals, a number, and the revision of the policy or profile it was reached under, none of which
+can hold a fragment of the message — so taking them ahead of the guard costs the guard nothing.
 
 Classification happens in two places and the drawing separates them deliberately. **A message is classified because it
 arrived**: the run asks for one as soon as it has committed the message and its content, and the work runs as an
@@ -147,11 +157,17 @@ behind classification would otherwise read exactly like a mailbox with no mail i
 
 ## Why the cut is not part of the commit
 
-The transaction that stores a message contains its metadata, its raw MIME, and its search document — and deliberately
-not its passages. Two stages run after that commit and before the cut, and both can change what the cut should produce:
-classification can decide the message is not derived from at all, and the owner's rules can file it into a folder mapped
-differently from the one it arrived in. Passages are not undone by a message moving afterwards, so cutting inside the
-commit would write passages of a placement and a verdict that had not been settled yet.
+The transaction that stores a message contains its metadata, the two judgements above, the conversation its own
+identifiers place it in, its raw MIME, and its search document — and deliberately not its passages. Two stages run after
+that commit and before the cut, and both can change what the cut should produce: classification can decide the message
+is not derived from at all, and the owner's rules can file it into a folder mapped differently from the one it arrived
+in. Passages are not undone by a message moving afterwards, so cutting inside the commit would write passages of a
+placement and a verdict that had not been settled yet.
+
+**The conversation is inside the commit for the opposite reason.** It is decided from the message's own identifiers and
+from nothing a later stage can change, and it is recorded as a relation other rows share rather than as a column — so
+committing it with the columns it was decided from is what keeps a message from ever being readable while belonging to
+nothing.
 
 The rules are the slower of the two, because a rule declares a move rather than performing one: the record is durable
 when the pass ends and the account's **next** run carries it to the mail server. So waiting for the pass is not enough
@@ -193,6 +209,15 @@ and, through them, the vectors the replacement cascades away.
   sweep to be released either: the account's own next run asks the gate again and cuts it in the same run the verdict
   admits it.
 
+**A fourth path re-reads stored mail and produces none of that.** `mfctl mailbox rederive` walks stored messages and
+reads each one's raw MIME back through the same reader the run uses, so the parse, both judgements, and redaction reach
+it exactly as they reach an arriving message; what it writes is the row's own columns and the conversation the message
+belongs to. It cuts no passages, embeds nothing, opens no mailbox session, and never reaches the classification gate, so
+it is the cheap way to fill in a column a later release added rather than a fourth way to derive from mail. State only a
+mailbox holds — flags, keywords, the internal date — is outside it, because nothing local can produce that. [Bringing
+stored mail up to a later release](../features/imap-synchronization.md#bringing-stored-mail-up-to-a-later-release)
+states its bounds and what it leaves behind.
+
 ## What the two folder switches decide
 
 `GenerateEmbeddings` and `VisibleToTools` are set per folder mapping;
@@ -215,6 +240,9 @@ has a scanner switched on.
 | Stage | Page |
 | --- | --- |
 | Fetching and committing a message | [IMAP synchronization](../features/imap-synchronization.md) |
+| Whether the displayed author authenticated, and whether the account recognizes them | [Sender authentication](../features/sender-authentication.md) |
+| How machine written a message's own text reads | [Machine authorship](../features/machine-authorship.md) |
+| The conversation a message is placed in | [The stored email](stored-email-schema.md#the-conversation-a-message-belongs-to) |
 | Classification, its verdicts, and the gate | [Spam classification](../features/spam-classification.md) |
 | The owner's rules and what a match asks for | [Mail rules](../features/mail-rules.md) |
 | Redaction, the stamp, and the egress guard | [Sensitive-content scanning](../features/sensitive-content-scanning.md) |

--- a/docs/architecture/toc.yml
+++ b/docs/architecture/toc.yml
@@ -13,7 +13,7 @@
   description: The three kinds of principal the application layer models, how each one reaches it, and why the use case checks a grant as well as the transport.
 - name: The arrival pipeline
   href: arrival-pipeline.md
-  description: The order a newly arrived message passes through — classification, rules, redaction, chunking, embedding — drawn once, with what each stage waits for and what each classification outcome permits.
+  description: The order a newly arrived message passes through — the judgements taken while it is read, redaction, the conversation it joins, classification, rules, chunking, embedding — drawn once, with what each stage waits for and what each classification outcome permits.
 - name: The stored email schema
   href: stored-email-schema.md
   description: The columns, constraints, and indexes the mail timeline is read from, and why raw MIME and search text live in tables of their own.

--- a/docs/features/sender-authentication.md
+++ b/docs/features/sender-authentication.md
@@ -205,19 +205,16 @@ name is put into its ASCII A-labels wherever it comes from, so an entry written 
 that carried `xn--bcher-kva.example`. A name no encoder accepts is refused rather than compared as it arrived, because
 a value nothing else can produce would match nothing and look like an author who is simply not on a list.
 
-**The list has two halves and one matcher reads both.** Configuration holds what an operator declared when they set the
-deployment up; a store holds what somebody added while it was running, because the useful act when a reader meets a
-warning on mail from a correspondent they trust is to trust them, and editing a file and restarting is not that act. An
-entry in either half recognizes, and neither can undo the other — configuration is not editable at runtime and the
-store is not editable by a configuration reload. Where both name one author the configured half is reported, so a
-deployment's declared trust is never described as something added later. The stored half and the surfaces that edit it
-are [issue #760](https://github.com/Krzysztof318/MailFathom/issues/760); until it exists the effective list is the
-configured one.
+**The list is what configuration declares, and nothing else adds to it.** An operator writes it when they set the
+deployment up, and no surface edits it while the deployment runs — not `mfctl`, not a tool on the MCP surface, and
+nothing a model can reach. So recognizing a new correspondent is a configuration change like any other: it is picked up
+by a reload, and the next extraction judges against it — mail already stored keeps the verdict the list it was judged
+under produced, which is what the revision below is for.
 
 An entry that names neither a domain nor an address, names both, writes one nothing can compare, or asks for subdomains
 on an address **fails startup**, naming the account and the entry's position and never the value it holds. The
 alternative is indistinguishable afterwards: a list nobody wrote and a list whose entries match nothing both leave
-every author unknown, and an operator would meet the difference as mail that never stops carrying a warning.
+every author unknown, and an operator would meet the difference as mail whose authors never stop reading as unknown.
 
 ### The verdict outlives the list
 
@@ -225,7 +222,7 @@ The answer is stored on the message rather than decided when the message is read
 ask whether an author is trusted without re-evaluating a policy that may since have changed. What makes that legible is
 the **policy revision** recorded beside it: a digest of the effective list, so two verdicts carrying different revisions
 were reached under different lists, and one carrying none was never put to a policy at all. Reordering a list is not a
-change to it and produces the same revision; adding to either half produces a different one.
+change to it and produces the same revision; adding an entry to it produces a different one.
 
 Adding a domain therefore does not silently rewrite what a reader was already shown. What re-judges mail already stored
 is [`mfctl mailbox rederive`](imap-synchronization.md#bringing-stored-mail-up-to-a-later-release), the same deliberate


### PR DESCRIPTION
Closes #934
Closes #935

## What changes

Two pages had stopped describing what the code does.

**The trusted-sender list has one half.** [Sender authentication](https://github.com/Krzysztof318/MailFathom/blob/main/docs/features/sender-authentication.md) told a reader that a store holds what somebody added while the deployment was running, and named the issue that would build it and the surfaces that would edit it. That issue was closed as not planned together with the banner it was built around, so the paragraph described a future the project had declined rather than one it had not reached. It now says what is true: configuration declares the list, nothing edits it at run time, and recognizing a new correspondent is a configuration change a reload picks up. The two sentences written around two halves — the one about a list whose entries match nothing, and the one about what changes the policy revision — read correctly for one.

**The arrival pipeline gained three derivations and drew none of them.** The drawing had extraction producing body text and the commit storing metadata, raw MIME, and a search document. Since then the sender-trust verdict and the machine-authorship reading joined the run as decorators over the reader that parses raw MIME — both before redaction, deliberately, because a reading taken afterwards would judge a message partly by what the scanner rewrote in it — and the conversation a message belongs to is assembled inside the transaction that commits it. The page is the one that exists to keep a new derived step off the wrong side of the classification gate, so drawing them is its whole job.

`mfctl mailbox rederive` is added to the paths that re-read stored mail, stated as what it is: the same reader, the row's own columns and the conversation, no cut, no vectors, no mailbox session, and no classification gate.

The page's `describes:` marker now names the two decorators and the thread assembly. It named none of them, which is why `scripts/review-obligations.sh` never reported this page while they were being written — the drift and the reason it went unnoticed are fixed in the same change.

Decided rather than derived: the opening count moved from six features to eight, counting the two feature pages that joined and leaving the conversation assembly out of it, since it has no feature page of its own and is documented in the stored-email schema. The stage table links all three.

What a rule condition may read is deliberately untouched here; #936 owns it.

## How it was verified

- `scripts/test-agent-workflow.sh` — 215 passed, 0 failed.
- `scripts/build-docs-site.sh` — build succeeded, 0 errors. Its 4 warnings are pre-existing and unrelated (`CHANGELOG.md` and the three `llms*.txt` links in `docs/index.md`).
- `scripts/review-obligations.sh` — no production file under `src/` changed, so it reports nothing owed.
- `scripts/verify-full.sh` was **not** run: the diff is three files under `docs/`, no C# and no project file, so the Release build, the test suite, and the formatting pass have nothing to prove about it. Skipping it was the owner's call in the session that produced this change.
- Every claim added was read against the code it describes: the reader chain composed in `ServiceCollectionExtensions`, `EmailThreadAssembly` as it is reached from `StoredEmailMetadataRepository` and from `StoredMailRederivationStore`, and the absence of any trusted-sender write surface under `src/Cli` and `src/Mcp`.

## Checklist

- [ ] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`. — not run; documentation-only diff, see above.
- [x] Behavior changes are covered by unit tests, and the coverage gate passes. — no behavior changed.
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail. — no C# file changed.
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set. — no dependency changed.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.

---

Issues: [#934](https://github.com/Krzysztof318/MailFathom/issues/934), [#935](https://github.com/Krzysztof318/MailFathom/issues/935)
