### PR TITLE
More proxy oauth logs

### DIFF
--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -138,21 +138,23 @@ try
         forwardedHeadersLogger.LogDebug(
             """
             AFTER ForwardedHeaders
+            TraceId: {TraceId}
+            Method: {Method}
+            Path: {Path}
+            Host: {Host}
             Scheme: {Scheme}
             IsHttps: {IsHttps}
             X-Forwarded-Proto: {ForwardedProto}
             X-Original-Proto: {OriginalProto}
-            X-Forwarded-Host: {ForwardedHost}
-            X-Original-Host: {OriginalHost}
-            RemoteIp: {RemoteIp}
             """,
+            context.TraceIdentifier,
+            context.Request.Method,
+            context.Request.Path,
+            context.Request.Host,
             context.Request.Scheme,
             context.Request.IsHttps,
             context.Request.Headers["X-Forwarded-Proto"].ToString(),
-            context.Request.Headers["X-Original-Proto"].ToString(),
-            context.Request.Headers["X-Forwarded-Host"].ToString(),
-            context.Request.Headers["X-Original-Host"].ToString(),
-            context.Connection.RemoteIpAddress);
+            context.Request.Headers["X-Original-Proto"].ToString());
 
         await next();
     });

--- a/src/Host/Security/Transport/TransportSecurityExtensions.cs
+++ b/src/Host/Security/Transport/TransportSecurityExtensions.cs
@@ -196,11 +196,22 @@ internal static partial class TransportSecurityExtensions
         {
             var forwardedProtocol = context.Request.Headers[ForwardedHeadersDefaults.XForwardedProtoHeaderName].ToString();
 
+            var originalProtocol = context.Request.Headers["X-Original-Proto"].ToString();
+
             LogTokenRefusedOnAClearTextHop(
-                context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>()
-                    .CreateLogger(typeof(TransportSecurityExtensions)),
-                context.Scheme.Name,
-                string.IsNullOrEmpty(forwardedProtocol) ? "none" : forwardedProtocol);
+            context.HttpContext.RequestServices
+                .GetRequiredService<ILoggerFactory>()
+                .CreateLogger(typeof(TransportSecurityExtensions)),
+            context.Scheme.Name,
+            context.HttpContext.TraceIdentifier,
+            context.Request.Method,
+            context.Request.Path.Value ?? string.Empty,
+            context.Request.Host.Value ?? string.Empty,
+            context.Request.Scheme,
+            string.IsNullOrEmpty(forwardedProtocol) ? "none" : forwardedProtocol,
+            string.IsNullOrEmpty(originalProtocol) ? "none" : originalProtocol,
+            context.HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown",
+            context.HttpContext.Connection.LocalPort);
         }
 
         context.NoResult();
@@ -209,17 +220,30 @@ internal static partial class TransportSecurityExtensions
     }
 
     [LoggerMessage(
-        Level = LogLevel.Warning,
-        Message = "An access token presented to {AuthenticationScheme} arrived over a hop this process sees as clear "
-            + "text, so it was refused without being read and the caller received the challenge an anonymous request "
-            + "receives. The request carried X-Forwarded-Proto: {ForwardedProtocol}. 'none' means nothing in front of "
-            + "this process sent a forwarded scheme; any other value means one was sent and not applied, which is what "
-            + "ReverseProxy:TrustedProxies and ReverseProxy:MaximumForwardedHops decide. Behind a TLS-terminating "
-            + "reverse proxy every authenticated request fails this way until one of those is corrected.")]
+    Level = LogLevel.Warning,
+    Message =
+        "An access token presented to {AuthenticationScheme} arrived over a request this process currently sees as "
+        + "clear text, so it was refused without being read. "
+        + "Request: TraceIdentifier={TraceIdentifier}, Method={Method}, Path={Path}, Host={Host}, "
+        + "Scheme={Scheme}, RemoteIp={RemoteIp}, LocalPort={LocalPort}. "
+        + "Forwarded protocol state after forwarded-header processing: "
+        + "X-Forwarded-Proto={ForwardedProtocol}, X-Original-Proto={OriginalProtocol}. "
+        + "A remaining X-Forwarded-Proto value may be an unprocessed value or the unconsumed remainder of a forwarded "
+        + "header chain; X-Original-Proto indicates that forwarded-header processing changed the request scheme at least "
+        + "once. Correlate this request by TraceIdentifier with forwarded-header diagnostics to determine where the "
+        + "request scheme became clear text.")]
     private static partial void LogTokenRefusedOnAClearTextHop(
         ILogger logger,
         string authenticationScheme,
-        string forwardedProtocol);
+        string traceIdentifier,
+        string method,
+        string path,
+        string host,
+        string scheme,
+        string forwardedProtocol,
+        string originalProtocol,
+        string remoteIp,
+        int localPort);
 
     /// <summary>Registers the scheme that reads the presented credential and forwards it to the handler that judges it.</summary>
     private static void AddRoutingScheme(


### PR DESCRIPTION
Closes #

## What changes

<!-- What this does and why this shape. The issue holds the requirement; this says how it was met and
     what a reviewer should look at first. Name anything you decided rather than derived. -->

## How it was verified

<!-- `scripts/verify-full.sh` output, which tests were added, and anything checked by hand. Say what
     you could not verify and why. -->

## Checklist

- [ ] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`.
- [ ] Behavior changes are covered by unit tests, and the coverage gate passes.
- [ ] Affected documentation is updated in this change set.
- [ ] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [ ] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [ ] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail.
- [ ] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set.
- [ ] No credential, token, private key, real mailbox data, or personal information is in the diff.

<!-- First contribution? CONTRIBUTING.md covers all of the above, including how contributions are
     licensed — there is nothing to sign, and no acceptance comment to post. -->
