### PR TITLE
[#1021] Keep one jittered backoff and one epoch-anchored window

### DIFF
--- a/docs/architecture/outbound-resilience.md
+++ b/docs/architecture/outbound-resilience.md
@@ -243,10 +243,12 @@ is the layer rather than something MailFathom re-implements:
   [Mail delivery § Failing, retrying, and the single layer of
   it](../features/mail-delivery.md#failing-retrying-and-the-single-layer-of-it) states what each ending records.
 
-  `JitteredRetryBackoff` is the delay both durable layers draw from — this one and the job queue above — because the
-  question they ask is identical: how long to wait before an attempt that failed for a reason that may have cleared. It
-  doubles from a base delay, caps at a ceiling, and draws inside the resulting window, which is what stops every send
-  and every job deferred by one outage returning together.
+  `JitteredRetryBackoff` is the delay every scheduler of this system draws from — this one, the job queue above, one
+  account's synchronization run, and a commit that lost a concurrency race — because the question they ask is
+  identical: how long to wait before an attempt that failed for a reason that may have cleared. It doubles from a base
+  delay, caps at a ceiling, and draws inside the resulting window, which is what stops every send and every job deferred
+  by one outage returning together. A caller that already has a wait of its own states it as the floor of the draw,
+  which is how a synchronization run is never returned to its server sooner than a healthy account would be.
 
 - **Optimistic concurrency.** `OptimisticConcurrencyRetryPolicy` in `Application` already retries a commit that lost a
   race. That is why the classifier reports a concurrency conflict as terminal: the pipeline must not become a second

--- a/src/Application/Emails/Embeddings/Limits/EmbeddingSpendBudget.cs
+++ b/src/Application/Emails/Embeddings/Limits/EmbeddingSpendBudget.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Scheduling;
+
 namespace MailFathom.Application.Emails.Embeddings.Limits;
 
 /// <summary>The aggregate ceiling an instance is willing to spend on embedding, and the period it is counted over.</summary>
@@ -67,19 +69,10 @@ public sealed class EmbeddingSpendBudget
     /// Anchored at the Unix epoch so that every process of a deployment, and every restart of one, agrees on where a
     /// period begins without anything having to be stored to say so.
     /// </remarks>
-    public DateTimeOffset PeriodStartAt(DateTimeOffset instant)
-    {
-        var elapsedTicks = instant.ToUniversalTime().Ticks - DateTimeOffset.UnixEpoch.Ticks;
-
-        // Floored rather than truncated, so an instant before the epoch — which no clock this runs on reports, but which
-        // a test may hand it — lands on the start of its period rather than on the end of the one before.
-        var periodsElapsed = (long)Math.Floor((double)elapsedTicks / this.Period.Ticks);
-
-        return DateTimeOffset.UnixEpoch.AddTicks(periodsElapsed * this.Period.Ticks);
-    }
+    public DateTimeOffset PeriodStartAt(DateTimeOffset instant) => EpochAnchoredPeriod.StartAt(this.Period, instant);
 
     /// <summary>Finds when the period an instant falls in rolls over, which is when paused work resumes.</summary>
     /// <param name="instant">The moment to place in a period.</param>
     /// <returns>The instant the next period begins, in UTC.</returns>
-    public DateTimeOffset PeriodEndAt(DateTimeOffset instant) => this.PeriodStartAt(instant) + this.Period;
+    public DateTimeOffset PeriodEndAt(DateTimeOffset instant) => EpochAnchoredPeriod.EndAt(this.Period, instant);
 }

--- a/src/Application/Jobs/Execution/JobExecutor.cs
+++ b/src/Application/Jobs/Execution/JobExecutor.cs
@@ -299,6 +299,7 @@ public sealed class JobExecutor
         var delay = JitteredRetryBackoff.DelayBeforeNextAttempt(
             this.settings.RetryBaseDelay,
             this.settings.RetryMaxDelay,
+            minimumDelay: TimeSpan.Zero,
             job.AttemptCount);
         var availableAt = this.timeProvider.GetUtcNow() + delay;
 

--- a/src/Application/Mail/Delivery/Outbox/MailOutboxDelivery.cs
+++ b/src/Application/Mail/Delivery/Outbox/MailOutboxDelivery.cs
@@ -347,6 +347,7 @@ public sealed class MailOutboxDelivery
         var availableAt = this.timeProvider.GetUtcNow() + JitteredRetryBackoff.DelayBeforeNextAttempt(
             this.settings.RetryBaseDelay,
             this.settings.RetryMaxDelay,
+            minimumDelay: TimeSpan.Zero,
             claimed.Record.AttemptCount);
 
         await this.CommitAsync(async (session, token) =>

--- a/src/Application/Persistence/OptimisticConcurrencyRetryPolicy.cs
+++ b/src/Application/Persistence/OptimisticConcurrencyRetryPolicy.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Security.Cryptography;
+using MailFathom.Application.Resilience;
 
 namespace MailFathom.Application.Persistence;
 
@@ -15,6 +15,16 @@ namespace MailFathom.Application.Persistence;
 /// </remarks>
 public sealed class OptimisticConcurrencyRetryPolicy
 {
+    /// <summary>The delay the first retry of a conflicted commit is drawn around.</summary>
+    /// <remarks>
+    /// A conflict is resolved by reading and writing again in the same process, so the whole curve is measured in
+    /// milliseconds rather than in the minutes a scheduler's backoff spans.
+    /// </remarks>
+    private static readonly TimeSpan ConflictRetryBaseDelay = TimeSpan.FromMilliseconds(50);
+
+    /// <summary>The ceiling a grown commit-retry delay never exceeds.</summary>
+    private static readonly TimeSpan ConflictRetryMaxDelay = TimeSpan.FromMilliseconds(1000);
+
     private readonly IPersistenceSessionFactory sessionFactory;
     private readonly TimeProvider timeProvider;
     private readonly int maximumAttempts;
@@ -94,7 +104,11 @@ public sealed class OptimisticConcurrencyRetryPolicy
             if (attemptNumber < this.maximumAttempts)
             {
                 await Task.Delay(
-                    CreateJitteredRetryDelay(attemptNumber),
+                    JitteredRetryBackoff.DelayBeforeNextAttempt(
+                        ConflictRetryBaseDelay,
+                        ConflictRetryMaxDelay,
+                        minimumDelay: TimeSpan.Zero,
+                        attemptNumber),
                     this.timeProvider,
                     cancellationToken);
             }
@@ -102,18 +116,5 @@ public sealed class OptimisticConcurrencyRetryPolicy
 
         throw new PersistenceConcurrencyConflictException(
             $"A local write did not commit within the configured {this.maximumAttempts} optimistic concurrency attempts.");
-    }
-
-    private static TimeSpan CreateJitteredRetryDelay(int completedAttemptCount)
-    {
-        var exponentialCeilingMilliseconds = Math.Min(
-            1000,
-            50 * (1 << Math.Min(completedAttemptCount - 1, 5)));
-        var minimumMilliseconds = exponentialCeilingMilliseconds / 2;
-        var jitteredMilliseconds = RandomNumberGenerator.GetInt32(
-            minimumMilliseconds,
-            exponentialCeilingMilliseconds + 1);
-
-        return TimeSpan.FromMilliseconds(jitteredMilliseconds);
     }
 }

--- a/src/Application/Resilience/JitteredRetryBackoff.cs
+++ b/src/Application/Resilience/JitteredRetryBackoff.cs
@@ -16,8 +16,10 @@ namespace MailFathom.Application.Resilience;
 /// keeps the attempt counts from multiplying into a retry storm.
 /// </para>
 /// <para>
-/// It is shared by the durable job queue and the outbox because both answer that question about work of their own, and
-/// a second implementation of it would be a second set of jitter arithmetic to get subtly wrong.
+/// Every backoff curve in this system is drawn here — the durable job queue, the outbox, one account's synchronization
+/// run, and a conflicted local commit — because each answers that same question about work of its own, and a second
+/// implementation of it would be a second set of jitter arithmetic to get subtly wrong. What the callers differ on is
+/// the arguments: the bounds of the curve, and whether a delay has a floor of its own to respect.
 /// </para>
 /// <para>
 /// The delay doubles per attempt and is drawn from a range rather than computed exactly. Work that failed together
@@ -38,17 +40,29 @@ public static class JitteredRetryBackoff
     /// <summary>Computes how long the work waits before its next attempt.</summary>
     /// <param name="baseDelay">The delay the first retry is drawn around, from which the doubling grows.</param>
     /// <param name="maxDelay">The ceiling a grown delay never exceeds.</param>
+    /// <param name="minimumDelay">The delay no draw falls below, which is <see cref="TimeSpan.Zero" /> for work that has no wait of its own to respect.</param>
     /// <param name="attemptCount">How many attempts the work has already been handed out for, counting from one.</param>
-    /// <returns>A jittered delay of at least half the grown ceiling and at most <paramref name="maxDelay" />.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="baseDelay" /> is not positive, when <paramref name="maxDelay" /> is below it, or when <paramref name="attemptCount" /> is not positive.</exception>
-    public static TimeSpan DelayBeforeNextAttempt(TimeSpan baseDelay, TimeSpan maxDelay, int attemptCount)
+    /// <returns>A jittered delay of at least half the grown ceiling, never below <paramref name="minimumDelay" />, and at most <paramref name="maxDelay" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="baseDelay" /> is not positive, when <paramref name="maxDelay" /> is below it, when <paramref name="minimumDelay" /> is negative or above <paramref name="baseDelay" />, or when <paramref name="attemptCount" /> is not positive.</exception>
+    /// <remarks>
+    /// The floor is bounded by the base delay rather than by the ceiling, because a floor above the range the first
+    /// attempt draws from is a caller stating two delays that contradict each other rather than one curve with a lower
+    /// bound.
+    /// </remarks>
+    public static TimeSpan DelayBeforeNextAttempt(
+        TimeSpan baseDelay,
+        TimeSpan maxDelay,
+        TimeSpan minimumDelay,
+        int attemptCount)
     {
         ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(baseDelay, TimeSpan.Zero);
         ArgumentOutOfRangeException.ThrowIfLessThan(maxDelay, baseDelay);
+        ArgumentOutOfRangeException.ThrowIfLessThan(minimumDelay, TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(minimumDelay, baseDelay);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(attemptCount);
 
         var ceilingTicks = GrowFromBaseDelay(baseDelay.Ticks, maxDelay.Ticks, attemptCount - 1);
-        var floorTicks = ceilingTicks / 2;
+        var floorTicks = Math.Max(minimumDelay.Ticks, ceilingTicks / 2);
 
         return TimeSpan.FromTicks(floorTicks + DrawJitterTicks(ceilingTicks - floorTicks));
     }

--- a/src/Application/Retrieval/AskMail/MailAnsweringPeriodBounds.cs
+++ b/src/Application/Retrieval/AskMail/MailAnsweringPeriodBounds.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Globalization;
+using MailFathom.Domain.Scheduling;
 
 namespace MailFathom.Application.Retrieval.AskMail;
 
@@ -78,22 +79,14 @@ public sealed record MailAnsweringPeriodBounds
     /// <returns>The period's start, in UTC.</returns>
     /// <remarks>
     /// Anchored at the Unix epoch, so where a period begins is a function of the clock alone and every restart of the
-    /// process places it identically. Floored rather than truncated, so an instant before the epoch — which no clock
-    /// this runs on reports, but which a test may hand it — lands on the start of its period rather than the end of the
-    /// one before.
+    /// process places it identically.
     /// </remarks>
-    public DateTimeOffset PeriodStartAt(DateTimeOffset instant)
-    {
-        var elapsedTicks = instant.ToUniversalTime().Ticks - DateTimeOffset.UnixEpoch.Ticks;
-        var periodsElapsed = (long)Math.Floor((double)elapsedTicks / this.Period.Ticks);
-
-        return DateTimeOffset.UnixEpoch.AddTicks(periodsElapsed * this.Period.Ticks);
-    }
+    public DateTimeOffset PeriodStartAt(DateTimeOffset instant) => EpochAnchoredPeriod.StartAt(this.Period, instant);
 
     /// <summary>Finds when the period an instant falls in rolls over, which is when a refused question is worth asking again.</summary>
     /// <param name="instant">The moment to place in a period.</param>
     /// <returns>The instant the next period begins, in UTC.</returns>
-    public DateTimeOffset PeriodEndAt(DateTimeOffset instant) => this.PeriodStartAt(instant) + this.Period;
+    public DateTimeOffset PeriodEndAt(DateTimeOffset instant) => EpochAnchoredPeriod.EndAt(this.Period, instant);
 
     /// <inheritdoc />
     public override string ToString() => string.Format(

--- a/src/Application/Synchronization/SynchronizationRunBackoff.cs
+++ b/src/Application/Synchronization/SynchronizationRunBackoff.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Security.Cryptography;
+using MailFathom.Application.Resilience;
 
 namespace MailFathom.Application.Synchronization;
 
@@ -20,16 +20,14 @@ namespace MailFathom.Application.Synchronization;
 /// caused it, and the delay is drawn from a range rather than computed exactly. Accounts that share a mail server fail
 /// together, and an exact delay would return every one of them to that server in the same instant on every later run.
 /// </para>
+/// <para>
+/// The curve itself is <see cref="JitteredRetryBackoff" />, which every scheduler of this system draws its delays from.
+/// What is decided here is what a synchronization run means by it: a failure count rather than an attempt count, the
+/// configured interval as the floor, and a healthy account answered before any of that arithmetic runs.
+/// </para>
 /// </remarks>
 public static class SynchronizationRunBackoff
 {
-    /// <summary>Bounds the exponent so the doubling stays inside the tick arithmetic that applies it.</summary>
-    /// <remarks>Growth has reached any usable ceiling long before this, so the bound costs nothing an operator can observe.</remarks>
-    private const int MaxGrowthSteps = 16;
-
-    /// <summary>How finely a delay is drawn from its range.</summary>
-    private const int JitterResolution = 1000;
-
     /// <summary>Computes the delay before one account's next synchronization run.</summary>
     /// <param name="interval">The configured interval a healthy account runs on.</param>
     /// <param name="maxDelay">The ceiling a backed-off delay never exceeds.</param>
@@ -55,36 +53,14 @@ public static class SynchronizationRunBackoff
             return interval;
         }
 
-        var ceilingTicks = GrowFromInterval(interval.Ticks, maxDelay.Ticks, consecutiveFailureCount);
-        var floorTicks = Math.Max(interval.Ticks, ceilingTicks / 2);
-
-        return TimeSpan.FromTicks(floorTicks + DrawJitterTicks(ceilingTicks - floorTicks));
+        // The shared curve counts attempts from one and grows by the attempts already made, while a failure count is
+        // zero for an account that has never failed. Passing the count without the increment would halve every
+        // backed-off delay. The increment saturates rather than wrapping, so a count no account reaches but a caller
+        // may still hand this is answered with the ceiling instead of being refused as a negative attempt count.
+        return JitteredRetryBackoff.DelayBeforeNextAttempt(
+            interval,
+            maxDelay,
+            minimumDelay: interval,
+            attemptCount: Math.Min(consecutiveFailureCount, int.MaxValue - 1) + 1);
     }
-
-    /// <summary>Doubles the interval once per consecutive failure and caps the result.</summary>
-    /// <remarks>
-    /// The comparison shifts the ceiling down rather than shifting the interval up, so the product that would exceed
-    /// the ceiling — and, for a large enough failure count, the tick range itself — is never computed.
-    /// </remarks>
-    private static long GrowFromInterval(
-        long intervalTicks,
-        long maxDelayTicks,
-        int consecutiveFailureCount)
-    {
-        var growthSteps = Math.Min(consecutiveFailureCount, MaxGrowthSteps);
-
-        return intervalTicks <= maxDelayTicks >> growthSteps
-            ? intervalTicks << growthSteps
-            : maxDelayTicks;
-    }
-
-    /// <summary>Draws the jitter added to the floor of the range.</summary>
-    /// <remarks>
-    /// The draw is a fraction of the range rather than a tick count, so one generator call covers every range width
-    /// without the range having to fit the generator's own bounds.
-    /// </remarks>
-    private static long DrawJitterTicks(long spreadTicks) =>
-        spreadTicks == 0
-            ? 0
-            : spreadTicks * RandomNumberGenerator.GetInt32(0, JitterResolution + 1) / JitterResolution;
 }

--- a/src/Domain/Delivery/Governance/AuthoredSendCeilings.cs
+++ b/src/Domain/Delivery/Governance/AuthoredSendCeilings.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Scheduling;
+
 namespace MailFathom.Domain.Delivery.Governance;
 
 /// <summary>How much mail one caller may ask this deployment for inside one period.</summary>
@@ -77,16 +79,7 @@ public sealed class AuthoredSendCeilings
     /// Anchored at the Unix epoch, so a period has a start an operator can name and a roll-over instant a refused caller
     /// can be told to come back after, with nothing stored to say where either is.
     /// </remarks>
-    public DateTimeOffset PeriodStartAt(DateTimeOffset instant)
-    {
-        var elapsedTicks = instant.ToUniversalTime().Ticks - DateTimeOffset.UnixEpoch.Ticks;
-
-        // Floored rather than truncated, so an instant before the epoch — which no clock this runs on reports, but which
-        // a test may hand it — lands on the start of its period rather than on the end of the one before.
-        var periodsElapsed = (long)Math.Floor((double)elapsedTicks / this.Period.Ticks);
-
-        return DateTimeOffset.UnixEpoch.AddTicks(periodsElapsed * this.Period.Ticks);
-    }
+    public DateTimeOffset PeriodStartAt(DateTimeOffset instant) => EpochAnchoredPeriod.StartAt(this.Period, instant);
 
     /// <summary>Finds the ceiling one further message would carry a caller's period past.</summary>
     /// <param name="usage">What the caller has already been admitted for in the period.</param>

--- a/src/Domain/Delivery/Governance/OutgoingMailCeilings.cs
+++ b/src/Domain/Delivery/Governance/OutgoingMailCeilings.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Domain.Scheduling;
+
 namespace MailFathom.Domain.Delivery.Governance;
 
 /// <summary>How much mail one period may be asked to send, for one account and for the whole deployment.</summary>
@@ -112,21 +114,12 @@ public sealed class OutgoingMailCeilings
     /// Anchored at the Unix epoch so every process of a deployment, and every restart of one, agrees on where a period
     /// begins without anything having to be stored to say so.
     /// </remarks>
-    public DateTimeOffset PeriodStartAt(DateTimeOffset instant)
-    {
-        var elapsedTicks = instant.ToUniversalTime().Ticks - DateTimeOffset.UnixEpoch.Ticks;
-
-        // Floored rather than truncated, so an instant before the epoch — which no clock this runs on reports, but which
-        // a test may hand it — lands on the start of its period rather than on the end of the one before.
-        var periodsElapsed = (long)Math.Floor((double)elapsedTicks / this.Period.Ticks);
-
-        return DateTimeOffset.UnixEpoch.AddTicks(periodsElapsed * this.Period.Ticks);
-    }
+    public DateTimeOffset PeriodStartAt(DateTimeOffset instant) => EpochAnchoredPeriod.StartAt(this.Period, instant);
 
     /// <summary>Finds when the period an instant falls in rolls over, which is when a refused send may be asked for again.</summary>
     /// <param name="instant">The moment to place in a period.</param>
     /// <returns>The instant the next period begins, in UTC.</returns>
-    public DateTimeOffset PeriodEndAt(DateTimeOffset instant) => this.PeriodStartAt(instant) + this.Period;
+    public DateTimeOffset PeriodEndAt(DateTimeOffset instant) => EpochAnchoredPeriod.EndAt(this.Period, instant);
 
     /// <summary>Finds the ceiling one further message would carry a period past.</summary>
     /// <param name="usage">What the period has already been asked for.</param>

--- a/src/Domain/Scheduling/EpochAnchoredPeriod.cs
+++ b/src/Domain/Scheduling/EpochAnchoredPeriod.cs
@@ -1,0 +1,46 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Domain.Scheduling;
+
+/// <summary>Places an instant in the fixed window of a given length that the Unix epoch anchors.</summary>
+/// <remarks>
+/// <para>
+/// Anchoring at the epoch is what lets every process of a deployment, and every restart of one, agree on where a period
+/// begins without anything having to be stored to say so: a boundary is a function of the clock and the period alone.
+/// </para>
+/// <para>
+/// The division is floored rather than truncated, so an instant before the epoch — which no clock this runs on reports,
+/// but which a test may hand it — lands on the start of its period rather than on the end of the one before.
+/// </para>
+/// <para>
+/// <c>JobRecurrence</c> deliberately does not use this, and is not a fifth caller waiting to be folded in. It truncates
+/// instead, and answers <see langword="null" /> for the latest occurrence and <c>-1</c> for the index of an instant
+/// before the epoch rather than placing it in a period at all; its own tests pin both.
+/// </para>
+/// </remarks>
+public static class EpochAnchoredPeriod
+{
+    /// <summary>Finds the start of the period an instant falls in.</summary>
+    /// <param name="period">How long one period lasts.</param>
+    /// <param name="instant">The moment to place in a period.</param>
+    /// <returns>The period's start, in UTC.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="period" /> is not positive.</exception>
+    public static DateTimeOffset StartAt(TimeSpan period, DateTimeOffset instant)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(period, TimeSpan.Zero);
+
+        var elapsedTicks = instant.ToUniversalTime().Ticks - DateTimeOffset.UnixEpoch.Ticks;
+        var periodsElapsed = (long)Math.Floor((double)elapsedTicks / period.Ticks);
+
+        return DateTimeOffset.UnixEpoch.AddTicks(periodsElapsed * period.Ticks);
+    }
+
+    /// <summary>Finds when the period an instant falls in rolls over.</summary>
+    /// <param name="period">How long one period lasts.</param>
+    /// <param name="instant">The moment to place in a period.</param>
+    /// <returns>The instant the next period begins, in UTC.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="period" /> is not positive.</exception>
+    public static DateTimeOffset EndAt(TimeSpan period, DateTimeOffset instant) => StartAt(period, instant) + period;
+}

--- a/tests/Application.UnitTests/Resilience/JitteredRetryBackoffTests.cs
+++ b/tests/Application.UnitTests/Resilience/JitteredRetryBackoffTests.cs
@@ -24,7 +24,7 @@ public sealed class JitteredRetryBackoffTests
         int ceilingSeconds)
     {
         // Act
-        var delay = JitteredRetryBackoff.DelayBeforeNextAttempt(BaseDelay, MaxDelay, attemptCount);
+        var delay = JitteredRetryBackoff.DelayBeforeNextAttempt(BaseDelay, MaxDelay, TimeSpan.Zero, attemptCount);
 
         // Assert
         Assert.InRange(delay, TimeSpan.FromSeconds(floorSeconds), TimeSpan.FromSeconds(ceilingSeconds));
@@ -41,7 +41,7 @@ public sealed class JitteredRetryBackoffTests
     public void DelayBeforeNextAttempt_AnAttemptCountPastTheCeiling_StaysWithinIt(int attemptCount)
     {
         // Act
-        var delay = JitteredRetryBackoff.DelayBeforeNextAttempt(BaseDelay, MaxDelay, attemptCount);
+        var delay = JitteredRetryBackoff.DelayBeforeNextAttempt(BaseDelay, MaxDelay, TimeSpan.Zero, attemptCount);
 
         // Assert
         Assert.InRange(delay, MaxDelay / 2, MaxDelay);
@@ -57,7 +57,7 @@ public sealed class JitteredRetryBackoffTests
         // Act
         var delays = Enumerable
             .Range(0, 64)
-            .Select(_ => JitteredRetryBackoff.DelayBeforeNextAttempt(BaseDelay, MaxDelay, attemptCount: 3))
+            .Select(_ => JitteredRetryBackoff.DelayBeforeNextAttempt(BaseDelay, MaxDelay, TimeSpan.Zero, attemptCount: 3))
             .ToArray();
 
         // Assert
@@ -71,11 +71,43 @@ public sealed class JitteredRetryBackoffTests
         // Act
         var delays = Enumerable
             .Range(1, 8)
-            .Select(attemptCount => JitteredRetryBackoff.DelayBeforeNextAttempt(BaseDelay, MaxDelay, attemptCount))
+            .Select(attemptCount => JitteredRetryBackoff.DelayBeforeNextAttempt(BaseDelay, MaxDelay, TimeSpan.Zero, attemptCount))
             .ToArray();
 
         // Assert
         Assert.All(delays, delay => Assert.True(delay > TimeSpan.Zero));
+    }
+
+    /// <summary>
+    /// Work with a wait of its own — an account that runs on a configured interval — must never be returned to its
+    /// dependency sooner than that wait, which is what the floor is for.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(20)]
+    public void DelayBeforeNextAttempt_AMinimumDelayAboveHalfTheCeiling_NeverFallsBelowIt(int attemptCount)
+    {
+        // Act
+        var delay = JitteredRetryBackoff.DelayBeforeNextAttempt(BaseDelay, MaxDelay, BaseDelay, attemptCount);
+
+        // Assert
+        Assert.InRange(delay, BaseDelay, MaxDelay);
+    }
+
+    /// <summary>A floor above the range the first attempt draws from is two contradictory delays rather than one curve.</summary>
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(31)]
+    public void DelayBeforeNextAttempt_AMinimumDelayOutsideTheCurve_IsRefused(int minimumDelaySeconds)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => JitteredRetryBackoff.DelayBeforeNextAttempt(
+            BaseDelay,
+            MaxDelay,
+            TimeSpan.FromSeconds(minimumDelaySeconds),
+            attemptCount: 1));
     }
 
     /// <summary>A bound that is not a bound would be read as one, so each is refused rather than corrected.</summary>
@@ -94,6 +126,7 @@ public sealed class JitteredRetryBackoffTests
         Assert.Throws<ArgumentOutOfRangeException>(() => JitteredRetryBackoff.DelayBeforeNextAttempt(
             TimeSpan.FromSeconds(baseDelaySeconds),
             TimeSpan.FromSeconds(maxDelaySeconds),
+            TimeSpan.Zero,
             attemptCount));
     }
 }

--- a/tests/Application.UnitTests/Synchronization/SynchronizationRunBackoffTests.cs
+++ b/tests/Application.UnitTests/Synchronization/SynchronizationRunBackoffTests.cs
@@ -59,6 +59,35 @@ public sealed class SynchronizationRunBackoffTests
         Assert.All(delays, delay => Assert.Equal(Interval, delay));
     }
 
+    /// <summary>
+    /// The first failure draws from the interval up to twice it, and a delay that never left the interval is the shared
+    /// curve being handed a failure count where it expects an attempt count — which halves every backed-off delay while
+    /// still satisfying every bound above.
+    /// </summary>
+    [Fact]
+    public void DelayBeforeNextRun_TheFirstFailure_DrawsPastTheIntervalRatherThanStayingOnIt()
+    {
+        // Arrange, Act
+        var delays = Enumerable.Range(0, 64)
+            .Select(_ => SynchronizationRunBackoff.DelayBeforeNextRun(Interval, MaxDelay, consecutiveFailureCount: 1))
+            .ToArray();
+
+        // Assert
+        Assert.All(delays, delay => Assert.InRange(delay, Interval, 2 * Interval));
+        Assert.Contains(delays, delay => delay > Interval);
+    }
+
+    /// <summary>A failure count no account reaches is still a count this answers with the ceiling rather than refuses.</summary>
+    [Fact]
+    public void DelayBeforeNextRun_TheLargestFailureCount_StaysWithinTheConfiguredCeiling()
+    {
+        // Arrange, Act
+        var delay = SynchronizationRunBackoff.DelayBeforeNextRun(Interval, MaxDelay, int.MaxValue);
+
+        // Assert
+        Assert.InRange(delay, MaxDelay / 2, MaxDelay);
+    }
+
     [Fact]
     public void DelayBeforeNextRun_ManyConsecutiveFailures_StaysWithinTheConfiguredCeiling()
     {

--- a/tests/Domain.UnitTests/Scheduling/EpochAnchoredPeriodTests.cs
+++ b/tests/Domain.UnitTests/Scheduling/EpochAnchoredPeriodTests.cs
@@ -1,0 +1,103 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Scheduling;
+using Xunit;
+
+namespace MailFathom.Domain.UnitTests.Scheduling;
+
+public sealed class EpochAnchoredPeriodTests
+{
+    private static readonly TimeSpan Hourly = TimeSpan.FromHours(1);
+
+    [Fact]
+    public void StartAt_AnInstantInsideAPeriod_ReturnsTheBoundaryBelowIt()
+    {
+        // Arrange
+        var instant = new DateTimeOffset(2026, 8, 20, 10, 17, 33, TimeSpan.Zero);
+
+        // Act
+        var start = EpochAnchoredPeriod.StartAt(Hourly, instant);
+
+        // Assert
+        Assert.Equal(new DateTimeOffset(2026, 8, 20, 10, 0, 0, TimeSpan.Zero), start);
+    }
+
+    [Fact]
+    public void StartAt_AnInstantOnABoundary_ReturnsThatInstant()
+    {
+        // Arrange
+        var instant = new DateTimeOffset(2026, 8, 20, 10, 0, 0, TimeSpan.Zero);
+
+        // Act
+        var start = EpochAnchoredPeriod.StartAt(Hourly, instant);
+
+        // Assert
+        Assert.Equal(instant, start);
+    }
+
+    /// <summary>
+    /// The zone an instant is written in says nothing about which period it falls in, so two spellings of one moment
+    /// must be counted under the same key.
+    /// </summary>
+    [Fact]
+    public void StartAt_AnInstantWrittenWithAnOffset_PlacesItByTheMomentRatherThanTheLocalClock()
+    {
+        // Arrange
+        var daily = TimeSpan.FromDays(1);
+        var instant = new DateTimeOffset(2026, 8, 20, 2, 30, 0, TimeSpan.FromHours(2));
+
+        // Act
+        var start = EpochAnchoredPeriod.StartAt(daily, instant);
+
+        // Assert
+        Assert.Equal(new DateTimeOffset(2026, 8, 20, 0, 0, 0, TimeSpan.Zero), start);
+    }
+
+    /// <summary>
+    /// No clock this runs on reports an instant before the epoch, but a test may hand it one, and truncating there
+    /// would answer with the end of the period before rather than with a start the instant actually falls in.
+    /// </summary>
+    [Fact]
+    public void StartAt_AnInstantBeforeTheEpoch_FloorsRatherThanTruncates()
+    {
+        // Arrange
+        var instant = DateTimeOffset.UnixEpoch - TimeSpan.FromMinutes(30);
+
+        // Act
+        var start = EpochAnchoredPeriod.StartAt(Hourly, instant);
+
+        // Assert
+        Assert.Equal(DateTimeOffset.UnixEpoch - Hourly, start);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(24)]
+    [InlineData(168)]
+    public void EndAt_AnyInstant_IsOnePeriodAfterTheStart(int periodHours)
+    {
+        // Arrange
+        var period = TimeSpan.FromHours(periodHours);
+        var instant = new DateTimeOffset(2026, 8, 20, 10, 17, 33, TimeSpan.Zero);
+
+        // Act
+        var end = EpochAnchoredPeriod.EndAt(period, instant);
+
+        // Assert
+        Assert.Equal(EpochAnchoredPeriod.StartAt(period, instant) + period, end);
+        Assert.InRange(instant, end - period, end);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void StartAt_APeriodThatIsNotPositive_IsRefused(int periodHours)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => EpochAnchoredPeriod.StartAt(
+            TimeSpan.FromHours(periodHours),
+            DateTimeOffset.UnixEpoch));
+    }
+}


### PR DESCRIPTION
## What this changes

Two pieces of arithmetic that must not drift each had several copies, and in both cases the newest one had lost
something. This leaves one of each.

**One jittered backoff.** `JitteredRetryBackoff` is now the single implementation of the exponential-with-jitter delay,
and `DelayBeforeNextAttempt` takes a `TimeSpan minimumDelay` every call site passes explicitly.

- `SynchronizationRunBackoff.DelayBeforeNextRun` keeps its name, its arguments, its zero-failure early return and its
  exception contract. Its body is one call passing `interval` as the floor and the failure count **plus one** as the
  attempt count, because the shared curve counts attempts from one while a failure count is zero for an account that
  has never failed — a comment on the call carries that, since it is the whole risk of the change. `GrowFromInterval`
  and `DrawJitterTicks` are gone from it, and so are the two constants they used. The increment saturates rather than
  wrapping, so `int.MaxValue` consecutive failures answers with the ceiling as before instead of being refused as a
  negative attempt count.
- `OptimisticConcurrencyRetryPolicy.CreateJitteredRetryDelay` folds into the same call with two named constants,
  `ConflictRetryBaseDelay` (50 ms) and `ConflictRetryMaxDelay` (1000 ms). The growth and the range are identical
  attempt for attempt; **the draw granularity changes**, from a uniform integer millisecond to a 1/1000 fraction of the
  tick spread. That is a distribution change inside an unchanged range, in the commit-retry path, and it is the one
  behavioural difference in this pull request.
- `JobExecutor` and `MailOutboxDelivery` pass `minimumDelay: TimeSpan.Zero`, which is the floor they already had.

`minimumDelay` is refused when negative or above `baseDelay`: a floor above the range the first attempt draws from
would be two contradictory delays rather than one curve with a lower bound, and bounding it there is what keeps the
draw spread non-negative without a second clamp.

**One epoch-anchored window.** `EpochAnchoredPeriod` in `src/Domain/Scheduling/` exposes `StartAt(period, instant)` and
`EndAt(period, instant)` as statics, and all four callers — `OutgoingMailCeilings`, `AuthoredSendCeilings`,
`EmbeddingSpendBudget`, `MailAnsweringPeriodBounds` — use it while keeping their own shape and their own `Period`
property. The flooring subtlety, which the fourth copy had already dropped, now lives in one place. The new type's
remarks record that `JobRecurrence` deliberately is not a fifth caller: it truncates and answers `null` / `-1` before
the epoch, and its own tests pin that.

## Contracts

No public surface breaks. `DelayBeforeNextAttempt` gains a parameter, which is an internal application type with four
call sites in this repository; the MCP tool contract, the configuration schema, the database schema and the deployment
contract are all untouched.

## Tests

- Existing backoff and window assertions are unchanged — only the added argument appears at the call sites.
- `SynchronizationRunBackoffTests` gains the curve assertion the acceptance asked for: the first failure draws *past*
  the interval, which is what fails if the shared curve is ever handed a failure count where it expects an attempt
  count. A second new test pins the saturating increment at `int.MaxValue`.
- `JitteredRetryBackoffTests` gains the floor and its two refusals.
- `EpochAnchoredPeriodTests` covers a boundary, an instant inside a period, an instant written with an offset, the
  before-the-epoch flooring, `EndAt`, and a non-positive period.

Full gate green; aggregate line coverage 95.44%.

## Documentation

`docs/architecture/outbound-resilience.md` said `JitteredRetryBackoff` is what "both durable layers" draw from. That
stopped being true, so it now names all four callers and the floor a caller with a wait of its own states.

Closes #1021
