### PR TITLE
Rename the spam action key to MoveToJunkFolder

### DIFF
--- a/docs/operations/configuration-reference.md
+++ b/docs/operations/configuration-reference.md
@@ -608,7 +608,7 @@ described below.
 | `SpamClassification:Scanner:ScanTimeoutSeconds` | int | `30` | 1 – 120 | restart |
 | `SpamClassification:Scanner:MaximumMessageBytes` | int | `512000` | 32 000 – 33 554 432 | restart |
 | `SpamClassification:Scanner:MaximumConcurrentScans` | int | `5` | 1 – 64 | restart |
-| `SpamClassification:Actions:FileInJunkFolder` | bool | `false` | Asking for it while `Enabled` is false fails startup, and so does an account that maps no destination to file into | reload |
+| `SpamClassification:Actions:MoveToJunkFolder` | bool | `false` | Asking for it while `Enabled` is false fails startup, and so does an account that maps no destination to file into | reload |
 | `SpamClassification:Actions:MarkAsRead` | bool | `false` | Asking for it while `Enabled` is false fails startup | reload |
 | `SpamClassification:Actions:JunkFolder` | string | `role:Junk` | A folder alias, or a role written as `role:<name>`; every configured account has to map it once filing is on | reload |
 | `SpamClassification:Actions:Threshold` | double | unset | 0.1 – 1000; unset acts on every spam verdict, and a value judges what a scanner scored | reload |

--- a/src/Host/Configuration/Spam/SpamActionOptions.cs
+++ b/src/Host/Configuration/Spam/SpamActionOptions.cs
@@ -33,7 +33,7 @@ internal sealed class SpamActionOptions
     /// carried out by the account's convergence pass. MailFathom never creates the folder, so an account with none is
     /// refused at startup rather than at the first spam message.
     /// </remarks>
-    public bool FileInJunkFolder { get; set; }
+    public bool MoveToJunkFolder { get; set; }
 
     /// <summary>Gets or sets whether junk has its remote <c>\Seen</c> flag set.</summary>
     /// <remarks>
@@ -61,7 +61,7 @@ internal sealed class SpamActionOptions
     public double? Threshold { get; set; }
 
     /// <summary>Gets whether either switch asks for anything.</summary>
-    internal bool IsAnyActionEnabled => this.FileInJunkFolder || this.MarkAsRead;
+    internal bool IsAnyActionEnabled => this.MoveToJunkFolder || this.MarkAsRead;
 
     /// <summary>Gets the folder junk is filed into, with the junk role standing in for a destination nobody named.</summary>
     /// <remarks>
@@ -76,7 +76,7 @@ internal sealed class SpamActionOptions
     /// <summary>Builds the settings these keys describe.</summary>
     /// <returns>The settings the recorder reads.</returns>
     internal SpamActionSettings ToSettings() => SpamActionSettings.Create(
-        this.FileInJunkFolder,
+        this.MoveToJunkFolder,
         this.MarkAsRead,
         this.Destination,
         this.Threshold);
@@ -90,7 +90,7 @@ internal sealed class SpamActionOptions
         {
             yield return new ValidationResult(
                 $"{SpamClassificationOptions.SectionName} asks for junk to be acted on while classification is disabled, and there is no verdict to act on. Set Enabled to true, or remove the switches under Actions.",
-                [nameof(this.FileInJunkFolder), nameof(this.MarkAsRead)]);
+                [nameof(this.MoveToJunkFolder), nameof(this.MarkAsRead)]);
         }
 
         if (this.JunkFolder is not null && !MailFolderReference.TryCreate(this.JunkFolder, out _))

--- a/src/Host/Configuration/Spam/SpamJunkFolderRules.cs
+++ b/src/Host/Configuration/Spam/SpamJunkFolderRules.cs
@@ -45,7 +45,7 @@ internal static class SpamJunkFolderRules
 
         // Nothing is judged unless filing is actually switched on. A destination written beside switches that are off is
         // an operator preparing a configuration, and refusing it would make staging the change impossible.
-        if (!options.Enabled || !actions.FileInJunkFolder)
+        if (!options.Enabled || !actions.MoveToJunkFolder)
         {
             return [];
         }

--- a/tests/Host.UnitTests/Configuration/Spam/ConfiguredSpamActionSettingsReaderTests.cs
+++ b/tests/Host.UnitTests/Configuration/Spam/ConfiguredSpamActionSettingsReaderTests.cs
@@ -34,7 +34,7 @@ public sealed class ConfiguredSpamActionSettingsReaderTests
             Enabled = true,
             Actions = new SpamActionOptions
             {
-                FileInJunkFolder = true,
+                MoveToJunkFolder = true,
                 MarkAsRead = true,
                 JunkFolder = "quarantine",
                 Threshold = 9,
@@ -59,7 +59,7 @@ public sealed class ConfiguredSpamActionSettingsReaderTests
         var reader = ReaderFor(new SpamClassificationOptions
         {
             Enabled = false,
-            Actions = new SpamActionOptions { FileInJunkFolder = true, MarkAsRead = true },
+            Actions = new SpamActionOptions { MoveToJunkFolder = true, MarkAsRead = true },
         });
 
         // Act
@@ -82,7 +82,7 @@ public sealed class ConfiguredSpamActionSettingsReaderTests
         options.ReportReload(new SpamClassificationOptions
         {
             Enabled = true,
-            Actions = new SpamActionOptions { FileInJunkFolder = true },
+            Actions = new SpamActionOptions { MoveToJunkFolder = true },
         });
 
         var afterReload = reader.Actions;

--- a/tests/Host.UnitTests/Configuration/Spam/SpamActionOptionsTests.cs
+++ b/tests/Host.UnitTests/Configuration/Spam/SpamActionOptionsTests.cs
@@ -31,17 +31,17 @@ public sealed class SpamActionOptionsTests
     [Theory]
     [InlineData(true, false)]
     [InlineData(false, true)]
-    public void FindErrors_AnActionAskedForWhileClassificationIsOff_IsRefused(bool fileInJunkFolder, bool markAsRead)
+    public void FindErrors_AnActionAskedForWhileClassificationIsOff_IsRefused(bool moveToJunkFolder, bool markAsRead)
     {
         // Arrange
-        var options = new SpamActionOptions { FileInJunkFolder = fileInJunkFolder, MarkAsRead = markAsRead };
+        var options = new SpamActionOptions { MoveToJunkFolder = moveToJunkFolder, MarkAsRead = markAsRead };
 
         // Act
         var error = Assert.Single(options.FindErrors(classificationEnabled: false));
 
         // Assert
         Assert.Equal(
-            [nameof(SpamActionOptions.FileInJunkFolder), nameof(SpamActionOptions.MarkAsRead)],
+            [nameof(SpamActionOptions.MoveToJunkFolder), nameof(SpamActionOptions.MarkAsRead)],
             error.MemberNames);
     }
 
@@ -51,7 +51,7 @@ public sealed class SpamActionOptionsTests
     public void FindErrors_AJunkFolderNamingNeitherAnAliasNorARole_IsRefused(string junkFolder)
     {
         // Arrange
-        var options = new SpamActionOptions { FileInJunkFolder = true, JunkFolder = junkFolder };
+        var options = new SpamActionOptions { MoveToJunkFolder = true, JunkFolder = junkFolder };
 
         // Act
         var error = Assert.Single(options.FindErrors(classificationEnabled: true));
@@ -80,7 +80,7 @@ public sealed class SpamActionOptionsTests
     public void Destination_NoJunkFolderNamed_ReadsAsTheJunkRole()
     {
         // Arrange
-        var options = new SpamActionOptions { FileInJunkFolder = true };
+        var options = new SpamActionOptions { MoveToJunkFolder = true };
 
         // Act
         var destination = options.Destination;
@@ -93,7 +93,7 @@ public sealed class SpamActionOptionsTests
     public void Destination_AnAliasNamed_ReadsAsThatFolderRatherThanARole()
     {
         // Arrange
-        var options = new SpamActionOptions { FileInJunkFolder = true, JunkFolder = "quarantine" };
+        var options = new SpamActionOptions { MoveToJunkFolder = true, JunkFolder = "quarantine" };
 
         // Act
         var destination = options.Destination;
@@ -109,7 +109,7 @@ public sealed class SpamActionOptionsTests
         // Arrange
         var options = new SpamActionOptions
         {
-            FileInJunkFolder = true,
+            MoveToJunkFolder = true,
             MarkAsRead = true,
             JunkFolder = $"{MailFolderReference.RoleScheme}{MailFolderSpecialUse.Junk}",
             Threshold = 8,

--- a/tests/Host.UnitTests/Configuration/Spam/SpamJunkFolderRulesTests.cs
+++ b/tests/Host.UnitTests/Configuration/Spam/SpamJunkFolderRulesTests.cs
@@ -101,7 +101,7 @@ public sealed class SpamJunkFolderRulesTests
     private static SpamClassificationOptions Filing(string? junkFolder) => new()
     {
         Enabled = true,
-        Actions = new SpamActionOptions { FileInJunkFolder = true, JunkFolder = junkFolder },
+        Actions = new SpamActionOptions { MoveToJunkFolder = true, JunkFolder = junkFolder },
     };
 
     private static DeclaredMailAccount AccountMapping(

--- a/tests/Host.UnitTests/Configuration/Spam/SpamJunkFolderValidatorTests.cs
+++ b/tests/Host.UnitTests/Configuration/Spam/SpamJunkFolderValidatorTests.cs
@@ -69,7 +69,7 @@ public sealed class SpamJunkFolderValidatorTests
     private static SpamClassificationOptions Filing() => new()
     {
         Enabled = true,
-        Actions = new SpamActionOptions { FileInJunkFolder = true },
+        Actions = new SpamActionOptions { MoveToJunkFolder = true },
     };
 
     private static IConfiguration Configuration(Dictionary<string, string?> keys) =>


### PR DESCRIPTION
`SpamClassification:Actions:FileInJunkFolder` is now `SpamClassification:Actions:MoveToJunkFolder`. The switch performs a relocation, and every other mailbox mutation in MailFathom is named as a move, so the key now reads as the act it carries out.

**Breaking (configuration schema)**: a deployment that switched the action on renames that one key in its configuration file. Startup fails on neither name being present only in the sense that the action silently reverts to off, so the rename is the operator's action before the upgrade.

Mechanical rename across the host options type, the junk-folder rules, their unit tests, and the configuration reference. The application-side setting is `SpamActionSettings.FilesJunk` and is untouched — it never carried the configuration name.

`CHANGELOG.md` still names the old key in the 0.6.0 section, deliberately: that section states what 0.6.0 shipped, and the release pull request records this break.

---

Pull request: https://github.com/Krzysztof318/MailFathom/pull/956
