### PR TITLE
[#936] Let a condition read the keywords, the two sender verdicts, and the authorship band

### DIFF
--- a/docs/features/machine-authorship.md
+++ b/docs/features/machine-authorship.md
@@ -13,9 +13,10 @@ already stored, kept on the message, re-derivable, and published on every read t
 
 **It is informational and it is not a safety signal.** A high likelihood says the text reads as machine written. It does
 not say the message is unwanted, dishonest, or dangerous, and a great deal of ordinary correspondence is drafted with a
-text generator by people who mean every word of it. Nothing here files, flags, hides, or refuses a message, no rule
-reads the value, and no other part of the system consults it — publishing it is the whole of what is done with it, and
-what to make of it is the reader's. Whether a message is *wanted* is [spam classification](spam-classification.md)'s
+text generator by people who mean every word of it. Nothing here files, flags, hides, or refuses a message and no other
+part of the system consults the value — publishing it is the whole of what this feature does with it, and what to make
+of it is the reader's. The one thing that can act on it is a rule the owner wrote, which reads the band rather than the
+number. Whether a message is *wanted* is [spam classification](spam-classification.md)'s
 question and is reached by other means entirely.
 
 **It is a heuristic estimate and not a measured probability.** Nothing here proves who or what wrote a message. No model
@@ -158,9 +159,11 @@ so no part of the message reaches a caller through it that the caller could not 
 
 - It asks no model, consults no service, and compares against no corpus. Every signal is a property of characters in
   text this deployment already stored.
-- It never acts on the reading. Nothing files, flags, hides, or refuses a message because of it, no rule reads it, and
-  it takes no part in spam classification, ranking, retrieval, or answering. Publishing it through the read tools is not
-  acting on it.
+- It acts on the reading nowhere by itself. Nothing files, flags, hides, or refuses a message because of it, and it
+  takes no part in spam classification, ranking, retrieval, or answering. What can act on it is a rule the owner wrote:
+  `machineAuthorship` is a [fact a condition can read](mail-rules.md#the-facts-a-condition-can-read), carrying the band
+  and not the likelihood, because a number comparable only within one profile is not something to write a threshold
+  against.
 - It does not claim to distinguish an AI text generator from any other program that assembles text. What the signals
   establish is that the text was constructed rather than typed, which is why the value is named for machine authorship
   and not for a particular tool.

--- a/docs/features/mail-rules.md
+++ b/docs/features/mail-rules.md
@@ -272,6 +272,15 @@ spelling you wrote is the one sent to the server.
 `AddKeywords: []` and `RemoveKeywords: []` are refused at startup, because a list naming nothing asks the server for
 nothing and is a mistyped list far more often than an intent. `SetKeywords: []` is the one that means something.
 
+**A condition reads keywords as well as writing them.** [`keywords`](#the-facts-a-condition-can-read) is a fact, so a
+rule can select on a label an earlier run put on a message, under the same case-insensitive comparison.
+
+What it reads is what the server last reported, never what a rule asked for. A keyword a rule declares in this pass is
+a change written down: the account's next run carries it to the server, and the fact carries it once
+[reconciliation](imap-synchronization.md#reconciling-against-the-server) has read the message's flags back. So a rule
+below one that adds `$Invoice` does not see `$Invoice` on that message in the same pass, which is deliberate — a fact
+that answered from a change nobody had performed yet would report labels the mailbox does not carry.
+
 **A server may refuse to keep a keyword**, and that is the one refusal that cannot be reported at startup. A folder
 tells MailFathom which flags it keeps permanently when it is opened, so a server that keeps no arbitrary keyword — some
 do not — is discovered as the change is issued, and `AddKeywords` and `SetKeywords` then fail with
@@ -418,7 +427,7 @@ metric, or a span.
 
 ## The facts a condition can read
 
-A condition reaches these twenty-two names and nothing else. Each carries one shape of value, which is what the
+A condition reaches these twenty-six names and nothing else. Each carries one shape of value, which is what the
 comparison, operator, and function checks below are made against.
 
 | Fact | Type | What it holds |
@@ -431,6 +440,8 @@ comparison, operator, and function checks below are made against.
 | `senderDomain` | text | The part of the sender's address after the at sign; absent when there is no sender |
 | `recipientAddresses` | text set | The addresses the email was sent to and copied to, in their comparison form |
 | `recipientDomains` | text set | The distinct domains of every recipient address |
+| `authorAuthentication` | text | What the receiving server established about the author the email displays — `authenticated`, `failed`, or `notEstablished` |
+| `senderTrust` | text | Whether this deployment recognizes that author — `trusted` or `unknown` |
 | `receivedAt` | timestamp | When the last receiving hop recorded the email; absent when no hop recorded one |
 | `sentAt` | timestamp | When the sender's client stamped the email; absent when it carries no such header |
 | `ageInDays` | number | Days since the email was received; absent when nothing recorded that |
@@ -443,15 +454,17 @@ comparison, operator, and function checks below are made against.
 | `isAnswered` | boolean | Whether the server reports the email as answered |
 | `isFlagged` | boolean | Whether the server reports the email as flagged |
 | `isDraft` | boolean | Whether the server reports the email as a draft |
+| `keywords` | text set | The keywords the server reports the email as carrying; empty when it carries none |
 | `hasExtractedContent` | boolean | Whether text has been extracted from the email's body |
 | `bodyText` | text | The text extracted from the email's body, after quoted history and signatures were removed; absent while no extraction has run for it |
+| `machineAuthorship` | text | How much the email's own text reads as machine written — `likely`, `possible`, `unlikely`, or `notAssessed` |
 
 Names are case-sensitive. `senderDomain` is a fact and `SenderDomain` is not, so the surface documented here and the
 surface accepted are the same one.
 
-**Every fact resolves only if the condition names it, and once per email however many rules name it.** Twenty of the
-twenty-two come from metadata a pass already holds, so they cost nothing to read. `folderRole` is read from configuration,
-which costs no read either. `bodyText` is the exception: it reads
+**Every fact resolves only if the condition names it, and once per email however many rules name it.** Twenty-four of
+the twenty-six come from metadata a pass already holds, so they cost nothing to read. `folderRole` is read from
+configuration, which costs no read either. `bodyText` is the exception: it reads
 stored content, which is why a rule set naming it nowhere pays for no read at all, and one naming it in five conditions
 pays for one. The boolean operators short-circuit, so a condition whose first half already decides it never resolves
 what its second half would have named.
@@ -464,7 +477,26 @@ never a requirement.
 `receivedAt >= #2026/01/01#` means the start of that day in UTC.
 
 **Text comparison ignores case and is ordinal.** `senderDomain == 'Supplier.TEST'` matches `supplier.test`, and it does
-so identically on every instance whatever locale its host is set to.
+so identically on every instance whatever locale its host is set to. That is what makes `keywords` symmetrical with the
+keyword actions: a rule that put `$Todo` on a message is selected by a later rule naming `contains(keywords, '$todo')`.
+
+**Three of the facts are verdicts this deployment stored when the email was extracted**, and reading one re-evaluates
+nothing: no DNS is resolved, no header is re-read, and no text is re-assessed. So a condition names what was concluded
+at the time rather than what the same policy would conclude now, and mail stored before a verdict existed reads as the
+value that says nothing was established — `notEstablished`, `unknown`, and `notAssessed` — until
+[`mfctl mailbox rederive`](imap-synchronization.md#bringing-stored-mail-up-to-a-later-release) fills it in.
+[Sender authentication](sender-authentication.md) and [machine authorship](machine-authorship.md) state what each value
+means and what it is worth.
+
+**`senderTrust` says little on its own and is written beside `authorAuthentication`.** `unknown` is the ordinary state
+of legitimate mail from a correspondent nobody has named, so a rule acting on it alone acts on most of a mailbox; what
+carries a real statement is `authorAuthentication == 'failed'`, which is a receiving server reporting that the
+displayed author did not satisfy their own domain's published policy.
+
+**`machineAuthorship` publishes the band and not the number behind it.** The likelihood a reader is shown is a
+heuristic comparable only within one weighting, so a rule written against a threshold would change meaning the next
+time that weighting moved. `likely` is not an accusation and warrants no action on its own — a rule acting on it is
+filing mail, not judging anybody.
 
 ## Operators
 
@@ -541,7 +573,7 @@ Every condition is read while the host composes itself, before any mail is seen.
 each is refused with a message naming the rule, what was wrong, and where:
 
 - **Syntax.** The condition parses, and a failure reports the position it failed at.
-- **The names.** Every identifier is one of the twenty-two facts and every call is one of the seven functions.
+- **The names.** Every identifier is one of the twenty-six facts and every call is one of the seven functions.
 - **The types.** Every comparison, operator, and argument holds between shapes that could match. `subject == 1`,
   `sizeInBytes > 'large'`, `recipientDomains == 'example.test'`, and `contains(subject, 3)` are each refused here.
 - **The result.** The condition produces a boolean. A condition producing text or a number is refused rather than read
@@ -844,6 +876,30 @@ Size measured in a unit an owner thinks in:
 
 ```text
 sizeInBytes / 1048576 > 25
+```
+
+Mail a rule of your own already labelled, which is what makes a keyword worth writing:
+
+```text
+contains(keywords, '$Invoice') and not isSeen
+```
+
+Mail whose displayed author failed their own domain's published policy:
+
+```text
+authorAuthentication == 'failed'
+```
+
+Mail from nobody this deployment recognizes, whose author nothing established either:
+
+```text
+senderTrust == 'unknown' and authorAuthentication != 'authenticated'
+```
+
+Bulk-generated mail from outside, filed without asking a model anything:
+
+```text
+machineAuthorship == 'likely' and senderTrust == 'unknown'
 ```
 
 ## Worked rules

--- a/docs/features/sender-authentication.md
+++ b/docs/features/sender-authentication.md
@@ -218,8 +218,8 @@ every author unknown, and an operator would meet the difference as mail whose au
 
 ### The verdict outlives the list
 
-The answer is stored on the message rather than decided when the message is read, so a reader — and later a rule — can
-ask whether an author is trusted without re-evaluating a policy that may since have changed. What makes that legible is
+The answer is stored on the message rather than decided when the message is read, so a reader and a rule can ask
+whether an author is trusted without re-evaluating a policy that may since have changed. What makes that legible is
 the **policy revision** recorded beside it: a digest of the effective list, so two verdicts carrying different revisions
 were reached under different lists, and one carrying none was never put to a policy at all. Reordering a list is not a
 change to it and produces the same revision; adding an entry to it produces a different one.
@@ -286,9 +286,11 @@ of them characterizes the message or the sender's intent. A failed authenticatio
   domain and consults no public suffix list, so it never reconstructs DMARC's relaxed alignment for itself. Everything
   recorded was read back out of one header.
 - It does not reason from the `Received` chain beyond identifying the trusted header.
-- It never acts on either verdict. Nothing here files, flags, or hides a message, and no rule reads them yet. Publishing
-  them through the read tools is not acting on them: what a caller is handed is the stored conclusion, and what to make
-  of it is the caller's.
+- It acts on neither verdict by itself. Nothing here files, flags, or hides a message, and publishing the pair through
+  the read tools is not acting on it: what a caller is handed is the stored conclusion, and what to make of it is the
+  caller's. What can act on it is a rule the owner wrote — `authorAuthentication` and `senderTrust` are
+  [facts a condition can read](mail-rules.md#the-facts-a-condition-can-read), so filing mail on a verdict is something
+  an owner declares rather than something this feature does.
 - It does not let a caller filter or sort a listing or a search by either verdict. That is a question about what may be
   asked for rather than about what a result carries, and it is a decision of its own.
 

--- a/src/Application/Rules/Facts/MailRuleEmailFacts.cs
+++ b/src/Application/Rules/Facts/MailRuleEmailFacts.cs
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Emails.Authentication;
+using MailFathom.Domain.Emails.Authorship;
+
 namespace MailFathom.Application.Rules.Facts;
 
 /// <summary>Carries everything a condition can read about one email without a further read of stored content.</summary>
@@ -11,6 +14,11 @@ namespace MailFathom.Application.Rules.Facts;
 /// keeps the cost of a condition a property of the fact surface rather than of what somebody typed. The two derived
 /// facts — the sender's domain and the recipients' domains — are computed from the addresses beside them rather than
 /// carried separately, so nothing can supply an address and a domain that disagree.
+/// </para>
+/// <para>
+/// Three of them are stored as domain enumerations rather than as the words a condition compares against, because the
+/// authoring names are part of the rule contract and belong beside the fact surface that publishes them rather than in
+/// whatever queried the row.
 /// </para>
 /// <para>
 /// The one fact this does not carry is the extracted body text, which reaches a condition through
@@ -33,6 +41,15 @@ public sealed record MailRuleEmailFacts
 
     /// <summary>Gets the addresses the email was sent to and copied to, in their comparison form.</summary>
     public IReadOnlyList<string> RecipientAddresses { get; init; } = [];
+
+    /// <summary>Gets what the receiving server established about the author the email displays.</summary>
+    public AuthorAuthenticationOutcome AuthorAuthentication { get; init; } = AuthorAuthenticationOutcome.NotEstablished;
+
+    /// <summary>Gets whether this deployment recognizes the author the email authenticated as.</summary>
+    public SenderTrustLevel SenderTrust { get; init; } = SenderTrustLevel.Unknown;
+
+    /// <summary>Gets how much the email's own text reads as machine written.</summary>
+    public MachineAuthorshipBand MachineAuthorship { get; init; } = MachineAuthorshipBand.NotAssessed;
 
     /// <summary>Gets when the last receiving hop recorded the email, or <see langword="null" /> when no hop recorded one.</summary>
     public DateTimeOffset? ReceivedAt { get; init; }
@@ -66,6 +83,9 @@ public sealed record MailRuleEmailFacts
 
     /// <summary>Gets whether the server reports the email as a draft.</summary>
     public bool IsDraft { get; init; }
+
+    /// <summary>Gets the keywords the server reports the email as carrying.</summary>
+    public IReadOnlyList<string> Keywords { get; init; } = [];
 
     /// <summary>Gets whether text has been extracted from the email's body.</summary>
     public bool HasExtractedContent { get; init; }

--- a/src/Application/Rules/Facts/MailRuleFact.cs
+++ b/src/Application/Rules/Facts/MailRuleFact.cs
@@ -76,6 +76,22 @@ public readonly record struct MailRuleFact
     /// <summary>Gets the distinct domains of every recipient address.</summary>
     public static MailRuleFact RecipientDomains { get; } = new("recipientDomains", MailRuleFactType.TextSet);
 
+    /// <summary>Gets what the receiving server established about the author the email displays.</summary>
+    /// <remarks>
+    /// The conclusion rather than the evidence behind it: <c>authenticated</c>, <c>failed</c>, or
+    /// <c>notEstablished</c>. What a condition reads was stored when the email was extracted, so a rule judges what a
+    /// receiving server reported at the time rather than re-evaluating a policy now.
+    /// </remarks>
+    public static MailRuleFact AuthorAuthentication { get; } = new("authorAuthentication", MailRuleFactType.Text);
+
+    /// <summary>Gets whether this deployment recognizes the author the email authenticated as.</summary>
+    /// <remarks>
+    /// <c>trusted</c> or <c>unknown</c>, and a classification this deployment made rather than an authentication
+    /// result. <c>unknown</c> is the ordinary state of legitimate mail from a correspondent nobody has named, which is
+    /// why a rule acting on it usually names <see cref="AuthorAuthentication" /> beside it.
+    /// </remarks>
+    public static MailRuleFact SenderTrust { get; } = new("senderTrust", MailRuleFactType.Text);
+
     #endregion
 
     #region When it arrived and how large it is
@@ -124,6 +140,14 @@ public readonly record struct MailRuleFact
     /// <summary>Gets whether the server reports the email as a draft.</summary>
     public static MailRuleFact IsDraft { get; } = new("isDraft", MailRuleFactType.Boolean);
 
+    /// <summary>Gets the keywords the server reports the email as carrying.</summary>
+    /// <remarks>
+    /// The set a rule's own keyword actions write to, read back under the case-insensitive comparison those actions
+    /// are declared under, so a rule adding <c>$Todo</c> is selected by a later rule naming <c>$todo</c>. An email
+    /// carrying none, and one whose folder keeps no keywords at all, both read as the empty set.
+    /// </remarks>
+    public static MailRuleFact Keywords { get; } = new("keywords", MailRuleFactType.TextSet);
+
     #endregion
 
     #region What was extracted from it
@@ -139,6 +163,16 @@ public readonly record struct MailRuleFact
     /// </remarks>
     public static MailRuleFact BodyText { get; } = new("bodyText", MailRuleFactType.Text, readsStoredContent: true);
 
+    /// <summary>Gets how much the email's own text reads as machine written.</summary>
+    /// <remarks>
+    /// The band rather than the number behind it: <c>likely</c>, <c>possible</c>, <c>unlikely</c>, or
+    /// <c>notAssessed</c>. The number is a heuristic comparable only within one weighting, so a rule written against a
+    /// threshold would change meaning the next time that weighting moved, while a band survives it. <c>notAssessed</c>
+    /// is what an email with no readable body carries, what a deployment assessing nothing records, and what mail
+    /// stored before the assessment existed carries until it is re-read.
+    /// </remarks>
+    public static MailRuleFact MachineAuthorship { get; } = new("machineAuthorship", MailRuleFactType.Text);
+
     #endregion
 
     /// <summary>Gets every declared fact.</summary>
@@ -153,6 +187,8 @@ public readonly record struct MailRuleFact
         SenderDomain,
         RecipientAddresses,
         RecipientDomains,
+        AuthorAuthentication,
+        SenderTrust,
         ReceivedAt,
         SentAt,
         AgeInDays,
@@ -165,8 +201,10 @@ public readonly record struct MailRuleFact
         IsAnswered,
         IsFlagged,
         IsDraft,
+        Keywords,
         HasExtractedContent,
         BodyText,
+        MachineAuthorship,
     ];
 
     /// <summary>Gets whether this value names a declared fact rather than the unusable struct default.</summary>

--- a/src/Application/Rules/Facts/MailRuleFacts.cs
+++ b/src/Application/Rules/Facts/MailRuleFacts.cs
@@ -5,6 +5,8 @@
 using System.Collections.Frozen;
 using MailFathom.Application.Folders;
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails.Authentication;
+using MailFathom.Domain.Emails.Authorship;
 using MailFathom.Domain.Folders;
 
 namespace MailFathom.Application.Rules.Facts;
@@ -50,6 +52,8 @@ public sealed class MailRuleFacts
             [MailRuleFact.SenderDomain] = facts => facts.email.SenderDomain,
             [MailRuleFact.RecipientAddresses] = facts => facts.email.RecipientAddresses,
             [MailRuleFact.RecipientDomains] = facts => facts.email.RecipientDomains,
+            [MailRuleFact.AuthorAuthentication] = facts => AuthoringName(facts.email.AuthorAuthentication),
+            [MailRuleFact.SenderTrust] = facts => AuthoringName(facts.email.SenderTrust),
             [MailRuleFact.ReceivedAt] = facts => facts.email.ReceivedAt?.UtcDateTime,
             [MailRuleFact.SentAt] = facts => facts.email.SentAt?.UtcDateTime,
             [MailRuleFact.AgeInDays] = facts => facts.email.ReceivedAt is { } receivedAt
@@ -64,6 +68,8 @@ public sealed class MailRuleFacts
             [MailRuleFact.IsAnswered] = facts => facts.email.IsAnswered,
             [MailRuleFact.IsFlagged] = facts => facts.email.IsFlagged,
             [MailRuleFact.IsDraft] = facts => facts.email.IsDraft,
+            [MailRuleFact.Keywords] = facts => facts.email.Keywords,
+            [MailRuleFact.MachineAuthorship] = facts => AuthoringName(facts.email.MachineAuthorship),
             [MailRuleFact.HasExtractedContent] = facts => facts.email.HasExtractedContent,
         }.ToFrozenDictionary();
 
@@ -183,6 +189,47 @@ public sealed class MailRuleFacts
         .FindFolderNamed(MailAccountId.Create(this.email.Account), MailFolderAlias.Create(this.email.Folder))
         ?.SpecialUse
         ?.ToString();
+
+    /// <summary>Names a stored verdict the way a condition writes it.</summary>
+    /// <remarks>
+    /// The words are declared here rather than taken from the enumeration's own member names, so that renaming a
+    /// member cannot silently change what an operator has to type — these are the authoring surface, and the MCP
+    /// surface publishes its own copy of the same words for the same reason.
+    /// </remarks>
+    private static string AuthoringName(AuthorAuthenticationOutcome outcome) => outcome switch
+    {
+        AuthorAuthenticationOutcome.NotEstablished => "notEstablished",
+        AuthorAuthenticationOutcome.Failed => "failed",
+        AuthorAuthenticationOutcome.Authenticated => "authenticated",
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(outcome),
+            outcome,
+            "The stored author-authentication outcome has no authoring name."),
+    };
+
+    /// <inheritdoc cref="AuthoringName(AuthorAuthenticationOutcome)" />
+    private static string AuthoringName(SenderTrustLevel level) => level switch
+    {
+        SenderTrustLevel.Unknown => "unknown",
+        SenderTrustLevel.Trusted => "trusted",
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(level),
+            level,
+            "The stored sender-trust level has no authoring name."),
+    };
+
+    /// <inheritdoc cref="AuthoringName(AuthorAuthenticationOutcome)" />
+    private static string AuthoringName(MachineAuthorshipBand band) => band switch
+    {
+        MachineAuthorshipBand.NotAssessed => "notAssessed",
+        MachineAuthorshipBand.Unlikely => "unlikely",
+        MachineAuthorshipBand.Possible => "possible",
+        MachineAuthorshipBand.Likely => "likely",
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(band),
+            band,
+            "The stored machine-authorship band has no authoring name."),
+    };
 
     private static Func<MailRuleFacts, object?> ReadMetadata(MailRuleFact fact) =>
         MetadataReaders.TryGetValue(fact, out var reader)

--- a/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
+++ b/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
@@ -195,6 +195,10 @@ internal sealed class MailRuleEvaluationStore(
                 email.IsRemotelyAnswered,
                 email.IsRemotelyFlagged,
                 email.IsRemotelyDraft,
+                email.RemoteKeywords,
+                email.AuthorAuthenticationOutcome,
+                email.SenderTrustLevel,
+                email.MachineAuthorshipBand,
                 HasExtractedContent = email.SearchDocument != null
                     && email.SearchDocument.TextSource != ExtractedEmailTextSource.BodyNotExtracted,
                 AwaitsExtraction =
@@ -233,6 +237,10 @@ internal sealed class MailRuleEvaluationStore(
                     IsAnswered = candidate.IsRemotelyAnswered,
                     IsFlagged = candidate.IsRemotelyFlagged,
                     IsDraft = candidate.IsRemotelyDraft,
+                    Keywords = candidate.RemoteKeywords,
+                    AuthorAuthentication = candidate.AuthorAuthenticationOutcome,
+                    SenderTrust = candidate.SenderTrustLevel,
+                    MachineAuthorship = candidate.MachineAuthorshipBand,
                     HasExtractedContent = candidate.HasExtractedContent,
                 },
                 candidate.AwaitsExtraction)),

--- a/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
+++ b/src/Infrastructure/Persistence/Rules/MailRuleEvaluationStore.cs
@@ -23,8 +23,8 @@ namespace MailFathom.Infrastructure.Persistence.Rules;
 /// <summary>EF Core state for the rule passes that run inside an account's synchronization run.</summary>
 /// <remarks>
 /// <para>
-/// Both walks project straight into the fact surface rather than loading rows, because a condition reads twenty of its
-/// twenty-two facts from metadata and none of them is the raw MIME sitting beside it in the same aggregate. Of the
+/// Both walks project straight into the fact surface rather than loading rows, because a condition reads twenty-four of its
+/// twenty-six facts from metadata and none of them is the raw MIME sitting beside it in the same aggregate. Of the
 /// other two, <c>folderRole</c> is read from configuration rather than from any row, and <c>bodyText</c> is read one
 /// email at a time and only when a condition names it, which is what keeps a rule set that mentions no body text free
 /// of a content read.

--- a/tests/Application.UnitTests/Rules/MailRuleFactTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleFactTests.cs
@@ -53,6 +53,10 @@ public sealed class MailRuleFactTests
     [InlineData("sizeInBytes", MailRuleFactType.Number)]
     [InlineData("isSeen", MailRuleFactType.Boolean)]
     [InlineData("receivedAt", MailRuleFactType.Timestamp)]
+    [InlineData("keywords", MailRuleFactType.TextSet)]
+    [InlineData("senderTrust", MailRuleFactType.Text)]
+    [InlineData("authorAuthentication", MailRuleFactType.Text)]
+    [InlineData("machineAuthorship", MailRuleFactType.Text)]
     public void TryParseName_DeclaredName_ResolvesTheFactWithItsShape(string name, MailRuleFactType expectedType)
     {
         // Act

--- a/tests/Application.UnitTests/Rules/MailRuleFactsTests.cs
+++ b/tests/Application.UnitTests/Rules/MailRuleFactsTests.cs
@@ -4,6 +4,8 @@
 
 using MailFathom.Application.Rules.Facts;
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails.Authentication;
+using MailFathom.Domain.Emails.Authorship;
 using MailFathom.Domain.Folders;
 using MailFathom.TestSupport;
 using Xunit;
@@ -253,6 +255,99 @@ public sealed class MailRuleFactsTests
         Assert.Null(value);
     }
 
+    /// <summary>The three stored verdicts are compared as the words a condition writes, not as member names.</summary>
+    [Theory]
+    [InlineData(AuthorAuthenticationOutcome.Authenticated, "authenticated")]
+    [InlineData(AuthorAuthenticationOutcome.Failed, "failed")]
+    [InlineData(AuthorAuthenticationOutcome.NotEstablished, "notEstablished")]
+    public async Task ResolveAsync_AuthorAuthentication_AnswersWithItsAuthoringName(
+        AuthorAuthenticationOutcome stored,
+        string expected)
+    {
+        // Arrange
+        var facts = CreateFacts(email: EmailCarrying(email => email with { AuthorAuthentication = stored }));
+
+        // Act
+        var value = await facts.ResolveAsync(
+            MailRuleFact.AuthorAuthentication,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData(SenderTrustLevel.Trusted, "trusted")]
+    [InlineData(SenderTrustLevel.Unknown, "unknown")]
+    public async Task ResolveAsync_SenderTrust_AnswersWithItsAuthoringName(SenderTrustLevel stored, string expected)
+    {
+        // Arrange
+        var facts = CreateFacts(email: EmailCarrying(email => email with { SenderTrust = stored }));
+
+        // Act
+        var value = await facts.ResolveAsync(MailRuleFact.SenderTrust, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData(MachineAuthorshipBand.Likely, "likely")]
+    [InlineData(MachineAuthorshipBand.Possible, "possible")]
+    [InlineData(MachineAuthorshipBand.Unlikely, "unlikely")]
+    [InlineData(MachineAuthorshipBand.NotAssessed, "notAssessed")]
+    public async Task ResolveAsync_MachineAuthorship_AnswersWithItsAuthoringName(
+        MachineAuthorshipBand stored,
+        string expected)
+    {
+        // Arrange
+        var facts = CreateFacts(email: EmailCarrying(email => email with { MachineAuthorship = stored }));
+
+        // Act
+        var value = await facts.ResolveAsync(MailRuleFact.MachineAuthorship, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(expected, value);
+    }
+
+    /// <summary>An email nothing derived any of the three for reads as the state that says so, never as absence.</summary>
+    [Fact]
+    public async Task ResolveAsync_EmailNothingJudged_AnswersWithTheStatesThatSayNothingWasEstablished()
+    {
+        // Arrange
+        var facts = new MailRuleFacts(
+            new MailRuleEmailFacts { Account = "work", Folder = "inbox" },
+            new RecordingMailRuleBodyTextReader(),
+            StubMailFolderMappings.Nothing,
+            EvaluatedAt);
+
+        // Act
+        var authentication = await facts.ResolveAsync(
+            MailRuleFact.AuthorAuthentication,
+            TestContext.Current.CancellationToken);
+        var trust = await facts.ResolveAsync(MailRuleFact.SenderTrust, TestContext.Current.CancellationToken);
+        var authorship = await facts.ResolveAsync(
+            MailRuleFact.MachineAuthorship,
+            TestContext.Current.CancellationToken);
+        var keywords = await facts.ResolveAsync(MailRuleFact.Keywords, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("notEstablished", authentication);
+        Assert.Equal("unknown", trust);
+        Assert.Equal("notAssessed", authorship);
+        Assert.Empty(Assert.IsAssignableFrom<IReadOnlyList<string>>(keywords));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_Keywords_AnswerWithTheSetTheServerReports()
+    {
+        // Act
+        var value = await CreateFacts().ResolveAsync(MailRuleFact.Keywords, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(["$Invoice", "$Todo"], Assert.IsAssignableFrom<IReadOnlyList<string>>(value));
+    }
+
     [Fact]
     public async Task ResolveAsync_UnspecifiedFact_IsRefused()
     {
@@ -263,23 +358,35 @@ public sealed class MailRuleFactsTests
 
     private static MailRuleFacts CreateFacts(
         RecordingMailRuleBodyTextReader? bodyTextReader = null,
-        StubMailFolderMappings? folderMappings = null) =>
+        StubMailFolderMappings? folderMappings = null,
+        MailRuleEmailFacts? email = null) =>
         new(
-            new MailRuleEmailFacts
-            {
-                Account = "work",
-                Folder = "inbox",
-                Subject = "March invoice 2026",
-                SenderAddress = "billing@supplier.test",
-                RecipientAddresses = ["owner@example.test", "accounts@example.test", "billing@supplier.test"],
-                ReceivedAt = ReceivedAt,
-                SentAt = ReceivedAt.AddMinutes(-5),
-                SizeInBytes = 250_000,
-                AttachmentCount = 2,
-                AttachmentTotalBytes = 200_000,
-                HasExtractedContent = true,
-            },
+            email ?? EmailCarrying(),
             bodyTextReader ?? new RecordingMailRuleBodyTextReader("Amount due on receipt."),
             folderMappings ?? StubMailFolderMappings.Nothing,
             EvaluatedAt);
+
+    private static MailRuleEmailFacts EmailCarrying(Func<MailRuleEmailFacts, MailRuleEmailFacts>? change = null)
+    {
+        var email = new MailRuleEmailFacts
+        {
+            Account = "work",
+            Folder = "inbox",
+            Subject = "March invoice 2026",
+            SenderAddress = "billing@supplier.test",
+            RecipientAddresses = ["owner@example.test", "accounts@example.test", "billing@supplier.test"],
+            ReceivedAt = ReceivedAt,
+            SentAt = ReceivedAt.AddMinutes(-5),
+            SizeInBytes = 250_000,
+            AttachmentCount = 2,
+            AttachmentTotalBytes = 200_000,
+            Keywords = ["$Invoice", "$Todo"],
+            AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+            SenderTrust = SenderTrustLevel.Trusted,
+            MachineAuthorship = MachineAuthorshipBand.Possible,
+            HasExtractedContent = true,
+        };
+
+        return change is null ? email : change(email);
+    }
 }

--- a/tests/Infrastructure.UnitTests/Rules/NCalcMailRuleConditionTests.cs
+++ b/tests/Infrastructure.UnitTests/Rules/NCalcMailRuleConditionTests.cs
@@ -4,6 +4,8 @@
 
 using MailFathom.Application.Rules.Conditions;
 using MailFathom.Application.Rules.Facts;
+using MailFathom.Domain.Emails.Authentication;
+using MailFathom.Domain.Emails.Authorship;
 using MailFathom.Infrastructure.Rules;
 using MailFathom.TestSupport;
 using Xunit;
@@ -45,6 +47,14 @@ public sealed class NCalcMailRuleConditionTests
     [InlineData("isFlagged and not isDraft", true)]
     [InlineData("isEncrypted or carriesUnverifiedSignature", true)]
     [InlineData("hasExtractedContent", true)]
+    [InlineData("contains(keywords, '$Invoice')", true)]
+    [InlineData("contains(keywords, '$Waiting')", false)]
+    [InlineData("senderTrust == 'trusted'", true)]
+    [InlineData("senderTrust == 'unknown'", false)]
+    [InlineData("authorAuthentication == 'authenticated'", true)]
+    [InlineData("authorAuthentication in ('failed', 'notEstablished')", false)]
+    [InlineData("machineAuthorship == 'possible'", true)]
+    [InlineData("machineAuthorship != 'likely'", true)]
     [InlineData("contains(bodyText, 'due on receipt')", true)]
     [InlineData("if(isSeen, 0, attachmentCount) > 1", true)]
     [InlineData("isFlagged ? attachmentCount > 1 : false", true)]
@@ -70,6 +80,8 @@ public sealed class NCalcMailRuleConditionTests
     [InlineData("startsWith(subject, 'march')")]
     [InlineData("contains(recipientDomains, 'EXAMPLE.TEST')")]
     [InlineData("folder in ('INBOX', 'ARCHIVE')")]
+    [InlineData("contains(keywords, '$invoice')")]
+    [InlineData("senderTrust == 'TRUSTED'")]
     public async Task EvaluateAsync_TextDifferingOnlyByCase_StillMatches(string conditionText)
     {
         // Arrange
@@ -210,6 +222,10 @@ public sealed class NCalcMailRuleConditionTests
                 IsAnswered = false,
                 IsFlagged = true,
                 IsDraft = false,
+                Keywords = ["$Invoice", "$Todo"],
+                AuthorAuthentication = AuthorAuthenticationOutcome.Authenticated,
+                SenderTrust = SenderTrustLevel.Trusted,
+                MachineAuthorship = MachineAuthorshipBand.Possible,
                 HasExtractedContent = true,
             },
             bodyTextReader ?? new RecordingMailRuleBodyTextReader("Amount due on receipt."),

--- a/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
@@ -2,12 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Rules;
 using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Rules.History;
 using MailFathom.Application.Synchronization;
+using MailFathom.Application.Synchronization.Reconciliation;
 using MailFathom.Domain.Emails;
+using MailFathom.Domain.Emails.Authentication;
+using MailFathom.Domain.Emails.Authorship;
 using MailFathom.Domain.Folders;
 using MailFathom.IntegrationTests.Orchestration;
 using Microsoft.Extensions.DependencyInjection;
@@ -55,6 +59,9 @@ public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationF
     /// <summary>An identity of the shape the compiler derives, restored rather than computed so the column is what is under test.</summary>
     private static readonly MailRuleSetRevision Revision = MailRuleSetRevision.Restore("0a1b2c3d4e5f");
 
+    /// <summary>The domain every message this test stores authenticated as, and is recognized by name for.</summary>
+    private static readonly SenderDomain AuthenticatedDomain = CreateDomain("mailfathom.test");
+
     /// <summary>
     /// The whole arrival path over a real schema: mail nobody has evaluated is what the queue holds, the fact surface
     /// comes back projected from the row rather than loaded from it, and recording an evaluation is what takes an email
@@ -69,6 +76,7 @@ public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationF
         await DrainArrivalQueueAsync(services, cancellationToken);
         var evaluated = await StoreOneMessageAsync(services, uid: 9401, cancellationToken);
         var awaiting = await StoreOneMessageAsync(services, uid: 9402, cancellationToken);
+        await ObserveKeywordsAsync(services, evaluated, ["$Invoice", "$Todo"], cancellationToken);
 
         // Act
         var queued = await ReadArrivalQueueAsync(services, resumeAfter: null, DrainBatchSize, cancellationToken);
@@ -94,6 +102,14 @@ public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationF
         Assert.Contains(NormalizedAddress(RecipientAddress), arrival.Facts.RecipientAddresses);
         Assert.Equal(SyntheticEmail.ReceivedAt, arrival.Facts.ReceivedAt);
         Assert.True(arrival.Facts.HasExtractedContent);
+
+        // The three verdicts and the keywords are columns of the row rather than anything a pass computes, so what
+        // proves them is a projection that reads them back as they were written — a fact left out of the projection
+        // would answer with its enumeration's default on every message and no condition naming it would ever match.
+        Assert.Equal(AuthorAuthenticationOutcome.Authenticated, arrival.Facts.AuthorAuthentication);
+        Assert.Equal(SenderTrustLevel.Trusted, arrival.Facts.SenderTrust);
+        Assert.Equal(MachineAuthorshipBand.Likely, arrival.Facts.MachineAuthorship);
+        Assert.Equal(["$Invoice", "$Todo"], arrival.Facts.Keywords.Order(StringComparer.Ordinal));
 
         // Text was extracted, so nothing about this message is still expected and a body-text condition reads it now.
         Assert.False(arrival.AwaitsExtraction);
@@ -388,6 +404,74 @@ public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationF
     }
 
     /// <summary>Stores one synthetic message, whose extraction the same session derives its search document from.</summary>
+    private static SenderDomain CreateDomain(string name)
+    {
+        Assert.True(SenderDomain.TryCreate(name, out var domain));
+
+        return domain;
+    }
+
+    /// <summary>Builds the extraction of a message every stored verdict was reached for.</summary>
+    /// <remarks>
+    /// Every message this test stores carries them, because what is under test is the projection rather than the
+    /// derivation: a value that differs from the enumeration's own default is what tells a column read from the row
+    /// apart from a fact left out of the projection.
+    /// </remarks>
+    private static ExtractedEmailMetadata JudgedExtractionOf(EmailOccurrenceId occurrenceId, string subject) =>
+        SyntheticEmail.ExtractionOf(
+            occurrenceId,
+            subject,
+            SyntheticEmail.BodyTextContaining(subject, wordCount: 40),
+            RecipientAddress) with
+        {
+            SenderAuthentication = SenderAuthentication.Authenticated(
+                [AuthenticatedDomain],
+                spfDomains: [],
+                AuthenticatedDomain,
+                DmarcOutcome.Pass),
+            SenderTrust = SenderTrust.Trusted(
+                SenderTrustSource.ConfiguredTrustedSender,
+                SenderTrustPolicyRevision.FromStoredValue("0a1b2c3d4e5f0a1b")),
+            MachineAuthorship = MachineAuthorshipAssessment.Assessed(
+                MachineAuthorshipBand.Likely,
+                likelihood: 0.9,
+                MachineAuthorshipSignals.FormulaicFraming,
+                MachineAuthorshipProfileRevision.FromStoredValue("0a1b2c3d4e5f0a1b")),
+        };
+
+    /// <summary>Records the keywords a server reported for one stored email, through the reconciliation write.</summary>
+    private static async Task ObserveKeywordsAsync(
+        OrchestratedMailFathomServices services,
+        StoredEmailId storedEmailId,
+        IReadOnlyList<string> keywords,
+        CancellationToken cancellationToken)
+    {
+        var commitResult = await services.CommitAsync(
+            async (scope, session, token) => await scope
+                .GetRequiredService<IStoredEmailReconciliationStore>()
+                .ApplyReconciliationOutcomeAsync(
+                    session,
+                    new ReconciledFolderOutcome(
+                        [
+                            new ObservedEmailFlags(
+                                storedEmailId,
+                                RemoteEmailFlagSnapshot.NeverObserved with
+                                {
+                                    ObservedAt = EvaluatedAt,
+                                    Keywords = RemoteEmailKeywords.Create(keywords),
+                                }),
+                        ],
+                        ConfirmedUnchanged: [],
+                        Disappeared: [],
+                        RemovedByOwnMutation: [],
+                        RemotelyDeletedEmailDisposition.RetainTombstone,
+                        EvaluatedAt),
+                    token),
+            cancellationToken);
+
+        Assert.Equal(PersistenceCommitResult.Committed, commitResult);
+    }
+
     private static async Task<StoredEmailId> StoreOneMessageAsync(
         OrchestratedMailFathomServices services,
         uint uid,
@@ -405,11 +489,7 @@ public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationF
                 .UpsertMetadataAsync(
                     session,
                     SyntheticEmail.RemoteMetadataOf(occurrenceId, subject),
-                    SyntheticEmail.ExtractionOf(
-                        occurrenceId,
-                        subject,
-                        SyntheticEmail.BodyTextContaining(subject, wordCount: 40),
-                        RecipientAddress),
+                    JudgedExtractionOf(occurrenceId, subject),
                     StoredEmailContentAvailability.Available,
                     token),
             cancellationToken);

--- a/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedMailRuleEvaluationTests.cs
@@ -109,7 +109,9 @@ public sealed class OrchestratedMailRuleEvaluationTests(MailFathomOrchestrationF
         Assert.Equal(AuthorAuthenticationOutcome.Authenticated, arrival.Facts.AuthorAuthentication);
         Assert.Equal(SenderTrustLevel.Trusted, arrival.Facts.SenderTrust);
         Assert.Equal(MachineAuthorshipBand.Likely, arrival.Facts.MachineAuthorship);
-        Assert.Equal(["$Invoice", "$Todo"], arrival.Facts.Keywords.Order(StringComparer.Ordinal));
+        // The keywords in their normalized form for the same reason as the alias and the addresses: RemoteEmailKeywords
+        // folds what a server wrote to upper case, and the fact surface publishes what the row holds.
+        Assert.Equal(["$INVOICE", "$TODO"], arrival.Facts.Keywords.Order(StringComparer.Ordinal));
 
         // Text was extracted, so nothing about this message is still expected and a body-text condition reads it now.
         Assert.False(arrival.AwaitsExtraction);


### PR DESCRIPTION
Closes #936

## What changes

Four values a message has carried for a while became readable in a rule condition: the keywords the server reports, what the receiving server established about the displayed author, whether this deployment recognizes that author, and how machine written the message's own text reads.

| Fact | Type | Values |
| --- | --- | --- |
| `keywords` | text set | Whatever the server reports; empty when it reports none |
| `authorAuthentication` | text | `authenticated`, `failed`, `notEstablished` |
| `senderTrust` | text | `trusted`, `unknown` |
| `machineAuthorship` | text | `likely`, `possible`, `unlikely`, `notAssessed` |

Two of those were gaps rather than scope not reached. A rule could already *write* keywords and could not select on them, which is most of what makes a keyword worth writing; and both feature pages said in their own words that no rule read their verdict.

**Decided rather than derived.**

- **`authorAuthentication` was added beside `senderTrust`**, which #936 did not originally list. The two are published as a pair and the feature page says a caller reads them together: `unknown` trust is the ordinary state of legitimate mail from anybody nobody has named, so the trust verdict alone cannot express the one strong statement in the pair — a displayed author that failed their own domain's published policy. The issue records the extension and why.
- **The machine-authorship likelihood is not a fact.** The band is. The number is a heuristic comparable only within one profile revision, so `machineAuthorshipLikelihood > 0.8` would change meaning the next time the weighting moved, silently, on a rule that files mail.
- **The authoring names are declared beside the fact surface**, not taken from the enumerations' member names, so renaming a member cannot change what an operator has to type. The MCP surface keeps its own copy of the same words for the same reason.
- **`MailRuleEmailFacts` carries the domain enumerations** and the reader turns them into the words a condition compares against, which keeps the published vocabulary in the layer that publishes it rather than in whatever queried the row.

Nothing new is derived, stored, or migrated: all four values are columns the arrival pipeline already writes. The type checker needed no change — it judges a comparison from the fact's declared shape.

## How it was verified

- `scripts/verify-full.sh` — passed on this branch rebased onto current `main`: 8798 unit tests, 0 failures; aggregate line coverage 96.10 % against a required 85 %; 215 workflow contracts passed, 0 failed; `dotnet format` reported nothing to change.
- `scripts/review-obligations.sh` — every row answered: the three `Application/Rules/Facts` files are covered by the unit tests in this change; `MailRuleEvaluationStore` is `[RequiresIntegrationCoverage]` and its projection is asserted in `OrchestratedMailRuleEvaluationTests`, which is where an EF projection can be proven; `stored-email-schema.md` and `email-search.md` describe columns and queries this change does not touch.
- Unit tests added: each name parses to its declared shape, each verdict resolves to its authoring name, an email nothing judged reads as `notEstablished` / `unknown` / `notAssessed` and an empty keyword set, and conditions over all four are evaluated end to end through the NCalc compiler — including the case-insensitive comparison that makes `contains(keywords, '$todo')` select a message a rule labelled `$Todo`.
- The integration suite was **not run here** — it starts a PostgreSQL container and is the owner's to run. The assertions added to `OrchestratedMailRuleEvaluationTests` compile and are what proves the projection reads the four columns back rather than answering with an enumeration's default.

## Checklist

- [x] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [x] Behavior changes are covered by unit tests, and the coverage gate passes.
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail. — no file was added.
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set. — no dependency changed.
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.

---

Issue: [#936](https://github.com/Krzysztof318/MailFathom/issues/936)
