### PR TITLE
[#589] Record every authorization refusal, and keep the caller out of what is counted

### DIFF
--- a/docs/architecture/authorized-principal.md
+++ b/docs/architecture/authorized-principal.md
@@ -116,6 +116,14 @@ permission, because reporting what the credential is and what it may do is what 
 to learn that it holds nothing.
 [The administrative endpoint page](../operations/admin-endpoint.md#what-the-endpoint-serves) carries the whole mapping.
 
+**Both surfaces record every refusal, and neither surface's answer is the record.** A refusal is counted by
+`mailfathom.authorization.refusals` — by surface, by the tool or route that was refused, and by the permission that
+would have sufficed — with a warning beside it naming the credential the work was admitted as, which the boundary reads
+from `AccessAuthorization` rather than from the refusal, since the failure itself is barred from carrying an identity. A
+tool withheld from a listing is not a refusal and is not recorded: nothing was refused, and every narrowed caller would
+produce one on every listing.
+[Telemetry](../operations/telemetry.md#what-an-authorization-refusal-records) holds what each channel carries.
+
 The other requirement in force is the download route's, which admits a signed capability and nothing else.
 
 The transport's own reading of the grant goes through the same `AccessAuthorization` the use cases ask, which reports a

--- a/docs/features/mcp-tools.md
+++ b/docs/features/mcp-tools.md
@@ -117,6 +117,11 @@ no grant makes a capability the deployment does not have appear. A caller grante
 The check runs twice. The endpoint refuses before a use case is reached, and the use case behind each tool asks for the
 same permission on its own — so an entrypoint added later reaches the same refusal without passing any of this.
 
+Either of them refusing is recorded, which on this surface is the only place the decision is visible at all: the caller
+is told nothing it could report, so a client that stopped working is diagnosed from the deployment's own counter and
+warning rather than from what it received. A tool merely withheld from a listing is not recorded, because nothing was
+refused. [Telemetry](../operations/telemetry.md#what-an-authorization-refusal-records) holds what each channel carries.
+
 ## Descriptor conventions
 
 Every tool is declared with the same deliberate metadata, because a client decides whether a tool is safe to call before

--- a/docs/operations/admin-endpoint.md
+++ b/docs/operations/admin-endpoint.md
@@ -183,6 +183,12 @@ later cannot widen the surface by forgetting a filter, and a use case's own refu
 rather than reaching the caller as a fault in the deployment. A route mapped without deciding a permission is refused
 outright — nobody reaches it — so forgetting to decide costs a route rather than opening one.
 
+Whichever of the two refused it, the deployment records it once: `mailfathom.authorization.refusals` counts it by
+surface, route, and the permission that was missing, and a warning beside it names the credential the caller was
+admitted as. One operator reading one `403` is not a rate anybody can watch, and a credential that starts asking for
+what it was never granted is what the record exists to make visible.
+[Telemetry](telemetry.md#what-an-authorization-refusal-records) says what it carries and what it deliberately does not.
+
 ## What the endpoint serves
 
 | Route | Permission | What it does |

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -723,7 +723,9 @@ saying one is required, and no `insufficient_scope` challenge inviting a client 
 came from a token's scopes and its authorization server could in principle mint it. The listing already said what this
 caller may do, and a refusal it could tell apart from an unknown tool would say that a capability exists which you chose
 not to offer it. Diagnosing a client that stopped working is therefore done from this deployment's own record rather
-than from what the client received.
+than from what the client received: every refusal is counted by `mailfathom.authorization.refusals` and written as a
+warning naming the credential and the permission it lacked, which
+[telemetry](telemetry.md#what-an-authorization-refusal-records) describes in full.
 
 **Which mailboxes a caller reaches is not something a credential decides.** Every tool call resolves the accounts the
 configured owner controls and refuses anything outside them, whichever credential got the caller in, and no setting
@@ -1701,6 +1703,11 @@ about why. When a client reports `54001`, the server log is where the reason is.
 
 A refused call is logged with the five-digit code it was refused with, so an operator can correlate a client's complaint
 against a server record without learning what was searched for.
+
+A call refused for want of a permission is recorded once more, and separately, because the caller was told nothing it
+could report: it is counted by `mailfathom.authorization.refusals` and written as a warning naming the credential and
+the permission the grant omits. That record is the whole of what an operator has for this boundary, and
+[telemetry](telemetry.md#what-an-authorization-refusal-records) says what it carries and what it deliberately does not.
 
 That same measurement is published as instruments, so a rate and a distribution can be read without going through the
 records one at a time. What they carry is the tool and how the call ended, and nothing else;

--- a/docs/operations/mcp-endpoint.md
+++ b/docs/operations/mcp-endpoint.md
@@ -724,8 +724,10 @@ came from a token's scopes and its authorization server could in principle mint 
 caller may do, and a refusal it could tell apart from an unknown tool would say that a capability exists which you chose
 not to offer it. Diagnosing a client that stopped working is therefore done from this deployment's own record rather
 than from what the client received: every refusal is counted by `mailfathom.authorization.refusals` and written as a
-warning naming the credential and the permission it lacked, which
-[telemetry](telemetry.md#what-an-authorization-refusal-records) describes in full.
+warning naming the credential it was refused, and the permission the grant omits wherever the tool the call named
+publishes one — a call naming no tool this surface publishes is refused for no permission and its warning names none,
+which is how a client on a stale or misspelled name reads apart from one asking for what it was never granted.
+[Telemetry](telemetry.md#what-an-authorization-refusal-records) describes both in full.
 
 **Which mailboxes a caller reaches is not something a credential decides.** Every tool call resolves the accounts the
 configured owner controls and refuses anything outside them, whichever credential got the caller in, and no setting

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -324,6 +324,41 @@ of, and the denominator is MailFathom's own sessions rather than EF Core's count
 issues. What was written is nowhere on it: a session covers whatever a use case staged, so any dimension naming it would
 eventually name mail.
 
+### What an authorization refusal records
+
+A caller reaching something its grant does not carry is counted by `mailfathom.authorization.refusals`, tagged with
+`mailfathom.authorization.surface` as `mail` or `administration`, `mailfathom.authorization.operation` with the tool or
+the route that was refused, and `mailfathom.authorization.permission` with the permission that would have sufficed. It
+is the signal worth alerting on rather than any single failure: one refusal is a client that was narrowed, and a
+credential that starts producing them is one being used for something it was never provisioned for.
+
+**On the MCP surface this record is the only place the boundary is visible at all.** A tool a caller may not reach is
+absent from its listing, and a call naming one is answered exactly as a call naming a tool that does not exist, so a
+client that stopped working is diagnosed from here rather than from anything it received —
+[the MCP endpoint page](mcp-endpoint.md#what-a-credential-decides-and-what-it-does-not) records why. The administrative
+surface names the permission to the caller as well, and is still counted here, because `mfctl` reporting one refusal to
+one operator is not a rate anybody can watch.
+
+Beside each measurement is a `Warning`, and it carries the one thing the counter deliberately does not: the credential
+the caller was admitted as, which is what an operator repairs the grant of. That value is on the log alone because its
+cardinality follows the credentials an operator wrote and, where a token admitted the caller, it is an issuer and that
+authorization server's identifier for a person — which belongs in a record a deployment sets a level on rather than in
+an exported series that never goes away. Work reached under no principal at all is recorded as `(none)`.
+
+The operation dimension is bounded the same way the tool dimension above is, and for the same reason: a tool name is
+used only where this surface publishes a tool answering to it and anything else is `(unpublished)`, while an
+administrative route is named by the pattern this repository mapped it under rather than by the address the request
+carried. A refusal that no grant would have satisfied — a route that published no decision, or a use case refusing over
+the kind of principal that reached it rather than over a grant — is counted under `(none)`, and its log line names no
+permission rather than naming one that would not have helped.
+
+**A listing that withholds a tool records nothing.** Nothing was refused there, every narrowed caller would produce one
+on every listing it asked for, and the omission has no operation to partition by — so the reading this signal exists for
+would sit under the steady state. Nor does a permitted call or a permitted route record anything here, so the ordinary
+path costs what it did before. Nothing about the refused request reaches either channel beyond the four values above:
+not an argument, not a route value, not a header, not the credential the caller presented, and nothing about the mail
+the request was for.
+
 ### What a request-path trace contains
 
 A tool call arrives with a span from the request pipeline and leaves a set of database spans behind it, and neither of

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -348,9 +348,14 @@ an exported series that never goes away. Work reached under no principal at all 
 The operation dimension is bounded the same way the tool dimension above is, and for the same reason: a tool name is
 used only where this surface publishes a tool answering to it and anything else is `(unpublished)`, while an
 administrative route is named by the pattern this repository mapped it under rather than by the address the request
-carried. A refusal that no grant would have satisfied — a route that published no decision, or a use case refusing over
-the kind of principal that reached it rather than over a grant — is counted under `(none)`, and its log line names no
-permission rather than naming one that would not have helped.
+carried. A refusal that no grant would have satisfied is counted under `(none)`, and its log line names no permission
+rather than naming one that would not have helped. Three arrangements produce one, and they are not equally
+interesting: a call naming a tool this surface does not publish, which lands as `(unpublished)` under `(none)` and is
+the ordinary mistake of a client on a stale or misspelled name; a route that published no decision; and a use case
+refusing over the kind of principal that reached it rather than over a grant. The first is a client to repair and the
+other two are defects in this repository, so read the operation before reading the remedy — and an alert on this
+counter as *a credential asking for what it was never granted* is written against the operations a grant could have
+reached rather than against `(unpublished)`.
 
 **A listing that withholds a tool records nothing.** Nothing was refused there, every narrowed caller would produce one
 on every listing it asked for, and the omission has no operation to partition by — so the reading this signal exists for

--- a/src/Application/Access/AccessAuthorization.cs
+++ b/src/Application/Access/AccessAuthorization.cs
@@ -45,6 +45,23 @@ public sealed class AccessAuthorization
         this.principals = principals;
     }
 
+    /// <summary>Gets what the work in hand was admitted as, or <see langword="null" /> where it was reached under no principal.</summary>
+    /// <remarks>
+    /// <para>
+    /// It decides nothing and is never asked before an operation runs. It is here for a boundary that has to name the
+    /// caller in a record of its own — which is what an operator diagnosing a refusal reads, since the MCP surface
+    /// tells a refused caller nothing at all — and reading it through the same object the decision was asked of is what
+    /// keeps a boundary from acquiring the principal source and deciding for itself what holding a permission means.
+    /// </para>
+    /// <para>
+    /// What it carries is what <see cref="AuthorizedPrincipal.Identity" /> carries, which for a token is the issuer and
+    /// the subject the deployment authorized — a host name and a remote party's identifier for a person. That is why
+    /// <see cref="PrincipalNotAuthorizedException" /> is barred from naming it and why a boundary reading it decides
+    /// for itself what its own readers may see.
+    /// </para>
+    /// </remarks>
+    public string? PrincipalIdentity => this.principals.Current?.Identity;
+
     /// <summary>Requires that an admitted caller holding one named capability is what reached this use case.</summary>
     /// <param name="permission">The capability the operation is published under.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="permission" /> names no published capability, which is a defect in the calling use case rather than a refusal.</exception>

--- a/src/Application/Observability/IAuthorizationRefusalTelemetry.cs
+++ b/src/Application/Observability/IAuthorizationRefusalTelemetry.cs
@@ -1,0 +1,44 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+
+namespace MailFathom.Application.Observability;
+
+/// <summary>Records that a caller reached something its grant does not carry, which is the only place that boundary is visible.</summary>
+/// <remarks>
+/// <para>
+/// A refusal on the MCP surface tells the caller nothing — a tool it may not reach is absent from the listing, and a
+/// call naming one is answered exactly as a call naming a tool that does not exist — so an operator diagnosing a client
+/// that stopped working has this record or nothing at all. On the administrative surface the caller is told the
+/// permission that would have sufficed, and the record is still what turns one operator's refusal into a rate somebody
+/// can alert on: a credential that starts asking for what it was never granted is the signal, rather than any single
+/// failure.
+/// </para>
+/// <para>
+/// What counts as a refusal is a call or a route refused for want of a permission. A tool omitted from a listing is not
+/// one: nothing was refused, every narrowed caller would report one on every listing, and the omission has no operation
+/// to partition by — so the thing worth alerting on would sit under the steady state.
+/// </para>
+/// <para>
+/// The operation a refusal names is MailFathom's own name for what was refused and never a value a caller chose. A
+/// dimension whose values a caller picks is a time series per value, so a boundary reduces a name that arrived on a
+/// request to one this repository publishes before it reaches here.
+/// </para>
+/// </remarks>
+public interface IAuthorizationRefusalTelemetry
+{
+    /// <summary>Records one refusal, on both the counted channel and the one an operator reads.</summary>
+    /// <param name="surface">The surface the refusal happened on.</param>
+    /// <param name="operation">MailFathom's own name for the tool or the route that was refused.</param>
+    /// <param name="requiredPermission">The permission that would have sufficed, unspecified where the refusal named none.</param>
+    /// <param name="refusedIdentity">What the caller was admitted as, or <see langword="null" /> where the work was reached under no principal.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="operation" /> is empty or white space, which would leave the refusal nothing to be partitioned by.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="operation" /> is <see langword="null" />.</exception>
+    void RecordRefusal(
+        ProtectedSurface surface,
+        string operation,
+        MailFathomPermission requiredPermission,
+        string? refusedIdentity);
+}

--- a/src/Host/Security/Endpoints/AdminRouteAuthorization.cs
+++ b/src/Host/Security/Endpoints/AdminRouteAuthorization.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Access;
+using MailFathom.Application.Observability;
 using MailFathom.Domain.Access;
 using Microsoft.AspNetCore.Http.HttpResults;
 
@@ -38,6 +39,9 @@ internal static class AdminRouteAuthorization
     /// the sentence would make the wording a contract, and the sentence is written for a person.
     /// </remarks>
     internal const string PermissionExtension = "permission";
+
+    /// <summary>The one name a refusal on an endpoint carrying no route pattern is recorded under.</summary>
+    internal const string UnroutedOperationName = "(unrouted)";
 
     /// <summary>States the one permission a route is published under.</summary>
     /// <param name="route">The route being mapped.</param>
@@ -94,12 +98,16 @@ internal static class AdminRouteAuthorization
 
         if (context.HttpContext.GetEndpoint()?.Metadata.GetOrderedMetadata<AdminRoutePermission>() is not [{ } published])
         {
+            RecordRefusal(context.HttpContext, default);
+
             return Undeclared();
         }
 
         if (published.Permission.IsSpecified
             && !context.HttpContext.RequestServices.GetRequiredService<AccessAuthorization>().Permits(published.Permission))
         {
+            RecordRefusal(context.HttpContext, published.Permission);
+
             return Refused(published.Permission);
         }
 
@@ -109,9 +117,43 @@ internal static class AdminRouteAuthorization
         }
         catch (PrincipalNotAuthorizedException refusal)
         {
+            RecordRefusal(context.HttpContext, refusal.RequiredPermission);
+
             return Refused(refusal.RequiredPermission);
         }
     }
+
+    /// <summary>Records the refusal beside the answer the caller receives, which is what makes a rate of them readable.</summary>
+    /// <remarks>
+    /// <para>
+    /// Recorded once per refused request, wherever the refusal was decided. The filter refuses before the use case is
+    /// reached, so a request stopped here never produces a second record from the authority behind it, and a use case
+    /// refusing a request the filter admitted is recorded here because that is where the refusal becomes an answer.
+    /// </para>
+    /// <para>
+    /// The operation is the route's own pattern rather than the address the caller sent: a pattern is written in this
+    /// repository and bounded by it, while a path carries whatever the request put in each segment. A route that
+    /// published no single decision is recorded under a permission of none, because none would have helped — the remedy
+    /// is a defect report rather than a wider grant, and a refusal nobody counted is the one nobody finds.
+    /// </para>
+    /// </remarks>
+    private static void RecordRefusal(HttpContext context, MailFathomPermission requiredPermission) =>
+        context.RequestServices.GetRequiredService<IAuthorizationRefusalTelemetry>().RecordRefusal(
+            ProtectedSurface.Administration,
+            OperationOf(context),
+            requiredPermission,
+            context.RequestServices.GetRequiredService<AccessAuthorization>().PrincipalIdentity);
+
+    /// <summary>Names the route that was refused, as this repository wrote it.</summary>
+    /// <remarks>
+    /// An endpoint that is not a routed one carries no pattern to name, which no mapped administrative route is; it is
+    /// recorded under a fixed name rather than left out, so the refusal is still counted and still says which
+    /// deployment produced it.
+    /// </remarks>
+    private static string OperationOf(HttpContext context) =>
+        context.GetEndpoint() is RouteEndpoint { RoutePattern.RawText: { Length: > 0 } pattern }
+            ? pattern
+            : UnroutedOperationName;
 
     /// <summary>Writes the refusal a caller reads, which names the permission and nothing beside it.</summary>
     /// <remarks>

--- a/src/Infrastructure/Observability/AuthorizationRefusalTelemetry.cs
+++ b/src/Infrastructure/Observability/AuthorizationRefusalTelemetry.cs
@@ -1,0 +1,131 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.Metrics;
+using MailFathom.Application.Observability;
+using MailFathom.Common.Observability;
+using MailFathom.Domain.Access;
+using Microsoft.Extensions.Logging;
+
+namespace MailFathom.Infrastructure.Observability;
+
+/// <summary>Publishes every authorization refusal on the two channels an operator has, and on no third one.</summary>
+/// <remarks>
+/// <para>
+/// The counter is what an alert is written against, because the reading worth acting on is a rate rather than an
+/// event: one refusal is a client that was narrowed, and a credential that starts producing them is one being used for
+/// something it was never provisioned for. The warning beside it is what turns that rate back into a repair, since a
+/// counter cannot say which credential to widen.
+/// </para>
+/// <para>
+/// The dimensions are three closed sets — the surface, MailFathom's own name for the tool or route that was refused,
+/// and the permission that would have sufficed — so a client looping over names it invented cannot mint a time series
+/// apiece. The identity is deliberately on the log alone: it is the one value here whose cardinality follows the
+/// credentials an operator wrote and, where a token admitted the caller, it is an issuer and a remote party's
+/// identifier for a person, which belongs in a record a deployment can set a level on rather than in an exported
+/// series that never goes away.
+/// </para>
+/// <para>
+/// Nothing else about the refused request reaches either channel. Not an argument, not a route value, not a header, not
+/// the credential material the caller presented, and nothing about the mail the request was for — a refused call is
+/// still a call a stranger composed, and none of what it carried belongs in the record written to prove it was stopped.
+/// </para>
+/// </remarks>
+internal sealed partial class AuthorizationRefusalTelemetry : IAuthorizationRefusalTelemetry
+{
+    internal const string SurfaceTagName = "mailfathom.authorization.surface";
+    internal const string OperationTagName = "mailfathom.authorization.operation";
+    internal const string PermissionTagName = "mailfathom.authorization.permission";
+
+    internal const string MailSurfaceName = "mail";
+    internal const string AdministrationSurfaceName = "administration";
+
+    /// <summary>The one value a refusal that no grant would have satisfied is counted under.</summary>
+    /// <remarks>
+    /// A refusal names no permission where the operation published none for a caller to hold: a route that declared
+    /// nothing, or a use case refusing over the kind of principal that reached it rather than over a grant. Counting
+    /// those under a permission name would tell an operator to grant something that would not have helped, and leaving
+    /// them out would drop the one refusal whose remedy is a defect report.
+    /// </remarks>
+    internal const string UnnamedPermissionValue = "(none)";
+
+    /// <summary>What the log names a refusal whose work was reached under no principal at all.</summary>
+    internal const string UnidentifiedCallerValue = "(none)";
+
+    private readonly ILogger<AuthorizationRefusalTelemetry> logger;
+    private readonly Counter<long> refusalCount;
+
+    /// <summary>Initializes the instrument every refusal is counted on.</summary>
+    /// <param name="logger">Records the credential and the permission it lacked.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="logger" /> is <see langword="null" />.</exception>
+    public AuthorizationRefusalTelemetry(ILogger<AuthorizationRefusalTelemetry> logger)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this.logger = logger;
+        this.refusalCount = Telemetry.Meter.CreateCounter<long>(
+            "mailfathom.authorization.refusals",
+            unit: "{refusal}",
+            description: "Calls and routes refused for want of a permission, by surface, operation, and the permission that was missing.");
+    }
+
+    /// <inheritdoc />
+    public void RecordRefusal(
+        ProtectedSurface surface,
+        string operation,
+        MailFathomPermission requiredPermission,
+        string? refusedIdentity)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(operation);
+
+        var surfaceName = NameOf(surface);
+
+        this.refusalCount.Add(
+            1,
+            new KeyValuePair<string, object?>(SurfaceTagName, surfaceName),
+            new KeyValuePair<string, object?>(OperationTagName, operation),
+            new KeyValuePair<string, object?>(
+                PermissionTagName,
+                requiredPermission.IsSpecified ? requiredPermission.Name : UnnamedPermissionValue));
+
+        var identity = refusedIdentity ?? UnidentifiedCallerValue;
+
+        if (requiredPermission.IsSpecified)
+        {
+            this.LogRefusalOfAPermission(identity, operation, surfaceName, requiredPermission.Name);
+        }
+        else
+        {
+            this.LogRefusalNamingNoPermission(identity, operation, surfaceName);
+        }
+    }
+
+    /// <summary>Names a surface as a dimension value.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when the surface is not one this adapter publishes.</exception>
+    /// <remarks>
+    /// A closed mapping rather than the member's own name, for the reason every published mapping here is closed: the
+    /// value is what a dashboard and an alert are written against, so a surface added without one has to fail rather
+    /// than silently rename a series.
+    /// </remarks>
+    private static string NameOf(ProtectedSurface surface) => surface switch
+    {
+        ProtectedSurface.Mail => MailSurfaceName,
+        ProtectedSurface.Administration => AdministrationSurfaceName,
+        _ => throw new ArgumentOutOfRangeException(nameof(surface), surface, "The surface has no published dimension value."),
+    };
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The credential '{RefusedIdentity}' was refused '{Operation}' on the {Surface} surface, because its grant does not carry '{RequiredPermission}'.")]
+    private partial void LogRefusalOfAPermission(
+        string refusedIdentity,
+        string operation,
+        string surface,
+        string requiredPermission);
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "The credential '{RefusedIdentity}' was refused '{Operation}' on the {Surface} surface, which publishes no permission any grant could carry.")]
+    private partial void LogRefusalNamingNoPermission(string refusedIdentity, string operation, string surface);
+}

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -239,6 +239,11 @@ public static class ServiceCollectionExtensions
         // arrived first.
         services.AddScoped<AccessAuthorization>();
 
+        // The record a refused caller is never told about. A singleton for the reason every other publisher here is
+        // one: the counter it holds is a fact about the process, and a scoped instance would create an instrument per
+        // request.
+        services.AddSingleton<IAuthorizationRefusalTelemetry, AuthorizationRefusalTelemetry>();
+
         // A value rather than an accessor, unlike the connection settings beside it: this one is compiled into the
         // search vector's column definition, so it is fixed for a deployment's schema and a reload cannot adopt a new
         // one without reindexing. Changing it is a migration, not a configuration reload.

--- a/src/Mcp/Observability/McpToolCallTelemetry.cs
+++ b/src/Mcp/Observability/McpToolCallTelemetry.cs
@@ -53,9 +53,6 @@ internal sealed class McpToolCallTelemetry
     /// <summary>Names a call that ended in a way nothing anticipated and was answered with the generic code.</summary>
     internal const string FailedOutcomeName = "failed";
 
-    /// <summary>The one name a tool nothing publishes is measured under.</summary>
-    internal const string UnpublishedToolName = "(unpublished)";
-
     private readonly Counter<long> calls;
     private readonly Histogram<double> callDuration;
 
@@ -113,15 +110,11 @@ internal sealed class McpToolCallTelemetry
     public void RecordUnexpectedFailure(string? requestedToolName, TimeSpan duration) =>
         this.Record(requestedToolName, FailedOutcomeName, duration);
 
-    /// <summary>Reduces the name a caller sent to one of the names this surface publishes.</summary>
-    private static string MeasurableToolName(string? requestedToolName) =>
-        PublishedTools.Contains(requestedToolName) ? requestedToolName! : UnpublishedToolName;
-
     private void Record(string? requestedToolName, string outcome, TimeSpan duration)
     {
         var tags = new TagList
         {
-            { ToolTagName, MeasurableToolName(requestedToolName) },
+            { ToolTagName, PublishedTools.MeasurableName(requestedToolName) },
             { OutcomeTagName, outcome },
         };
 

--- a/src/Mcp/Tools/McpToolAuthorization.cs
+++ b/src/Mcp/Tools/McpToolAuthorization.cs
@@ -3,6 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Access;
+using MailFathom.Application.Observability;
+using MailFathom.Domain.Access;
 using Microsoft.Extensions.DependencyInjection;
 using ModelContextProtocol;
 using ModelContextProtocol.Protocol;
@@ -109,14 +111,58 @@ internal static class McpToolAuthorization
         ArgumentNullException.ThrowIfNull(request);
 
         var requestedToolName = request.Params?.Name;
+        var authorization = RequiredAuthorization(request);
 
-        if (!IsPermitted(RequiredAuthorization(request), requestedToolName))
+        if (!IsPermitted(authorization, requestedToolName))
         {
+            PublishedTools.TryGetRequiredPermission(requestedToolName, out var declaredPermission);
+            RecordRefusal(request, authorization, requestedToolName, declaredPermission);
+
             throw UnknownTool(requestedToolName);
         }
 
-        return await next(request, cancellationToken);
+        try
+        {
+            return await next(request, cancellationToken);
+        }
+        catch (PrincipalNotAuthorizedException refusal)
+        {
+            // The use case is the authority and this filter is the cheap reading in front of it, so the two can
+            // disagree — over a permission the tool and the use case name differently, or over the kind of principal
+            // that reached the work. The refusal keeps the answer it already had; what is added is that a boundary the
+            // caller learns nothing from is not also one the deployment learns nothing from.
+            RecordRefusal(request, authorization, requestedToolName, refusal.RequiredPermission);
+
+            throw;
+        }
     }
+
+    /// <summary>Records the refusal on the one channel that can report it, since the caller is told nothing.</summary>
+    /// <remarks>
+    /// <para>
+    /// A call is recorded and a withheld descriptor is not. Nothing was refused by a listing, every narrowed caller
+    /// would report one on every listing it asked for, and the omission has no operation to partition by — so counting
+    /// it would bury the reading this record exists for, which is a credential that has begun asking for what it was
+    /// never granted.
+    /// </para>
+    /// <para>
+    /// The operation is reduced to a name this surface publishes before it is recorded, because the name a call carried
+    /// is a string of the caller's choosing and a dimension taking one would let a client mint a time series apiece.
+    /// The permission is unspecified for a name no tool declared anything for, and for a use case refusing over the
+    /// kind of principal that reached it — which is the refusal no grant would have satisfied rather than a narrower
+    /// one.
+    /// </para>
+    /// </remarks>
+    private static void RecordRefusal(
+        MessageContext request,
+        AccessAuthorization authorization,
+        string? requestedToolName,
+        MailFathomPermission requiredPermission) =>
+        RequiredService<IAuthorizationRefusalTelemetry>(request).RecordRefusal(
+            ProtectedSurface.Mail,
+            PublishedTools.MeasurableName(requestedToolName),
+            requiredPermission,
+            authorization.PrincipalIdentity);
 
     /// <summary>Reports whether the caller may be offered, and may call, the tool a descriptor or a request named.</summary>
     /// <remarks>A tool this surface does not publish answers <see langword="false" />: nothing declared what reaching it requires, and a boundary that let an undeclared tool through would make forgetting to grant one the way to publish it ungoverned.</remarks>
@@ -151,7 +197,13 @@ internal static class McpToolAuthorization
     /// established this caller holds, so the composition fault is raised instead.
     /// </remarks>
     private static AccessAuthorization RequiredAuthorization(MessageContext request) =>
-        request.Services?.GetRequiredService<AccessAuthorization>()
-        ?? throw new InvalidOperationException(
-            "A tool request arrived without a service provider, so the caller's grant could not be read.");
+        RequiredService<AccessAuthorization>(request);
+
+    /// <summary>Resolves one service from the scope the request arrived in.</summary>
+    private static TService RequiredService<TService>(MessageContext request)
+        where TService : notnull =>
+        request.Services is { } services
+            ? services.GetRequiredService<TService>()
+            : throw new InvalidOperationException(
+                "A tool request arrived without a service provider, so the caller's grant could not be read.");
 }

--- a/src/Mcp/Tools/PublishedTools.cs
+++ b/src/Mcp/Tools/PublishedTools.cs
@@ -24,6 +24,15 @@ namespace MailFathom.Mcp.Tools;
 /// </remarks>
 internal static class PublishedTools
 {
+    /// <summary>The one name every tool this surface does not publish is reported under.</summary>
+    /// <remarks>
+    /// A signal about a call names the tool only where a published tool answers to it, and this otherwise. That is what
+    /// separates a dimension from a log line, where the same name is recorded whenever its shape is safe: a log line
+    /// costs what it is written to, and a dimension costs a time series that never goes away, so a client calling
+    /// <c>list_email</c> in a loop must not be able to mint one apiece.
+    /// </remarks>
+    internal const string UnpublishedToolName = "(unpublished)";
+
     private static readonly FrozenDictionary<string, MailFathomPermission> RequiredPermissionsByName =
         new Dictionary<string, MailFathomPermission>(StringComparer.Ordinal)
         {
@@ -44,6 +53,12 @@ internal static class PublishedTools
     /// <returns><see langword="true" /> when a published tool answers to that name.</returns>
     public static bool Contains(string? toolName) =>
         toolName is not null && RequiredPermissionsByName.ContainsKey(toolName);
+
+    /// <summary>Reduces a name a caller sent to one this surface publishes, so it is safe to make a dimension of.</summary>
+    /// <param name="toolName">The name the request carried, which may be absent or anything at all.</param>
+    /// <returns>The name itself where a published tool answers to it, and <see cref="UnpublishedToolName" /> otherwise.</returns>
+    /// <remarks>It lives here rather than beside a publisher because the closed set is what decides the answer, and two publishers reducing the same name apart would let one of them drift into measuring what a caller wrote.</remarks>
+    public static string MeasurableName(string? toolName) => Contains(toolName) ? toolName! : UnpublishedToolName;
 
     /// <summary>Reports the permission a caller must hold to be offered a tool and to call it.</summary>
     /// <param name="toolName">The name the request or the descriptor carried.</param>

--- a/tests/Application.UnitTests/Access/AccessAuthorizationTests.cs
+++ b/tests/Application.UnitTests/Access/AccessAuthorizationTests.cs
@@ -339,6 +339,29 @@ public sealed class AccessAuthorizationTests
         Assert.False(authorization.Permits(default));
     }
 
+    /// <summary>A boundary recording a refusal has to name the credential, since the refusal itself may name nothing.</summary>
+    [Fact]
+    public void PrincipalIdentity_WorkAdmittedUnderACaller_ReportsWhatTheTransportAdmittedItAs()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(
+            AuthorizedPrincipal.Caller(ConfiguredCredentialName, [MailFathomPermission.MailRead]));
+
+        // Act, Assert
+        Assert.Equal(ConfiguredCredentialName, authorization.PrincipalIdentity);
+    }
+
+    /// <summary>An entrypoint that stated nothing has nothing to name, and reporting a name for it would invent one.</summary>
+    [Fact]
+    public void PrincipalIdentity_WorkReachedUnderNoPrincipal_ReportsNothing()
+    {
+        // Arrange
+        var authorization = AuthorizationOver(principal: null);
+
+        // Act, Assert
+        Assert.Null(authorization.PrincipalIdentity);
+    }
+
     public static TheoryData<MailFathomPermission> EveryPublishedPermission() =>
         [.. MailFathomPermission.All];
 

--- a/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/AdminApiEndpointsTests.cs
@@ -12,6 +12,7 @@ using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Application.Emails.Embeddings.Indexing;
 using MailFathom.Application.Emails.Embeddings.Limits;
 using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Application.Observability;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Access;
 using MailFathom.Host.Api;
@@ -355,6 +356,7 @@ public sealed class AdminApiEndpointsTests
         services.AddScoped(_ => Substitute.For<IMailAccountCatalog>());
         services.AddScoped(_ => Substitute.For<IMailboxMutationAuditEntryStore>());
         services.AddScoped(_ => Substitute.For<IAuthorizedPrincipalSource>());
+        services.AddSingleton(Substitute.For<IAuthorizationRefusalTelemetry>());
         RegisterEmbeddingAdministration(services);
         RegisterContactBook(services);
 

--- a/tests/Host.UnitTests/Security/Endpoints/AdminRouteAuthorizationTests.cs
+++ b/tests/Host.UnitTests/Security/Endpoints/AdminRouteAuthorizationTests.cs
@@ -3,12 +3,16 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Access;
+using MailFathom.Application.Observability;
 using MailFathom.Domain.Access;
 using MailFathom.Host.Security.Endpoints;
 using MailFathom.TestSupport;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
 using Xunit;
 
 namespace MailFathom.Host.UnitTests.Security.Endpoints;
@@ -22,6 +26,12 @@ namespace MailFathom.Host.UnitTests.Security.Endpoints;
 /// </remarks>
 public sealed class AdminRouteAuthorizationTests
 {
+    /// <summary>The pattern every route in this suite is mapped under, which is what a refusal is recorded as.</summary>
+    private const string RoutePattern = "/api/admin/an-administrative-route";
+
+    /// <summary>What the shared helper admits every test caller as, which is what a refusal names in a log.</summary>
+    private const string CallerIdentity = "test-caller";
+
     /// <summary>The ordinary path: a caller holding what the route publishes reaches the handler and gets its answer.</summary>
     [Fact]
     public async Task RefuseUnpermittedAsync_ACallerHoldingWhatTheRoutePublishes_ReachesTheHandler()
@@ -196,26 +206,131 @@ public sealed class AdminRouteAuthorizationTests
         Assert.DoesNotContain(AdminRouteAuthorization.PermissionExtension, refusal.ProblemDetails.Extensions);
     }
 
+    /// <summary>The caller is told the permission, and the deployment is told which credential kept asking for it.</summary>
+    [Fact]
+    public async Task RefuseUnpermittedAsync_ACallerWithoutIt_IsRecordedNamingTheRouteAndThePermission()
+    {
+        // Arrange
+        var refusals = Substitute.For<IAuthorizationRefusalTelemetry>();
+        var context = ContextFor(
+            AdminRoutePermission.Requiring(MailFathomPermission.AdminRead),
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminOperate),
+            refusals);
+
+        // Act
+        await AdminRouteAuthorization.RefuseUnpermittedAsync(context, _ => ValueTask.FromResult<object?>("served"));
+
+        // Assert
+        refusals.Received(1).RecordRefusal(
+            ProtectedSurface.Administration,
+            RoutePattern,
+            MailFathomPermission.AdminRead,
+            CallerIdentity);
+    }
+
+    /// <summary>A route no grant reaches is the refusal whose remedy is a defect report, so it is the last one to go uncounted.</summary>
+    [Fact]
+    public async Task RefuseUnpermittedAsync_ARouteThatDecidedNothing_IsRecordedNamingNoPermission()
+    {
+        // Arrange
+        var refusals = Substitute.For<IAuthorizationRefusalTelemetry>();
+        var context = ContextFor(
+            publishedPermission: null,
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead),
+            refusals);
+
+        // Act
+        await AdminRouteAuthorization.RefuseUnpermittedAsync(context, _ => ValueTask.FromResult<object?>("served"));
+
+        // Assert
+        refusals.Received(1).RecordRefusal(
+            ProtectedSurface.Administration,
+            RoutePattern,
+            Arg.Is<MailFathomPermission>(static permission => !permission.IsSpecified),
+            CallerIdentity);
+    }
+
+    /// <summary>The use case is the authority, so its refusal is recorded where it becomes the answer a caller receives.</summary>
+    [Fact]
+    public async Task RefuseUnpermittedAsync_AUseCaseRefusingBehindAPermittedRoute_IsRecordedOnce()
+    {
+        // Arrange
+        var refusals = Substitute.For<IAuthorizationRefusalTelemetry>();
+        var authorization = AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead);
+        var context = ContextFor(
+            AdminRoutePermission.Requiring(MailFathomPermission.AdminRead),
+            authorization,
+            refusals);
+
+        // Act
+        await AdminRouteAuthorization.RefuseUnpermittedAsync(
+            context,
+            _ =>
+            {
+                authorization.RequirePermission(MailFathomPermission.AdminErase);
+
+                return ValueTask.FromResult<object?>("served");
+            });
+
+        // Assert
+        refusals.Received(1).RecordRefusal(
+            ProtectedSurface.Administration,
+            RoutePattern,
+            MailFathomPermission.AdminErase,
+            CallerIdentity);
+    }
+
+    /// <summary>A permitted request records nothing beyond what the existing request instrumentation already does.</summary>
+    [Fact]
+    public async Task RefuseUnpermittedAsync_ACallerHoldingWhatTheRoutePublishes_RecordsNoRefusal()
+    {
+        // Arrange
+        var refusals = Substitute.For<IAuthorizationRefusalTelemetry>();
+        var context = ContextFor(
+            AdminRoutePermission.Requiring(MailFathomPermission.AdminRead),
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.AdminRead),
+            refusals);
+
+        // Act
+        await AdminRouteAuthorization.RefuseUnpermittedAsync(context, _ => ValueTask.FromResult<object?>("served"));
+
+        // Assert
+        refusals.DidNotReceiveWithAnyArgs().RecordRefusal(default, default!, default, default);
+    }
+
     /// <summary>Builds one request against a route carrying the decision named, or carrying none at all.</summary>
     private static EndpointFilterInvocationContext ContextFor(
         AdminRoutePermission? publishedPermission,
-        AccessAuthorization authorization) =>
+        AccessAuthorization authorization,
+        IAuthorizationRefusalTelemetry? refusals = null) =>
         ContextFor(
             publishedPermission is null
                 ? EndpointMetadataCollection.Empty
                 : new EndpointMetadataCollection(publishedPermission),
-            authorization);
+            authorization,
+            refusals);
 
     /// <summary>Builds one request against a route carrying exactly the metadata named.</summary>
+    /// <remarks>
+    /// The endpoint is a routed one because the route's own pattern is what a refusal is recorded under, and an
+    /// endpoint without one would leave every test asserting the fallback rather than the name an operator reads.
+    /// </remarks>
     private static EndpointFilterInvocationContext ContextFor(
         EndpointMetadataCollection metadata,
-        AccessAuthorization authorization)
+        AccessAuthorization authorization,
+        IAuthorizationRefusalTelemetry? refusals = null)
     {
         var services = new ServiceCollection();
         services.AddSingleton(authorization);
+        services.AddSingleton(refusals ?? Substitute.For<IAuthorizationRefusalTelemetry>());
 
         var httpContext = new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
-        httpContext.SetEndpoint(new Endpoint(requestDelegate: null, metadata, "an administrative route"));
+        httpContext.SetEndpoint(new RouteEndpoint(
+            static _ => Task.CompletedTask,
+            RoutePatternFactory.Parse(RoutePattern),
+            order: 0,
+            metadata,
+            "an administrative route"));
 
         return EndpointFilterInvocationContext.Create(httpContext);
     }

--- a/tests/Infrastructure.UnitTests/Observability/AuthorizationRefusalTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/AuthorizationRefusalTelemetryTests.cs
@@ -12,9 +12,12 @@ namespace MailFathom.Infrastructure.UnitTests.Observability;
 
 /// <summary>Covers the only record an operator has of a boundary a refused caller is told nothing about.</summary>
 /// <remarks>
-/// One telemetry instance serves the whole class, because its counter is created on the application's one meter and an
-/// instance per test would leave an instrument per test on it. Each test therefore names an operation of its own,
-/// which is what keeps the measurements it asserts on apart from the ones the other tests published.
+/// The publisher is built per test, because each one asserts over a logger of its own and a shared instance could
+/// carry only one. What that costs is an instrument per test on the application's one meter, which is affordable here
+/// and would not be for an observable one: a counter measures when something calls it, so an instance nothing calls
+/// again reports nothing, while a gauge would answer the meter for the rest of the run. What keeps the measurements
+/// apart is not the instance but the operation — every test names one of its own, so a listener watching a shared
+/// counter name reads back only what that test published.
 /// </remarks>
 public sealed class AuthorizationRefusalTelemetryTests : IDisposable
 {

--- a/tests/Infrastructure.UnitTests/Observability/AuthorizationRefusalTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/AuthorizationRefusalTelemetryTests.cs
@@ -1,0 +1,196 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Access;
+using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Observability;
+
+/// <summary>Covers the only record an operator has of a boundary a refused caller is told nothing about.</summary>
+/// <remarks>
+/// One telemetry instance serves the whole class, because its counter is created on the application's one meter and an
+/// instance per test would leave an instrument per test on it. Each test therefore names an operation of its own,
+/// which is what keeps the measurements it asserts on apart from the ones the other tests published.
+/// </remarks>
+public sealed class AuthorizationRefusalTelemetryTests : IDisposable
+{
+    private const string RefusalsInstrumentName = "mailfathom.authorization.refusals";
+
+    private const string CallerIdentity = "an-api-key";
+
+    private readonly RecordingLoggerProvider logs = new();
+    private readonly ILoggerFactory loggerFactory;
+    private readonly AuthorizationRefusalTelemetry telemetry;
+
+    public AuthorizationRefusalTelemetryTests()
+    {
+        this.loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(this.logs));
+        this.telemetry = new AuthorizationRefusalTelemetry(
+            this.loggerFactory.CreateLogger<AuthorizationRefusalTelemetry>());
+    }
+
+    public void Dispose()
+    {
+        this.loggerFactory.Dispose();
+        this.logs.Dispose();
+    }
+
+    /// <summary>The three dimensions are what an alert partitions by: which surface, what was reached, and what was missing.</summary>
+    [Theory]
+    [InlineData(ProtectedSurface.Mail, "mail")]
+    [InlineData(ProtectedSurface.Administration, "administration")]
+    public void RecordRefusal_ARefusalOnASurface_CountsItUnderThatSurfaceOperationAndPermission(
+        ProtectedSurface surface,
+        string expectedSurfaceName)
+    {
+        // Arrange
+        var operation = $"dimensions-{expectedSurfaceName}";
+        using var measurements = new RecordedMailFathomMeasurements(RefusalsInstrumentName);
+
+        // Act
+        this.telemetry.RecordRefusal(surface, operation, MailFathomPermission.MailRead, CallerIdentity);
+
+        // Assert
+        var measurement = Assert.Single(RefusalsOf(measurements, operation));
+        Assert.Equal(1, measurement.Value);
+        Assert.Equal(expectedSurfaceName, measurement.Tags[AuthorizationRefusalTelemetry.SurfaceTagName]);
+        Assert.Equal(
+            MailFathomPermission.MailRead.Name,
+            measurement.Tags[AuthorizationRefusalTelemetry.PermissionTagName]);
+    }
+
+    /// <summary>A refusal no grant would have satisfied is still counted, under the one value that says so.</summary>
+    [Fact]
+    public void RecordRefusal_ARefusalNamingNoPermission_CountsItUnderTheUnnamedPermission()
+    {
+        // Arrange
+        const string Operation = "no-permission-would-have-helped";
+        using var measurements = new RecordedMailFathomMeasurements(RefusalsInstrumentName);
+
+        // Act
+        this.telemetry.RecordRefusal(ProtectedSurface.Administration, Operation, default, CallerIdentity);
+
+        // Assert
+        var measurement = Assert.Single(RefusalsOf(measurements, Operation));
+        Assert.Equal(
+            AuthorizationRefusalTelemetry.UnnamedPermissionValue,
+            measurement.Tags[AuthorizationRefusalTelemetry.PermissionTagName]);
+    }
+
+    /// <summary>The credential is what an operator repairs the grant of, and the counter cannot say which one it was.</summary>
+    [Fact]
+    public void RecordRefusal_ARefusalOfACaller_LogsTheCredentialAndThePermissionItLacked()
+    {
+        // Arrange
+        const string Operation = "logs-the-credential";
+
+        // Act
+        this.telemetry.RecordRefusal(
+            ProtectedSurface.Mail,
+            Operation,
+            MailFathomPermission.MailContactsWrite,
+            CallerIdentity);
+
+        // Assert
+        var record = Assert.Single(this.logs.Records);
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Equal(CallerIdentity, record.Properties["RefusedIdentity"]);
+        Assert.Equal(Operation, record.Properties["Operation"]);
+        Assert.Equal(MailFathomPermission.MailContactsWrite.Name, record.Properties["RequiredPermission"]);
+    }
+
+    /// <summary>A log line telling an operator to grant a permission that would not have helped is worse than none.</summary>
+    [Fact]
+    public void RecordRefusal_ARefusalNamingNoPermission_LogsWithoutNamingOne()
+    {
+        // Arrange
+
+        // Act
+        this.telemetry.RecordRefusal(ProtectedSurface.Administration, "logs-no-permission", default, CallerIdentity);
+
+        // Assert
+        var record = Assert.Single(this.logs.Records);
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.DoesNotContain("RequiredPermission", record.Properties.Keys, StringComparer.Ordinal);
+    }
+
+    /// <summary>Work reached under no principal has nothing to name, and the record still says a refusal happened.</summary>
+    [Fact]
+    public void RecordRefusal_ARefusalUnderNoPrincipal_LogsTheFixedUnidentifiedValue()
+    {
+        // Arrange
+
+        // Act
+        this.telemetry.RecordRefusal(
+            ProtectedSurface.Mail,
+            "under-no-principal",
+            MailFathomPermission.MailRead,
+            refusedIdentity: null);
+
+        // Assert
+        Assert.Equal(
+            AuthorizationRefusalTelemetry.UnidentifiedCallerValue,
+            Assert.Single(this.logs.Records).Properties["RefusedIdentity"]);
+    }
+
+    /// <summary>Nothing about the caller reaches the counter, where a value the operator's credentials decide would be a series apiece.</summary>
+    [Fact]
+    public void RecordRefusal_ARefusalOfACaller_PutsNothingAboutTheCallerOnTheCounter()
+    {
+        // Arrange
+        const string Operation = "identity-stays-off-the-counter";
+        using var measurements = new RecordedMailFathomMeasurements(RefusalsInstrumentName);
+
+        // Act
+        this.telemetry.RecordRefusal(ProtectedSurface.Mail, Operation, MailFathomPermission.MailAsk, CallerIdentity);
+
+        // Assert
+        Assert.DoesNotContain(
+            Assert.Single(RefusalsOf(measurements, Operation)).Tags,
+            tag => tag.Value is string value && value.Contains(CallerIdentity, StringComparison.Ordinal));
+    }
+
+    /// <summary>A refusal with nothing to partition by is a defect in the boundary that recorded it, not a series to open.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RecordRefusal_AnOperationThatNamesNothing_IsRefused(string operation)
+    {
+        // Arrange
+
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() => this.telemetry.RecordRefusal(
+            ProtectedSurface.Mail,
+            operation,
+            MailFathomPermission.MailRead,
+            CallerIdentity));
+    }
+
+    /// <summary>A surface added without a published value has to fail rather than silently rename a series.</summary>
+    [Fact]
+    public void RecordRefusal_ASurfaceWithNoPublishedValue_IsRefused()
+    {
+        // Arrange
+
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => this.telemetry.RecordRefusal(
+            (ProtectedSurface)int.MaxValue,
+            "an-unpublished-surface",
+            MailFathomPermission.MailRead,
+            CallerIdentity));
+    }
+
+    /// <summary>Reads the refusals one test published, which is what keeps the classes running in parallel apart.</summary>
+    private static IReadOnlyList<RecordedMeasurement> RefusalsOf(
+        RecordedMailFathomMeasurements measurements,
+        string operation) =>
+        [
+            .. measurements.Read(RefusalsInstrumentName).Where(measurement => StringComparer.Ordinal.Equals(
+                measurement.Tags.GetValueOrDefault(AuthorizationRefusalTelemetry.OperationTagName) as string,
+                operation)),
+        ];
+}

--- a/tests/Infrastructure.UnitTests/Observability/TelemetrySurfaceContractTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/TelemetrySurfaceContractTests.cs
@@ -21,6 +21,7 @@ using MailFathom.Application.SensitiveContent.Egress;
 using MailFathom.Application.SensitiveContent.Redaction;
 using MailFathom.Application.Spam.Gating;
 using MailFathom.Application.Synchronization;
+using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Answering.Audit;
 using MailFathom.Domain.Emails;
@@ -75,6 +76,9 @@ public sealed class TelemetrySurfaceContractTests
     private static readonly AiProviderHealthTracker ProviderHealth =
         new(Clock, NullLogger<AiProviderHealthTracker>.Instance);
 
+    private static readonly AuthorizationRefusalTelemetry AuthorizationRefusals =
+        new(NullLogger<AuthorizationRefusalTelemetry>.Instance);
+
     private static readonly DerivedWorkGateTelemetry DerivedWorkGate = new();
     private static readonly EmailEmbeddingBackfillTelemetry EmbeddingBackfill = new();
     private static readonly EmailEmbeddingTelemetry Embedding = new();
@@ -117,6 +121,7 @@ public sealed class TelemetrySurfaceContractTests
     private static readonly Type[] DrivenPublishers =
     [
         typeof(AiProviderHealthTracker),
+        typeof(AuthorizationRefusalTelemetry),
         typeof(BoundedEmailEmbeddingBacklog),
         typeof(DerivedWorkGateTelemetry),
         typeof(EmailEmbeddingBackfillTelemetry),
@@ -243,6 +248,7 @@ public sealed class TelemetrySurfaceContractTests
         var surface = new EmittedTelemetrySurface();
 
         DriveProviderHealth();
+        DriveAuthorizationRefusals();
         DriveDerivedWorkGate();
         DriveEmbedding();
         DriveJobQueue();
@@ -267,6 +273,31 @@ public sealed class TelemetrySurfaceContractTests
         ProviderHealth.RecordServed(AiProviderRole.Embedding);
         ProviderHealth.RecordUnavailable(AiProviderRole.Chat);
         ProviderHealth.RecordMisconfigured(AiProviderRole.Chat);
+    }
+
+    /// <summary>Drives every refusal shape, with the identity poisoned and the operation left as one this repository publishes.</summary>
+    /// <remarks>
+    /// The identity is the string a caller could influence here — a token brings its own issuer and subject — so it is
+    /// a sentinel, and the contract then says it reached no dimension. The operation is not one: the port's contract is
+    /// that a boundary reduces the name a request carried to a name this repository publishes before it records one,
+    /// and each boundary's own suite asserts that reduction over a name a caller chose.
+    /// </remarks>
+    private static void DriveAuthorizationRefusals()
+    {
+        foreach (var surface in Enum.GetValues<ProtectedSurface>())
+        {
+            AuthorizationRefusals.RecordRefusal(
+                surface,
+                "list_emails",
+                MailFathomPermission.PublishedFor(surface)[0],
+                TelemetryRedactionContract.CallerSuppliedSentinel);
+        }
+
+        AuthorizationRefusals.RecordRefusal(
+            ProtectedSurface.Administration,
+            "/api/admin/session",
+            default,
+            refusedIdentity: null);
     }
 
     private static void DriveDerivedWorkGate()

--- a/tests/Mcp.UnitTests/Observability/TelemetrySurfaceContractTests.cs
+++ b/tests/Mcp.UnitTests/Observability/TelemetrySurfaceContractTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Mcp.Observability;
+using MailFathom.Mcp.Tools;
 using MailFathom.TestSupport;
 using Xunit;
 
@@ -48,7 +49,7 @@ public sealed class TelemetrySurfaceContractTests
         Assert.Contains(
             surface.EmittedTags,
             tag => tag.Key == McpToolCallTelemetry.ToolTagName
-                && Equals(tag.Value, McpToolCallTelemetry.UnpublishedToolName));
+                && Equals(tag.Value, PublishedTools.UnpublishedToolName));
     }
 
     /// <summary>Nothing this boundary publishes is named after a message, a person, or a secret.</summary>

--- a/tests/Mcp.UnitTests/TestDoubles/RegisteredMcpToolSurface.cs
+++ b/tests/Mcp.UnitTests/TestDoubles/RegisteredMcpToolSurface.cs
@@ -123,6 +123,7 @@ internal static class RegisteredMcpToolSurface
         services.AddSingleton<IMailAccountCatalog>(new StubMailAccountCatalog("personal"));
         services.AddSingleton<MailboxScopeResolver>();
         services.AddSingleton(Substitute.For<IMailboxReadTelemetry>());
+        services.AddSingleton(Substitute.For<IAuthorizationRefusalTelemetry>());
         services.AddSingleton<MailAccountDirectoryReader>();
         services.AddSingleton<MailboxTimelineReader>();
         services.AddSingleton<EmailContentReader>();

--- a/tests/Mcp.UnitTests/Tools/McpToolAuthorizationTests.cs
+++ b/tests/Mcp.UnitTests/Tools/McpToolAuthorizationTests.cs
@@ -23,7 +23,8 @@ namespace MailFathom.Mcp.UnitTests.Tools;
 /// </remarks>
 public sealed class McpToolAuthorizationTests
 {
-    private const string UnpublishedToolName = "delete_everything";
+    /// <summary>A name no tool answers to, which is what a caller sends; never the placeholder such a name is measured under.</summary>
+    private const string UndeclaredToolName = "delete_everything";
 
     /// <summary>What the shared helper admits every test caller as, which is what a refusal names in a log.</summary>
     private const string CallerIdentity = "test-caller";
@@ -104,7 +105,7 @@ public sealed class McpToolAuthorizationTests
         // Act
         var listing = await FilteredListingAsync(
             authorization,
-            ListingOf([UnpublishedToolName, SearchEmailsTool.ToolName]));
+            ListingOf([UndeclaredToolName, SearchEmailsTool.ToolName]));
 
         // Assert
         Assert.Equal([SearchEmailsTool.ToolName], listing.Tools.Select(static tool => tool.Name));
@@ -223,12 +224,12 @@ public sealed class McpToolAuthorizationTests
         // Act
         var refusal = await Assert.ThrowsAsync<McpProtocolException>(() => CalledAsync(
             authorization,
-            UnpublishedToolName,
+            UndeclaredToolName,
             ServedResult,
             onReached: () => reached = true));
 
         // Assert
-        Assert.Equal($"Unknown tool: '{UnpublishedToolName}'", refusal.Message);
+        Assert.Equal($"Unknown tool: '{UndeclaredToolName}'", refusal.Message);
         Assert.Equal(McpErrorCode.InvalidParams, refusal.ErrorCode);
         Assert.False(reached);
     }
@@ -265,7 +266,7 @@ public sealed class McpToolAuthorizationTests
         // Act
         await Assert.ThrowsAsync<McpProtocolException>(() => CalledAsync(
             AccessAuthorizations.ForCallerGranted([.. MailFathomPermission.PublishedFor(ProtectedSurface.Mail)]),
-            UnpublishedToolName,
+            UndeclaredToolName,
             ServedResult,
             refusals: refusals));
 

--- a/tests/Mcp.UnitTests/Tools/McpToolAuthorizationTests.cs
+++ b/tests/Mcp.UnitTests/Tools/McpToolAuthorizationTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Access;
+using MailFathom.Application.Observability;
 using MailFathom.Domain.Access;
 using MailFathom.Mcp.Tools;
 using MailFathom.TestSupport;
@@ -23,6 +24,9 @@ namespace MailFathom.Mcp.UnitTests.Tools;
 public sealed class McpToolAuthorizationTests
 {
     private const string UnpublishedToolName = "delete_everything";
+
+    /// <summary>What the shared helper admits every test caller as, which is what a refusal names in a log.</summary>
+    private const string CallerIdentity = "test-caller";
 
     [Fact]
     public async Task WithoutUnauthorizedToolsAsync_ACallerGrantedTheWholeSurface_IsOfferedEveryTool()
@@ -229,6 +233,113 @@ public sealed class McpToolAuthorizationTests
         Assert.False(reached);
     }
 
+    /// <summary>The caller is told nothing, so the deployment's own record is the only place this boundary is visible.</summary>
+    [Fact]
+    public async Task RefuseUnauthorizedToolAsync_ACallTheGrantDoesNotPermit_IsRecordedNamingTheToolAndThePermission()
+    {
+        // Arrange
+        var refusals = Substitute.For<IAuthorizationRefusalTelemetry>();
+
+        // Act
+        await Assert.ThrowsAsync<McpProtocolException>(() => CalledAsync(
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailRead),
+            AskMailTool.ToolName,
+            ServedResult,
+            refusals: refusals));
+
+        // Assert
+        refusals.Received(1).RecordRefusal(
+            ProtectedSurface.Mail,
+            AskMailTool.ToolName,
+            MailFathomPermission.MailAsk,
+            CallerIdentity);
+    }
+
+    /// <summary>A name a caller invented must not become a dimension, or a client looping over misspellings mints one apiece.</summary>
+    [Fact]
+    public async Task RefuseUnauthorizedToolAsync_ACallNamingNoPublishedTool_IsRecordedUnderThePlaceholderAndNoPermission()
+    {
+        // Arrange
+        var refusals = Substitute.For<IAuthorizationRefusalTelemetry>();
+
+        // Act
+        await Assert.ThrowsAsync<McpProtocolException>(() => CalledAsync(
+            AccessAuthorizations.ForCallerGranted([.. MailFathomPermission.PublishedFor(ProtectedSurface.Mail)]),
+            UnpublishedToolName,
+            ServedResult,
+            refusals: refusals));
+
+        // Assert
+        refusals.Received(1).RecordRefusal(
+            ProtectedSurface.Mail,
+            PublishedTools.UnpublishedToolName,
+            Arg.Is<MailFathomPermission>(static permission => !permission.IsSpecified),
+            CallerIdentity);
+    }
+
+    /// <summary>The use case is the authority, so a refusal it raises behind a permitted tool is recorded here too.</summary>
+    [Fact]
+    public async Task RefuseUnauthorizedToolAsync_AUseCaseRefusingBehindAPermittedTool_IsRecorded()
+    {
+        // Arrange
+        var refusals = Substitute.For<IAuthorizationRefusalTelemetry>();
+        var authorization = AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailRead);
+
+        // Act
+        await Assert.ThrowsAsync<PrincipalNotAuthorizedException>(() => CalledAsync(
+            authorization,
+            SearchEmailsTool.ToolName,
+            ServedResult,
+            onReached: () => authorization.RequirePermission(MailFathomPermission.MailAsk),
+            refusals: refusals));
+
+        // Assert
+        refusals.Received(1).RecordRefusal(
+            ProtectedSurface.Mail,
+            SearchEmailsTool.ToolName,
+            MailFathomPermission.MailAsk,
+            CallerIdentity);
+    }
+
+    /// <summary>A call the grant permits is the ordinary path, and the ordinary path costs nothing new.</summary>
+    [Fact]
+    public async Task RefuseUnauthorizedToolAsync_ACallTheGrantPermits_RecordsNoRefusal()
+    {
+        // Arrange
+        var refusals = Substitute.For<IAuthorizationRefusalTelemetry>();
+
+        // Act
+        await CalledAsync(
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailRead),
+            SearchEmailsTool.ToolName,
+            ServedResult,
+            refusals: refusals);
+
+        // Assert
+        refusals.DidNotReceiveWithAnyArgs().RecordRefusal(default, default!, default, default);
+    }
+
+    /// <summary>
+    /// A tool withheld from a listing is not a refusal. Nothing was refused, every narrowed caller would report one on
+    /// every listing, and the omission has no operation to partition by — so the record worth alerting on would sit
+    /// under the steady state.
+    /// </summary>
+    [Fact]
+    public async Task WithoutUnauthorizedToolsAsync_AWithheldTool_RecordsNoRefusal()
+    {
+        // Arrange
+        var refusals = Substitute.For<IAuthorizationRefusalTelemetry>();
+
+        // Act
+        await FilteredListingAsync(
+            AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailRead),
+            ListingOf(EveryPublishedToolName),
+            refusals);
+
+        // Assert
+        refusals.DidNotReceiveWithAnyArgs().RecordRefusal(default, default!, default, default);
+    }
+
     /// <summary>Serving a call nobody could apply a grant to would reach a tool this caller was never granted.</summary>
     [Fact]
     public async Task RefuseUnauthorizedToolAsync_ACallWithNoServiceProvider_IsRefused()
@@ -260,9 +371,10 @@ public sealed class McpToolAuthorizationTests
 
     private static async Task<ListToolsResult> FilteredListingAsync(
         AccessAuthorization authorization,
-        ListToolsResult listing)
+        ListToolsResult listing,
+        IAuthorizationRefusalTelemetry? refusals = null)
     {
-        await using var provider = ProviderOver(authorization);
+        await using var provider = ProviderOver(authorization, refusals);
 
         var request = new RequestContext<ListToolsRequestParams>(
             Substitute.For<McpServer>(),
@@ -282,9 +394,10 @@ public sealed class McpToolAuthorizationTests
         AccessAuthorization authorization,
         string toolName,
         CallToolResult? served,
-        Action? onReached = null)
+        Action? onReached = null,
+        IAuthorizationRefusalTelemetry? refusals = null)
     {
-        await using var provider = ProviderOver(authorization);
+        await using var provider = ProviderOver(authorization, refusals);
 
         var request = new RequestContext<CallToolRequestParams>(
             Substitute.For<McpServer>(),
@@ -305,10 +418,13 @@ public sealed class McpToolAuthorizationTests
             TestContext.Current.CancellationToken);
     }
 
-    private static ServiceProvider ProviderOver(AccessAuthorization authorization)
+    private static ServiceProvider ProviderOver(
+        AccessAuthorization authorization,
+        IAuthorizationRefusalTelemetry? refusals)
     {
         var services = new ServiceCollection();
         services.AddSingleton(authorization);
+        services.AddSingleton(refusals ?? Substitute.For<IAuthorizationRefusalTelemetry>());
 
         return services.BuildServiceProvider();
     }

--- a/tests/Mcp.UnitTests/Tools/PublishedToolsTests.cs
+++ b/tests/Mcp.UnitTests/Tools/PublishedToolsTests.cs
@@ -151,4 +151,24 @@ public sealed class PublishedToolsTests
         // Act, Assert
         Assert.False(PublishedTools.Contains(toolName));
     }
+
+    /// <summary>A published name is what a signal about the call carries, because the closed set bounds the series it opens.</summary>
+    [Fact]
+    public void MeasurableName_APublishedTool_IsTheNameItself()
+    {
+        // Act, Assert
+        Assert.Equal(SearchEmailsTool.ToolName, PublishedTools.MeasurableName(SearchEmailsTool.ToolName));
+    }
+
+    /// <summary>Anything else is one fixed value, so a client looping over names it invented mints no series apiece.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("List_Accounts")]
+    [InlineData("delete_everything")]
+    public void MeasurableName_ANameNoToolAnswersTo_IsTheOnePlaceholder(string? toolName)
+    {
+        // Act, Assert
+        Assert.Equal(PublishedTools.UnpublishedToolName, PublishedTools.MeasurableName(toolName));
+    }
 }


### PR DESCRIPTION
## What this changes

An authorization boundary nobody can observe is one an operator learns about from a user complaint. On the MCP surface
a refused caller is told nothing — a tool it may not reach is absent from the listing, and a call naming one is answered
exactly as a call naming a tool that does not exist — so this record is the *only* place the boundary is visible.

Both protected surfaces now publish one signal through one publisher:

- **`IAuthorizationRefusalTelemetry`** (`src/Application/Observability/`) is the port; the adapter
  (`src/Infrastructure/Observability/AuthorizationRefusalTelemetry.cs`) holds
  `mailfathom.authorization.refusals` on MailFathom's own meter and writes a `Warning` beside every measurement.
- **The counter carries three closed sets**: `mailfathom.authorization.surface` (`mail` / `administration`),
  `mailfathom.authorization.operation`, and `mailfathom.authorization.permission`. A refusal no grant would have
  satisfied is counted under `(none)`.
- **The credential is on the log alone.** Its cardinality follows the operator's own entries, and where a token
  admitted the caller it is an issuer and that authorization server's identifier for a person — which belongs in a
  record a deployment sets a level on rather than in an exported series that never goes away. Work reached under no
  principal is logged as `(none)`.

### Where a refusal is recorded

| Boundary | What is recorded |
|---|---|
| `McpToolAuthorization` — a call the grant does not permit | The tool, reduced to a name `PublishedTools` publishes or to `(unpublished)`; the tool's own permission, unspecified for a name no tool declared |
| `McpToolAuthorization` — a use case refusing behind a tool the transport admitted | The tool, and the permission the refusal named |
| `AdminRouteAuthorization` — the transport's refusal, a use case's own, and a route that published no decision | The route's own pattern rather than the address the request carried |

**A tool withheld from a listing is not recorded.** Nothing was refused, every narrowed caller would produce one on
every listing, and the omission has no operation to partition by — so the reading worth alerting on would sit under the
steady state. A permitted call and a permitted route record nothing new either.

`AccessAuthorization.PrincipalIdentity` is what a boundary names the caller from, because
`PrincipalNotAuthorizedException` is barred from carrying an identity and a boundary reading the principal source
directly could come to disagree about what holding a permission means.

`PublishedTools.MeasurableName` now owns the reduction of a caller-sent tool name that `McpToolCallTelemetry` used to
keep privately, so two publishers cannot drift into measuring what a caller wrote.

## Contract surfaces

No break. The change adds one metric and one log family, one application port, and one property on
`AccessAuthorization`; the MCP tool contract, the configuration schema, the database schema, and the deployment
contract are untouched. `McpToolCallTelemetry.UnpublishedToolName` moved to `PublishedTools.UnpublishedToolName` — an
internal constant with the same value, so no published name changed.

## Verification

- `scripts/verify-full.sh` — passed (Release build, 8850 unit tests, coverage gate, agent-workflow suite 228/228).
- New tests: `AuthorizationRefusalTelemetryTests` (dimensions per surface, the unnamed permission, the log's credential
  and permission, no identity on the counter, an operation that names nothing, an unpublished surface);
  `McpToolAuthorizationTests` and `AdminRouteAuthorizationTests` (each refusal path recorded once, a permitted call and
  a withheld listing recording nothing); `AccessAuthorizationTests`; `PublishedToolsTests`.
- The new publisher is driven by `TelemetrySurfaceContractTests`, so the redaction contract holds over it beside the
  rest of the surface.

## Documentation

`docs/operations/telemetry.md` gains § *What an authorization refusal records*;
`docs/operations/mcp-endpoint.md`, `docs/operations/admin-endpoint.md`, `docs/features/mcp-tools.md`, and
`docs/architecture/authorized-principal.md` point at it from the places that already state what a refused caller is
told.

Closes #589

Issue: https://github.com/Krzysztof318/MailFathom/issues/589
