### PR TITLE
[#944] Say why a token was refused when it arrived over a clear-text hop

### DIFF
--- a/src/Host/Security/Transport/TransportSecurityExtensions.cs
+++ b/src/Host/Security/Transport/TransportSecurityExtensions.cs
@@ -14,6 +14,7 @@ using MailFathom.Infrastructure.Security.OAuth;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -34,7 +35,7 @@ namespace MailFathom.Host.Security.Transport;
 /// by the other's credential — because a policy names only its own routing scheme.
 /// </para>
 /// </remarks>
-internal static class TransportSecurityExtensions
+internal static partial class TransportSecurityExtensions
 {
     /// <summary>Names the registered transport an authorization server's metadata is retrieved over.</summary>
     /// <remarks>One transport for every scheme on every surface, because what it carries is the same fetch of the same kind of document under the same bounds. Each scheme still holds a client of its own over it, so no key refresh can observe another scheme's.</remarks>
@@ -172,21 +173,53 @@ internal static class TransportSecurityExtensions
     /// fetches; neither says anything about the transport an incoming request arrived on.
     /// </para>
     /// <para>
-    /// The refusal is silent — no result rather than a failure — so the caller receives the same challenge an
-    /// unauthenticated request receives, and the token is never read, validated, or recorded.
+    /// The refusal is silent to the caller — no result rather than a failure — so the answer is the same challenge an
+    /// unauthenticated request receives, and the token is never read, validated, or recorded. It is not silent to the
+    /// operator: behind a TLS-terminating proxy this refusal fires on every authenticated request the moment a
+    /// forwarded scheme stops arriving, and a challenge indistinguishable from the anonymous one is the one symptom no
+    /// amount of reading the client's logs explains. The record names the forwarded scheme the request carried, which
+    /// is what separates a proxy that sends none from a proxy whose value this process does not believe.
     /// </para>
     /// </remarks>
     internal static Task RefuseATokenThatArrivedWithoutTransportEncryption(MessageReceivedContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        if (!context.Request.IsHttps)
+        if (context.Request.IsHttps)
         {
-            context.NoResult();
+            return Task.CompletedTask;
         }
+
+        // The event fires for every request the scheme sees, and one that presented nothing has nothing refused, so
+        // only a request that actually carried a credential is worth a record.
+        if (context.Request.Headers.Authorization.Count > 0)
+        {
+            var forwardedProtocol = context.Request.Headers[ForwardedHeadersDefaults.XForwardedProtoHeaderName].ToString();
+
+            LogTokenRefusedOnAClearTextHop(
+                context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger(typeof(TransportSecurityExtensions)),
+                context.Scheme.Name,
+                string.IsNullOrEmpty(forwardedProtocol) ? "none" : forwardedProtocol);
+        }
+
+        context.NoResult();
 
         return Task.CompletedTask;
     }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "An access token presented to {AuthenticationScheme} arrived over a hop this process sees as clear "
+            + "text, so it was refused without being read and the caller received the challenge an anonymous request "
+            + "receives. The request carried X-Forwarded-Proto: {ForwardedProtocol}. 'none' means nothing in front of "
+            + "this process sent a forwarded scheme; any other value means one was sent and not applied, which is what "
+            + "ReverseProxy:TrustedProxies and ReverseProxy:MaximumForwardedHops decide. Behind a TLS-terminating "
+            + "reverse proxy every authenticated request fails this way until one of those is corrected.")]
+    private static partial void LogTokenRefusedOnAClearTextHop(
+        ILogger logger,
+        string authenticationScheme,
+        string forwardedProtocol);
 
     /// <summary>Registers the scheme that reads the presented credential and forwards it to the handler that judges it.</summary>
     private static void AddRoutingScheme(

--- a/tests/Host.UnitTests/Security/Transport/TransportSecurityExtensionsTests.cs
+++ b/tests/Host.UnitTests/Security/Transport/TransportSecurityExtensionsTests.cs
@@ -11,11 +11,13 @@ using MailFathom.Host.Security.ClientAssertions;
 using MailFathom.Host.Security.Transport;
 using MailFathom.Infrastructure.Secrets.Discovery;
 using MailFathom.Infrastructure.Security.OAuth;
+using MailFathom.TestSupport;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -46,6 +48,83 @@ public sealed class TransportSecurityExtensionsTests
         // Assert
         Assert.NotNull(context.Result);
         Assert.True(context.Result.None);
+    }
+
+    /// <summary>
+    /// The caller cannot tell this refusal from the challenge an anonymous request receives, which is deliberate and
+    /// which is also why the operator has to be able to. Behind a proxy that stopped forwarding a scheme, this record
+    /// is the only place the cause appears at all.
+    /// </summary>
+    [Fact]
+    public async Task RefuseATokenThatArrivedWithoutTransportEncryption_APresentedToken_RecordsThatNoSchemeWasForwarded()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(logs));
+        using var services = new ServiceCollection()
+            .AddSingleton(loggerFactory)
+            .BuildServiceProvider();
+
+        var context = MessageReceivedOver("http", authorization: "Bearer a-token", services: services);
+
+        // Act
+        await TransportSecurityExtensions.RefuseATokenThatArrivedWithoutTransportEncryption(context);
+
+        // Assert
+        Assert.True(context.Result?.None);
+
+        var record = Assert.Single(logs.Records);
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Equal("none", Assert.Contains("ForwardedProtocol", record.Properties));
+    }
+
+    /// <summary>
+    /// A forwarded scheme that arrived and was not applied is a different fault from one that was never sent — the
+    /// first is who this process believes, the second is what the proxy sends — so the record names which it was.
+    /// </summary>
+    [Fact]
+    public async Task RefuseATokenThatArrivedWithoutTransportEncryption_AForwardedSchemeThatWasNotApplied_RecordsIt()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(logs));
+        using var services = new ServiceCollection()
+            .AddSingleton(loggerFactory)
+            .BuildServiceProvider();
+
+        var context = MessageReceivedOver(
+            "http",
+            authorization: "Bearer a-token",
+            forwardedProtocol: "https",
+            services: services);
+
+        // Act
+        await TransportSecurityExtensions.RefuseATokenThatArrivedWithoutTransportEncryption(context);
+
+        // Assert
+        Assert.True(context.Result?.None);
+        Assert.Equal("https", Assert.Contains("ForwardedProtocol", Assert.Single(logs.Records).Properties));
+    }
+
+    /// <summary>A request that presented nothing has nothing refused, so it is not worth a line in an operator's log.</summary>
+    [Fact]
+    public async Task RefuseATokenThatArrivedWithoutTransportEncryption_APlaintextRequestCarryingNoToken_RecordsNothing()
+    {
+        // Arrange
+        using var logs = new RecordingLoggerProvider();
+        using var loggerFactory = LoggerFactory.Create(logging => logging.AddProvider(logs));
+        using var services = new ServiceCollection()
+            .AddSingleton(loggerFactory)
+            .BuildServiceProvider();
+
+        var context = MessageReceivedOver("http", services: services);
+
+        // Act
+        await TransportSecurityExtensions.RefuseATokenThatArrivedWithoutTransportEncryption(context);
+
+        // Assert
+        Assert.True(context.Result?.None);
+        Assert.Empty(logs.Records);
     }
 
     [Fact]
@@ -578,10 +657,29 @@ public sealed class TransportSecurityExtensionsTests
             ],
             surface.IsSpecified ? surface.ApiKeySchemeName : "unused");
 
-    private static MessageReceivedContext MessageReceivedOver(string scheme)
+    private static MessageReceivedContext MessageReceivedOver(
+        string scheme,
+        string? authorization = null,
+        string? forwardedProtocol = null,
+        IServiceProvider? services = null)
     {
         var request = new DefaultHttpContext();
         request.Request.Scheme = scheme;
+
+        if (authorization is not null)
+        {
+            request.Request.Headers.Authorization = authorization;
+        }
+
+        if (forwardedProtocol is not null)
+        {
+            request.Request.Headers["X-Forwarded-Proto"] = forwardedProtocol;
+        }
+
+        if (services is not null)
+        {
+            request.RequestServices = services;
+        }
 
         return new MessageReceivedContext(
             request,


### PR DESCRIPTION
## What this changes

`RefuseATokenThatArrivedWithoutTransportEncryption` discards a bearer token presented over a hop this process sees as clear text, and answers with the challenge an anonymous request receives. That silence towards the caller is deliberate and is unchanged here — the token is still never read, validated, or recorded, and an encrypted request is untouched.

What changes is that the operator now hears about it. The refusal is recorded at `Warning`, naming the authentication scheme and the forwarded scheme the request carried.

## Why

Behind a TLS-terminating reverse proxy, `Request.IsHttps` is decided entirely by `X-Forwarded-Proto`. When that header stops being applied — the proxy does not send it, or `ReverseProxy:TrustedProxies` does not believe the peer that did — every authenticated request fails identically and the deployment produces no authentication failure, no distinguishable response, and no log line. The symptom reaching a client is an opaque tool error; the symptom reaching the server's logs is a stream of `challenged` events indistinguishable from anonymous traffic.

A live deployment behind nginx hit exactly this, and diagnosing it took a full day through the proxy configuration, the TLS chain, and the authorization server before the refusal was found by reading the source. Nothing in the running system pointed at it.

The forwarded value is in the message because it separates the two faults an operator has to tell apart:

- `none` — nothing in front of this process sent a forwarded scheme, so the proxy is what to fix
- any other value — one was sent and was not applied, which is what `ReverseProxy:TrustedProxies` and `ReverseProxy:MaximumForwardedHops` decide

Only a request that actually presented a credential is recorded. The event fires for every request the scheme sees, and one that presented nothing has nothing refused, so anonymous traffic produces no noise.

## Surfaces

No change to the MCP tool contract, the configuration schema, the database schema, or the deployment contract. The response a caller receives is byte-for-byte what it was.

## Verification

- `scripts/verify-fast.sh` — 8880 tests, all passing
- `scripts/verify-full.sh` — passed, digest recorded

Three tests added to `TransportSecurityExtensionsTests`: a presented token over plaintext records the scheme and `none`; a forwarded scheme that was not applied is recorded by value; a plaintext request carrying no token records nothing. The existing assertions about the caller-visible result are unchanged and still pass.

Closes https://github.com/Krzysztof318/MailFathom/issues/944