### PR TITLE
[#1015] Name the spam classification run's primary key in the concurrency classifier

### DIFF
--- a/src/Infrastructure/Persistence/MailFathomDbContext.cs
+++ b/src/Infrastructure/Persistence/MailFathomDbContext.cs
@@ -136,7 +136,7 @@ internal sealed class MailFathomDbContext : DbContext
     /// </remarks>
     internal const string MailRuleEvaluationRunPrimaryKeyConstraintName = "pk_mail_rule_evaluation_runs";
 
-    /// <summary>The key that keeps one whole-mailbox classification run per account, and which a second request meets.</summary>
+    /// <summary>The key that keeps one whole-mailbox classification run per account, and which a second request is recognized by.</summary>
     /// <remarks>
     /// Named for the reason the rule run's key is: two requests for one account's first run reach the database together,
     /// one of them violates this key, and the retry reads back the run the winner asked for — which is how asking twice

--- a/src/Infrastructure/Persistence/Sessions/PersistenceConcurrencyConflicts.cs
+++ b/src/Infrastructure/Persistence/Sessions/PersistenceConcurrencyConflicts.cs
@@ -51,9 +51,19 @@ internal static class PersistenceConcurrencyConflicts
     /// is that a different reindex is already running.
     /// </para>
     /// <para>
-    /// The next is the mutation identity's case once more, for the account's whole-mailbox rule run: two requests
-    /// for an account that has never had one reach the database together, and the retry reads back the run the
-    /// winner asked for instead of the second caller starting a second walk of one mailbox.
+    /// The next two are the mutation identity's case once more, for the account's whole-mailbox runs — the rule run
+    /// and the classification run, each keyed by the account because an account has one of either outstanding. Two
+    /// requests for an account that has never had one reach the database together, and the retry reads back the run
+    /// the winner asked for instead of the second caller starting a second walk of one mailbox. The two are listed
+    /// together because they are one shape: a run table keyed by the account is exactly the write that loses this
+    /// race, so the next one added belongs here on the day its key does.
+    /// </para>
+    /// <para>
+    /// The next is the one classification an occurrence carries, and it is that convergence a message at a time: an
+    /// arrival classifies an occurrence while a run's pass or a reclassification reaches the same one, both read that
+    /// nothing is recorded, and the loser violates the key. The retry re-reads, finds the winner's record, and
+    /// replaces it in place — which is how classifying one message twice leaves one verdict beside the signals it
+    /// rests on rather than a provider failure ending the pass that lost.
     /// </para>
     /// <para>
     /// The last two are one message met by two writers, at the two stages that write per passage. The passage
@@ -133,6 +143,8 @@ internal static class PersistenceConcurrencyConflicts
                 or MailFathomDbContext.EmbeddingProfileFingerprintUniqueIndexName
                 or MailFathomDbContext.EmbeddingProfileLifecycleUniqueIndexName
                 or MailFathomDbContext.MailRuleEvaluationRunPrimaryKeyConstraintName
+                or MailFathomDbContext.SpamClassificationRunPrimaryKeyConstraintName
+                or MailFathomDbContext.EmailSpamClassificationPrimaryKeyConstraintName
                 or MailFathomDbContext.EmailChunkOrdinalUniqueIndexName
                 or MailFathomDbContext.EmailEmbeddingPrimaryKeyConstraintName
                 or MailFathomDbContext.MailRederivationPositionPrimaryKeyConstraintName

--- a/tests/Infrastructure.UnitTests/Persistence/Sessions/PersistenceConcurrencyConflictsTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Sessions/PersistenceConcurrencyConflictsTests.cs
@@ -24,6 +24,8 @@ public sealed class PersistenceConcurrencyConflictsTests
         MailFathomDbContext.EmbeddingProfileFingerprintUniqueIndexName,
         MailFathomDbContext.EmbeddingProfileLifecycleUniqueIndexName,
         MailFathomDbContext.MailRuleEvaluationRunPrimaryKeyConstraintName,
+        MailFathomDbContext.SpamClassificationRunPrimaryKeyConstraintName,
+        MailFathomDbContext.EmailSpamClassificationPrimaryKeyConstraintName,
         MailFathomDbContext.EmailChunkOrdinalUniqueIndexName,
         MailFathomDbContext.EmailEmbeddingPrimaryKeyConstraintName,
         MailFathomDbContext.MailRederivationPositionPrimaryKeyConstraintName,


### PR DESCRIPTION
## What this changes

`PersistenceConcurrencyConflicts.IsConcurrencyConflict` is the whole of what makes a lost race retryable, and spam classification appeared in it nowhere. Two constants are added to the list, and the remarks that explain the list now cover both.

`MailFathomDbContext.SpamClassificationRunPrimaryKeyConstraintName` is the issue's subject. `SpamClassificationRunStore` was written as a near-verbatim clone of `MailRuleEvaluationRunStore` on a parallel branch, and the registration did not travel with the store, so two first submissions for one account left the loser as a raw `DbUpdateException`. Both `SpamClassificationRunRequests.SubmitAsync` and `docs/architecture/stored-email-schema.md:495` already stated the opposite — that the loser "meets the account's own key, is retried from a fresh read, and is answered with the run the winner asked for". The prose was right and the predicate was the defect, which is why no page in this change needed editing.

## The third acceptance item, answered

`EmailSpamClassificationPrimaryKeyConstraintName` belongs in the list, and it is now in it.

- `EmailSpamClassificationStore.SaveAsync` (`src/Infrastructure/Persistence/Spam/EmailSpamClassificationStore.cs:52-58`) is a primary-key lookup followed by an insert when it finds nothing — the read-then-write over a natural key that `src/Infrastructure/AGENTS.md:16` names as the shape that looks safe and is not.
- It is committed through `OptimisticConcurrencyRetryPolicy` (`EmailSpamClassifier.cs:176-179`), so the retry that resolves the race is already wired; only the classification of the failure was missing.
- The two writers are real and documented: an arrival classifying an occurrence while a reclassification or a run's pass reaches the same one. `docs/architecture/stored-email-schema.md:262` says so, and the constant's own remarks (`MailFathomDbContext.cs:110-117`) already claimed it is "which a second concurrent run is recognized by" — nothing recognized it.
- Retrying it is safe in the strong sense: the key is the primary key of a one-row-per-message table whose only writer is that store, so a violation of it can only mean a competing writer got there first. There is no input that makes the retry repeat a write which cannot succeed.

Both are listed as one shape in the remarks, so the next account-keyed run table is named on the day its key exists rather than after a deployment reports it.

## Contract surfaces

None. No MCP tool contract, configuration key, database schema, or deployment contract moves — the constants and their bindings already existed and no migration is owed. What changes is which provider exception is classified as a race, which turns two failures into the retry the callers were already written for.

## Verification

- `scripts/verify-fast.sh` — passed, 10185/10185.
- `scripts/verify-full.sh` — passed over this exact content.
- `scripts/review-obligations.sh` — tests covered by the touched test file; every documentation row read in place and confirmed still true.
- `$check-docs-licenses` — Docs `pass`, Changelog `n/a`, Licenses `pass` (inventory empty).

Closes #1015

Part of #1012.
