### PR TITLE
[#755] Address a message by naming a contact, without becoming a way around the recipient policy

### DIFF
--- a/docs/architecture/stored-email-schema.md
+++ b/docs/architecture/stored-email-schema.md
@@ -761,7 +761,14 @@ send being attempted, and it would be worth nothing if it also stopped the send 
 in its recipient list. A message is offered per address and answered per address, so a mistyped address among five must
 not stop the other four, and the four the message reached must not be offered it again when the fifth is retried. Each
 row carries the `Address`, the `Role` the composed message names them in — `To`, `Cc`, or `Bcc`, which reach `RCPT TO`
-identically — the `Status`, and the `LastReplyCode` and `AnsweredAt` of the last answer about them. It carries an `xmin`
+identically — the `Status`, and the `LastReplyCode` and `AnsweredAt` of the last answer about them. It also carries a
+nullable `ContactId` where the address came out of the contact book rather than from an author's own typing, which the
+`AddOutgoingRecipientContact` migration adds. Both are kept because they answer different questions: the address is what
+a resumed attempt offers, and the contact is which person the message was addressed by naming — a record holding only the
+person would answer the wrong question a year later, since a message sent to somebody whose address changed afterwards
+was sent to the address they had. It carries no foreign key onto `contacts` and no index, deliberately in both cases: a
+contact amended, promoted, or erased later must not rewrite what was sent, and nothing ever looks a send up by contact.
+It carries an `xmin`
 token of its own rather than relying on the record's, because an attempt answers about one address without touching the
 record above it: without one, two attempts settling the same recipient would be a last writer winning silently, and
 settling a recipient is what decides whether anybody is offered the message again.
@@ -929,9 +936,11 @@ them, and why the record carries no subject, no body, and no header of its own. 
 `outgoing_email_contents` and is reached by identifier, so listing the outbox, advancing a stage, or answering about a
 recipient never loads it. The two cascades from `outgoing_emails` are what make erasure structural: deleting the
 record destroys the recipients and the stored message with it, so an outgoing message cannot outlive the record that
-says who it was for. Nothing in any of the three reaches a log, a metric, a trace, or an exception message — an
-exception about a recipient names the record, and the position where the row it was reading has one, rather than the
-address.
+says who it was for. A recipient's `ContactId` does not widen any of that: it is the one column of the three that is not
+personal data, it is the same identifier a failure is allowed to name, and it points at `contacts` without a constraint
+so erasing a contact leaves the send saying who it went to rather than rewriting it. Nothing in any of the three reaches
+a log, a metric, a trace, or an exception message — an exception about a recipient names the record, and the position
+where the row it was reading has one, rather than the address.
 
 `embedding_profiles` is the exception on this page: it holds no personal data at all. It describes a model, and the credential that reaches that model is configuration rather than a column here, so nothing in this table is a secret or is derived from anybody's mail.
 

--- a/docs/features/contacts.md
+++ b/docs/features/contacts.md
@@ -15,6 +15,12 @@ deployment itself: [§ Collecting contacts from arriving mail](#collecting-conta
 account records on its own, and it is off until an owner switches it on, so an instance nobody has written to and nobody
 switched collection on for holds no contacts at all.
 
+**One reader is not a surface at all.** A message may be addressed by naming somebody in the book rather than by writing
+an address, and the send resolves that name against the book on its way to the outgoing record; [mail delivery §
+Addressing a message by naming a contact](mail-delivery.md#addressing-a-message-by-naming-a-contact) holds how a name
+becomes an address, which name refuses to, and what the record then keeps. Nothing about that writes the book: addressing
+somebody is not a fact about them, so no contact is created, amended, or promoted by being written to.
+
 ## A contact is a person, not an address
 
 One person uses a work address, a personal one, and an old one they still receive on. A book keyed on the address could
@@ -201,11 +207,18 @@ answered as a contact the book does not hold rather than putting the person back
 
 ## Reading the book
 
-Two lookups and one listing:
+Three lookups and one listing:
 
-- **By identity**, which is what every other part of the system will name a person by.
+- **By identity**, which is what every other part of the system names a person by.
 - **By address**, which answers "who is this from" and is served from the unique index rather than from a scan. At most
   one contact can answer, which is the uniqueness rule above rather than a property of the lookup.
+- **By the whole name**, which answers "who did they mean" and is what addressing a message to somebody reads. It matches
+  the name's comparison form exactly rather than looking for text inside it, so it is served from the listing index the
+  name's key leads, and it answers with the one contact carrying the name or with how many carry it. More than one is not
+  a result to choose from: nothing here ranks people, and [mail delivery §
+  Addressing a message by naming a contact](mail-delivery.md#addressing-a-message-by-naming-a-contact) is where refusing
+  that is argued. The count is exact and comes from the database, and the addresses of the people a shared name matched
+  are never read, so a name a hundred collected contacts happen to share costs one number rather than a hundred records.
 - **A page of the book**, bounded and continued by a keyset cursor. The order is the name's comparison form and then the
   identity, which makes it total: two people with one name are still served in a fixed order, so a walk of the book
   serves every contact exactly once. A page holds 50 contacts unless the caller asks for fewer, and never more than 200.

--- a/docs/features/contacts.md
+++ b/docs/features/contacts.md
@@ -219,11 +219,18 @@ Three lookups and one listing:
   Addressing a message by naming a contact](mail-delivery.md#addressing-a-message-by-naming-a-contact) is where refusing
   that is argued. The count is exact and comes from the database, and the addresses of the people a shared name matched
   are never read, so a name a hundred collected contacts happen to share costs one number rather than a hundred records.
+  A name resolving to one person answers with that person and with the count that decided it read together, so the answer
+  can never be one of two people a namesake written down meanwhile made ambiguous.
 - **A page of the book**, bounded and continued by a keyset cursor. The order is the name's comparison form and then the
   identity, which makes it total: two people with one name are still served in a fixed order, so a walk of the book
   serves every contact exactly once. A page holds 50 contacts unless the caller asks for fewer, and never more than 200.
   A listing may be narrowed to one origin, which is the question "what did my instance pick up" and its inverse, and to
   a **search**.
+
+The name lookup and the identity lookup each also answer a **set**, up to a page of the book's worth in one read, because
+one message may name many people and a query per person would let its recipients decide what addressing it costs. What
+comes back is a match for every name and a contact for every identity the book holds; both are the same answers the
+single-value lookups give, which is why nothing above changes for a caller with one name in hand.
 
 A search is text a contact has to carry somewhere in its name or in one of its addresses, matched on the same comparison
 forms everything else here is matched on — so the search text is upper-cased once and compared against the stored name

--- a/docs/features/contacts.md
+++ b/docs/features/contacts.md
@@ -229,7 +229,8 @@ Three lookups and one listing:
 
 The name lookup and the identity lookup each also answer a **set**, up to a page of the book's worth in one read, because
 one message may name many people and a query per person would let its recipients decide what addressing it costs. What
-comes back is a match for every name and a contact for every identity the book holds; both are the same answers the
+comes back is a match for every name asked about — reporting nobody where nobody carries it — and a contact for each of
+the identities the book holds, with nothing standing in for the ones it does not. Both are the same answers the
 single-value lookups give, which is why nothing above changes for a caller with one name in hand.
 
 A search is text a contact has to carry somewhere in its name or in one of its addresses, matched on the same comparison

--- a/docs/features/mail-delivery.md
+++ b/docs/features/mail-delivery.md
@@ -251,6 +251,12 @@ person rather than to a mailbox.
 **One unresolved recipient refuses the whole message.** Sending to everybody else would tell an author their message went
 out while the person they cared about never receives it.
 
+**The book is read once for the identities named and once for the names**, whatever a message names, so what addressing
+costs follows from how a message was addressed rather than from how many people it goes to. The recipient count is
+bounded before the first of those reads at the most an outgoing record can hold, because the reads carry what the caller
+supplied. A name resolving to one person comes back with the count that decided it, which is what stops a namesake
+written down while the read ran from turning an ambiguous name into an arbitrary one of two people.
+
 **The record keeps both facts.** A recipient resolved from the book is written down with the address the send was offered
 to and the contact it came from, so what was sent stays answerable after the contact is amended, promoted, or erased. The
 addresses in the composed message are the ones that were resolved; nothing re-reads the book to resume a send.

--- a/docs/features/mail-delivery.md
+++ b/docs/features/mail-delivery.md
@@ -251,8 +251,10 @@ person rather than to a mailbox.
 **One unresolved recipient refuses the whole message.** Sending to everybody else would tell an author their message went
 out while the person they cared about never receives it.
 
-**The book is read once for the identities named and once for the names**, whatever a message names, so what addressing
-costs follows from how a message was addressed rather than from how many people it goes to. The recipient count is
+**The identities named and the names are each read in groups of at most a page of the book**, so a message costs one read
+per way its recipients were named and a second of that way only past two hundred distinct people — four reads for the
+longest recipient list an outgoing record can hold, against one per recipient. What addressing costs therefore follows
+from how a message was addressed rather than from how many people it goes to. The recipient count is
 bounded before the first of those reads at the most an outgoing record can hold, because the reads carry what the caller
 supplied. A name resolving to one person comes back with the count that decided it, which is what stops a namesake
 written down while the read ran from turning an ambiguous name into an arbitrary one of two people.

--- a/docs/features/mail-delivery.md
+++ b/docs/features/mail-delivery.md
@@ -252,9 +252,10 @@ person rather than to a mailbox.
 out while the person they cared about never receives it.
 
 **The identities named and the names are each read in groups of at most a page of the book**, so a message costs one read
-per way its recipients were named and a second of that way only past two hundred distinct people — four reads for the
-longest recipient list an outgoing record can hold, against one per recipient. What addressing costs therefore follows
-from how a message was addressed rather than from how many people it goes to. The recipient count is
+per way its recipients were named, and a second of one such way only past two hundred distinct people in it. Both ways are
+named out of one recipient list bounded below twice that, so at most one of them ever reaches its second read: three reads
+for the longest recipient list an outgoing record can hold, against one per recipient. What addressing costs therefore
+follows from how a message was addressed rather than from how many people it goes to. The recipient count is
 bounded before the first of those reads at the most an outgoing record can hold, because the reads carry what the caller
 supplied. A name resolving to one person comes back with the count that decided it, which is what stops a namesake
 written down while the read ran from turning an ambiguous name into an arbitrary one of two people.

--- a/docs/features/mail-delivery.md
+++ b/docs/features/mail-delivery.md
@@ -4,7 +4,8 @@
 
 Reading a mailbox and submitting to one are two capabilities against two servers, and MailFathom holds them apart. The
 submission half is whole: an account declares where its mail is submitted, a **delivery session** is opened against that
-server — connected, encrypted, authenticated, and asked what it will accept — an authored message is **composed into
+server — connected, encrypted, authenticated, and asked what it will accept — a recipient named as a person is
+**resolved against the contact book**, an authored message is **composed into
 MIME**, a **reply or a forward is authored** from mail this deployment already holds, the send is written down durably
 before anything acts on it, and it is then **claimed, transmitted, and settled** against the record it was written as. A
 deployment that configures a submission endpoint sends mail.
@@ -225,6 +226,46 @@ are `28001` for an account configuring no address to send from, `28002` for an i
 message can be composed from, `28004` for an internationalized address the server cannot carry, and `28005` for any
 bound.
 
+## Addressing a message by naming a contact
+
+An author names each recipient either by an address or by somebody [the contact book](contacts.md) holds, and
+`NamedRecipientResolver` is the single place the second becomes the first. It sits between authoring and composition on
+the way to the outgoing record, which is what makes naming a person a convenience of addressing rather than a second way
+out of the deployment: what it produces is an ordinary address, indistinguishable from one an author typed, so every
+bound, refusal, and check a written-down address meets it meets as well. Naming a contact can therefore reach no mailbox
+that naming an address could not.
+
+**A contact is named by the identity the book gave it or by the whole name the owner recorded**, and a name addresses a
+message only where exactly one contact carries it. Nothing ranks candidates, nothing prefers the most recently written
+down, and nothing falls back to a near match: a recipient chosen that way is a message delivered to somebody nobody
+named. The name is compared on the form the book compares its own values in, so the casing an author wrote is immaterial,
+and it is the whole name rather than part of one — text that merely appears inside somebody's name is not that person
+being named, which is what separates addressing from the contained match a search of the book performs.
+
+**The address used is the one the owner made preferred**, unless the authored act names another address of that same
+contact — and an address that contact does not hold is refused rather than sent to and rather than quietly replaced by
+the preferred one. The value that reaches the message is the book's own spelling of it. The name written beside it in the
+header is the name the owner recorded, which is the point of addressing somebody by it: the message reads as one to a
+person rather than to a mailbox.
+
+**One unresolved recipient refuses the whole message.** Sending to everybody else would tell an author their message went
+out while the person they cared about never receives it.
+
+**The record keeps both facts.** A recipient resolved from the book is written down with the address the send was offered
+to and the contact it came from, so what was sent stays answerable after the contact is amended, promoted, or erased. The
+addresses in the composed message are the ones that were resolved; nothing re-reads the book to resume a send.
+
+**A refusal names how many contacts matched and nothing else about them.** The codes are `28013` for a contact the book
+does not hold — an identity nothing answers to and a name nobody carries are one answer, because the remedy is the same —
+`28014` for a name several contacts carry, which carries the count, and `28015` for an address the named contact does not
+hold, which text naming no mailbox at all also produces. No refusal, result, or log line reveals an address the caller
+did not supply, and none of them names anybody who was counted.
+
+**The resolution asks for no permission of its own.** Every use case above it runs under a principal, and only a caller
+can hold a grant at all — the process identity that runs work nobody requested holds none — so a grant demanded there
+would refuse a rule addressing a contact rather than authorize anything. Whether a caller may name people out of the book
+is decided at the boundary the caller reached, beside the grant that lets it send.
+
 ## Replying and forwarding from mail this deployment already holds
 
 A reply and a forward are the two sends that begin from a message rather than from a blank one, and everything that makes
@@ -256,7 +297,11 @@ reaches what a reply to all *adds* and nothing else: whoever asked for answers i
 is this account's own address, which is what a message somebody sent themselves and a shared mailbox two colleagues both
 send as both look like, and leaving it out would resolve the reply to nobody and refuse it. One mailbox is offered once and in the more visible header, as it is for any
 authored list. A forward addresses nobody of its own: the people it goes to are people the original never named, so its
-author names all of them. Which act it is, is explicit; there is no default that quietly becomes the other.
+author names all of them. Which act it is, is explicit; there is no default that quietly becomes the other. Whoever the
+author names themselves may be named as a person out of the contact book, resolved exactly as on a message answering
+nothing, while everybody the act itself derives is an address already by the time it is read out of the stored copy's own
+headers — so an answer can reach no mailbox a new message could not, and a name several contacts carry refuses the answer
+rather than addressing one of them.
 
 **The subject takes the conventional prefix only where there is not one already.** `Re:` and `Fwd:` are what this system
 writes, and the comparison that decides whether to write one recognizes the prefixes actually in use — `Aw`, `Sv`,
@@ -507,6 +552,16 @@ in two headers becoming one offer in the more visible one, a blind recipient app
 the transmitted bytes, an eight-bit body transfer-encoded when the server takes none, the two threading headers written
 together or not at all, and the line ending a stored message carries — which matters precisely because the bytes are
 transmitted verbatim rather than re-serialized.
+
+Resolving a recipient named as a person is settled in the unit suite too, against an in-memory book rather than a
+substitute, because every claim is about what a lookup of the book can answer: a name one person carries whatever casing
+it was written in, a name several carry refusing and naming how many, an identity and a name nobody answers to producing
+one refusal, an act naming another of the contact's addresses and an act naming one they do not hold, an address the
+author wrote reaching the composition unparsed and naming no contact, and one recipient nobody can be found for refusing
+the whole message. That a resolved address is then an ordinary address is proven where it would stop being one — in the
+composition, where a contact-resolved address refused for internationalization is refused exactly as a written-down one
+is, and where a contact and a typed address naming one mailbox become one offer. That the record keeps the contact beside
+the address is the integration suite's, since only a real column can round-trip it.
 
 Authoring a reply or a forward is settled in the unit suite for the same reason, since it reaches no server either. What
 the tests establish there is the threading of an answer to a message with and without a `References` header and to one

--- a/src/Application/Contacts/ContactMatch.cs
+++ b/src/Application/Contacts/ContactMatch.cs
@@ -1,0 +1,61 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Contacts;
+
+namespace MailFathom.Application.Contacts;
+
+/// <summary>States who a lookup of the book resolved to: how many people answer to it, and which one when exactly one does.</summary>
+/// <remarks>
+/// <para>
+/// The count is here because a caller that cannot use the answer still has to be told what was wrong with it, and the
+/// only thing it may be told is how many. A name several people carry resolves to nobody — nothing ranks them and
+/// nothing picks the closest — so the record carries the number and none of the contacts it counted. A lookup by
+/// identity answers in the same shape and never counts past one, which is what lets a caller act on the count rather
+/// than on how the contact was named.
+/// </para>
+/// <para>
+/// The contact is present for exactly one match, which is what makes the unique case usable without a second read and
+/// the ambiguous case impossible to use by accident.
+/// </para>
+/// </remarks>
+public sealed record ContactMatch
+{
+    private ContactMatch(int matchCount, Contact? onlyMatch)
+    {
+        this.MatchCount = matchCount;
+        this.OnlyMatch = onlyMatch;
+    }
+
+    /// <summary>Gets a match reporting that nobody in the book carries the name.</summary>
+    public static ContactMatch None { get; } = new(matchCount: 0, onlyMatch: null);
+
+    /// <summary>Gets how many contacts carry the name.</summary>
+    public int MatchCount { get; }
+
+    /// <summary>Gets the contact carrying the name, which is present exactly when <see cref="MatchCount" /> is one.</summary>
+    public Contact? OnlyMatch { get; }
+
+    /// <summary>Reports the one person the book holds under the name.</summary>
+    /// <param name="contact">The contact carrying it.</param>
+    /// <returns>A unique match.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contact" /> is <see langword="null" />.</exception>
+    public static ContactMatch Unique(Contact contact)
+    {
+        ArgumentNullException.ThrowIfNull(contact);
+
+        return new ContactMatch(matchCount: 1, contact);
+    }
+
+    /// <summary>Reports that several people carry the name, and how many.</summary>
+    /// <param name="matchCount">How many contacts carry it.</param>
+    /// <returns>An ambiguous match.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="matchCount" /> is below two, which is a unique match or none rather than an ambiguous one.</exception>
+    public static ContactMatch Several(int matchCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(matchCount, 2, nameof(matchCount));
+
+        return new ContactMatch(matchCount, onlyMatch: null);
+    }
+}

--- a/src/Application/Contacts/IContactDirectory.cs
+++ b/src/Application/Contacts/IContactDirectory.cs
@@ -7,7 +7,7 @@ using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Contacts;
 
-/// <summary>Reads the contact book: one person by identity, by name, or by an address they use, and a page of the whole.</summary>
+/// <summary>Reads the contact book: one person by identity or by an address they use, a set of them by identity or by name, and a page of the whole.</summary>
 /// <remarks>
 /// Every read joins no transaction and returns complete contacts rather than an entity graph, which is why it is a port
 /// of its own beside <see cref="IContactStore" /> rather than a set of methods on it. Every lookup is answered from an
@@ -21,6 +21,22 @@ public interface IContactDirectory
     /// <returns>The complete contact, or <see langword="null" /> when the book holds none.</returns>
     Task<Contact?> FindAsync(ContactId contactId, CancellationToken cancellationToken);
 
+    /// <summary>Reads several contacts by the identities the book gave them.</summary>
+    /// <param name="contactIds">The contacts to read, at most one page of the book's worth.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>An entry for every identity the book holds, keyed by that identity; identities it holds none of are absent.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="contactIds" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when more identities are supplied than one page of the book holds.</exception>
+    /// <remarks>
+    /// One read for a whole set rather than one per identity, because a caller resolving the people an act named would
+    /// otherwise make the number of queries its own input's to decide. A caller with more identities than the bound admits
+    /// asks in bounded groups; the bound is the same one a page of the book is read under, so no read here is larger than
+    /// one this port already answers.
+    /// </remarks>
+    Task<IReadOnlyDictionary<ContactId, Contact>> FindAllAsync(
+        IReadOnlyCollection<ContactId> contactIds,
+        CancellationToken cancellationToken);
+
     /// <summary>Reads the person who uses one address.</summary>
     /// <param name="address">The address to resolve.</param>
     /// <param name="cancellationToken">Cancels the read.</param>
@@ -31,24 +47,28 @@ public interface IContactDirectory
     /// </remarks>
     Task<Contact?> FindByAddressAsync(EmailAddress address, CancellationToken cancellationToken);
 
-    /// <summary>Reads who one name resolves to, by the whole of that name rather than by part of it.</summary>
-    /// <param name="displayName">The name to resolve.</param>
+    /// <summary>Reads who each name resolves to, by the whole of that name rather than by part of it.</summary>
+    /// <param name="displayNames">The names to resolve, at most one page of the book's worth.</param>
     /// <param name="cancellationToken">Cancels the read.</param>
-    /// <returns>The one contact carrying the name, or how many carry it when that is not one.</returns>
+    /// <returns>An entry for every supplied name at least one contact carries, keyed by the name as supplied; a name nobody carries is absent.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="displayNames" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when more names are supplied than one page of the book holds.</exception>
     /// <remarks>
     /// <para>
-    /// The comparison is on the name's whole comparison form, which is what separates this from the contained match a
+    /// The comparison is on each name's whole comparison form, which is what separates this from the contained match a
     /// page's search performs: a lookup that addresses a message resolves to one person or to nobody, and text that
     /// merely appears inside somebody's name is not that person being named. Both are answered from the listing index
     /// the book is ordered by.
     /// </para>
     /// <para>
-    /// The count is exact and the addresses of the people it counted are never read, so an ambiguous name costs one
-    /// number rather than a page of somebody else's correspondents.
+    /// The count an ambiguous name answers with is exact, and the addresses of the people it counted are never read, so a
+    /// name a hundred collected contacts happen to share costs one number rather than a page of somebody else's
+    /// correspondents. A name resolving to one person answers with that person and with the count that decided it read
+    /// together, so no caller can be handed a contact the book no longer holds uniquely.
     /// </para>
     /// </remarks>
-    Task<ContactMatch> MatchDisplayNameAsync(
-        ContactDisplayName displayName,
+    Task<IReadOnlyDictionary<ContactDisplayName, ContactMatch>> MatchDisplayNamesAsync(
+        IReadOnlyCollection<ContactDisplayName> displayNames,
         CancellationToken cancellationToken);
 
     /// <summary>Reads which contacts already hold each of the given addresses.</summary>

--- a/src/Application/Contacts/IContactDirectory.cs
+++ b/src/Application/Contacts/IContactDirectory.cs
@@ -50,7 +50,7 @@ public interface IContactDirectory
     /// <summary>Reads who each name resolves to, by the whole of that name rather than by part of it.</summary>
     /// <param name="displayNames">The names to resolve, at most one page of the book's worth.</param>
     /// <param name="cancellationToken">Cancels the read.</param>
-    /// <returns>An entry for every supplied name at least one contact carries, keyed by the name as supplied; a name nobody carries is absent.</returns>
+    /// <returns>An entry for every supplied name, keyed by the name as supplied, carrying the one contact under it or how many carry it; a name nobody carries reports none.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="displayNames" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when more names are supplied than one page of the book holds.</exception>
     /// <remarks>
@@ -65,6 +65,10 @@ public interface IContactDirectory
     /// name a hundred collected contacts happen to share costs one number rather than a page of somebody else's
     /// correspondents. A name resolving to one person answers with that person and with the count that decided it read
     /// together, so no caller can be handed a contact the book no longer holds uniquely.
+    /// </para>
+    /// <para>
+    /// Every supplied name is answered rather than only the ones somebody carries, because <see cref="ContactMatch" />
+    /// already states "nobody" and a caller reading a set has to tell that answer from a name the read never covered.
     /// </para>
     /// </remarks>
     Task<IReadOnlyDictionary<ContactDisplayName, ContactMatch>> MatchDisplayNamesAsync(

--- a/src/Application/Contacts/IContactDirectory.cs
+++ b/src/Application/Contacts/IContactDirectory.cs
@@ -7,10 +7,10 @@ using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Contacts;
 
-/// <summary>Reads the contact book: one person by identity, the person behind an address, and a page of the whole.</summary>
+/// <summary>Reads the contact book: one person by identity, by name, or by an address they use, and a page of the whole.</summary>
 /// <remarks>
 /// Every read joins no transaction and returns complete contacts rather than an entity graph, which is why it is a port
-/// of its own beside <see cref="IContactStore" /> rather than a set of methods on it. Both lookups are answered from an
+/// of its own beside <see cref="IContactStore" /> rather than a set of methods on it. Every lookup is answered from an
 /// index rather than from a scan, and the page is bounded and ordered so a walk of the book terminates.
 /// </remarks>
 public interface IContactDirectory
@@ -30,6 +30,26 @@ public interface IContactDirectory
     /// recorded. At most one contact can answer, which is a property of the store rather than of this method.
     /// </remarks>
     Task<Contact?> FindByAddressAsync(EmailAddress address, CancellationToken cancellationToken);
+
+    /// <summary>Reads who one name resolves to, by the whole of that name rather than by part of it.</summary>
+    /// <param name="displayName">The name to resolve.</param>
+    /// <param name="cancellationToken">Cancels the read.</param>
+    /// <returns>The one contact carrying the name, or how many carry it when that is not one.</returns>
+    /// <remarks>
+    /// <para>
+    /// The comparison is on the name's whole comparison form, which is what separates this from the contained match a
+    /// page's search performs: a lookup that addresses a message resolves to one person or to nobody, and text that
+    /// merely appears inside somebody's name is not that person being named. Both are answered from the listing index
+    /// the book is ordered by.
+    /// </para>
+    /// <para>
+    /// The count is exact and the addresses of the people it counted are never read, so an ambiguous name costs one
+    /// number rather than a page of somebody else's correspondents.
+    /// </para>
+    /// </remarks>
+    Task<ContactMatch> MatchDisplayNameAsync(
+        ContactDisplayName displayName,
+        CancellationToken cancellationToken);
 
     /// <summary>Reads which contacts already hold each of the given addresses.</summary>
     /// <param name="addresses">The addresses to look up, at most as many as one contact may hold.</param>

--- a/src/Application/Mail/Delivery/Addressing/NamedRecipient.cs
+++ b/src/Application/Mail/Delivery/Addressing/NamedRecipient.cs
@@ -1,0 +1,160 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Contacts;
+using MailFathom.Domain.Delivery;
+
+namespace MailFathom.Application.Mail.Delivery.Addressing;
+
+/// <summary>States how an author named one recipient: by an address, or by somebody the contact book holds.</summary>
+/// <remarks>
+/// <para>
+/// This is the shape every author writes, and it is deliberately not the shape a message is composed from. An address is
+/// what a submission server is offered, so a recipient named as a person becomes one before anything is composed —
+/// naming a contact is a convenience of the authoring boundary rather than a second kind of recipient the rest of the
+/// send has to understand.
+/// </para>
+/// <para>
+/// A contact is named either by the identity the book gave it or by the name the owner recorded, and exactly one of the
+/// two. The name is the whole name rather than part of one, and it addresses a message only where it belongs to one
+/// person: a recipient chosen out of several by a ranking is a message delivered to somebody nobody named.
+/// </para>
+/// <para>
+/// Everything a caller supplied is untrusted, and the address text is carried unparsed for the same reason
+/// <see cref="Composition.AuthoredEmailRecipient" /> carries one: repairing an address before it is composed would mail
+/// somebody nobody named.
+/// </para>
+/// </remarks>
+public sealed record NamedRecipient
+{
+    private NamedRecipient(
+        OutgoingRecipientRole role,
+        string? address,
+        string? displayName,
+        ContactId? contact,
+        ContactDisplayName? contactName,
+        string? contactAddress)
+    {
+        this.Role = role;
+        this.Address = address;
+        this.DisplayName = displayName;
+        this.Contact = contact;
+        this.ContactName = contactName;
+        this.ContactAddress = contactAddress;
+    }
+
+    /// <summary>Gets the header the author wants this person named in.</summary>
+    public OutgoingRecipientRole Role { get; }
+
+    /// <summary>Gets the addr-spec the author supplied, or <see langword="null" /> when they named a contact instead.</summary>
+    public string? Address { get; }
+
+    /// <summary>Gets the name to write beside a supplied address, or <see langword="null" /> to write the address alone.</summary>
+    /// <remarks>
+    /// It belongs to an address the author wrote down. A contact carries the name the owner recorded for that person, so
+    /// resolution supplies it and nothing here overrides it.
+    /// </remarks>
+    public string? DisplayName { get; }
+
+    /// <summary>Gets the contact named by identity, or <see langword="null" /> when the recipient was named another way.</summary>
+    public ContactId? Contact { get; }
+
+    /// <summary>Gets the contact named by the owner's own name for them, or <see langword="null" /> when the recipient was named another way.</summary>
+    public ContactDisplayName? ContactName { get; }
+
+    /// <summary>Gets which of the contact's addresses to use, or <see langword="null" /> to use the one they prefer.</summary>
+    /// <remarks>
+    /// It is present only where a contact is named, and it narrows rather than widens: an address the contact does not
+    /// hold is refused rather than sent to, so naming a person cannot reach a mailbox that naming an address could not.
+    /// </remarks>
+    public string? ContactAddress { get; }
+
+    /// <summary>Names a recipient by the address the author wrote.</summary>
+    /// <param name="role">The header to name them in.</param>
+    /// <param name="address">The addr-spec the author supplied, unparsed.</param>
+    /// <param name="displayName">The name to write beside it, or <see langword="null" /> to write the address alone.</param>
+    /// <returns>The recipient the author named.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="address" /> is blank, which names nobody at all.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="role" /> is not a declared role.</exception>
+    public static NamedRecipient AtAddress(OutgoingRecipientRole role, string address, string? displayName = null)
+    {
+        RequireDeclared(role);
+        ArgumentException.ThrowIfNullOrWhiteSpace(address);
+
+        return new NamedRecipient(role, address, displayName, contact: null, contactName: null, contactAddress: null);
+    }
+
+    /// <summary>Names a recipient by the identity the book gave them.</summary>
+    /// <param name="role">The header to name them in.</param>
+    /// <param name="contact">The contact to address.</param>
+    /// <param name="contactAddress">Which of their addresses to use, or <see langword="null" /> for the one they prefer.</param>
+    /// <returns>The recipient the author named.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="contactAddress" /> is supplied blank.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="role" /> is not a declared role.</exception>
+    public static NamedRecipient ByContact(
+        OutgoingRecipientRole role,
+        ContactId contact,
+        string? contactAddress = null)
+    {
+        RequireDeclared(role);
+        RequireUsableContactAddress(contactAddress);
+
+        return new NamedRecipient(
+            role,
+            address: null,
+            displayName: null,
+            contact,
+            contactName: null,
+            contactAddress);
+    }
+
+    /// <summary>Names a recipient by the name the owner recorded for them.</summary>
+    /// <param name="role">The header to name them in.</param>
+    /// <param name="contactName">The whole name the owner wrote down.</param>
+    /// <param name="contactAddress">Which of their addresses to use, or <see langword="null" /> for the one they prefer.</param>
+    /// <returns>The recipient the author named.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="contactAddress" /> is supplied blank.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="role" /> is not a declared role.</exception>
+    public static NamedRecipient ByContactName(
+        OutgoingRecipientRole role,
+        ContactDisplayName contactName,
+        string? contactAddress = null)
+    {
+        RequireDeclared(role);
+        RequireUsableContactAddress(contactAddress);
+
+        return new NamedRecipient(
+            role,
+            address: null,
+            displayName: null,
+            contact: null,
+            contactName,
+            contactAddress);
+    }
+
+    private static void RequireDeclared(OutgoingRecipientRole role)
+    {
+        if (!Enum.IsDefined(role))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(role),
+                role,
+                "An authored recipient is named in one of the declared headers.");
+        }
+    }
+
+    /// <summary>Refuses a chosen address that carries nothing, which no contact can hold.</summary>
+    /// <remarks>
+    /// Whether the text names a mailbox this contact uses is the resolution's question, because the answer depends on the
+    /// book. Blank text is not that question: it names nothing, and admitting it would silently become the preferred
+    /// address the caller did not ask for.
+    /// </remarks>
+    private static void RequireUsableContactAddress(string? contactAddress)
+    {
+        if (contactAddress is not null)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(contactAddress);
+        }
+    }
+}

--- a/src/Application/Mail/Delivery/Addressing/NamedRecipientResolver.cs
+++ b/src/Application/Mail/Delivery/Addressing/NamedRecipientResolver.cs
@@ -52,8 +52,10 @@ public sealed class NamedRecipientResolver(IContactDirectory contacts)
     /// parsing it is the composition's to do and to refuse.
     /// </para>
     /// <para>
-    /// The book is read once for the identities named and once for the names, whatever the list holds, so the number of
-    /// queries follows from how a message is addressed rather than from how many people it is addressed to. The count is
+    /// The identities named and the names are each read in groups of at most a page of the book, so a message costs one
+    /// read per way its recipients were named and a second of that way only past two hundred distinct people — at most
+    /// four for the longest list an outgoing record can hold, against one per recipient. What addressing costs therefore
+    /// follows from how a message was addressed rather than from how many people it goes to. The count is
     /// bounded before the first lookup all the same, because the reads carry what the caller supplied: the bound is the
     /// greatest number of recipients an outgoing record can hold at all, so a longer list describes a send that could not
     /// be written down whatever the book answered — and the deployment's own, smaller recipient bound is still the
@@ -142,8 +144,8 @@ public sealed class NamedRecipientResolver(IContactDirectory contacts)
 
     /// <summary>Reads every contact the act named by the identity the book gave it.</summary>
     /// <remarks>
-    /// The identities are read in groups the book answers in one statement, so the reads are counted by the bound rather
-    /// than by the recipients: the whole of a message's recipients takes at most two of them.
+    /// The identities are read in groups the book answers in one read, so what a message costs is counted by that bound
+    /// rather than by its recipients: the most an outgoing record can hold takes two of them.
     /// </remarks>
     private async Task<IReadOnlyDictionary<ContactId, Contact>> ReadContactsNamedByIdentityAsync(
         IReadOnlyList<NamedRecipient> namedContacts,

--- a/src/Application/Mail/Delivery/Addressing/NamedRecipientResolver.cs
+++ b/src/Application/Mail/Delivery/Addressing/NamedRecipientResolver.cs
@@ -53,9 +53,11 @@ public sealed class NamedRecipientResolver(IContactDirectory contacts)
     /// </para>
     /// <para>
     /// The identities named and the names are each read in groups of at most a page of the book, so a message costs one
-    /// read per way its recipients were named and a second of that way only past two hundred distinct people — at most
-    /// four for the longest list an outgoing record can hold, against one per recipient. What addressing costs therefore
-    /// follows from how a message was addressed rather than from how many people it goes to. The count is
+    /// read per way its recipients were named, and a second of one such way only past two hundred distinct people in it.
+    /// Both ways are named out of one recipient list, and that list is bounded below twice two hundred, so at most one of
+    /// them ever reaches its second read: three for the longest list an outgoing record can hold, against one per
+    /// recipient. What addressing costs therefore follows from how a message was addressed rather than from how many
+    /// people it goes to. The count is
     /// bounded before the first lookup all the same, because the reads carry what the caller supplied: the bound is the
     /// greatest number of recipients an outgoing record can hold at all, so a longer list describes a send that could not
     /// be written down whatever the book answered — and the deployment's own, smaller recipient bound is still the

--- a/src/Application/Mail/Delivery/Addressing/NamedRecipientResolver.cs
+++ b/src/Application/Mail/Delivery/Addressing/NamedRecipientResolver.cs
@@ -52,11 +52,12 @@ public sealed class NamedRecipientResolver(IContactDirectory contacts)
     /// parsing it is the composition's to do and to refuse.
     /// </para>
     /// <para>
-    /// The count is bounded before the first lookup, because each contact named is a read of the book: without a ceiling
-    /// here, a caller would decide how many queries addressing one message costs. The bound is the greatest number of
-    /// recipients an outgoing record can hold at all, so a longer list describes a send that could not be written down
-    /// whatever the book answered — and the deployment's own, smaller recipient bound is still the composition's to apply,
-    /// where it is refused as a bound rather than raised as a defect.
+    /// The book is read once for the identities named and once for the names, whatever the list holds, so the number of
+    /// queries follows from how a message is addressed rather than from how many people it is addressed to. The count is
+    /// bounded before the first lookup all the same, because the reads carry what the caller supplied: the bound is the
+    /// greatest number of recipients an outgoing record can hold at all, so a longer list describes a send that could not
+    /// be written down whatever the book answered — and the deployment's own, smaller recipient bound is still the
+    /// composition's to apply, where it is refused as a bound rather than raised as a defect.
     /// </para>
     /// </remarks>
     public async Task<RecipientResolution> ResolveAsync(
@@ -69,6 +70,10 @@ public sealed class NamedRecipientResolver(IContactDirectory contacts)
             OutgoingEmailRequest.MaximumRecipientCount,
             nameof(recipients));
 
+        var namedContacts = recipients.Where(named => named.Address is null).ToArray();
+        var contactsByIdentity = await this.ReadContactsNamedByIdentityAsync(namedContacts, cancellationToken);
+        var matchesByName = await this.MatchContactsNamedByNameAsync(namedContacts, cancellationToken);
+
         var resolved = new List<AuthoredEmailRecipient>(recipients.Count);
 
         foreach (var named in recipients)
@@ -80,7 +85,7 @@ public sealed class NamedRecipientResolver(IContactDirectory contacts)
                 continue;
             }
 
-            var match = await this.MatchContactAsync(named, cancellationToken);
+            var match = MatchOf(named, contactsByIdentity, matchesByName);
 
             if (match.OnlyMatch is not { } contact)
             {
@@ -108,20 +113,21 @@ public sealed class NamedRecipientResolver(IContactDirectory contacts)
         return RecipientResolution.Resolved(resolved);
     }
 
-    /// <summary>Reads who one recipient names, whichever of the two ways it names them.</summary>
+    /// <summary>States who one recipient names, whichever of the two ways it names them, out of what the book answered.</summary>
     /// <remarks>
     /// An identity resolves to one contact or to none and can never be ambiguous, so both ways of naming answer in the
     /// same shape and the caller acts on the count rather than on which way was used.
     /// </remarks>
-    private async Task<ContactMatch> MatchContactAsync(
+    private static ContactMatch MatchOf(
         NamedRecipient named,
-        CancellationToken cancellationToken)
+        IReadOnlyDictionary<ContactId, Contact> contactsByIdentity,
+        IReadOnlyDictionary<ContactDisplayName, ContactMatch> matchesByName)
     {
         if (named.Contact is { } contactId)
         {
-            var contact = await contacts.FindAsync(contactId, cancellationToken);
-
-            return contact is null ? ContactMatch.None : ContactMatch.Unique(contact);
+            return contactsByIdentity.TryGetValue(contactId, out var contact)
+                ? ContactMatch.Unique(contact)
+                : ContactMatch.None;
         }
 
         if (named.ContactName is not { } contactName)
@@ -131,7 +137,60 @@ public sealed class NamedRecipientResolver(IContactDirectory contacts)
             throw new InvalidOperationException("An authored recipient names an address or a contact.");
         }
 
-        return await contacts.MatchDisplayNameAsync(contactName, cancellationToken);
+        return matchesByName.GetValueOrDefault(contactName, ContactMatch.None);
+    }
+
+    /// <summary>Reads every contact the act named by the identity the book gave it.</summary>
+    /// <remarks>
+    /// The identities are read in groups the book answers in one statement, so the reads are counted by the bound rather
+    /// than by the recipients: the whole of a message's recipients takes at most two of them.
+    /// </remarks>
+    private async Task<IReadOnlyDictionary<ContactId, Contact>> ReadContactsNamedByIdentityAsync(
+        IReadOnlyList<NamedRecipient> namedContacts,
+        CancellationToken cancellationToken)
+    {
+        var identities = namedContacts
+            .Where(named => named.Contact is not null)
+            .Select(named => named.Contact!.Value)
+            .Distinct()
+            .ToArray();
+
+        var held = new Dictionary<ContactId, Contact>();
+
+        foreach (var group in identities.Chunk(ContactQuery.MaximumPageSize))
+        {
+            foreach (var (contactId, contact) in await contacts.FindAllAsync(group, cancellationToken))
+            {
+                held[contactId] = contact;
+            }
+        }
+
+        return held;
+    }
+
+    /// <summary>Resolves every name the act named a contact by.</summary>
+    /// <remarks>Grouped for the same reason the identities are, and answered by the same bound.</remarks>
+    private async Task<IReadOnlyDictionary<ContactDisplayName, ContactMatch>> MatchContactsNamedByNameAsync(
+        IReadOnlyList<NamedRecipient> namedContacts,
+        CancellationToken cancellationToken)
+    {
+        var contactNames = namedContacts
+            .Where(named => named.Contact is null && named.ContactName is not null)
+            .Select(named => named.ContactName!.Value)
+            .Distinct()
+            .ToArray();
+
+        var matches = new Dictionary<ContactDisplayName, ContactMatch>();
+
+        foreach (var group in contactNames.Chunk(ContactQuery.MaximumPageSize))
+        {
+            foreach (var (contactName, match) in await contacts.MatchDisplayNamesAsync(group, cancellationToken))
+            {
+                matches[contactName] = match;
+            }
+        }
+
+        return matches;
     }
 
     /// <summary>Decides which of the contact's addresses the message is offered to.</summary>

--- a/src/Application/Mail/Delivery/Addressing/NamedRecipientResolver.cs
+++ b/src/Application/Mail/Delivery/Addressing/NamedRecipientResolver.cs
@@ -1,0 +1,162 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Contacts;
+using MailFathom.Application.Mail.Delivery.Composition;
+using MailFathom.Domain.Contacts;
+using MailFathom.Domain.Delivery;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Application.Mail.Delivery.Addressing;
+
+/// <summary>Turns the people an author named into the addresses a message is composed and offered to.</summary>
+/// <remarks>
+/// <para>
+/// This is the single place a contact becomes a recipient, and it sits between authoring and composition on the way to
+/// the outgoing record — which is what makes naming a person a convenience rather than a second route out of the
+/// deployment. Everything the record creation point applies to a recipient applies to a resolved one: the address it
+/// produces is an ordinary address from that moment on, indistinguishable from one an author wrote down, so whatever
+/// bounds, policy, and ceilings hold for a literal address hold for this one without being restated here.
+/// </para>
+/// <para>
+/// A lookup either finds exactly one contact or it does not. Nothing ranks candidates, nothing prefers the most recently
+/// written down, and nothing falls back to a near match: a recipient chosen that way is a message delivered to somebody
+/// nobody named, which is a worse outcome than the send being refused.
+/// </para>
+/// <para>
+/// It reads the book and writes nothing. Addressing somebody is not a fact about them, so no contact is created,
+/// amended, or promoted by being written to.
+/// </para>
+/// <para>
+/// It asks for no permission of its own, and that is deliberate rather than an omission. Every use case above it is
+/// reached under a principal — a caller holding a grant, or the process running work nobody requested — and only the
+/// first of those can hold one at all, so a grant demanded here would refuse a rule addressing a contact rather than
+/// authorize anything. Whether a caller may name people out of the book is therefore the boundary's question, asked
+/// where the caller is known and beside the grant that lets it send at all.
+/// </para>
+/// </remarks>
+/// <param name="contacts">Reads the book a named contact is resolved against.</param>
+public sealed class NamedRecipientResolver(IContactDirectory contacts)
+{
+    /// <summary>Resolves every recipient one authored message names.</summary>
+    /// <param name="recipients">The people the author named, in the order they named them.</param>
+    /// <param name="cancellationToken">Cancels the reads of the book.</param>
+    /// <returns>The recipients to compose with, or the refusal that stopped one of them.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="recipients" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when more recipients are named than an outgoing message may hold, which is a caller that assembled something it did not mean rather than an author to refuse.</exception>
+    /// <remarks>
+    /// <para>
+    /// One recipient that resolves to nobody refuses the whole message. The order the author wrote is kept, because it is
+    /// the order the composition writes its headers in, and an address the author supplied is carried through unparsed:
+    /// parsing it is the composition's to do and to refuse.
+    /// </para>
+    /// <para>
+    /// The count is bounded before the first lookup, because each contact named is a read of the book: without a ceiling
+    /// here, a caller would decide how many queries addressing one message costs. The bound is the greatest number of
+    /// recipients an outgoing record can hold at all, so a longer list describes a send that could not be written down
+    /// whatever the book answered — and the deployment's own, smaller recipient bound is still the composition's to apply,
+    /// where it is refused as a bound rather than raised as a defect.
+    /// </para>
+    /// </remarks>
+    public async Task<RecipientResolution> ResolveAsync(
+        IReadOnlyList<NamedRecipient> recipients,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(recipients);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            recipients.Count,
+            OutgoingEmailRequest.MaximumRecipientCount,
+            nameof(recipients));
+
+        var resolved = new List<AuthoredEmailRecipient>(recipients.Count);
+
+        foreach (var named in recipients)
+        {
+            if (named.Address is { } authoredAddress)
+            {
+                resolved.Add(new AuthoredEmailRecipient(named.Role, authoredAddress, named.DisplayName));
+
+                continue;
+            }
+
+            var match = await this.MatchContactAsync(named, cancellationToken);
+
+            if (match.OnlyMatch is not { } contact)
+            {
+                return match.MatchCount == 0
+                    ? RecipientResolution.Refused(RecipientResolutionRefusalReason.ContactUnknown)
+                    : RecipientResolution.Refused(
+                        RecipientResolutionRefusalReason.ContactNameAmbiguous,
+                        match.MatchCount);
+            }
+
+            if (AddressOf(named, contact) is not { } address)
+            {
+                return RecipientResolution.Refused(RecipientResolutionRefusalReason.ContactAddressNotHeld);
+            }
+
+            // The name written beside the address is the one the owner recorded for this person, which is the whole point
+            // of addressing them by it: a message to a contact reads as a message to somebody rather than to a mailbox.
+            resolved.Add(new AuthoredEmailRecipient(
+                named.Role,
+                address.Address,
+                contact.DisplayName.Value,
+                contact.Id));
+        }
+
+        return RecipientResolution.Resolved(resolved);
+    }
+
+    /// <summary>Reads who one recipient names, whichever of the two ways it names them.</summary>
+    /// <remarks>
+    /// An identity resolves to one contact or to none and can never be ambiguous, so both ways of naming answer in the
+    /// same shape and the caller acts on the count rather than on which way was used.
+    /// </remarks>
+    private async Task<ContactMatch> MatchContactAsync(
+        NamedRecipient named,
+        CancellationToken cancellationToken)
+    {
+        if (named.Contact is { } contactId)
+        {
+            var contact = await contacts.FindAsync(contactId, cancellationToken);
+
+            return contact is null ? ContactMatch.None : ContactMatch.Unique(contact);
+        }
+
+        if (named.ContactName is not { } contactName)
+        {
+            // A recipient naming neither an address nor a contact cannot be built, so reaching here is a defect in this
+            // type rather than anything an author wrote.
+            throw new InvalidOperationException("An authored recipient names an address or a contact.");
+        }
+
+        return await contacts.MatchDisplayNameAsync(contactName, cancellationToken);
+    }
+
+    /// <summary>Decides which of the contact's addresses the message is offered to.</summary>
+    /// <returns>The address to use, or <see langword="null" /> when the act chose one the contact does not hold.</returns>
+    /// <remarks>
+    /// The book's own spelling is what comes back rather than the caller's, so the record and the composed headers carry
+    /// the value the owner wrote down. Text naming no mailbox at all resolves to nothing here for the same reason an
+    /// address the contact does not hold does: nobody holds an address that is not one.
+    /// </remarks>
+    private static EmailAddress? AddressOf(NamedRecipient named, Contact contact)
+    {
+        if (named.ContactAddress is not { } chosenAddress)
+        {
+            return contact.PreferredAddress;
+        }
+
+        if (!EmailAddress.TryCreate(displayName: null, chosenAddress, out var chosen))
+        {
+            return null;
+        }
+
+        // A default instance is what a contact holding no such address answers with, since the addresses compare by their
+        // normalized form and an absent one leaves the struct's default behind.
+        var held = contact.Addresses.FirstOrDefault(candidate => candidate == chosen);
+
+        return string.IsNullOrEmpty(held.Address) ? null : held;
+    }
+}

--- a/src/Application/Mail/Delivery/Addressing/RecipientResolution.cs
+++ b/src/Application/Mail/Delivery/Addressing/RecipientResolution.cs
@@ -1,0 +1,63 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Delivery.Composition;
+
+namespace MailFathom.Application.Mail.Delivery.Addressing;
+
+/// <summary>Carries the recipients a message is addressed to, or the reason one of them addressed nobody.</summary>
+/// <remarks>
+/// <para>
+/// A refusal is a result rather than an exception for the reason every other refusal on this path is: the caller acts on
+/// it directly, nothing has been written down, and the send simply does not exist.
+/// </para>
+/// <para>
+/// One unresolved recipient refuses the whole message rather than dropping that person from it. A message delivered to
+/// everybody but the person whose name was ambiguous is a message whose author was told it was sent, and the one reader
+/// they cared about never receives it.
+/// </para>
+/// </remarks>
+public sealed record RecipientResolution
+{
+    private RecipientResolution(
+        IReadOnlyList<AuthoredEmailRecipient> recipients,
+        RecipientResolutionRefusal? refusal)
+    {
+        this.Recipients = recipients;
+        this.Refusal = refusal;
+    }
+
+    /// <summary>Gets the recipients the message is composed with, which is empty when the resolution was refused.</summary>
+    /// <remarks>
+    /// A refusal is what a caller checks rather than an empty list, because a message addressed to nobody is refused by
+    /// the composition on its own terms and would otherwise arrive there as an author who named nobody.
+    /// </remarks>
+    public IReadOnlyList<AuthoredEmailRecipient> Recipients { get; }
+
+    /// <summary>Gets why no recipients were resolved, or <see langword="null" /> when they were.</summary>
+    public RecipientResolutionRefusal? Refusal { get; }
+
+    /// <summary>Gets whether every recipient the author named resolved to an address.</summary>
+    public bool IsResolved => this.Refusal is null;
+
+    /// <summary>Reports every recipient the author named, in the order they named them.</summary>
+    /// <param name="recipients">The resolved recipients.</param>
+    /// <returns>A resolved result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="recipients" /> is <see langword="null" />.</exception>
+    public static RecipientResolution Resolved(IReadOnlyList<AuthoredEmailRecipient> recipients)
+    {
+        ArgumentNullException.ThrowIfNull(recipients);
+
+        return new RecipientResolution(recipients, refusal: null);
+    }
+
+    /// <summary>Reports that a recipient addressed nobody, and why.</summary>
+    /// <param name="reason">What stopped it.</param>
+    /// <param name="matchedContactCount">How many contacts carried the name, when the reason is an ambiguous one.</param>
+    /// <returns>A refused result.</returns>
+    public static RecipientResolution Refused(
+        RecipientResolutionRefusalReason reason,
+        int? matchedContactCount = null) =>
+        new([], new RecipientResolutionRefusal(reason, matchedContactCount));
+}

--- a/src/Application/Mail/Delivery/Addressing/RecipientResolutionRefusal.cs
+++ b/src/Application/Mail/Delivery/Addressing/RecipientResolutionRefusal.cs
@@ -1,0 +1,34 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Failures;
+
+namespace MailFathom.Application.Mail.Delivery.Addressing;
+
+/// <summary>States why a recipient an author named resolved to nobody, in terms that name no address.</summary>
+/// <param name="Reason">What stopped it.</param>
+/// <param name="MatchedContactCount">How many contacts carried the name, when the reason is an ambiguous one; otherwise <see langword="null" />.</param>
+/// <remarks>
+/// The pair is the whole of what a refusal may carry. A resolution knows a name, an address the author chose, and — for
+/// an ambiguous name — several people's records, and every one of those is personal data of somebody who is not this
+/// mailbox's owner. So the count is reported and nothing that was counted is, and an address is never echoed back: a
+/// caller that supplied one already holds it, and a caller that supplied none must not learn one from a refusal.
+/// </remarks>
+public sealed record RecipientResolutionRefusal(
+    RecipientResolutionRefusalReason Reason,
+    int? MatchedContactCount = null)
+{
+    /// <summary>Gets the published identity of this refusal.</summary>
+    /// <exception cref="InvalidOperationException">Thrown when the reason is not one this system declares, which a refusal built from a cast integer is.</exception>
+    public MailFathomErrorCode Failure => this.Reason switch
+    {
+        RecipientResolutionRefusalReason.ContactUnknown => MailFathomErrorCode.OutgoingEmailContactUnknown,
+        RecipientResolutionRefusalReason.ContactNameAmbiguous =>
+            MailFathomErrorCode.OutgoingEmailContactNameAmbiguous,
+        RecipientResolutionRefusalReason.ContactAddressNotHeld =>
+            MailFathomErrorCode.OutgoingEmailContactAddressNotHeld,
+        _ => throw new InvalidOperationException(
+            "The recipient resolution refusal reason is not one this system declares."),
+    };
+}

--- a/src/Application/Mail/Delivery/Addressing/RecipientResolutionRefusalReason.cs
+++ b/src/Application/Mail/Delivery/Addressing/RecipientResolutionRefusalReason.cs
@@ -1,0 +1,37 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Application.Mail.Delivery.Addressing;
+
+/// <summary>States what stopped a recipient an author named from becoming an address.</summary>
+/// <remarks>
+/// All three are about the book rather than about the message, which is what separates them from a composition's own
+/// refusals: none of them is corrected by writing the message differently, and none of them can be resolved by anything
+/// choosing on the author's behalf.
+/// </remarks>
+public enum RecipientResolutionRefusalReason
+{
+    /// <summary>The book holds no contact under the identity or the name the author used.</summary>
+    /// <remarks>
+    /// One answer for both, because the remedy is the same: name somebody the book holds, or write the address down. It
+    /// is also what a name nobody carries produces, so a lookup that found nothing never reads as a lookup that found
+    /// too many.
+    /// </remarks>
+    ContactUnknown = 0,
+
+    /// <summary>Several contacts carry the name the author used, so the name addresses nobody.</summary>
+    /// <remarks>
+    /// The refusal carries how many matched and nothing else about them. Picking the closest, the most recently written
+    /// down, or the one with the most addresses would each deliver the message to somebody nobody named.
+    /// </remarks>
+    ContactNameAmbiguous = 1,
+
+    /// <summary>The address the author chose for the contact is not one that contact holds.</summary>
+    /// <remarks>
+    /// It covers text naming no mailbox at all, since nobody holds an address that is not one. Refusing rather than
+    /// falling back to the preferred address is what keeps naming a contact from becoming a way to reach a mailbox
+    /// alongside them.
+    /// </remarks>
+    ContactAddressNotHeld = 2,
+}

--- a/src/Application/Mail/Delivery/Authoring/AuthoredResponse.cs
+++ b/src/Application/Mail/Delivery/Authoring/AuthoredResponse.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Mail.Delivery.Addressing;
 using MailFathom.Application.Mail.Delivery.Composition;
 using MailFathom.Domain.Accounts;
 
@@ -64,4 +65,36 @@ public sealed record AuthoredResponse
     /// <returns>A refused result.</returns>
     public static AuthoredResponse Refused(AuthoredResponseRefusalReason reason, long? bound = null) =>
         new(default, email: null, new AuthoredResponseRefusal(reason, bound));
+
+    /// <summary>Reports that a recipient the author added addressed nobody, in this result's own terms.</summary>
+    /// <param name="refusal">Why the recipient resolved to nobody.</param>
+    /// <returns>A refused result.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="refusal" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the resolution reason is not one this system declares, which a refusal built from a cast integer is.</exception>
+    /// <remarks>
+    /// The reason is translated rather than carried, because an author of an answer acts on one refusal shape whatever
+    /// part of the send produced it. The two identities stay the same on the other side of the translation: each reason
+    /// maps to the code the resolution itself publishes.
+    /// </remarks>
+    public static AuthoredResponse Refused(RecipientResolutionRefusal refusal)
+    {
+        ArgumentNullException.ThrowIfNull(refusal);
+
+        var reason = refusal.Reason switch
+        {
+            RecipientResolutionRefusalReason.ContactUnknown =>
+                AuthoredResponseRefusalReason.RecipientContactUnknown,
+            RecipientResolutionRefusalReason.ContactNameAmbiguous =>
+                AuthoredResponseRefusalReason.RecipientContactNameAmbiguous,
+            RecipientResolutionRefusalReason.ContactAddressNotHeld =>
+                AuthoredResponseRefusalReason.RecipientContactAddressNotHeld,
+            _ => throw new InvalidOperationException(
+                "The recipient resolution refusal reason is not one this system declares."),
+        };
+
+        return new AuthoredResponse(
+            default,
+            email: null,
+            new AuthoredResponseRefusal(reason, Bound: null, refusal.MatchedContactCount));
+    }
 }

--- a/src/Application/Mail/Delivery/Authoring/AuthoredResponseRefusal.cs
+++ b/src/Application/Mail/Delivery/Authoring/AuthoredResponseRefusal.cs
@@ -9,13 +9,18 @@ namespace MailFathom.Application.Mail.Delivery.Authoring;
 /// <summary>States why no answer was authored, in terms that carry nothing of the message it was about.</summary>
 /// <param name="Reason">What stopped it.</param>
 /// <param name="Bound">The number that was exceeded, when the reason is a bound; otherwise <see langword="null" />.</param>
+/// <param name="MatchedContactCount">How many contacts carried the name, when the reason is an ambiguous one; otherwise <see langword="null" />.</param>
 /// <remarks>
-/// The pair is the whole of what a refusal may carry. Everything an authoring attempt knows besides them — the
-/// addresses it resolved, the subject it would have written, the text it would have quoted, the files it would have
-/// carried — is the correspondence of the people the message is between, so a refusal that named any of it would put
-/// mail content into every log line and exception that travelled with it.
+/// The three together are the whole of what a refusal may carry, and each number belongs to the reasons it says
+/// something about. Everything an authoring attempt knows besides them — the addresses it resolved, the subject it would
+/// have written, the text it would have quoted, the files it would have carried, the people a shared name matched — is
+/// the correspondence of the people the message is between, so a refusal that named any of it would put mail content
+/// into every log line and exception that travelled with it.
 /// </remarks>
-public sealed record AuthoredResponseRefusal(AuthoredResponseRefusalReason Reason, long? Bound = null)
+public sealed record AuthoredResponseRefusal(
+    AuthoredResponseRefusalReason Reason,
+    long? Bound = null,
+    int? MatchedContactCount = null)
 {
     /// <summary>Gets the published identity of this refusal.</summary>
     /// <exception cref="InvalidOperationException">Thrown when the reason is not one this system declares, which a refusal built from a cast integer is.</exception>
@@ -26,6 +31,11 @@ public sealed record AuthoredResponseRefusal(AuthoredResponseRefusalReason Reaso
             MailFathomErrorCode.AnsweredEmailContentUnavailable,
         AuthoredResponseRefusalReason.SenderUnconfigured => MailFathomErrorCode.OutgoingEmailSenderUnconfigured,
         AuthoredResponseRefusalReason.BoundExceeded => MailFathomErrorCode.OutgoingEmailBoundExceeded,
+        AuthoredResponseRefusalReason.RecipientContactUnknown => MailFathomErrorCode.OutgoingEmailContactUnknown,
+        AuthoredResponseRefusalReason.RecipientContactNameAmbiguous =>
+            MailFathomErrorCode.OutgoingEmailContactNameAmbiguous,
+        AuthoredResponseRefusalReason.RecipientContactAddressNotHeld =>
+            MailFathomErrorCode.OutgoingEmailContactAddressNotHeld,
         _ => throw new InvalidOperationException("The authoring refusal reason is not one this system declares."),
     };
 }

--- a/src/Application/Mail/Delivery/Authoring/AuthoredResponseRefusalReason.cs
+++ b/src/Application/Mail/Delivery/Authoring/AuthoredResponseRefusalReason.cs
@@ -45,4 +45,19 @@ public enum AuthoredResponseRefusalReason
     /// message.
     /// </remarks>
     BoundExceeded = 3,
+
+    /// <summary>A recipient the author added named a contact the book does not hold.</summary>
+    /// <remarks>
+    /// The three reasons below are the resolution's own, restated here because an author of an answer meets them exactly
+    /// as an author of a message answering nothing does. Which of the three it is decides what the author changes, which
+    /// is why one reason for all of them would not do.
+    /// </remarks>
+    RecipientContactUnknown = 4,
+
+    /// <summary>A recipient the author added named a contact by a name more than one contact carries.</summary>
+    /// <remarks>The refusal carries how many matched, so the author knows the name is shared rather than wrong.</remarks>
+    RecipientContactNameAmbiguous = 5,
+
+    /// <summary>A recipient the author added chose an address the named contact does not hold.</summary>
+    RecipientContactAddressNotHeld = 6,
 }

--- a/src/Application/Mail/Delivery/Authoring/AuthoredResponseRequest.cs
+++ b/src/Application/Mail/Delivery/Authoring/AuthoredResponseRequest.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using MailFathom.Application.Mail.Delivery.Composition;
+using MailFathom.Application.Mail.Delivery.Addressing;
 using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Mail.Delivery.Authoring;
@@ -40,9 +40,17 @@ public sealed record AuthoredResponseRequest
 
     /// <summary>Gets the people the author named themselves, which is everybody a forward goes to.</summary>
     /// <remarks>
+    /// <para>
     /// They are added to whoever the act itself addresses rather than replacing them, so naming somebody on a reply
     /// copies them in without dropping the person being answered. A forward addresses nobody of its own, so this is the
     /// whole of where it goes and a forward naming nobody is refused when it is composed.
+    /// </para>
+    /// <para>
+    /// Each of them is named by an address or by somebody the contact book holds, exactly as they are on a message
+    /// answering nothing. What the answer itself derives — whoever asked for answers, and everybody a reply to all keeps
+    /// in the conversation — is read out of the stored copy's own headers and is an address by the time it is read, so
+    /// the book is asked about what an author added and about nothing else.
+    /// </para>
     /// </remarks>
-    public IReadOnlyList<AuthoredEmailRecipient> Recipients { get; init; } = [];
+    public IReadOnlyList<NamedRecipient> Recipients { get; init; } = [];
 }

--- a/src/Application/Mail/Delivery/Authoring/StoredEmailResponseAuthoring.cs
+++ b/src/Application/Mail/Delivery/Authoring/StoredEmailResponseAuthoring.cs
@@ -11,6 +11,7 @@ using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
+using MailFathom.Application.Mail.Delivery.Addressing;
 using MailFathom.Application.Mail.Delivery.Composition;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Delivery;
@@ -40,6 +41,11 @@ namespace MailFathom.Application.Mail.Delivery.Authoring;
 /// is an email nothing may answer, and the refusal is the same not-found answer a read of it gives.
 /// </para>
 /// <para>
+/// Whoever the author copies in may be named out of the contact book rather than by an address, and is resolved here
+/// through the one resolution every author shares. That keeps a person the answer is addressed to an ordinary address by
+/// the time anything is composed: an answer to a message cannot reach a mailbox a message answering nothing could not.
+/// </para>
+/// <para>
 /// Nothing is written down here and nothing is sent. What comes back is an authored message, which the composition
 /// turns into MIME and the outbox makes durable, exactly as it does for a message answering nothing.
 /// </para>
@@ -53,6 +59,7 @@ public sealed class StoredEmailResponseAuthoring
     private readonly IEmailContentRepairRequestStore repairRequestStore;
     private readonly MailboxScopeResolver scopeResolver;
     private readonly IOutgoingSenderIdentityReader senderIdentities;
+    private readonly NamedRecipientResolver recipientResolver;
     private readonly OutgoingEmailBounds bounds;
     private readonly AccessAuthorization authorization;
 
@@ -64,6 +71,7 @@ public sealed class StoredEmailResponseAuthoring
     /// <param name="repairRequestStore">Records durably that a local copy has to be fetched or read again.</param>
     /// <param name="scopeResolver">Answers whether a tool may read the mailbox the answered email was stored from.</param>
     /// <param name="senderIdentities">Resolves the address the answering account sends from, which is what a reply to all leaves out.</param>
+    /// <param name="recipientResolver">Turns the people the author added into addresses, asking the contact book for the ones named as somebody.</param>
     /// <param name="bounds">What this deployment is willing to compose, which decides how much history and how many files an answer carries.</param>
     /// <param name="authorization">Answers which principal reached this use case.</param>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
@@ -75,6 +83,7 @@ public sealed class StoredEmailResponseAuthoring
         IEmailContentRepairRequestStore repairRequestStore,
         MailboxScopeResolver scopeResolver,
         IOutgoingSenderIdentityReader senderIdentities,
+        NamedRecipientResolver recipientResolver,
         OutgoingEmailBounds bounds,
         AccessAuthorization authorization)
     {
@@ -85,6 +94,7 @@ public sealed class StoredEmailResponseAuthoring
         ArgumentNullException.ThrowIfNull(repairRequestStore);
         ArgumentNullException.ThrowIfNull(scopeResolver);
         ArgumentNullException.ThrowIfNull(senderIdentities);
+        ArgumentNullException.ThrowIfNull(recipientResolver);
         ArgumentNullException.ThrowIfNull(bounds);
         ArgumentNullException.ThrowIfNull(authorization);
 
@@ -95,6 +105,7 @@ public sealed class StoredEmailResponseAuthoring
         this.repairRequestStore = repairRequestStore;
         this.scopeResolver = scopeResolver;
         this.senderIdentities = senderIdentities;
+        this.recipientResolver = recipientResolver;
         this.bounds = bounds;
         this.authorization = authorization;
     }
@@ -185,6 +196,15 @@ public sealed class StoredEmailResponseAuthoring
             return attachmentRefusal;
         }
 
+        // Before any attachment is read, because a recipient nobody can be found for refuses the answer whatever it
+        // would have carried, and the book is one indexed lookup against a forward's worth of decoded files.
+        var recipients = await this.recipientResolver.ResolveAsync(request.Recipients, cancellationToken);
+
+        if (recipients.Refusal is { } recipientRefusal)
+        {
+            return AuthoredResponse.Refused(recipientRefusal);
+        }
+
         IReadOnlyList<AuthoredEmailAttachment>? attachments = request.Act is AuthoredResponseAct.Forward
             ? await this.CarryAttachmentsAsync(content, rendering.Attachments, cancellationToken)
             : [];
@@ -205,7 +225,7 @@ public sealed class StoredEmailResponseAuthoring
                 request.Act,
                 rendering.Headers,
                 new HashSet<EmailAddress> { sender.Address },
-                request.Recipients),
+                recipients.Recipients),
             Subject = request.Act is AuthoredResponseAct.Forward
                 ? ResponseSubject.ForForward(rendering.Headers.Subject)
                 : ResponseSubject.ForReply(rendering.Headers.Subject),

--- a/src/Application/Mail/Delivery/Composition/AuthoredEmailRecipient.cs
+++ b/src/Application/Mail/Delivery/Composition/AuthoredEmailRecipient.cs
@@ -2,14 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Delivery;
 
 namespace MailFathom.Application.Mail.Delivery.Composition;
 
-/// <summary>Names one person an author addressed a message to, exactly as they wrote it.</summary>
+/// <summary>Names one person a message is addressed to by an address, whoever decided which address that is.</summary>
 /// <param name="Role">The header the author wants this person named in.</param>
-/// <param name="Address">The addr-spec the author supplied, unparsed and unvalidated.</param>
-/// <param name="DisplayName">The name the author wants written beside the address, or nothing to write the address alone.</param>
+/// <param name="Address">The addr-spec to compose with, unparsed and unvalidated.</param>
+/// <param name="DisplayName">The name to write beside the address, or nothing to write the address alone.</param>
+/// <param name="Contact">The contact the address was resolved from, or nothing when an author supplied the address itself.</param>
 /// <remarks>
 /// <para>
 /// Both text members are an author's input rather than a value this system produced, which is why they arrive as text.
@@ -17,9 +19,19 @@ namespace MailFathom.Application.Mail.Delivery.Composition;
 /// a boundary that repaired an address before this point would compose a message to somebody nobody named.
 /// </para>
 /// <para>
+/// A recipient addressed by naming somebody in the contact book arrives here as an address like any other, which is what
+/// keeps the book out of the composition entirely. What the contact adds is the identity beside it, which the outgoing
+/// record keeps so that what was sent stays answerable after the book changes; nothing composes from it, and no path
+/// resolves one here — <see cref="Addressing.NamedRecipientResolver" /> is the only place a contact becomes an address.
+/// </para>
+/// <para>
 /// The display name reaches the composed message and nothing else. The outgoing record holds addresses because a send
 /// cannot be resumed without them; a name is presentation, so it stays in the stored MIME the way every other authored
 /// field does.
 /// </para>
 /// </remarks>
-public sealed record AuthoredEmailRecipient(OutgoingRecipientRole Role, string Address, string? DisplayName = null);
+public sealed record AuthoredEmailRecipient(
+    OutgoingRecipientRole Role,
+    string Address,
+    string? DisplayName = null,
+    ContactId? Contact = null);

--- a/src/Domain/Delivery/OutgoingRecipient.cs
+++ b/src/Domain/Delivery/OutgoingRecipient.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Emails;
 
 namespace MailFathom.Domain.Delivery;
@@ -17,6 +18,12 @@ namespace MailFathom.Domain.Delivery;
 /// A recipient address is personal data of somebody who is not this mailbox's owner. It is on the record because a send
 /// cannot be resumed without it, and it reaches no log line, metric dimension, span attribute, or exception message.
 /// </para>
+/// <para>
+/// The address is here even when a contact was what the author named, and the contact is beside it rather than instead
+/// of it. A record naming only the person would answer the wrong question a year later: a message sent to somebody whose
+/// address changed afterwards was sent to the address they had, and an attempt resuming from the record has to offer
+/// that address rather than whichever one the book holds now.
+/// </para>
 /// </remarks>
 public readonly record struct OutgoingRecipient
 {
@@ -29,10 +36,11 @@ public readonly record struct OutgoingRecipient
     /// </remarks>
     public const int MaximumAddressLength = 320;
 
-    private OutgoingRecipient(EmailAddress address, OutgoingRecipientRole role)
+    private OutgoingRecipient(EmailAddress address, OutgoingRecipientRole role, ContactId? contact)
     {
         this.Address = address;
         this.Role = role;
+        this.Contact = contact;
     }
 
     /// <summary>Gets the address the message is offered to.</summary>
@@ -41,13 +49,26 @@ public readonly record struct OutgoingRecipient
     /// <summary>Gets the header the composed message names this recipient in.</summary>
     public OutgoingRecipientRole Role { get; }
 
+    /// <summary>Gets the contact the address was resolved from, or <see langword="null" /> when the author supplied the address itself.</summary>
+    /// <remarks>
+    /// It is the identity rather than anything about the person, which is the one part of a contact that is not personal
+    /// data and therefore the only part a record of a send may keep beside the address. Absence is the ordinary case and
+    /// says the author wrote an address down; presence says the book was asked, and it survives the contact being
+    /// amended, promoted, or erased because nothing reads it to address anybody again.
+    /// </remarks>
+    public ContactId? Contact { get; }
+
     /// <summary>Names one recipient of an outgoing email.</summary>
     /// <param name="address">The address the message is offered to.</param>
     /// <param name="role">The header the composed message names them in.</param>
-    /// <returns>The recipient those two name.</returns>
+    /// <param name="contact">The contact the address was resolved from, or <see langword="null" /> when the author supplied it.</param>
+    /// <returns>The recipient those name.</returns>
     /// <exception cref="ArgumentException">Thrown when <paramref name="address" /> names no mailbox or is longer than <see cref="MaximumAddressLength" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="role" /> is not a declared role.</exception>
-    public static OutgoingRecipient Create(EmailAddress address, OutgoingRecipientRole role)
+    public static OutgoingRecipient Create(
+        EmailAddress address,
+        OutgoingRecipientRole role,
+        ContactId? contact = null)
     {
         if (!Enum.IsDefined(role))
         {
@@ -72,7 +93,7 @@ public readonly record struct OutgoingRecipient
                 nameof(address));
         }
 
-        return new OutgoingRecipient(address, role);
+        return new OutgoingRecipient(address, role, contact);
     }
 
     /// <summary>Describes the recipient by the header they are named in, and never by their address.</summary>

--- a/src/Domain/Failures/MailFathomErrorCode.cs
+++ b/src/Domain/Failures/MailFathomErrorCode.cs
@@ -241,6 +241,32 @@ public readonly record struct MailFathomErrorCode
     /// </remarks>
     public static MailFathomErrorCode OutgoingEmailDeliveryFailedUnexpectedly { get; } = new(28012);
 
+    /// <summary>Gets subcategory 8, message composition: the contact a recipient was named by is not one the book holds.</summary>
+    /// <remarks>
+    /// An identity nothing answers to and a name nobody in the book carries arrive here together, because the caller's
+    /// remedy is the same for both — name somebody the book holds, or write the address down — and the difference between
+    /// them would only say whether the caller had an identifier or a name in hand.
+    /// </remarks>
+    public static MailFathomErrorCode OutgoingEmailContactUnknown { get; } = new(28013);
+
+    /// <summary>Gets subcategory 8, message composition: the name a recipient was addressed by is carried by more than one contact.</summary>
+    /// <remarks>
+    /// It is separate from an unknown contact because the answer exists and there are several of it. Nothing ranks them:
+    /// a recipient chosen by a best match is a message delivered to somebody nobody named, so the send is refused and the
+    /// caller names the person by identity instead. The refusal carries how many contacts matched and nothing about any
+    /// of them.
+    /// </remarks>
+    public static MailFathomErrorCode OutgoingEmailContactNameAmbiguous { get; } = new(28014);
+
+    /// <summary>Gets subcategory 8, message composition: the address an authored act chose for a contact is not one that contact uses.</summary>
+    /// <remarks>
+    /// Addressing a contact uses the address the owner made their preferred one unless the act names another of theirs,
+    /// and one they do not hold is refused rather than sent to. Reaching an arbitrary mailbox by naming a contact beside
+    /// it would make the book a way around whatever the deployment allows a literal address to be, which is exactly what
+    /// naming a contact must never become.
+    /// </remarks>
+    public static MailFathomErrorCode OutgoingEmailContactAddressNotHeld { get; } = new(28015);
+
     #endregion
 
     #region Category 3 — Persistence
@@ -554,6 +580,9 @@ public readonly record struct MailFathomErrorCode
         OutgoingEmailAttemptsExhausted,
         OutgoingEmailOutcomeUnknown,
         OutgoingEmailDeliveryFailedUnexpectedly,
+        OutgoingEmailContactUnknown,
+        OutgoingEmailContactNameAmbiguous,
+        OutgoingEmailContactAddressNotHeld,
         PersistenceConcurrencyConflict,
         DatabaseSchemaOutOfDate,
         DatabaseSchemaStateUnreadable,

--- a/src/Infrastructure/Mail/Mime/Composition/MimeKitAuthoredEmailComposer.cs
+++ b/src/Infrastructure/Mail/Mime/Composition/MimeKitAuthoredEmailComposer.cs
@@ -315,7 +315,7 @@ internal sealed class MimeKitAuthoredEmailComposer(
             if (alreadyPlaced.Add(address))
             {
                 placed.Add(new PlacedRecipient(
-                    OutgoingRecipient.Create(address, authoredRecipient.Role),
+                    OutgoingRecipient.Create(address, authoredRecipient.Role, authoredRecipient.Contact),
                     address.DisplayName));
             }
         }

--- a/src/Infrastructure/Persistence/Contacts/ContactDirectory.cs
+++ b/src/Infrastructure/Persistence/Contacts/ContactDirectory.cs
@@ -43,6 +43,37 @@ internal sealed class ContactDirectory(MailFathomDbContext readContext) : IConta
     }
 
     /// <inheritdoc />
+    public async Task<IReadOnlyDictionary<ContactId, Contact>> FindAllAsync(
+        IReadOnlyCollection<ContactId> contactIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(contactIds);
+
+        // The bound the contract states, enforced here rather than trusted: the identities become the elements of one
+        // query parameter, so a caller asking about more people than a page of the book holds would decide the size of
+        // this read.
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            contactIds.Count,
+            ContactQuery.MaximumPageSize,
+            nameof(contactIds));
+
+        if (contactIds.Count == 0)
+        {
+            return new Dictionary<ContactId, Contact>();
+        }
+
+        var contactValues = contactIds.Select(contactId => contactId.Value).Distinct().ToArray();
+
+        var entities = await readContext.Contacts
+            .AsNoTracking()
+            .Include(record => record.Addresses)
+            .Where(record => contactValues.Contains(record.Id))
+            .ToArrayAsync(cancellationToken);
+
+        return entities.ToDictionary(entity => ContactId.Create(entity.Id), ContactMapping.ToContact);
+    }
+
+    /// <inheritdoc />
     public async Task<Contact?> FindByAddressAsync(EmailAddress address, CancellationToken cancellationToken)
     {
         var normalizedAddress = address.NormalizedAddress;
@@ -59,34 +90,55 @@ internal sealed class ContactDirectory(MailFathomDbContext readContext) : IConta
 
     /// <inheritdoc />
     /// <remarks>
-    /// The count comes back from the database rather than from a page this read would otherwise have to hold, which is
-    /// what keeps a name a hundred collected contacts happen to share from costing a hundred records to answer with one
-    /// number. The one contact is read only where there is exactly one, so the addresses of people a shared name matched
-    /// are never loaded at all.
+    /// Two statements answer the whole set, whatever it holds: one groups the names by their comparison form and counts
+    /// the carriers of each, and one reads the contacts of the names exactly one person carries. The counts come back
+    /// from the database rather than from pages this read would otherwise have to hold, which is what keeps a name a
+    /// hundred collected contacts happen to share from costing a hundred records to answer with one number, and the
+    /// addresses of the people a shared name matched are never loaded at all.
     /// </remarks>
-    public async Task<ContactMatch> MatchDisplayNameAsync(
-        ContactDisplayName displayName,
+    public async Task<IReadOnlyDictionary<ContactDisplayName, ContactMatch>> MatchDisplayNamesAsync(
+        IReadOnlyCollection<ContactDisplayName> displayNames,
         CancellationToken cancellationToken)
     {
-        var sortKey = displayName.SortKey;
+        ArgumentNullException.ThrowIfNull(displayNames);
 
-        var matchCount = await readContext.Contacts
-            .AsNoTracking()
-            .CountAsync(record => record.DisplayNameSortKey == sortKey, cancellationToken);
+        // The bound the contract states, enforced here rather than trusted, for the reason the identity lookup above
+        // carries: the names become the elements of one query parameter.
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            displayNames.Count,
+            ContactQuery.MaximumPageSize,
+            nameof(displayNames));
 
-        if (matchCount != 1)
+        if (displayNames.Count == 0)
         {
-            return matchCount == 0 ? ContactMatch.None : ContactMatch.Several(matchCount);
+            return new Dictionary<ContactDisplayName, ContactMatch>();
         }
 
-        var entity = await readContext.Contacts
-            .AsNoTracking()
-            .Include(record => record.Addresses)
-            .FirstOrDefaultAsync(record => record.DisplayNameSortKey == sortKey, cancellationToken);
+        var sortKeys = displayNames.Select(displayName => displayName.SortKey).Distinct().ToArray();
 
-        // A contact renamed or erased between the two reads leaves the name matching nobody, which is the same answer as
-        // a name nobody carried when the count was taken. Reporting it as unique would answer with no contact at all.
-        return entity is null ? ContactMatch.None : ContactMatch.Unique(ContactMapping.ToContact(entity));
+        var carrierCounts = await readContext.Contacts
+            .AsNoTracking()
+            .Where(record => sortKeys.Contains(record.DisplayNameSortKey))
+            .GroupBy(record => record.DisplayNameSortKey)
+            .Select(carriers => new { SortKey = carriers.Key, CarrierCount = carriers.Count() })
+            .ToArrayAsync(cancellationToken);
+
+        var countBySortKey = carrierCounts.ToDictionary(
+            row => row.SortKey,
+            row => row.CarrierCount,
+            StringComparer.Ordinal);
+
+        var carriersBySortKey = await this.ReadCarriersOfAsync(
+            [.. carrierCounts.Where(row => row.CarrierCount == 1).Select(row => row.SortKey)],
+            cancellationToken);
+
+        return displayNames
+            .Distinct()
+            .ToDictionary(
+                displayName => displayName,
+                displayName => MatchOf(
+                    countBySortKey.GetValueOrDefault(displayName.SortKey),
+                    carriersBySortKey.GetValueOrDefault(displayName.SortKey, [])));
     }
 
     /// <inheritdoc />
@@ -149,6 +201,59 @@ internal sealed class ContactDirectory(MailFathomDbContext readContext) : IConta
             entities.Length > query.PageSize && contacts.Length > 0
                 ? ContactCursor.After(contacts[^1].DisplayName, contacts[^1].Id)
                 : null);
+    }
+
+    /// <summary>States what a name resolved to, from the count of its carriers and the ones actually read.</summary>
+    /// <remarks>
+    /// The count and the contacts come from two statements, so a namesake written down between them leaves a name the
+    /// count called unique carrying two people. The verdict for such a name is therefore taken from the read that
+    /// produced the contact rather than from the count alone: two carriers refuse as ambiguous, and none — a contact
+    /// renamed or erased — resolves to nobody. Either answer is one the count itself would have given a moment later, and
+    /// neither hands back a contact the book no longer holds that name uniquely for.
+    /// </remarks>
+    private static ContactMatch MatchOf(int countedCarriers, ContactEntity[] readCarriers)
+    {
+        if (countedCarriers == 0)
+        {
+            return ContactMatch.None;
+        }
+
+        if (countedCarriers > 1)
+        {
+            return ContactMatch.Several(countedCarriers);
+        }
+
+        return readCarriers.Length switch
+        {
+            0 => ContactMatch.None,
+            1 => ContactMatch.Unique(ContactMapping.ToContact(readCarriers[0])),
+            _ => ContactMatch.Several(readCarriers.Length),
+        };
+    }
+
+    /// <summary>Reads the contacts carrying each of the names exactly one person was counted under.</summary>
+    /// <remarks>
+    /// A name is grouped by its comparison form rather than read as one row, because the read is what decides whether the
+    /// count still holds and a second carrier has to be visible to it.
+    /// </remarks>
+    private async Task<IReadOnlyDictionary<string, ContactEntity[]>> ReadCarriersOfAsync(
+        string[] sortKeys,
+        CancellationToken cancellationToken)
+    {
+        if (sortKeys.Length == 0)
+        {
+            return new Dictionary<string, ContactEntity[]>(StringComparer.Ordinal);
+        }
+
+        var entities = await readContext.Contacts
+            .AsNoTracking()
+            .Include(record => record.Addresses)
+            .Where(record => sortKeys.Contains(record.DisplayNameSortKey))
+            .ToArrayAsync(cancellationToken);
+
+        return entities
+            .GroupBy(entity => entity.DisplayNameSortKey, StringComparer.Ordinal)
+            .ToDictionary(carriers => carriers.Key, carriers => carriers.ToArray(), StringComparer.Ordinal);
     }
 
     /// <summary>Applies the filter and the boundary a query names, leaving the ordering to the caller.</summary>

--- a/src/Infrastructure/Persistence/Contacts/ContactDirectory.cs
+++ b/src/Infrastructure/Persistence/Contacts/ContactDirectory.cs
@@ -15,8 +15,9 @@ namespace MailFathom.Infrastructure.Persistence.Contacts;
 /// <remarks>
 /// <para>
 /// Every read uses the scoped context and joins no transaction, and every one of them is bounded: a contact carries at
-/// most the addresses the domain admits, and a page carries at most what the query asked for. Both lookups are answered
-/// from an index — the primary key and the unique index over the address comparison form — rather than from a scan.
+/// most the addresses the domain admits, and a page carries at most what the query asked for. Every lookup is answered
+/// from an index — the primary key, the unique index over the address comparison form, and the listing index the name's
+/// comparison form leads — rather than from a scan.
 /// </para>
 /// <para>
 /// A page narrowed by a search is the one read no index answers, because a contained match has no prefix to seek on. It
@@ -54,6 +55,38 @@ internal sealed class ContactDirectory(MailFathomDbContext readContext) : IConta
                 cancellationToken);
 
         return entity is null ? null : ContactMapping.ToContact(entity);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The count comes back from the database rather than from a page this read would otherwise have to hold, which is
+    /// what keeps a name a hundred collected contacts happen to share from costing a hundred records to answer with one
+    /// number. The one contact is read only where there is exactly one, so the addresses of people a shared name matched
+    /// are never loaded at all.
+    /// </remarks>
+    public async Task<ContactMatch> MatchDisplayNameAsync(
+        ContactDisplayName displayName,
+        CancellationToken cancellationToken)
+    {
+        var sortKey = displayName.SortKey;
+
+        var matchCount = await readContext.Contacts
+            .AsNoTracking()
+            .CountAsync(record => record.DisplayNameSortKey == sortKey, cancellationToken);
+
+        if (matchCount != 1)
+        {
+            return matchCount == 0 ? ContactMatch.None : ContactMatch.Several(matchCount);
+        }
+
+        var entity = await readContext.Contacts
+            .AsNoTracking()
+            .Include(record => record.Addresses)
+            .FirstOrDefaultAsync(record => record.DisplayNameSortKey == sortKey, cancellationToken);
+
+        // A contact renamed or erased between the two reads leaves the name matching nobody, which is the same answer as
+        // a name nobody carried when the count was taken. Reporting it as unique would answer with no contact at all.
+        return entity is null ? ContactMatch.None : ContactMatch.Unique(ContactMapping.ToContact(entity));
     }
 
     /// <inheritdoc />

--- a/src/Infrastructure/Persistence/Delivery/OutgoingEmailRecordMapping.cs
+++ b/src/Infrastructure/Persistence/Delivery/OutgoingEmailRecordMapping.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
@@ -64,11 +65,20 @@ internal static class OutgoingEmailRecordMapping
         }
 
         return OutgoingRecipientOutcome.Create(
-            OutgoingRecipient.Create(address, entity.Role),
+            OutgoingRecipient.Create(address, entity.Role, ContactOf(entity)),
             entity.Status,
             entity.LastReplyCode,
             entity.AnsweredAt);
     }
+
+    /// <summary>Reads back which contact the recipient's address was resolved from, where one was.</summary>
+    /// <remarks>
+    /// An empty identifier is read as no contact rather than failing the read. The value is a record of how the address
+    /// came to be on the send and nothing offers the message by it, so a row written with one would cost the read of an
+    /// otherwise perfectly deliverable send.
+    /// </remarks>
+    private static ContactId? ContactOf(OutgoingEmailRecipientEntity entity) =>
+        entity.ContactId is { } contactId && contactId != Guid.Empty ? ContactId.Create(contactId) : null;
 
     /// <summary>Reads back the code of the failure the last attempt ended in.</summary>
     /// <remarks>

--- a/src/Infrastructure/Persistence/Delivery/OutgoingEmailStore.cs
+++ b/src/Infrastructure/Persistence/Delivery/OutgoingEmailStore.cs
@@ -89,6 +89,7 @@ internal sealed class OutgoingEmailStore(MailFathomDbContext readContext, TimePr
                 OutgoingEmail = entity,
                 Ordinal = ordinal,
                 Address = recipient.Address.Address,
+                ContactId = recipient.Contact?.Value,
                 Role = recipient.Role,
                 Status = OutgoingRecipientStatus.Pending,
             });

--- a/src/Infrastructure/Persistence/Entities/OutgoingEmailRecipientEntity.cs
+++ b/src/Infrastructure/Persistence/Entities/OutgoingEmailRecipientEntity.cs
@@ -31,6 +31,15 @@ internal sealed class OutgoingEmailRecipientEntity
     /// </remarks>
     public required string Address { get; set; }
 
+    /// <summary>Gets or sets the contact the address was resolved from, and <see langword="null" /> when the author supplied the address.</summary>
+    /// <remarks>
+    /// No foreign key stands behind it, which is the point rather than an omission: the row states which person this
+    /// message was addressed by naming, and a contact the owner amends, promotes, or erases afterwards does not change
+    /// what was sent. A cascade or a null-out would rewrite that answer, and nothing reads the value to address anybody
+    /// again — the address beside it is what an attempt offers.
+    /// </remarks>
+    public Guid? ContactId { get; set; }
+
     public OutgoingRecipientRole Role { get; set; }
 
     public OutgoingRecipientStatus Status { get; set; }

--- a/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -1419,6 +1419,11 @@ internal sealed class MailFathomDbContext : DbContext
                 .HasMaxLength(OutgoingRecipient.MaximumAddressLength)
                 .IsRequired();
 
+            // The contact the address was resolved from is deliberately left with no relationship, no constraint, and no
+            // index of its own. It records which person this message was addressed by naming, so a contact amended or
+            // erased afterwards must not change what was sent, and nothing ever looks a send up by it: the column is read
+            // back with the record it belongs to, exactly as the address beside it is.
+
             // Stored as text for the reason every other enum on this feature is, and required on both: a row whose text
             // names no declared value fails the read rather than being taken as a neighbouring one by elimination.
             entity.Property(recipient => recipient.Role).HasConversion<string>().HasMaxLength(64).IsRequired();

--- a/src/Infrastructure/Persistence/Migrations/20260818220053_AddOutgoingRecipientContact.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260818220053_AddOutgoingRecipientContact.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MailFathom.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace MailFathom.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(MailFathomDbContext))]
-    partial class MailFathomDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260818220053_AddOutgoingRecipientContact")]
+    partial class AddOutgoingRecipientContact
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260818220053_AddOutgoingRecipientContact.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260818220053_AddOutgoingRecipientContact.cs
@@ -1,0 +1,33 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MailFathom.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOutgoingRecipientContact : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ContactId",
+                table: "outgoing_email_recipients",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ContactId",
+                table: "outgoing_email_recipients");
+        }
+    }
+}

--- a/src/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Infrastructure/ServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ using MailFathom.Application.Jobs.Execution;
 using MailFathom.Application.Jobs.Scheduling;
 using MailFathom.Application.Mail;
 using MailFathom.Application.Mail.Delivery;
+using MailFathom.Application.Mail.Delivery.Addressing;
 using MailFathom.Application.Mail.Delivery.Authoring;
 using MailFathom.Application.Mail.Delivery.Composition;
 using MailFathom.Application.Mail.Delivery.Outbox;
@@ -709,6 +710,10 @@ public static class ServiceCollectionExtensions
             provider.GetRequiredService<IOutgoingSenderIdentityReader>(),
             provider.GetRequiredService<OutgoingEmailBounds>(),
             provider.GetRequiredService<TimeProvider>()));
+        // Scoped because the book it reads is read through the scoped context, and registered beside the composition
+        // rather than beside the book: it is the step every author passes through on the way to an outgoing record, so
+        // whatever authors a message resolves the people it names here and nowhere else.
+        services.AddScoped<NamedRecipientResolver>();
         // Registered beside the composition it produces work for, and scoped for the reason every mailbox read is: it
         // reads stored mail through the same ports a read of that mail uses, and answers with what the composer takes.
         services.AddScoped<StoredEmailResponseAuthoring>();

--- a/tests/Application.UnitTests/Contacts/ContactMatchTests.cs
+++ b/tests/Application.UnitTests/Contacts/ContactMatchTests.cs
@@ -1,0 +1,79 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Contacts;
+using MailFathom.Domain.Contacts;
+using MailFathom.Domain.Emails;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Contacts;
+
+/// <summary>Covers the three answers a lookup of the book can give, and which of them carries a contact.</summary>
+public sealed class ContactMatchTests
+{
+    private static readonly DateTimeOffset Recorded = new(2026, 3, 1, 9, 0, 0, TimeSpan.Zero);
+
+    /// <summary>Nobody answering is a count of none and no contact to read.</summary>
+    [Fact]
+    public void None_NobodyAnswers_CarriesNoContact()
+    {
+        // Act
+        var match = ContactMatch.None;
+
+        // Assert
+        Assert.Equal(0, match.MatchCount);
+        Assert.Null(match.OnlyMatch);
+    }
+
+    /// <summary>Exactly one person answering is the one case a caller may use, so that is the one carrying a contact.</summary>
+    [Fact]
+    public void Unique_OnePersonAnswers_CarriesThem()
+    {
+        // Arrange
+        var contact = AContact();
+
+        // Act
+        var match = ContactMatch.Unique(contact);
+
+        // Assert
+        Assert.Equal(1, match.MatchCount);
+        Assert.Same(contact, match.OnlyMatch);
+    }
+
+    /// <summary>Several answering carries how many and nothing about any of them.</summary>
+    [Fact]
+    public void Several_SeveralAnswer_CarriesTheCountAndNoContact()
+    {
+        // Act
+        var match = ContactMatch.Several(3);
+
+        // Assert
+        Assert.Equal(3, match.MatchCount);
+        Assert.Null(match.OnlyMatch);
+    }
+
+    /// <summary>A count below two is a unique answer or none, and reporting it as ambiguous would hide the contact.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void Several_ACountBelowTwo_IsRefused(int matchCount) =>
+
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => ContactMatch.Several(matchCount));
+
+    private static Contact AContact()
+    {
+        EmailAddress.TryCreate(displayName: null, "anna@example.test", out var address);
+
+        return Contact.Create(
+            ContactId.Create(Guid.CreateVersion7(Recorded)),
+            ContactDisplayName.Create("Anna Kowalska"),
+            [address],
+            address,
+            note: null,
+            ContactOrigin.Asserted,
+            Recorded,
+            Recorded);
+    }
+}

--- a/tests/Application.UnitTests/Mail/Delivery/Addressing/NamedRecipientResolverTests.cs
+++ b/tests/Application.UnitTests/Mail/Delivery/Addressing/NamedRecipientResolverTests.cs
@@ -272,6 +272,46 @@ public sealed class NamedRecipientResolverTests
             new NamedRecipientResolver(book).ResolveAsync(
                 beyondTheBound,
                 TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, book.BatchedLookupCount);
+    }
+
+    /// <summary>
+    /// The book is read once for the identities named and once for the names, so what a message costs to address follows
+    /// from how it was addressed rather than from how many people it names.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_ManyContactsNamedBothWays_ReadsTheBookOncePerWayTheyWereNamed()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+
+        var held = Enumerable
+            .Range(0, 20)
+            .Select(number => ContactOf($"Correspondent {number:D2}", $"correspondent.{number:D2}@example.test"))
+            .ToArray();
+
+        foreach (var contact in held)
+        {
+            book.Hold(contact);
+        }
+
+        var namedBothWays = held
+            .Select(contact => NamedRecipient.ByContact(OutgoingRecipientRole.To, contact.Id))
+            .Concat(held.Select(contact => NamedRecipient.ByContactName(
+                OutgoingRecipientRole.Cc,
+                contact.DisplayName)))
+            .ToArray();
+
+        // Act
+        var resolution = await new NamedRecipientResolver(book).ResolveAsync(
+            namedBothWays,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(resolution.IsResolved);
+        Assert.Equal(namedBothWays.Length, resolution.Recipients.Count);
+        Assert.Equal(2, book.BatchedLookupCount);
     }
 
     /// <summary>Addressing somebody is not a fact about them, so the book is read and never written.</summary>

--- a/tests/Application.UnitTests/Mail/Delivery/Addressing/NamedRecipientResolverTests.cs
+++ b/tests/Application.UnitTests/Mail/Delivery/Addressing/NamedRecipientResolverTests.cs
@@ -1,0 +1,317 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Delivery.Addressing;
+using MailFathom.Application.UnitTests.TestDoubles;
+using MailFathom.Domain.Contacts;
+using MailFathom.Domain.Delivery;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Failures;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Mail.Delivery.Addressing;
+
+/// <summary>Covers what happens between an author naming somebody and a message being addressed to an address.</summary>
+/// <remarks>
+/// The book is a real in-memory one rather than a substitute, because every claim here is about what a lookup of it
+/// answers — one person, nobody, or several — and a substitute would let a test arrange an answer the book cannot give.
+/// Every address belongs to a reserved test domain.
+/// </remarks>
+public sealed class NamedRecipientResolverTests
+{
+    private static readonly DateTimeOffset Recorded = new(2026, 3, 1, 9, 0, 0, TimeSpan.Zero);
+
+    /// <summary>Addressing somebody without saying which of their mailboxes uses the one the owner chose.</summary>
+    [Fact]
+    public async Task ResolveAsync_ContactNamedByIdentity_AddressesTheAddressTheyPrefer()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        var anna = ContactOf("Anna Kowalska", "anna.work@example.test", "anna@example.test");
+        book.Hold(anna);
+
+        // Act
+        var resolution = await new NamedRecipientResolver(book).ResolveAsync(
+            [NamedRecipient.ByContact(OutgoingRecipientRole.To, anna.Id)],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var recipient = Assert.Single(resolution.Recipients);
+        Assert.True(resolution.IsResolved);
+        Assert.Equal("anna.work@example.test", recipient.Address);
+        Assert.Equal(anna.Id, recipient.Contact);
+        Assert.Equal("Anna Kowalska", recipient.DisplayName);
+    }
+
+    /// <summary>A name belonging to one person addresses that person, whatever casing the author wrote it in.</summary>
+    [Theory]
+    [InlineData("Anna Kowalska")]
+    [InlineData("anna kowalska")]
+    public async Task ResolveAsync_NameOnePersonCarries_AddressesThatPerson(string writtenAs)
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        var anna = ContactOf("Anna Kowalska", "anna@example.test");
+        book.Hold(anna);
+
+        // Act
+        var resolution = await new NamedRecipientResolver(book).ResolveAsync(
+            [NamedRecipient.ByContactName(OutgoingRecipientRole.To, ContactDisplayName.Create(writtenAs))],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var recipient = Assert.Single(resolution.Recipients);
+        Assert.Equal("anna@example.test", recipient.Address);
+        Assert.Equal(anna.Id, recipient.Contact);
+    }
+
+    /// <summary>
+    /// A name several people carry addresses nobody. Nothing ranks them, and the refusal says how many matched and
+    /// nothing about any of them.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_NameSeveralPeopleCarry_IsRefusedAsAmbiguousNamingHowManyMatched()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        book.Hold(ContactOf("Anna Kowalska", "anna@example.test"));
+        book.Hold(ContactOf("Anna Kowalska", "anna.k@example.test"));
+        book.Hold(ContactOf("Bruno Nowak", "bruno@example.test"));
+
+        // Act
+        var resolution = await new NamedRecipientResolver(book).ResolveAsync(
+            [NamedRecipient.ByContactName(OutgoingRecipientRole.To, ContactDisplayName.Create("Anna Kowalska"))],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(resolution.IsResolved);
+        Assert.Empty(resolution.Recipients);
+        var refusal = Assert.IsType<RecipientResolutionRefusal>(resolution.Refusal);
+        Assert.Equal(RecipientResolutionRefusalReason.ContactNameAmbiguous, refusal.Reason);
+        Assert.Equal(2, refusal.MatchedContactCount);
+        Assert.Equal(MailFathomErrorCode.OutgoingEmailContactNameAmbiguous, refusal.Failure);
+    }
+
+    /// <summary>An identity nothing answers to and a name nobody carries are the same refusal and carry no count.</summary>
+    [Fact]
+    public async Task ResolveAsync_ContactTheBookDoesNotHold_IsRefusedAsUnknown()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        book.Hold(ContactOf("Anna Kowalska", "anna@example.test"));
+
+        // Act
+        var byIdentity = await new NamedRecipientResolver(book).ResolveAsync(
+            [NamedRecipient.ByContact(OutgoingRecipientRole.To, AContactId())],
+            TestContext.Current.CancellationToken);
+
+        var byName = await new NamedRecipientResolver(book).ResolveAsync(
+            [NamedRecipient.ByContactName(OutgoingRecipientRole.To, ContactDisplayName.Create("Nobody Here"))],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(RecipientResolutionRefusalReason.ContactUnknown, byIdentity.Refusal?.Reason);
+        Assert.Equal(RecipientResolutionRefusalReason.ContactUnknown, byName.Refusal?.Reason);
+        Assert.Null(byIdentity.Refusal?.MatchedContactCount);
+        Assert.Null(byName.Refusal?.MatchedContactCount);
+        Assert.Equal(MailFathomErrorCode.OutgoingEmailContactUnknown, byName.Refusal?.Failure);
+    }
+
+    /// <summary>An act may name another mailbox of theirs, and then that one is what the message is offered to.</summary>
+    [Fact]
+    public async Task ResolveAsync_ActNamingAnotherAddressTheContactHolds_AddressesThatOne()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        var anna = ContactOf("Anna Kowalska", "anna.work@example.test", "anna.home@example.test");
+        book.Hold(anna);
+
+        // Act
+        var resolution = await new NamedRecipientResolver(book).ResolveAsync(
+            [NamedRecipient.ByContact(OutgoingRecipientRole.To, anna.Id, "ANNA.HOME@example.test")],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var recipient = Assert.Single(resolution.Recipients);
+
+        // The book's own spelling rather than the caller's, so the record carries what the owner wrote down.
+        Assert.Equal("anna.home@example.test", recipient.Address);
+        Assert.Equal(anna.Id, recipient.Contact);
+    }
+
+    /// <summary>
+    /// Naming a contact must never reach a mailbox alongside them, so an address they do not hold is refused rather
+    /// than sent to and rather than falling back to the one they prefer.
+    /// </summary>
+    [Theory]
+    [InlineData("someone.else@example.test")]
+    [InlineData("not-an-address")]
+    public async Task ResolveAsync_ActNamingAnAddressTheContactDoesNotHold_IsRefused(string chosenAddress)
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        var anna = ContactOf("Anna Kowalska", "anna@example.test");
+        book.Hold(anna);
+
+        // Act
+        var resolution = await new NamedRecipientResolver(book).ResolveAsync(
+            [NamedRecipient.ByContact(OutgoingRecipientRole.To, anna.Id, chosenAddress)],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(resolution.IsResolved);
+        Assert.Equal(RecipientResolutionRefusalReason.ContactAddressNotHeld, resolution.Refusal?.Reason);
+        Assert.Equal(MailFathomErrorCode.OutgoingEmailContactAddressNotHeld, resolution.Refusal?.Failure);
+    }
+
+    /// <summary>An address an author wrote reaches the composition exactly as they wrote it, and names no contact.</summary>
+    [Fact]
+    public async Task ResolveAsync_AddressTheAuthorSupplied_IsCarriedThroughUnparsed()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+
+        // Act
+        var resolution = await new NamedRecipientResolver(book).ResolveAsync(
+            [NamedRecipient.AtAddress(OutgoingRecipientRole.Cc, " Bruno@Example.test ", "Bruno Nowak")],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        var recipient = Assert.Single(resolution.Recipients);
+        Assert.Equal(" Bruno@Example.test ", recipient.Address);
+        Assert.Equal("Bruno Nowak", recipient.DisplayName);
+        Assert.Null(recipient.Contact);
+    }
+
+    /// <summary>The order the author wrote is the order the composition writes its headers in.</summary>
+    [Fact]
+    public async Task ResolveAsync_AddressesAndContactsTogether_KeepsTheOrderTheAuthorNamedThemIn()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        var anna = ContactOf("Anna Kowalska", "anna@example.test");
+        book.Hold(anna);
+
+        // Act
+        var resolution = await new NamedRecipientResolver(book).ResolveAsync(
+            [
+                NamedRecipient.AtAddress(OutgoingRecipientRole.To, "first@example.test"),
+                NamedRecipient.ByContact(OutgoingRecipientRole.Cc, anna.Id),
+                NamedRecipient.AtAddress(OutgoingRecipientRole.Bcc, "last@example.test"),
+            ],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(
+            ["first@example.test", "anna@example.test", "last@example.test"],
+            resolution.Recipients.Select(recipient => recipient.Address));
+    }
+
+    /// <summary>
+    /// One recipient nobody can be found for refuses the whole message. Delivering to the rest would tell an author
+    /// their message was sent while the person they cared about never receives it.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_OneRecipientRefused_RefusesTheWholeMessage()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+
+        // Act
+        var resolution = await new NamedRecipientResolver(book).ResolveAsync(
+            [
+                NamedRecipient.AtAddress(OutgoingRecipientRole.To, "reachable@example.test"),
+                NamedRecipient.ByContact(OutgoingRecipientRole.Cc, AContactId()),
+            ],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(resolution.IsResolved);
+        Assert.Empty(resolution.Recipients);
+    }
+
+    /// <summary>
+    /// A message naming nobody resolves rather than refuses. Addressing nobody is what the composition refuses, on its
+    /// own terms and against the field it names, so answering with a refusal here would report it as a contact problem.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_NobodyNamedAtAll_IsResolvedToNoRecipients()
+    {
+        // Arrange
+        var resolver = new NamedRecipientResolver(new InMemoryContactBookStore());
+
+        // Act
+        RecipientResolution resolution = await resolver.ResolveAsync([], TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(resolution.IsResolved);
+        Assert.Empty(resolution.Recipients);
+        Assert.Null(resolution.Refusal);
+    }
+
+    /// <summary>
+    /// Each contact named is a read of the book, so the count is bounded before the first of them. A list longer than an
+    /// outgoing record can hold describes a send that could not be written down whatever the book answered.
+    /// </summary>
+    [Fact]
+    public async Task ResolveAsync_MoreRecipientsThanARecordCanHold_IsRefusedBeforeTheBookIsRead()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        var contact = ContactOf("Anna Kowalska", "anna@example.test");
+        book.Hold(contact);
+
+        var beyondTheBound = Enumerable
+            .Range(0, OutgoingEmailRequest.MaximumRecipientCount + 1)
+            .Select(_ => NamedRecipient.ByContact(OutgoingRecipientRole.To, contact.Id))
+            .ToArray();
+
+        // Act, Assert
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            new NamedRecipientResolver(book).ResolveAsync(
+                beyondTheBound,
+                TestContext.Current.CancellationToken));
+    }
+
+    /// <summary>Addressing somebody is not a fact about them, so the book is read and never written.</summary>
+    [Fact]
+    public async Task ResolveAsync_ContactAddressed_LeavesTheBookAsItWas()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        var anna = ContactOf("Anna Kowalska", "anna@example.test");
+        book.Hold(anna);
+
+        // Act
+        await new NamedRecipientResolver(book).ResolveAsync(
+            [NamedRecipient.ByContact(OutgoingRecipientRole.To, anna.Id)],
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, book.ContactCount);
+        Assert.Equal(anna, Assert.Single(book.Contacts));
+    }
+
+    private static ContactId AContactId() => ContactId.Create(Guid.CreateVersion7(Recorded));
+
+    private static Contact ContactOf(string displayName, params string[] addresses) => Contact.Create(
+        AContactId(),
+        ContactDisplayName.Create(displayName),
+        [.. addresses.Select(Address)],
+        Address(addresses[0]),
+        note: null,
+        ContactOrigin.Asserted,
+        Recorded,
+        Recorded);
+
+    private static EmailAddress Address(string address)
+    {
+        if (!EmailAddress.TryCreate(displayName: null, address, out var emailAddress))
+        {
+            throw new InvalidOperationException($"The test address '{address}' names no mailbox.");
+        }
+
+        return emailAddress;
+    }
+}

--- a/tests/Application.UnitTests/Mail/Delivery/Addressing/NamedRecipientTests.cs
+++ b/tests/Application.UnitTests/Mail/Delivery/Addressing/NamedRecipientTests.cs
@@ -1,0 +1,90 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Delivery.Addressing;
+using MailFathom.Domain.Contacts;
+using MailFathom.Domain.Delivery;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Mail.Delivery.Addressing;
+
+/// <summary>Covers what a recipient may be named by, and what naming nobody is refused as.</summary>
+public sealed class NamedRecipientTests
+{
+    private static readonly ContactId Contact =
+        ContactId.Create(Guid.Parse("0198f0a0-3333-7000-8000-000000000001"));
+
+    /// <summary>Exactly one of the three ways of naming somebody is present, so nothing downstream has to choose.</summary>
+    [Fact]
+    public void AtAddress_AnAddressTheAuthorWrote_NamesNoContact()
+    {
+        // Act
+        var named = NamedRecipient.AtAddress(OutgoingRecipientRole.To, "anna@example.test", "Anna Kowalska");
+
+        // Assert
+        Assert.Equal("anna@example.test", named.Address);
+        Assert.Equal("Anna Kowalska", named.DisplayName);
+        Assert.Null(named.Contact);
+        Assert.Null(named.ContactName);
+        Assert.Null(named.ContactAddress);
+    }
+
+    /// <summary>A contact named by identity carries no address of its own until the book has been read.</summary>
+    [Fact]
+    public void ByContact_AContactIdentity_CarriesNoAddress()
+    {
+        // Act
+        var named = NamedRecipient.ByContact(OutgoingRecipientRole.Cc, Contact);
+
+        // Assert
+        Assert.Equal(Contact, named.Contact);
+        Assert.Null(named.Address);
+        Assert.Null(named.ContactAddress);
+        Assert.Equal(OutgoingRecipientRole.Cc, named.Role);
+    }
+
+    /// <summary>A contact named by name carries the name in the form the book compares its own values in.</summary>
+    [Fact]
+    public void ByContactName_AName_CarriesItAndNoIdentity()
+    {
+        // Act
+        var named = NamedRecipient.ByContactName(
+            OutgoingRecipientRole.Bcc,
+            ContactDisplayName.Create("Anna Kowalska"));
+
+        // Assert
+        Assert.Equal("Anna Kowalska", named.ContactName?.Value);
+        Assert.Null(named.Contact);
+        Assert.Null(named.Address);
+    }
+
+    /// <summary>Blank text names nobody, so it is refused rather than composed into a message addressed to nothing.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AtAddress_BlankAddress_IsRefused(string address) =>
+
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() =>
+            NamedRecipient.AtAddress(OutgoingRecipientRole.To, address));
+
+    /// <summary>
+    /// A blank chosen address is refused rather than read as no choice at all, which would silently send to the
+    /// preferred address the caller did not ask for.
+    /// </summary>
+    [Fact]
+    public void ByContact_BlankChosenAddress_IsRefused() =>
+
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() =>
+            NamedRecipient.ByContact(OutgoingRecipientRole.To, Contact, "  "));
+
+    /// <summary>A header this system does not declare is a boundary that mapped its input wrongly.</summary>
+    [Fact]
+    public void AtAddress_UndeclaredRole_IsRefused() =>
+
+        // Act, Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            NamedRecipient.AtAddress((OutgoingRecipientRole)99, "anna@example.test"));
+}

--- a/tests/Application.UnitTests/Mail/Delivery/Authoring/AuthoredResponseTests.cs
+++ b/tests/Application.UnitTests/Mail/Delivery/Authoring/AuthoredResponseTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Mail.Delivery.Addressing;
 using MailFathom.Application.Mail.Delivery.Authoring;
 using MailFathom.Application.Mail.Delivery.Composition;
 using MailFathom.Domain.Accounts;
@@ -58,6 +59,9 @@ public sealed class AuthoredResponseTests
     [InlineData(AuthoredResponseRefusalReason.AnsweredEmailContentUnavailable, 28007)]
     [InlineData(AuthoredResponseRefusalReason.SenderUnconfigured, 28001)]
     [InlineData(AuthoredResponseRefusalReason.BoundExceeded, 28005)]
+    [InlineData(AuthoredResponseRefusalReason.RecipientContactUnknown, 28013)]
+    [InlineData(AuthoredResponseRefusalReason.RecipientContactNameAmbiguous, 28014)]
+    [InlineData(AuthoredResponseRefusalReason.RecipientContactAddressNotHeld, 28015)]
     public void Failure_DeclaredReason_PublishesItsOwnCode(
         AuthoredResponseRefusalReason reason,
         int expectedCode)
@@ -71,6 +75,47 @@ public sealed class AuthoredResponseTests
         // Assert
         Assert.Equal(expectedCode, failure.Value);
         Assert.True(failure.IsSpecified);
+    }
+
+    /// <summary>
+    /// A recipient that addressed nobody is translated into this result's own terms, so an author acts on one refusal
+    /// shape whatever part of the send produced it — and the identity it publishes stays the resolution's own.
+    /// </summary>
+    [Theory]
+    [InlineData(RecipientResolutionRefusalReason.ContactUnknown, AuthoredResponseRefusalReason.RecipientContactUnknown)]
+    [InlineData(
+        RecipientResolutionRefusalReason.ContactNameAmbiguous,
+        AuthoredResponseRefusalReason.RecipientContactNameAmbiguous)]
+    [InlineData(
+        RecipientResolutionRefusalReason.ContactAddressNotHeld,
+        AuthoredResponseRefusalReason.RecipientContactAddressNotHeld)]
+    public void Refused_ARecipientThatAddressedNobody_TranslatesTheReasonAndKeepsTheIdentity(
+        RecipientResolutionRefusalReason resolved,
+        AuthoredResponseRefusalReason expected)
+    {
+        // Arrange
+        var refusal = new RecipientResolutionRefusal(resolved, MatchedContactCount: 3);
+
+        // Act
+        var response = AuthoredResponse.Refused(refusal);
+
+        // Assert
+        Assert.False(response.IsAuthored);
+        Assert.Equal(expected, response.Refusal!.Reason);
+        Assert.Equal(3, response.Refusal.MatchedContactCount);
+        Assert.Null(response.Refusal.Bound);
+        Assert.Equal(refusal.Failure, response.Refusal.Failure);
+    }
+
+    /// <summary>A resolution reason cast from a number this system never declared cannot be translated either.</summary>
+    [Fact]
+    public void Refused_AResolutionReasonThisSystemDoesNotDeclare_IsRefused()
+    {
+        // Arrange
+        var refusal = new RecipientResolutionRefusal((RecipientResolutionRefusalReason)99);
+
+        // Act and assert
+        Assert.Throws<InvalidOperationException>(() => AuthoredResponse.Refused(refusal));
     }
 
     /// <summary>A reason cast from a number this system never declared has no identity to publish.</summary>

--- a/tests/Application.UnitTests/Mail/Delivery/Authoring/StoredEmailResponseAuthoringTests.cs
+++ b/tests/Application.UnitTests/Mail/Delivery/Authoring/StoredEmailResponseAuthoringTests.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using MailFathom.Application.Access;
 using MailFathom.Application.Accounts;
+using MailFathom.Application.Contacts;
 using MailFathom.Application.EmailContent.Attachments;
 using MailFathom.Application.EmailContent.Rendering;
 using MailFathom.Application.EmailContent.Repair;
@@ -14,12 +15,14 @@ using MailFathom.Application.Emails.Extraction;
 using MailFathom.Application.Emails.Mailboxes;
 using MailFathom.Application.Emails.Summaries;
 using MailFathom.Application.Folders;
+using MailFathom.Application.Mail.Delivery.Addressing;
 using MailFathom.Application.Mail.Delivery.Authoring;
 using MailFathom.Application.Mail.Delivery.Composition;
 using MailFathom.Application.Synchronization.Sessions;
 using MailFathom.Application.UnitTests.TestDoubles;
 using MailFathom.Domain.Access;
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
@@ -169,7 +172,7 @@ public sealed class StoredEmailResponseAuthoringTests
         var authoring = AuthoringOver(Rendering(participants: ExchangeNamingTheAccount()));
         var request = Request(AuthoredResponseAct.Forward) with
         {
-            Recipients = [new AuthoredEmailRecipient(OutgoingRecipientRole.To, "elsewhere@example.test")],
+            Recipients = [NamedRecipient.AtAddress(OutgoingRecipientRole.To, "elsewhere@example.test")],
         };
 
         // Act
@@ -177,6 +180,66 @@ public sealed class StoredEmailResponseAuthoringTests
 
         // Assert
         Assert.Equal(["elsewhere@example.test"], Addressed(response, OutgoingRecipientRole.To));
+    }
+
+    /// <summary>
+    /// Somebody the author copies in may be named out of the contact book, and is an ordinary address by the time the
+    /// answer is composed — with the contact recorded beside it.
+    /// </summary>
+    [Fact]
+    public async Task AuthorAsync_AuthorCopiesInAContact_AddressesTheAddressThatContactPrefers()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        var anna = ContactHeldBy(book, "Anna Kowalska", "anna@example.test");
+        var authoring = AuthoringOver(Rendering(), contacts: book);
+        var request = Request() with
+        {
+            Recipients = [NamedRecipient.ByContact(OutgoingRecipientRole.Cc, anna.Id)],
+        };
+
+        // Act
+        var response = await authoring.AuthorAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(["anna@example.test"], Addressed(response, OutgoingRecipientRole.Cc));
+        Assert.Equal(
+            anna.Id,
+            Assert.Single(response.Email!.Recipients, recipient => recipient.Contact is not null).Contact);
+    }
+
+    /// <summary>
+    /// A name several people carry addresses nobody, and the answer is refused as a whole rather than sent to the
+    /// people whose names were unambiguous.
+    /// </summary>
+    [Fact]
+    public async Task AuthorAsync_AuthorNamesAContactSeveralPeopleCarry_IsRefusedNamingHowManyMatched()
+    {
+        // Arrange
+        var book = new InMemoryContactBookStore();
+        ContactHeldBy(book, "Anna Kowalska", "anna@example.test");
+        ContactHeldBy(book, "Anna Kowalska", "anna.k@example.test");
+        var authoring = AuthoringOver(Rendering(), contacts: book);
+        var request = Request() with
+        {
+            Recipients =
+            [
+                NamedRecipient.ByContactName(
+                    OutgoingRecipientRole.Cc,
+                    ContactDisplayName.Create("Anna Kowalska")),
+            ],
+        };
+
+        // Act
+        var response = await authoring.AuthorAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(response.IsAuthored);
+        Assert.Equal(
+            AuthoredResponseRefusalReason.RecipientContactNameAmbiguous,
+            response.Refusal?.Reason);
+        Assert.Equal(2, response.Refusal?.MatchedContactCount);
+        Assert.Equal(MailFathomErrorCode.OutgoingEmailContactNameAmbiguous, response.Refusal?.Failure);
     }
 
     /// <summary>
@@ -875,6 +938,26 @@ public sealed class StoredEmailResponseAuthoringTests
         return new EmailParticipant(role, emailAddress);
     }
 
+    /// <summary>Puts one person into the book and answers with them, so a test names the contact it just held.</summary>
+    private static Contact ContactHeldBy(InMemoryContactBookStore book, string displayName, string address)
+    {
+        Assert.True(EmailAddress.TryCreate(displayName: null, address, out var emailAddress));
+
+        var contact = Contact.Create(
+            ContactId.Create(Guid.CreateVersion7()),
+            ContactDisplayName.Create(displayName),
+            [emailAddress],
+            emailAddress,
+            note: null,
+            ContactOrigin.Asserted,
+            SentAt,
+            SentAt);
+
+        book.Hold(contact);
+
+        return contact;
+    }
+
     private static AuthoredResponseRequest Request(AuthoredResponseAct act = AuthoredResponseAct.Reply) => new()
     {
         AnsweredEmailId = StoredEmailId.Create(Guid.CreateVersion7()),
@@ -927,6 +1010,7 @@ public sealed class StoredEmailResponseAuthoringTests
         IEmailContentRepairRequestStore? repairRequestStore = null,
         IMailFolderParticipationReader? folderParticipation = null,
         IOutgoingSenderIdentityReader? senderIdentities = null,
+        IContactDirectory? contacts = null,
         OutgoingEmailBounds? bounds = null,
         AccessAuthorization? authorization = null)
     {
@@ -945,6 +1029,7 @@ public sealed class StoredEmailResponseAuthoringTests
                 StubJunkMailFolderCatalog.None,
                 StubMailFolderMappings.ResolvingNothing),
             senderIdentities ?? SenderIdentitiesFor(answered.AccountId),
+            new NamedRecipientResolver(contacts ?? new InMemoryContactBookStore()),
             bounds ?? Bounds(),
             authorization ?? AccessAuthorizations.ForCallerGranted(MailFathomPermission.MailRead));
     }

--- a/tests/Application.UnitTests/TestDoubles/InMemoryContactBookStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryContactBookStore.cs
@@ -26,6 +26,14 @@ internal sealed class InMemoryContactBookStore : IContactStore, IContactDirector
     /// <summary>Gets every contact the book holds, for a test asserting on the records rather than on their number.</summary>
     internal IReadOnlyCollection<Contact> Contacts => this.contactsById.Values;
 
+    /// <summary>Gets how many batched lookups the directory has answered, for a test asserting the cost of a read.</summary>
+    /// <remarks>
+    /// A real book is read by a query, and a caller looking one person up at a time cannot be told apart from one looking
+    /// a set up in a single read by what either of them gets back. The number of lookups is the only observation that
+    /// separates them, so it is the one this double publishes.
+    /// </remarks>
+    internal int BatchedLookupCount { get; private set; }
+
     /// <summary>Puts a contact into the book without going through a write, for arranging what was already held.</summary>
     internal void Hold(Contact contact) => this.contactsById[contact.Id] = contact;
 
@@ -99,23 +107,44 @@ internal sealed class InMemoryContactBookStore : IContactStore, IContactDirector
         Task.FromResult(this.contactsById.Values.FirstOrDefault(contact => contact.Holds(address)));
 
     /// <inheritdoc />
-    public Task<ContactMatch> MatchDisplayNameAsync(
-        ContactDisplayName displayName,
+    public Task<IReadOnlyDictionary<ContactId, Contact>> FindAllAsync(
+        IReadOnlyCollection<ContactId> contactIds,
         CancellationToken cancellationToken)
     {
-        var carrying = this.contactsById.Values
-            .Where(contact => string.Equals(
-                contact.DisplayName.SortKey,
-                displayName.SortKey,
-                StringComparison.Ordinal))
-            .ToArray();
+        ArgumentNullException.ThrowIfNull(contactIds);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            contactIds.Count,
+            ContactQuery.MaximumPageSize,
+            nameof(contactIds));
 
-        return Task.FromResult(carrying.Length switch
-        {
-            0 => ContactMatch.None,
-            1 => ContactMatch.Unique(carrying[0]),
-            _ => ContactMatch.Several(carrying.Length),
-        });
+        this.BatchedLookupCount++;
+
+        IReadOnlyDictionary<ContactId, Contact> held = contactIds
+            .Distinct()
+            .Where(this.contactsById.ContainsKey)
+            .ToDictionary(contactId => contactId, contactId => this.contactsById[contactId]);
+
+        return Task.FromResult(held);
+    }
+
+    /// <inheritdoc />
+    public Task<IReadOnlyDictionary<ContactDisplayName, ContactMatch>> MatchDisplayNamesAsync(
+        IReadOnlyCollection<ContactDisplayName> displayNames,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(displayNames);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            displayNames.Count,
+            ContactQuery.MaximumPageSize,
+            nameof(displayNames));
+
+        this.BatchedLookupCount++;
+
+        IReadOnlyDictionary<ContactDisplayName, ContactMatch> matches = displayNames
+            .Distinct()
+            .ToDictionary(displayName => displayName, this.MatchOf);
+
+        return Task.FromResult(matches);
     }
 
     /// <inheritdoc />
@@ -158,6 +187,24 @@ internal sealed class InMemoryContactBookStore : IContactStore, IContactDirector
         var byName = string.CompareOrdinal(contact.DisplayName.SortKey, cursor.DisplayNameSortKey);
 
         return byName > 0 || (byName == 0 && contact.Id.Value > cursor.ContactId.Value);
+    }
+
+    /// <summary>States who one name resolves to, on the comparison form the listing index is built on.</summary>
+    private ContactMatch MatchOf(ContactDisplayName displayName)
+    {
+        var carrying = this.contactsById.Values
+            .Where(contact => string.Equals(
+                contact.DisplayName.SortKey,
+                displayName.SortKey,
+                StringComparison.Ordinal))
+            .ToArray();
+
+        return carrying.Length switch
+        {
+            0 => ContactMatch.None,
+            1 => ContactMatch.Unique(carrying[0]),
+            _ => ContactMatch.Several(carrying.Length),
+        };
     }
 
     /// <summary>Names the other contact already holding one of this record's addresses, as the unique index would.</summary>

--- a/tests/Application.UnitTests/TestDoubles/InMemoryContactBookStore.cs
+++ b/tests/Application.UnitTests/TestDoubles/InMemoryContactBookStore.cs
@@ -99,6 +99,26 @@ internal sealed class InMemoryContactBookStore : IContactStore, IContactDirector
         Task.FromResult(this.contactsById.Values.FirstOrDefault(contact => contact.Holds(address)));
 
     /// <inheritdoc />
+    public Task<ContactMatch> MatchDisplayNameAsync(
+        ContactDisplayName displayName,
+        CancellationToken cancellationToken)
+    {
+        var carrying = this.contactsById.Values
+            .Where(contact => string.Equals(
+                contact.DisplayName.SortKey,
+                displayName.SortKey,
+                StringComparison.Ordinal))
+            .ToArray();
+
+        return Task.FromResult(carrying.Length switch
+        {
+            0 => ContactMatch.None,
+            1 => ContactMatch.Unique(carrying[0]),
+            _ => ContactMatch.Several(carrying.Length),
+        });
+    }
+
+    /// <inheritdoc />
     public Task<IReadOnlyDictionary<EmailAddress, ContactId>> FindHoldersOfAsync(
         IReadOnlyCollection<EmailAddress> addresses,
         CancellationToken cancellationToken)

--- a/tests/Domain.UnitTests/Delivery/OutgoingRecipientTests.cs
+++ b/tests/Domain.UnitTests/Delivery/OutgoingRecipientTests.cs
@@ -1,0 +1,78 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Contacts;
+using MailFathom.Domain.Delivery;
+using MailFathom.Domain.Emails;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Delivery;
+
+public sealed class OutgoingRecipientTests
+{
+    private static readonly ContactId Contact =
+        ContactId.Create(Guid.Parse("0198f0a0-2222-7000-8000-000000000001"));
+
+    /// <summary>An address an author wrote down came from nobody in the book, and the record says so.</summary>
+    [Fact]
+    public void Create_AddressWithoutAContact_NamesNoContact()
+    {
+        // Arrange
+        var address = Address("anna@example.test");
+
+        // Act
+        var recipient = OutgoingRecipient.Create(address, OutgoingRecipientRole.To);
+
+        // Assert
+        Assert.Null(recipient.Contact);
+        Assert.Equal(address, recipient.Address);
+    }
+
+    /// <summary>
+    /// The address and the contact are both kept, because they answer different questions: what a resumed attempt
+    /// offers, and which person the message was addressed by naming.
+    /// </summary>
+    [Fact]
+    public void Create_AddressResolvedFromAContact_KeepsBoth()
+    {
+        // Arrange
+        var address = Address("anna@example.test");
+
+        // Act
+        var recipient = OutgoingRecipient.Create(address, OutgoingRecipientRole.Cc, Contact);
+
+        // Assert
+        Assert.Equal(address, recipient.Address);
+        Assert.Equal(Contact, recipient.Contact);
+        Assert.Equal(OutgoingRecipientRole.Cc, recipient.Role);
+    }
+
+    /// <summary>
+    /// The description names the header and nothing else. An address is personal data of a third party and would
+    /// otherwise reach every log template, exception message, and interpolated string that mentions a recipient.
+    /// </summary>
+    [Fact]
+    public void ToString_RecipientResolvedFromAContact_DescribesTheRoleAlone()
+    {
+        // Arrange
+        var recipient = OutgoingRecipient.Create(Address("anna@example.test"), OutgoingRecipientRole.Bcc, Contact);
+
+        // Act
+        var described = recipient.ToString();
+
+        // Assert
+        Assert.Equal("Bcc recipient", described);
+        Assert.DoesNotContain("example.test", described, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static EmailAddress Address(string address)
+    {
+        if (!EmailAddress.TryCreate(displayName: null, address, out var emailAddress))
+        {
+            throw new InvalidOperationException($"The test address '{address}' names no mailbox.");
+        }
+
+        return emailAddress;
+    }
+}

--- a/tests/Infrastructure.UnitTests/Mail/Mime/Composition/MimeKitAuthoredEmailComposerTests.cs
+++ b/tests/Infrastructure.UnitTests/Mail/Mime/Composition/MimeKitAuthoredEmailComposerTests.cs
@@ -6,6 +6,7 @@ using System.Text;
 using MailFathom.Application.Mail.Delivery;
 using MailFathom.Application.Mail.Delivery.Composition;
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
@@ -30,6 +31,10 @@ public sealed class MimeKitAuthoredEmailComposerTests
     private static readonly MailAccountId Account = MailAccountId.Create("primary");
 
     private static readonly DateTimeOffset ComposedAt = new(2026, 8, 17, 9, 30, 0, TimeSpan.Zero);
+
+    /// <summary>The contact a resolved recipient came from, which the composition carries and never reads.</summary>
+    private static readonly ContactId Contact =
+        ContactId.Create(Guid.Parse("0198f0a0-4444-7000-8000-000000000001"));
 
     /// <summary>The account's own address is what a message is written from, and there is no input path that names one.</summary>
     [Fact]
@@ -142,6 +147,92 @@ public sealed class MimeKitAuthoredEmailComposerTests
         var message = Parse(composition);
         Assert.Equal("anna@example.test", Assert.IsType<MailboxAddress>(Assert.Single(message.To)).Address);
         Assert.Empty(message.Bcc);
+    }
+
+    /// <summary>
+    /// A recipient whose address came out of the contact book is recorded with the contact beside the address, so what
+    /// was sent stays answerable after the book changes.
+    /// </summary>
+    [Fact]
+    public void Compose_RecipientResolvedFromAContact_RecordsTheContactBesideTheAddress()
+    {
+        // Arrange
+        var composer = CreateComposer();
+        var authored = Authored() with
+        {
+            Recipients =
+            [
+                new AuthoredEmailRecipient(OutgoingRecipientRole.To, "anna@example.test", "Anna Kowalska", Contact),
+            ],
+        };
+
+        // Act
+        var composition = composer.Compose(Account, Requester(), authored, Capabilities());
+
+        // Assert
+        var recipient = Assert.Single(composition.Email!.Request.Recipients);
+        Assert.Equal("anna@example.test", recipient.Address.Address);
+        Assert.Equal(Contact, recipient.Contact);
+        Assert.Equal(
+            "Anna Kowalska",
+            Assert.IsType<MailboxAddress>(Assert.Single(Parse(composition).To)).Name);
+    }
+
+    /// <summary>
+    /// An address the book supplied is an ordinary address from that moment on, so every refusal a written-down address
+    /// meets it meets as well. Naming a contact is therefore no way to reach a mailbox naming an address could not.
+    /// </summary>
+    [Fact]
+    public void Compose_ContactResolvedAddressTheServerCannotCarry_IsRefusedLikeAnyOther()
+    {
+        // Arrange
+        var composer = CreateComposer();
+        var authored = Authored() with
+        {
+            Recipients = [new AuthoredEmailRecipient(OutgoingRecipientRole.To, "zoë@example.test", null, Contact)],
+        };
+
+        // Act
+        var composition = composer.Compose(
+            Account,
+            Requester(),
+            authored,
+            Capabilities(acceptsInternationalizedAddresses: false));
+
+        // Assert
+        AssertRefused(
+            composition,
+            AuthoredEmailRefusalReason.InternationalizationUnsupported,
+            AuthoredEmailField.To,
+            MailFathomErrorCode.OutgoingEmailInternationalizationUnsupported);
+    }
+
+    /// <summary>
+    /// One mailbox is offered once whether it was named as a person or written down, because the envelope compares the
+    /// address and knows nothing about the book.
+    /// </summary>
+    [Fact]
+    public void Compose_AContactAndAWrittenAddressNamingOneMailbox_OffersItOnce()
+    {
+        // Arrange
+        var composer = CreateComposer();
+        var authored = Authored() with
+        {
+            Recipients =
+            [
+                new AuthoredEmailRecipient(OutgoingRecipientRole.To, "anna@example.test", "Anna Kowalska", Contact),
+                new AuthoredEmailRecipient(OutgoingRecipientRole.Cc, "Anna@Example.test"),
+            ],
+        };
+
+        // Act
+        var composition = composer.Compose(Account, Requester(), authored, Capabilities());
+
+        // Assert
+        var recipient = Assert.Single(composition.Email!.Request.Recipients);
+        Assert.Equal(OutgoingRecipientRole.To, recipient.Role);
+        Assert.Equal(Contact, recipient.Contact);
+        Assert.Empty(Parse(composition).Cc);
     }
 
     /// <summary>A blind recipient is offered exactly as any other is, and the transmitted headers do not name them.</summary>

--- a/tests/IntegrationTests/Persistence/OrchestratedContactBookTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedContactBookTests.cs
@@ -17,12 +17,14 @@ namespace MailFathom.IntegrationTests.Persistence;
 /// <summary>Proves the contact book against real PostgreSQL, where its constraints, its order, and its erasure live.</summary>
 /// <remarks>
 /// <para>
-/// Four claims, none of which a substitute can settle. That erasing a person removes every row derived from them runs
+/// Five claims, none of which a substitute can settle. That erasing a person removes every row derived from them runs
 /// along a foreign key the schema declares. That one address stays in one person's hands is a unique index, and losing
 /// that race has to reach a caller as a conflict rather than as a provider failure. That a walk of the book serves every
 /// contact once depends on PostgreSQL comparing the same two columns the index is ordered by, which is also the one part
-/// of the read that has to survive being translated into SQL at all. And that an amendment which drops an address frees
-/// it is the interaction between the replacement's deletes and that same index.
+/// of the read that has to survive being translated into SQL at all. That resolving a whole name answers with one person
+/// or with an exact count turns on that same collation and on a count the database takes rather than a page this read
+/// holds. And that an amendment which drops an address frees it is the interaction between the replacement's deletes and
+/// that same index.
 /// </para>
 /// <para>
 /// Every test owns its own domain of addresses, because the index they turn on is unique across the whole book and the
@@ -285,6 +287,58 @@ public sealed class OrchestratedContactBookTests(MailFathomOrchestrationFixture 
         Assert.Null(matchedNothing.NextCursor);
     }
 
+    /// <summary>
+    /// Addressing a message by naming somebody turns on this lookup answering with one person or with a count, and both
+    /// halves of it are PostgreSQL's: the equality is on a column pinned to the <c>C</c> collation, and the count is the
+    /// database's own rather than the length of a page this read never holds.
+    /// </summary>
+    [Fact]
+    public async Task MatchDisplayNameAsync_ANameOnePersonCarriesAndOneSeveralDo_AnswersWithThePersonAndWithTheCount()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+
+        var unique = await RecordAsync(
+            services,
+            "Solveig Lindqvist",
+            ["solveig@named.contacts.test"],
+            ContactOrigin.Asserted,
+            cancellationToken);
+
+        await RecordAsync(
+            services,
+            "Namesake Halvorsen",
+            ["namesake.one@named.contacts.test"],
+            ContactOrigin.Asserted,
+            cancellationToken);
+
+        await RecordAsync(
+            services,
+            "Namesake Halvorsen",
+            ["namesake.two@named.contacts.test"],
+            ContactOrigin.Asserted,
+            cancellationToken);
+
+        // Act
+        // The casing is the author's rather than the book's, which is the whole reason the comparison form is stored.
+        var byName = await MatchDisplayNameAsync(services, "solveig lindqvist", cancellationToken);
+        var shared = await MatchDisplayNameAsync(services, "Namesake Halvorsen", cancellationToken);
+        var carriedByNobody = await MatchDisplayNameAsync(services, "Solveig", cancellationToken);
+
+        // Assert
+        Assert.Equal(1, byName.MatchCount);
+        Assert.Equal(unique.Contact!.Id, byName.OnlyMatch?.Id);
+        Assert.Equal("solveig@named.contacts.test", byName.OnlyMatch?.PreferredAddress.Address);
+
+        Assert.Equal(2, shared.MatchCount);
+        Assert.Null(shared.OnlyMatch);
+
+        // Part of a name is not a person being named, which is what separates this lookup from a search.
+        Assert.Equal(0, carriedByNobody.MatchCount);
+        Assert.Null(carriedByNobody.OnlyMatch);
+    }
+
     /// <summary>An amendment is the whole record: what it stops naming is removed, and the address it releases is free.</summary>
     [Fact]
     public async Task AmendAsync_DroppingAnAddress_RemovesItsRowAndReleasesItToAnotherContact()
@@ -396,6 +450,15 @@ public sealed class OrchestratedContactBookTests(MailFathomOrchestrationFixture 
         CancellationToken cancellationToken) => services.InScopeAsync(
             (scope, token) => scope.GetRequiredService<IContactDirectory>().ReadPageAsync(
                 ContactQuery.Create(ContactOrigin.Collected, search: null, pageSize, cursor),
+                token),
+            cancellationToken);
+
+    private static Task<ContactMatch> MatchDisplayNameAsync(
+        OrchestratedMailFathomServices services,
+        string displayName,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IContactDirectory>().MatchDisplayNameAsync(
+                ContactDisplayName.Create(displayName),
                 token),
             cancellationToken);
 

--- a/tests/IntegrationTests/Persistence/OrchestratedContactBookTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedContactBookTests.cs
@@ -21,9 +21,10 @@ namespace MailFathom.IntegrationTests.Persistence;
 /// along a foreign key the schema declares. That one address stays in one person's hands is a unique index, and losing
 /// that race has to reach a caller as a conflict rather than as a provider failure. That a walk of the book serves every
 /// contact once depends on PostgreSQL comparing the same two columns the index is ordered by, which is also the one part
-/// of the read that has to survive being translated into SQL at all. That resolving a whole name answers with one person
-/// or with an exact count turns on that same collation and on a count the database takes rather than a page this read
-/// holds. And that an amendment which drops an address frees it is the interaction between the replacement's deletes and
+/// of the read that has to survive being translated into SQL at all. That resolving whole names answers each with one
+/// person or with an exact count turns on that same collation, on counts the database groups rather than pages this read
+/// holds, and on the one translation that grouping is. And that an amendment which drops an address frees it is the
+/// interaction between the replacement's deletes and
 /// that same index.
 /// </para>
 /// <para>
@@ -288,12 +289,13 @@ public sealed class OrchestratedContactBookTests(MailFathomOrchestrationFixture 
     }
 
     /// <summary>
-    /// Addressing a message by naming somebody turns on this lookup answering with one person or with a count, and both
-    /// halves of it are PostgreSQL's: the equality is on a column pinned to the <c>C</c> collation, and the count is the
-    /// database's own rather than the length of a page this read never holds.
+    /// Addressing a message by naming somebody turns on this lookup answering with one person or with a count, and every
+    /// half of it is PostgreSQL's: the equality is on a column pinned to the <c>C</c> collation, the counts are grouped by
+    /// the database rather than read as pages this query never holds, and one statement answers however many names a
+    /// message named.
     /// </summary>
     [Fact]
-    public async Task MatchDisplayNameAsync_ANameOnePersonCarriesAndOneSeveralDo_AnswersWithThePersonAndWithTheCount()
+    public async Task MatchDisplayNamesAsync_NamesOnePersonCarriesAndSeveralDo_AnswerWithThePeopleAndWithTheCounts()
     {
         // Arrange
         var cancellationToken = TestContext.Current.CancellationToken;
@@ -321,14 +323,25 @@ public sealed class OrchestratedContactBookTests(MailFathomOrchestrationFixture 
             cancellationToken);
 
         // Act
-        // The casing is the author's rather than the book's, which is the whole reason the comparison form is stored.
-        var byName = await MatchDisplayNameAsync(services, "solveig lindqvist", cancellationToken);
-        var shared = await MatchDisplayNameAsync(services, "Namesake Halvorsen", cancellationToken);
-        var carriedByNobody = await MatchDisplayNameAsync(services, "Solveig", cancellationToken);
+        // Every name a message named, in one read. The casing is the author's rather than the book's, which is the whole
+        // reason the comparison form is stored.
+        var matches = await MatchDisplayNamesAsync(
+            services,
+            ["solveig lindqvist", "Namesake Halvorsen", "Solveig"],
+            cancellationToken);
+
+        var held = await FindAllAsync(
+            services,
+            [unique.Contact!.Id, ContactId.Create(Guid.CreateVersion7())],
+            cancellationToken);
 
         // Assert
+        var byName = matches[ContactDisplayName.Create("solveig lindqvist")];
+        var shared = matches[ContactDisplayName.Create("Namesake Halvorsen")];
+        var carriedByNobody = matches[ContactDisplayName.Create("Solveig")];
+
         Assert.Equal(1, byName.MatchCount);
-        Assert.Equal(unique.Contact!.Id, byName.OnlyMatch?.Id);
+        Assert.Equal(unique.Contact.Id, byName.OnlyMatch?.Id);
         Assert.Equal("solveig@named.contacts.test", byName.OnlyMatch?.PreferredAddress.Address);
 
         Assert.Equal(2, shared.MatchCount);
@@ -337,6 +350,11 @@ public sealed class OrchestratedContactBookTests(MailFathomOrchestrationFixture 
         // Part of a name is not a person being named, which is what separates this lookup from a search.
         Assert.Equal(0, carriedByNobody.MatchCount);
         Assert.Null(carriedByNobody.OnlyMatch);
+
+        // The identity lookup answers the same way for a set: the people the book holds, and nothing standing in for the
+        // one it does not.
+        Assert.Equal([unique.Contact.Id], held.Keys);
+        Assert.Equal("solveig@named.contacts.test", held[unique.Contact.Id].PreferredAddress.Address);
     }
 
     /// <summary>An amendment is the whole record: what it stops naming is removed, and the address it releases is free.</summary>
@@ -453,13 +471,20 @@ public sealed class OrchestratedContactBookTests(MailFathomOrchestrationFixture 
                 token),
             cancellationToken);
 
-    private static Task<ContactMatch> MatchDisplayNameAsync(
+    private static Task<IReadOnlyDictionary<ContactDisplayName, ContactMatch>> MatchDisplayNamesAsync(
         OrchestratedMailFathomServices services,
-        string displayName,
+        IReadOnlyCollection<string> displayNames,
         CancellationToken cancellationToken) => services.InScopeAsync(
-            (scope, token) => scope.GetRequiredService<IContactDirectory>().MatchDisplayNameAsync(
-                ContactDisplayName.Create(displayName),
+            (scope, token) => scope.GetRequiredService<IContactDirectory>().MatchDisplayNamesAsync(
+                [.. displayNames.Select(ContactDisplayName.Create)],
                 token),
+            cancellationToken);
+
+    private static Task<IReadOnlyDictionary<ContactId, Contact>> FindAllAsync(
+        OrchestratedMailFathomServices services,
+        IReadOnlyCollection<ContactId> contactIds,
+        CancellationToken cancellationToken) => services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<IContactDirectory>().FindAllAsync(contactIds, token),
             cancellationToken);
 
     private static Task<ContactPage> SearchAsync(

--- a/tests/IntegrationTests/Persistence/OrchestratedOutgoingEmailStoreTests.cs
+++ b/tests/IntegrationTests/Persistence/OrchestratedOutgoingEmailStoreTests.cs
@@ -8,6 +8,7 @@ using MailFathom.Application.Mail.Delivery;
 using MailFathom.Application.Mail.Delivery.Outbox;
 using MailFathom.Application.Persistence;
 using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
@@ -106,6 +107,44 @@ public sealed class OrchestratedOutgoingEmailStoreTests(MailFathomOrchestrationF
             "The stored outgoing message is not the one the first enqueue wrote.");
         Assert.Null(storedContent.FindIntegrityDefect());
         Assert.Equal(firstMime.Length, retried.MimeByteLength);
+    }
+
+    /// <summary>
+    /// A recipient addressed by naming somebody keeps both facts on the record: the address the send was offered to, and
+    /// the contact it was resolved from. The pair is what makes a send answerable after the book has moved on, and only a
+    /// real column can establish that it round-trips.
+    /// </summary>
+    [Fact]
+    public async Task EnqueueAsync_RecipientResolvedFromAContact_ReadsBackTheAddressAndTheContact()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var services = await OrchestratedMailFathomServices.StartAsync(orchestration, cancellationToken);
+        var contact = ContactId.Create(Guid.CreateVersion7());
+        var request = OutgoingEmailRequest.Create(
+            Account,
+            OutgoingEmailRequester.Command("outbox-contact-recipient"),
+            [
+                RecipientOf("dana@example.test", contact),
+                RecipientOf("erik@example.test"),
+            ]);
+
+        // Act
+        await services.InScopeAsync(
+            (scope, token) => scope.GetRequiredService<MailOutbox>()
+                .EnqueueAsync(request, MimeOf("contact-recipient"), token),
+            cancellationToken);
+
+        // Assert
+        var record = Assert.Single(await ReadOutstandingAsync(services, request, cancellationToken));
+
+        Assert.Equal(
+            [contact, null],
+            record.Recipients.Select(outcome => outcome.Recipient.Contact));
+
+        Assert.Equal(
+            ["dana@example.test", "erik@example.test"],
+            record.Recipients.Select(outcome => outcome.Recipient.Address.Address));
     }
 
     /// <summary>
@@ -361,11 +400,11 @@ public sealed class OrchestratedOutgoingEmailStoreTests(MailFathomOrchestrationF
             OutgoingEmailRequester.Command(invocationIdentity),
             [.. addresses.Select(address => RecipientOf(address))]);
 
-    private static OutgoingRecipient RecipientOf(string address)
+    private static OutgoingRecipient RecipientOf(string address, ContactId? contact = null)
     {
         Assert.True(EmailAddress.TryCreate(displayName: null, address, out var emailAddress));
 
-        return OutgoingRecipient.Create(emailAddress, OutgoingRecipientRole.To);
+        return OutgoingRecipient.Create(emailAddress, OutgoingRecipientRole.To, contact);
     }
 
     /// <summary>Builds a synthetic outgoing message whose bytes differ per scenario.</summary>


### PR DESCRIPTION
## What this changes

An author may now address a message by naming somebody the contact book holds rather than by writing an address, and
`NamedRecipientResolver` (`src/Application/Mail/Delivery/Addressing/`) is the single place a contact becomes a recipient.
It sits between authoring and composition on the way to the outgoing record, which is what keeps the book a convenience
of addressing rather than a second route out of the deployment: what it produces is an ordinary address, so every bound,
refusal, and check a written-down address meets, a resolved one meets as well.

- **Naming.** A contact is named by the identity the book gave it or by the whole name the owner recorded, and a name
  addresses a message only where exactly one contact carries it. The name is compared on the book's own comparison form,
  so casing is immaterial, and it is the whole name rather than part of one — the contained match a search performs is
  not somebody being named.
- **Refusals.** Nothing ranks, guesses, or picks a best match. A name several contacts carry is refused as ambiguous
  naming *how many* matched and nothing about any of them; a contact the book does not hold is refused as unknown, for an
  identity and a name alike. One unresolved recipient refuses the whole message rather than sending to the rest.
- **Which address.** The owner's preferred one, unless the authored act names another address of that same contact — and
  one they do not hold is refused rather than sent to and rather than silently replaced by the preferred one, which is
  what stops naming a contact reaching a mailbox alongside them. Text naming no mailbox takes the same refusal. The value
  that reaches the message is the book's own spelling; the name written beside it is the name the owner recorded.
- **The record keeps both facts.** `outgoing_email_recipients` gains a nullable `ContactId` beside the address, so what
  was sent stays answerable after the contact is amended, promoted, or erased.
- **The reply and forward path goes through it too.** `AuthoredResponseRequest.Recipients` is now a list of
  `NamedRecipient`, and `StoredEmailResponseAuthoring` resolves what the author added before anything is composed.
  Whoever the act itself derives is already an address, read out of the stored copy's own headers.

New failure identities, in the composition subcategory: `28013` contact unknown, `28014` name ambiguous (carries the
count), `28015` address the contact does not hold.

## Breaking changes

- **Database schema (additive).** Migration `AddOutgoingRecipientContact` adds one nullable `uuid` column,
  `outgoing_email_recipients.ContactId`. No backfill, no rewrite, no destructive statement; the reviewed SQL is
  `ALTER TABLE outgoing_email_recipients ADD "ContactId" uuid;`. **Operator action: none beyond applying the release's
  schema artifact as usual.** Deployable over the previous release's data.
- No configuration key, MCP tool contract, or deployment contract changes. `AuthoredResponseRequest.Recipients` changes
  shape, which is an internal application contract with no boundary above it yet.

## Decisions worth a reviewer's attention

- **The resolution asks for no permission of its own.** `AccessAuthorization.RequirePermission` admits only a *caller*,
  and the process identity that runs a rule holds no grant at all, so demanding `MailContactsRead` inside the resolver
  would refuse a rule addressing a contact rather than authorize anything. Whether a caller may name people out of the
  book is therefore the boundary's question, asked where the caller is known and beside the grant that lets it send. #768
  is where the sending tools decide it.
- **The book's display name is written into the header.** That is the point of addressing somebody by name — the message
  reads as one to a person — and it is the same thing a mail client does with its own address book, but it does mean the
  owner's own name for a third party reaches the other recipients of that message. Flagging it as a deliberate choice
  rather than an oversight.
- **The book is read per way a message names people, not per person.** `IContactDirectory` answers a set of identities
  (`FindAllAsync`) and a set of names (`MatchDisplayNamesAsync`), the latter in two statements whatever the set holds: one
  groups the carriers per comparison form and counts them, one loads the contacts of the names exactly one person carries.
  Both are read in groups of `ContactQuery.MaximumPageSize`, which is where the ceiling on a single query's parameter
  lives — so one read per naming category, and a second of that category only past two hundred distinct people. Both
  categories are drawn from one recipient list bounded below twice that, so only one of them can ever need its second
  read: three reads for the longest recipient list an outgoing record can hold, against 256 before.
- **The count in an ambiguity refusal is exact and comes from the database**, so a name a hundred collected contacts
  share costs one number rather than a hundred records, and the addresses of the people it counted are never read.
- **A unique name's verdict comes from the read that produced the contact**, not from the count alone. Two carriers refuse
  as ambiguous with the number that read saw, none resolves to nobody — the renamed-or-erased case — so a namesake
  committed between the two statements cannot turn an ambiguous name into an arbitrary one of two people. That is the
  concurrency property, argued at `ContactDirectory.MatchOf`; nothing unit-tests it, because the interleaving is between
  two statements inside one method.
- **The input count is bounded before the first lookup**, at `OutgoingEmailRequest.MaximumRecipientCount`, because the
  reads carry what the caller supplied. A longer list describes a send that could not be written down whatever the book
  answered, so it raises rather than refuses; the deployment's own smaller recipient bound stays the composition's to
  apply.

## What is not in this change, and why

The acceptance list has two items that name artifacts this repository does not yet have, and neither was cut for
convenience:

- **"A test proves a contact cannot reach an address the policy refuses."** The recipient policy and the ceilings are
  #740, which is open, so there is no policy to refuse anything yet. What is proven instead is the property the policy
  will inherit: resolution happens strictly before the record is created, and a contact-resolved address is refused by
  the composition's existing rules exactly as a written-down one is
  (`MimeKitAuthoredEmailComposerTests.Compose_ContactResolvedAddressTheServerCannotCarry_IsRefusedLikeAnyOther`), and a
  contact and a typed address naming one mailbox become one offer. #740's own policy test should cover the resolved-address
  case when it lands.
- **"Where the MCP surface exposes it, the sending tools accept a contact identity."** No sending tool exists — that is
  #768 — so the clause's own condition is unmet. `NamedRecipient` is the shape those tools will map onto.

## Verification

- `scripts/verify-full.sh` — pass (9199 unit tests, 228 agent-workflow contract assertions, coverage gate).
- `scripts/verify-fast.sh` — pass.
- The migration was generated and reviewed as SQL via `scripts/script-migration.sh`. It was **not** applied against a
  live local database: that occupies a shared Docker orchestration this machine's other sessions are using, and the
  pull-request `Pending model changes` job is what gates model-and-snapshot agreement.
- Integration coverage added for the two things only PostgreSQL settles: the contact round-tripping on the recipient row
  (`OrchestratedOutgoingEmailStoreTests`) and the name lookup answering with one person or an exact count
  (`OrchestratedContactBookTests`). The suite runs only when asked, so neither has been executed here.

## Documentation

`docs/features/mail-delivery.md` gains a section for addressing by contact and the tests paragraph;
`docs/features/contacts.md` gains the third lookup and the reader that is not a surface;
`docs/architecture/stored-email-schema.md` records the column, the absent foreign key, and what the identifier is under
the privacy rules.

Closes #755
