### PR TITLE
[#1022] Resolve the named account in one place across the administrative endpoints

### DIFF
--- a/src/Host/Api/AdminAccountRequest.cs
+++ b/src/Host/Api/AdminAccountRequest.cs
@@ -1,0 +1,107 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using MailFathom.Application.Accounts;
+using MailFathom.Domain.Accounts;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace MailFathom.Host.Api;
+
+/// <summary>Reads the account an administrative request named, and states the one refusal when it names none this deployment serves.</summary>
+/// <remarks>
+/// <para>
+/// Every administrative endpoint that takes an account asks the same two questions of it — is there one, and is it one
+/// this deployment configures — and every one of them answers a caller who got it wrong in the same sentence. Holding
+/// that here is what keeps the sentence one sentence: the wording was copied into six files before this type existed
+/// and had already drifted apart in what it echoed back.
+/// </para>
+/// <para>
+/// What it echoes is the identifier as <see cref="MailAccountId" /> normalizes it rather than the text the request
+/// carried, so a caller who padded the name with whitespace is told about the name that was looked up. The refusal
+/// names what MailFathom searched for, and no request text reaches the response body unaltered.
+/// </para>
+/// </remarks>
+internal static class AdminAccountRequest
+{
+    /// <summary>Reads the account a request named, or nothing when this deployment does not serve it.</summary>
+    /// <param name="account">The account identifier the request carried, which may be absent or blank.</param>
+    /// <param name="accounts">Reports the accounts this deployment serves.</param>
+    /// <returns>The served account, or <see langword="null" /> when the request named none or named one this deployment does not serve.</returns>
+    internal static MailAccountId? Resolve(string? account, IMailAccountCatalog accounts)
+    {
+        if (string.IsNullOrWhiteSpace(account))
+        {
+            return null;
+        }
+
+        var accountId = MailAccountId.Create(account);
+
+        return accounts.ServedAccounts.Any(served => served.Id == accountId) ? accountId : null;
+    }
+
+    /// <summary>States why the account a request named did not resolve, without echoing an empty one.</summary>
+    /// <param name="account">The account identifier the request carried.</param>
+    /// <returns><see cref="Missing" /> for an absent or blank account, and <see cref="Unknown" /> for one this deployment does not serve.</returns>
+    internal static ProblemHttpResult Refuse(string? account) => string.IsNullOrWhiteSpace(account)
+        ? Missing()
+        : Unknown(MailAccountId.Create(account).Value);
+
+    /// <summary>States that the request named no account at all, where naming one is what the endpoint asks for.</summary>
+    /// <returns>The refusal.</returns>
+    internal static ProblemHttpResult Missing() => TypedResults.Problem(
+        "The request named no mail account.",
+        statusCode: StatusCodes.Status400BadRequest);
+
+    /// <summary>States that an account filter was present and empty, where leaving it out reads every account.</summary>
+    /// <returns>The refusal.</returns>
+    internal static ProblemHttpResult MissingFilter() => TypedResults.Problem(
+        "The account filter named no mail account. Leave it out to read every account.",
+        statusCode: StatusCodes.Status400BadRequest);
+
+    /// <summary>States that the account a request named is not one this deployment serves.</summary>
+    /// <param name="account">The normalized identifier that was looked up.</param>
+    /// <returns>The refusal.</returns>
+    internal static ProblemHttpResult Unknown(string account) => TypedResults.Problem(
+        $"This deployment configures no mail account named '{account}'.",
+        statusCode: StatusCodes.Status400BadRequest);
+
+    /// <summary>Reads an optional account filter, which narrows a reading to one account or leaves it across every account.</summary>
+    /// <param name="account">The account filter the request carried, absent for every account.</param>
+    /// <param name="accounts">Reports the accounts this deployment serves.</param>
+    /// <param name="accountId">The account to narrow to, or <see langword="null" /> for every account.</param>
+    /// <param name="refusal">What the caller is told when the filter is present and names no served account.</param>
+    /// <returns><see langword="true" /> when the reading may go ahead.</returns>
+    /// <remarks>
+    /// An absent filter is every account rather than a refusal, which is why this is a form of its own: a present filter
+    /// is held to the same two questions as a required account, and only the absent case differs.
+    /// </remarks>
+    internal static bool TryResolveFilter(
+        string? account,
+        IMailAccountCatalog accounts,
+        out MailAccountId? accountId,
+        [NotNullWhen(false)] out ProblemHttpResult? refusal)
+    {
+        accountId = null;
+        refusal = null;
+
+        if (account is null)
+        {
+            return true;
+        }
+
+        if (Resolve(account, accounts) is not { } servedAccount)
+        {
+            refusal = string.IsNullOrWhiteSpace(account)
+                ? MissingFilter()
+                : Unknown(MailAccountId.Create(account).Value);
+
+            return false;
+        }
+
+        accountId = servedAccount;
+
+        return true;
+    }
+}

--- a/src/Host/Api/JobDeadLetterEndpoints.cs
+++ b/src/Host/Api/JobDeadLetterEndpoints.cs
@@ -6,7 +6,6 @@ using MailFathom.Application.Accounts;
 using MailFathom.Application.Jobs;
 using MailFathom.Application.Jobs.DeadLetters;
 using MailFathom.Domain.Access;
-using MailFathom.Domain.Accounts;
 using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
@@ -100,16 +99,9 @@ internal static class JobDeadLetterEndpoints
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(deadLetters);
 
-        MailAccountId? accountId = null;
-
-        if (account is not null)
+        if (!AdminAccountRequest.TryResolveFilter(account, accounts, out var accountId, out var refusal))
         {
-            if (ResolveAccount(account, accounts) is not { } servedAccount)
-            {
-                return UnknownAccount(account);
-            }
-
-            accountId = servedAccount;
+            return refusal;
         }
 
         JobType? jobType = null;
@@ -210,27 +202,7 @@ internal static class JobDeadLetterEndpoints
         ? JobId.Create(identifier)
         : null;
 
-    /// <summary>Reads the account a request named, or nothing when this deployment does not serve it.</summary>
-    private static MailAccountId? ResolveAccount(string? account, IMailAccountCatalog accounts)
-    {
-        if (string.IsNullOrWhiteSpace(account))
-        {
-            return null;
-        }
-
-        var accountId = MailAccountId.Create(account);
-
-        return accounts.ServedAccounts.Any(served => served.Id == accountId) ? accountId : null;
-    }
-
     private static string DeclaredJobTypes() => string.Join(", ", JobType.All.Select(declared => declared.Name));
-
-    /// <summary>States that the request named no account this deployment serves, without echoing an empty one.</summary>
-    private static ProblemHttpResult UnknownAccount(string? account) => TypedResults.Problem(
-        string.IsNullOrWhiteSpace(account)
-            ? "The account filter named no mail account. Leave it out to read every account."
-            : $"This deployment configures no mail account named '{account}'.",
-        statusCode: StatusCodes.Status400BadRequest);
 
     /// <summary>States that the request named no job to decide about.</summary>
     private static ProblemHttpResult NoJobNamed() => TypedResults.Problem(

--- a/src/Host/Api/MailAnsweringAuditEndpoint.cs
+++ b/src/Host/Api/MailAnsweringAuditEndpoint.cs
@@ -5,7 +5,6 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Retrieval.AskMail.Audit;
 using MailFathom.Domain.Access;
-using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Answering.Audit;
 using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -77,18 +76,9 @@ internal static class MailAnsweringAuditEndpoint
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(trail);
 
-        if (string.IsNullOrWhiteSpace(account))
+        if (AdminAccountRequest.Resolve(account, accounts) is not { } accountId)
         {
-            return TypedResults.Problem("The request named no mail account.", statusCode: StatusCodes.Status400BadRequest);
-        }
-
-        var accountId = MailAccountId.Create(account);
-
-        if (!accounts.ServedAccounts.Any(account => account.Id == accountId))
-        {
-            return TypedResults.Problem(
-                $"This deployment configures no mail account named '{accountId.Value}'.",
-                statusCode: StatusCodes.Status400BadRequest);
+            return AdminAccountRequest.Refuse(account);
         }
 
         MailAnsweringAuditCursor? decodedCursor = null;

--- a/src/Host/Api/MailFolderErasureEndpoint.cs
+++ b/src/Host/Api/MailFolderErasureEndpoint.cs
@@ -5,7 +5,6 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Folders;
 using MailFathom.Domain.Access;
-using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
 using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -86,9 +85,9 @@ internal static class MailFolderErasureEndpoint
         ArgumentNullException.ThrowIfNull(mappings);
         ArgumentNullException.ThrowIfNull(eraser);
 
-        if (ResolveAccount(request?.Account, accounts) is not { } accountId)
+        if (AdminAccountRequest.Resolve(request?.Account, accounts) is not { } accountId)
         {
-            return UnknownAccount(request?.Account);
+            return AdminAccountRequest.Refuse(request?.Account);
         }
 
         if (!MailFolderAlias.TryCreate(request?.Folder, out var folderAlias))
@@ -113,26 +112,6 @@ internal static class MailFolderErasureEndpoint
             erasure.ErasedEmailCount,
             erasure.EmailsRemain));
     }
-
-    /// <summary>Reads the account a request named, or nothing when this deployment does not serve it.</summary>
-    private static MailAccountId? ResolveAccount(string? account, IMailAccountCatalog accounts)
-    {
-        if (string.IsNullOrWhiteSpace(account))
-        {
-            return null;
-        }
-
-        var accountId = MailAccountId.Create(account);
-
-        return accounts.ServedAccounts.Any(served => served.Id == accountId) ? accountId : null;
-    }
-
-    /// <summary>States that the request named no account this deployment serves, without echoing an empty one.</summary>
-    private static ProblemHttpResult UnknownAccount(string? account) => TypedResults.Problem(
-        string.IsNullOrWhiteSpace(account)
-            ? "The request named no mail account."
-            : $"This deployment configures no mail account named '{account}'.",
-        statusCode: StatusCodes.Status400BadRequest);
 }
 
 /// <summary>What a deployment is asked when a folder's stored mail is to be erased.</summary>

--- a/src/Host/Api/MailRuleEndpoints.cs
+++ b/src/Host/Api/MailRuleEndpoints.cs
@@ -7,7 +7,6 @@ using MailFathom.Application.Rules;
 using MailFathom.Application.Rules.Evaluation;
 using MailFathom.Application.Rules.History;
 using MailFathom.Domain.Access;
-using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Host.Configuration;
 using MailFathom.Host.Configuration.Rules;
@@ -142,9 +141,9 @@ internal static class MailRuleEndpoints
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(requests);
 
-        if (ResolveAccount(request?.Account, accounts) is not { } accountId)
+        if (AdminAccountRequest.Resolve(request?.Account, accounts) is not { } accountId)
         {
-            return UnknownAccount(request?.Account);
+            return AdminAccountRequest.Refuse(request?.Account);
         }
 
         var submitted = await requests.SubmitAsync(accountId, cancellationToken);
@@ -174,9 +173,9 @@ internal static class MailRuleEndpoints
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(runs);
 
-        if (ResolveAccount(account, accounts) is not { } accountId)
+        if (AdminAccountRequest.Resolve(account, accounts) is not { } accountId)
         {
-            return UnknownAccount(account);
+            return AdminAccountRequest.Refuse(account);
         }
 
         var run = await runs.FindLatestAsync(accountId, cancellationToken);
@@ -218,9 +217,9 @@ internal static class MailRuleEndpoints
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(history);
 
-        if (ResolveAccount(account, accounts) is not { } accountId)
+        if (AdminAccountRequest.Resolve(account, accounts) is not { } accountId)
         {
-            return UnknownAccount(account);
+            return AdminAccountRequest.Refuse(account);
         }
 
         MailRuleExecutionCursor? decodedCursor = null;
@@ -257,26 +256,6 @@ internal static class MailRuleEndpoints
 
         return TypedResults.Ok(MailRuleHistoryPageResponse.For(page));
     }
-
-    /// <summary>Reads the account a request named, or nothing when this deployment does not serve it.</summary>
-    private static MailAccountId? ResolveAccount(string? account, IMailAccountCatalog accounts)
-    {
-        if (string.IsNullOrWhiteSpace(account))
-        {
-            return null;
-        }
-
-        var accountId = MailAccountId.Create(account);
-
-        return accounts.ServedAccounts.Any(served => served.Id == accountId) ? accountId : null;
-    }
-
-    /// <summary>States that the request named no account this deployment serves, without echoing an empty one.</summary>
-    private static ProblemHttpResult UnknownAccount(string? account) => TypedResults.Problem(
-        string.IsNullOrWhiteSpace(account)
-            ? "The request named no mail account."
-            : $"This deployment configures no mail account named '{account}'.",
-        statusCode: StatusCodes.Status400BadRequest);
 
     /// <summary>States what a caller has to change, without restating the filters they already sent.</summary>
     private static string DescribeRefusal(MailRuleExecutionQueryOutcome outcome) => outcome switch

--- a/src/Host/Api/MailboxMaintenanceEndpoints.cs
+++ b/src/Host/Api/MailboxMaintenanceEndpoints.cs
@@ -5,7 +5,6 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Mail.Maintenance;
 using MailFathom.Domain.Access;
-using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Folders;
 using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -237,7 +236,7 @@ internal static class MailboxMaintenanceEndpoints
     /// </remarks>
     private static StoredMailScope? ResolveScope(string? account, string? folder, IMailAccountCatalog accounts)
     {
-        if (ResolveAccount(account, accounts) is not { } accountId)
+        if (AdminAccountRequest.Resolve(account, accounts) is not { } accountId)
         {
             return null;
         }
@@ -252,19 +251,6 @@ internal static class MailboxMaintenanceEndpoints
             : null;
     }
 
-    /// <summary>Reads the account a request named, or nothing when this deployment does not serve it.</summary>
-    private static MailAccountId? ResolveAccount(string? account, IMailAccountCatalog accounts)
-    {
-        if (string.IsNullOrWhiteSpace(account))
-        {
-            return null;
-        }
-
-        var accountId = MailAccountId.Create(account);
-
-        return accounts.ServedAccounts.Any(served => served.Id == accountId) ? accountId : null;
-    }
-
     /// <summary>States which half of the scope was wrong, without echoing an empty one.</summary>
     /// <remarks>
     /// The folder is not a parameter because it is not read: a scope that failed to resolve with an account this
@@ -272,17 +258,13 @@ internal static class MailboxMaintenanceEndpoints
     /// </remarks>
     private static ProblemHttpResult Refusal(string? account, IMailAccountCatalog accounts)
     {
-        if (ResolveAccount(account, accounts) is not null)
+        if (AdminAccountRequest.Resolve(account, accounts) is not null)
         {
             return TypedResults.Problem(
                 "The request named a folder that is not an alias. Name the alias of one folder, or name none at all to cover every folder the account holds mail in.",
                 statusCode: StatusCodes.Status400BadRequest);
         }
 
-        return TypedResults.Problem(
-            string.IsNullOrWhiteSpace(account)
-                ? "The request named no mail account."
-                : $"This deployment configures no mail account named '{account}'.",
-            statusCode: StatusCodes.Status400BadRequest);
+        return AdminAccountRequest.Refuse(account);
     }
 }

--- a/src/Host/Api/MailboxMutationAuditEndpoint.cs
+++ b/src/Host/Api/MailboxMutationAuditEndpoint.cs
@@ -5,7 +5,6 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Mail.Mutations.Audit;
 using MailFathom.Domain.Access;
-using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Mutations;
 using MailFathom.Domain.Mutations.Audit;
 using MailFathom.Host.Security.Endpoints;
@@ -81,18 +80,9 @@ internal static class MailboxMutationAuditEndpoint
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(trail);
 
-        if (string.IsNullOrWhiteSpace(account))
+        if (AdminAccountRequest.Resolve(account, accounts) is not { } accountId)
         {
-            return TypedResults.Problem("The request named no mail account.", statusCode: StatusCodes.Status400BadRequest);
-        }
-
-        var accountId = MailAccountId.Create(account);
-
-        if (!accounts.ServedAccounts.Any(account => account.Id == accountId))
-        {
-            return TypedResults.Problem(
-                $"This deployment configures no mail account named '{accountId.Value}'.",
-                statusCode: StatusCodes.Status400BadRequest);
+            return AdminAccountRequest.Refuse(account);
         }
 
         // The unspecified default is what "every mutation" is written as, so an absent filter and a named one reach the

--- a/src/Host/Api/OutboxEndpoints.cs
+++ b/src/Host/Api/OutboxEndpoints.cs
@@ -5,7 +5,6 @@
 using MailFathom.Application.Accounts;
 using MailFathom.Application.Mail.Delivery.Operations;
 using MailFathom.Domain.Access;
-using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Delivery;
 using MailFathom.Host.Security.Endpoints;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -113,16 +112,9 @@ internal static class OutboxEndpoints
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(outbox);
 
-        MailAccountId? accountId = null;
-
-        if (account is not null)
+        if (!AdminAccountRequest.TryResolveFilter(account, accounts, out var accountId, out var refusal))
         {
-            if (ResolveAccount(account, accounts) is not { } servedAccount)
-            {
-                return UnknownAccount(account);
-            }
-
-            accountId = servedAccount;
+            return refusal;
         }
 
         var summary = await outbox.ReadSummaryAsync(accountId, cancellationToken);
@@ -156,16 +148,9 @@ internal static class OutboxEndpoints
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(outbox);
 
-        MailAccountId? accountId = null;
-
-        if (account is not null)
+        if (!AdminAccountRequest.TryResolveFilter(account, accounts, out var accountId, out var refusal))
         {
-            if (ResolveAccount(account, accounts) is not { } servedAccount)
-            {
-                return UnknownAccount(account);
-            }
-
-            accountId = servedAccount;
+            return refusal;
         }
 
         OutgoingEmailStage? namedStage = null;
@@ -301,26 +286,6 @@ internal static class OutboxEndpoints
             ? OutgoingEmailId.Create(identifier)
             : null;
 
-    /// <summary>Reads the account a request named, or nothing when this deployment does not serve it.</summary>
-    private static MailAccountId? ResolveAccount(string? account, IMailAccountCatalog accounts)
-    {
-        if (string.IsNullOrWhiteSpace(account))
-        {
-            return null;
-        }
-
-        var accountId = MailAccountId.Create(account);
-
-        return accounts.ServedAccounts.Any(served => served.Id == accountId) ? accountId : null;
-    }
-
-    /// <summary>States that the request named no account this deployment serves, without echoing an empty one.</summary>
-    private static ProblemHttpResult UnknownAccount(string? account) => TypedResults.Problem(
-        string.IsNullOrWhiteSpace(account)
-            ? "The account filter named no mail account. Leave it out to read every account."
-            : $"This deployment configures no mail account named '{account}'.",
-        statusCode: StatusCodes.Status400BadRequest);
-
     /// <summary>States that the request named no stage a send can stand at.</summary>
     private static ProblemHttpResult UnknownStage() => TypedResults.Problem(
         $"The stage filter names no stage a queued message stands at. It is one of {OutboxQuery.DeclaredStages()}.",
@@ -340,201 +305,4 @@ internal static class OutboxEndpoints
             $"The stage filter names no stage a queued message stands at. It is one of {OutboxQuery.DeclaredStages()}.",
         _ => "The continuation cursor was issued for a different set of outbox filters.",
     };
-}
-
-/// <summary>What a deployment is asked when one send is to be withdrawn.</summary>
-/// <param name="OutgoingEmail">The identifier the outbox reading reports for the send.</param>
-internal sealed record OutboxCancellationRequest(Guid? OutgoingEmail);
-
-/// <summary>What a deployment is asked when one send is to be offered again.</summary>
-/// <param name="OutgoingEmail">The identifier the outbox reading reports for the send.</param>
-/// <param name="RefusalRestated">Whether the caller has restated a permanent refusal, which is what a refused send needs before it is offered again.</param>
-internal sealed record OutboxRequeueRequest(Guid? OutgoingEmail, bool RefusalRestated);
-
-/// <summary>How much stands at each stage of an outbox.</summary>
-/// <param name="Stages">One count per declared stage, in the order the stages are declared.</param>
-/// <param name="OutstandingCount">How many sends nothing has finished with, which is the depth an operator means.</param>
-internal sealed record OutboxSummaryResponse(IReadOnlyList<OutboxStageCountResponse> Stages, int OutstandingCount)
-{
-    /// <summary>Describes the summary as the administrative surface reports it.</summary>
-    /// <param name="summary">The summary read.</param>
-    /// <returns>The response body.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="summary" /> is <see langword="null" />.</exception>
-    internal static OutboxSummaryResponse For(OutboxSummary summary)
-    {
-        ArgumentNullException.ThrowIfNull(summary);
-
-        return new OutboxSummaryResponse(
-            [.. summary.Stages.Select(stage => new OutboxStageCountResponse(stage.Stage.ToString(), stage.Count))],
-            summary.OutstandingCount);
-    }
-}
-
-/// <summary>How many sends stand at one stage.</summary>
-/// <param name="Stage">The stage.</param>
-/// <param name="Count">How many sends stand at it.</param>
-internal sealed record OutboxStageCountResponse(string Stage, int Count);
-
-/// <summary>One page of what a deployment has been asked to send.</summary>
-/// <param name="Sends">The sends, ordered by when each one was written down, newest first.</param>
-/// <param name="NextCursor">The cursor the following page is asked with, or <see langword="null" /> at the end.</param>
-internal sealed record OutboxPageResponse(IReadOnlyList<OutboxEntryResponse> Sends, string? NextCursor)
-{
-    /// <summary>Describes one page as the administrative surface reports it.</summary>
-    /// <param name="page">The page read.</param>
-    /// <returns>The response body.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="page" /> is <see langword="null" />.</exception>
-    internal static OutboxPageResponse For(OutboxPage page)
-    {
-        ArgumentNullException.ThrowIfNull(page);
-
-        return new OutboxPageResponse(
-            [.. page.Sends.Select(OutboxEntryResponse.For)],
-            page.NextCursor?.Encode());
-    }
-}
-
-/// <summary>One recorded send as a listing names it.</summary>
-/// <param name="OutgoingEmail">The identifier a decision names it by.</param>
-/// <param name="Account">The account the message is sent from.</param>
-/// <param name="Stage">How far along its submission sequence it has durably reached.</param>
-/// <param name="Origin">What asked for the send.</param>
-/// <param name="AttemptCount">How many attempts have been handed out for it.</param>
-/// <param name="MimeByteLength">How many bytes of MIME are stored for the message.</param>
-/// <param name="RecordedAt">When the send was written down.</param>
-/// <param name="StageChangedAt">When it last moved between stages.</param>
-/// <param name="AvailableAt">The instant from which it may be claimed again.</param>
-/// <param name="LastFailureCode">The code identifying what the last attempt ended in, absent where the row records none.</param>
-/// <param name="LastReplyCode">The reply code the server answered with, absent where it answered none.</param>
-internal sealed record OutboxEntryResponse(
-    Guid OutgoingEmail,
-    string Account,
-    string Stage,
-    string Origin,
-    int AttemptCount,
-    long MimeByteLength,
-    DateTimeOffset RecordedAt,
-    DateTimeOffset StageChangedAt,
-    DateTimeOffset AvailableAt,
-    int? LastFailureCode,
-    int? LastReplyCode)
-{
-    /// <summary>Describes one listing entry as the administrative surface reports it.</summary>
-    /// <param name="entry">The entry read.</param>
-    /// <returns>The response record.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="entry" /> is <see langword="null" />.</exception>
-    internal static OutboxEntryResponse For(OutboxEntry entry)
-    {
-        ArgumentNullException.ThrowIfNull(entry);
-
-        return new OutboxEntryResponse(
-            entry.OutgoingEmailId.Value,
-            entry.AccountId.Value,
-            entry.Stage.ToString(),
-            entry.Origin.ToString(),
-            entry.AttemptCount,
-            entry.MimeByteLength,
-            entry.RecordedAt,
-            entry.StageChangedAt,
-            entry.AvailableAt,
-            entry.LastFailure?.Value,
-            entry.LastReplyCode);
-    }
-}
-
-/// <summary>One recorded send, with what each of its recipients was told.</summary>
-/// <param name="OutgoingEmail">The identifier a decision names it by.</param>
-/// <param name="Account">The account the message is sent from.</param>
-/// <param name="Stage">How far along its submission sequence it has durably reached.</param>
-/// <param name="Origin">What asked for the send.</param>
-/// <param name="Requester">The identity the send is idempotent under, which is MailFathom's own name for what asked.</param>
-/// <param name="AttemptCount">How many attempts have been handed out for it.</param>
-/// <param name="MimeByteLength">How many bytes of MIME are stored for the message.</param>
-/// <param name="RecordedAt">When the send was written down.</param>
-/// <param name="StageChangedAt">When it last moved between stages.</param>
-/// <param name="AvailableAt">The instant from which it may be claimed again.</param>
-/// <param name="LastFailureCode">The code identifying what the last attempt ended in, absent where the row records none.</param>
-/// <param name="LastReplyCode">The reply code the server answered with, absent where it answered none.</param>
-/// <param name="Recipients">Who the message is offered to, and what each of them was told.</param>
-internal sealed record OutboxSendResponse(
-    Guid OutgoingEmail,
-    string Account,
-    string Stage,
-    string Origin,
-    string Requester,
-    int AttemptCount,
-    long MimeByteLength,
-    DateTimeOffset RecordedAt,
-    DateTimeOffset StageChangedAt,
-    DateTimeOffset AvailableAt,
-    int? LastFailureCode,
-    int? LastReplyCode,
-    IReadOnlyList<OutboxRecipientResponse> Recipients)
-{
-    /// <summary>Describes one send as the administrative surface reports it.</summary>
-    /// <param name="record">The record read.</param>
-    /// <returns>The response body.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="record" /> is <see langword="null" />.</exception>
-    internal static OutboxSendResponse For(OutgoingEmailRecord record)
-    {
-        ArgumentNullException.ThrowIfNull(record);
-
-        return new OutboxSendResponse(
-            record.Id.Value,
-            record.AccountId.Value,
-            record.Stage.ToString(),
-            record.Requester.Origin.ToString(),
-            record.Requester.Identity,
-            record.AttemptCount,
-            record.MimeByteLength,
-            record.RecordedAt,
-            record.StageChangedAt,
-            record.AvailableAt,
-            record.LastFailure?.Value,
-            record.LastReplyCode,
-            [.. record.Recipients.Select(OutboxRecipientResponse.For)]);
-    }
-}
-
-/// <summary>One person a message is offered to, and what the server said about them.</summary>
-/// <param name="Address">The address the envelope names.</param>
-/// <param name="Role">Whether the address is on the message as a recipient, a copy, or a blind copy.</param>
-/// <param name="Status">What the last attempt settled about it.</param>
-/// <param name="LastReplyCode">The reply code the server answered for this address, absent where it answered none.</param>
-/// <param name="AnsweredAt">When that answer was recorded, absent where none was.</param>
-internal sealed record OutboxRecipientResponse(
-    string Address,
-    string Role,
-    string Status,
-    int? LastReplyCode,
-    DateTimeOffset? AnsweredAt)
-{
-    /// <summary>Describes one recipient as the administrative surface reports it.</summary>
-    /// <param name="outcome">The outcome read.</param>
-    /// <returns>The response record.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="outcome" /> is <see langword="null" />.</exception>
-    internal static OutboxRecipientResponse For(OutgoingRecipientOutcome outcome)
-    {
-        ArgumentNullException.ThrowIfNull(outcome);
-
-        return new OutboxRecipientResponse(
-            outcome.Recipient.Address.Address,
-            outcome.Recipient.Role.ToString(),
-            outcome.Status.ToString(),
-            outcome.LastReplyCode,
-            outcome.AnsweredAt);
-    }
-}
-
-/// <summary>What became of a send an operator decided about.</summary>
-/// <param name="OutgoingEmail">The send the decision named.</param>
-/// <param name="Outcome">What happened: <c>Accepted</c>, <c>RecordUnknown</c>, <c>StageDoesNotAllowIt</c>, <c>AttemptUnderWay</c>, or <c>RefusalNotRestated</c>.</param>
-internal sealed record OutboxDecisionResponse(Guid OutgoingEmail, string Outcome)
-{
-    /// <summary>Describes one decision as the administrative surface reports it.</summary>
-    /// <param name="outgoingEmailId">The send the decision named.</param>
-    /// <param name="outcome">What happened.</param>
-    /// <returns>The response body.</returns>
-    internal static OutboxDecisionResponse For(OutgoingEmailId outgoingEmailId, OutboxDecisionOutcome outcome) =>
-        new(outgoingEmailId.Value, outcome.ToString());
 }

--- a/src/Host/Api/OutboxResponses.cs
+++ b/src/Host/Api/OutboxResponses.cs
@@ -1,0 +1,205 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Delivery.Operations;
+using MailFathom.Domain.Delivery;
+
+namespace MailFathom.Host.Api;
+
+/// <summary>What a deployment is asked when one send is to be withdrawn.</summary>
+/// <param name="OutgoingEmail">The identifier the outbox reading reports for the send.</param>
+internal sealed record OutboxCancellationRequest(Guid? OutgoingEmail);
+
+/// <summary>What a deployment is asked when one send is to be offered again.</summary>
+/// <param name="OutgoingEmail">The identifier the outbox reading reports for the send.</param>
+/// <param name="RefusalRestated">Whether the caller has restated a permanent refusal, which is what a refused send needs before it is offered again.</param>
+internal sealed record OutboxRequeueRequest(Guid? OutgoingEmail, bool RefusalRestated);
+
+/// <summary>How much stands at each stage of an outbox.</summary>
+/// <param name="Stages">One count per declared stage, in the order the stages are declared.</param>
+/// <param name="OutstandingCount">How many sends nothing has finished with, which is the depth an operator means.</param>
+internal sealed record OutboxSummaryResponse(IReadOnlyList<OutboxStageCountResponse> Stages, int OutstandingCount)
+{
+    /// <summary>Describes the summary as the administrative surface reports it.</summary>
+    /// <param name="summary">The summary read.</param>
+    /// <returns>The response body.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="summary" /> is <see langword="null" />.</exception>
+    internal static OutboxSummaryResponse For(OutboxSummary summary)
+    {
+        ArgumentNullException.ThrowIfNull(summary);
+
+        return new OutboxSummaryResponse(
+            [.. summary.Stages.Select(stage => new OutboxStageCountResponse(stage.Stage.ToString(), stage.Count))],
+            summary.OutstandingCount);
+    }
+}
+
+/// <summary>How many sends stand at one stage.</summary>
+/// <param name="Stage">The stage.</param>
+/// <param name="Count">How many sends stand at it.</param>
+internal sealed record OutboxStageCountResponse(string Stage, int Count);
+
+/// <summary>One page of what a deployment has been asked to send.</summary>
+/// <param name="Sends">The sends, ordered by when each one was written down, newest first.</param>
+/// <param name="NextCursor">The cursor the following page is asked with, or <see langword="null" /> at the end.</param>
+internal sealed record OutboxPageResponse(IReadOnlyList<OutboxEntryResponse> Sends, string? NextCursor)
+{
+    /// <summary>Describes one page as the administrative surface reports it.</summary>
+    /// <param name="page">The page read.</param>
+    /// <returns>The response body.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="page" /> is <see langword="null" />.</exception>
+    internal static OutboxPageResponse For(OutboxPage page)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        return new OutboxPageResponse(
+            [.. page.Sends.Select(OutboxEntryResponse.For)],
+            page.NextCursor?.Encode());
+    }
+}
+
+/// <summary>One recorded send as a listing names it.</summary>
+/// <param name="OutgoingEmail">The identifier a decision names it by.</param>
+/// <param name="Account">The account the message is sent from.</param>
+/// <param name="Stage">How far along its submission sequence it has durably reached.</param>
+/// <param name="Origin">What asked for the send.</param>
+/// <param name="AttemptCount">How many attempts have been handed out for it.</param>
+/// <param name="MimeByteLength">How many bytes of MIME are stored for the message.</param>
+/// <param name="RecordedAt">When the send was written down.</param>
+/// <param name="StageChangedAt">When it last moved between stages.</param>
+/// <param name="AvailableAt">The instant from which it may be claimed again.</param>
+/// <param name="LastFailureCode">The code identifying what the last attempt ended in, absent where the row records none.</param>
+/// <param name="LastReplyCode">The reply code the server answered with, absent where it answered none.</param>
+internal sealed record OutboxEntryResponse(
+    Guid OutgoingEmail,
+    string Account,
+    string Stage,
+    string Origin,
+    int AttemptCount,
+    long MimeByteLength,
+    DateTimeOffset RecordedAt,
+    DateTimeOffset StageChangedAt,
+    DateTimeOffset AvailableAt,
+    int? LastFailureCode,
+    int? LastReplyCode)
+{
+    /// <summary>Describes one listing entry as the administrative surface reports it.</summary>
+    /// <param name="entry">The entry read.</param>
+    /// <returns>The response record.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="entry" /> is <see langword="null" />.</exception>
+    internal static OutboxEntryResponse For(OutboxEntry entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        return new OutboxEntryResponse(
+            entry.OutgoingEmailId.Value,
+            entry.AccountId.Value,
+            entry.Stage.ToString(),
+            entry.Origin.ToString(),
+            entry.AttemptCount,
+            entry.MimeByteLength,
+            entry.RecordedAt,
+            entry.StageChangedAt,
+            entry.AvailableAt,
+            entry.LastFailure?.Value,
+            entry.LastReplyCode);
+    }
+}
+
+/// <summary>One recorded send, with what each of its recipients was told.</summary>
+/// <param name="OutgoingEmail">The identifier a decision names it by.</param>
+/// <param name="Account">The account the message is sent from.</param>
+/// <param name="Stage">How far along its submission sequence it has durably reached.</param>
+/// <param name="Origin">What asked for the send.</param>
+/// <param name="Requester">The identity the send is idempotent under, which is MailFathom's own name for what asked.</param>
+/// <param name="AttemptCount">How many attempts have been handed out for it.</param>
+/// <param name="MimeByteLength">How many bytes of MIME are stored for the message.</param>
+/// <param name="RecordedAt">When the send was written down.</param>
+/// <param name="StageChangedAt">When it last moved between stages.</param>
+/// <param name="AvailableAt">The instant from which it may be claimed again.</param>
+/// <param name="LastFailureCode">The code identifying what the last attempt ended in, absent where the row records none.</param>
+/// <param name="LastReplyCode">The reply code the server answered with, absent where it answered none.</param>
+/// <param name="Recipients">Who the message is offered to, and what each of them was told.</param>
+internal sealed record OutboxSendResponse(
+    Guid OutgoingEmail,
+    string Account,
+    string Stage,
+    string Origin,
+    string Requester,
+    int AttemptCount,
+    long MimeByteLength,
+    DateTimeOffset RecordedAt,
+    DateTimeOffset StageChangedAt,
+    DateTimeOffset AvailableAt,
+    int? LastFailureCode,
+    int? LastReplyCode,
+    IReadOnlyList<OutboxRecipientResponse> Recipients)
+{
+    /// <summary>Describes one send as the administrative surface reports it.</summary>
+    /// <param name="record">The record read.</param>
+    /// <returns>The response body.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="record" /> is <see langword="null" />.</exception>
+    internal static OutboxSendResponse For(OutgoingEmailRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+
+        return new OutboxSendResponse(
+            record.Id.Value,
+            record.AccountId.Value,
+            record.Stage.ToString(),
+            record.Requester.Origin.ToString(),
+            record.Requester.Identity,
+            record.AttemptCount,
+            record.MimeByteLength,
+            record.RecordedAt,
+            record.StageChangedAt,
+            record.AvailableAt,
+            record.LastFailure?.Value,
+            record.LastReplyCode,
+            [.. record.Recipients.Select(OutboxRecipientResponse.For)]);
+    }
+}
+
+/// <summary>One person a message is offered to, and what the server said about them.</summary>
+/// <param name="Address">The address the envelope names.</param>
+/// <param name="Role">Whether the address is on the message as a recipient, a copy, or a blind copy.</param>
+/// <param name="Status">What the last attempt settled about it.</param>
+/// <param name="LastReplyCode">The reply code the server answered for this address, absent where it answered none.</param>
+/// <param name="AnsweredAt">When that answer was recorded, absent where none was.</param>
+internal sealed record OutboxRecipientResponse(
+    string Address,
+    string Role,
+    string Status,
+    int? LastReplyCode,
+    DateTimeOffset? AnsweredAt)
+{
+    /// <summary>Describes one recipient as the administrative surface reports it.</summary>
+    /// <param name="outcome">The outcome read.</param>
+    /// <returns>The response record.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="outcome" /> is <see langword="null" />.</exception>
+    internal static OutboxRecipientResponse For(OutgoingRecipientOutcome outcome)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+
+        return new OutboxRecipientResponse(
+            outcome.Recipient.Address.Address,
+            outcome.Recipient.Role.ToString(),
+            outcome.Status.ToString(),
+            outcome.LastReplyCode,
+            outcome.AnsweredAt);
+    }
+}
+
+/// <summary>What became of a send an operator decided about.</summary>
+/// <param name="OutgoingEmail">The send the decision named.</param>
+/// <param name="Outcome">What happened: <c>Accepted</c>, <c>RecordUnknown</c>, <c>StageDoesNotAllowIt</c>, <c>AttemptUnderWay</c>, or <c>RefusalNotRestated</c>.</param>
+internal sealed record OutboxDecisionResponse(Guid OutgoingEmail, string Outcome)
+{
+    /// <summary>Describes one decision as the administrative surface reports it.</summary>
+    /// <param name="outgoingEmailId">The send the decision named.</param>
+    /// <param name="outcome">What happened.</param>
+    /// <returns>The response body.</returns>
+    internal static OutboxDecisionResponse For(OutgoingEmailId outgoingEmailId, OutboxDecisionOutcome outcome) =>
+        new(outgoingEmailId.Value, outcome.ToString());
+}

--- a/src/Host/Api/SpamClassificationEndpoints.cs
+++ b/src/Host/Api/SpamClassificationEndpoints.cs
@@ -8,7 +8,6 @@ using MailFathom.Application.Spam.Actions;
 using MailFathom.Application.Spam.History;
 using MailFathom.Application.Spam.Runs;
 using MailFathom.Domain.Access;
-using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Folders;
 using MailFathom.Domain.Spam;
@@ -111,9 +110,9 @@ internal static class SpamClassificationEndpoints
         ArgumentNullException.ThrowIfNull(settings);
         ArgumentNullException.ThrowIfNull(requests);
 
-        if (ResolveAccount(request?.Account, accounts) is not { } accountId)
+        if (AdminAccountRequest.Resolve(request?.Account, accounts) is not { } accountId)
         {
-            return UnknownAccount(request?.Account);
+            return AdminAccountRequest.Refuse(request?.Account);
         }
 
         var configuredScope = settings.Settings.ScannedFolderAliases;
@@ -156,9 +155,9 @@ internal static class SpamClassificationEndpoints
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(runs);
 
-        if (ResolveAccount(account, accounts) is not { } accountId)
+        if (AdminAccountRequest.Resolve(account, accounts) is not { } accountId)
         {
-            return UnknownAccount(account);
+            return AdminAccountRequest.Refuse(account);
         }
 
         var run = await runs.FindLatestAsync(accountId, cancellationToken);
@@ -201,9 +200,9 @@ internal static class SpamClassificationEndpoints
         ArgumentNullException.ThrowIfNull(accounts);
         ArgumentNullException.ThrowIfNull(classifications);
 
-        if (ResolveAccount(account, accounts) is not { } accountId)
+        if (AdminAccountRequest.Resolve(account, accounts) is not { } accountId)
         {
-            return UnknownAccount(account);
+            return AdminAccountRequest.Refuse(account);
         }
 
         SpamClassificationHistoryCursor? decodedCursor = null;
@@ -246,19 +245,6 @@ internal static class SpamClassificationEndpoints
         var page = await classifications.ReadPageAsync(query, cancellationToken);
 
         return TypedResults.Ok(SpamClassificationPageResponse.For(page));
-    }
-
-    /// <summary>Reads the account a request named, or nothing when this deployment does not serve it.</summary>
-    private static MailAccountId? ResolveAccount(string? account, IMailAccountCatalog accounts)
-    {
-        if (string.IsNullOrWhiteSpace(account))
-        {
-            return null;
-        }
-
-        var accountId = MailAccountId.Create(account);
-
-        return accounts.ServedAccounts.Any(served => served.Id == accountId) ? accountId : null;
     }
 
     /// <summary>Resolves the folders a run walks, defaulting to and bounded by the scope classification is configured over.</summary>
@@ -329,13 +315,6 @@ internal static class SpamClassificationEndpoints
     }
 
     private static string DeclaredVerdicts() => string.Join(", ", Enum.GetNames<SpamVerdict>());
-
-    /// <summary>States that the request named no account this deployment serves, without echoing an empty one.</summary>
-    private static ProblemHttpResult UnknownAccount(string? account) => TypedResults.Problem(
-        string.IsNullOrWhiteSpace(account)
-            ? "The request named no mail account."
-            : $"This deployment configures no mail account named '{account}'.",
-        statusCode: StatusCodes.Status400BadRequest);
 
     /// <summary>States what a caller has to change, without restating the filters they already sent.</summary>
     private static string DescribeRefusal(SpamClassificationHistoryQueryOutcome outcome) => outcome switch

--- a/tests/Host.UnitTests/Api/AdminAccountRequestTests.cs
+++ b/tests/Host.UnitTests/Api/AdminAccountRequestTests.cs
@@ -1,0 +1,213 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Accounts;
+using MailFathom.Domain.Accounts;
+using MailFathom.Domain.Synchronization;
+using MailFathom.Host.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Host.UnitTests.Api;
+
+/// <summary>Covers the one guard every administrative endpoint puts in front of the account a request names.</summary>
+/// <remarks>
+/// The refusals are the contract here, not an implementation detail: eight endpoints answer a caller who named the
+/// wrong account, and what they say is now decided in one place. The wording is asserted rather than described, because
+/// the copies this type replaced had already drifted apart in what they echoed back to the caller.
+/// </remarks>
+public sealed class AdminAccountRequestTests
+{
+    private static readonly MailAccountId Work = MailAccountId.Create("work");
+
+    /// <summary>The ordinary case: a name this deployment serves resolves to its identifier.</summary>
+    [Fact]
+    public void Resolve_AnAccountTheDeploymentServes_ReadsTheIdentifier()
+    {
+        // Arrange
+        var accounts = CatalogServing(Work);
+
+        // Act
+        var accountId = AdminAccountRequest.Resolve("work", accounts);
+
+        // Assert
+        Assert.Equal(Work, accountId);
+    }
+
+    /// <summary>Whitespace around the name is not part of it, so a padded name reaches the same account.</summary>
+    [Fact]
+    public void Resolve_AnAccountNamedWithSurroundingWhitespace_ReadsTheSameIdentifier()
+    {
+        // Arrange
+        var accounts = CatalogServing(Work);
+
+        // Act
+        var accountId = AdminAccountRequest.Resolve("  work  ", accounts);
+
+        // Assert
+        Assert.Equal(Work, accountId);
+    }
+
+    /// <summary>An absent, empty, or blank name resolves to nothing rather than to a refusal of its own.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_NoAccountNamed_ReadsNothing(string? account)
+    {
+        // Arrange
+        var accounts = CatalogServing(Work);
+
+        // Act
+        var accountId = AdminAccountRequest.Resolve(account, accounts);
+
+        // Assert
+        Assert.Null(accountId);
+    }
+
+    /// <summary>A name this deployment does not configure resolves to nothing, exactly as an absent one does.</summary>
+    [Fact]
+    public void Resolve_AnAccountTheDeploymentDoesNotServe_ReadsNothing()
+    {
+        // Arrange
+        var accounts = CatalogServing(Work);
+
+        // Act
+        var accountId = AdminAccountRequest.Resolve("archive", accounts);
+
+        // Assert
+        Assert.Null(accountId);
+    }
+
+    /// <summary>A request that named no account is told so, without an empty name echoed into the sentence.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Refuse_NoAccountNamed_StatesThatTheRequestNamedNone(string? account)
+    {
+        // Act
+        var refusal = AdminAccountRequest.Refuse(account);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        Assert.Equal("The request named no mail account.", Detail(refusal));
+    }
+
+    /// <summary>An account nobody configured is named back to the caller, so they can see what was looked up.</summary>
+    [Fact]
+    public void Refuse_AnAccountTheDeploymentDoesNotServe_NamesItBack()
+    {
+        // Act
+        var refusal = AdminAccountRequest.Refuse("archive");
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal.StatusCode);
+        Assert.Equal("This deployment configures no mail account named 'archive'.", Detail(refusal));
+    }
+
+    /// <summary>
+    /// The direction the whitespace question was settled in. What the refusal echoes is the identifier that was looked
+    /// up rather than the text the request carried, so a padded name and a bare one are answered with one sentence
+    /// wherever they are sent — which two of the eight endpoints already did and six did not.
+    /// </summary>
+    [Fact]
+    public void Refuse_AnAccountNamedWithSurroundingWhitespace_NamesTheIdentifierThatWasLookedUp()
+    {
+        // Act
+        var padded = AdminAccountRequest.Refuse("  archive  ");
+        var bare = AdminAccountRequest.Refuse("archive");
+
+        // Assert
+        Assert.Equal("This deployment configures no mail account named 'archive'.", Detail(padded));
+        Assert.Equal(Detail(bare), Detail(padded));
+    }
+
+    /// <summary>An absent filter narrows nothing, which is the reading a caller asked for rather than a mistake.</summary>
+    [Fact]
+    public void TryResolveFilter_NoFilter_ReadsEveryAccount()
+    {
+        // Arrange
+        var accounts = CatalogServing(Work);
+
+        // Act
+        var admitted = AdminAccountRequest.TryResolveFilter(null, accounts, out var accountId, out var refusal);
+
+        // Assert
+        Assert.True(admitted);
+        Assert.Null(accountId);
+        Assert.Null(refusal);
+    }
+
+    /// <summary>A filter naming a served account narrows the reading to it.</summary>
+    [Fact]
+    public void TryResolveFilter_AnAccountTheDeploymentServes_NarrowsToIt()
+    {
+        // Arrange
+        var accounts = CatalogServing(Work);
+
+        // Act
+        var admitted = AdminAccountRequest.TryResolveFilter("  work  ", accounts, out var accountId, out var refusal);
+
+        // Assert
+        Assert.True(admitted);
+        Assert.Equal(Work, accountId);
+        Assert.Null(refusal);
+    }
+
+    /// <summary>A filter present and empty is a mistake rather than every account, and the refusal names the remedy.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void TryResolveFilter_AnEmptyFilter_SaysToLeaveItOut(string account)
+    {
+        // Arrange
+        var accounts = CatalogServing(Work);
+
+        // Act
+        var admitted = AdminAccountRequest.TryResolveFilter(account, accounts, out var accountId, out var refusal);
+
+        // Assert
+        Assert.False(admitted);
+        Assert.Null(accountId);
+        Assert.Equal(StatusCodes.Status400BadRequest, refusal!.StatusCode);
+        Assert.Equal(
+            "The account filter named no mail account. Leave it out to read every account.",
+            Detail(refusal));
+    }
+
+    /// <summary>A filter naming an account nobody configured is refused in the same sentence a required one is.</summary>
+    [Fact]
+    public void TryResolveFilter_AnAccountTheDeploymentDoesNotServe_NamesItBack()
+    {
+        // Arrange
+        var accounts = CatalogServing(Work);
+
+        // Act
+        var admitted = AdminAccountRequest.TryResolveFilter("  archive  ", accounts, out var accountId, out var refusal);
+
+        // Assert
+        Assert.False(admitted);
+        Assert.Null(accountId);
+        Assert.Equal("This deployment configures no mail account named 'archive'.", Detail(refusal!));
+    }
+
+    private static string? Detail(ProblemHttpResult refusal) => refusal.ProblemDetails.Detail;
+
+    private static IMailAccountCatalog CatalogServing(params MailAccountId[] accounts)
+    {
+        var catalog = Substitute.For<IMailAccountCatalog>();
+        catalog.ServedAccounts.Returns(
+        [
+            .. accounts.Select(account => new ServedMailAccount(
+                account,
+                MailAccountDisplayName.Create(account.Value),
+                MailSynchronizationMode.Polling)),
+        ]);
+
+        return catalog;
+    }
+}


### PR DESCRIPTION
## What this changes

Eight administrative endpoints asked the same two questions of the account a request named — is there one, and is it one this deployment serves — and each answered a caller who got it wrong out of its own copy of the same sentence. Six files carried an identical ten-line `ResolveAccount`, five an `UnknownAccount` with the same two blank-account variants, and two inlined both checks. Seven branches wrote them, none of which could see the others.

`src/Host/Api/AdminAccountRequest.cs` now holds the guard — `internal static`, no interface, no DI:

- `Resolve(string?, IMailAccountCatalog)` reads the account, or nothing when the deployment does not serve it;
- `Refuse(string?)` picks between `Missing()` and `Unknown(account)`;
- `MissingFilter()` states the optional-filter case, where leaving the filter out reads every account;
- `TryResolveFilter(...)` carries the shape the two paged readings use, where an absent filter is every account rather than a refusal.

All six `ResolveAccount` copies, the five refusals and the two inlined blocks route through it. `MailboxMaintenanceEndpoints.Refusal` keeps its folder half and delegates the account half.

## The whitespace difference, settled

The two inlined guards echoed `accountId.Value` and the other six echoed the raw request text, so `?account=%20archive%20` was answered with two different sentences depending on which route received it. It is settled toward **the identifier that was looked up**: the refusal names what MailFathom searched for, and no request text reaches the response body unaltered. `AdminAccountRequestTests.Refuse_AnAccountNamedWithSurroundingWhitespace_NamesTheIdentifierThatWasLookedUp` asserts the wording and that the padded and bare forms produce one sentence.

## The file move

The eleven request and response records of `OutboxEndpoints.cs` move to an `OutboxResponses.cs` companion, which is the convention `MailRuleResponses`, `SpamClassificationResponses`, `MailboxMaintenanceResponses`, `ContactResponses` and `EmbeddingAdministrationResponses` already follow — request records included, as those files do. The 540-line file is now 309 lines of routes and handlers. The smaller files named in the issue were left to wait.

## Contract

No route, verb, status code, problem type, permission, request shape or response shape changes. The only externally visible difference is the refusal detail for an account name carrying surrounding whitespace, which six endpoints now answer as the other two already did. No public surface is broken, so nothing is owed to the changelog.

## Verification

- `scripts/verify-full.sh` — passed; 10215 unit tests, formatting clean, coverage gate green
- `scripts/review-obligations.sh` — named ADR 0012, `docs/operations/admin-endpoint.md` and `docs/operations/mailbox-oauth.md`; all three read. The two pages quote the refusal text only for the `mailbox authorize` path (`MailboxRefreshTokenEndpoint`, out of scope and untouched) and elide the account name; every other refusal is described there in general terms rather than quoted. Nothing stopped being true, so no page changed.
- `$check-docs-licenses` — Docs `n/a`, Changelog `n/a`, Licenses `n/a` (empty inventory; no package, service or asset added)

## Out of scope

`MailboxRefreshTokenEndpoint.cs` keeps its own sentence, which comes from a caught `MailAccountNotAccessibleException` on a write path and shares no control flow with this guard.

Closes #1022
