### PR TITLE
[#940] Hold the virtual clock until the step it advanced has been answered

### DIFF
--- a/tests/Infrastructure.UnitTests/Resilience/OutboundResilienceTestHostTests.cs
+++ b/tests/Infrastructure.UnitTests/Resilience/OutboundResilienceTestHostTests.cs
@@ -1,0 +1,77 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.UnitTests.TestDoubles;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Resilience;
+
+/// <summary>
+/// Covers the virtual-time pump every resilience and mail-session test drives its pipelines with. A test that asserts
+/// which of two nested budgets expired is only evidence about the product while the pump holds the clock for the work
+/// each step starts, so what the pump guarantees is worth proving here rather than in each of its callers.
+/// </summary>
+public sealed class OutboundResilienceTestHostTests
+{
+    /// <summary>
+    /// Enough thread-pool hops that a loop trading a fixed number of scheduler turns for an advance would move the
+    /// clock several times over before the work of the first one surfaced.
+    /// </summary>
+    private const int HopsBeforeTheFailureSurfaces = 512;
+
+    /// <summary>The budget that comes due, chosen so a step of the same length brings it due on the first advance.</summary>
+    private static readonly TimeSpan ExpiringBudget = TimeSpan.FromSeconds(1);
+
+    /// <summary>A budget that comes due must be what a test reads, and it stops being that once a later one can expire first.</summary>
+    [Fact]
+    public async Task CompleteOnVirtualTimeAsync_WorkSurfacingSeveralHopsLater_HoldsTheClockAtTheStepThatStartedIt()
+    {
+        // Arrange
+        using var host = OutboundResilienceTestHost.WithConfiguredSettings();
+        var startedAt = host.TimeProvider.GetUtcNow();
+        using var budget = new CancellationTokenSource(ExpiringBudget, host.TimeProvider);
+        var observedAt = default(DateTimeOffset);
+
+        // Act
+        var execution = Task.Run(
+            async () =>
+            {
+                try
+                {
+                    await Task.Delay(Timeout.InfiniteTimeSpan, budget.Token);
+                }
+                catch (OperationCanceledException)
+                {
+                    for (var hop = 0; hop < HopsBeforeTheFailureSurfaces; hop++)
+                    {
+                        await Task.Yield();
+                    }
+
+                    observedAt = host.TimeProvider.GetUtcNow();
+                }
+            },
+            TestContext.Current.CancellationToken);
+
+        await host.CompleteOnVirtualTimeAsync(execution, ExpiringBudget);
+
+        // Assert
+        Assert.Equal(startedAt + ExpiringBudget, observedAt);
+    }
+
+    /// <summary>An execution that stops answering is a defect to read, so the pump ends it rather than the suite's timeout.</summary>
+    [Fact]
+    public async Task CompleteOnVirtualTimeAsync_ExecutionThatNeverCompletes_FailsNamingTheAdvancesItSpent()
+    {
+        // Arrange
+        using var host = OutboundResilienceTestHost.WithConfiguredSettings();
+        var stalled = new TaskCompletionSource();
+
+        // Act
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => host.CompleteOnVirtualTimeAsync(stalled.Task, ExpiringBudget, maximumAdvances: 4));
+
+        // Assert
+        Assert.Contains("4 advances", failure.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Infrastructure.UnitTests/TestDoubles/OutboundResilienceTestHost.cs
+++ b/tests/Infrastructure.UnitTests/TestDoubles/OutboundResilienceTestHost.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Diagnostics;
 using MailFathom.Application.Resilience;
 using MailFathom.Infrastructure.Resilience;
 using MailFathom.TestSupport;
@@ -9,20 +10,25 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Time.Testing;
 
 namespace MailFathom.Infrastructure.UnitTests.TestDoubles;
 
 /// <summary>Builds a container holding the real pipelines over a clock the test controls.</summary>
 internal sealed class OutboundResilienceTestHost : IDisposable
 {
-    /// <summary>How many times the pumping loop offers the scheduler a turn before it moves the clock again.</summary>
+    /// <summary>How many times the pumping loop offers the scheduler a turn before it waits on the real clock instead.</summary>
     /// <remarks>
     /// One yield is not enough. An abandoned attempt resumes through a cancellation callback several thread-pool hops
-    /// away, and a loop that yields once per advance keeps requeueing itself ahead of that chain and runs the clock
-    /// past every remaining limit. Offering a batch of turns lets the chain finish while the clock stands still.
+    /// away, and a loop that yields once per advance keeps requeueing itself ahead of that chain. A batch of turns
+    /// settles the common case without leaving the pumping thread parked, which is why it comes before the waits.
     /// </remarks>
-    private const int SchedulerTurnsPerAdvance = 32;
+    private const int SchedulerTurnsPerObservation = 32;
+
+    /// <summary>How often the loop looks again once its scheduler turns are spent.</summary>
+    private static readonly TimeSpan ObservationPollInterval = TimeSpan.FromMilliseconds(2);
+
+    /// <summary>How long the work of one step may take to surface before the execution is reported as hung.</summary>
+    private static readonly TimeSpan ObservationBound = TimeSpan.FromSeconds(30);
 
     private readonly ServiceProvider services;
     private readonly IConfigurationRoot configuration;
@@ -45,7 +51,7 @@ internal sealed class OutboundResilienceTestHost : IDisposable
         this.services = serviceCollection.BuildServiceProvider();
     }
 
-    internal FakeTimeProvider TimeProvider { get; } = new();
+    internal WaitRecordingTimeProvider TimeProvider { get; } = new();
 
     internal RecordingLoggerProvider Logs { get; } = new();
 
@@ -75,11 +81,20 @@ internal sealed class OutboundResilienceTestHost : IDisposable
     /// therefore also sets how precisely a recorded delay can be measured.
     /// </para>
     /// <para>
-    /// Nothing here waits on the real clock. Between advances the loop only offers the scheduler turns, so a test
-    /// costs what its continuations cost and never a fixed delay per step. Both bounds are escapes from a hang rather
-    /// than part of any behavior a test asserts on.
+    /// A step that brought a wait due is not taken as observed until the execution has answered it, by finishing or by
+    /// arming the wait it will sit on next. The work a due wait starts runs on the thread pool, so a loaded runner
+    /// answers later rather than differently: the loop holds the clock and waits on the real one instead of running
+    /// ahead into a later budget and letting that expire first. What a step guarantees is therefore the answer to the
+    /// step before it, never a fixed amount of scheduling.
+    /// </para>
+    /// <para>
+    /// Both bounds are escapes from a hang rather than part of any behavior a test asserts on, and both end an
+    /// execution that stops answering as a failure naming what it was doing rather than as a suite that times out.
     /// </para>
     /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the execution stops answering the clock, or does not complete within <paramref name="maximumAdvances" />.
+    /// </exception>
     internal async Task CompleteOnVirtualTimeAsync(
         Task execution,
         TimeSpan advanceStep,
@@ -87,12 +102,30 @@ internal sealed class OutboundResilienceTestHost : IDisposable
     {
         for (var advance = 0; advance < maximumAdvances && !execution.IsCompleted; advance++)
         {
-            for (var turn = 0; turn < SchedulerTurnsPerAdvance && !execution.IsCompleted; turn++)
+            for (var turn = 0;
+                turn < SchedulerTurnsPerObservation
+                    && !execution.IsCompleted
+                    && this.TimeProvider.OutstandingWaits == 0;
+                turn++)
             {
                 await Task.Yield();
             }
 
+            var waitsArmedBeforeTheStep = this.TimeProvider.ScheduledWaits;
+            var waitsElapsedBeforeTheStep = this.TimeProvider.ElapsedWaits;
+
             this.TimeProvider.Advance(advanceStep);
+
+            if (this.TimeProvider.ElapsedWaits != waitsElapsedBeforeTheStep)
+            {
+                await this.ObserveTheStepAsync(execution, waitsArmedBeforeTheStep, advanceStep);
+            }
+        }
+
+        if (!execution.IsCompleted)
+        {
+            throw new InvalidOperationException(
+                $"The execution did not complete within {maximumAdvances} advances of {advanceStep} on virtual time.");
         }
 
         await execution;
@@ -107,6 +140,38 @@ internal sealed class OutboundResilienceTestHost : IDisposable
         await this.CompleteOnVirtualTimeAsync((Task)execution, advanceStep, maximumAdvances);
 
         return await execution;
+    }
+
+    /// <summary>Holds the clock until the execution has answered the wait that just came due.</summary>
+    /// <remarks>
+    /// An answer is the execution finishing or a new wait being armed, which is every way a pipeline reacts to a
+    /// budget expiring. Scheduler turns come first because a thread pool with room answers within a few of them; the
+    /// polling that follows is what a saturated pool needs, and it parks the pumping thread rather than competing with
+    /// the chain it is waiting for.
+    /// </remarks>
+    private async Task ObserveTheStepAsync(Task execution, long waitsArmedBeforeTheStep, TimeSpan advanceStep)
+    {
+        var startedWaiting = Stopwatch.GetTimestamp();
+
+        bool Answered() =>
+            execution.IsCompleted || this.TimeProvider.ScheduledWaits != waitsArmedBeforeTheStep;
+
+        for (var turn = 0; turn < SchedulerTurnsPerObservation && !Answered(); turn++)
+        {
+            await Task.Yield();
+        }
+
+        while (!Answered())
+        {
+            if (Stopwatch.GetElapsedTime(startedWaiting) > ObservationBound)
+            {
+                throw new InvalidOperationException(
+                    $"The execution did not answer a wait that came due within {ObservationBound}, so the clock was "
+                    + $"held at {this.TimeProvider.GetUtcNow():O} rather than advanced by another {advanceStep}.");
+            }
+
+            await Task.Delay(ObservationPollInterval);
+        }
     }
 
     public void Dispose()

--- a/tests/Infrastructure.UnitTests/TestDoubles/OutboundResilienceTestHost.cs
+++ b/tests/Infrastructure.UnitTests/TestDoubles/OutboundResilienceTestHost.cs
@@ -16,16 +16,13 @@ namespace MailFathom.Infrastructure.UnitTests.TestDoubles;
 /// <summary>Builds a container holding the real pipelines over a clock the test controls.</summary>
 internal sealed class OutboundResilienceTestHost : IDisposable
 {
-    /// <summary>How many times the pumping loop offers the scheduler a turn before it waits on the real clock instead.</summary>
+    /// <summary>How many turns the loop offers the scheduler while nothing is waiting on the clock yet.</summary>
     /// <remarks>
-    /// One yield is not enough. An abandoned attempt resumes through a cancellation callback several thread-pool hops
-    /// away, and a loop that yields once per advance keeps requeueing itself ahead of that chain. A batch of turns
-    /// settles the common case without leaving the pumping thread parked, which is why it comes before the waits.
+    /// One yield is not enough: a pipeline reaches the wait it will sit on several thread-pool hops after the call
+    /// that started it, and a clock moved before then measures a delay nobody had armed. A batch of turns settles
+    /// that, and the loop stops spending them as soon as something is waiting on the clock.
     /// </remarks>
-    private const int SchedulerTurnsPerObservation = 32;
-
-    /// <summary>How often the loop looks again once its scheduler turns are spent.</summary>
-    private static readonly TimeSpan ObservationPollInterval = TimeSpan.FromMilliseconds(2);
+    private const int SchedulerTurnsBeforeAStep = 32;
 
     /// <summary>How long the work of one step may take to surface before the execution is reported as hung.</summary>
     private static readonly TimeSpan ObservationBound = TimeSpan.FromSeconds(30);
@@ -83,13 +80,15 @@ internal sealed class OutboundResilienceTestHost : IDisposable
     /// <para>
     /// A step that brought a wait due is not taken as observed until the execution has answered it, by finishing or by
     /// arming the wait it will sit on next. The work a due wait starts runs on the thread pool, so a loaded runner
-    /// answers later rather than differently: the loop holds the clock and waits on the real one instead of running
-    /// ahead into a later budget and letting that expire first. What a step guarantees is therefore the answer to the
-    /// step before it, never a fixed amount of scheduling.
+    /// answers later rather than differently: the loop holds the clock and takes its turn behind that work instead of
+    /// running ahead into a later budget and letting that expire first. What a step guarantees is therefore the answer
+    /// to the step before it, never a fixed amount of scheduling.
     /// </para>
     /// <para>
-    /// Both bounds are escapes from a hang rather than part of any behavior a test asserts on, and both end an
-    /// execution that stops answering as a failure naming what it was doing rather than as a suite that times out.
+    /// Nothing here waits on the real clock: the loop spends scheduler turns, and elapsed real time is read only to
+    /// end an execution that has stopped answering. Both bounds are escapes from a hang rather than part of any
+    /// behavior a test asserts on, and both end such an execution as a failure naming what it was doing rather than as
+    /// a suite that times out.
     /// </para>
     /// </remarks>
     /// <exception cref="InvalidOperationException">
@@ -103,7 +102,7 @@ internal sealed class OutboundResilienceTestHost : IDisposable
         for (var advance = 0; advance < maximumAdvances && !execution.IsCompleted; advance++)
         {
             for (var turn = 0;
-                turn < SchedulerTurnsPerObservation
+                turn < SchedulerTurnsBeforeAStep
                     && !execution.IsCompleted
                     && this.TimeProvider.OutstandingWaits == 0;
                 turn++)
@@ -145,9 +144,8 @@ internal sealed class OutboundResilienceTestHost : IDisposable
     /// <summary>Holds the clock until the execution has answered the wait that just came due.</summary>
     /// <remarks>
     /// An answer is the execution finishing or a new wait being armed, which is every way a pipeline reacts to a
-    /// budget expiring. Scheduler turns come first because a thread pool with room answers within a few of them; the
-    /// polling that follows is what a saturated pool needs, and it parks the pumping thread rather than competing with
-    /// the chain it is waiting for.
+    /// budget expiring. Waiting for one costs turns of the scheduler rather than time on any clock, and the elapsed
+    /// real time is read for one purpose only: ending an execution that has stopped answering as a failure.
     /// </remarks>
     private async Task ObserveTheStepAsync(Task execution, long waitsArmedBeforeTheStep, TimeSpan advanceStep)
     {
@@ -155,11 +153,6 @@ internal sealed class OutboundResilienceTestHost : IDisposable
 
         bool Answered() =>
             execution.IsCompleted || this.TimeProvider.ScheduledWaits != waitsArmedBeforeTheStep;
-
-        for (var turn = 0; turn < SchedulerTurnsPerObservation && !Answered(); turn++)
-        {
-            await Task.Yield();
-        }
 
         while (!Answered())
         {
@@ -170,8 +163,28 @@ internal sealed class OutboundResilienceTestHost : IDisposable
                     + $"held at {this.TimeProvider.GetUtcNow():O} rather than advanced by another {advanceStep}.");
             }
 
-            await Task.Delay(ObservationPollInterval);
+            await TakeATurnBehindTheQueuedWorkAsync();
         }
+    }
+
+    /// <summary>Returns through the pool's global queue, so the work already queued runs before the loop looks again.</summary>
+    /// <remarks>
+    /// <see cref="Task.Yield" /> is the wrong primitive to wait on here, and it is the one the whole race came from:
+    /// it requeues the continuation on the pumping thread's own queue, which that thread serves before it takes
+    /// anything else, so a loop built on it keeps handing itself the turns it is waiting for the chain to use. Queuing
+    /// without that preference puts the loop behind the work already waiting for a thread instead, which is what makes
+    /// a saturated pool slow the loop down rather than starve the chain under it.
+    /// </remarks>
+    private static Task TakeATurnBehindTheQueuedWorkAsync()
+    {
+        var resumed = new TaskCompletionSource();
+
+        ThreadPool.UnsafeQueueUserWorkItem(
+            static waiting => waiting.SetResult(),
+            resumed,
+            preferLocal: false);
+
+        return resumed.Task;
     }
 
     public void Dispose()

--- a/tests/Infrastructure.UnitTests/TestDoubles/WaitRecordingTimeProvider.cs
+++ b/tests/Infrastructure.UnitTests/TestDoubles/WaitRecordingTimeProvider.cs
@@ -1,0 +1,81 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using Microsoft.Extensions.Time.Testing;
+
+namespace MailFathom.Infrastructure.UnitTests.TestDoubles;
+
+/// <summary>A controllable clock that also reports what the code under test is waiting on it for.</summary>
+/// <remarks>
+/// <para>
+/// Moving virtual time is only half of driving a pipeline that waits: the other half is knowing whether the step just
+/// taken has been acted on, because the work a due timer starts runs on the thread pool long after
+/// <see cref="FakeTimeProvider.Advance" /> has returned. The two counters here are what makes that observable.
+/// <see cref="ScheduledWaits" /> rises whenever a wait is armed on the clock, and <see cref="ElapsedWaits" /> whenever
+/// one comes due, so a caller can hold the clock still until the execution has either finished or armed the wait it
+/// will sit on next.
+/// </para>
+/// <para>
+/// A periodic timer arms its next occurrence by firing, so its callback records both. An infinite due time arms
+/// nothing and is therefore not counted, which is what keeps a disarmed timer out of the totals.
+/// </para>
+/// </remarks>
+internal sealed class WaitRecordingTimeProvider : FakeTimeProvider
+{
+    private long scheduledWaits;
+    private long elapsedWaits;
+
+    /// <summary>Gets how many waits have been armed on this clock.</summary>
+    internal long ScheduledWaits => Interlocked.Read(ref this.scheduledWaits);
+
+    /// <summary>Gets how many armed waits have come due.</summary>
+    internal long ElapsedWaits => Interlocked.Read(ref this.elapsedWaits);
+
+    /// <summary>Gets how many armed waits are still ahead of the clock, so a caller can tell whether anything is waiting on it.</summary>
+    internal long OutstandingWaits => this.ScheduledWaits - this.ElapsedWaits;
+
+    /// <inheritdoc />
+    public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+
+        this.RecordArmedWait(dueTime);
+
+        return new RecordingTimer(
+            base.CreateTimer(
+                timerState =>
+                {
+                    Interlocked.Increment(ref this.elapsedWaits);
+                    this.RecordArmedWait(period);
+                    callback(timerState);
+                },
+                state,
+                dueTime,
+                period),
+            this);
+    }
+
+    private void RecordArmedWait(TimeSpan dueTime)
+    {
+        if (dueTime != Timeout.InfiniteTimeSpan)
+        {
+            Interlocked.Increment(ref this.scheduledWaits);
+        }
+    }
+
+    /// <summary>A timer that reports the waits it is re-armed with, since arming one is not always a creation.</summary>
+    private sealed class RecordingTimer(ITimer timer, WaitRecordingTimeProvider clock) : ITimer
+    {
+        public bool Change(TimeSpan dueTime, TimeSpan period)
+        {
+            clock.RecordArmedWait(dueTime);
+
+            return timer.Change(dueTime, period);
+        }
+
+        public void Dispose() => timer.Dispose();
+
+        public ValueTask DisposeAsync() => timer.DisposeAsync();
+    }
+}


### PR DESCRIPTION
`MailKitSmtpDeliverySessionTests.OpenForDeliveryAsync_TransportThatNeverOpens_FailsWithATimeoutNamingTheStage`
failed on pull requests whose diffs touch nothing near SMTP delivery, and passed on a rerun of the same commit. The
assertion was right about the behaviour and wrong about which timer won the race: `OutboundResilienceTestHost`'s pump
traded a fixed batch of `Task.Yield()` turns for each advance of the fake clock, which is no guarantee that the work
the previous advance started has run. A due wait cancels on the pumping thread, and the failure it becomes surfaces
several thread-pool hops later; on a saturated runner the loop kept advancing past the 15-second phase budget and
reached the pipeline's ten-minute total timeout before the phase failure had surfaced.

## What changed

- `WaitRecordingTimeProvider` (new) is the host's clock: a `FakeTimeProvider` that also counts the waits armed on it
  and the waits that have come due. Arming is counted at creation and at every `ITimer.Change`, and a periodic timer
  arms its next occurrence by firing, so its callback records both. An infinite due time arms nothing and is not
  counted.
- `CompleteOnVirtualTimeAsync` now holds the clock after any step that brought a wait due, until the execution has
  *answered* it — by finishing, or by arming the wait it will sit on next. Those are the two ways a pipeline reacts to
  a budget expiring, so a loaded pool answers later rather than differently, and the loop can no longer run ahead into
  a later budget and let that expire first.
- The loop no longer spends its scheduler turns once something is already waiting on the clock, which is why the
  advance-heavy backoff tests do not pay for the new waiting.
- An execution that stops answering now ends as an `InvalidOperationException` naming what the clock was holding, and
  an execution that outlives `maximumAdvances` throws instead of awaiting a task that will never complete. Both bounds
  were escapes from a hang that could not actually end one before.
- The remarks on the pump said the opposite of what it now does — that nothing between advances waits — and are
  rewritten to say what a step guarantees.

## Waiting without a clock

The loop waits by queuing a work item with `preferLocal: false` and awaiting it, never by sleeping. `Task.Yield` is
the wrong primitive here and is where the original race came from: it requeues the continuation on the pumping
thread's own queue, which that thread serves before it takes anything else, so a loop built on it keeps handing
itself the turns it is waiting for the chain to use. Queuing without that preference puts the loop behind the work
already waiting for a thread, so a saturated pool slows it down instead of starving the chain under it. Elapsed real
time is read for one purpose only: ending an execution that has stopped answering, which is the hang detection the
harness previously could not do at all.

## Verification

- `scripts/verify-full.sh`: passed, 8851 tests, aggregate line coverage 96.12%.
- The whole `Infrastructure.UnitTests` assembly passes pinned to two cores (`taskset -c 0,1`) and to a single core
  (`taskset -c 0`) — fewer cores than tests in flight, which is the condition the flake needs.
- The new `OutboundResilienceTestHostTests` has teeth: with the pump's observation removed, its first test reports the
  clock at `00:02:04` where the step that started the work was `00:00:01`.

No production code, dependency, configuration key, database column, or MCP tool contract is touched; nothing here
breaks a public surface.

Closes #940
