### PR TITLE
[#970] Prepare a Compose deployment to evaluate with, from one guided script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ MailFathom synchronizes your IMAP accounts into a PostgreSQL database you run, i
 ```bash
 git clone https://github.com/Krzysztof318/MailFathom.git
 cd MailFathom
+scripts/quick-start-compose.sh
 ```
+
+That third line is the quick way to *try* it and not the way to run it: [the script](https://github.com/Krzysztof318/MailFathom/blob/main/scripts/quick-start-compose.sh) asks where your mailbox lives, generates the credentials, writes the configuration, starts the stack, offers the schema step, and hands you the address a chat client connects to — and what it prepares serves that one machine over plain HTTP, keeps its credentials in files under the checkout, and backs nothing up. It prints that list when it finishes. [Trying it first, with one command](https://krzysztof318.github.io/MailFathom/operations/deployment-compose.html#trying-it-first-with-one-command) is the whole of what it does and does not decide. Leave it out to install by hand, which is what the rest of this section describes.
 
 From there, [installing MailFathom](https://krzysztof318.github.io/MailFathom/users/installation.html) covers what every shape needs — Linux, PostgreSQL with the `vector` extension, an IMAP account, an explicit schema step — and routes you to the guide for Compose, [Podman Quadlet](https://krzysztof318.github.io/MailFathom/operations/deployment-quadlet.html), Kubernetes, or a native systemd process. [Getting started](https://krzysztof318.github.io/MailFathom/users/getting-started.html) then walks from an installed instance to a first successful tool call: provisioning the secrets, configuring a mailbox, applying the schema, verifying health, enabling the MCP endpoint, and connecting a client.
 

--- a/docs/operations/deployment-compose.md
+++ b/docs/operations/deployment-compose.md
@@ -1,6 +1,6 @@
 # Deploying with Docker Compose
 
-<!-- describes: deploy/compose/** -->
+<!-- describes: deploy/compose/**, scripts/quick-start-compose.sh -->
 
 `deploy/compose/` is the supported Compose deployment: MailFathom and PostgreSQL, with the schema applied as an explicit
 operator action that nothing in the deployment performs. It is the shape to use for self-hosting on one machine.
@@ -19,6 +19,42 @@ knowing before you start, because neither announces itself:
 - Rootless Podman publishes no port below 1024 until `net.ipv4.ip_unprivileged_port_start` allows it. This deployment
   publishes 8080 and 8081, so what meets that limit is a reverse proxy terminating TLS on 443 in front of MailFathom
   rather than MailFathom itself.
+
+## Trying it first, with one command
+
+`scripts/quick-start-compose.sh` performs everything on this page that is typed rather than decided: it asks where the
+mailbox lives, generates the credentials, writes the configuration, sets the modes, starts the stack, offers the schema
+step, and reports the two probes.
+
+```bash
+scripts/quick-start-compose.sh
+```
+
+**It prepares a deployment to evaluate MailFathom with, and that is not the recommended way to run one.** What it
+produces serves this machine over plain HTTP, keeps its credentials in files under the checkout, narrows no grant, and
+backs nothing up — enough to find out what the product does, and less than a deployment anybody depends on should have.
+It prints that list when it finishes, and [installing MailFathom](../users/installation.md) is where the shape of a real
+installation is chosen. The rest of this page is that path, and it stays the one this deployment is documented by: the
+script writes the same files with the same values, so a deployment it prepared is read, changed, and upgraded exactly as
+one prepared by hand.
+
+Four things it will not decide for you, because each is a decision rather than a step:
+
+- **It publishes nothing beyond loopback**, and offers no answer that would.
+- **It configures no chat or embedding model**, so `ask_mail` is absent from what it prepares.
+- **It applies the schema only to an empty database**, after asking, and against a database that already carries
+  migrations it stops and hands the step back — that is an upgrade, and an upgrade takes a backup first.
+- **It overwrites nothing.** An existing `.env`, configuration file, or secret stops the run naming the file, so it
+  cannot replace the credentials of a deployment already prepared here.
+
+The two answers it does ask for are the ones with a cost worth stating before they are given. The MCP endpoint takes a
+generated API key unless you ask for none, which is legal, announced with a startup warning, and the only shape the
+chat clients with no field for a static header can connect to. The administrative endpoint is off unless you ask for it,
+and enabling it publishes port 8090 through a generated `compose.override.yaml` — its own default port is 8080, which is
+the socket the MCP endpoint is already served on, and `compose.yaml` publishes nothing for it.
+
+`--non-interactive` takes every answer as an argument instead, with `--password-file` for the credential, and
+`--no-start` writes the files and stops. `scripts/quick-start-compose.sh --help` lists all of them.
 
 ## Before the first start
 

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -8,6 +8,12 @@ from [installing MailFathom](installation.md); a developer evaluating from the c
 [Aspire orchestration](../operations/local-development.md#running-locally-with-aspire) instead, which provisions
 PostgreSQL and applies the schema on its own.
 
+**Somebody evaluating MailFathom on the Compose shape can have steps 1 to 6 performed for them.**
+`scripts/quick-start-compose.sh` asks the same questions this page does, writes the same values, and ends by printing
+the two a client needs in step 7 — [trying it first, with one
+command](../operations/deployment-compose.md#trying-it-first-with-one-command) is that path, including what a deployment
+it prepares is missing before anybody depends on it. Read this page anyway, for what each answer means.
+
 The examples write configuration as JSON. Every setting can arrive as an environment variable instead — `:` becomes
 `__`, so `MailSynchronization:Enabled` is `MailSynchronization__Enabled` — and the
 [configuration reference](../operations/configuration-reference.md) maps every key used below to the page that

--- a/docs/users/installation.md
+++ b/docs/users/installation.md
@@ -38,6 +38,13 @@ git clone https://github.com/Krzysztof318/MailFathom.git
 cd MailFathom
 ```
 
+**To try MailFathom before choosing any of this, `scripts/quick-start-compose.sh` prepares the Compose shape for you** —
+it asks where the mailbox lives and performs every step
+[deploying with Docker Compose](../operations/deployment-compose.md#trying-it-first-with-one-command) otherwise asks you
+to type. What it produces is a deployment to evaluate with rather than one to depend on: it serves the machine it runs
+on over plain HTTP, keeps its credentials in files under the checkout, and backs nothing up. The choice below is the one
+it does not make for you, and it stays yours to make afterwards.
+
 ## Choosing a shape
 
 | Shape | Choose it when | Guide |

--- a/scripts/quick-start-compose.sh
+++ b/scripts/quick-start-compose.sh
@@ -1,0 +1,771 @@
+#!/usr/bin/env bash
+# Copyright © 2026 Krzysztof Kasprowicz
+# Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+# Project repository: https://github.com/Krzysztof318/MailFathom
+
+set -euo pipefail
+
+### Prepares a Docker Compose deployment to evaluate MailFathom with, asking for the mailbox it is to synchronize.
+#
+# Usage:
+#   scripts/quick-start-compose.sh
+#   scripts/quick-start-compose.sh --provider fastmail --user-name you@fastmail.com \
+#     --display-name 'Personal mail' --password-file /path/to/password --non-interactive
+#
+# **This is the fastest way to try MailFathom, and it is not the recommended way to run it.** What it produces is a
+# deployment on one machine, reachable from that machine alone, with its credentials in files under this checkout and
+# no TLS, no backup, and no narrowed grant — which is the right shape for finding out what the product does and the
+# wrong shape for a deployment anybody depends on. docs/users/installation.md is where that decision is made, and the
+# four shapes it routes to are what a real installation is built from; this script decides none of it for you.
+#
+# What it performs is what docs/operations/deployment-compose.md documents by hand, in that order and with nothing
+# added: the three files that have to exist, the directory and file modes the container's own account needs, the
+# database, the schema step, and the two probes. Every value it writes is one the manual path writes too, so what it
+# produces is an ordinary Compose deployment rather than a second shape of one — every setting stays editable, and
+# what makes it an evaluation is what nobody has configured yet rather than anything it did.
+#
+# Two of those steps are why this exists rather than a shorter page. A mode left at the clone's umask reaches startup
+# as material that could not be found, because MailFathom collapses every file-system failure into one result so that
+# no diagnostic quotes the path it was handed — so the modes are set here rather than asked for. And the schema step is
+# separate on purpose: a deployment that skips it starts and refuses to serve, naming a migration rather than the step
+# that applies it.
+#
+# What it will not do is decide anything the deployment's own defaults decide. It publishes no port on an address other
+# than loopback, enables no scanner, configures no model, and turns no authentication off that was not asked for by
+# name. The one place it writes outside deploy/compose/ is nowhere: every file it creates is under that directory, and
+# it creates none of them until every question has been answered.
+#
+# It reads a checkout, so unlike scripts/install-mfctl.sh it is not fetched over HTTP and run — `git clone` comes
+# first, and the file is here to be read before it is run.
+
+readonly repository='Krzysztof318/MailFathom'
+readonly release_base="https://github.com/$repository/releases"
+readonly documentation_base='https://krzysztof318.github.io/MailFathom'
+
+# The administrative endpoint's own default port is 8080, which is the socket the MCP endpoint is already served on, and
+# compose.yaml publishes nothing for it. So enabling it here means stating a port of its own and publishing that one —
+# see the note on the missing mapping in compose.yaml.
+readonly admin_port='8090'
+
+usage() {
+  cat << 'TEXT'
+Prepares a MailFathom Docker Compose deployment to evaluate, and starts it.
+
+The fastest way to try MailFathom on one machine. Not the recommended way to run one: what it
+prepares has no TLS, no backup, and credentials in files under this checkout.
+
+  --provider <name>        gmail, fastmail, icloud, yahoo, zoho, or custom. Decides the address.
+  --host <host>            The IMAP host, for a custom provider.
+  --port <port>            The IMAP port, for a custom provider. Defaults to 993.
+  --user-name <address>    What the mailbox authenticates as.
+  --display-name <name>    What an assistant calls this mailbox. Required, and never an identifier.
+  --account-id <id>        The name every tool argument and log line uses. Defaults to 'primary'.
+  --password-file <path>   Where to read the mailbox password from, instead of asking for it.
+  --mcp-authentication <api-key|none>
+                           Whether the MCP endpoint requires a generated key. Defaults to api-key.
+  --admin-endpoint <off|api-key|none>
+                           Whether the administrative endpoint is served, and how. Defaults to off.
+  --version <version>      The release to deploy, for example 0.6.0. Defaults to the newest.
+  --no-start               Write the files and stop, without starting anything or applying a schema.
+  --non-interactive        Ask nothing. Every answer above has to be given, and the schema is not applied.
+  --help                   Print this and exit.
+
+The mailbox password is read without echo and written straight to its file, so it reaches neither the
+shell history nor the process list. --password-file is the same thing for an unattended run.
+
+Nothing is overwritten. An existing .env, configuration file, or secret stops the run naming the file.
+TEXT
+}
+
+provider=''
+imap_host=''
+imap_port=''
+user_name=''
+display_name=''
+account_id='primary'
+password_file=''
+mcp_authentication='api-key'
+admin_endpoint='off'
+requested_version=''
+start_stack='yes'
+interactive='yes'
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --provider | --host | --port | --user-name | --display-name | --account-id | --password-file | \
+      --mcp-authentication | --admin-endpoint | --version)
+      [[ $# -ge 2 ]] || { printf '%s takes a value.\n' "$1" >&2; exit 1; }
+      case "$1" in
+        --provider) provider="$2" ;;
+        --host) imap_host="$2" ;;
+        --port) imap_port="$2" ;;
+        --user-name) user_name="$2" ;;
+        --display-name) display_name="$2" ;;
+        --account-id) account_id="$2" ;;
+        --password-file) password_file="$2" ;;
+        --mcp-authentication) mcp_authentication="$2" ;;
+        --admin-endpoint) admin_endpoint="$2" ;;
+        --version) requested_version="$2" ;;
+      esac
+      shift 2
+      ;;
+    --no-start) start_stack='no'; shift ;;
+    --non-interactive) interactive='no'; shift ;;
+    --help | -h) usage; exit 0 ;;
+    *)
+      printf 'Unrecognized argument: %s\n\n' "$1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Resolved against the caller's own directory, because everything below runs from deploy/compose and a relative path
+# would otherwise name a file there instead of the one they meant.
+if [[ -n "$password_file" && "$password_file" != /* ]]; then
+  password_file="$PWD/$password_file"
+fi
+
+if ! repository_root="$(git rev-parse --show-toplevel 2> /dev/null)"; then
+  printf 'quick-start-compose.sh runs from a checkout of %s, and this is not one.\n' "$repository" >&2
+  printf 'Clone it first: git clone https://github.com/%s.git\n' "$repository" >&2
+  exit 1
+fi
+
+readonly compose_directory="$repository_root/deploy/compose"
+if [[ ! -f "$compose_directory/compose.yaml" ]]; then
+  printf 'This checkout has no %s, so there is no Compose deployment to prepare.\n' 'deploy/compose/compose.yaml' >&2
+  exit 1
+fi
+
+cd "$compose_directory"
+
+for required_command in openssl curl; do
+  if ! command -v "$required_command" > /dev/null 2>&1; then
+    printf 'This script needs %s and it is not on the PATH.\n' "$required_command" >&2
+    exit 1
+  fi
+done
+
+if [[ "$start_stack" == 'yes' ]] && ! docker compose version > /dev/null 2>&1; then
+  printf 'This script needs Docker Compose v2 (`docker compose`) to start the deployment.\n' >&2
+  printf 'Install it, or pass --no-start to write the files and start the stack yourself.\n' >&2
+  exit 1
+fi
+
+# Every question is answered before anything is written, so a refusal here leaves the directory as it was found. An
+# existing file is a deployment somebody already prepared, and replacing its credentials silently is the one failure
+# this script must not have.
+refuse_existing() {
+  local existing_path="$1"
+
+  if [[ -e "$existing_path" ]]; then
+    printf 'deploy/compose/%s already exists, so this checkout already carries a prepared deployment.\n' \
+      "$existing_path" >&2
+    printf 'Remove it deliberately, or read %s/operations/deployment-compose.html to change it in place.\n' \
+      "$documentation_base" >&2
+    exit 1
+  fi
+}
+
+refuse_existing '.env'
+refuse_existing 'config/10-mailfathom.json'
+refuse_existing 'secrets/postgres-superuser-password'
+refuse_existing 'secrets/mailfathom-database-password'
+
+if [[ "$interactive" == 'yes' && ! -r /dev/tty ]]; then
+  printf 'There is no terminal to ask on. Pass --non-interactive with every answer, and --password-file for\n' >&2
+  printf 'the credential: scripts/quick-start-compose.sh --help\n' >&2
+  exit 1
+fi
+
+ask() {
+  local prompt="$1"
+  local default_value="${2:-}"
+  local answer=''
+
+  if [[ "$interactive" != 'yes' ]]; then
+    printf '%s\n' "$default_value"
+    return 0
+  fi
+
+  if [[ -n "$default_value" ]]; then
+    read -r -p "$prompt [$default_value]: " answer < /dev/tty
+  else
+    read -r -p "$prompt: " answer < /dev/tty
+  fi
+
+  printf '%s\n' "${answer:-$default_value}"
+}
+
+confirm() {
+  local prompt="$1"
+  local answer=''
+
+  [[ "$interactive" == 'yes' ]] || return 1
+
+  read -r -p "$prompt [y/N]: " answer < /dev/tty
+  [[ "$answer" == 'y' || "$answer" == 'Y' ]]
+}
+
+require_answer() {
+  local value="$1"
+  local what="$2"
+  local argument="$3"
+
+  if [[ -z "$value" ]]; then
+    printf 'No %s was given. Pass %s, or run without --non-interactive to be asked for it.\n' \
+      "$what" "$argument" >&2
+    exit 1
+  fi
+}
+
+# The addresses come from docs/users/mailbox-providers.md, which is where they are reviewed and dated. Three services
+# are refused rather than configured: a mailbox that accepts no password cannot be prepared by a script that asks for
+# one, and a configuration written anyway would fail at the first synchronization with an authentication error that
+# says nothing about why.
+resolve_provider() {
+  case "$provider" in
+    gmail) imap_host='imap.gmail.com'; imap_port="${imap_port:-993}" ;;
+    fastmail) imap_host='imap.fastmail.com'; imap_port="${imap_port:-993}" ;;
+    icloud) imap_host='imap.mail.me.com'; imap_port="${imap_port:-993}" ;;
+    yahoo) imap_host='imap.mail.yahoo.com'; imap_port="${imap_port:-993}" ;;
+    zoho) imap_host='imap.zoho.com'; imap_port="${imap_port:-993}" ;;
+    custom)
+      require_answer "$imap_host" 'IMAP host' '--host'
+      imap_port="${imap_port:-993}"
+      ;;
+    google-workspace | outlook | exchange | microsoft365)
+      local service_name
+      case "$provider" in
+        google-workspace) service_name='A Google Workspace' ;;
+        outlook) service_name='An Outlook.com' ;;
+        exchange) service_name='An Exchange Online' ;;
+        microsoft365) service_name='A Microsoft 365' ;;
+      esac
+
+      printf '%s mailbox accepts no password, so this script cannot prepare it.\n' "$service_name" >&2
+      printf 'It authenticates with an OAuth refresh token, obtained first: %s/operations/mailbox-oauth.html\n' \
+        "$documentation_base" >&2
+      exit 1
+      ;;
+    proton)
+      printf 'Proton Mail is reached through the local bridge, which listens on the host rather than in a\n' >&2
+      printf 'container and does not speak TLS on connect, so it needs a transport and a network this script\n' >&2
+      printf 'does not write. Configure it by hand: %s/users/mailbox-providers.html\n' "$documentation_base" >&2
+      exit 1
+      ;;
+    *)
+      printf 'Unknown provider: %s\n' "$provider" >&2
+      printf 'Choose gmail, fastmail, icloud, yahoo, zoho, or custom. Every service and what it accepts is at\n' >&2
+      printf '%s/users/mailbox-providers.html\n' "$documentation_base" >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [[ "$interactive" == 'yes' ]]; then
+  cat << TEXT
+
+MailFathom quick start, for the Docker Compose deployment.
+
+This is the fastest way to try MailFathom, and it is not the recommended way to run one. What it
+prepares serves this machine over plain HTTP, keeps its credentials in files under this checkout, and
+backs nothing up — enough to find out what the product does, and less than a deployment anybody
+depends on should have. What that costs, and where to go instead, is printed at the end.
+
+It prepares deploy/compose/ in this checkout: the credentials, the configuration, and the database.
+It writes nothing until every question below is answered, and nothing outside that directory ever.
+
+Where your mailbox lives decides its address and whether a password is accepted at all —
+$documentation_base/users/mailbox-providers.html has every service.
+
+TEXT
+
+  [[ -n "$provider" ]] || provider="$(ask 'Provider (gmail, fastmail, icloud, yahoo, zoho, custom)' 'custom')"
+fi
+
+require_answer "$provider" 'provider' '--provider'
+
+if [[ "$provider" == 'custom' && -z "$imap_host" && "$interactive" == 'yes' ]]; then
+  imap_host="$(ask 'IMAP host')"
+  imap_port="$(ask 'IMAP port' '993')"
+fi
+
+resolve_provider
+
+if [[ ! "$imap_port" =~ ^[0-9]+$ ]] || ((imap_port < 1 || imap_port > 65535)); then
+  printf 'Not a port number: %s\n' "$imap_port" >&2
+  exit 1
+fi
+
+if [[ "$interactive" == 'yes' ]]; then
+  [[ -n "$user_name" ]] || user_name="$(ask 'Mailbox user name, usually the address')"
+  [[ -n "$display_name" ]] || display_name="$(ask 'What an assistant should call this mailbox' 'Personal mail')"
+fi
+
+require_answer "$user_name" 'mailbox user name' '--user-name'
+require_answer "$display_name" 'display name' '--display-name'
+
+# `AccountId` and every alias are names the operator chooses and every tool argument, log line, and error message then
+# uses, so the characters are held to what reads back unambiguously in all three.
+if [[ ! "$account_id" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  printf 'An account identifier holds letters, digits, dots, hyphens, and underscores: %s\n' "$account_id" >&2
+  exit 1
+fi
+
+case "$mcp_authentication" in
+  api-key | none) ;;
+  *) printf 'The MCP endpoint takes api-key or none, not %s.\n' "$mcp_authentication" >&2; exit 1 ;;
+esac
+
+case "$admin_endpoint" in
+  off | api-key | none) ;;
+  *) printf 'The administrative endpoint takes off, api-key, or none, not %s.\n' "$admin_endpoint" >&2; exit 1 ;;
+esac
+
+if [[ "$interactive" == 'yes' ]]; then
+  cat << TEXT
+
+The MCP endpoint is what a chat client connects to. It is served over plain HTTP on 127.0.0.1 either
+way — MailFathom terminates no TLS of its own — so what this decides is whether a client also has to
+present a key.
+
+  api-key  A key is generated and the client sends it as a bearer credential. Two popular chat
+           clients offer no field for one, and cannot connect to an endpoint configured this way.
+  none     Anything that can reach 127.0.0.1:8080 reads your mail. Legal, announced with a startup
+           warning, and reasonable only because the port is published on loopback alone.
+
+TEXT
+
+  if [[ "$mcp_authentication" == 'api-key' ]] && confirm 'Serve the MCP endpoint without authentication?'; then
+    mcp_authentication='none'
+  fi
+
+  cat << TEXT
+
+The administrative endpoint is what mfctl talks to: synchronization state, what was changed, what a
+question read, and the operations that store a credential or erase a folder. It is off unless you ask
+for it, and it is served on its own port ($admin_port), also on 127.0.0.1 and also over plain HTTP.
+
+An entry that writes no grant reaches every administrative operation, so a key here is as sensitive
+as the mail it can dispose of.
+
+TEXT
+
+  if [[ "$admin_endpoint" == 'off' ]] && confirm 'Serve the administrative endpoint as well?'; then
+    admin_endpoint='api-key'
+
+    if confirm 'Without authentication? Anything that reaches the port can then administer the service'; then
+      admin_endpoint='none'
+    fi
+  fi
+fi
+
+mailbox_password=''
+if [[ -n "$password_file" ]]; then
+  if [[ ! -r "$password_file" ]]; then
+    printf 'No readable file at %s.\n' "$password_file" >&2
+    exit 1
+  fi
+
+  # One trailing newline is stripped, because a file written by an editor almost always ends with one and an untrimmed
+  # byte becomes part of the password. This is the rule MailFathom's own secret resolution applies, and the sentinel is
+  # what keeps it to exactly one.
+  mailbox_password="$(cat -- "$password_file"; printf 'x')"
+  mailbox_password="${mailbox_password%x}"
+  mailbox_password="${mailbox_password%$'\n'}"
+elif [[ "$interactive" == 'yes' ]]; then
+  printf '\nThe password or app password for %s.\n' "$user_name" >&2
+  printf 'It is not echoed, and it is written straight to a file rather than to a command line.\n' >&2
+  read -r -s -p 'Mailbox password: ' mailbox_password < /dev/tty
+  printf '\n' >&2
+else
+  printf 'No mailbox password. Pass --password-file, or run without --non-interactive to be asked for it.\n' >&2
+  exit 1
+fi
+
+if [[ -z "$mailbox_password" ]]; then
+  printf 'The mailbox password is empty.\n' >&2
+  exit 1
+fi
+
+# The redirect `/releases/latest` serves is what names the newest release, rather than the REST API, which answers the
+# same question and rate-limits an unauthenticated caller by IP address while doing it.
+if [[ -z "$requested_version" ]]; then
+  if ! latest_url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$release_base/latest")"; then
+    printf 'Could not ask %s which release is newest. Pass --version to deploy a particular one.\n' \
+      "$release_base/latest" >&2
+    exit 1
+  fi
+
+  requested_version="${latest_url##*/tag/}"
+fi
+
+version="${requested_version#v}"
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+  printf 'Not a release version: %s. It looks like 0.6.0, and %s lists the ones there are.\n' \
+    "$requested_version" "$release_base" >&2
+  exit 1
+fi
+
+# json_string below runs inside a command substitution, and an exit there is the substitution's rather than the script's,
+# so a value carrying a control character would reach the file as broken JSON instead of stopping the run. The check
+# therefore happens here, where it stops it.
+for written_value in "$account_id" "$display_name" "$imap_host" "$user_name"; do
+  if [[ "$written_value" == *[$'\x01'-$'\x1f']* ]]; then
+    printf 'A control character cannot be part of a value written into the configuration: %s\n' "$written_value" >&2
+    exit 1
+  fi
+done
+
+readonly imap_password_name="imap-$account_id-password"
+readonly mcp_key_name='mcp-workstation-key'
+readonly admin_key_name='admin-workstation-key'
+readonly schema_asset="mailfathom-schema-$version.sql"
+
+# Written into JSON as a string. Only these two characters can end a string early or start an escape, and a control
+# character is refused rather than encoded, because a name carrying one is a mistake in every case that reaches here.
+json_string() {
+  local value="$1"
+
+  if [[ "$value" == *[$'\x01'-$'\x1f']* ]]; then
+    printf 'A control character cannot be part of %s.\n' "$value" >&2
+    exit 1
+  fi
+
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '"%s"' "$value"
+}
+
+write_secret() {
+  local secret_path="$1"
+  local material="$2"
+
+  printf '%s' "$material" > "$secret_path"
+  chmod 444 "$secret_path"
+}
+
+refuse_existing "secrets/mailfathom/$imap_password_name"
+[[ "$mcp_authentication" != 'api-key' ]] || refuse_existing "secrets/mailfathom/$mcp_key_name"
+[[ "$admin_endpoint" != 'api-key' ]] || refuse_existing "secrets/mailfathom/$admin_key_name"
+[[ "$admin_endpoint" == 'off' ]] || refuse_existing 'compose.override.yaml'
+
+printf '\nPreparing deploy/compose for MailFathom %s.\n' "$version" >&2
+
+mkdir -p secrets/mailfathom config
+
+# What is mounted has to be reachable by the container's own account; what is not mounted is what restricts access.
+# MailFathom runs as an unprivileged account that is nobody's host user and holds no capability to override a mode
+# with, and Compose bind-mounts with the host's own permissions rather than applying `mode`. Git records no directory
+# mode either, so config/ arrives with whatever umask the clone ran under.
+chmod 700 secrets
+chmod 711 secrets/mailfathom
+chmod 755 config
+
+write_secret 'secrets/postgres-superuser-password' "$(openssl rand -base64 33 | tr -d '\n')"
+write_secret 'secrets/mailfathom-database-password' "$(openssl rand -base64 33 | tr -d '\n')"
+write_secret "secrets/mailfathom/$imap_password_name" "$mailbox_password"
+
+mcp_authentication_block='[]'
+if [[ "$mcp_authentication" == 'api-key' ]]; then
+  write_secret "secrets/mailfathom/$mcp_key_name" "$(openssl rand -base64 33 | tr -d '\n')"
+  mcp_authentication_block=$(
+    cat << JSON
+[
+      {
+        "ApiKey": {
+          "Name": "workstation",
+          "SecretReference": "file:/etc/mailfathom/secrets/$mcp_key_name",
+          "Lifetime": "NoLimit"
+        }
+      }
+    ]
+JSON
+  )
+fi
+
+admin_section=''
+if [[ "$admin_endpoint" != 'off' ]]; then
+  admin_authentication_block='[]'
+
+  if [[ "$admin_endpoint" == 'api-key' ]]; then
+    write_secret "secrets/mailfathom/$admin_key_name" "$(openssl rand -base64 33 | tr -d '\n')"
+    admin_authentication_block=$(
+      cat << JSON
+[
+      {
+        "ApiKey": {
+          "Name": "workstation",
+          "SecretReference": "file:/etc/mailfathom/secrets/$admin_key_name",
+          "Lifetime": "NoLimit"
+        }
+      }
+    ]
+JSON
+    )
+  fi
+
+  # The port is stated here and published in compose.override.yaml below. The bind address is left at its default,
+  # which is every address inside the container — that is what makes the published mapping reach it, and the mapping is
+  # what restricts the endpoint to this machine.
+  admin_section=$(
+    cat << JSON
+  "AdminEndpoint": {
+    "Enabled": true,
+    "Port": $admin_port,
+    "Authentication": $admin_authentication_block
+  },
+JSON
+  )
+fi
+
+cat > config/10-mailfathom.json << JSON
+// Written by scripts/quick-start-compose.sh. It is ordinary configuration from here on: edit it, review it as a diff,
+// and restart the deployment to apply a change. See $documentation_base/operations/configuration-reference.html
+//
+// Nothing here is a secret. Every credential is a reference to a file under ./secrets/mailfathom/, which compose.yaml
+// mounts read-only at /etc/mailfathom/secrets.
+{
+  "MailSynchronization": {
+    "Enabled": true,
+    "Interval": "00:05:00",
+    "Accounts": [
+      {
+        "AccountId": $(json_string "$account_id"),
+        "DisplayName": $(json_string "$display_name"),
+        "Host": $(json_string "$imap_host"),
+        "Port": $imap_port,
+        "UserName": $(json_string "$user_name"),
+        "Secrets": {
+          "Password": {
+            "Name": $(json_string "$imap_password_name"),
+            "SecretReference": $(json_string "file:/etc/mailfathom/secrets/$imap_password_name")
+          }
+        },
+        "TransportSecurity": {
+          "ConnectionSecurity": "TlsOnConnect"
+        },
+        "Folders": [
+          { "Alias": "inbox", "SpecialUse": "Inbox" },
+          { "Alias": "sent", "SpecialUse": "Sent" }
+        ]
+      }
+    ]
+  },
+$admin_section
+  "McpEndpoint": {
+    "Enabled": true,
+    "Authentication": $mcp_authentication_block,
+    "Cors": {
+      "AllowedOrigins": []
+    }
+  }
+}
+JSON
+
+chmod 644 config/10-mailfathom.json
+
+cat > .env << ENV
+# Written by scripts/quick-start-compose.sh. .env.example documents every other value this file can carry.
+#
+# The image is pinned to a release rather than tracking a moving tag: an immutable tag is what makes a deployment
+# reproducible and an upgrade a decision. The pull policy below pairs with it, so Compose pulls this image instead of
+# building the checkout — the two are one decision, which is why they move together.
+MAILFATHOM_IMAGE=ghcr.io/krzysztof318/mailfathom:$version
+MAILFATHOM_PULL_POLICY=missing
+ENV
+
+chmod 644 .env
+
+if [[ "$admin_endpoint" != 'off' ]]; then
+  # compose.yaml publishes no port for the administrative endpoint, deliberately, and it is a tracked file. An override
+  # is what publishes one without editing it — .gitignore already covers this path for exactly that reason.
+  cat > compose.override.yaml << YAML
+# Written by scripts/quick-start-compose.sh, and ignored by Git.
+#
+# The administrative endpoint is configured in ./config, and this publishes the port it is served on. Loopback, like
+# every other port this deployment publishes: mfctl reaches it from this machine, and nothing else reaches it at all.
+services:
+  mailfathom:
+    ports:
+      - "127.0.0.1:$admin_port:$admin_port"
+YAML
+
+  chmod 644 compose.override.yaml
+fi
+
+printf 'Wrote .env, config/10-mailfathom.json, and the credentials under secrets/.\n' >&2
+
+report_connection() {
+  printf '\nThe MCP endpoint answers at http://127.0.0.1:8080/mcp, over the Streamable HTTP transport.\n' >&2
+
+  if [[ "$mcp_authentication" == 'api-key' ]]; then
+    printf 'Give the client an Authorization header of `Bearer <key>`, where the key is:\n\n' >&2
+    printf '  cat %s/secrets/mailfathom/%s\n' "$compose_directory" "$mcp_key_name" >&2
+  else
+    printf 'It requires no credential, so a client needs the address alone.\n' >&2
+  fi
+
+  printf '\nWhich clients take which of those, by name: %s/users/mcp-clients.html\n' "$documentation_base" >&2
+
+  if [[ "$admin_endpoint" != 'off' ]]; then
+    printf '\nThe administrative endpoint answers at http://127.0.0.1:%s/api/admin.\n' "$admin_port" >&2
+    printf '  mfctl login --endpoint http://127.0.0.1:%s\n' "$admin_port" >&2
+
+    if [[ "$admin_endpoint" == 'api-key' ]]; then
+      printf '  cat %s/secrets/mailfathom/%s\n' "$compose_directory" "$admin_key_name" >&2
+    fi
+
+    printf 'Getting the command: %s/operations/admin-endpoint.html\n' "$documentation_base" >&2
+  fi
+}
+
+# Said at the end rather than only at the start, because this is the point at which somebody has a working deployment
+# and stops reading. Each line is a decision this script deliberately did not make, not a defect in what it produced.
+report_what_an_evaluation_is_missing() {
+  cat << TEXT >&2
+
+This is a deployment to evaluate MailFathom with. Before it is one anybody depends on:
+
+  Transport   Both ports are published on 127.0.0.1 and MailFathom terminates no TLS, so a client on
+              another machine has nothing to connect to and nothing protecting it if it did. Put a
+              TLS-terminating proxy in front, or configure McpEndpoint:Https.
+              $documentation_base/operations/mcp-endpoint.html
+  Credentials They are files under this checkout, protected by the mode on secrets/ and nothing else.
+              The Podman Quadlet shape encrypts them as systemd credentials bound to the machine, and
+              Kubernetes mounts a Secret you manage.
+              $documentation_base/operations/secret-provisioning.html
+  Grants      Every credential written here reaches its whole surface, because nothing narrowed it.
+              A deployment with more than one client narrows each one.
+              $documentation_base/operations/permissions.html
+  Backups     Nothing here backs the database up, and the mail in it costs a full resynchronization
+              to rebuild — the audit trail and the embeddings do not come back at all.
+              $documentation_base/operations/database-schema.html
+
+Which shape a real installation takes is a decision this script did not make for you:
+$documentation_base/users/installation.html
+TEXT
+}
+
+if [[ "$start_stack" != 'yes' ]]; then
+  printf '\nNothing was started. From %s:\n\n' "$compose_directory" >&2
+  printf '  docker compose up -d postgres\n' >&2
+  printf '  # apply %s — %s/operations/deployment-compose.html\n' "$schema_asset" "$documentation_base" >&2
+  printf '  docker compose up -d\n' >&2
+  report_connection
+  report_what_an_evaluation_is_missing
+  exit 0
+fi
+
+printf '\nStarting PostgreSQL.\n' >&2
+docker compose up -d postgres
+
+printf 'Waiting for it to report healthy.\n' >&2
+for _ in $(seq 1 60); do
+  if [[ "$(docker compose ps --format '{{.Health}}' postgres 2> /dev/null)" == 'healthy' ]]; then
+    break
+  fi
+
+  sleep 2
+done
+
+if [[ "$(docker compose ps --format '{{.Health}}' postgres 2> /dev/null)" != 'healthy' ]]; then
+  printf 'PostgreSQL did not become healthy. `docker compose logs postgres` says why.\n' >&2
+  exit 1
+fi
+
+# Run inside the container, where both credentials are already mounted and the socket is local, so no password reaches
+# a command line and no port has to be published to ask this.
+psql_in_container() {
+  docker compose exec --no-TTY postgres sh -c \
+    'PGPASSWORD="$(cat /run/secrets/mailfathom-database-password)" exec psql \
+       --username "$MAILFATHOM_DATABASE_ROLE" --dbname "$MAILFATHOM_DATABASE" --set ON_ERROR_STOP=on '"$1"
+}
+
+applied_migrations="$(psql_in_container "--tuples-only --no-align --command \
+  \"SELECT COUNT(*) FROM information_schema.tables WHERE table_name = '__EFMigrationsHistory'\"" | tr -d '[:space:]')"
+
+if [[ "$applied_migrations" != '0' ]]; then
+  # Not an empty database, so this is an upgrade rather than a first installation. An upgrade takes a backup first and
+  # is never something a convenience script decides to perform.
+  printf '\nThis database already carries migrations, so the schema step is an upgrade and yours to take.\n' >&2
+  printf 'Back the database up, read the SQL, and apply it: %s/operations/database-schema.html\n' \
+    "$documentation_base" >&2
+  exit 1
+fi
+
+printf '\nThe database is empty, so it needs the release schema before MailFathom will serve.\n' >&2
+printf 'MailFathom never applies a migration while starting: it verifies the schema and refuses one it\n' >&2
+printf 'does not recognize, which is why this is a step rather than something that happens on its own.\n\n' >&2
+printf '  %s/download/v%s/%s\n\n' "$release_base" "$version" "$schema_asset" >&2
+
+if ! confirm "Download that file, verify it against its checksum, and apply it to this empty database?"; then
+  printf '\nNothing was applied. Download it, read it, and apply it from deploy/compose:\n\n' >&2
+  printf '  curl -LO %s/download/v%s/%s\n' "$release_base" "$version" "$schema_asset" >&2
+  printf "  docker compose exec --no-TTY postgres sh -c \\\\\n" >&2
+  printf "    'PGPASSWORD=\"\$(cat /run/secrets/mailfathom-database-password)\" exec psql \\\\\n" >&2
+  printf "       --username \"\$MAILFATHOM_DATABASE_ROLE\" --dbname \"\$MAILFATHOM_DATABASE\" --set ON_ERROR_STOP=on' \\\\\n" >&2
+  printf "    < %s\n" "$schema_asset" >&2
+  printf '\nThen: docker compose up -d\n' >&2
+  report_connection
+  report_what_an_evaluation_is_missing
+  exit 0
+fi
+
+schema_directory="$(mktemp --directory)"
+trap 'rm --recursive --force "$schema_directory"' EXIT
+
+for asset in "$schema_asset" "$schema_asset.sha256"; do
+  if ! curl -fsSL --output "$schema_directory/$asset" "$release_base/download/v$version/$asset"; then
+    printf 'Could not download %s. Check that %s is a release that exists: %s\n' "$asset" "$version" "$release_base" >&2
+    exit 1
+  fi
+done
+
+# The checksum file names its file as the release built it, so the check runs from the directory it downloaded into.
+if ! (cd "$schema_directory" && sha256sum --check --ignore-missing --quiet "$schema_asset.sha256"); then
+  printf '\n%s does not match the checksum %s publishes for it, so nothing was applied.\n' \
+    "$schema_asset" "$version" >&2
+  exit 1
+fi
+
+printf 'Applying the schema as the role MailFathom connects as.\n' >&2
+
+# As `mailfathom`, never as `postgres`: PostgreSQL makes the role that ran the DDL the owner of what it created, and a
+# schema applied by the superuser leaves MailFathom refusing to start against a schema that plainly exists.
+psql_in_container '' < "$schema_directory/$schema_asset" > /dev/null
+
+printf 'Starting MailFathom.\n' >&2
+docker compose up -d
+
+printf 'Waiting for the probes.\n' >&2
+started='no'
+for _ in $(seq 1 60); do
+  if curl -fsS 'http://127.0.0.1:8081/started' > /dev/null 2>&1; then
+    started='yes'
+    break
+  fi
+
+  sleep 2
+done
+
+if [[ "$started" != 'yes' ]]; then
+  printf '\n/started never answered. The refusal names the setting that caused it:\n\n' >&2
+  printf '  docker compose logs mailfathom\n' >&2
+  exit 1
+fi
+
+if curl -fsS 'http://127.0.0.1:8081/health' > /dev/null 2>&1; then
+  printf '\nMailFathom %s is running and ready.\n' "$version" >&2
+else
+  printf '\nMailFathom %s started, and /health is not ready yet — the first synchronization is running.\n' "$version" >&2
+fi
+
+report_connection
+
+printf '\nThe first synchronization takes a while on a large mailbox. Every tool result carries how fresh\n' >&2
+printf 'the local copy is: %s/users/usage.html\n' "$documentation_base" >&2
+
+report_what_an_evaluation_is_missing

--- a/scripts/test-agent-workflow.sh
+++ b/scripts/test-agent-workflow.sh
@@ -5908,6 +5908,266 @@ install_script_refuses_a_platform_no_release_publishes() {
   assert_contains 'linux-x64, linux-arm64, win-x64, and win-arm64' "$output_file"
 }
 
+# The guided Compose setup, which is the one script here that writes a deployment's credentials. Every contract below
+# runs the committed script against a checkout of its own — a fixture carrying `deploy/compose/`, never this
+# repository's own — because what it writes is exactly what must never be written over somebody's prepared deployment.
+#
+# None of them reaches the network or a Docker daemon: `--version` is what the release resolution would otherwise ask
+# GitHub for, and `--no-start` stops before the stack, the schema step, and the probes. What that leaves asserted is
+# the half a reader cannot check by eye — the modes, the two postures, and the refusals.
+stage_quick_start_checkout() {
+  local case_name="$1"
+  local checkout_root="$test_directory/$case_name-checkout"
+
+  mkdir -p "$checkout_root/deploy/compose/config" "$checkout_root/deploy/compose/secrets/mailfathom"
+
+  # Only its existence is read, which is what says this checkout carries the Compose deployment at all.
+  printf 'name: mailfathom\n' > "$checkout_root/deploy/compose/compose.yaml"
+
+  # A clone made under a strict umask is what leaves `config/` unlistable by the container's account, so the fixture
+  # starts from one rather than from whatever the runner's umask happens to be.
+  chmod 700 "$checkout_root/deploy/compose/config" "$checkout_root/deploy/compose/secrets/mailfathom"
+  printf 'the mailbox password\n' > "$checkout_root/password"
+
+  git -C "$checkout_root" init --initial-branch=main --quiet
+
+  printf '%s\n' "$checkout_root"
+}
+
+run_quick_start() {
+  local checkout_root="$1"
+  shift
+
+  (
+    cd "$checkout_root/deploy/compose"
+    bash "$source_repository_root/scripts/quick-start-compose.sh" \
+      --user-name 'you@example.test' --display-name 'Personal mail' \
+      --password-file "$checkout_root/password" --version 9.9.9 --no-start --non-interactive "$@"
+  )
+}
+
+# The whole of the manual preparation, asserted where it is invisible: a mode nobody sees is what makes a secret
+# reference resolve, and getting one wrong reports itself at startup as material that could not be found.
+quick_start_prepares_the_deployment_the_documentation_describes() {
+  local checkout_root compose_directory
+  local output_file="$test_directory/quick-start-prepared-log"
+
+  checkout_root="$(stage_quick_start_checkout 'quick-start-prepared')"
+  compose_directory="$checkout_root/deploy/compose"
+
+  run_quick_start "$checkout_root" --provider fastmail > "$output_file" 2>&1
+
+  assert_contains 'MAILFATHOM_IMAGE=ghcr.io/krzysztof318/mailfathom:9.9.9' "$compose_directory/.env"
+  # The image and how it is obtained are one decision: a release tag with the build policy left in place would build
+  # the checkout and ignore the pin.
+  assert_contains 'MAILFATHOM_PULL_POLICY=missing' "$compose_directory/.env"
+
+  assert_file_content 'the mailbox password' "$compose_directory/secrets/mailfathom/imap-primary-password"
+  assert_contains '"Host": "imap.fastmail.com"' "$compose_directory/config/10-mailfathom.json"
+  assert_contains '"SecretReference": "file:/etc/mailfathom/secrets/imap-primary-password"' \
+    "$compose_directory/config/10-mailfathom.json"
+
+  local expected_modes='700 secrets
+711 secrets/mailfathom
+755 config
+444 secrets/postgres-superuser-password
+444 secrets/mailfathom-database-password
+444 secrets/mailfathom/imap-primary-password
+644 config/10-mailfathom.json'
+  local actual_modes
+
+  actual_modes="$(
+    cd "$compose_directory"
+    stat --format '%a %n' \
+      secrets secrets/mailfathom config \
+      secrets/postgres-superuser-password secrets/mailfathom-database-password \
+      secrets/mailfathom/imap-primary-password config/10-mailfathom.json
+  )"
+
+  if [[ "$actual_modes" != "$expected_modes" ]]; then
+    printf 'The prepared deployment carries modes the container cannot read:\nExpected:\n%s\nActual:\n%s\n' \
+      "$expected_modes" "$actual_modes" >&2
+    return 1
+  fi
+
+  # Two database passwords generated independently. Equal ones would mean a single generation reused, which is what a
+  # refactor of the generation would silently produce.
+  if [[ "$(cat "$compose_directory/secrets/postgres-superuser-password")" == \
+    "$(cat "$compose_directory/secrets/mailfathom-database-password")" ]]; then
+    printf 'The superuser and the service share one database password.\n' >&2
+    return 1
+  fi
+}
+
+# The credential is in a file, and the point of that is which places it is therefore not in.
+quick_start_keeps_the_mailbox_password_out_of_everything_but_its_own_file() {
+  local checkout_root compose_directory
+  local output_file="$test_directory/quick-start-password-log"
+
+  checkout_root="$(stage_quick_start_checkout 'quick-start-password')"
+  compose_directory="$checkout_root/deploy/compose"
+
+  run_quick_start "$checkout_root" --provider gmail > "$output_file" 2>&1
+
+  assert_excludes 'the mailbox password' "$compose_directory/config/10-mailfathom.json"
+  assert_excludes 'the mailbox password' "$compose_directory/.env"
+  assert_excludes 'the mailbox password' "$output_file"
+}
+
+# A prepared deployment is somebody's running instance. Replacing its credentials because a script was run twice is the
+# one failure this must not have, so the refusal comes before anything is written rather than after.
+quick_start_refuses_to_overwrite_a_prepared_deployment() {
+  local checkout_root compose_directory
+  local first_run="$test_directory/quick-start-overwrite-first"
+  local second_run="$test_directory/quick-start-overwrite-second"
+
+  checkout_root="$(stage_quick_start_checkout 'quick-start-overwrite')"
+  compose_directory="$checkout_root/deploy/compose"
+
+  run_quick_start "$checkout_root" --provider zoho > "$first_run" 2>&1
+
+  local original_key
+  original_key="$(cat "$compose_directory/secrets/mailfathom/mcp-workstation-key")"
+
+  if run_quick_start "$checkout_root" --provider zoho > "$second_run" 2>&1; then
+    printf 'A second run replaced a prepared deployment instead of refusing.\n' >&2
+    return 1
+  fi
+
+  assert_contains 'deploy/compose/.env already exists' "$second_run"
+  assert_file_content "$original_key" "$compose_directory/secrets/mailfathom/mcp-workstation-key"
+}
+
+# A mailbox whose provider accepts no password cannot be prepared by a script that asks for one, and a configuration
+# written anyway fails at the first synchronization with an authentication error that says nothing about why.
+quick_start_refuses_a_mailbox_that_accepts_no_password() {
+  local checkout_root compose_directory
+  local output_file="$test_directory/quick-start-oauth-log"
+
+  checkout_root="$(stage_quick_start_checkout 'quick-start-oauth')"
+  compose_directory="$checkout_root/deploy/compose"
+
+  if run_quick_start "$checkout_root" --provider outlook > "$output_file" 2>&1; then
+    printf 'A mailbox that accepts no password was prepared with one.\n' >&2
+    return 1
+  fi
+
+  assert_contains 'accepts no password' "$output_file"
+  assert_contains 'mailbox-oauth' "$output_file"
+
+  if [[ -e "$compose_directory/.env" || -e "$compose_directory/config/10-mailfathom.json" ]]; then
+    printf 'The refusal left a prepared deployment behind.\n' >&2
+    return 1
+  fi
+}
+
+# The unauthenticated posture is legal and is never what a run that did not ask for it produces.
+quick_start_authenticates_the_mcp_endpoint_unless_asked_otherwise() {
+  local guarded_root open_root
+  local guarded_log="$test_directory/quick-start-guarded-log"
+  local open_log="$test_directory/quick-start-open-log"
+
+  guarded_root="$(stage_quick_start_checkout 'quick-start-guarded')"
+  run_quick_start "$guarded_root" --provider icloud > "$guarded_log" 2>&1
+
+  assert_contains '"SecretReference": "file:/etc/mailfathom/secrets/mcp-workstation-key"' \
+    "$guarded_root/deploy/compose/config/10-mailfathom.json"
+
+  if [[ ! -s "$guarded_root/deploy/compose/secrets/mailfathom/mcp-workstation-key" ]]; then
+    printf 'The default posture wrote no MCP credential.\n' >&2
+    return 1
+  fi
+
+  open_root="$(stage_quick_start_checkout 'quick-start-open')"
+  run_quick_start "$open_root" --provider icloud --mcp-authentication none > "$open_log" 2>&1
+
+  assert_contains '"Authentication": [],' "$open_root/deploy/compose/config/10-mailfathom.json"
+
+  if [[ -e "$open_root/deploy/compose/secrets/mailfathom/mcp-workstation-key" ]]; then
+    printf 'An endpoint asked to serve without authentication was given a key anyway.\n' >&2
+    return 1
+  fi
+}
+
+# A value carrying a control character would reach the configuration file as broken JSON, and the deployment would then
+# fail to start on a file nobody edited. The check that prevents it cannot live in the function that writes the string,
+# because that runs inside a command substitution whose exit the heredoc calling it does not propagate.
+quick_start_refuses_a_value_that_would_write_broken_configuration() {
+  local checkout_root
+  local output_file="$test_directory/quick-start-control-character-log"
+
+  checkout_root="$(stage_quick_start_checkout 'quick-start-control-character')"
+
+  if run_quick_start "$checkout_root" --provider fastmail --display-name "$(printf 'Personal\tmail')" \
+    > "$output_file" 2>&1; then
+    printf 'A control character was written into the configuration instead of stopping the run.\n' >&2
+    return 1
+  fi
+
+  assert_contains 'control character' "$output_file"
+
+  if [[ -e "$checkout_root/deploy/compose/config/10-mailfathom.json" ]]; then
+    printf 'The refusal left a configuration file behind.\n' >&2
+    return 1
+  fi
+}
+
+# What this script produces is a deployment to find out what the product does, and the difference between that and one
+# somebody depends on is four decisions nobody has taken yet. A convenience path that stopped saying so would be read as
+# the recommended installation, which is the one thing it must never become — so the framing is asserted rather than
+# left to whoever edits the text next.
+quick_start_says_it_is_an_evaluation_rather_than_a_recommended_deployment() {
+  local checkout_root
+  local output_file="$test_directory/quick-start-framing-log"
+  local help_file="$test_directory/quick-start-help-log"
+
+  bash "$source_repository_root/scripts/quick-start-compose.sh" --help > "$help_file" 2>&1
+
+  checkout_root="$(stage_quick_start_checkout 'quick-start-framing')"
+  run_quick_start "$checkout_root" --provider fastmail > "$output_file" 2>&1
+
+  assert_contains 'Not the recommended way to run one' "$help_file"
+  assert_contains 'evaluate MailFathom with' "$output_file"
+
+  local missing_decision
+  for missing_decision in 'Transport' 'Credentials' 'Grants' 'Backups'; do
+    assert_contains "  $missing_decision " "$output_file"
+  done
+
+  assert_contains 'users/installation.html' "$output_file"
+}
+
+# The administrative endpoint's own default port is the socket the MCP endpoint is served on, and compose.yaml
+# publishes nothing for it. So enabling it means a port of its own, published from an override rather than by editing a
+# tracked file — and on loopback, like every other port this deployment publishes.
+quick_start_serves_the_administrative_endpoint_on_a_port_of_its_own() {
+  local checkout_root compose_directory
+  local off_root
+  local output_file="$test_directory/quick-start-admin-log"
+
+  checkout_root="$(stage_quick_start_checkout 'quick-start-admin')"
+  compose_directory="$checkout_root/deploy/compose"
+
+  run_quick_start "$checkout_root" --provider yahoo --admin-endpoint api-key > "$output_file" 2>&1
+
+  assert_contains '"Port": 8090' "$compose_directory/config/10-mailfathom.json"
+  assert_contains '"SecretReference": "file:/etc/mailfathom/secrets/admin-workstation-key"' \
+    "$compose_directory/config/10-mailfathom.json"
+  assert_contains '"127.0.0.1:8090:8090"' "$compose_directory/compose.override.yaml"
+
+  # Off unless it is asked for, which is the product's own default and what makes the override file the marker of a
+  # deliberate answer rather than of a run having happened.
+  off_root="$(stage_quick_start_checkout 'quick-start-admin-off')"
+  run_quick_start "$off_root" --provider yahoo > /dev/null 2>&1
+
+  assert_excludes 'AdminEndpoint' "$off_root/deploy/compose/config/10-mailfathom.json"
+
+  if [[ -e "$off_root/deploy/compose/compose.override.yaml" ]]; then
+    printf 'An administrative endpoint nobody asked for was published.\n' >&2
+    return 1
+  fi
+}
+
 # The Actions policy, as far as a committed file can state it. Half of that policy lives in GitHub's
 # repository settings — which action owners are allowed at all, whether a mutable `uses:` is
 # accepted, how long an artifact is kept — and settings do not fail a pull request. These five
@@ -6796,6 +7056,14 @@ run_test winget_manifests_refuse_a_missing_windows_binary
 run_test install_script_installs_the_binary_the_release_published
 run_test install_script_refuses_a_binary_the_checksum_file_disowns
 run_test install_script_refuses_a_platform_no_release_publishes
+run_test quick_start_prepares_the_deployment_the_documentation_describes
+run_test quick_start_keeps_the_mailbox_password_out_of_everything_but_its_own_file
+run_test quick_start_refuses_to_overwrite_a_prepared_deployment
+run_test quick_start_refuses_a_mailbox_that_accepts_no_password
+run_test quick_start_authenticates_the_mcp_endpoint_unless_asked_otherwise
+run_test quick_start_serves_the_administrative_endpoint_on_a_port_of_its_own
+run_test quick_start_refuses_a_value_that_would_write_broken_configuration
+run_test quick_start_says_it_is_an_evaluation_rather_than_a_recommended_deployment
 run_test every_external_action_names_an_approved_owner
 run_test every_workflow_job_declares_its_permissions
 run_test every_write_scope_is_one_the_policy_records


### PR DESCRIPTION
Closes #970

## What changes

`scripts/quick-start-compose.sh` performs what [deploying with Docker Compose](https://github.com/Krzysztof318/MailFathom/blob/main/docs/operations/deployment-compose.md) otherwise asks somebody to type: it asks where the mailbox lives, generates the credentials, writes `config/10-mailfathom.json` and `.env`, sets the directory and file modes, starts the stack, offers the schema step, and reports the two probes.

**What it produces is a deployment to evaluate MailFathom with, and the script says so three times** — in `--help`, before the first question, and again at the end, where it names the four decisions nobody has taken yet (transport, credential handling, grants, backups), each pointing at the page that covers it. The four installation shapes stay where the real decision is made and the manual path stays the documented installation; this is the path for finding out what the product does before any of that is worth reading.

Three parts are decisions rather than convenience, and they are what a reviewer should look at first:

- **The schema step.** The artifact is downloaded, verified against the checksum file beside it, and applied only to a database carrying no `__EFMigrationsHistory`, after an explicit confirmation. Against a database that already holds migrations the script stops and hands the step back — that is an upgrade, and an upgrade takes a backup first.
- **The password.** Read without echo and written straight to its file, so it reaches neither the shell history nor the process list. `--password-file` is the same thing unattended, resolved against the caller's directory before the run moves to `deploy/compose`.
- **Nothing is overwritten.** An existing `.env`, configuration file, or secret stops the run naming the file, and every question is answered before anything is written, so a refusal leaves the directory as it was found.

Two answers it asks for, both stating their cost before they are given. The MCP endpoint takes a generated key unless the unauthenticated posture is asked for by name — that posture exists because two popular chat clients have no field for a static header, and it is legal here for the reason [the MCP endpoint](https://github.com/Krzysztof318/MailFathom/blob/main/docs/operations/mcp-endpoint.md) gives. The administrative endpoint is off unless asked for, and enabling it publishes port 8090 from a generated `compose.override.yaml`: its own default is 8080, which is the socket the MCP endpoint is already served on, and `compose.yaml` publishes nothing for it. Neither answer moves a published port off loopback.

Decided rather than derived: the override file rather than an edit to the tracked `compose.yaml` for the administrative port; `type:infra` on the issue, following #792, the same shape of user-facing script under `scripts/`; and the provider presets taken from the table in [configuring a mailbox at your provider](https://github.com/Krzysztof318/MailFathom/blob/main/docs/users/mailbox-providers.md), with the four OAuth-only services and Proton's bridge refused rather than written into a configuration that cannot start.

## How it was verified

`bash scripts/test-agent-workflow.sh` — **236 passed, 0 failed**, including eight new contracts covering the generated files and their modes, the password staying out of everything but its own file, the refusal to overwrite a prepared deployment, the OAuth-only refusal, both endpoint postures, a value that would write broken JSON, and the evaluation framing itself. None reaches the network or a Docker daemon.

`bash scripts/review-obligations.sh` — two rows, `docs/operations/agent-workflow.md` and `docs/operations/local-development.md`, both via `scripts/**`. Neither owes a line: `install-mfctl.sh`, the same shape of script, appears in neither and is documented on its subject page, which is the precedent this follows by documenting the new script in `deployment-compose.md` and widening that page's `describes:` marker.

**What could not be verified here, and why:** `scripts/verify-fast.sh` and `scripts/verify-full.sh` did not run. The session's container has no .NET SDK and its network policy denies `builds.dotnet.microsoft.com`, so the SDK could not be installed either — `verify-fast.sh` exits 127 on `dotnet: command not found`. The change adds no C# and touches no project file, so what those gates cover beyond the contract suite is the build and the unit tests of code this diff does not reach; CI runs both on this pull request. The Docker-dependent half of the script — the stack, the schema application, the probes — is likewise unexercised: no daemon was available. What was exercised by hand, against fixture checkouts, is every path up to the first `docker compose` call, in both the guarded and the unauthenticated posture, with the generated JSON parsed and the modes asserted.

## Checklist

- [ ] `bash scripts/verify-full.sh` passes on this branch, rebased onto current `main`. — **not run**, see above; CI covers it
- [x] Behavior changes are covered by unit tests, and the coverage gate passes. — eight contracts in `scripts/test-agent-workflow.sh`; no C# changed, so the coverage gate has nothing new to measure
- [x] Affected documentation is updated in this change set.
- [x] `bash scripts/review-obligations.sh` was run, and every row it reported is answered — by a test, by a page, or by why nothing is owed there.
- [x] `CHANGELOG.md` is untouched — it is written by the release pull request alone.
- [x] Every new C# file carries the repository's standard header, applied by `scripts/verify-fast.sh` rather than typed, and no file gained a second copyright line, an author tag, a name, or a contact detail. — no C# file added; the new shell script carries the three-line header from `.editorconfig`, asserted by `every_shell_script_carries_the_license_header`
- [x] Nothing here is under terms MailFathom could not distribute under Apache-2.0. A new dependency, service, container image, or externally sourced sample has its row in `THIRD_PARTY_LICENSES.md` in this change set. — nothing added; the script calls only tools the manual path already requires
- [x] No credential, token, private key, real mailbox data, or personal information is in the diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DAydGnNQR4dfAUzigPSyqc)_