### PR TITLE
[#978] Establish the displayed author from a signing domain within its own branch of the naming tree

### DIFF
--- a/docs/features/sender-authentication.md
+++ b/docs/features/sender-authentication.md
@@ -104,20 +104,25 @@ the verdict above, beside the identity it was reached from.
 Two things establish the author, and neither believes the header on its own.
 
 - **A trusted `dmarc=pass`** is the receiving server's own statement that the displayed domain passed under the
-  sender's published policy. That policy may permit a signing subdomain, which is exactly why the result is read back
-  rather than reconstructed: nothing here resolves DNS, computes an organizational domain, or consults a public suffix
-  list, so this answer is not one MailFathom could reach for itself.
-- **An authenticated identity whose domain is exactly the displayed one**, where no usable DMARC result was reported.
-  Exactly, because `mail.example.test` and `example.test` are two names and only the sender's own policy says whether
-  the first may speak for the second. Every identity the trusted header reported as passing is compared, DKIM and SPF
-  alike, so a delivery provider's signature listed first cannot hide the author's own listed after it.
+  sender's published policy. That is the whole of what the policy answers and it is why the result is read back rather
+  than reconstructed: nothing here resolves a DMARC record, computes an organizational domain, or consults a public
+  suffix list, so this answer is not one MailFathom could reach for itself.
+- **An authenticated identity that is the displayed domain, or lies with it on one branch of the naming tree**, where
+  no usable DMARC result was reported. One of the two names has to be a suffix of the other at a label boundary —
+  `p1.mail.example.test` signing `@example.test`, or `example.test` signing `@notice.example.test` — because whoever
+  publishes a key under such a name was delegated that zone by the displayed domain or delegated the displayed domain
+  themselves. The relation rests on DNS control flowing down the tree rather than on a policy nobody read. Two names
+  that merely share a parent are unrelated: `a.example.test` does not speak for `b.example.test`, so DMARC's relaxed
+  alignment stays unreconstructed. Every identity the trusted header reported as passing is compared, DKIM and SPF
+  alike, so a delivery provider's signature listed first cannot hide the author's own listed after it, and the domain
+  the author is established as is the **displayed** one rather than whichever name signed.
 
 **`dmarc=fail` is the only route to a failure**, and it ends the question rather than falling through to the second
 route: the receiving server reached it with the displayed domain's own policy in hand, which is more than a comparison
-made here without one. Everything else that establishes nothing is *not established* instead — a signing subdomain with
-no DMARC result to interpret it, an identity belonging to somebody else, a message displaying no usable domain, a
-header nothing trusted could be read from. A DKIM signature that did not verify is among them: it says nothing about
-the author, because the signature may never have been theirs.
+made here without one. Everything else that establishes nothing is *not established* instead — an identity belonging to
+somebody else, a sibling under a shared parent, a message displaying no usable domain, a header nothing trusted could
+be read from. A DKIM signature that did not verify is among them: it says nothing about the author, because the
+signature may never have been theirs.
 
 So a message may hold a passing DKIM identity, a passing SPF identity, and a failed author all at once, and it may hold
 `dmarc=pass` while the domain that signed it is not the domain it displays. Both are ordinary readings rather than
@@ -181,9 +186,10 @@ What such a verdict reaches is the same three outcomes as any other, decided by 
   nothing whatever about the sender, and a verdict calling that a failure would turn this deployment's own network
   trouble into a statement against somebody's mail.
 
-The author conclusion follows [the same rule](#whether-the-displayed-author-authenticated) and is not relaxed for
-running here. With no DMARC result to interpret a signing subdomain, an author is established only by a verified
-signature whose domain is exactly the displayed one.
+The author conclusion follows [the same rule](#whether-the-displayed-author-authenticated) and is neither relaxed nor
+tightened for running here. An author is established by a verified signature whose domain is the displayed one or lies
+with it on one branch of the naming tree, and by nothing else — no DMARC result is ever reported on this path, so the
+only route left is the comparison, and a signer outside that branch establishes nothing.
 
 **The recorded verdict says which of the two reached it**, and that is the whole reason the column exists: a
 cryptographic signature check and a verdict taken with network context nobody has any more are worth different amounts,
@@ -372,7 +378,15 @@ of them characterizes the message or the sender's intent. A failed authenticatio
 
 - It evaluates no SPF policy and no DMARC policy, ever, whichever reading produced the verdict. It computes no
   organizational domain and consults no public suffix list, so it never reconstructs DMARC's relaxed alignment for
-  itself. The only DNS it resolves is a published DKIM key, and only on the fallback path above.
+  itself: two names under one parent stay unrelated here, which is the case relaxed alignment exists to accept. What it
+  does accept is one name within the other at a label boundary, which is a delegation readable from the two names alone
+  rather than a policy. The only DNS it resolves is a published DKIM key, and only on the fallback path above.
+- **The residual risk of accepting that delegation is stated rather than mitigated.** A subdomain delegated to a third
+  party — a marketing platform holding `mail.example.test`, a tenant holding a name under somebody's zone — can
+  establish the author of mail displaying the parent domain, and MailFathom does not read the DMARC record that would
+  say whether the parent permits it. That record's own default, `adkim=r`, permits considerably more than this, so the
+  assumption is the one nearly every sender publishes; it is an assumption nonetheless, and a domain owner who
+  delegates a subdomain delegates this with it.
 - It does not reason from the `Received` chain beyond identifying the trusted header.
 - It does not validate an ARC chain. An intact chain says an upstream relay signed a claim about what *it* saw, which
   establishes no author and decides nothing about trust.

--- a/src/Domain/Emails/Authentication/AuthorAuthenticationOutcome.cs
+++ b/src/Domain/Emails/Authentication/AuthorAuthenticationOutcome.cs
@@ -15,14 +15,16 @@ namespace MailFathom.Domain.Emails.Authentication;
 /// <para>
 /// The <c>From</c> header takes no part in reaching it. It is attacker-controlled message content, so it says who the
 /// message <em>claims</em> to be from and never who it is from; what establishes the author is the trusted receiving
-/// server's own DMARC result, or an authenticated identity whose domain is exactly the displayed one.
+/// server's own DMARC result, or an authenticated identity whose domain is the displayed one or lies with it on one
+/// branch of the naming tree.
 /// </para>
 /// </remarks>
 public enum AuthorAuthenticationOutcome
 {
     /// <summary>The trusted evidence is not enough to conclude either way about the displayed author.</summary>
     /// <remarks>
-    /// It is deliberately not <see cref="Failed" />. A message signed by a subdomain of the displayed domain, with no
+    /// It is deliberately not <see cref="Failed" />. A message signed by a domain unrelated to the displayed one — a
+    /// tenant's default signing domain, a delivery provider's own name, a sibling under a shared parent — with no
     /// usable DMARC result to say whether the sender's own policy permits that, is the ordinary case here: MailFathom
     /// evaluates no policy, so it does not know, and a verdict that said the author failed would be inventing a refusal
     /// the receiving server never made.

--- a/src/Domain/Emails/Authentication/LocalSenderAuthenticationReading.cs
+++ b/src/Domain/Emails/Authentication/LocalSenderAuthenticationReading.cs
@@ -20,9 +20,10 @@ namespace MailFathom.Domain.Emails.Authentication;
 /// the stronger of the two: a key the signing domain publishes signed exactly these octets.
 /// </para>
 /// <para>
-/// The author conclusion follows from the same rule the trusted reading uses and is not relaxed for running here. With
-/// no DMARC result to interpret a signing subdomain, an author is established only by a verified signature whose domain
-/// is exactly the displayed one — which is what MailFathom can honestly conclude without a policy in hand.
+/// The author conclusion follows from the same rule the trusted reading uses and is neither relaxed nor tightened for
+/// running here. An author is established by a verified signature whose domain is the displayed one or is one within
+/// the other at a label boundary, which is a delegation in the naming tree rather than a policy — and a policy is what
+/// MailFathom still has none of, so a signer outside that branch establishes nothing.
 /// </para>
 /// </remarks>
 public static class LocalSenderAuthenticationReading

--- a/src/Domain/Emails/Authentication/SenderAuthentication.cs
+++ b/src/Domain/Emails/Authentication/SenderAuthentication.cs
@@ -110,10 +110,11 @@ public sealed record SenderAuthentication
     /// <see cref="AuthorAuthenticationOutcome.Authenticated" /> is reached two ways and neither of them believes the
     /// <c>From</c> header on its own. A trusted <see cref="DmarcOutcome.Pass" /> is the receiving server's own statement
     /// that the displayed domain passed under its published policy, so the displayed domain is the answer. Failing
-    /// that, an authenticated identity whose domain is exactly the displayed one is the same claim reached without
-    /// DMARC — exactly, because a differing
-    /// subdomain would need the sender's own policy to say whether relaxed alignment is permitted, and reading that
-    /// policy is not something MailFathom does.
+    /// that, an authenticated identity that is the displayed domain, sits beneath it, or holds it beneath itself is
+    /// the same claim reached without DMARC. A suffix relation at a label boundary means whoever publishes the signing
+    /// key was delegated that zone by the displayed domain or delegated the displayed domain themselves, so it rests
+    /// on DNS control flowing down the tree rather than on a policy nobody read. Two names that merely share a parent
+    /// stay unrelated, and no organizational domain and no public suffix list is computed to reach any of it.
     /// </para>
     /// <para>
     /// <see cref="AuthorAuthenticationOutcome.Failed" /> comes from <see cref="DmarcOutcome.Fail" /> alone, and it ends
@@ -306,8 +307,8 @@ public sealed record SenderAuthentication
     /// decided here outranks it. A message displaying no usable domain has no author to conclude anything about, which
     /// is why it stops at not established rather than at an identity comparison against nothing — but a DMARC failure
     /// still stands above that, since the server evaluated a displayed domain whether or not this reading could parse
-    /// one. What is left is the two routes that establish an author, and the exact comparison is over every identity
-    /// that authenticated rather than over the one kept as evidence.
+    /// one. What is left is the two routes that establish an author, and the comparison is over every identity that
+    /// authenticated rather than over the one kept as evidence.
     /// </remarks>
     private static (AuthorAuthenticationOutcome Outcome, SenderDomain? Domain) EstablishAuthor(
         SenderDomain? fromDomain,
@@ -324,8 +325,23 @@ public sealed record SenderAuthentication
             return (AuthorAuthenticationOutcome.NotEstablished, null);
         }
 
-        return dmarc == DmarcOutcome.Pass || authenticatedIdentities.Contains(displayed)
+        return dmarc == DmarcOutcome.Pass
+            || authenticatedIdentities.Any(identity => SpeaksForDisplayedDomain(identity, displayed))
             ? (AuthorAuthenticationOutcome.Authenticated, displayed)
             : (AuthorAuthenticationOutcome.NotEstablished, null);
     }
+
+    /// <summary>Answers whether an authenticated identity is close enough to the displayed domain to be its author.</summary>
+    /// <remarks>
+    /// The two names have to be one within the other at a label boundary, in either direction. Whoever publishes a key
+    /// under <c>p1.mail.example.test</c> was delegated that zone by <c>example.test</c>, and whoever publishes one for
+    /// <c>example.test</c> delegated <c>notice.example.test</c> themselves, so the relation rests on DNS control
+    /// flowing down the naming tree rather than on a DMARC policy nothing here reads. Siblings are therefore not
+    /// related — <c>a.example.test</c> and <c>b.example.test</c> are two names whose only connection is a parent
+    /// neither of them signed for — and DMARC's relaxed alignment, which would call them aligned, stays
+    /// unreconstructed. What the widening assumes without confirming is what <c>adkim=r</c> permits by default: a
+    /// subdomain delegated to a third party can speak for its parent.
+    /// </remarks>
+    private static bool SpeaksForDisplayedDomain(SenderDomain identity, SenderDomain displayed) =>
+        identity == displayed || identity.IsSubdomainOf(displayed) || displayed.IsSubdomainOf(identity);
 }

--- a/tests/Domain.UnitTests/Emails/Authentication/LocalSenderAuthenticationReadingTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/LocalSenderAuthenticationReadingTests.cs
@@ -69,13 +69,32 @@ public sealed class LocalSenderAuthenticationReadingTests
         Assert.Equal("SIGNER.EXAMPLE.TEST", verdict.AuthenticatedAuthorDomain?.NormalizedValue);
     }
 
-    /// <summary>A signing subdomain establishes nothing about the author, because no DMARC result says whether it may.</summary>
+    /// <summary>A signing subdomain establishes the displayed author here exactly as it does on the trusted path.</summary>
+    /// <remarks>
+    /// The two readings must reach the same conclusion about the same message, so the widened comparison is the domain
+    /// type's rather than either reading's. What is established stays the displayed domain, not the signing one.
+    /// </remarks>
     [Fact]
-    public void Read_ASignatureFromASubdomainOfTheDisplayedOne_LeavesTheAuthorUnestablished()
+    public void Read_ASignatureFromASubdomainOfTheDisplayedOne_EstablishesTheAuthor()
     {
         // Act
         var verdict = LocalSenderAuthenticationReading.Read(
             [DomainOf("mail.signer.example.test")],
+            anySignatureRejected: false,
+            "anna@signer.example.test");
+
+        // Assert
+        Assert.Equal(AuthorAuthenticationOutcome.Authenticated, verdict.AuthorAuthentication);
+        Assert.Equal("SIGNER.EXAMPLE.TEST", verdict.AuthenticatedAuthorDomain?.NormalizedValue);
+    }
+
+    /// <summary>A signature from an unrelated third party still establishes nothing, which is the bound on the widening.</summary>
+    [Fact]
+    public void Read_ASignatureFromAThirdPartyDomain_LeavesTheAuthorUnestablished()
+    {
+        // Act
+        var verdict = LocalSenderAuthenticationReading.Read(
+            [DomainOf("tenant.provider.example.test")],
             anySignatureRejected: false,
             "anna@signer.example.test");
 

--- a/tests/Domain.UnitTests/Emails/Authentication/SenderAuthenticationReadingTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/SenderAuthenticationReadingTests.cs
@@ -212,9 +212,14 @@ public sealed class SenderAuthenticationReadingTests
         Assert.Equal("MAIL.BANK.TEST", authentication.AuthenticatedDomain?.NormalizedValue);
     }
 
-    /// <summary>Without a usable DMARC result, a signing subdomain leaves the author unestablished rather than refused.</summary>
+    /// <summary>A signing subdomain establishes the displayed author even where no DMARC result interprets it.</summary>
+    /// <remarks>
+    /// The trusted reading reaches this the same way the local one does, from the two names alone, so a deployment
+    /// whose server reports no DMARC result concludes what one reporting <c>pass</c> concludes about the same message.
+    /// The established domain stays the displayed one while the identity that authenticated stays the signer.
+    /// </remarks>
     [Fact]
-    public void Read_SigningSubdomainWithoutDmarc_EstablishesNoAuthor()
+    public void Read_SigningSubdomainWithoutDmarc_EstablishesTheDisplayedAuthor()
     {
         // Arrange
         var headers = new[] { Header(TrustedIdentifier, Dkim("pass", "mail.bank.test")) };
@@ -223,8 +228,9 @@ public sealed class SenderAuthenticationReadingTests
         var authentication = SenderAuthenticationReading.Read(headers, TrustedAuthority, "alerts@bank.test");
 
         // Assert
-        Assert.Equal(AuthorAuthenticationOutcome.NotEstablished, authentication.AuthorAuthentication);
-        Assert.Null(authentication.AuthenticatedAuthorDomain);
+        Assert.Equal(AuthorAuthenticationOutcome.Authenticated, authentication.AuthorAuthentication);
+        Assert.Equal("BANK.TEST", authentication.AuthenticatedAuthorDomain?.NormalizedValue);
+        Assert.Equal("MAIL.BANK.TEST", authentication.AuthenticatedDomain?.NormalizedValue);
     }
 
     /// <summary>DKIM is the authoritative identity where both checks produced one, and both are still recorded.</summary>

--- a/tests/Domain.UnitTests/Emails/Authentication/SenderAuthenticationTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/SenderAuthenticationTests.cs
@@ -199,17 +199,72 @@ public sealed class SenderAuthenticationTests
         Assert.Equal(attacker, authentication.AuthenticatedDomain);
     }
 
-    /// <summary>Without a usable DMARC result, a signing subdomain of the displayed domain establishes nothing.</summary>
+    /// <summary>Without a usable DMARC result, an identity one within the other establishes the displayed author.</summary>
     /// <remarks>
-    /// Whether the sender's policy permits the relaxed form is written in a DNS record MailFathom never reads, so the
-    /// honest answer is that this reading does not know. It is deliberately not a failure: legitimate mail is signed
-    /// this way, and the receiving server said nothing against it.
+    /// Both directions are the same fact about the naming tree: a zone was delegated, downwards, by whoever holds the
+    /// name above it. What is established stays the displayed domain rather than the signing one, because the
+    /// trusted-sender list is held against what the reader is shown.
     /// </remarks>
-    [Fact]
-    public void AuthorAuthentication_SigningSubdomainWithoutDmarc_IsNotEstablished()
+    [Theory]
+    [InlineData("mail.partner.test", "partner.test")]
+    [InlineData("p1.mail.partner.test", "partner.test")]
+    [InlineData("partner.test", "notice.partner.test")]
+    public void AuthorAuthentication_IdentityWithinTheDisplayedDomainsBranch_IsAuthenticated(
+        string signingDomain,
+        string displayedDomain)
     {
         // Arrange
-        SenderDomain.TryCreate("mail.partner.test", out var signer);
+        SenderDomain.TryCreate(signingDomain, out var signer);
+        SenderDomain.TryCreate(displayedDomain, out var displayed);
+
+        // Act
+        var authentication = SenderAuthentication.Authenticated(
+            [signer],
+            spfDomains: [],
+            displayed,
+            DmarcOutcome.NotReported);
+
+        // Assert
+        Assert.Equal(AuthorAuthenticationOutcome.Authenticated, authentication.AuthorAuthentication);
+        Assert.Equal(displayed, authentication.AuthenticatedAuthorDomain);
+    }
+
+    /// <summary>Two names under one parent are unrelated, whichever of them signed the message.</summary>
+    /// <remarks>
+    /// This is the line between a delegation and DMARC's relaxed alignment. Calling siblings aligned needs the
+    /// organizational domain they share, which needs a public suffix list — neither of which exists here, and a shared
+    /// parent is no evidence that either name was ever permitted to speak for the other.
+    /// </remarks>
+    [Fact]
+    public void AuthorAuthentication_SiblingOfTheDisplayedDomain_IsNotEstablished()
+    {
+        // Arrange
+        SenderDomain.TryCreate("a.partner.test", out var signer);
+        SenderDomain.TryCreate("b.partner.test", out var displayed);
+
+        // Act
+        var authentication = SenderAuthentication.Authenticated(
+            [signer],
+            spfDomains: [],
+            displayed,
+            DmarcOutcome.NotReported);
+
+        // Assert
+        Assert.Equal(AuthorAuthenticationOutcome.NotEstablished, authentication.AuthorAuthentication);
+        Assert.Null(authentication.AuthenticatedAuthorDomain);
+    }
+
+    /// <summary>A name that merely ends in the displayed one as text is a different domain and establishes nothing.</summary>
+    /// <remarks>
+    /// The widened comparison is on whole labels, so <c>notpartner.test</c> is somebody else's registration rather than
+    /// a zone <c>partner.test</c> delegated. Anything less would hand every displayed domain to whoever registers a
+    /// name ending in its characters.
+    /// </remarks>
+    [Fact]
+    public void AuthorAuthentication_IdentitySharingOnlyASuffixOfCharacters_IsNotEstablished()
+    {
+        // Arrange
+        SenderDomain.TryCreate("notpartner.test", out var signer);
         SenderDomain.TryCreate("partner.test", out var displayed);
 
         // Act
@@ -221,6 +276,30 @@ public sealed class SenderAuthenticationTests
 
         // Assert
         Assert.Equal(AuthorAuthenticationOutcome.NotEstablished, authentication.AuthorAuthentication);
+        Assert.Null(authentication.AuthenticatedAuthorDomain);
+    }
+
+    /// <summary>A DMARC failure ends the question before the widened comparison is reached.</summary>
+    /// <remarks>
+    /// The receiving server refused the displayed domain under that domain's own published policy, which outranks a
+    /// delegation this reading inferred from two names. Widening the comparison must not reopen a question DMARC closed.
+    /// </remarks>
+    [Fact]
+    public void AuthorAuthentication_IdentityWithinTheDisplayedDomainsBranchButDmarcFailed_IsFailed()
+    {
+        // Arrange
+        SenderDomain.TryCreate("mail.partner.test", out var signer);
+        SenderDomain.TryCreate("partner.test", out var displayed);
+
+        // Act
+        var authentication = SenderAuthentication.Authenticated(
+            [signer],
+            spfDomains: [],
+            displayed,
+            DmarcOutcome.Fail);
+
+        // Assert
+        Assert.Equal(AuthorAuthenticationOutcome.Failed, authentication.AuthorAuthentication);
         Assert.Null(authentication.AuthenticatedAuthorDomain);
     }
 


### PR DESCRIPTION
## What changed

`SenderAuthentication.EstablishAuthor` established the displayed author only where an authenticated identity's domain
was **exactly** the displayed domain. It now also establishes it where one of the two names is a suffix of the other at
a label boundary, in either direction: `p1.mail.example.test` signing `From: @example.test`, and `example.test` signing
`From: @notice.example.test`.

The comparison rests on `SenderDomain.IsSubdomainOf`, which compares whole labels, so nothing new enters the system: no
DMARC record is resolved, no organizational domain is computed, and no public suffix list is consulted. Two names that
merely share a parent stay unrelated — `a.example.test` still does not speak for `b.example.test` — so DMARC's relaxed
alignment stays unreconstructed, and a name ending in another's characters without a label boundary
(`notpartner.test` against `partner.test`) is still somebody else's registration.

- The established `AuthenticatedAuthorDomain` stays the **displayed** domain, so what the trusted-sender list is held
  against is still what the reader sees.
- `dmarc=fail` still ends the question before any comparison is reached.
- The widening lives in the domain type both readings share, so a trusted `Authentication-Results` header and a locally
  verified signature reach the same conclusion about the same message.

## Why

On a deployment whose receiving server writes no `Authentication-Results`, local DKIM verification is the only route to
an author. A measurement over roughly 30 000 stored messages found 1 369 of them — 4.5% — carrying a signature that
verified while their author stayed not established, and about a third of those were pairs of names one within the other.
Those are the ones this accepts; the remaining two thirds, signed by an unrelated third party, are refused exactly as
before.

## Contract change

This reverses a documented posture rather than fixing a defect, and it is a **behavior change on the sender
authentication verdict**, not a break of the MCP tool contract, the configuration schema, the database schema, or the
deployment contract. No column, key, or tool argument moves, and no operator action is required. Mail already stored
keeps the verdict it was derived with; an operator who wants the wider rule applied to it reaches that with
`mfctl mailbox rederive`, which is unchanged by this.

## Residual risk, stated on the page

A subdomain delegated to a third party can now establish the author of mail displaying the parent domain, without
MailFathom reading the DMARC record that would say whether the parent permits it. That record's own default, `adkim=r`,
permits considerably more than this, but it is an assumption nonetheless, and
`docs/features/sender-authentication.md` § *What MailFathom does not do* names it as one.

## Tests

- Both directions of the suffix relation, over three name pairs, and the same case on the trusted-header path and the
  local-verification path.
- A sibling pair under a shared parent, a third-party signer, and a name sharing only a suffix of characters, all of
  which stay not established.
- A DMARC failure over a signing subdomain, which stays a failure.

## Documentation

`docs/features/sender-authentication.md` states the widened rule in all three places that stated the exact one — the
author section, the local-verification section, and *What MailFathom does not do* — still records that no
organizational domain and no public suffix list is computed, and adds the residual risk above.

Closes #978

https://github.com/Krzysztof318/MailFathom/issues/978
https://github.com/Krzysztof318/MailFathom/pull/979
