### PR TITLE
Report remotely deleted mail at information level

### DIFF
--- a/docs/features/imap-synchronization.md
+++ b/docs/features/imap-synchronization.md
@@ -1493,7 +1493,7 @@ that caused it and searching the folder for something that looks right is refuse
 ### What a run reports
 
 The counts reach the log and nothing else does. A window that observed something logs how many snapshots it refreshed
-and whether the folder has more to reconcile; a window that found messages gone logs that at warning level, with the
+and whether the folder has more to reconcile; a window that found messages gone logs that at information level, with the
 account, the folder alias, the count, and the disposition that was applied. A run that recognized changes of
 MailFathom's own logs them on a line of their own, at information level: how many discoveries carried an existing local
 email across, and how many occurrences left the folder because MailFathom moved or deleted them. Without it an operator

--- a/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
+++ b/src/Host/Hosting/Workers/AccountSynchronizationSupervisor.cs
@@ -1007,9 +1007,8 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// <summary>Emits the audit line for the backward pass, and emits it only when the pass found something to record.</summary>
     /// <remarks>
     /// A window that observed nothing says nothing, so a folder whose emails are all up to date does not repeat a line
-    /// per interval forever. Local deletion is reported at warning level whichever disposition produced it, because an
-    /// operator watching this is watching for mail leaving the local copy — and a misconfigured folder alias or a
-    /// server rebuilding a mailbox shows up here first.
+    /// per interval forever. Local deletion is reported at information level whichever disposition produced it, because
+    /// mail leaving a mailbox is what synchronization is for rather than a fault an operator has to act on.
     /// </remarks>
     private void ReportReconciliation(
         string folderAlias,
@@ -1154,7 +1153,7 @@ internal sealed partial class AccountSynchronizationSupervisor
     /// it. Only counts and MailFathom's own configured names appear here; nothing derived from a message may.
     /// </remarks>
     [LoggerMessage(
-        Level = LogLevel.Warning,
+        Level = LogLevel.Information,
         Message = "Mail server no longer holds {RemotelyDeletedEmailCount} messages stored for {AccountId}/{FolderAlias}; their local copies were handled as {RemotelyDeletedEmailDisposition}.")]
     private partial void LogRemotelyDeletedEmailsRecorded(
         string accountId,


### PR DESCRIPTION
## What changed

The reconciliation line that records mail the server no longer holds is logged at information level instead of warning. Mail leaving a mailbox is the outcome synchronization exists to observe, not a fault an operator has to act on, so it no longer raises a warning on every window that finds a deletion.

The disposition, the counts, the account, and the folder alias stay on the line unchanged; only the level moves. `docs/features/imap-synchronization.md` § *What a run reports* is updated to match.

## Verification

Not run — this is a level change on a single `LoggerMessage` and the prose that describes it, requested without the verification gate.

Pull request: https://github.com/Krzysztof318/MailFathom/pull/964
