### PR TITLE
[#1018] Publish one telemetry vocabulary, one folder dimension, and a cancelled mutation ending

### DIFF
--- a/docs/features/mail-delivery.md
+++ b/docs/features/mail-delivery.md
@@ -620,7 +620,7 @@ refusal states the rule and never repeats the instant, the address, or the subje
 **A moment that came and went while nothing was running is the case with no obviously right answer**, and the deployment
 decides it. `MailDelivery:AllowedSendLateness` is how much later than its due time a message may still be delivered as
 written; the default is a working day. Up to that, the pass sends it. Past it, the send is refused with `28016`, stands
-in the outbox where an operator can see it, and counts under the delivery outcome `missed-due-time` — neither outcome is
+in the outbox where an operator can see it, and counts under the delivery outcome `missed_due_time` — neither outcome is
 silent, and nothing decides on the owner's behalf that a message which missed its moment should still go out. The bound
 applies to a message written for a named time and to nothing else: a send that named none is never late, however long a
 retry or an unreachable provider has held it.
@@ -809,7 +809,7 @@ exception that ended it.
 
 Such a send is **visible rather than silent**: it stays in the outbox an operator reads, it says *unknown* rather than
 *stuck*, whichever pass settled it logs it at error level — the signalled worker and the account's own run alike — and
-the delivery counter measures it under `outcome-unknown`. It moves only
+the delivery counter measures it under `outcome_unknown`. It moves only
 when somebody decides what happened; nothing automatic re-queues it.
 
 A pass stamps whatever it finds in that stage before it claims anything, so a send stranded by a process that stopped is
@@ -1057,7 +1057,7 @@ belongs between an agent and a recipient.
 ## What an operator sees while mail is leaving
 
 Each attempt opens the `submit_outgoing_email` span over the exchange with the server, its duration is recorded, and
-its outcome counts under `mailfathom.mail.delivery.attempts` by account. `outcome-unknown` is the value worth alerting
+its outcome counts under `mailfathom.mail.delivery.attempts` by account. `outcome_unknown` is the value worth alerting
 on at any rate above zero, because each measurement is a message nothing will attempt again until a person decides.
 Filing is counted beside it, under `mailfathom.mail.filing.attempts` by account, place, and outcome, and each append
 opens a span of its own in the mailbox-mutation record. Keeping the drafts folder in step is counted separately again,

--- a/docs/operations/configuration-mail.md
+++ b/docs/operations/configuration-mail.md
@@ -403,7 +403,7 @@ no time is never late, however long a retry or an unreachable provider has held 
 changes nothing about ordinary correspondence. What it decides is the case where the moment came and went with nothing
 running — an instance that was down, a queue that was full — where delivering and dropping are both wrong answers. Up to
 this much lateness the message is delivered as written; past it the send is refused, stands in the outbox where an
-operator sees it, and reports the outcome `missed-due-time` on
+operator sees it, and reports the outcome `missed_due_time` on
 [the delivery counter](telemetry.md). Neither outcome is silent. The default is a working day, which is the span over
 which a message written for nine in the morning still reads as the message its author meant; what to do about one later
 than that is a person's decision rather than a bound's.

--- a/docs/operations/telemetry.md
+++ b/docs/operations/telemetry.md
@@ -158,11 +158,18 @@ impossible rather than merely discouraged: there is no second source to give a d
 because disposing a shared source would silence every other publisher, so a type that reports through them implements
 no disposal on their account.
 
+Every dimension MailFathom names for itself is written in `snake_case`, and an outcome is written as a past
+participle — `succeeded`, `failed`, `cancelled`, `lease_lost`, `outcome_unknown`. That is what lets a panel written
+against one subsystem be reused against the next, so a query grouping the job queue by `lease_lost` groups delivery by
+the same word. A value MailFathom carries in rather than names — a mutation's own name such as `set-seen`, a lifecycle
+such as `dead-lettered` — is published exactly as the contract that owns it spells it, because renaming one for a
+dashboard would put a second spelling of it into the world rather than remove one.
+
 What publishes to that name is documented with the subsystem that does it.
 
 Every change MailFathom makes to a remote mailbox opens a span named after the mutation, and is counted by
 `mailfathom.mailbox.mutations` and timed by `mailfathom.mailbox.mutation.duration`, both broken down by the mutation,
-the account, the folder alias, and whether it succeeded. Two of those names are not mutations —
+the account, the folder, and how it ended. Two of those names are not mutations —
 `file-outgoing-copy` and `withdraw-outgoing-copy`, which put a copy of this deployment's own outgoing message into a
 folder and take it back out — and they report here regardless, because an operator asking what MailFathom changed about
 a mailbox wants one answer rather than two dashboards. It is deliberately
@@ -170,6 +177,15 @@ a mailbox wants one answer rather than two dashboards. It is deliberately
 offered RFC 6851 `MOVE` or the copy-flag-expunge sequence was used instead, and a dimension telling the two apart is
 exactly what would make a missing server extension look like a different operation on a dashboard. Which path ran is in
 the debug log.
+
+The folder is carried on `mailfathom.mail.folder`, the same key every other mail family publishes it under, so a
+mutation panel and a synchronization panel answer for the same folder somebody asked about. The ending is carried on
+`mailfathom.mailbox.mutation.outcome`, whose values are `succeeded`, `failed`, and `cancelled`. The third one is
+shutdown rather than a defect: a change the host stopped waiting for counts as cancelled and leaves its span's status
+unset, for the reason `interrupted` is kept apart from `failed` on the synchronization counter below — a rolling
+restart that reads as a burst of failed writes is a dashboard reporting the deployment's own restart as a mail-server
+problem. What such a change left behind is not folded into success either: the write may have reached the server, and
+which it was is settled from the change's own record, which the two gauges below report the backlog of.
 
 That counter answers what happened; two gauges beside it answer what has not happened yet, which is the question an
 operator opens a dashboard with. `mailfathom.mailbox.mutations.outstanding` reports how many changes an account has
@@ -709,32 +725,32 @@ for it. Five questions are worth answering, and each has one signal.
 
 **Is anything piling up?** `mailfathom.mail.outbox.depth` reports how many messages stand at each stage a send can still
 move from, tagged with the account alias and `mailfathom.mail.delivery.stage`, whose values are `recorded` and
-`transmission-begun`. It is a gauge fed by the delivery pass rather than a query the collector runs on its own
+`transmission_begun`. It is a gauge fed by the delivery pass rather than a query the collector runs on its own
 interval, exactly as [the job queue's depth](#durable-background-work) is: an outbox is read per account by the worker
 that already reads it, and asking the database again on a schedule would count the same rows a second time for nothing.
-A level that rises and does not come back down is mail that is not leaving; a `transmission-begun` level that does not
+A level that rises and does not come back down is mail that is not leaving; a `transmission_begun` level that does not
 return to zero is the one an operator acts on, because nothing moves those messages without a person. The gauge covers
 the two unfinished stages alone — what has been sent, refused, or withdrawn is history rather than backlog, and
 [`mfctl outbox status`](admin-endpoint.md#reading-what-is-in-the-outbox-and-deciding-about-one-message) is where the
 whole of it is counted.
 
 **Is mail leaving?** `mailfathom.mail.delivery.attempts` counts every attempt that ended, tagged with the account alias
-and `mailfathom.mail.delivery.outcome`, whose values are `sent`, `refused`, `deferred`, `outcome-unknown`, `released`,
-`lease-lost`, `not-recorded`, and `missed-due-time`. One measurement per send rather than per pass, because a pass routinely ends in
-several of them. A send a stopped process left mid-transmission is counted too, under `outcome-unknown`, at the pass
+and `mailfathom.mail.delivery.outcome`, whose values are `sent`, `refused`, `deferred`, `outcome_unknown`, `released`,
+`lease_lost`, `not_recorded`, and `missed_due_time`. One measurement per send rather than per pass, because a pass routinely ends in
+several of them. A send a stopped process left mid-transmission is counted too, under `outcome_unknown`, at the pass
 that finds it: the attempt was made by a process that never lived to report it, and it is stamped once, so counting it
 where it becomes knowable is the only place it can be counted at all.
 
-`outcome-unknown` is a dimension of that counter rather than a counter of its own, deliberately: a send whose server
+`outcome_unknown` is a dimension of that counter rather than a counter of its own, deliberately: a send whose server
 never answered is neither a success nor a failure, and giving it an instrument would let a dashboard summing successes
 and failures report a total that quietly omits it. **It is the one value worth alerting on at any rate above zero** —
 each measurement is a message that may or may not have reached somebody and that nothing will attempt again until a
 person decides. `refused` is a terminal failure and worth watching as a rate; `deferred` is the ordinary answer to a
 provider that is briefly busy and is only interesting when it stops turning into `sent`. `released` is shutdown and
-`lease-lost` is an attempt that had already been taken over, so neither counts against a deployment's health.
-`not-recorded` is the store refusing to take an attempt's answer rather than a server refusing the message: the record
+`lease_lost` is an attempt that had already been taken over, so neither counts against a deployment's health.
+`not_recorded` is the store refusing to take an attempt's answer rather than a server refusing the message: the record
 stands where the failed write left it and its lease is what frees it, so a rate above zero is a database to look at and
-not an outbox to act on. `missed-due-time` is a message written to leave at a named time that a pass reached later than
+not an outbox to act on. `missed_due_time` is a message written to leave at a named time that a pass reached later than
 `MailDelivery:AllowedSendLateness` allows — nothing was running when the moment came, or the queue was full — and it is
 the value that says a held send ended without being transmitted. It stands in the outbox like any other refusal, so a
 measurement above zero is a message somebody has to decide about rather than a provider to investigate;
@@ -749,26 +765,26 @@ never counted here, so the two series are read together rather than one being a 
 **Can the owner see what they sent?** `mailfathom.mail.filing.attempts` counts every attempt to put a copy of an
 outgoing message into one of this account's own folders, tagged with the account alias, `mailfathom.mail.filing.place`
 — `draft`, `held`, `sent`, or `undetermined` where a failure ended before any place was chosen — and
-`mailfathom.mail.filing.outcome`, whose values are `filed`, `already-filed`,
-`not-requested`, `destination-unavailable`, `outcome-unknown`, `failed`, and `withdrawn`. Most of them are ordinary:
-`not-requested` is an account that files no copy, `already-filed` is a settlement asked for twice, and `withdrawn` is a
-mirror going away because its message left. Two are worth a dashboard. `destination-unavailable` is a deployment whose
+`mailfathom.mail.filing.outcome`, whose values are `filed`, `already_filed`,
+`not_requested`, `destination_unavailable`, `outcome_unknown`, `failed`, and `withdrawn`. Most of them are ordinary:
+`not_requested` is an account that files no copy, `already_filed` is a settlement asked for twice, and `withdrawn` is a
+mirror going away because its message left. Two are worth a dashboard. `destination_unavailable` is a deployment whose
 `Sent` folder mapping resolves to nothing, so every message it sends goes unrecorded in the mailbox — a configuration
-answer rather than a server one. And `outcome-unknown` means the same here as it does above and for the same reason:
+answer rather than a server one. And `outcome_unknown` means the same here as it does above and for the same reason:
 the append may or may not have reached the folder, nothing will attempt it again, and repeating it would put a second
 copy of somebody's own message in front of them.
 
 **Is the drafts folder showing what is held?** `mailfathom.mail.draft.attempts` counts every attempt to bring a
 mailbox's drafts folder into step with a draft this deployment holds, tagged with the account alias and
-`mailfathom.mail.draft.outcome`, whose values are `filed`, `replaced`, `discarded`, `already-settled`,
-`destination-unavailable`, `diverged`, `outcome-unknown`, and `failed`. It is a counter of its own beside the filing
+`mailfathom.mail.draft.outcome`, whose values are `filed`, `replaced`, `discarded`, `already_settled`,
+`destination_unavailable`, `diverged`, `outcome_unknown`, and `failed`. It is a counter of its own beside the filing
 one above, because a draft was never offered to a submission server: nothing about it is a delivery, and summing the
 two would report an outbox busier than the mail actually leaving it. The first four are ordinary — a draft written, a
-draft edited, a draft given up or sent, and a pass finding nothing owed. `destination-unavailable` is a deployment
+draft edited, a draft given up or sent, and a pass finding nothing owed. `destination_unavailable` is a deployment
 whose drafts-role mapping resolves to nothing, so what an owner writes here is never in front of them in their own mail
 client. `diverged` is the one that names the owner rather than the system: the tracked copy is no longer provably the
 one this deployment appended — the role resolves elsewhere, the folder was recreated, the server named no placement —
-so the message is left exactly where it is and a person decides. `outcome-unknown` means here what it means above and
+so the message is left exactly where it is and a person decides. `outcome_unknown` means here what it means above and
 for the same reason: the append may or may not have reached the folder, nothing will attempt it again, and repeating it
 would put a second draft in front of somebody.
 
@@ -781,7 +797,7 @@ submission is otherwise a duration with nothing to act on. It is MailFathom's ow
 names neither the message nor anybody it is addressed to. Both cover the exchange with the
 server and nothing else: the claim, the record movements, and the backoff are local work, and including them would blur
 the one thing the span exists to attribute. A span that ends without the server having answered is marked as an error,
-which is what makes the trace and the `outcome-unknown` measurement the same event read two ways. A caller that stopped
+which is what makes the trace and the `outcome_unknown` measurement the same event read two ways. A caller that stopped
 waiting and a host that is shutting down are the exception and leave the span unmarked, because neither says anything
 about the provider and marking them would make a rolling restart read as an outage on the rate an operator alerts on.
 

--- a/src/Common/Observability/Telemetry.cs
+++ b/src/Common/Observability/Telemetry.cs
@@ -33,6 +33,20 @@ namespace MailFathom.Common.Observability;
 /// cardinality rule as much as a privacy one, because every one of those would open a time series per message or per
 /// person.
 /// </para>
+/// <para>
+/// A publisher choosing a word for one of its own dimensions writes it in <c>snake_case</c>, and writes an outcome as a
+/// past participle: <c>succeeded</c>, <c>failed</c>, <c>cancelled</c>, <c>lease_lost</c>, <c>outcome_unknown</c>. This
+/// is stated once because the cost of a second spelling is not local to the publisher that invents it — a family
+/// writing <c>lease-lost</c> where another writes <c>lease_lost</c> is two words for one ending, and a panel written
+/// against either one silently answers for half the deployment. The same rule is why one dimension keeps one key
+/// wherever it is published: a folder is <c>mailfathom.mail.folder</c> in every family, so a query written against one
+/// subsystem can be reused against the next.
+/// </para>
+/// <para>
+/// It governs the words a publisher chooses, not the ones it carries in. A value that arrives already named — a domain
+/// identity such as a mutation's own name, or a word a protocol contract publishes — is published exactly as it is
+/// named there, because renaming it for a dashboard would put a second spelling into the world rather than remove one.
+/// </para>
 /// </remarks>
 public static class Telemetry
 {

--- a/src/Infrastructure/Mail/MailKit/Writes/MailKitImapWriteSession.cs
+++ b/src/Infrastructure/Mail/MailKit/Writes/MailKitImapWriteSession.cs
@@ -358,7 +358,11 @@ internal sealed class MailKitImapWriteSession : IMailboxWriteSession
             throw new ArgumentException("A message is appended with the bytes it was composed as.", nameof(rawMime));
         }
 
-        using var scope = this.telemetry.BeginFiling(FileOperationName, this.SessionAccountId, this.folder.Alias);
+        using var scope = this.telemetry.BeginFiling(
+            FileOperationName,
+            this.SessionAccountId,
+            this.folder.Alias,
+            cancellationToken);
 
         var copy = await this.lease.Connection.ExecuteMutationAsync(
             async (_, openFolder, attemptToken) =>
@@ -391,7 +395,11 @@ internal sealed class MailKitImapWriteSession : IMailboxWriteSession
         ImapUid uid,
         CancellationToken cancellationToken)
     {
-        using var scope = this.telemetry.BeginFiling(WithdrawOperationName, this.SessionAccountId, this.folder.Alias);
+        using var scope = this.telemetry.BeginFiling(
+            WithdrawOperationName,
+            this.SessionAccountId,
+            this.folder.Alias,
+            cancellationToken);
 
         await this.lease.Connection.ExecuteMutationAsync(
             async (client, openFolder, attemptToken) =>
@@ -798,7 +806,7 @@ internal sealed class MailKitImapWriteSession : IMailboxWriteSession
         Func<IImapClient, IMailFolder, MailboxMutationScope, CancellationToken, Task<TResult>> change,
         CancellationToken cancellationToken)
     {
-        using var scope = this.telemetry.Begin(mutation, this.SessionAccountId, this.folder.Alias);
+        using var scope = this.telemetry.Begin(mutation, this.SessionAccountId, this.folder.Alias, cancellationToken);
 
         var result = await this.lease.Connection.ExecuteMutationAsync(
             (client, openFolder, attemptToken) =>

--- a/src/Infrastructure/Observability/EmailEmbeddingBackfillTelemetry.cs
+++ b/src/Infrastructure/Observability/EmailEmbeddingBackfillTelemetry.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using MailFathom.Application.Emails.Embeddings;
 using MailFathom.Application.Emails.Embeddings.Backfill;
 using MailFathom.Application.Emails.Embeddings.Generations;
 using MailFathom.Common.Observability;
@@ -137,7 +136,7 @@ public sealed class EmailEmbeddingBackfillTelemetry
         var tags = new TagList
         {
             { OutcomeTagName, OutcomeTagOf(result.Outcome) },
-            { FailureTagName, FailureTagOf(result.Failure) },
+            { FailureTagName, EmailEmbeddingTelemetry.FailureTagOf(result.Failure) },
         };
 
         this.runCount.Add(1, tags);
@@ -181,22 +180,6 @@ public sealed class EmailEmbeddingBackfillTelemetry
         _ => "unknown",
     };
 
-    /// <summary>Names the failure, or says there was none, so the tag stays present on every series.</summary>
-    /// <remarks>
-    /// A tag left off some of the measurements and set on others produces two time series for one instrument, which a
-    /// dashboard reads as a gap rather than as an absence.
-    /// </remarks>
-    private static string FailureTagOf(EmbeddingGenerationFailure? failure) => failure switch
-    {
-        EmbeddingGenerationFailure.CredentialRejected => "credential_rejected",
-        EmbeddingGenerationFailure.RateLimited => "rate_limited",
-        EmbeddingGenerationFailure.RequestTimedOut => "request_timed_out",
-        EmbeddingGenerationFailure.TransportFaulted => "transport_faulted",
-        EmbeddingGenerationFailure.RequestRefused => "request_refused",
-        EmbeddingGenerationFailure.VectorShapeUnexpected => "vector_shape_unexpected",
-        _ => "none",
-    };
-
     /// <summary>Carries one bounded upkeep pass from the span that opens it to the result that ends it.</summary>
     /// <remarks>
     /// A pass that reached no result is published with an error status and no outcome, which is what an unresolved
@@ -223,7 +206,7 @@ public sealed class EmailEmbeddingBackfillTelemetry
             var sweep = result.Sweep;
 
             this.activity?.SetTag(OutcomeTagName, OutcomeTagOf(sweep.Outcome));
-            this.activity?.SetTag(FailureTagName, FailureTagOf(sweep.Failure));
+            this.activity?.SetTag(FailureTagName, EmailEmbeddingTelemetry.FailureTagOf(sweep.Failure));
             this.activity?.SetTag(ChunkedEmailCountTagName, sweep.ChunkedEmailCount);
             this.activity?.SetTag(EmbeddedEmailCountTagName, sweep.EmbeddedEmailCount);
             this.activity?.SetTag(PassageCountTagName, sweep.EmbeddedChunkCount);

--- a/src/Infrastructure/Observability/EmailEmbeddingTelemetry.cs
+++ b/src/Infrastructure/Observability/EmailEmbeddingTelemetry.cs
@@ -154,9 +154,10 @@ public sealed class EmailEmbeddingTelemetry
     /// <summary>Names the failure, or says there was none, so the tag stays present on every series.</summary>
     /// <remarks>
     /// A tag left off some of the measurements and set on others produces two time series for one instrument, which a
-    /// dashboard reads as a gap rather than as an absence.
+    /// dashboard reads as a gap rather than as an absence. <see cref="EmailEmbeddingBackfillTelemetry" /> publishes the
+    /// same dimension and calls this rather than restating it, so one failure has one word in both families.
     /// </remarks>
-    private static string FailureTagOf(EmbeddingGenerationFailure? failure) => failure switch
+    internal static string FailureTagOf(EmbeddingGenerationFailure? failure) => failure switch
     {
         EmbeddingGenerationFailure.CredentialRejected => "credential_rejected",
         EmbeddingGenerationFailure.RateLimited => "rate_limited",

--- a/src/Infrastructure/Observability/MailDeliveryTelemetry.cs
+++ b/src/Infrastructure/Observability/MailDeliveryTelemetry.cs
@@ -237,7 +237,7 @@ public sealed class MailDeliveryTelemetry
     private static string NameOf(OutgoingEmailStage stage) => stage switch
     {
         OutgoingEmailStage.Recorded => "recorded",
-        OutgoingEmailStage.TransmissionBegun => "transmission-begun",
+        OutgoingEmailStage.TransmissionBegun => "transmission_begun",
         _ => throw new ArgumentOutOfRangeException(nameof(stage), stage, "No outbox depth dimension is defined for this stage."),
     };
 
@@ -253,24 +253,24 @@ public sealed class MailDeliveryTelemetry
         MailOutboxDeliveryOutcome.Sent => "sent",
         MailOutboxDeliveryOutcome.Refused => "refused",
         MailOutboxDeliveryOutcome.Deferred => "deferred",
-        MailOutboxDeliveryOutcome.OutcomeUnknown => "outcome-unknown",
+        MailOutboxDeliveryOutcome.OutcomeUnknown => "outcome_unknown",
         MailOutboxDeliveryOutcome.ReleasedForShutdown => "released",
-        MailOutboxDeliveryOutcome.LeaseLost => "lease-lost",
-        MailOutboxDeliveryOutcome.NotRecorded => "not-recorded",
-        MailOutboxDeliveryOutcome.MissedItsDueTime => "missed-due-time",
+        MailOutboxDeliveryOutcome.LeaseLost => "lease_lost",
+        MailOutboxDeliveryOutcome.NotRecorded => "not_recorded",
+        MailOutboxDeliveryOutcome.MissedItsDueTime => "missed_due_time",
         _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "No metric dimension is defined for this delivery outcome."),
     };
 
     /// <summary>Names a draft outcome as the dimension a dashboard groups by, under the same rule as the one above.</summary>
     private static string NameOf(MailDraftFilingOutcome outcome) => outcome switch
     {
-        MailDraftFilingOutcome.AlreadySettled => "already-settled",
+        MailDraftFilingOutcome.AlreadySettled => "already_settled",
         MailDraftFilingOutcome.Filed => "filed",
         MailDraftFilingOutcome.Replaced => "replaced",
         MailDraftFilingOutcome.Discarded => "discarded",
-        MailDraftFilingOutcome.DestinationUnavailable => "destination-unavailable",
+        MailDraftFilingOutcome.DestinationUnavailable => "destination_unavailable",
         MailDraftFilingOutcome.Diverged => "diverged",
-        MailDraftFilingOutcome.OutcomeUnknown => "outcome-unknown",
+        MailDraftFilingOutcome.OutcomeUnknown => "outcome_unknown",
         MailDraftFilingOutcome.Failed => "failed",
         _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "No metric dimension is defined for this draft outcome."),
     };
@@ -279,10 +279,10 @@ public sealed class MailDeliveryTelemetry
     private static string NameOf(OutgoingMailFilingOutcome outcome) => outcome switch
     {
         OutgoingMailFilingOutcome.Filed => "filed",
-        OutgoingMailFilingOutcome.AlreadyFiled => "already-filed",
-        OutgoingMailFilingOutcome.NotRequested => "not-requested",
-        OutgoingMailFilingOutcome.DestinationUnavailable => "destination-unavailable",
-        OutgoingMailFilingOutcome.OutcomeUnknown => "outcome-unknown",
+        OutgoingMailFilingOutcome.AlreadyFiled => "already_filed",
+        OutgoingMailFilingOutcome.NotRequested => "not_requested",
+        OutgoingMailFilingOutcome.DestinationUnavailable => "destination_unavailable",
+        OutgoingMailFilingOutcome.OutcomeUnknown => "outcome_unknown",
         OutgoingMailFilingOutcome.Failed => "failed",
         OutgoingMailFilingOutcome.Withdrawn => "withdrawn",
         _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, "No metric dimension is defined for this filing outcome."),

--- a/src/Infrastructure/Observability/MailboxMutationScope.cs
+++ b/src/Infrastructure/Observability/MailboxMutationScope.cs
@@ -15,6 +15,12 @@ namespace MailFathom.Infrastructure.Observability;
 /// mutation is counted rather than dropping the operation out of the record entirely.
 /// </para>
 /// <para>
+/// A mutation that ended without completing while the caller's token was cancelled is published as cancelled rather
+/// than failed. Shutdown is what produces it, and a rolling restart that reads as a burst of failed writes is a
+/// dashboard telling an operator about their own deployment restarting; what such a mutation cost the mailbox is
+/// decided from the change's own durable record, which is where a half-applied write is resolved anyway.
+/// </para>
+/// <para>
 /// The outcome is the only thing the counter is broken down by beyond the mutation itself. Which protocol path ran is
 /// deliberately not a dimension, because a dimension is exactly the thing that would let a dashboard tell a native
 /// relocation from a fallback one; it is written to the debug log instead, where somebody diagnosing a broken fallback
@@ -29,6 +35,7 @@ internal sealed class MailboxMutationScope : IDisposable
     private readonly MailFolderAlias folderAlias;
     private readonly Activity? activity;
     private readonly long startingTimestamp;
+    private readonly CancellationToken cancellationToken;
 
     private bool succeeded;
     private bool reported;
@@ -39,7 +46,8 @@ internal sealed class MailboxMutationScope : IDisposable
         MailAccountId accountId,
         MailFolderAlias folderAlias,
         Activity? activity,
-        long startingTimestamp)
+        long startingTimestamp,
+        CancellationToken cancellationToken)
     {
         this.telemetry = telemetry;
         this.operationName = operationName;
@@ -47,6 +55,7 @@ internal sealed class MailboxMutationScope : IDisposable
         this.folderAlias = folderAlias;
         this.activity = activity;
         this.startingTimestamp = startingTimestamp;
+        this.cancellationToken = cancellationToken;
     }
 
     /// <summary>Records which protocol path is carrying the mutation, as debug detail and nowhere else.</summary>
@@ -80,16 +89,25 @@ internal sealed class MailboxMutationScope : IDisposable
 
         this.reported = true;
 
+        var outcome = this.succeeded
+            ? MailboxMutationTelemetry.SucceededOutcomeName
+            : this.cancellationToken.IsCancellationRequested
+                ? MailboxMutationTelemetry.CancelledOutcomeName
+                : MailboxMutationTelemetry.FailedOutcomeName;
+
         if (!this.succeeded)
         {
-            this.activity?.SetStatus(ActivityStatusCode.Error);
+            this.activity?.SetStatus(
+                outcome == MailboxMutationTelemetry.CancelledOutcomeName
+                    ? ActivityStatusCode.Unset
+                    : ActivityStatusCode.Error);
         }
 
         this.telemetry.RecordOutcome(
             this.operationName,
             this.accountId,
             this.folderAlias,
-            this.succeeded,
+            outcome,
             this.telemetry.ElapsedSince(this.startingTimestamp));
 
         this.activity?.Dispose();

--- a/src/Infrastructure/Observability/MailboxMutationTelemetry.cs
+++ b/src/Infrastructure/Observability/MailboxMutationTelemetry.cs
@@ -39,8 +39,15 @@ public sealed partial class MailboxMutationTelemetry
 {
     private const string MutationTagName = "mailfathom.mailbox.mutation";
     private const string AccountTagName = "mailfathom.mail.account";
-    private const string FolderAliasTagName = "mailfathom.mail.folder_alias";
+    private const string FolderTagName = "mailfathom.mail.folder";
     private const string OutcomeTagName = "mailfathom.mailbox.mutation.outcome";
+
+    internal const string SucceededOutcomeName = "succeeded";
+
+    /// <summary>Names a mutation nobody waited for the end of, which is shutdown rather than a defect.</summary>
+    internal const string CancelledOutcomeName = "cancelled";
+
+    internal const string FailedOutcomeName = "failed";
 
     private readonly ILogger<MailboxMutationTelemetry> logger;
     private readonly TimeProvider timeProvider;
@@ -72,15 +79,21 @@ public sealed partial class MailboxMutationTelemetry
     /// <param name="mutation">The change the caller asked for, which names the span, the log line, and the counter dimension.</param>
     /// <param name="accountId">The account whose mailbox is being changed.</param>
     /// <param name="folderAlias">The folder the change is performed in.</param>
-    /// <returns>The scope, which the caller must dispose; a scope disposed without <see cref="MailboxMutationScope.Completed" /> reports a failure.</returns>
-    internal MailboxMutationScope Begin(MailboxMutation mutation, MailAccountId accountId, MailFolderAlias folderAlias) =>
-        this.BeginFiling(mutation.Name, accountId, folderAlias);
+    /// <param name="cancellationToken">The token the change runs under, which is what separates a cancelled ending from a failed one.</param>
+    /// <returns>The scope, which the caller must dispose; a scope disposed without <see cref="MailboxMutationScope.Completed" /> reports a failure, or a cancellation where <paramref name="cancellationToken" /> was cancelled.</returns>
+    internal MailboxMutationScope Begin(
+        MailboxMutation mutation,
+        MailAccountId accountId,
+        MailFolderAlias folderAlias,
+        CancellationToken cancellationToken) =>
+        this.BeginFiling(mutation.Name, accountId, folderAlias, cancellationToken);
 
     /// <summary>Begins reporting one operation that is not a mutation of an existing message, under its own name.</summary>
     /// <param name="operationName">The name of the operation, which names the span, the log line, and the counter dimension.</param>
     /// <param name="accountId">The account whose mailbox is being changed.</param>
     /// <param name="folderAlias">The folder the operation is performed in.</param>
-    /// <returns>The scope, which the caller must dispose; a scope disposed without <see cref="MailboxMutationScope.Completed" /> reports a failure.</returns>
+    /// <param name="cancellationToken">The token the operation runs under, which is what separates a cancelled ending from a failed one.</param>
+    /// <returns>The scope, which the caller must dispose; a scope disposed without <see cref="MailboxMutationScope.Completed" /> reports a failure, or a cancellation where <paramref name="cancellationToken" /> was cancelled.</returns>
     /// <remarks>
     /// Filing a copy of an outgoing message and taking that copy back out are changes to a mailbox and belong in the
     /// same record as the mutations — an operator asking what MailFathom changed wants one answer rather than two
@@ -90,12 +103,13 @@ public sealed partial class MailboxMutationTelemetry
     internal MailboxMutationScope BeginFiling(
         string operationName,
         MailAccountId accountId,
-        MailFolderAlias folderAlias)
+        MailFolderAlias folderAlias,
+        CancellationToken cancellationToken)
     {
         var activity = Telemetry.ActivitySource.StartActivity(operationName, ActivityKind.Client);
         activity?.SetTag(MutationTagName, operationName);
         activity?.SetTag(AccountTagName, accountId.Value);
-        activity?.SetTag(FolderAliasTagName, folderAlias.Value);
+        activity?.SetTag(FolderTagName, folderAlias.Value);
 
         this.LogMutationStarted(operationName, accountId.Value, folderAlias.Value);
 
@@ -105,7 +119,8 @@ public sealed partial class MailboxMutationTelemetry
             accountId,
             folderAlias,
             activity,
-            this.timeProvider.GetTimestamp());
+            this.timeProvider.GetTimestamp(),
+            cancellationToken);
     }
 
     [LoggerMessage(
@@ -126,6 +141,15 @@ public sealed partial class MailboxMutationTelemetry
         Level = LogLevel.Warning,
         Message = "Mailbox mutation {Mutation} failed for {AccountId}/{FolderAlias} after {ElapsedMilliseconds} ms.")]
     private partial void LogMutationFailed(
+        string mutation,
+        string accountId,
+        string folderAlias,
+        double elapsedMilliseconds);
+
+    [LoggerMessage(
+        Level = LogLevel.Information,
+        Message = "Mailbox mutation {Mutation} for {AccountId}/{FolderAlias} was cancelled after {ElapsedMilliseconds} ms. What it left behind is resolved from the change's own record.")]
+    private partial void LogMutationCancelled(
         string mutation,
         string accountId,
         string folderAlias,
@@ -167,28 +191,31 @@ public sealed partial class MailboxMutationTelemetry
         string operationName,
         MailAccountId accountId,
         MailFolderAlias folderAlias,
-        bool succeeded,
+        string outcome,
         TimeSpan elapsed)
     {
-        var outcome = succeeded ? "success" : "failure";
         var tags = new TagList
         {
             { MutationTagName, operationName },
             { AccountTagName, accountId.Value },
-            { FolderAliasTagName, folderAlias.Value },
+            { FolderTagName, folderAlias.Value },
             { OutcomeTagName, outcome },
         };
 
         this.mutationCount.Add(1, tags);
         this.mutationDuration.Record(elapsed.TotalSeconds, tags);
 
-        if (succeeded)
+        switch (outcome)
         {
-            this.LogMutationCompleted(operationName, accountId.Value, folderAlias.Value, elapsed.TotalMilliseconds);
-        }
-        else
-        {
-            this.LogMutationFailed(operationName, accountId.Value, folderAlias.Value, elapsed.TotalMilliseconds);
+            case SucceededOutcomeName:
+                this.LogMutationCompleted(operationName, accountId.Value, folderAlias.Value, elapsed.TotalMilliseconds);
+                break;
+            case CancelledOutcomeName:
+                this.LogMutationCancelled(operationName, accountId.Value, folderAlias.Value, elapsed.TotalMilliseconds);
+                break;
+            default:
+                this.LogMutationFailed(operationName, accountId.Value, folderAlias.Value, elapsed.TotalMilliseconds);
+                break;
         }
     }
 

--- a/src/Infrastructure/Observability/SensitiveContentDerivationTelemetry.cs
+++ b/src/Infrastructure/Observability/SensitiveContentDerivationTelemetry.cs
@@ -26,8 +26,16 @@ namespace MailFathom.Infrastructure.Observability;
 /// </remarks>
 public sealed class SensitiveContentDerivationTelemetry : ISensitiveContentDerivationTelemetry
 {
-    private const string CategoryTagName = "mailfathom.sensitive_content.category";
-    private const string ScannerTagName = "mailfathom.sensitive_content.scanner";
+    /// <summary>The category one finding belongs to, which both sensitive-content families are broken down by.</summary>
+    /// <remarks>
+    /// Declared once and read by <see cref="SensitiveContentEgressTelemetry" /> as well. The two publishers are named
+    /// apart by their own instruments, so a dashboard splitting either family by category should split both on one
+    /// dimension — and two identical string literals are two places for that dimension to drift.
+    /// </remarks>
+    internal const string CategoryTagName = "mailfathom.sensitive_content.category";
+
+    /// <summary>The scanner an outcome belongs to, shared with <see cref="SensitiveContentEgressTelemetry" /> for the same reason.</summary>
+    internal const string ScannerTagName = "mailfathom.sensitive_content.scanner";
 
     private readonly Counter<long> derivedTextCount;
     private readonly Counter<long> findingCount;
@@ -93,9 +101,10 @@ public sealed class SensitiveContentDerivationTelemetry : ISensitiveContentDeriv
     /// <remarks>
     /// A closed mapping rather than the member's own name, for the reason every published mapping here is closed: the
     /// tag value is what a dashboard and an alert are written against, so a member added without one has to fail rather
-    /// than silently rename a series.
+    /// than silently rename a series. <see cref="SensitiveContentEgressTelemetry" /> publishes the same dimension and
+    /// calls this rather than restating it, so one scanner has one word wherever it appears.
     /// </remarks>
-    private static string TagOf(SensitiveContentScannerKind scanner) => scanner switch
+    internal static string TagOf(SensitiveContentScannerKind scanner) => scanner switch
     {
         SensitiveContentScannerKind.Secrets => "secrets",
         SensitiveContentScannerKind.Pii => "pii",

--- a/src/Infrastructure/Observability/SensitiveContentEgressTelemetry.cs
+++ b/src/Infrastructure/Observability/SensitiveContentEgressTelemetry.cs
@@ -36,8 +36,11 @@ public sealed class SensitiveContentEgressTelemetry : ISensitiveContentEgressTel
     internal const string GuardedOperationSpanName = "scan_sensitive_content";
 
     private const string EgressPointTagName = "mailfathom.sensitive_content.egress_point";
-    private const string CategoryTagName = "mailfathom.sensitive_content.category";
-    private const string ScannerTagName = "mailfathom.sensitive_content.scanner";
+    // The category and the scanner are one dimension apiece across both sensitive-content families, so they are read
+    // from the derivation publisher rather than restated here: a dashboard splitting either family by category splits
+    // both on the same key, and a second literal would be the second place for it to drift.
+    private const string CategoryTagName = SensitiveContentDerivationTelemetry.CategoryTagName;
+    private const string ScannerTagName = SensitiveContentDerivationTelemetry.ScannerTagName;
 
     /// <summary>How many texts one guarded operation scanned, which is what its duration has to be read against.</summary>
     private const string GuardedTextCountTagName = "mailfathom.sensitive_content.texts";
@@ -119,7 +122,7 @@ public sealed class SensitiveContentEgressTelemetry : ISensitiveContentEgressTel
             new TagList
             {
                 { EgressPointTagName, TagOf(egressPoint) },
-                { ScannerTagName, TagOf(scanner) },
+                { ScannerTagName, SensitiveContentDerivationTelemetry.TagOf(scanner) },
             });
 
     /// <inheritdoc />
@@ -145,13 +148,6 @@ public sealed class SensitiveContentEgressTelemetry : ISensitiveContentEgressTel
         SensitiveContentEgressPoint.HostedEmbeddingInput => "hosted_embedding_input",
         SensitiveContentEgressPoint.McpSnippet => "mcp_snippet",
         SensitiveContentEgressPoint.McpEmailContent => "mcp_email_content",
-        _ => "unknown",
-    };
-
-    private static string TagOf(SensitiveContentScannerKind scanner) => scanner switch
-    {
-        SensitiveContentScannerKind.Secrets => "secrets",
-        SensitiveContentScannerKind.Pii => "pii",
         _ => "unknown",
     };
 

--- a/tests/Infrastructure.UnitTests/Observability/MailboxMutationTelemetryTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/MailboxMutationTelemetryTests.cs
@@ -1,0 +1,252 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using MailFathom.Common.Observability;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Mutations;
+using MailFathom.Infrastructure.Observability;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Observability;
+
+/// <summary>Covers the three endings a mutation is published under, and the dimensions it is published by.</summary>
+/// <remarks>
+/// The listener and the collector both observe the application's own source and meter, which everything MailFathom
+/// publishes shares, so each test names an account of its own and reads only what carries it. That is what keeps a
+/// mutation published by another test class at the same moment out of these assertions.
+/// </remarks>
+public sealed class MailboxMutationTelemetryTests : IDisposable
+{
+    private const string CountInstrumentName = "mailfathom.mailbox.mutations";
+    private const string DurationInstrumentName = "mailfathom.mailbox.mutation.duration";
+    private const string MutationTagName = "mailfathom.mailbox.mutation";
+    private const string AccountTagName = "mailfathom.mail.account";
+    private const string FolderTagName = "mailfathom.mail.folder";
+    private const string OutcomeTagName = "mailfathom.mailbox.mutation.outcome";
+
+    private static readonly MailFolderAlias Folder = MailFolderAlias.Create("INBOX");
+
+    private readonly ConcurrentBag<Activity> published = [];
+    private readonly ActivityListener listener;
+    private readonly RecordingLoggerProvider logs = new();
+    private readonly ILoggerFactory loggerFactory;
+    private readonly MailboxMutationTelemetry telemetry;
+
+    public MailboxMutationTelemetryTests()
+    {
+        this.loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(this.logs));
+        this.telemetry = new MailboxMutationTelemetry(
+            this.loggerFactory.CreateLogger<MailboxMutationTelemetry>(),
+            new FakeTimeProvider());
+
+        this.listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == Telemetry.Name,
+            Sample = static (ref ActivityCreationOptions<ActivityContext> _) =>
+                ActivitySamplingResult.AllDataAndRecorded,
+            ActivityStopped = activity => this.published.Add(activity),
+        };
+
+        ActivitySource.AddActivityListener(this.listener);
+    }
+
+    public void Dispose()
+    {
+        this.listener.Dispose();
+        this.loggerFactory.Dispose();
+        this.logs.Dispose();
+    }
+
+    /// <summary>
+    /// The folder dimension is the one every other mail publisher already writes, which is what lets a mutation panel
+    /// be joined with a synchronization one on the folder somebody is asking about.
+    /// </summary>
+    [Fact]
+    public void Begin_ACompletedMutation_PublishesItAsSucceededUnderTheSharedFolderDimension()
+    {
+        // Arrange
+        var account = MailAccountId.Create("publishes-succeeded");
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (var scope = this.telemetry.Begin(
+            MailboxMutation.Relocate,
+            account,
+            Folder,
+            TestContext.Current.CancellationToken))
+        {
+            scope.Completed();
+        }
+
+        // Assert
+        var counted = Assert.Single(collector.Read(CountInstrumentName, account));
+
+        Assert.Equal(1, counted.Value);
+        Assert.Equal(MailboxMutation.Relocate.Name, counted.Tags[MutationTagName]);
+        Assert.Equal(Folder.Value, counted.Tags[FolderTagName]);
+        Assert.Equal("succeeded", counted.Tags[OutcomeTagName]);
+        Assert.DoesNotContain("mailfathom.mail.folder_alias", counted.Tags.Keys);
+
+        var span = this.SpanOf(account);
+
+        Assert.Equal(Folder.Value, span.GetTagItem(FolderTagName));
+        Assert.Equal(ActivityStatusCode.Ok, span.Status);
+    }
+
+    /// <summary>
+    /// Shutdown mid-mutation is what produces this, and counting it as a failure would make a rolling restart read as a
+    /// burst of failed writes on the rate an operator alerts on. The span is left unset rather than in error for the
+    /// same reason: nothing here says the mail server refused anything.
+    /// </summary>
+    [Fact]
+    public void Begin_AMutationCancelledBeforeItCompleted_PublishesItAsCancelledRatherThanFailed()
+    {
+        // Arrange
+        var account = MailAccountId.Create("publishes-cancelled");
+        using var collector = new MeasurementCollector();
+        using var caller = new CancellationTokenSource();
+
+        // Act
+        using (this.telemetry.Begin(MailboxMutation.Delete, account, Folder, caller.Token))
+        {
+            caller.Cancel();
+        }
+
+        // Assert
+        Assert.Equal("cancelled", Assert.Single(collector.Read(CountInstrumentName, account)).Tags[OutcomeTagName]);
+        Assert.Equal("cancelled", Assert.Single(collector.Read(DurationInstrumentName, account)).Tags[OutcomeTagName]);
+
+        Assert.Equal(ActivityStatusCode.Unset, this.SpanOf(account).Status);
+    }
+
+    /// <summary>A mutation that neither completed nor was cancelled is one that raised, and it stays a failure.</summary>
+    [Fact]
+    public void Begin_AMutationThatEndedWithoutCompleting_PublishesItAsFailed()
+    {
+        // Arrange
+        var account = MailAccountId.Create("publishes-failed");
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (this.telemetry.Begin(MailboxMutation.SetSeen, account, Folder, TestContext.Current.CancellationToken))
+        {
+        }
+
+        // Assert
+        Assert.Equal("failed", Assert.Single(collector.Read(CountInstrumentName, account)).Tags[OutcomeTagName]);
+        Assert.Equal(ActivityStatusCode.Error, this.SpanOf(account).Status);
+    }
+
+    /// <summary>
+    /// The log channel carries the same distinction as the metric one. A warning per interrupted write is the same
+    /// false alarm read from the other side, so a cancelled mutation is recorded and not complained about.
+    /// </summary>
+    [Fact]
+    public void Begin_AMutationCancelledBeforeItCompleted_RecordsItWithoutWarning()
+    {
+        // Arrange
+        var account = MailAccountId.Create("logs-cancelled");
+        using var caller = new CancellationTokenSource();
+
+        // Act
+        using (this.telemetry.Begin(MailboxMutation.Copy, account, Folder, caller.Token))
+        {
+            caller.Cancel();
+        }
+
+        // Assert
+        Assert.DoesNotContain(
+            this.logs.Records,
+            record => record.Level == LogLevel.Warning
+                && record.Properties.TryGetValue("AccountId", out var logged)
+                && Equals(logged, account.Value));
+    }
+
+    /// <summary>Filing a copy of an outgoing message reports through the same instruments, under its own name.</summary>
+    [Fact]
+    public void BeginFiling_ACompletedFiling_PublishesItBesideTheMutations()
+    {
+        // Arrange
+        var account = MailAccountId.Create("publishes-filing");
+        using var collector = new MeasurementCollector();
+
+        // Act
+        using (var scope = this.telemetry.BeginFiling(
+            "file-outgoing-copy",
+            account,
+            Folder,
+            TestContext.Current.CancellationToken))
+        {
+            scope.Completed();
+        }
+
+        // Assert
+        var counted = Assert.Single(collector.Read(CountInstrumentName, account));
+
+        Assert.Equal("file-outgoing-copy", counted.Tags[MutationTagName]);
+        Assert.Equal("succeeded", counted.Tags[OutcomeTagName]);
+    }
+
+    private Activity SpanOf(MailAccountId accountId) =>
+        Assert.Single(
+            this.published,
+            activity => Equals(activity.GetTagItem(AccountTagName), accountId.Value));
+
+    /// <summary>Collects what the application's meter published while one test ran.</summary>
+    private sealed class MeasurementCollector : IDisposable
+    {
+        private readonly MeterListener listener = new();
+        private readonly ConcurrentQueue<PublishedMeasurement> measurements = new();
+
+        internal MeasurementCollector()
+        {
+            this.listener.InstrumentPublished = (instrument, activeListener) =>
+            {
+                if (StringComparer.Ordinal.Equals(instrument.Meter.Name, Telemetry.Name))
+                {
+                    activeListener.EnableMeasurementEvents(instrument);
+                }
+            };
+            this.listener.SetMeasurementEventCallback<long>(this.Record);
+            this.listener.SetMeasurementEventCallback<double>(this.Record);
+            this.listener.Start();
+        }
+
+        public void Dispose() => this.listener.Dispose();
+
+        /// <summary>Returns what one instrument published for one account since this collector started.</summary>
+        internal IReadOnlyList<PublishedMeasurement> Read(string instrumentName, MailAccountId accountId) =>
+        [
+            .. this.measurements.Where(measurement =>
+                StringComparer.Ordinal.Equals(measurement.InstrumentName, instrumentName)
+                && measurement.Tags.TryGetValue(AccountTagName, out var account)
+                && Equals(account, accountId.Value)),
+        ];
+
+        private void Record<TMeasurement>(
+            Instrument instrument,
+            TMeasurement measurement,
+            ReadOnlySpan<KeyValuePair<string, object?>> tags,
+            object? state)
+            where TMeasurement : struct =>
+            this.measurements.Enqueue(new PublishedMeasurement(
+                instrument.Name,
+                Convert.ToDouble(measurement, CultureInfo.InvariantCulture),
+                tags.ToArray().ToDictionary(tag => tag.Key, tag => tag.Value, StringComparer.Ordinal)));
+    }
+
+    /// <summary>One measurement an instrument published, with the dimensions it carried.</summary>
+    private sealed record PublishedMeasurement(
+        string InstrumentName,
+        double Value,
+        IReadOnlyDictionary<string, object?> Tags);
+}

--- a/tests/Infrastructure.UnitTests/Observability/TelemetrySurfaceContractTests.cs
+++ b/tests/Infrastructure.UnitTests/Observability/TelemetrySurfaceContractTests.cs
@@ -580,7 +580,7 @@ public sealed class TelemetrySurfaceContractTests
 
     private static void DriveMutations()
     {
-        using (var scope = Mutation.Begin(MailboxMutation.Relocate, Account, FolderAlias))
+        using (var scope = Mutation.Begin(MailboxMutation.Relocate, Account, FolderAlias, CancellationToken.None))
         {
             scope.ProtocolPathChosen(TelemetryRedactionContract.CallerSuppliedSentinel);
             scope.CommandIssued(TelemetryRedactionContract.CallerSuppliedSentinel);

--- a/tests/shared/TelemetryRedactionContract.cs
+++ b/tests/shared/TelemetryRedactionContract.cs
@@ -54,7 +54,6 @@ internal static class TelemetryRedactionContract
     [
         "mailfathom.mail.account",
         "mailfathom.mail.folder",
-        "mailfathom.mail.folder_alias",
         "mailfathom.answering.endpoint",
     ];
 


### PR DESCRIPTION
Closes #1018

Four telemetry findings from the wave-1 sweep of #1012, two of them correctness-adjacent: a dimension published under two keys and a family published in a different word case cannot be joined in a dashboard.

## What changed

**A mutation now has a cancelled ending.** `MailboxMutationTelemetry.Begin` and `BeginFiling` take the caller's `CancellationToken` and hand it to `MailboxMutationScope`, which on dispose without `Completed()` publishes `cancelled` with `ActivityStatusCode.Unset` where the token was cancelled and leaves everything else `failed` with `ActivityStatusCode.Error`. Before this, a mutation interrupted by shutdown was exported as a failed mutation, so a rolling restart read as a burst of write failures on the rate an operator alerts on. Three sibling scopes already draw exactly this distinction and each argues for it in its own remarks; `MailSynchronizationTelemetry` publishes `interrupted` for the same event and `docs/operations/telemetry.md` explains at length why that is deliberately not `failed`. All three live call sites in `MailKitImapWriteSession` already held a token. The log channel carries the same distinction: a cancelled mutation is recorded at information level instead of complained about at warning level.

A cancelled mutation is deliberately **not** folded into success. A cancelled write may have reached the server, so the third word stays distinct and what the change left behind is settled from its own durable record.

**One vocabulary.** `MailDeliveryTelemetry` was the only publisher hyphenating a multi-word tag value, against snake_case at about eight others — `lease-lost` versus `JobQueueTelemetry`'s `lease_lost` was two spellings of one word. All of them are rewritten: `transmission_begun`, `outcome_unknown`, `lease_lost`, `not_recorded`, `missed_due_time`, `already_settled`, `destination_unavailable`, `already_filed`, `not_requested`. The mutation counter's two inline `"success"`/`"failure"` literals become named `SucceededOutcomeName`/`FailedOutcomeName` constants carrying the wording six other publishers already use.

**One folder dimension.** `MailboxMutationTelemetry` published `mailfathom.mail.folder_alias` while `MailSynchronizationTelemetry`, `MailboxContentVolumeTelemetry` and `StoredMailRederivationTelemetry` all call the same `MailFolderAlias` dimension `mailfathom.mail.folder`. It now publishes `mailfathom.mail.folder`, so the mutation series can be joined with the rest on folder.

**Two duplicated mappings collapse to a reference rather than a holder.** `SensitiveContentEgressTelemetry` reads the two tag keys and `TagOf(SensitiveContentScannerKind)` from `SensitiveContentDerivationTelemetry`, keeping the derivation copy's remarks; `EmailEmbeddingTelemetry.FailureTagOf` becomes `internal static` and `EmailEmbeddingBackfillTelemetry` calls it. Both consts are internal in one assembly, so a shared holder would have been the premature centralisation `src/AGENTS.md` refuses. The backfill's own restatement of the two *tag keys* stays, because the file already explains at its declaration why it restates them — a noticed decision about the published contract rather than an accident.

**The convention is written down once**, in the remarks on `MailFathom.Common.Observability.Telemetry`: snake_case tag values, past-participle outcome words, and one key per dimension across families. It also records what it does not govern — a value carried in from a domain identity or a protocol contract is published exactly as that contract spells it, which is why `set-seen` and `dead-lettered` are untouched. `docs/operations/telemetry.md` states the operator-facing half of the same fact.

## Breaking changes

Per ADR 0004 the major version is `0`, so a break on a public surface is permitted; this names it. It reaches the **telemetry surface** and nothing else — no configuration key, no database column, no MCP tool argument, no deployment contract.

**What an operator does:** rewrite any dashboard query, alert rule, or recording rule that matches on the values or keys below. Nothing needs to be redeployed in a particular order and no data is lost; existing series simply stop receiving samples under the old spelling.

| Surface | Was | Is now |
| --- | --- | --- |
| Tag key on `mailfathom.mailbox.mutations` and `mailfathom.mailbox.mutation.duration`, and on the mutation span | `mailfathom.mail.folder_alias` | `mailfathom.mail.folder` |
| `mailfathom.mailbox.mutation.outcome` values | `success`, `failure` | `succeeded`, `failed`, and the new `cancelled` |
| `mailfathom.mail.delivery.stage` value | `transmission-begun` | `transmission_begun` |
| `mailfathom.mail.delivery.outcome` values | `outcome-unknown`, `lease-lost`, `not-recorded`, `missed-due-time` | `outcome_unknown`, `lease_lost`, `not_recorded`, `missed_due_time` |
| `mailfathom.mail.draft.outcome` values | `already-settled`, `destination-unavailable`, `outcome-unknown` | `already_settled`, `destination_unavailable`, `outcome_unknown` |
| `mailfathom.mail.filing.outcome` values | `already-filed`, `not-requested`, `destination-unavailable`, `outcome-unknown` | `already_filed`, `not_requested`, `destination_unavailable`, `outcome_unknown` |

A mutation span interrupted by shutdown also changes status from `Error` to `Unset`, which is the point of the change rather than a side effect of it.

## Out of scope, as the issue records

The throw-versus-`"unknown"` fallback difference at `MailDeliveryTelemetry`'s outcome mappings, which is defended deliberately there; a `MailTelemetryTags` holder beyond the two genuinely cross-subsystem keys; every per-class *outcome* mapping, which are genuinely two closed sets each rather than one duplicated one.

One observation the issue does not carry, recorded here rather than acted on: the issue's premise that `MailDeliveryTelemetry` was the only class in `src/` hyphenating a multi-word tag value is not quite right. `MailboxMutation.SetSeen` (`set-seen`), its siblings, `MailboxMutationLifecycle.DeadLettered` (`dead-lettered`), and the two filing operation names in `MailKitImapWriteSession` are hyphenated and reach a tag value too. They are left alone deliberately: each is a domain identity that also crosses the MCP tool contract — `RecordedMailboxChange` documents `dead-lettered` to a client — so renaming them is a break on a different surface, and the convention paragraph states that a carried-in value keeps its own spelling for exactly that reason.

## Tests

New `MailboxMutationTelemetryTests` drives the real source and meter and covers the three endings, the shared folder key, and that a cancelled mutation writes no warning. `TelemetrySurfaceContractTests` and `TelemetryRedactionContract` move with the tag key.

## Verification

`scripts/verify-full.sh` — 10188 unit tests and 236 workflow assertions, all passing.
`scripts/review-obligations.sh` — every row answered; `MailKitImapWriteSession` and `MailboxMutationScope` are named by no test directly, and both are covered through `MailboxMutationTelemetryTests` and the write-session harness.
`$check-docs-licenses` — Docs pass, Changelog n/a, Licenses n/a.

https://github.com/Krzysztof318/MailFathom/issues/1018

https://github.com/Krzysztof318/MailFathom/pull/1046
