### PR TITLE
[#959] Say that sender trust needs the receiving server to stamp Authentication-Results

### DIFF
--- a/docs/features/sender-authentication.md
+++ b/docs/features/sender-authentication.md
@@ -38,13 +38,22 @@ than of MailFathom, so there is nothing to default it to; [the mail
 configuration](../operations/configuration-mail.md#one-account--mailsynchronizationaccountsn) states where the setting
 lives. What to write in it is read off
 the mail the account already holds: open a message that arrived recently, read its topmost `Authentication-Results`
-header, and take the token before the first semicolon, which is the identifier that server stamps on everything it
-delivers to this mailbox.
+header, and take the first token after the colon, which is the identifier that server stamps on everything it
+delivers to this mailbox. RFC 8601 lets a server write a version number after that token, and the digit is not part of
+the identifier — a configured value carrying whitespace fails startup rather than matching a header.
 
 **An account naming no identifier believes no header at all**, and every message it holds carries the not-established
 verdict below. That is an ordinary state rather than a misconfiguration: it is also what a deployment whose provider
 publishes no results sees on every message. A value that is *present* and unusable — blank, longer than a domain name,
 or carrying whitespace — fails startup instead, because the two are indistinguishable afterwards.
+
+**A server that writes no header at all is the second of those two, and configuration does not answer it.** Nothing
+here verifies a sender, so a deployment whose receiving server neither evaluates SPF, DKIM, and DMARC nor records what
+it found has no route to any verdict but not established — and therefore no route to a trusted author either, since
+[the list below](#the-trusted-sender-list) is held against one. Switching those checks on at that server reaches mail
+delivered afterwards and cannot reach mail already delivered, because the header is part of the message. [Whether your
+server says who sent a message](../users/mailbox-providers.md#whether-your-server-says-who-sent-a-message) is how a
+reader tells the two cases apart against their own delivered mail.
 
 The `ARC-Authentication-Results` header of RFC 8617 is deliberately not read here. It preserves an upstream hop's
 findings across forwarding, which is a claim a relay signed rather than something this mailbox's own server observed.

--- a/docs/operations/configuration-mail.md
+++ b/docs/operations/configuration-mail.md
@@ -95,7 +95,11 @@ here cannot be exploited by writing their address into a message. Most legitimat
 intended outcome: the claim is that this deployment does not know the author, not that the message is suspicious.
 Turning `TrustOwnAccountDomains` off is the right move for a deployment whose accounts sit on a large shared provider,
 since every user of that provider writes from the same domain; the same page states what an address entry rests on and
-what it deliberately does not establish.
+what it deliberately does not establish. Both are unreachable where no trusted header is read at all — an account
+that names no authority, and equally one whose receiving server records no results — because a message with no
+established author reaches unknown without either being consulted. [Whether your server says who sent a
+message](../users/mailbox-providers.md#whether-your-server-says-who-sent-a-message) is how that is checked against a
+deployment's own delivered mail before entries are written here.
 
 `AssessMachineAuthorship` answers a different question again — how a message's text was *written* rather than who sent
 it — and it defaults to on because the reading costs one pass over text extraction has already produced and needs

--- a/docs/users/mailbox-providers.md
+++ b/docs/users/mailbox-providers.md
@@ -403,6 +403,41 @@ it is correct: all three shapes of the question reach the same end state, and
 command each server gets. There is nothing to configure and nothing to check — a server that supports neither is slower
 and no less right.
 
+## Whether your server says who sent a message
+
+MailFathom verifies no sender itself. It resolves no DNS, evaluates no SPF policy, and verifies no DKIM signature — it
+reads back the `Authentication-Results` header that the server receiving your mail wrote, because that server is the
+only party in the chain that observed the connection. So whether sender verification works at all is your provider's
+decision rather than yours, and it is settled before any setting of yours is consulted.
+
+**A server that records no results leaves every message stating that nothing was established**, and no account setting
+changes that. `TrustedSenders` is the least useful thing to reach for: the list is held against an established author,
+so on a message that has none it is never consulted at all and its entries cannot match. `TrustOwnAccountDomains` is in
+the same position, since it too recognizes an author rather than a `From` header.
+
+Check the mail you were actually delivered rather than the provider's documentation. Open a recently arrived message in
+any mail client, view its source or full headers, and look for `Authentication-Results`:
+
+| What you find | What it means |
+| --- | --- |
+| `Authentication-Results: some.host; dkim=pass …` | `some.host`, the first token after the colon, is the authserv-id and is what `TrustedAuthenticationServiceIdentifier` takes. A server may write a version number after it, as `some.host 1;` — that digit belongs to the header rather than to the identifier, and a configured value carrying whitespace fails startup |
+| Only `ARC-Authentication-Results` | An upstream hop's findings preserved across forwarding, which is a claim a relay signed rather than something your own server observed. It is deliberately never read, and there is nothing to configure from it |
+| No such header at all | Your server either does not check the sender or does not record what it found. Nothing on this side substitutes for it |
+
+The third case is a question for whoever runs that server: SPF, DKIM, and DMARC have to be evaluated as mail is
+delivered, and the outcome written into the message as an RFC 8601 header carrying that server's own identifier. Which
+software does it, and how it is switched on, is that server's own documentation.
+
+Two things are worth knowing before asking for it. It reaches mail delivered afterwards and cannot reach mail already
+delivered, because the header is part of the message and nobody can add one to a message that has already arrived. And
+the verdict is recorded when a message is extracted rather than worked out when it is read, so mail already
+synchronized keeps the answer it was stored with until [a re-derivation](administering.md#filling-in-what-a-newer-version-records)
+re-reads it — which is also what applies a newly configured authserv-id to the mail you already hold.
+
+[Sender authentication](../features/sender-authentication.md) states what the verdict records and how the header is
+chosen; [the mail configuration](../operations/configuration-mail.md#one-account--mailsynchronizationaccountsn) states
+where the setting lives.
+
 ## Related
 
 - [Getting started](getting-started.md) — the whole path from an installed instance to a first tool call


### PR DESCRIPTION
Sender trust rests entirely on the `Authentication-Results` header the receiving mail server writes, and the documentation stated that only as a property of the verdict rather than as something an operator has to have. Nothing in the guide layer mentioned the header at all, so a deployment whose server records no results reads as a defect: every message says nothing was established, every author is unknown, and the setting an operator reaches for next — `TrustedSenders` — is the one that cannot help, because the list is never consulted on a message with no established author.

This adds the prerequisite where a reader connecting a mailbox meets it, and states the two consequences no page carried: that switching the checks on at the server reaches mail delivered afterwards only, and that a re-derivation is what applies a newly configured authserv-id to mail already stored.

- `docs/users/mailbox-providers.md` gains a section stating that whether sender verification works at all is the provider's decision, a self-check against the reader's own delivered mail with the three outcomes it can have, and what to ask for when the header is absent. It links the feature page and the configuration reference for the contract rather than restating either.
- `docs/features/sender-authentication.md` says that a server writing no header has no route to a trusted author either, since the trusted-sender list is held against one, and that the fix cannot reach mail already delivered.
- `docs/operations/configuration-mail.md` says the same at the point `TrustedSenders` and `TrustOwnAccountDomains` are described, because that is where an operator writes entries that would never match.

One existing sentence is corrected in passing. Both the feature page and the new section describe how to read the authserv-id out of a header, and "the token before the first semicolon" is wrong where a server writes RFC 8601's optional version number after the identifier: the configured value would carry whitespace and fail startup. Both now say the first token after the colon and name the version number as not part of it, which is what `AuthenticationResults.AuthenticationServiceIdentifier` returns.

No behavior changes and nothing under `src/` is touched. It breaks no public surface.

Verified with `scripts/verify-full.sh`, `scripts/test-agent-workflow.sh` (228 passed), and `scripts/build-docs-site.sh`, whose only warnings are the four pre-existing link warnings on `CHANGELOG.md` and `docs/index.md`.

Closes #959

- Issue: https://github.com/Krzysztof318/MailFathom/issues/959
