### PR TITLE
[#1020] Fold the seven persistence clones the paging and delivery branches left behind

### DIFF
--- a/src/Infrastructure/Persistence/Answering/MailAnsweringAuditEntryStore.cs
+++ b/src/Infrastructure/Persistence/Answering/MailAnsweringAuditEntryStore.cs
@@ -9,6 +9,7 @@ using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Answering.Audit;
 using MailFathom.Infrastructure.Observability;
 using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Mutations;
 using MailFathom.Infrastructure.Persistence.Sessions;
 using Microsoft.EntityFrameworkCore;
 
@@ -64,6 +65,7 @@ internal sealed class MailAnsweringAuditEntryStore(
     }
 
     /// <inheritdoc />
+    /// <remarks>The read takes one row past the page, for the reason <see cref="KeysetPageSplit" /> states.</remarks>
     public async Task<MailAnsweringAuditPage> ReadPageAsync(
         MailAnsweringAuditQuery query,
         CancellationToken cancellationToken)
@@ -80,13 +82,10 @@ internal sealed class MailAnsweringAuditEntryStore(
             .Include(record => record.Emails)
             .OrderByDescending(record => record.CompletedAt)
             .ThenByDescending(record => record.Id)
-
-            // One more than the page holds, which is how the answer says whether a following page exists without a
-            // second count query over the same filtered set.
             .Take(query.PageSize + 1)
             .ToArrayAsync(cancellationToken);
 
-        var pageEntities = entities.Take(query.PageSize).ToArray();
+        var (pageEntities, hasMore) = KeysetPageSplit.Of(entities, query.PageSize);
         var entries = new List<MailAnsweringAuditEntry>(pageEntities.Length);
         var unreadableCount = 0;
 
@@ -111,7 +110,7 @@ internal sealed class MailAnsweringAuditEntryStore(
         // costs its own place in the page and nothing else: the walk neither stalls on it nor repeats the rows around it.
         return new MailAnsweringAuditPage(
             entries,
-            entities.Length > query.PageSize && pageEntities.Length > 0
+            hasMore
                 ? MailAnsweringAuditCursor.After(
                     pageEntities[^1].CompletedAt,
                     MailAnsweringAuditEntryId.Create(pageEntities[^1].Id),
@@ -120,6 +119,10 @@ internal sealed class MailAnsweringAuditEntryStore(
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The bounded set is read first and deleted by key, for the reason
+    /// <see cref="MailboxMutationAuditEntryStore.EraseCompletedBeforeAsync" /> states.
+    /// </remarks>
     public async Task<int> EraseCompletedBeforeAsync(
         MailAccountId accountId,
         DateTimeOffset completedBefore,
@@ -130,10 +133,6 @@ internal sealed class MailAnsweringAuditEntryStore(
 
         var accountValue = accountId.Value;
 
-        // The bounded set is read first and deleted by key, rather than bounding the delete itself: PostgreSQL has no
-        // `DELETE ... LIMIT`, so a bound expressed on the delete either fails to translate or becomes a subquery whose
-        // shape depends on the provider. Two statements over the same index cost one extra round trip and keep the
-        // statement that takes row locks small enough to state.
         var expiringIds = await readContext.MailAnsweringAuditEntries
             .AsNoTracking()
             .Where(record => record.MailboxAccountId == accountValue && record.CompletedAt < completedBefore)

--- a/src/Infrastructure/Persistence/Delivery/MailDraftRecordMapping.cs
+++ b/src/Infrastructure/Persistence/Delivery/MailDraftRecordMapping.cs
@@ -3,13 +3,9 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Domain.Accounts;
-using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Delivery.Drafts;
-using MailFathom.Domain.Emails;
-using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
-using MailFathom.Domain.Mutations;
 using MailFathom.Infrastructure.Persistence.Entities;
 
 namespace MailFathom.Infrastructure.Persistence.Delivery;
@@ -51,7 +47,7 @@ internal static class MailDraftRecordMapping
                 : null,
             Copies = [.. entity.Copies.Select(ToCopy).OrderByDescending(copy => copy.Revision)],
             Divergence = ToDivergence(entity),
-            LastFailure = ToFailure(entity.LastFailureCode),
+            LastFailure = StoredFailureCode.ToErrorCode(entity.LastFailureCode),
         };
     }
 
@@ -63,22 +59,11 @@ internal static class MailDraftRecordMapping
             FolderAlias = MailFolderAlias.Create(entity.FolderAlias),
             FolderPath = RemoteFolderPath.Create(entity.FolderPath),
             Stage = entity.Stage,
-            Placement = ToPlacement(entity),
+            Placement = StoredRemotePlacement.Of(entity.PlacementUidValidity, entity.PlacementUid),
             InternetMessageId = entity.InternetMessageId,
             AppendedAt = entity.AppendedAt,
             SettledAt = entity.SettledAt,
         };
-
-    /// <summary>Reads back where the server said it put the copy, which on most servers is nowhere it named.</summary>
-    /// <remarks>
-    /// The two columns are written together and read together. A row carrying one of them is a row no code path here
-    /// can produce, and reading it as a placement would name a UID with no UID space to interpret it in — which is the
-    /// one thing a removal must never do.
-    /// </remarks>
-    private static RemoteEmailPlacement ToPlacement(MailDraftCopyEntity entity) =>
-        entity is { PlacementUidValidity: { } uidValidity, PlacementUid: { } uid }
-            ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(uidValidity), ImapUid.Create(uid))
-            : RemoteEmailPlacement.NotReported();
 
     /// <summary>Reads back why the tracked copy stopped being one MailFathom may touch.</summary>
     /// <remarks>
@@ -91,42 +76,13 @@ internal static class MailDraftRecordMapping
             : null;
 
     /// <summary>Restores one person the draft is addressed to.</summary>
-    /// <remarks>
-    /// An address that no longer parses fails the read rather than being dropped, for the reason a send's does: a draft
-    /// promoted with fewer recipients than its author wrote is a person who never receives the message and is told
-    /// nothing about it.
-    /// </remarks>
-    private static OutgoingRecipient ToRecipient(Guid draftId, MailDraftRecipientEntity entity)
-    {
-        if (!EmailAddress.TryCreate(displayName: null, entity.Address, out var address))
-        {
-            // The address itself stays out of the message: it is personal data, and the ordinal names the row exactly.
-            throw new InvalidOperationException(
-                $"Mail draft {draftId} carries a recipient at position {entity.Ordinal} whose address names no mailbox.");
-        }
-
-        return OutgoingRecipient.Create(address, entity.Role, ContactOf(entity));
-    }
-
-    /// <summary>Reads back which contact the address was resolved from, where one was.</summary>
-    /// <remarks>An empty identifier is read as no contact, for the reason a send's is: the value records how the
-    /// address came to be on the draft and nothing addresses anybody by it.</remarks>
-    private static ContactId? ContactOf(MailDraftRecipientEntity entity) =>
-        entity.ContactId is { } contactId && contactId != Guid.Empty ? ContactId.Create(contactId) : null;
-
-    /// <summary>Reads back the code of the failure the last attempt on the mailbox ended in.</summary>
-    /// <remarks>
-    /// A number this build does not recognize is a row written by one that allocated a code since. It is diagnostic
-    /// detail rather than something acted on, so it is reported as absent instead of failing the read of a draft that
-    /// is otherwise perfectly readable.
-    /// </remarks>
-    private static MailFathomErrorCode? ToFailure(int? storedCode)
-    {
-        if (storedCode is not { } failureCode)
-        {
-            return null;
-        }
-
-        return MailFathomErrorCode.TryParse(failureCode, out var failure) ? failure : null;
-    }
+    /// <remarks>The address and the contact are read as <see cref="StoredOutgoingRecipient" /> states.</remarks>
+    private static OutgoingRecipient ToRecipient(Guid draftId, MailDraftRecipientEntity entity) =>
+        StoredOutgoingRecipient.ToRecipient(
+            "Mail draft",
+            draftId,
+            entity.Ordinal,
+            entity.Address,
+            entity.Role,
+            entity.ContactId);
 }

--- a/src/Infrastructure/Persistence/Delivery/OutboxOperationStore.cs
+++ b/src/Infrastructure/Persistence/Delivery/OutboxOperationStore.cs
@@ -6,7 +6,6 @@ using MailFathom.Application.Mail.Delivery.Operations;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Delivery;
-using MailFathom.Domain.Failures;
 using MailFathom.Infrastructure.Persistence.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -61,6 +60,7 @@ internal sealed class OutboxOperationStore(MailFathomDbContext dbContext, TimePr
     }
 
     /// <inheritdoc />
+    /// <remarks>The read takes one row past the page, for the reason <see cref="KeysetPageSplit" /> states.</remarks>
     public async Task<OutboxPage> ReadPageAsync(OutboxQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
@@ -68,9 +68,6 @@ internal sealed class OutboxOperationStore(MailFathomDbContext dbContext, TimePr
         var rows = await this.Filter(query)
             .OrderByDescending(message => message.RecordedAt)
             .ThenByDescending(message => message.Id)
-
-            // One more than the page holds, which is how the answer says whether a following page exists without a
-            // second count query over the same filtered set.
             .Take(query.PageSize + 1)
             .Select(message => new OutboxRow(
                 message.Id,
@@ -86,11 +83,11 @@ internal sealed class OutboxOperationStore(MailFathomDbContext dbContext, TimePr
                 message.LastReplyCode))
             .ToArrayAsync(cancellationToken);
 
-        var pageRows = rows.Take(query.PageSize).ToArray();
+        var (pageRows, hasMore) = KeysetPageSplit.Of(rows, query.PageSize);
 
         return new OutboxPage(
             [.. pageRows.Select(ToEntry)],
-            rows.Length > query.PageSize && pageRows.Length > 0
+            hasMore
                 ? OutboxCursor.After(
                     pageRows[^1].RecordedAt,
                     OutgoingEmailId.Create(pageRows[^1].Id),
@@ -254,25 +251,9 @@ internal sealed class OutboxOperationStore(MailFathomDbContext dbContext, TimePr
         RecordedAt = row.RecordedAt,
         StageChangedAt = row.StageChangedAt,
         AvailableAt = row.AvailableAt,
-        LastFailure = ToFailure(row.LastFailureCode),
+        LastFailure = StoredFailureCode.ToErrorCode(row.LastFailureCode),
         LastReplyCode = row.LastReplyCode,
     };
-
-    /// <summary>Reads back the code of the failure the last attempt ended in.</summary>
-    /// <remarks>
-    /// A number this build does not recognize is a row written by one that allocated a code since. It is diagnostic
-    /// detail rather than something acted on, so it is reported as absent instead of failing the read of a page that is
-    /// otherwise perfectly readable — which is the same rule the record mapping follows.
-    /// </remarks>
-    private static MailFathomErrorCode? ToFailure(int? storedCode)
-    {
-        if (storedCode is not { } failureCode)
-        {
-            return null;
-        }
-
-        return MailFathomErrorCode.TryParse(failureCode, out var failure) ? failure : null;
-    }
 
     /// <summary>The columns one listing row is read from, which are the ones that name no person.</summary>
     private sealed record OutboxRow(

--- a/src/Infrastructure/Persistence/Delivery/OutgoingEmailRecordMapping.cs
+++ b/src/Infrastructure/Persistence/Delivery/OutgoingEmailRecordMapping.cs
@@ -3,13 +3,9 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Domain.Accounts;
-using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Delivery.Filing;
-using MailFathom.Domain.Emails;
-using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
-using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Scheduling;
 using MailFathom.Infrastructure.Persistence.Entities;
 
@@ -51,10 +47,10 @@ internal static class OutgoingEmailRecordMapping
             StageChangedAt = entity.StageChangedAt,
             AvailableAt = entity.AvailableAt,
             DueAt = ToDueTime(entity),
-            LastFailure = ToFailure(entity.LastFailureCode),
+            LastFailure = StoredFailureCode.ToErrorCode(entity.LastFailureCode),
             LastReplyCode = entity.LastReplyCode,
             Filings = [.. entity.Filings.Select(ToFiling).OrderBy(filing => filing.Filing.Name, StringComparer.Ordinal)],
-            LastFilingFailure = ToFailure(entity.LastFilingFailureCode),
+            LastFilingFailure = StoredFailureCode.ToErrorCode(entity.LastFilingFailureCode),
         };
     }
 
@@ -81,7 +77,7 @@ internal static class OutgoingEmailRecordMapping
             FolderAlias = MailFolderAlias.Create(entity.FolderAlias),
             FolderPath = RemoteFolderPath.Create(entity.FolderPath),
             Stage = entity.Stage,
-            Placement = ToPlacement(entity),
+            Placement = StoredRemotePlacement.Of(entity.PlacementUidValidity, entity.PlacementUid),
             InternetMessageId = entity.InternetMessageId,
             AppendedAt = entity.AppendedAt,
             ObservedAt = entity.ObservedAt,
@@ -89,46 +85,20 @@ internal static class OutgoingEmailRecordMapping
         };
     }
 
-    /// <summary>Reads back where the server said it put the copy, which on most servers is nowhere it named.</summary>
-    /// <remarks>
-    /// The two columns are written together and read together. A row carrying one of them is a row no code path here
-    /// can produce, and reading it as a placement would put a UID into a join with no UID space to interpret it in.
-    /// </remarks>
-    private static RemoteEmailPlacement ToPlacement(OutgoingEmailFilingEntity entity) =>
-        entity is { PlacementUidValidity: { } uidValidity, PlacementUid: { } uid }
-            ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(uidValidity), ImapUid.Create(uid))
-            : RemoteEmailPlacement.NotReported();
-
     /// <summary>Restores one recipient and what the server last said about them.</summary>
-    /// <remarks>
-    /// An address that no longer parses fails the read rather than being dropped. A send offered to fewer people than
-    /// it was authored for is a message somebody never receives and nothing afterwards would say so, which is a worse
-    /// answer than a record that refuses to be read.
-    /// </remarks>
-    private static OutgoingRecipientOutcome ToOutcome(Guid recordId, OutgoingEmailRecipientEntity entity)
-    {
-        if (!EmailAddress.TryCreate(displayName: null, entity.Address, out var address))
-        {
-            // The address itself stays out of the message: it is personal data, and the ordinal names the row exactly.
-            throw new InvalidOperationException(
-                $"Outgoing email record {recordId} carries a recipient at position {entity.Ordinal} whose address names no mailbox.");
-        }
-
-        return OutgoingRecipientOutcome.Create(
-            OutgoingRecipient.Create(address, entity.Role, ContactOf(entity)),
+    /// <remarks>The address and the contact are read as <see cref="StoredOutgoingRecipient" /> states.</remarks>
+    private static OutgoingRecipientOutcome ToOutcome(Guid recordId, OutgoingEmailRecipientEntity entity) =>
+        OutgoingRecipientOutcome.Create(
+            StoredOutgoingRecipient.ToRecipient(
+                "Outgoing email record",
+                recordId,
+                entity.Ordinal,
+                entity.Address,
+                entity.Role,
+                entity.ContactId),
             entity.Status,
             entity.LastReplyCode,
             entity.AnsweredAt);
-    }
-
-    /// <summary>Reads back which contact the recipient's address was resolved from, where one was.</summary>
-    /// <remarks>
-    /// An empty identifier is read as no contact rather than failing the read. The value is a record of how the address
-    /// came to be on the send and nothing offers the message by it, so a row written with one would cost the read of an
-    /// otherwise perfectly deliverable send.
-    /// </remarks>
-    private static ContactId? ContactOf(OutgoingEmailRecipientEntity entity) =>
-        entity.ContactId is { } contactId && contactId != Guid.Empty ? ContactId.Create(contactId) : null;
 
     /// <summary>Reads back the time the message was written to leave at, where one was named.</summary>
     /// <remarks>
@@ -167,21 +137,5 @@ internal static class OutgoingEmailRecordMapping
                 $"Outgoing email record {recordId} carries a principal fingerprint this system did not write.",
                 malformed);
         }
-    }
-
-    /// <summary>Reads back the code of the failure the last attempt ended in.</summary>
-    /// <remarks>
-    /// A number this build does not recognize is a row written by one that allocated a code since. It is diagnostic
-    /// detail rather than something acted on, so it is reported as absent instead of failing the read of a send that is
-    /// otherwise perfectly readable.
-    /// </remarks>
-    private static MailFathomErrorCode? ToFailure(int? storedCode)
-    {
-        if (storedCode is not { } failureCode)
-        {
-            return null;
-        }
-
-        return MailFathomErrorCode.TryParse(failureCode, out var failure) ? failure : null;
     }
 }

--- a/src/Infrastructure/Persistence/Delivery/RecurringSendMapping.cs
+++ b/src/Infrastructure/Persistence/Delivery/RecurringSendMapping.cs
@@ -3,10 +3,8 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Domain.Accounts;
-using MailFathom.Domain.Contacts;
 using MailFathom.Domain.Delivery;
 using MailFathom.Domain.Delivery.Scheduling;
-using MailFathom.Domain.Emails;
 using MailFathom.Infrastructure.Persistence.Entities;
 
 namespace MailFathom.Infrastructure.Persistence.Delivery;
@@ -49,27 +47,15 @@ internal static class RecurringSendMapping
     }
 
     /// <summary>Restores one recipient every occasion of the declaration is offered to.</summary>
-    /// <remarks>
-    /// An address that no longer parses fails the read rather than being dropped, for the reason an outgoing record's
-    /// does: a repetition offered to fewer people than it was declared for is somebody who stops receiving mail with
-    /// nothing afterwards saying so.
-    /// </remarks>
-    private static OutgoingRecipient ToRecipient(Guid declarationId, RecurringSendRecipientEntity entity)
-    {
-        if (!EmailAddress.TryCreate(displayName: null, entity.Address, out var address))
-        {
-            // The address itself stays out of the message: it is personal data, and the ordinal names the row exactly.
-            throw new InvalidOperationException(
-                $"Recurring send {declarationId} carries a recipient at position {entity.Ordinal} whose address names no mailbox.");
-        }
-
-        return OutgoingRecipient.Create(address, entity.Role, ContactOf(entity));
-    }
-
-    /// <summary>Reads back which contact the recipient's address was resolved from, where one was.</summary>
-    /// <remarks>An empty identifier is read as no contact rather than failing the read, exactly as it is on an outgoing record: nothing addresses anybody by it.</remarks>
-    private static ContactId? ContactOf(RecurringSendRecipientEntity entity) =>
-        entity.ContactId is { } contactId && contactId != Guid.Empty ? ContactId.Create(contactId) : null;
+    /// <remarks>The address and the contact are read as <see cref="StoredOutgoingRecipient" /> states.</remarks>
+    private static OutgoingRecipient ToRecipient(Guid declarationId, RecurringSendRecipientEntity entity) =>
+        StoredOutgoingRecipient.ToRecipient(
+            "Recurring send",
+            declarationId,
+            entity.Ordinal,
+            entity.Address,
+            entity.Role,
+            entity.ContactId);
 
     /// <summary>Reads back the message the last occasion produced, where there has been one.</summary>
     /// <remarks>

--- a/src/Infrastructure/Persistence/Delivery/StoredFailureCode.cs
+++ b/src/Infrastructure/Persistence/Delivery/StoredFailureCode.cs
@@ -1,0 +1,30 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Failures;
+
+namespace MailFathom.Infrastructure.Persistence.Delivery;
+
+/// <summary>Reads back the code a stored attempt ended in, from the column that records it.</summary>
+/// <remarks>
+/// A number this build does not recognize is a row written by one that allocated a code since. It is diagnostic detail
+/// rather than something acted on, so it is reported as absent instead of failing the read of a record that is
+/// otherwise perfectly readable. Every table that records a failure code stores it as a nullable number, which is why
+/// the reading is one method rather than one per table.
+/// </remarks>
+internal static class StoredFailureCode
+{
+    /// <summary>Reads the error code the stored number names.</summary>
+    /// <param name="storedCode">The number the column holds, where the row holds one.</param>
+    /// <returns>The code, or <see langword="null" /> when the column is empty or names a code this build has no member for.</returns>
+    internal static MailFathomErrorCode? ToErrorCode(int? storedCode)
+    {
+        if (storedCode is not { } failureCode)
+        {
+            return null;
+        }
+
+        return MailFathomErrorCode.TryParse(failureCode, out var failure) ? failure : null;
+    }
+}

--- a/src/Infrastructure/Persistence/Delivery/StoredOutgoingRecipient.cs
+++ b/src/Infrastructure/Persistence/Delivery/StoredOutgoingRecipient.cs
@@ -1,0 +1,51 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Contacts;
+using MailFathom.Domain.Delivery;
+using MailFathom.Domain.Emails;
+
+namespace MailFathom.Infrastructure.Persistence.Delivery;
+
+/// <summary>Restores one person a stored send, draft, or declaration is addressed to.</summary>
+/// <remarks>
+/// An address that no longer parses fails the read rather than being dropped. A message offered to fewer people than it
+/// was written for is somebody who never receives it and is told nothing about it, which is a worse answer than a
+/// record that refuses to be read. An empty contact identifier is read as no contact instead: that value records how
+/// the address came to be on the message and nothing addresses anybody by it.
+/// </remarks>
+internal static class StoredOutgoingRecipient
+{
+    /// <summary>Restores the recipient one stored row names.</summary>
+    /// <param name="carrier">What the row belongs to, as the refusal names it — an outgoing email record, a draft, or a recurring send.</param>
+    /// <param name="carrierId">The identity of that record, which is what an operator reaches the row by.</param>
+    /// <param name="ordinal">The position the row holds in the message's headers.</param>
+    /// <param name="address">The stored address.</param>
+    /// <param name="role">The header the composed message names them in.</param>
+    /// <param name="contactId">The contact the address was resolved from, where the row names one.</param>
+    /// <returns>The recipient that row states.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the stored address names no mailbox.</exception>
+    internal static OutgoingRecipient ToRecipient(
+        string carrier,
+        Guid carrierId,
+        int ordinal,
+        string address,
+        OutgoingRecipientRole role,
+        Guid? contactId)
+    {
+        if (!EmailAddress.TryCreate(displayName: null, address, out var recipientAddress))
+        {
+            // The address itself stays out of the message: it is personal data, and the ordinal names the row exactly.
+            throw new InvalidOperationException(
+                $"{carrier} {carrierId} carries a recipient at position {ordinal} whose address names no mailbox.");
+        }
+
+        return OutgoingRecipient.Create(
+            recipientAddress,
+            role,
+            contactId is { } resolvedContact && resolvedContact != Guid.Empty
+                ? ContactId.Create(resolvedContact)
+                : null);
+    }
+}

--- a/src/Infrastructure/Persistence/Delivery/StoredRemotePlacement.cs
+++ b/src/Infrastructure/Persistence/Delivery/StoredRemotePlacement.cs
@@ -1,0 +1,27 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Mutations;
+
+namespace MailFathom.Infrastructure.Persistence.Delivery;
+
+/// <summary>Reads back where a server said it put a copy of a message, from the two columns that record it.</summary>
+/// <remarks>
+/// The two columns are written together and read together. A row carrying one of them is a row no code path here can
+/// produce, and reading it as a placement would name a UID with no UID space to interpret it in — which is the one thing
+/// a removal must never do. Every table that records a placement stores it this way, which is why the reading is one
+/// method rather than one per table.
+/// </remarks>
+internal static class StoredRemotePlacement
+{
+    /// <summary>Reads the placement the two stored columns describe.</summary>
+    /// <param name="uidValidity">The UID space the server named, where it named one.</param>
+    /// <param name="uid">The UID the server named, where it named one.</param>
+    /// <returns>The placement, or <see cref="RemoteEmailPlacement.NotReported" /> when either column is absent.</returns>
+    internal static RemoteEmailPlacement Of(uint? uidValidity, uint? uid) =>
+        uidValidity is { } storedUidValidity && uid is { } storedUid
+            ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(storedUidValidity), ImapUid.Create(storedUid))
+            : RemoteEmailPlacement.NotReported();
+}

--- a/src/Infrastructure/Persistence/Emails/EmailContentStore.cs
+++ b/src/Infrastructure/Persistence/Emails/EmailContentStore.cs
@@ -58,10 +58,7 @@ internal sealed class EmailContentStore(
 
         read.Found(storedContent.RawMime.LongLength);
 
-        return new StoredEmailContent(
-            storedContent.RawMime.AsMemory(),
-            storedContent.MimeByteLength,
-            storedContent.Sha256Hash.AsMemory());
+        return storedContent.ToStoredContent();
     }
 
     /// <inheritdoc />
@@ -238,12 +235,7 @@ internal sealed class EmailContentStore(
             .Select(content => new StoredEmailContentRow(content.RawMime, content.MimeByteLength, content.Sha256Hash))
             .SingleOrDefaultAsync(cancellationToken);
 
-        return storedContent is null
-            ? null
-            : new StoredEmailContent(
-                storedContent.RawMime.AsMemory(),
-                storedContent.MimeByteLength,
-                storedContent.Sha256Hash.AsMemory());
+        return storedContent?.ToStoredContent();
     }
 
     /// <inheritdoc />
@@ -315,12 +307,7 @@ internal sealed class EmailContentStore(
             .Select(draft => new StoredEmailContentRow(draft.DraftMime, draft.DraftByteLength, draft.Sha256Hash))
             .SingleOrDefaultAsync(cancellationToken);
 
-        return storedDraft is null
-            ? null
-            : new StoredEmailContent(
-                storedDraft.RawMime.AsMemory(),
-                storedDraft.MimeByteLength,
-                storedDraft.Sha256Hash.AsMemory());
+        return storedDraft?.ToStoredContent();
     }
 
     /// <inheritdoc />
@@ -427,12 +414,7 @@ internal sealed class EmailContentStore(
             .Select(content => new StoredEmailContentRow(content.RawMime, content.MimeByteLength, content.Sha256Hash))
             .SingleOrDefaultAsync(cancellationToken);
 
-        return storedContent is null
-            ? null
-            : new StoredEmailContent(
-                storedContent.RawMime.AsMemory(),
-                storedContent.MimeByteLength,
-                storedContent.Sha256Hash.AsMemory());
+        return storedContent?.ToStoredContent();
     }
 
     private static void EnsureOccurrenceMatches(

--- a/src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailChunkingStore.cs
@@ -10,7 +10,6 @@ using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
-using MailFathom.Domain.Spam;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
 using MailFathom.Infrastructure.Persistence.Spam;
@@ -63,18 +62,19 @@ internal sealed class StoredEmailChunkingStore(
             .Take(batchSize)
             .Select(email => new OutstandingEmailRow(
                 email.Id,
-                email.MailFolder.MailboxAccountId,
-                email.MailFolder.Alias,
-                email.StoredAt,
-                email.ContentAvailability,
-                email.SpamClassification == null ? null : email.SpamClassification.Verdict))
+                new StoredDerivedWorkCandidateRow(
+                    email.MailFolder.MailboxAccountId,
+                    email.MailFolder.Alias,
+                    email.StoredAt,
+                    email.ContentAvailability,
+                    email.SpamClassification == null ? null : email.SpamClassification.Verdict)))
             .ToArrayAsync(cancellationToken);
 
         return
         [
-            .. candidates.Select(candidate => new StoredEmailAwaitingChunking(
-                StoredEmailId.Create(candidate.Id),
-                AdmissionOf(terms, candidate))),
+            .. candidates.Select(row => new StoredEmailAwaitingChunking(
+                StoredEmailId.Create(row.Id),
+                row.Candidate.AdmittedUnder(terms))),
         ];
     }
 
@@ -133,27 +133,6 @@ internal sealed class StoredEmailChunkingStore(
             embeddedFolders),
         terms);
 
-    /// <summary>Names the answer the predicate above already reached about one selected row.</summary>
-    /// <remarks>
-    /// The query admits the message; this says which of the gate's answers admitted it, which is the only place a
-    /// release is decidable per message. A withheld one never reaches here, so the answer is always an admitting one.
-    /// </remarks>
-    private static DerivedWorkAdmission AdmissionOf(DerivedWorkAdmissionTerms terms, OutstandingEmailRow candidate) =>
-        DerivedWorkGate.Admit(
-            terms,
-            new DerivedWorkCandidate(
-                MailAccountId.Create(candidate.MailboxAccountId),
-                MailFolderAlias.Create(candidate.Alias),
-                candidate.StoredAt,
-                candidate.ContentAvailability,
-                candidate.Verdict));
-
     /// <summary>One message awaiting the cut, as the walk's projection returns it.</summary>
-    private sealed record OutstandingEmailRow(
-        Guid Id,
-        string MailboxAccountId,
-        string Alias,
-        DateTimeOffset StoredAt,
-        StoredEmailContentAvailability ContentAvailability,
-        SpamVerdict? Verdict);
+    private sealed record OutstandingEmailRow(Guid Id, StoredDerivedWorkCandidateRow Candidate);
 }

--- a/src/Infrastructure/Persistence/Emails/StoredEmailContentRow.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailContentRow.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.EmailContent.Storage;
 using MailFathom.CodeCoverage;
 
 namespace MailFathom.Infrastructure.Persistence.Emails;
@@ -15,4 +16,15 @@ namespace MailFathom.Infrastructure.Persistence.Emails;
 /// <see cref="byte" /> arrays, which the store then hands over as read-only memory so no caller can write through them.
 /// </remarks>
 [RequiresIntegrationCoverage]
-internal sealed record StoredEmailContentRow(byte[] RawMime, long MimeByteLength, byte[] Sha256Hash);
+internal sealed record StoredEmailContentRow(byte[] RawMime, long MimeByteLength, byte[] Sha256Hash)
+{
+    /// <summary>Turns the returned columns into the application's own value.</summary>
+    /// <returns>The stored content, whose payload and digest are read-only views over the arrays the provider returned.</returns>
+    /// <remarks>
+    /// Every table this store reads a message out of — arrived mail, an outgoing send, a draft, a recurring send's
+    /// template — projects into this row and ends here, so the conversion from the provider's arrays to read-only
+    /// memory is stated once rather than at each read.
+    /// </remarks>
+    internal StoredEmailContent ToStoredContent() =>
+        new(this.RawMime.AsMemory(), this.MimeByteLength, this.Sha256Hash.AsMemory());
+}

--- a/src/Infrastructure/Persistence/Emails/StoredEmailExtractionBackfillStore.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailExtractionBackfillStore.cs
@@ -7,9 +7,7 @@ using MailFathom.Application.Persistence;
 using MailFathom.Application.SensitiveContent.Derivation;
 using MailFathom.Application.Spam.Gating;
 using MailFathom.CodeCoverage;
-using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
-using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
@@ -89,28 +87,14 @@ internal sealed class StoredEmailExtractionBackfillStore(
             .Where(email => resumeAfterId == null || email.Id > resumeAfterId)
             .OrderBy(email => email.Id)
             .Take(batchSize)
-            .Select(email => new
-            {
-                email.Id,
-                email.MailFolder.MailboxAccountId,
-                email.MailFolder.Alias,
-                email.MailFolder.ResolutionGeneration,
-                email.UidValidity,
-                email.Uid,
-            })
+            .Select(StoredEmailOccurrenceRow.Projection)
             .ToArrayAsync(cancellationToken);
 
         return
         [
             .. candidates.Select(candidate => new StoredEmailAwaitingExtraction(
                 StoredEmailId.Create(candidate.Id),
-                EmailOccurrenceId.Create(
-                    MailAccountId.Create(candidate.MailboxAccountId),
-                    new MailFolderResolutionId(
-                        MailFolderAlias.Create(candidate.Alias),
-                        MailFolderResolutionGeneration.Create(candidate.ResolutionGeneration)),
-                    ImapUidValidity.Create(candidate.UidValidity),
-                    ImapUid.Create(candidate.Uid)))),
+                candidate.ToOccurrenceId())),
         ];
     }
 

--- a/src/Infrastructure/Persistence/Emails/StoredEmailOccurrenceRow.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredEmailOccurrenceRow.cs
@@ -1,0 +1,55 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Linq.Expressions;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Infrastructure.Persistence.Entities;
+
+namespace MailFathom.Infrastructure.Persistence.Emails;
+
+/// <summary>The columns a walk reads to name one stored email and the remote occurrence it came from.</summary>
+/// <param name="Id">The stable local identity of the email.</param>
+/// <param name="MailboxAccountId">The configured account the email's folder belongs to.</param>
+/// <param name="Alias">The configured alias of that folder.</param>
+/// <param name="ResolutionGeneration">The generation the folder alias resolved in.</param>
+/// <param name="UidValidity">The UID space the occurrence was read in.</param>
+/// <param name="Uid">The UID the occurrence carried in that space.</param>
+/// <remarks>
+/// The projection stops here rather than constructing the occurrence identity directly, because a domain value object's
+/// factory inside an <c>IQueryable</c> projection is either untranslatable or silently evaluated on the client. Both
+/// backfill walks that resume by identity read exactly these columns, so the projection and the rebuild are one shape
+/// rather than one per walk.
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed record StoredEmailOccurrenceRow(
+    Guid Id,
+    string MailboxAccountId,
+    string Alias,
+    int ResolutionGeneration,
+    uint UidValidity,
+    uint Uid)
+{
+    /// <summary>Gets the projection every walk over outstanding occurrences selects.</summary>
+    public static Expression<Func<StoredEmailEntity, StoredEmailOccurrenceRow>> Projection { get; } = email =>
+        new StoredEmailOccurrenceRow(
+            email.Id,
+            email.MailFolder.MailboxAccountId,
+            email.MailFolder.Alias,
+            email.MailFolder.ResolutionGeneration,
+            email.UidValidity,
+            email.Uid);
+
+    /// <summary>Rebuilds the remote occurrence identity the returned columns describe.</summary>
+    /// <returns>The occurrence the row came from.</returns>
+    public EmailOccurrenceId ToOccurrenceId() => EmailOccurrenceId.Create(
+        MailAccountId.Create(this.MailboxAccountId),
+        new MailFolderResolutionId(
+            MailFolderAlias.Create(this.Alias),
+            MailFolderResolutionGeneration.Create(this.ResolutionGeneration)),
+        ImapUidValidity.Create(this.UidValidity),
+        ImapUid.Create(this.Uid));
+}

--- a/src/Infrastructure/Persistence/Emails/StoredMailRederivationStore.cs
+++ b/src/Infrastructure/Persistence/Emails/StoredMailRederivationStore.cs
@@ -9,7 +9,6 @@ using MailFathom.Application.Persistence;
 using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
-using MailFathom.Domain.Folders;
 using MailFathom.Infrastructure.Persistence.Emails.Threads;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
@@ -69,28 +68,14 @@ internal sealed class StoredMailRederivationStore(
             .Where(email => resumeAfterId == null || email.Id > resumeAfterId)
             .OrderBy(email => email.Id)
             .Take(batchSize)
-            .Select(email => new
-            {
-                email.Id,
-                email.MailFolder.MailboxAccountId,
-                email.MailFolder.Alias,
-                email.MailFolder.ResolutionGeneration,
-                email.UidValidity,
-                email.Uid,
-            })
+            .Select(StoredEmailOccurrenceRow.Projection)
             .ToArrayAsync(cancellationToken);
 
         return
         [
             .. candidates.Select(candidate => new StoredMailAwaitingRederivation(
                 StoredEmailId.Create(candidate.Id),
-                EmailOccurrenceId.Create(
-                    MailAccountId.Create(candidate.MailboxAccountId),
-                    new MailFolderResolutionId(
-                        MailFolderAlias.Create(candidate.Alias),
-                        MailFolderResolutionGeneration.Create(candidate.ResolutionGeneration)),
-                    ImapUidValidity.Create(candidate.UidValidity),
-                    ImapUid.Create(candidate.Uid)))),
+                candidate.ToOccurrenceId())),
         ];
     }
 

--- a/src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs
+++ b/src/Infrastructure/Persistence/Embeddings/StoredEmailEmbeddingBackfillStore.cs
@@ -8,11 +8,8 @@ using MailFathom.Application.Folders;
 using MailFathom.Application.Persistence;
 using MailFathom.Application.Spam.Gating;
 using MailFathom.CodeCoverage;
-using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
-using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
-using MailFathom.Domain.Spam;
 using MailFathom.Infrastructure.Persistence.Emails;
 using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Sessions;
@@ -76,19 +73,20 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
             .Select(email => new OutstandingEmailRow(
                 email.Id,
                 !email.Chunks.Any(),
-                email.MailFolder.MailboxAccountId,
-                email.MailFolder.Alias,
-                email.StoredAt,
-                email.ContentAvailability,
-                email.SpamClassification == null ? null : email.SpamClassification.Verdict))
+                new StoredDerivedWorkCandidateRow(
+                    email.MailFolder.MailboxAccountId,
+                    email.MailFolder.Alias,
+                    email.StoredAt,
+                    email.ContentAvailability,
+                    email.SpamClassification == null ? null : email.SpamClassification.Verdict)))
             .ToArrayAsync(cancellationToken);
 
         return
         [
-            .. candidates.Select(candidate => new StoredEmailAwaitingEmbedding(
-                StoredEmailId.Create(candidate.Id),
-                candidate.RequiresChunking,
-                AdmissionOf(terms, candidate))),
+            .. candidates.Select(row => new StoredEmailAwaitingEmbedding(
+                StoredEmailId.Create(row.Id),
+                row.RequiresChunking,
+                row.Candidate.AdmittedUnder(terms))),
         ];
     }
 
@@ -213,28 +211,9 @@ internal sealed class StoredEmailEmbeddingBackfillStore(
             folderParticipation.FoldersGeneratingEmbeddings),
         terms);
 
-    /// <summary>Names the answer the predicate above already reached about one selected row.</summary>
-    /// <remarks>
-    /// The query admits the message; this says which of the gate's answers admitted it, which is the only place a
-    /// release is decidable per message. A withheld one never reaches here, so the answer is always an admitting one.
-    /// </remarks>
-    private static DerivedWorkAdmission AdmissionOf(DerivedWorkAdmissionTerms terms, OutstandingEmailRow candidate) =>
-        DerivedWorkGate.Admit(
-            terms,
-            new DerivedWorkCandidate(
-                MailAccountId.Create(candidate.MailboxAccountId),
-                MailFolderAlias.Create(candidate.Alias),
-                candidate.StoredAt,
-                candidate.ContentAvailability,
-                candidate.Verdict));
-
     /// <summary>One outstanding message, as the walk's projection returns it.</summary>
     private sealed record OutstandingEmailRow(
         Guid Id,
         bool RequiresChunking,
-        string MailboxAccountId,
-        string Alias,
-        DateTimeOffset StoredAt,
-        StoredEmailContentAvailability ContentAvailability,
-        SpamVerdict? Verdict);
+        StoredDerivedWorkCandidateRow Candidate);
 }

--- a/src/Infrastructure/Persistence/Jobs/DeadLetteredJobDecisionStatements.cs
+++ b/src/Infrastructure/Persistence/Jobs/DeadLetteredJobDecisionStatements.cs
@@ -1,0 +1,74 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Jobs;
+
+namespace MailFathom.Infrastructure.Persistence.Jobs;
+
+/// <summary>Composes the two statements an operator's decision about one dead-lettered job is.</summary>
+/// <remarks>
+/// <para>
+/// Both are conditional updates rather than a read followed by a write, and the condition is the safety property: a job
+/// that is no longer dead-lettered has been decided about by somebody else, and the update that finds it writes nothing
+/// instead of taking a running job away from the worker holding it. The row count is what says which happened.
+/// </para>
+/// <para>
+/// They are a type of their own so the statements can be read and asserted without a database. Losing the state
+/// predicate would fail silently at run time — as a claimed job reset under its holder, or a succeeded one dropped — so
+/// the statements are verified as text.
+/// </para>
+/// <para>
+/// Every value is a parameter. The identifiers are quoted because EF Core names the columns after the properties, which
+/// PostgreSQL would otherwise fold to lower case and fail to find.
+/// </para>
+/// </remarks>
+internal static class DeadLetteredJobDecisionStatements
+{
+    /// <summary>Composes the statement that offers one dead-lettered job to the queue again.</summary>
+    /// <param name="jobId">The job the decision is about.</param>
+    /// <param name="retriedAt">The instant the decision is taken and stamped at.</param>
+    /// <returns>The statement, whose row count is one when the decision took effect.</returns>
+    /// <remarks>
+    /// The attempt count goes back to nothing and the available instant to now, so the job is claimable by the next pass
+    /// rather than after whatever backoff the failed attempt had written. The failure columns are left where they are:
+    /// the row goes on saying why it stopped until an attempt replaces the answer.
+    /// </remarks>
+    internal static FormattableString ComposeRetry(Guid jobId, DateTimeOffset retriedAt)
+    {
+        var deadLettered = nameof(JobState.DeadLettered);
+        var pending = nameof(JobState.Pending);
+
+        return $"""
+                UPDATE jobs
+                SET "State" = {pending},
+                    "AvailableAt" = {retriedAt},
+                    "AttemptCount" = 0,
+                    "StateChangedAt" = {retriedAt}
+                WHERE "Id" = {jobId}
+                  AND "State" = {deadLettered}
+                """;
+    }
+
+    /// <summary>Composes the statement that closes one dead-lettered job without running it again.</summary>
+    /// <param name="jobId">The job the decision is about.</param>
+    /// <param name="droppedAt">The instant the decision is taken and stamped at.</param>
+    /// <returns>The statement, whose row count is one when the decision took effect.</returns>
+    /// <remarks>
+    /// The failure columns are left where they are for the reason the retry leaves them: what stopped the job is the
+    /// only account of it there is, and dropping it is a decision about that account rather than a replacement for it.
+    /// </remarks>
+    internal static FormattableString ComposeDrop(Guid jobId, DateTimeOffset droppedAt)
+    {
+        var deadLettered = nameof(JobState.DeadLettered);
+        var dropped = nameof(JobState.Dropped);
+
+        return $"""
+                UPDATE jobs
+                SET "State" = {dropped},
+                    "StateChangedAt" = {droppedAt}
+                WHERE "Id" = {jobId}
+                  AND "State" = {deadLettered}
+                """;
+    }
+}

--- a/src/Infrastructure/Persistence/Jobs/DeadLetteredJobStore.cs
+++ b/src/Infrastructure/Persistence/Jobs/DeadLetteredJobStore.cs
@@ -29,6 +29,7 @@ internal sealed class DeadLetteredJobStore(MailFathomDbContext dbContext, TimePr
     : IDeadLetteredJobStore
 {
     /// <inheritdoc />
+    /// <remarks>The read takes one row past the page, for the reason <see cref="KeysetPageSplit" /> states.</remarks>
     public async Task<DeadLetteredJobPage> ReadPageAsync(
         DeadLetteredJobQuery query,
         CancellationToken cancellationToken)
@@ -38,9 +39,6 @@ internal sealed class DeadLetteredJobStore(MailFathomDbContext dbContext, TimePr
         var rows = await this.Filter(query)
             .OrderByDescending(job => job.StateChangedAt)
             .ThenByDescending(job => job.Id)
-
-            // One more than the page holds, which is how the answer says whether a following page exists without a
-            // second count query over the same filtered set.
             .Take(query.PageSize + 1)
             .Select(job => new DeadLetteredJobRow(
                 job.Id,
@@ -54,7 +52,7 @@ internal sealed class DeadLetteredJobStore(MailFathomDbContext dbContext, TimePr
                 job.StateChangedAt))
             .ToArrayAsync(cancellationToken);
 
-        var pageRows = rows.Take(query.PageSize).ToArray();
+        var (pageRows, hasMore) = KeysetPageSplit.Of(rows, query.PageSize);
 
         // A row whose type this build does not declare is left out of the answer but still counted for the boundary:
         // the cursor is the position in the reading, so skipping a row must not move where the next page resumes.
@@ -68,7 +66,7 @@ internal sealed class DeadLetteredJobStore(MailFathomDbContext dbContext, TimePr
 
         return new DeadLetteredJobPage(
             jobs,
-            rows.Length > query.PageSize && pageRows.Length > 0
+            hasMore
                 ? DeadLetteredJobCursor.After(
                     pageRows[^1].StateChangedAt,
                     JobId.Create(pageRows[^1].Id),
@@ -77,28 +75,13 @@ internal sealed class DeadLetteredJobStore(MailFathomDbContext dbContext, TimePr
     }
 
     /// <inheritdoc />
-    /// <remarks>
-    /// The attempt count goes back to nothing and the available instant to now, so the job is claimable by the next
-    /// pass rather than after whatever backoff the failed attempt had written. The failure columns are left where they
-    /// are: the row goes on saying why it stopped until an attempt replaces the answer.
-    /// </remarks>
+    /// <remarks>What the statement writes and leaves alone is <see cref="DeadLetteredJobDecisionStatements.ComposeRetry" />'s.</remarks>
     public async Task<JobRecoveryOutcome> RetryAsync(JobId jobId, CancellationToken cancellationToken)
     {
-        var retriedAt = timeProvider.GetUtcNow();
         var jobIdValue = jobId.Value;
-        var deadLettered = nameof(JobState.DeadLettered);
-        var pending = nameof(JobState.Pending);
 
         var retriedRows = await dbContext.Database.ExecuteSqlAsync(
-            $"""
-             UPDATE jobs
-             SET "State" = {pending},
-                 "AvailableAt" = {retriedAt},
-                 "AttemptCount" = 0,
-                 "StateChangedAt" = {retriedAt}
-             WHERE "Id" = {jobIdValue}
-               AND "State" = {deadLettered}
-             """,
+            DeadLetteredJobDecisionStatements.ComposeRetry(jobIdValue, timeProvider.GetUtcNow()),
             cancellationToken);
 
         return retriedRows == 1
@@ -107,21 +90,13 @@ internal sealed class DeadLetteredJobStore(MailFathomDbContext dbContext, TimePr
     }
 
     /// <inheritdoc />
+    /// <remarks>What the statement writes and leaves alone is <see cref="DeadLetteredJobDecisionStatements.ComposeDrop" />'s.</remarks>
     public async Task<JobRecoveryOutcome> DropAsync(JobId jobId, CancellationToken cancellationToken)
     {
-        var droppedAt = timeProvider.GetUtcNow();
         var jobIdValue = jobId.Value;
-        var deadLettered = nameof(JobState.DeadLettered);
-        var dropped = nameof(JobState.Dropped);
 
         var droppedRows = await dbContext.Database.ExecuteSqlAsync(
-            $"""
-             UPDATE jobs
-             SET "State" = {dropped},
-                 "StateChangedAt" = {droppedAt}
-             WHERE "Id" = {jobIdValue}
-               AND "State" = {deadLettered}
-             """,
+            DeadLetteredJobDecisionStatements.ComposeDrop(jobIdValue, timeProvider.GetUtcNow()),
             cancellationToken);
 
         return droppedRows == 1

--- a/src/Infrastructure/Persistence/KeysetPageSplit.cs
+++ b/src/Infrastructure/Persistence/KeysetPageSplit.cs
@@ -1,0 +1,38 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Infrastructure.Persistence;
+
+/// <summary>Splits what a bounded keyset read returned into the page it holds and the answer about a following one.</summary>
+/// <remarks>
+/// <para>
+/// Every keyset reader here reads one more row than the page holds, which is how the answer says whether a following
+/// page exists without a second count query over the same filtered set. The extra row is never presented: it is read so
+/// that its existence can be observed, and then dropped.
+/// </para>
+/// <para>
+/// A read that reached beyond the page is by construction a read that filled it, so a caller building a cursor from the
+/// last row of the page needs no second guard against an empty one: the boundary row exists wherever a following page
+/// does.
+/// </para>
+/// </remarks>
+internal static class KeysetPageSplit
+{
+    /// <summary>Splits the rows one bounded read returned.</summary>
+    /// <typeparam name="TRow">The row shape the read projected.</typeparam>
+    /// <param name="readRows">The rows the read returned, taken as one more than the page holds.</param>
+    /// <param name="pageSize">The number of rows the page holds.</param>
+    /// <returns>The page, and whether the read reached past it.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="readRows" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="pageSize" /> is not positive.</exception>
+    internal static (TRow[] Page, bool HasMore) Of<TRow>(TRow[] readRows, int pageSize)
+    {
+        ArgumentNullException.ThrowIfNull(readRows);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(pageSize);
+
+        return readRows.Length > pageSize
+            ? (readRows[..pageSize], true)
+            : (readRows, false);
+    }
+}

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryMapping.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryMapping.cs
@@ -5,10 +5,10 @@
 using System.Diagnostics.CodeAnalysis;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
-using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Mutations.Audit;
+using MailFathom.Infrastructure.Persistence.Delivery;
 using MailFathom.Infrastructure.Persistence.Entities;
 
 namespace MailFathom.Infrastructure.Persistence.Mutations;
@@ -54,7 +54,7 @@ internal static class MailboxMutationAuditEntryMapping
     /// entries this one has no value for, and a rollback then reads them.
     /// </para>
     /// <para>
-    /// It is reported rather than thrown for the reason <see cref="ToFailure" /> degrades an unrecognized failure code:
+    /// It is reported rather than thrown for the reason <see cref="StoredFailureCode" /> degrades an unrecognized code:
     /// this trail is read a page at a time and paginated by position, so one unreadable row thrown out of the mapping
     /// would fail the whole page and every page after it. The caller leaves the row out, says so, and walks on.
     /// </para>
@@ -86,13 +86,13 @@ internal static class MailboxMutationAuditEntryMapping
             SourceUidValidity = ImapUidValidity.Create(entity.SourceUidValidity),
             SourceUid = ImapUid.Create(entity.SourceUid),
             DestinationFolderPath = destinationFolderPath,
-            Placement = ToPlacement(entity),
+            Placement = StoredRemotePlacement.Of(entity.PlacementUidValidity, entity.PlacementUid),
             DesiredSeenState = entity.DesiredSeenState,
             Requester = MailboxMutationRequester.Create(entity.RequesterOrigin, entity.RequesterIdentity),
             RequestedAt = entity.RequestedAt,
             CompletedAt = entity.CompletedAt,
             Outcome = entity.Outcome,
-            Failure = ToFailure(entity),
+            Failure = StoredFailureCode.ToErrorCode(entity.FailureCode),
         };
 
         return true;
@@ -126,25 +126,5 @@ internal static class MailboxMutationAuditEntryMapping
         folderPath = parsed ? storedFolderPath : null;
 
         return parsed;
-    }
-
-    private static RemoteEmailPlacement ToPlacement(MailboxMutationAuditEntryEntity entity) =>
-        entity is { PlacementUidValidity: { } uidValidity, PlacementUid: { } uid }
-            ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(uidValidity), ImapUid.Create(uid))
-            : RemoteEmailPlacement.NotReported();
-
-    /// <summary>Reads back the code an abandoned change was given up on for.</summary>
-    /// <remarks>
-    /// A number this build does not recognize is a row written by one that allocated a code since. It is diagnostic
-    /// detail rather than something acted on, so it is reported as absent instead of failing the read of the whole page.
-    /// </remarks>
-    private static MailFathomErrorCode? ToFailure(MailboxMutationAuditEntryEntity entity)
-    {
-        if (entity.FailureCode is not { } failureCode)
-        {
-            return null;
-        }
-
-        return MailFathomErrorCode.TryParse(failureCode, out var failure) ? failure : null;
     }
 }

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryStore.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationAuditEntryStore.cs
@@ -63,6 +63,7 @@ internal sealed class MailboxMutationAuditEntryStore(
     }
 
     /// <inheritdoc />
+    /// <remarks>The read takes one row past the page, for the reason <see cref="KeysetPageSplit" /> states.</remarks>
     public async Task<MailboxMutationAuditPage> ReadPageAsync(
         MailboxMutationAuditQuery query,
         CancellationToken cancellationToken)
@@ -75,13 +76,10 @@ internal sealed class MailboxMutationAuditEntryStore(
             .Where(entry => entry.MailboxAccountId == accountValue)
             .OrderByDescending(entry => entry.CompletedAt)
             .ThenByDescending(entry => entry.Id)
-
-            // One more than the page holds, which is how the answer says whether a following page exists without a
-            // second count query over the same filtered set.
             .Take(query.PageSize + 1)
             .ToArrayAsync(cancellationToken);
 
-        var pageEntities = entities.Take(query.PageSize).ToArray();
+        var (pageEntities, hasMore) = KeysetPageSplit.Of(entities, query.PageSize);
         var entries = new List<MailboxMutationAuditEntry>(pageEntities.Length);
         var unreadableCount = 0;
 
@@ -106,7 +104,7 @@ internal sealed class MailboxMutationAuditEntryStore(
         // costs its own place in the page and nothing else: the walk neither stalls on it nor repeats the rows around it.
         return new MailboxMutationAuditPage(
             entries,
-            entities.Length > query.PageSize && pageEntities.Length > 0
+            hasMore
                 ? MailboxMutationAuditCursor.After(
                     pageEntities[^1].CompletedAt,
                     MailboxMutationAuditEntryId.Create(pageEntities[^1].Id),
@@ -115,6 +113,12 @@ internal sealed class MailboxMutationAuditEntryStore(
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The bounded set is read first and deleted by key, rather than bounding the delete itself: PostgreSQL has no
+    /// <c>DELETE ... LIMIT</c>, so a bound expressed on the delete either fails to translate or becomes a subquery whose
+    /// shape depends on the provider. Two statements over the same index cost one extra round trip and keep the
+    /// statement that takes row locks small enough to state. Every retention sweep here is written that way.
+    /// </remarks>
     public async Task<int> EraseCompletedBeforeAsync(
         MailAccountId accountId,
         DateTimeOffset completedBefore,
@@ -125,10 +129,6 @@ internal sealed class MailboxMutationAuditEntryStore(
 
         var accountValue = accountId.Value;
 
-        // The bounded set is read first and deleted by key, rather than bounding the delete itself: PostgreSQL has no
-        // `DELETE ... LIMIT`, so a bound expressed on the delete either fails to translate or becomes a subquery whose
-        // shape depends on the provider. Two statements over the same index cost one extra round trip and keep the
-        // statement that takes row locks small enough to state.
         var expiringIds = await readContext.MailboxMutationAuditEntries
             .AsNoTracking()
             .Where(entry => entry.MailboxAccountId == accountValue && entry.CompletedAt < completedBefore)

--- a/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordMapping.cs
+++ b/src/Infrastructure/Persistence/Mutations/MailboxMutationRecordMapping.cs
@@ -4,9 +4,9 @@
 
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
-using MailFathom.Domain.Failures;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Mutations;
+using MailFathom.Infrastructure.Persistence.Delivery;
 using MailFathom.Infrastructure.Persistence.Entities;
 
 namespace MailFathom.Infrastructure.Persistence.Mutations;
@@ -56,11 +56,11 @@ internal static class MailboxMutationRecordMapping
             Stage = entity.Stage,
             IsAudited = entity.AuditTrailEnabled,
             RequiresSourceRemoval = entity.RequiresSourceRemoval,
-            Placement = ToPlacement(entity),
+            Placement = StoredRemotePlacement.Of(entity.PlacementUidValidity, entity.PlacementUid),
             AttemptCount = entity.AttemptCount,
             RecordedAt = entity.RecordedAt,
             StageChangedAt = entity.StageChangedAt,
-            LastFailure = ToFailure(entity),
+            LastFailure = StoredFailureCode.ToErrorCode(entity.LastFailureCode),
             PlacementObservedAt = entity.PlacementObservedAt,
             SourceRemovalObservedAt = entity.SourceRemovalObservedAt,
         };
@@ -149,26 +149,5 @@ internal static class MailboxMutationRecordMapping
             ? destinationPath
             : throw new InvalidOperationException(
                 $"Mailbox mutation record {entity.Id} carries a destination folder path that names no folder.");
-    }
-
-    private static RemoteEmailPlacement ToPlacement(MailboxMutationEntity entity) =>
-        entity is { PlacementUidValidity: { } uidValidity, PlacementUid: { } uid }
-            ? RemoteEmailPlacement.Reported(ImapUidValidity.Create(uidValidity), ImapUid.Create(uid))
-            : RemoteEmailPlacement.NotReported();
-
-    /// <summary>Reads back the code of the failure the last attempt ended in.</summary>
-    /// <remarks>
-    /// A number this build does not recognize is a row written by one that allocated a code since. It is diagnostic
-    /// detail rather than something acted on, so it is reported as absent instead of failing the read of every other
-    /// mutation the account has.
-    /// </remarks>
-    private static MailFathomErrorCode? ToFailure(MailboxMutationEntity entity)
-    {
-        if (entity.LastFailureCode is not { } failureCode)
-        {
-            return null;
-        }
-
-        return MailFathomErrorCode.TryParse(failureCode, out var failure) ? failure : null;
     }
 }

--- a/src/Infrastructure/Persistence/Rules/MailRuleExecutionStore.cs
+++ b/src/Infrastructure/Persistence/Rules/MailRuleExecutionStore.cs
@@ -8,6 +8,7 @@ using MailFathom.CodeCoverage;
 using MailFathom.Domain.Accounts;
 using MailFathom.Infrastructure.Observability;
 using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Mutations;
 using MailFathom.Infrastructure.Persistence.Sessions;
 using Microsoft.EntityFrameworkCore;
 
@@ -59,6 +60,7 @@ internal sealed class MailRuleExecutionStore(
     }
 
     /// <inheritdoc />
+    /// <remarks>The read takes one row past the page, for the reason <see cref="KeysetPageSplit" /> states.</remarks>
     public async Task<MailRuleExecutionPage> ReadPageAsync(
         MailRuleExecutionQuery query,
         CancellationToken cancellationToken)
@@ -75,13 +77,10 @@ internal sealed class MailRuleExecutionStore(
             .Include(execution => execution.Actions)
             .OrderByDescending(execution => execution.EvaluatedAt)
             .ThenByDescending(execution => execution.Id)
-
-            // One more than the page holds, which is how the answer says whether a following page exists without a
-            // second count query over the same filtered set.
             .Take(query.PageSize + 1)
             .ToArrayAsync(cancellationToken);
 
-        var pageEntities = entities.Take(query.PageSize).ToArray();
+        var (pageEntities, hasMore) = KeysetPageSplit.Of(entities, query.PageSize);
         var executions = new List<MailRuleExecution>(pageEntities.Length);
         var unreadableCount = 0;
 
@@ -107,7 +106,7 @@ internal sealed class MailRuleExecutionStore(
         // either side of it.
         return new MailRuleExecutionPage(
             executions,
-            entities.Length > query.PageSize && pageEntities.Length > 0
+            hasMore
                 ? MailRuleExecutionCursor.After(
                     pageEntities[^1].EvaluatedAt,
                     MailRuleExecutionId.Create(pageEntities[^1].Id),
@@ -116,6 +115,10 @@ internal sealed class MailRuleExecutionStore(
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// The bounded set is read first and deleted by key, for the reason
+    /// <see cref="MailboxMutationAuditEntryStore.EraseCompletedBeforeAsync" /> states.
+    /// </remarks>
     public async Task<int> EraseEvaluatedBeforeAsync(
         MailAccountId accountId,
         DateTimeOffset evaluatedBefore,
@@ -126,10 +129,6 @@ internal sealed class MailRuleExecutionStore(
 
         var accountValue = accountId.Value;
 
-        // The bounded set is read first and deleted by key, rather than bounding the delete itself: PostgreSQL has no
-        // `DELETE ... LIMIT`, so a bound expressed on the delete either fails to translate or becomes a subquery whose
-        // shape depends on the provider. Two statements over the same index cost one extra round trip and keep the
-        // statement that takes row locks small enough to state.
         var expiringIds = await readContext.MailRuleExecutions
             .AsNoTracking()
             .Where(execution => execution.MailboxAccountId == accountValue && execution.EvaluatedAt < evaluatedBefore)

--- a/src/Infrastructure/Persistence/Spam/SpamClassificationHistoryReader.cs
+++ b/src/Infrastructure/Persistence/Spam/SpamClassificationHistoryReader.cs
@@ -29,6 +29,7 @@ namespace MailFathom.Infrastructure.Persistence.Spam;
 internal sealed class SpamClassificationHistoryReader(MailFathomDbContext dbContext) : ISpamClassificationHistoryReader
 {
     /// <inheritdoc />
+    /// <remarks>The read takes one row past the page, for the reason <see cref="KeysetPageSplit" /> states.</remarks>
     public async Task<SpamClassificationHistoryPage> ReadPageAsync(
         SpamClassificationHistoryQuery query,
         CancellationToken cancellationToken)
@@ -41,9 +42,6 @@ internal sealed class SpamClassificationHistoryReader(MailFathomDbContext dbCont
             .Where(classification => classification.StoredEmail!.MailboxAccountId == accountValue)
             .OrderByDescending(classification => classification.EvaluatedAt)
             .ThenByDescending(classification => classification.StoredEmailId)
-
-            // One more than the page holds, which is how the answer says whether a following page exists without a
-            // second count query over the same filtered set.
             .Take(query.PageSize + 1)
             .Select(classification => new ClassificationRow(
                 classification.StoredEmailId,
@@ -61,7 +59,7 @@ internal sealed class SpamClassificationHistoryReader(MailFathomDbContext dbCont
                     .ToList()))
             .ToArrayAsync(cancellationToken);
 
-        var pageRows = rows.Take(query.PageSize).ToArray();
+        var (pageRows, hasMore) = KeysetPageSplit.Of(rows, query.PageSize);
         var requestedMutations = await this.ReadRequestedMutationsAsync(pageRows, cancellationToken);
 
         var entries = pageRows
@@ -82,7 +80,7 @@ internal sealed class SpamClassificationHistoryReader(MailFathomDbContext dbCont
 
         return new SpamClassificationHistoryPage(
             entries,
-            rows.Length > query.PageSize && pageRows.Length > 0
+            hasMore
                 ? SpamClassificationHistoryCursor.After(
                     pageRows[^1].EvaluatedAt,
                     StoredEmailId.Create(pageRows[^1].StoredEmailId),

--- a/src/Infrastructure/Persistence/Spam/StoredDerivedWorkCandidateRow.cs
+++ b/src/Infrastructure/Persistence/Spam/StoredDerivedWorkCandidateRow.cs
@@ -1,0 +1,49 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Spam.Gating;
+using MailFathom.CodeCoverage;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Emails;
+using MailFathom.Domain.Folders;
+using MailFathom.Domain.Spam;
+
+namespace MailFathom.Infrastructure.Persistence.Spam;
+
+/// <summary>The columns an admission is decided from, as a walk over stored mail returns them.</summary>
+/// <param name="MailboxAccountId">The configured account the occurrence's folder belongs to.</param>
+/// <param name="Alias">The configured alias of the folder holding it now.</param>
+/// <param name="StoredAt">When the occurrence was first recorded locally.</param>
+/// <param name="ContentAvailability">Whether the raw MIME a classification reads is stored, is coming, or never will be.</param>
+/// <param name="Verdict">What classification concluded, or <see langword="null" /> when it has reached none yet.</param>
+/// <remarks>
+/// The stored counterpart of <see cref="DerivedWorkCandidate" />, carried by every walk that both narrows mail through
+/// <see cref="DerivedWorkAdmittedEmails" /> and then reports which of the gate's answers admitted each row. The domain
+/// value objects are built here rather than in the projection, because a factory inside an <c>IQueryable</c> lambda is
+/// either untranslatable or silently evaluated on the client.
+/// </remarks>
+[RequiresIntegrationCoverage]
+internal sealed record StoredDerivedWorkCandidateRow(
+    string MailboxAccountId,
+    string Alias,
+    DateTimeOffset StoredAt,
+    StoredEmailContentAvailability ContentAvailability,
+    SpamVerdict? Verdict)
+{
+    /// <summary>Names the answer the walk's own predicate already reached about this row.</summary>
+    /// <param name="terms">The terms the whole batch is decided under, read once beside the query that selected it.</param>
+    /// <returns>The admission, which is always an admitting one.</returns>
+    /// <remarks>
+    /// The query admits the message; this says which of the gate's answers admitted it, which is the only place a
+    /// release is decidable per message. A withheld one never reaches here, so the answer is always an admitting one.
+    /// </remarks>
+    public DerivedWorkAdmission AdmittedUnder(DerivedWorkAdmissionTerms terms) => DerivedWorkGate.Admit(
+        terms,
+        new DerivedWorkCandidate(
+            MailAccountId.Create(this.MailboxAccountId),
+            MailFolderAlias.Create(this.Alias),
+            this.StoredAt,
+            this.ContentAvailability,
+            this.Verdict));
+}

--- a/tests/Infrastructure.UnitTests/Persistence/Delivery/StoredFailureCodeTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Delivery/StoredFailureCodeTests.cs
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Failures;
+using MailFathom.Infrastructure.Persistence.Delivery;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Delivery;
+
+/// <summary>
+/// Covers the one reading every table that records why an attempt stopped shares. The number a later build allocated is
+/// the case worth stating: refusing such a row would cost the read of a record that is otherwise entirely readable, for
+/// a value nothing acts on.
+/// </summary>
+public sealed class StoredFailureCodeTests
+{
+    /// <summary>A code this build has a member for is read back as that member.</summary>
+    [Fact]
+    public void ToErrorCode_ACodeThisBuildDeclares_ReadsItBack()
+    {
+        // Arrange
+        var declared = MailFathomErrorCode.PersistenceConcurrencyConflict;
+
+        // Act
+        var code = StoredFailureCode.ToErrorCode(declared.Value);
+
+        // Assert
+        Assert.Equal(declared, code);
+    }
+
+    /// <summary>A column nothing was written into is the ordinary row of a record that never failed.</summary>
+    [Fact]
+    public void ToErrorCode_AnEmptyColumn_ReadsAsNoFailure()
+    {
+        // Act
+        var code = StoredFailureCode.ToErrorCode(null);
+
+        // Assert
+        Assert.Null(code);
+    }
+
+    /// <summary>Version skew rather than corruption: a build that allocated a code since wrote the row.</summary>
+    [Fact]
+    public void ToErrorCode_ACodeThisBuildHasNotAllocated_ReadsAsNoFailure()
+    {
+        // Act
+        var code = StoredFailureCode.ToErrorCode(99999);
+
+        // Assert
+        Assert.Null(code);
+    }
+}

--- a/tests/Infrastructure.UnitTests/Persistence/Delivery/StoredOutgoingRecipientTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Delivery/StoredOutgoingRecipientTests.cs
@@ -1,0 +1,87 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Delivery;
+using MailFathom.Infrastructure.Persistence.Delivery;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Delivery;
+
+/// <summary>
+/// Covers the one reading a send, a draft, and a recurring send all restore their recipients through. Two of its rules
+/// are the reason it exists at all: an address that no longer parses stops the read rather than quietly shrinking the
+/// envelope, and the refusal names the row without carrying the address into a message an operator will read.
+/// </summary>
+public sealed class StoredOutgoingRecipientTests
+{
+    private static readonly Guid Carrier = new("2f1c9d4e-0b71-4f2a-9d3c-5e6a7b8c9d01");
+
+    /// <summary>The ordinary row: an address, a header, and the contact it was resolved from.</summary>
+    [Fact]
+    public void ToRecipient_ARowNamingAContact_RestoresTheRecipientAndTheContact()
+    {
+        // Arrange
+        var contactId = Guid.NewGuid();
+
+        // Act
+        var recipient = StoredOutgoingRecipient.ToRecipient(
+            "Outgoing email record",
+            Carrier,
+            ordinal: 0,
+            "someone@example.test",
+            OutgoingRecipientRole.To,
+            contactId);
+
+        // Assert
+        Assert.Equal("someone@example.test", recipient.Address.Address);
+        Assert.Equal(OutgoingRecipientRole.To, recipient.Role);
+        Assert.Equal(contactId, recipient.Contact?.Value);
+    }
+
+    /// <summary>An address the author supplied by hand carries no contact, and neither does a row written with none.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("00000000-0000-0000-0000-000000000000")]
+    public void ToRecipient_ARowNamingNoContact_RestoresTheRecipientWithoutOne(string? storedContact)
+    {
+        // Arrange
+        var contactId = storedContact is null ? (Guid?)null : Guid.Parse(storedContact);
+
+        // Act
+        var recipient = StoredOutgoingRecipient.ToRecipient(
+            "Mail draft",
+            Carrier,
+            ordinal: 1,
+            "someone@example.test",
+            OutgoingRecipientRole.Cc,
+            contactId);
+
+        // Assert
+        Assert.Null(recipient.Contact);
+    }
+
+    /// <summary>
+    /// The read stops rather than dropping the row. A message offered to fewer people than it was written for is
+    /// somebody who never receives it and is told nothing about it.
+    /// </summary>
+    [Fact]
+    public void ToRecipient_AnAddressThatNoLongerParses_StopsTheReadNamingTheRowRatherThanTheAddress()
+    {
+        // Act
+        var refusal = Record.Exception(() => StoredOutgoingRecipient.ToRecipient(
+            "Recurring send",
+            Carrier,
+            ordinal: 3,
+            "not-a-mailbox",
+            OutgoingRecipientRole.Bcc,
+            contactId: null));
+
+        // Assert
+        var stopped = Assert.IsType<InvalidOperationException>(refusal);
+        Assert.Contains("Recurring send", stopped.Message, StringComparison.Ordinal);
+        Assert.Contains(Carrier.ToString(), stopped.Message, StringComparison.Ordinal);
+        Assert.Contains("position 3", stopped.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("not-a-mailbox", stopped.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/Infrastructure.UnitTests/Persistence/Delivery/StoredRemotePlacementTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Delivery/StoredRemotePlacementTests.cs
@@ -1,0 +1,53 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Persistence.Delivery;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Delivery;
+
+/// <summary>
+/// Covers the one reading every table that records where a server put a copy shares. The half-written row is the case
+/// worth stating: read as a placement it would name a UID with no UID space to interpret it in, which is what a later
+/// removal would act on.
+/// </summary>
+public sealed class StoredRemotePlacementTests
+{
+    /// <summary>Both columns present is the server having named where the copy went.</summary>
+    [Fact]
+    public void Of_BothColumnsWritten_ReadsThePlacementTheServerNamed()
+    {
+        // Act
+        var placement = StoredRemotePlacement.Of(uidValidity: 42u, uid: 7u);
+
+        // Assert
+        Assert.True(placement.IsReported);
+        Assert.Equal(42u, placement.UidValidity?.Value);
+        Assert.Equal(7u, placement.Uid?.Value);
+    }
+
+    /// <summary>The ordinary row: most servers answer an append without naming anything.</summary>
+    [Fact]
+    public void Of_NeitherColumnWritten_ReadsAsNothingReported()
+    {
+        // Act
+        var placement = StoredRemotePlacement.Of(uidValidity: null, uid: null);
+
+        // Assert
+        Assert.False(placement.IsReported);
+    }
+
+    /// <summary>A row no writer here produces, and the one that must never become half a placement.</summary>
+    [Theory]
+    [InlineData(42u, null)]
+    [InlineData(null, 7u)]
+    public void Of_OneColumnWritten_ReadsAsNothingReported(uint? uidValidity, uint? uid)
+    {
+        // Act
+        var placement = StoredRemotePlacement.Of(uidValidity, uid);
+
+        // Assert
+        Assert.False(placement.IsReported);
+    }
+}

--- a/tests/Infrastructure.UnitTests/Persistence/Jobs/DeadLetteredJobDecisionStatementsTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Jobs/DeadLetteredJobDecisionStatementsTests.cs
@@ -1,0 +1,113 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Jobs;
+using MailFathom.Infrastructure.Persistence.Entities;
+using MailFathom.Infrastructure.Persistence.Jobs;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence.Jobs;
+
+/// <summary>
+/// Reads the two decisions as the text they are. Both are conditional updates whose condition is the safety property:
+/// without it a retry resets a job under the worker holding it and a drop closes one that already succeeded, and
+/// neither failure says anything at run time beyond a row count that still reads as one.
+/// </summary>
+/// <remarks>
+/// The column names are asserted through <see cref="JobEntity" /> rather than as text, so renaming a property fails
+/// this test at compile time instead of leaving a statement PostgreSQL refuses at run time.
+/// </remarks>
+public sealed class DeadLetteredJobDecisionStatementsTests
+{
+    private static readonly Guid JobIdentity = new("6b0e1a52-4c8d-4f31-9a77-1d2e3f4a5b60");
+    private static readonly DateTimeOffset DecidedAt = new(2026, 8, 20, 9, 30, 0, TimeSpan.Zero);
+
+    /// <summary>Only a dead-lettered job may be offered again, which is what keeps a claimed one with its holder.</summary>
+    [Fact]
+    public void ComposeRetry_ADecision_TakesOnlyADeadLetteredJob()
+    {
+        // Act
+        var statement = DeadLetteredJobDecisionStatements.ComposeRetry(JobIdentity, DecidedAt);
+
+        // Assert
+        Assert.Contains($"""WHERE "{nameof(JobEntity.Id)}" =""", statement.Format, StringComparison.Ordinal);
+        Assert.Contains($"""AND "{nameof(JobEntity.State)}" =""", statement.Format, StringComparison.Ordinal);
+        Assert.Contains(nameof(JobState.DeadLettered), statement.GetArguments().OfType<string>());
+    }
+
+    /// <summary>
+    /// The attempt count goes back to nothing and the available instant to now, so the next pass may claim the job
+    /// rather than the backoff the failed attempt had written holding it back.
+    /// </summary>
+    [Fact]
+    public void ComposeRetry_ADecision_ClearsTheAttemptsAndMakesTheJobAvailableAtOnce()
+    {
+        // Act
+        var statement = DeadLetteredJobDecisionStatements.ComposeRetry(JobIdentity, DecidedAt);
+
+        // Assert
+        Assert.Contains($"""SET "{nameof(JobEntity.State)}" =""", statement.Format, StringComparison.Ordinal);
+        Assert.Contains($"""    "{nameof(JobEntity.AvailableAt)}" =""", statement.Format, StringComparison.Ordinal);
+        Assert.Contains($"""    "{nameof(JobEntity.AttemptCount)}" = 0""", statement.Format, StringComparison.Ordinal);
+        Assert.Contains($"""    "{nameof(JobEntity.StateChangedAt)}" =""", statement.Format, StringComparison.Ordinal);
+        Assert.Contains(nameof(JobState.Pending), statement.GetArguments().OfType<string>());
+    }
+
+    /// <summary>The failure columns say why the job stopped, and a decision about that account must not erase it.</summary>
+    [Fact]
+    public void ComposeRetry_ADecision_LeavesTheFailureColumnsWhereTheyAre()
+    {
+        // Act
+        var statement = DeadLetteredJobDecisionStatements.ComposeRetry(JobIdentity, DecidedAt);
+
+        // Assert
+        Assert.DoesNotContain(nameof(JobEntity.LastFailureReason), statement.Format, StringComparison.Ordinal);
+        Assert.DoesNotContain(nameof(JobEntity.LastFailureClassification), statement.Format, StringComparison.Ordinal);
+    }
+
+    /// <summary>A drop is terminal, so it reaches a job nothing else has decided about since.</summary>
+    [Fact]
+    public void ComposeDrop_ADecision_TakesOnlyADeadLetteredJob()
+    {
+        // Act
+        var statement = DeadLetteredJobDecisionStatements.ComposeDrop(JobIdentity, DecidedAt);
+
+        // Assert
+        Assert.Contains($"""WHERE "{nameof(JobEntity.Id)}" =""", statement.Format, StringComparison.Ordinal);
+        Assert.Contains($"""AND "{nameof(JobEntity.State)}" =""", statement.Format, StringComparison.Ordinal);
+        Assert.Contains(nameof(JobState.DeadLettered), statement.GetArguments().OfType<string>());
+        Assert.Contains(nameof(JobState.Dropped), statement.GetArguments().OfType<string>());
+    }
+
+    /// <summary>A drop changes the state and when it changed, and nothing else about the job.</summary>
+    [Fact]
+    public void ComposeDrop_ADecision_WritesTheStateAndTheInstantAlone()
+    {
+        // Act
+        var statement = DeadLetteredJobDecisionStatements.ComposeDrop(JobIdentity, DecidedAt);
+
+        // Assert
+        Assert.Contains($"""SET "{nameof(JobEntity.State)}" =""", statement.Format, StringComparison.Ordinal);
+        Assert.Contains($"""    "{nameof(JobEntity.StateChangedAt)}" =""", statement.Format, StringComparison.Ordinal);
+        Assert.DoesNotContain(nameof(JobEntity.AttemptCount), statement.Format, StringComparison.Ordinal);
+        Assert.DoesNotContain(nameof(JobEntity.AvailableAt), statement.Format, StringComparison.Ordinal);
+    }
+
+    /// <summary>Every value is a parameter, so nothing a caller composes reaches either statement as text.</summary>
+    [Fact]
+    public void Compose_EitherDecision_PassesEveryValueAsAParameter()
+    {
+        // Act
+        var retry = DeadLetteredJobDecisionStatements.ComposeRetry(JobIdentity, DecidedAt);
+        var drop = DeadLetteredJobDecisionStatements.ComposeDrop(JobIdentity, DecidedAt);
+
+        // Assert
+        Assert.DoesNotContain(JobIdentity.ToString(), retry.Format, StringComparison.Ordinal);
+        Assert.DoesNotContain(JobIdentity.ToString(), drop.Format, StringComparison.Ordinal);
+        Assert.Contains(retry.GetArguments(), argument => Equals(argument, JobIdentity));
+        Assert.Contains(retry.GetArguments(), argument => Equals(argument, DecidedAt));
+        Assert.Contains(drop.GetArguments(), argument => Equals(argument, JobIdentity));
+        Assert.Contains(drop.GetArguments(), argument => Equals(argument, DecidedAt));
+    }
+}

--- a/tests/Infrastructure.UnitTests/Persistence/Jobs/JobClaimStatementTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/Jobs/JobClaimStatementTests.cs
@@ -5,6 +5,7 @@
 using MailFathom.Application.Jobs;
 using MailFathom.Infrastructure.Persistence;
 using MailFathom.Infrastructure.Persistence.Connections;
+using MailFathom.Infrastructure.Persistence.Entities;
 using MailFathom.Infrastructure.Persistence.Jobs;
 using Microsoft.EntityFrameworkCore;
 using Xunit;
@@ -17,6 +18,10 @@ namespace MailFathom.Infrastructure.UnitTests.Persistence.Jobs;
 /// bound one claim drains the queue, and without the terminal-state predicate the partial index stops applying. None of
 /// that needs a database to establish, so it is established here.
 /// </summary>
+/// <remarks>
+/// The column names are asserted through <see cref="JobEntity" /> rather than as text, so renaming a property fails
+/// this test at compile time instead of leaving a statement PostgreSQL refuses at run time.
+/// </remarks>
 public sealed class JobClaimStatementTests
 {
     private static readonly DateTimeOffset ClaimedAt = new(2026, 8, 12, 12, 0, 0, TimeSpan.Zero);
@@ -65,8 +70,14 @@ public sealed class JobClaimStatementTests
         var statement = JobClaimStatement.Compose(Request, ClaimedAt);
 
         // Assert
-        Assert.Contains("candidate.\"AvailableAt\" <= ", statement.Format, StringComparison.Ordinal);
-        Assert.Contains("candidate.\"LeaseExpiresAt\" <= ", statement.Format, StringComparison.Ordinal);
+        Assert.Contains(
+            $"candidate.\"{nameof(JobEntity.AvailableAt)}\" <= ",
+            statement.Format,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"candidate.\"{nameof(JobEntity.LeaseExpiresAt)}\" <= ",
+            statement.Format,
+            StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -82,7 +93,10 @@ public sealed class JobClaimStatementTests
         var statement = JobClaimStatement.Compose(Request, ClaimedAt);
 
         // Assert
-        Assert.Contains("candidate.\"State\" = ANY(", statement.Format, StringComparison.Ordinal);
+        Assert.Contains(
+            $"candidate.\"{nameof(JobEntity.State)}\" = ANY(",
+            statement.Format,
+            StringComparison.Ordinal);
         Assert.Contains(
             statement.GetArguments(),
             argument => argument is string[] states
@@ -117,8 +131,14 @@ public sealed class JobClaimStatementTests
         var statement = JobClaimStatement.Compose(Request, ClaimedAt);
 
         // Assert
-        Assert.Contains("\"AttemptCount\" = job.\"AttemptCount\" + 1", statement.Format, StringComparison.Ordinal);
-        Assert.Contains("RETURNING job.\"Id\" AS \"Value\"", statement.Format, StringComparison.Ordinal);
+        Assert.Contains(
+            $"\"{nameof(JobEntity.AttemptCount)}\" = job.\"{nameof(JobEntity.AttemptCount)}\" + 1",
+            statement.Format,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"RETURNING job.\"{nameof(JobEntity.Id)}\" AS \"Value\"",
+            statement.Format,
+            StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -165,6 +185,9 @@ public sealed class JobClaimStatementTests
 
         // Assert
         Assert.Contains("WITH due AS", sql, StringComparison.Ordinal);
-        Assert.EndsWith("RETURNING job.\"Id\" AS \"Value\"", sql.TrimEnd(), StringComparison.Ordinal);
+        Assert.EndsWith(
+            $"RETURNING job.\"{nameof(JobEntity.Id)}\" AS \"Value\"",
+            sql.TrimEnd(),
+            StringComparison.Ordinal);
     }
 }

--- a/tests/Infrastructure.UnitTests/Persistence/KeysetPageSplitTests.cs
+++ b/tests/Infrastructure.UnitTests/Persistence/KeysetPageSplitTests.cs
@@ -1,0 +1,85 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Persistence;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Persistence;
+
+/// <summary>
+/// Covers the split every keyset reader ends on. Both answers it gives are ones a page is wrong about silently: a page
+/// carrying the row that was read only to be counted serves a row twice, and a cursor handed out at the end of the set
+/// walks the caller into an empty page it has to ask for to discover.
+/// </summary>
+public sealed class KeysetPageSplitTests
+{
+    /// <summary>The extra row is what says a page follows, and it never reaches the page itself.</summary>
+    [Fact]
+    public void Of_AReadThatReachedPastThePage_KeepsThePageAndSaysAnotherFollows()
+    {
+        // Act
+        var (page, hasMore) = KeysetPageSplit.Of([1, 2, 3, 4], pageSize: 3);
+
+        // Assert
+        Assert.Equal([1, 2, 3], page);
+        Assert.True(hasMore);
+    }
+
+    /// <summary>A read that exactly filled the page reached no further, so there is nothing to resume from.</summary>
+    [Fact]
+    public void Of_AReadThatExactlyFilledThePage_SaysNothingFollows()
+    {
+        // Act
+        var (page, hasMore) = KeysetPageSplit.Of([1, 2, 3], pageSize: 3);
+
+        // Assert
+        Assert.Equal([1, 2, 3], page);
+        Assert.False(hasMore);
+    }
+
+    /// <summary>The end of the set, where a cursor would send the caller after rows that do not exist.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2)]
+    public void Of_AReadThatFellShortOfThePage_SaysNothingFollows(int readCount)
+    {
+        // Arrange
+        var readRows = Enumerable.Range(1, readCount).ToArray();
+
+        // Act
+        var (page, hasMore) = KeysetPageSplit.Of(readRows, pageSize: 3);
+
+        // Assert
+        Assert.Equal(readRows, page);
+        Assert.False(hasMore);
+    }
+
+    /// <summary>
+    /// A following page implies a full one, which is what lets a caller take the boundary row from the end of the page
+    /// without a second guard against it being empty.
+    /// </summary>
+    [Fact]
+    public void Of_AFollowingPage_LeavesTheBoundaryRowAtTheEndOfThePage()
+    {
+        // Act
+        var (page, hasMore) = KeysetPageSplit.Of([10, 20, 30], pageSize: 2);
+
+        // Assert
+        Assert.True(hasMore);
+        Assert.Equal(20, page[^1]);
+    }
+
+    /// <summary>A page of no rows is a bound no reader composes, and it would make the split meaningless.</summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Of_APageBoundOfNothing_IsRefused(int pageSize)
+    {
+        // Act
+        var refusal = Record.Exception(() => KeysetPageSplit.Of([1, 2], pageSize));
+
+        // Assert
+        Assert.IsType<ArgumentOutOfRangeException>(refusal);
+    }
+}


### PR DESCRIPTION
Seven small clones under `src/Infrastructure/Persistence/` are folded into one statement each, and the reasoning four of them had copied along with the code is now written once. Nothing observable moves: no schema, no migration, no configuration key, no MCP tool argument, no page bound, no cursor semantics. 399 lines removed against 150 added.

## What each fold is

**The descending keyset page split, six times → `KeysetPageSplit.Of<TRow>(readRows, pageSize)`.** `MailboxMutationAuditEntryStore`, `MailAnsweringAuditEntryStore`, `MailRuleExecutionStore`, `SpamClassificationHistoryReader`, `DeadLetteredJobStore`, and `OutboxOperationStore` now call it, and the byte-identical two-line comment about reading one row past the page lives in its remarks with a `<see cref>` in each caller's own `<remarks>`. The helper also states the invariant that made the second half of each cursor guard dead: a read that reached past the page is a read that filled it, so `entities.Length > query.PageSize && pageEntities.Length > 0` is now just `hasMore` and the boundary row is safe to take by construction. `ContactDirectory` is left alone, as the issue's acceptance says — it orders ascending and computes its guard from the mapped result.

**The delivery and mutation mapping helpers.** `StoredRemotePlacement.Of(uint?, uint?)` replaces four copies of `ToPlacement`, `StoredFailureCode.ToErrorCode(int?)` five copies of `ToFailure` (both entity-taking variants now pass the column), and `StoredOutgoingRecipient.ToRecipient(...)` three copies of the recipient guard together with the three copies of `ContactOf`. The privacy rule the three copies carried verbatim — the address stays out of the refusal, the ordinal names the row — is written once; each refusal still reads exactly as it did, because the carrier is passed as its name and identity.

**`EmailContentStore`.** All four read tails end in `StoredEmailContentRow.ToStoredContent()`, following the `StoredEmailSummaryRow.ToSummary()` shape already in the directory. `FindStoredContentAsync` keeps its own telemetry branching around it.

**Two rows shared between exactly the two stores that carried them.** `StoredEmailOccurrenceRow` carries the six-column projection and the occurrence-id rebuild that `StoredEmailExtractionBackfillStore` and `StoredMailRederivationStore` each had; `StoredDerivedWorkCandidateRow` carries the five columns an admission is decided from plus `AdmittedUnder`, which `StoredEmailChunkingStore` and `StoredEmailEmbeddingBackfillStore` each had as a private `AdmissionOf`. Both projections were checked to translate before being committed, through the design-time context and `ToQueryString()`; the nested candidate row composes into each walk's own projection without client evaluation.

**The two `DeadLetteredJobStore` updates → `DeadLetteredJobDecisionStatements`.** They were built inline inside `ExecuteSqlAsync`, which is what kept them unassertable without a database. They now compose like `JobClaimStatement` and `OutgoingEmailClaimStatement` do, and `DeadLetteredJobDecisionStatementsTests` reads both as text: the dead-lettered predicate that keeps a retry off a job somebody else's worker is holding, what each writes, and what each leaves alone. Every column name in that test and in `JobClaimStatementTests` is now `nameof(JobEntity.X)`, so renaming a property fails the test at compile time rather than leaving a production SQL claim that PostgreSQL refuses at run time. The production statements keep their bare quoted identifiers: an interpolated `FormattableString` makes a parameter of every hole, so a `nameof` written there would arrive as a parameter marker rather than as the column — which is why the assertion belongs in the test.

**The retention read-then-delete rationale.** The four-line "PostgreSQL has no `DELETE ... LIMIT`" block lives in `MailboxMutationAuditEntryStore.EraseCompletedBeforeAsync`'s remarks; the answering and rule stores point at it with a `<see cref>`. Each keeps its own one-line note about its foreign key cascading, which is a fact about its own table rather than a copy.

## Out of scope, as the issue set it

The write-once extraction in `EmailContentStore`, a generic `EraseOldestAsync`, rewriting the five short `JobStore` updates as positional consts, merging the two claim statements, the three other occurrence-id sites, and whether `MailAnsweringAuditEntryStore` should have been a second audit table at all.

## Two things worth a reviewer's eye

- **`StoredRemotePlacement` and `StoredFailureCode` are in `Delivery/` because the acceptance places them there**, and two of the four placement callers and two of the five failure callers live in `Mutations/`, which now takes a `using` on the delivery namespace. `src/Infrastructure/Persistence/` — where `KeysetPageSplit` sits — would carry no direction at all. Say the word and I move them; I followed the issue rather than my own preference.
- **`StoredEmailContent.From(StoredEmailContentRow?)` is not literally what landed.** `StoredEmailContent` is a public record in `src/Application/EmailContent/Storage/`, so a factory there taking an infrastructure projection row would invert the layer dependency. The method is `StoredEmailContentRow.ToStoredContent()` instead — same one call at all four tails, on the type that already knows the columns, and the same shape `StoredEmailSummaryRow` uses.

## Verification

`scripts/verify-full.sh` passed over exactly this tree. Five new unit-test classes cover the four helpers that left `[RequiresIntegrationCoverage]` code and entered the unit denominator — `KeysetPageSplitTests`, `StoredRemotePlacementTests`, `StoredFailureCodeTests`, `StoredOutgoingRecipientTests`, `DeadLetteredJobDecisionStatementsTests`. The three new projection rows keep the marker their stores carry, as `StoredEmailSummaryRow` does. No documentation is owed: `scripts/review-obligations.sh` names `docs/architecture/stored-email-schema.md` and the feature pages by marker, and none of them says anything about the internals that moved.

Closes #1020
