### PR TITLE
[#837] Bump main version to 0.8.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
        same assembly identity. InformationalVersion is left to the SDK, which is what composes VersionPrefix,
        VersionSuffix, and SourceRevisionId into the single string the runtime reports. -->
   <PropertyGroup>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>0.8.0</VersionPrefix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
   </PropertyGroup>

--- a/src/AI/packages.lock.json
+++ b/src/AI/packages.lock.json
@@ -428,7 +428,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/src/Cli/packages.lock.json
+++ b/src/Cli/packages.lock.json
@@ -67,7 +67,7 @@
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/src/Host/packages.lock.json
+++ b/src/Host/packages.lock.json
@@ -627,8 +627,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "Microsoft.Agents.AI": "[1.15.0, )",
           "Microsoft.Extensions.AI": "[10.8.1, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.8.1, )",
@@ -640,13 +640,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -659,9 +659,9 @@
           "BouncyCastle.Cryptography": "[2.6.2, )",
           "DnsClient": "[1.8.0, )",
           "HtmlSanitizer": "[9.1.974, )",
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Common": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Common": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "MailKit": "[4.17.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",
@@ -679,9 +679,9 @@
       "MailFathom.Mcp": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Common": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Common": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }
       },

--- a/src/Infrastructure/packages.lock.json
+++ b/src/Infrastructure/packages.lock.json
@@ -767,13 +767,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/src/Mcp/packages.lock.json
+++ b/src/Mcp/packages.lock.json
@@ -130,13 +130,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/AI.UnitTests/packages.lock.json
+++ b/tests/AI.UnitTests/packages.lock.json
@@ -520,8 +520,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "Microsoft.Agents.AI": "[1.15.0, )",
           "Microsoft.Extensions.AI": "[10.8.1, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.8.1, )",
@@ -534,7 +534,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/Application.UnitTests/packages.lock.json
+++ b/tests/Application.UnitTests/packages.lock.json
@@ -267,7 +267,7 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/Boundaries.UnitTests/packages.lock.json
+++ b/tests/Boundaries.UnitTests/packages.lock.json
@@ -804,8 +804,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "Microsoft.Agents.AI": "[1.15.0, )",
           "Microsoft.Extensions.AI": "[10.8.1, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.8.1, )",
@@ -818,13 +818,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -833,12 +833,12 @@
       "MailFathom.Host": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.AI": "[0.7.0, )",
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Common": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
-          "MailFathom.Infrastructure": "[0.7.0, )",
-          "MailFathom.Mcp": "[0.7.0, )",
+          "MailFathom.AI": "[0.8.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Common": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
+          "MailFathom.Infrastructure": "[0.8.0, )",
+          "MailFathom.Mcp": "[0.8.0, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.10, )",
           "Microsoft.Extensions.Http.Resilience": "[10.6.0, )",
           "Microsoft.Extensions.ServiceDiscovery": "[10.6.0, )",
@@ -856,9 +856,9 @@
           "BouncyCastle.Cryptography": "[2.6.2, )",
           "DnsClient": "[1.8.0, )",
           "HtmlSanitizer": "[9.1.974, )",
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Common": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Common": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "MailKit": "[4.17.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",
@@ -879,9 +879,9 @@
       "MailFathom.Mcp": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Common": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Common": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }
@@ -889,7 +889,7 @@
       "mfctl": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Common": "[0.7.0, )",
+          "MailFathom.Common": "[0.8.0, )",
           "Spectre.Console": "[0.57.2, )",
           "System.CommandLine": "[2.0.10, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.10, )"

--- a/tests/Cli.UnitTests/packages.lock.json
+++ b/tests/Cli.UnitTests/packages.lock.json
@@ -250,7 +250,7 @@
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -259,7 +259,7 @@
       "mfctl": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Common": "[0.7.0, )",
+          "MailFathom.Common": "[0.8.0, )",
           "Spectre.Console": "[0.57.2, )",
           "System.CommandLine": "[2.0.10, )",
           "System.Security.Cryptography.ProtectedData": "[10.0.10, )"

--- a/tests/Common.UnitTests/packages.lock.json
+++ b/tests/Common.UnitTests/packages.lock.json
@@ -245,7 +245,7 @@
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {

--- a/tests/Host.UnitTests/packages.lock.json
+++ b/tests/Host.UnitTests/packages.lock.json
@@ -800,8 +800,8 @@
         "type": "Project",
         "dependencies": {
           "Azure.Identity": "[1.21.0, )",
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "Microsoft.Agents.AI": "[1.15.0, )",
           "Microsoft.Extensions.AI": "[10.8.1, )",
           "Microsoft.Extensions.AI.Abstractions": "[10.8.1, )",
@@ -814,13 +814,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -829,12 +829,12 @@
       "MailFathom.Host": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.AI": "[0.7.0, )",
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Common": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
-          "MailFathom.Infrastructure": "[0.7.0, )",
-          "MailFathom.Mcp": "[0.7.0, )",
+          "MailFathom.AI": "[0.8.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Common": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
+          "MailFathom.Infrastructure": "[0.8.0, )",
+          "MailFathom.Mcp": "[0.8.0, )",
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.10, )",
           "Microsoft.Extensions.Http.Resilience": "[10.6.0, )",
           "Microsoft.Extensions.ServiceDiscovery": "[10.6.0, )",
@@ -852,9 +852,9 @@
           "BouncyCastle.Cryptography": "[2.6.2, )",
           "DnsClient": "[1.8.0, )",
           "HtmlSanitizer": "[9.1.974, )",
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Common": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Common": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "MailKit": "[4.17.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",
@@ -875,9 +875,9 @@
       "MailFathom.Mcp": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Common": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Common": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }

--- a/tests/Infrastructure.UnitTests/packages.lock.json
+++ b/tests/Infrastructure.UnitTests/packages.lock.json
@@ -610,13 +610,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -629,9 +629,9 @@
           "BouncyCastle.Cryptography": "[2.6.2, )",
           "DnsClient": "[1.8.0, )",
           "HtmlSanitizer": "[9.1.974, )",
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Common": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Common": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "MailKit": "[4.17.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.10, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",

--- a/tests/Mcp.UnitTests/packages.lock.json
+++ b/tests/Mcp.UnitTests/packages.lock.json
@@ -312,13 +312,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {
@@ -327,9 +327,9 @@
       "MailFathom.Mcp": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Application": "[0.7.0, )",
-          "MailFathom.Common": "[0.7.0, )",
-          "MailFathom.Domain": "[0.7.0, )",
+          "MailFathom.Application": "[0.8.0, )",
+          "MailFathom.Common": "[0.8.0, )",
+          "MailFathom.Domain": "[0.8.0, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.10, )",
           "ModelContextProtocol.AspNetCore": "[2.0.0, )"
         }

--- a/tests/SharedSources.UnitTests/packages.lock.json
+++ b/tests/SharedSources.UnitTests/packages.lock.json
@@ -254,13 +254,13 @@
       "MailFathom.Application": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Common": {
         "type": "Project",
         "dependencies": {
-          "MailFathom.Domain": "[0.7.0, )"
+          "MailFathom.Domain": "[0.8.0, )"
         }
       },
       "MailFathom.Domain": {


### PR DESCRIPTION
Returns `main` to naming the release being worked toward rather than the one just published. **Merge this after the `v0.7.0` tag is pushed**, never before: the tag is what makes `0.7.0` real, and `main` has to keep declaring it until then.

Pairs with #1038, which closes the changelog on `0.7.0` and whose merge commit is what gets tagged.

## What moved

`<VersionPrefix>` in `Directory.Build.props` to `0.8.0`. It is the only place a version is written for the build — the image's tags and labels arrive as build arguments, and the chart's `version` and `appVersion` are both supplied at package time from the same declaration.

Every `packages.lock.json` records the version of each `MailFathom.*` project it references, so they move with it. Regenerated with `dotnet restore MailFathom.slnx --force-evaluate`, and the diff was checked for anything that is not a project version:

```
$ git diff -U0 -- '**/packages.lock.json' | grep -E '^[+-][^+-]' | grep -v 'MailFathom\.'
(nothing)
```

**No transitive resolution moved**, so no dependency change is hidden inside the bump. `AppHost` and `IntegrationTests` carry no lock file and are not given one here.

## What deliberately did not move

- **`server.json` stays on `0.7.0`.** It always records the latest stable MailFathom release, whereas `VersionPrefix` now names the next one. The next release's preparation pull request brings it forward, immediately before that version is published to the official MCP Registry.
- **`CHANGELOG.md`, `README.md`, `docs/users/README.md`, and `SECURITY.md` stay as #1038 left them.** They name the release that has just been *published*, and this pull request merges after the tag — a file corrected here would have been wrong in the tagged tree.
- **`deploy/helm/mailfathom/Chart.yaml` is untouched.** Its `version` is a `0.0.0` placeholder and it declares no `appVersion`; the release run supplies both.

## Verification

- `scripts/verify-full.sh` — passed (236 workflow assertions, 10183 unit tests, 95.44% line coverage against an 85% gate)
- `scripts/review-obligations.sh` — no row
- `$check-docs-licenses` — `n/a`. The change is one property and the lock files it implies; it reaches no user, operator, contributor, architectural, or security guidance, adds no dependency, and moves no transitive one

Closes #837
