### PR TITLE
[#1023] Give mfctl one query-string builder, one set of shared options, and one confirmation rule

### DIFF
--- a/src/Cli/Administration/AdminApiClient.cs
+++ b/src/Cli/Administration/AdminApiClient.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -207,7 +206,7 @@ internal sealed class AdminApiClient
 
         return this.RequestAsync(
             HttpMethod.Get,
-            $"{AdminEndpointRoutes.MailboxRewindPath}{ScopeQuery(account, folder)}",
+            $"{AdminEndpointRoutes.MailboxRewindPath}{new AdminQueryString().Add("account", account).Add("folder", folder)}",
             token,
             CliJsonContext.Default.MailboxRewindAssessment,
             cancellationToken);
@@ -294,7 +293,7 @@ internal sealed class AdminApiClient
 
         return this.RequestAsync(
             HttpMethod.Get,
-            AdminEndpointRoutes.MailboxRederivationPath + ScopeQuery(account, folder),
+            $"{AdminEndpointRoutes.MailboxRederivationPath}{new AdminQueryString().Add("account", account).Add("folder", folder)}",
             token,
             CliJsonContext.Default.MailboxRederivationState,
             cancellationToken);
@@ -603,7 +602,7 @@ internal sealed class AdminApiClient
         CancellationToken cancellationToken) =>
         this.RequestAsync(
             HttpMethod.Get,
-            $"{AdminEndpointRoutes.OutboxSummaryPath}{AccountQuery(account)}",
+            $"{AdminEndpointRoutes.OutboxSummaryPath}{new AdminQueryString().Add("account", account)}",
             token,
             CliJsonContext.Default.OutboxStatus,
             cancellationToken);
@@ -755,7 +754,7 @@ internal sealed class AdminApiClient
         CancellationToken cancellationToken) =>
         this.RequestAsync(
             HttpMethod.Get,
-            $"{AdminEndpointRoutes.ContactsPath}{ContactPageQuery(origin, pageSize, cursor)}",
+            $"{AdminEndpointRoutes.ContactsPath}{new AdminQueryString().Add("origin", origin).Add("pageSize", pageSize).Add("cursor", cursor)}",
             token,
             CliJsonContext.Default.ContactPage,
             cancellationToken);
@@ -925,51 +924,6 @@ internal sealed class AdminApiClient
             token,
             CliJsonContext.Default.ContactExport,
             cancellationToken);
-
-    /// <summary>Writes the one account filter a summary takes as a query string.</summary>
-    /// <remarks>An absent account is left out rather than sent empty, so the deployment reads it as every account it serves rather than as one more shape to have an opinion about.</remarks>
-    private static string AccountQuery(string? account) => account is { Length: > 0 } narrowed
-        ? $"?account={Uri.EscapeDataString(narrowed)}"
-        : string.Empty;
-
-    /// <summary>Writes the narrowing an operator asked a listing for as a query string.</summary>
-    /// <remarks>
-    /// A filter the operator left out is left out of the query rather than sent empty, so the request says what they
-    /// said: the deployment reads an absent origin as the whole book and an absent size as its own default, and a
-    /// parameter present but blank would be one more shape for it to have an opinion about.
-    /// </remarks>
-    private static string ContactPageQuery(string? origin, int? pageSize, string? cursor)
-    {
-        var filters = new List<string>(3);
-
-        if (origin is { Length: > 0 } narrowed)
-        {
-            filters.Add($"origin={Uri.EscapeDataString(narrowed)}");
-        }
-
-        if (pageSize is { } size)
-        {
-            filters.Add($"pageSize={size.ToString(CultureInfo.InvariantCulture)}");
-        }
-
-        if (cursor is { Length: > 0 } continuation)
-        {
-            filters.Add($"cursor={Uri.EscapeDataString(continuation)}");
-        }
-
-        return filters.Count == 0 ? string.Empty : $"?{string.Join('&', filters)}";
-    }
-
-    /// <summary>Writes the scope an operator named as a query string, escaping both halves.</summary>
-    /// <remarks>
-    /// An omitted folder is left out of the query rather than sent empty, so the request says what the operator said:
-    /// a deployment reads an absent folder as the whole account, and a parameter present but blank would be one more
-    /// shape for it to have an opinion about.
-    /// </remarks>
-    private static string ScopeQuery(string account, string? folder) =>
-        folder is { Length: > 0 } narrowed
-            ? $"?account={Uri.EscapeDataString(account)}&folder={Uri.EscapeDataString(narrowed)}"
-            : $"?account={Uri.EscapeDataString(account)}";
 
     /// <summary>Sends one credentialed request and reads the answer, or turns the refusal into a sentence.</summary>
     /// <remarks>

--- a/src/Cli/Administration/AdminQueryString.cs
+++ b/src/Cli/Administration/AdminQueryString.cs
@@ -1,0 +1,74 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Globalization;
+
+namespace MailFathom.Cli.Administration;
+
+/// <summary>Writes the filters one administrative request carries as the query string it sends them in.</summary>
+/// <remarks>
+/// <para>
+/// One place decides how a filter is escaped and how an absent one is left out, because every route asking for a
+/// narrowed reading needs both decisions and each answered them again. A rule name may carry a space, a cursor is
+/// base64url, and a verdict is a word an operator typed, so a query string assembled by hand is a defect waiting for
+/// the first value that is not a bare word.
+/// </para>
+/// <para>
+/// A filter the caller named nothing for is left out rather than sent empty, so the request says what the operator
+/// said: the deployment reads an absent account as every account it serves and an absent size as its own default, and
+/// a parameter present but blank would be one more shape for it to have an opinion about.
+/// </para>
+/// </remarks>
+internal sealed class AdminQueryString
+{
+    private readonly List<string> filters = [];
+
+    /// <summary>Adds a filter carrying a word an operator wrote.</summary>
+    /// <param name="name">The parameter's name, which is this tool's own rather than anything typed.</param>
+    /// <param name="value">The value, or <see langword="null" /> or empty to leave the filter out.</param>
+    /// <returns>This builder, so one request's filters read as one expression.</returns>
+    internal AdminQueryString Add(string name, string? value)
+    {
+        if (value is { Length: > 0 } named)
+        {
+            this.filters.Add($"{name}={Uri.EscapeDataString(named)}");
+        }
+
+        return this;
+    }
+
+    /// <summary>Adds a filter carrying a count.</summary>
+    /// <param name="name">The parameter's name, which is this tool's own rather than anything typed.</param>
+    /// <param name="value">The value, or <see langword="null" /> to leave the filter out.</param>
+    /// <returns>This builder, so one request's filters read as one expression.</returns>
+    internal AdminQueryString Add(string name, int? value)
+    {
+        if (value is { } counted)
+        {
+            this.filters.Add($"{name}={counted.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        return this;
+    }
+
+    /// <summary>Adds a filter naming one record by its identifier.</summary>
+    /// <param name="name">The parameter's name, which is this tool's own rather than anything typed.</param>
+    /// <param name="value">The value, or <see langword="null" /> to leave the filter out.</param>
+    /// <returns>This builder, so one request's filters read as one expression.</returns>
+    /// <remarks>Written in the hyphenated form invariantly, which is the one every administrative route reads an identifier in.</remarks>
+    internal AdminQueryString Add(string name, Guid? value)
+    {
+        if (value is { } identified)
+        {
+            this.filters.Add($"{name}={identified.ToString("D", CultureInfo.InvariantCulture)}");
+        }
+
+        return this;
+    }
+
+    /// <summary>Writes what was added as a query string.</summary>
+    /// <returns>An empty string where no filter was named, and the filters after a <c>?</c> otherwise.</returns>
+    public override string ToString() =>
+        this.filters.Count == 0 ? string.Empty : $"?{string.Join('&', this.filters)}";
+}

--- a/src/Cli/Administration/Jobs/DeadLetteredJobQuery.cs
+++ b/src/Cli/Administration/Jobs/DeadLetteredJobQuery.cs
@@ -2,15 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Globalization;
-
 namespace MailFathom.Cli.Administration.Jobs;
 
 /// <summary>Which part of the background work a deployment has stopped one request asks for.</summary>
 /// <remarks>
-/// Built here rather than composed at the call site so that one place decides how a filter is escaped and how an absent
-/// filter is left out. A cursor is base64url, so a query string assembled by hand is a defect waiting for the first
-/// page somebody continues.
+/// One record rather than four arguments, because the filters narrow one reading and a call site passing them
+/// separately would be one that can pass them in the wrong order. How each is escaped and how an absent one is left
+/// out belong to <see cref="AdminQueryString" />, which every narrowed reading here composes through.
 /// </remarks>
 /// <param name="Type">The job type to narrow to, or <see langword="null" /> for every type.</param>
 /// <param name="Account">The account to narrow to, or <see langword="null" /> for every account.</param>
@@ -24,30 +22,10 @@ internal sealed record DeadLetteredJobQuery(
 {
     /// <summary>Writes the filters as the query string the administrative endpoint reads them from.</summary>
     /// <returns>The query string, beginning with <c>?</c>, and empty where no filter was named.</returns>
-    internal string ToQueryString()
-    {
-        var filters = new List<string>();
-
-        if (this.Type is { Length: > 0 } type)
-        {
-            filters.Add($"type={Uri.EscapeDataString(type)}");
-        }
-
-        if (this.Account is { Length: > 0 } account)
-        {
-            filters.Add($"account={Uri.EscapeDataString(account)}");
-        }
-
-        if (this.PageSize is { } pageSize)
-        {
-            filters.Add($"pageSize={pageSize.ToString(CultureInfo.InvariantCulture)}");
-        }
-
-        if (this.Cursor is { Length: > 0 } cursor)
-        {
-            filters.Add($"cursor={Uri.EscapeDataString(cursor)}");
-        }
-
-        return filters.Count == 0 ? string.Empty : $"?{string.Join('&', filters)}";
-    }
+    internal string ToQueryString() => new AdminQueryString()
+        .Add("type", this.Type)
+        .Add("account", this.Account)
+        .Add("pageSize", this.PageSize)
+        .Add("cursor", this.Cursor)
+        .ToString();
 }

--- a/src/Cli/Administration/Outbox/OutboxQuery.cs
+++ b/src/Cli/Administration/Outbox/OutboxQuery.cs
@@ -2,15 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Globalization;
-
 namespace MailFathom.Cli.Administration.Outbox;
 
 /// <summary>Which part of what a deployment has been asked to send one request asks for.</summary>
 /// <remarks>
-/// Built here rather than composed at the call site so that one place decides how a filter is escaped and how an absent
-/// filter is left out. A cursor is base64url, so a query string assembled by hand is a defect waiting for the first
-/// page somebody continues.
+/// One record rather than four arguments, because the filters narrow one reading and a call site passing them
+/// separately would be one that can pass them in the wrong order. How each is escaped and how an absent one is left
+/// out belong to <see cref="AdminQueryString" />, which every narrowed reading here composes through.
 /// </remarks>
 /// <param name="Account">The account to narrow to, or <see langword="null" /> for every account.</param>
 /// <param name="Stage">The stage to narrow to, or <see langword="null" /> for every stage.</param>
@@ -24,30 +22,10 @@ internal sealed record OutboxQuery(
 {
     /// <summary>Writes the filters as the query string the administrative endpoint reads them from.</summary>
     /// <returns>The query string, beginning with <c>?</c>, and empty where no filter was named.</returns>
-    internal string ToQueryString()
-    {
-        var filters = new List<string>();
-
-        if (this.Account is { Length: > 0 } account)
-        {
-            filters.Add($"account={Uri.EscapeDataString(account)}");
-        }
-
-        if (this.Stage is { Length: > 0 } stage)
-        {
-            filters.Add($"stage={Uri.EscapeDataString(stage)}");
-        }
-
-        if (this.PageSize is { } pageSize)
-        {
-            filters.Add($"pageSize={pageSize.ToString(CultureInfo.InvariantCulture)}");
-        }
-
-        if (this.Cursor is { Length: > 0 } cursor)
-        {
-            filters.Add($"cursor={Uri.EscapeDataString(cursor)}");
-        }
-
-        return filters.Count == 0 ? string.Empty : $"?{string.Join('&', filters)}";
-    }
+    internal string ToQueryString() => new AdminQueryString()
+        .Add("account", this.Account)
+        .Add("stage", this.Stage)
+        .Add("pageSize", this.PageSize)
+        .Add("cursor", this.Cursor)
+        .ToString();
 }

--- a/src/Cli/Administration/Rules/MailRuleHistoryQuery.cs
+++ b/src/Cli/Administration/Rules/MailRuleHistoryQuery.cs
@@ -2,15 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Globalization;
-
 namespace MailFathom.Cli.Administration.Rules;
 
 /// <summary>Which part of a deployment's rule history one request asks for.</summary>
 /// <remarks>
-/// Built here rather than composed at the call site so that one place decides how a filter is escaped and how an absent
-/// filter is left out. A rule name may carry a space and a cursor is base64url, so a query string assembled by hand is
-/// a defect waiting for the first rule somebody names with two words.
+/// One record rather than five arguments, because the four filters narrow one reading and a call site passing them
+/// separately would be one that can pass them in the wrong order. How each is escaped and how an absent one is left
+/// out belong to <see cref="AdminQueryString" />, which every narrowed reading here composes through.
 /// </remarks>
 /// <param name="Account">The account whose history is read, which every other filter narrows within.</param>
 /// <param name="Rule">The rule to narrow to, or <see langword="null" /> for every rule of the account.</param>
@@ -25,31 +23,12 @@ internal sealed record MailRuleHistoryQuery(
     string? Cursor = null)
 {
     /// <summary>Writes the filters as the query string the administrative endpoint reads them from.</summary>
-    /// <returns>The query string, beginning with <c>?</c>.</returns>
-    internal string ToQueryString()
-    {
-        var filters = new List<string> { $"account={Uri.EscapeDataString(this.Account)}" };
-
-        if (this.Rule is { Length: > 0 } rule)
-        {
-            filters.Add($"rule={Uri.EscapeDataString(rule)}");
-        }
-
-        if (this.Email is { } email)
-        {
-            filters.Add($"email={email.ToString("D", CultureInfo.InvariantCulture)}");
-        }
-
-        if (this.PageSize is { } pageSize)
-        {
-            filters.Add($"pageSize={pageSize.ToString(CultureInfo.InvariantCulture)}");
-        }
-
-        if (this.Cursor is { Length: > 0 } cursor)
-        {
-            filters.Add($"cursor={Uri.EscapeDataString(cursor)}");
-        }
-
-        return $"?{string.Join('&', filters)}";
-    }
+    /// <returns>The query string, beginning with <c>?</c>, and empty where no filter was named.</returns>
+    internal string ToQueryString() => new AdminQueryString()
+        .Add("account", this.Account)
+        .Add("rule", this.Rule)
+        .Add("email", this.Email)
+        .Add("pageSize", this.PageSize)
+        .Add("cursor", this.Cursor)
+        .ToString();
 }

--- a/src/Cli/Administration/Spam/SpamClassificationQuery.cs
+++ b/src/Cli/Administration/Spam/SpamClassificationQuery.cs
@@ -2,15 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Globalization;
-
 namespace MailFathom.Cli.Administration.Spam;
 
 /// <summary>Which part of what a deployment classified one request asks for.</summary>
 /// <remarks>
-/// Built here rather than composed at the call site so that one place decides how a filter is escaped and how an absent
-/// filter is left out. A cursor is base64url and an instant carries a <c>+</c> in its offset, so a query string
-/// assembled by hand is a defect waiting for the first page somebody continues.
+/// One record rather than five arguments, because the four filters narrow one reading and a call site passing them
+/// separately would be one that can pass them in the wrong order. How each is escaped and how an absent one is left
+/// out belong to <see cref="AdminQueryString" />, which every narrowed reading here composes through.
 /// </remarks>
 /// <param name="Account">The account whose classifications are read, which every other filter narrows within.</param>
 /// <param name="Email">The message to narrow to, or <see langword="null" /> for every message of the account.</param>
@@ -25,31 +23,12 @@ internal sealed record SpamClassificationQuery(
     string? Cursor = null)
 {
     /// <summary>Writes the filters as the query string the administrative endpoint reads them from.</summary>
-    /// <returns>The query string, beginning with <c>?</c>.</returns>
-    internal string ToQueryString()
-    {
-        var filters = new List<string> { $"account={Uri.EscapeDataString(this.Account)}" };
-
-        if (this.Email is { } email)
-        {
-            filters.Add($"email={email.ToString("D", CultureInfo.InvariantCulture)}");
-        }
-
-        if (this.Verdict is { Length: > 0 } verdict)
-        {
-            filters.Add($"verdict={Uri.EscapeDataString(verdict)}");
-        }
-
-        if (this.PageSize is { } pageSize)
-        {
-            filters.Add($"pageSize={pageSize.ToString(CultureInfo.InvariantCulture)}");
-        }
-
-        if (this.Cursor is { Length: > 0 } cursor)
-        {
-            filters.Add($"cursor={Uri.EscapeDataString(cursor)}");
-        }
-
-        return $"?{string.Join('&', filters)}";
-    }
+    /// <returns>The query string, beginning with <c>?</c>, and empty where no filter was named.</returns>
+    internal string ToQueryString() => new AdminQueryString()
+        .Add("account", this.Account)
+        .Add("email", this.Email)
+        .Add("verdict", this.Verdict)
+        .Add("pageSize", this.PageSize)
+        .Add("cursor", this.Cursor)
+        .ToString();
 }

--- a/src/Cli/CliConfirmation.cs
+++ b/src/Cli/CliConfirmation.cs
@@ -1,0 +1,40 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+namespace MailFathom.Cli;
+
+/// <summary>The one rule every command that does something irreversible asks its question under.</summary>
+/// <remarks>
+/// Written once because the rule is one rule: the flag states the agreement, an invocation with nobody at the terminal
+/// is refused rather than guessed at, and everything else is asked. Each command that had its own copy could have
+/// answered the middle case differently, and a redirected input answered from whatever was piped in would turn a stray
+/// line into an agreement to spend money or to erase somebody.
+/// </remarks>
+internal static class CliConfirmation
+{
+    /// <summary>Reports whether the person running this agreed to what the command is about to do.</summary>
+    /// <param name="context">What the command needs from its surroundings, which is where the terminal is reached.</param>
+    /// <param name="confirmedUpFront">Whether the operator stated the agreement in the command with <c>--yes</c>.</param>
+    /// <param name="unattendedRefusal">What to tell an invocation with nobody at the terminal, naming what it would have done and the flag that states the agreement.</param>
+    /// <param name="question">The question to put to the operator, ending in the accepted answers.</param>
+    /// <returns><see langword="true" /> when the command may go ahead.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="context" /> is <see langword="null" />.</exception>
+    /// <exception cref="CliFailure">Thrown when nothing was stated in the command and there is nobody to ask.</exception>
+    internal static bool Agreed(CliContext context, bool confirmedUpFront, string unattendedRefusal, string question)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (confirmedUpFront)
+        {
+            return true;
+        }
+
+        if (!context.Console.CanConfirm)
+        {
+            throw new CliFailure(unattendedRefusal);
+        }
+
+        return context.Console.Confirm(question);
+    }
+}

--- a/src/Cli/CliOptions.cs
+++ b/src/Cli/CliOptions.cs
@@ -120,13 +120,50 @@ internal static class CliOptions
         Description = "The name to remember this deployment under. Defaults to its host name.",
     };
 
+    /// <summary>Builds the option continuing a listing from where the previous page ended.</summary>
+    /// <returns>The option.</returns>
+    /// <remarks>
+    /// Declared here rather than per listing because a cursor is one thing: an opaque value the deployment printed,
+    /// handed back unread. A description written again per family is the first place the five listings would start
+    /// telling an operator different things about the same value.
+    /// </remarks>
+    internal static Option<string?> Cursor() => new("--cursor")
+    {
+        Description = "Continue from where a previous page ended, using the cursor it printed.",
+    };
+
+    /// <summary>Builds the option bounding how much of a listing one page holds.</summary>
+    /// <param name="noun">What the page holds, in the plural, as the listing's own output names it.</param>
+    /// <returns>The option.</returns>
+    /// <remarks>The noun is the whole of what differs between the listings, and an absent value stays the deployment's own default rather than a number this tool would have to keep in step with it.</remarks>
+    internal static Option<int?> PageSize(string noun) => new("--page-size")
+    {
+        Description = $"How many {noun} to read. Defaults to what the deployment serves.",
+    };
+
+    /// <summary>Builds the option an operator states an irreversible act's agreement in the command with.</summary>
+    /// <param name="description">What is being agreed to, as the command's own output names it.</param>
+    /// <returns>The option.</returns>
+    /// <remarks>The prompt is the default and this is the exception, rather than the other way round: a command that assumed consent would be one an operator can only find out about afterwards.</remarks>
+    internal static Option<bool> Confirmed(string description) => new("--yes", "-y")
+    {
+        Description = $"Agree to the {description} without being asked, which is what a scripted run needs.",
+    };
+
     /// <summary>Reports which deployment the operator named for this invocation, if any.</summary>
     /// <param name="configuredEndpoint">What the operator passed to <c>--endpoint</c>, or <see langword="null" />.</param>
+    /// <param name="endpointVariable">What <see cref="EndpointVariable" /> holds, or <see langword="null" /> when it is unset.</param>
     /// <returns>A profile name, an address, or <see langword="null" /> to fall back to the stored default.</returns>
-    internal static string? RequestedDeployment(string? configuredEndpoint) =>
+    /// <remarks>
+    /// The variable is a parameter rather than read here, for the reason <see cref="RecordsInvocation" /> takes its own
+    /// one: the process environment is shared by every test in an assembly that runs them in parallel, so a developer
+    /// who exported the variable for their own shell would otherwise have command tests resolve a deployment nobody
+    /// asked for.
+    /// </remarks>
+    internal static string? RequestedDeployment(string? configuredEndpoint, string? endpointVariable) =>
         configuredEndpoint is { Length: > 0 } named
             ? named.Trim()
-            : Environment.GetEnvironmentVariable(EndpointVariable) is { Length: > 0 } fromEnvironment
+            : endpointVariable is { Length: > 0 } fromEnvironment
                 ? fromEnvironment.Trim()
                 : null;
 

--- a/src/Cli/Commands/ActivateEmbeddingCommand.cs
+++ b/src/Cli/Commands/ActivateEmbeddingCommand.cs
@@ -36,10 +36,7 @@ internal static class ActivateEmbeddingCommand
         ArgumentNullException.ThrowIfNull(context);
 
         var endpointOption = CliOptions.Endpoint();
-        var confirmedOption = new Option<bool>("--yes", "-y")
-        {
-            Description = "Agree to the estimated cost without being asked, which is what a scripted activation needs.",
-        };
+        var confirmedOption = CliOptions.Confirmed("estimated cost");
 
         Command command = new(
             "activate",
@@ -51,7 +48,7 @@ internal static class ActivateEmbeddingCommand
 
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             result.GetValue(confirmedOption),
             cancellationToken));
 
@@ -122,25 +119,15 @@ internal static class ActivateEmbeddingCommand
 
     /// <summary>Reports whether the person running this agreed to the cost, refusing to guess where nobody can answer.</summary>
     /// <remarks>
-    /// A redirected input has nobody to ask, and reading the answer out of whatever was piped in would turn a stray line
-    /// into an agreement to a provider bill. Such an invocation is told to pass the flag instead, which is an operator
-    /// stating the agreement in the command rather than a command inferring it.
+    /// The refusal names what the spend would be, which is the one thing the shared rule cannot supply: an invocation
+    /// with nobody at the terminal is told what it would have agreed to rather than only that it was not asked.
     /// </remarks>
-    private static bool Agreed(CliContext context, EmbeddingActivationAssessment assessment, bool confirmedUpFront)
-    {
-        if (confirmedUpFront)
-        {
-            return true;
-        }
-
-        if (!context.Console.CanConfirm)
-        {
-            throw new CliFailure(
-                $"This would spend {assessment.Estimate?.DescribeCost() ?? "an unreported amount"} at your provider, and there is nobody at the terminal to agree to it. Pass --yes to activate without being asked.");
-        }
-
-        return context.Console.Confirm("Embed the mailbox under that model? [y/N] ");
-    }
+    private static bool Agreed(CliContext context, EmbeddingActivationAssessment assessment, bool confirmedUpFront) =>
+        CliConfirmation.Agreed(
+            context,
+            confirmedUpFront,
+            $"This would spend {assessment.Estimate?.DescribeCost() ?? "an unreported amount"} at your provider, and there is nobody at the terminal to agree to it. Pass --yes to activate without being asked.",
+            "Embed the mailbox under that model? [y/N] ");
 
     /// <summary>States the two numbers the deployment refused the activation as, before it is asked to refuse again.</summary>
     /// <remarks>

--- a/src/Cli/Commands/AuthorizeMailboxCommand.cs
+++ b/src/Cli/Commands/AuthorizeMailboxCommand.cs
@@ -122,7 +122,7 @@ internal static class AuthorizeMailboxCommand
             parseResult.GetValue(redirectUriOption),
             parseResult.GetValue(publicClientOption),
             parseResult.GetValue(accountOption),
-            CliOptions.RequestedDeployment(parseResult.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(parseResult.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/CancelEmbeddingReindexCommand.cs
+++ b/src/Cli/Commands/CancelEmbeddingReindexCommand.cs
@@ -40,7 +40,7 @@ internal static class CancelEmbeddingReindexCommand
 
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Contacts/AddContactAddressCommand.cs
+++ b/src/Cli/Commands/Contacts/AddContactAddressCommand.cs
@@ -46,7 +46,7 @@ internal static class AddContactAddressCommand
             result.GetValue(identityOption),
             result.GetValue(addressOption) ?? string.Empty,
             result.GetValue(preferredOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Contacts/CreateContactCommand.cs
+++ b/src/Cli/Commands/Contacts/CreateContactCommand.cs
@@ -64,7 +64,7 @@ internal static class CreateContactCommand
             result.GetValue(addressOption) ?? [],
             result.GetValue(preferredOption),
             result.GetValue(noteOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Contacts/DeleteCollectedContactsCommand.cs
+++ b/src/Cli/Commands/Contacts/DeleteCollectedContactsCommand.cs
@@ -33,10 +33,7 @@ internal static class DeleteCollectedContactsCommand
 
         var endpointOption = CliOptions.Endpoint();
 
-        Option<bool> confirmedOption = new("--yes", "-y")
-        {
-            Description = "Agree to the erasure without being asked, which is what a scripted erasure needs.",
-        };
+        var confirmedOption = CliOptions.Confirmed("erasure");
 
         Command command = new(
             "delete-collected",
@@ -48,7 +45,7 @@ internal static class DeleteCollectedContactsCommand
 
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             result.GetValue(confirmedOption),
             cancellationToken));
 
@@ -63,7 +60,13 @@ internal static class DeleteCollectedContactsCommand
     {
         var profile = await context.Deployment().ReachAsync(requestedDeployment, cancellationToken);
 
-        if (!Agreed(context, confirmedUpFront))
+        // Asked before the book is read rather than after, unlike the erasure of one person: there is no record to show
+        // first, and counting what would go would mean reading a page of people the operator is about to dispose of.
+        if (!CliConfirmation.Agreed(
+                context,
+                confirmedUpFront,
+                "There is nobody at the terminal to agree to this, and erasing what was collected cannot be undone. Pass --yes to erase without being asked.",
+                "Erase every contact this deployment collected from arriving mail? The ones you entered are kept. [y/N] "))
         {
             context.Console.WriteError("Nothing was erased.");
 
@@ -80,28 +83,6 @@ internal static class DeleteCollectedContactsCommand
             : $"Erased {Describe(erasure.ContactsErased, "contact", "contacts")} the deployment had collected, and {Describe(erasure.AddressesErased, "address", "addresses")}. Nothing in MailFathom can put them back.");
 
         return CliExitCode.Success;
-    }
-
-    /// <summary>Reports whether the person running this agreed to the erasure, refusing to guess where nobody can answer.</summary>
-    /// <remarks>
-    /// Asked before the book is read rather than after, unlike the erasure of one person: there is no record to show
-    /// first, and counting what would go would mean reading a page of people the operator is about to dispose of.
-    /// </remarks>
-    private static bool Agreed(CliContext context, bool confirmedUpFront)
-    {
-        if (confirmedUpFront)
-        {
-            return true;
-        }
-
-        if (!context.Console.CanConfirm)
-        {
-            throw new CliFailure(
-                "There is nobody at the terminal to agree to this, and erasing what was collected cannot be undone. Pass --yes to erase without being asked.");
-        }
-
-        return context.Console.Confirm(
-            "Erase every contact this deployment collected from arriving mail? The ones you entered are kept. [y/N] ");
     }
 
     /// <summary>Counts one kind of thing invariantly, for the reason every other figure this tool prints is.</summary>

--- a/src/Cli/Commands/Contacts/DeleteContactCommand.cs
+++ b/src/Cli/Commands/Contacts/DeleteContactCommand.cs
@@ -38,10 +38,7 @@ internal static class DeleteContactCommand
         var endpointOption = CliOptions.Endpoint();
         var identityOption = ContactOptions.Identity();
 
-        Option<bool> confirmedOption = new("--yes", "-y")
-        {
-            Description = "Agree to the erasure without being asked, which is what a scripted erasure needs.",
-        };
+        var confirmedOption = CliOptions.Confirmed("erasure");
 
         Command command = new("delete", "Erase one person from the deployment's contact book. This cannot be undone.")
         {
@@ -53,7 +50,7 @@ internal static class DeleteContactCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(identityOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             result.GetValue(confirmedOption),
             cancellationToken));
 
@@ -84,7 +81,11 @@ internal static class DeleteContactCommand
 
         ContactOutput.WriteContact(context.Console, held);
 
-        if (!Agreed(context, confirmedUpFront))
+        if (!CliConfirmation.Agreed(
+                context,
+                confirmedUpFront,
+                "There is nobody at the terminal to agree to this, and erasing a contact cannot be undone. Pass --yes to erase without being asked.",
+                "Erase that contact and everything derived from it? [y/N] "))
         {
             context.Console.WriteError("Nothing was erased.");
 
@@ -98,28 +99,6 @@ internal static class DeleteContactCommand
             : $"The deployment's contact book held no contact {erasure.Contact:D} by the time the erasure ran, so nothing was erased.");
 
         return CliExitCode.Success;
-    }
-
-    /// <summary>Reports whether the person running this agreed to the erasure, refusing to guess where nobody can answer.</summary>
-    /// <remarks>
-    /// A redirected input has nobody to ask, and reading the answer out of whatever was piped in would turn a stray line
-    /// into an agreement to erase somebody. Such an invocation is told to pass the flag instead, which is an operator
-    /// stating the agreement in the command rather than a command inferring it.
-    /// </remarks>
-    private static bool Agreed(CliContext context, bool confirmedUpFront)
-    {
-        if (confirmedUpFront)
-        {
-            return true;
-        }
-
-        if (!context.Console.CanConfirm)
-        {
-            throw new CliFailure(
-                "There is nobody at the terminal to agree to this, and erasing a contact cannot be undone. Pass --yes to erase without being asked.");
-        }
-
-        return context.Console.Confirm("Erase that contact and everything derived from it? [y/N] ");
     }
 
     /// <summary>Describes how many addresses went with the person, grouped invariantly for the reason every other figure this tool prints is.</summary>

--- a/src/Cli/Commands/Contacts/ExportContactCommand.cs
+++ b/src/Cli/Commands/Contacts/ExportContactCommand.cs
@@ -43,7 +43,7 @@ internal static class ExportContactCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(identityOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Contacts/ListContactsCommand.cs
+++ b/src/Cli/Commands/Contacts/ListContactsCommand.cs
@@ -37,15 +37,8 @@ internal static class ListContactsCommand
                 "Narrow to contacts of one origin: Asserted for the people written down, Collected for the addresses the deployment picked up. Defaults to the whole book.",
         };
 
-        Option<int?> pageSizeOption = new("--page-size")
-        {
-            Description = "How many contacts to read. Defaults to what the deployment serves.",
-        };
-
-        Option<string?> cursorOption = new("--cursor")
-        {
-            Description = "Continue from where a previous page ended, using the cursor it printed.",
-        };
+        var pageSizeOption = CliOptions.PageSize("contacts");
+        var cursorOption = CliOptions.Cursor();
 
         Command command = new("list", "Read one page of the deployment's contact book.")
         {
@@ -60,7 +53,7 @@ internal static class ListContactsCommand
             result.GetValue(originOption),
             result.GetValue(pageSizeOption),
             result.GetValue(cursorOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Contacts/PromoteContactCommand.cs
+++ b/src/Cli/Commands/Contacts/PromoteContactCommand.cs
@@ -35,7 +35,7 @@ internal static class PromoteContactCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(identityOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Contacts/RemoveContactAddressCommand.cs
+++ b/src/Cli/Commands/Contacts/RemoveContactAddressCommand.cs
@@ -46,7 +46,7 @@ internal static class RemoveContactAddressCommand
             result.GetValue(identityOption),
             result.GetValue(addressOption) ?? string.Empty,
             result.GetValue(preferredOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Contacts/ShowContactCommand.cs
+++ b/src/Cli/Commands/Contacts/ShowContactCommand.cs
@@ -46,7 +46,7 @@ internal static class ShowContactCommand
             context,
             result.GetValue(identityOption),
             result.GetValue(addressOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Contacts/UpdateContactCommand.cs
+++ b/src/Cli/Commands/Contacts/UpdateContactCommand.cs
@@ -79,7 +79,7 @@ internal static class UpdateContactCommand
                 result.GetValue(preferredOption),
                 result.GetValue(noteOption),
                 result.GetValue(clearNoteOption)),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/EmbeddingStatusCommand.cs
+++ b/src/Cli/Commands/EmbeddingStatusCommand.cs
@@ -35,7 +35,7 @@ internal static class EmbeddingStatusCommand
 
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Folders/EraseFolderCommand.cs
+++ b/src/Cli/Commands/Folders/EraseFolderCommand.cs
@@ -53,7 +53,7 @@ internal static class EraseFolderCommand
             context,
             result.GetValue(accountOption) ?? string.Empty,
             result.GetValue(folderOption) ?? string.Empty,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Jobs/DeadLettersCommand.cs
+++ b/src/Cli/Commands/Jobs/DeadLettersCommand.cs
@@ -48,15 +48,8 @@ internal static class DeadLettersCommand
             Description = "Report only work belonging to this account, as the deployment's configuration names it.",
         };
 
-        Option<int?> pageSizeOption = new("--page-size")
-        {
-            Description = "How many jobs to read. Defaults to what the deployment serves.",
-        };
-
-        Option<string?> cursorOption = new("--cursor")
-        {
-            Description = "Continue from where a previous page ended, using the cursor it printed.",
-        };
+        var pageSizeOption = CliOptions.PageSize("jobs");
+        var cursorOption = CliOptions.Cursor();
 
         Command command = new(
             "dead-letters",
@@ -76,7 +69,7 @@ internal static class DeadLettersCommand
                 result.GetValue(accountOption),
                 result.GetValue(pageSizeOption),
                 result.GetValue(cursorOption)),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Jobs/DropJobCommand.cs
+++ b/src/Cli/Commands/Jobs/DropJobCommand.cs
@@ -42,7 +42,7 @@ internal static class DropJobCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(jobOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Jobs/RetryJobCommand.cs
+++ b/src/Cli/Commands/Jobs/RetryJobCommand.cs
@@ -45,7 +45,7 @@ internal static class RetryJobCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(jobOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/LoginCommand.cs
+++ b/src/Cli/Commands/LoginCommand.cs
@@ -124,7 +124,7 @@ internal static class LoginCommand
 
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             result.GetValue(nameOption),
             new SignInRequest(
                 result.GetValue(modeOption),

--- a/src/Cli/Commands/LogoutCommand.cs
+++ b/src/Cli/Commands/LogoutCommand.cs
@@ -35,7 +35,7 @@ internal static class LogoutCommand
             // argument, and so that naming an address removes the profile serving it rather than reporting that no
             // profile carries that name.
             var (name, credential) = context.Store.Locate(
-                CliOptions.RequestedDeployment(result.GetValue(endpointOption)));
+                CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)));
 
             context.Store.Remove(name);
 

--- a/src/Cli/Commands/MailboxStatusCommand.cs
+++ b/src/Cli/Commands/MailboxStatusCommand.cs
@@ -35,7 +35,7 @@ internal static class MailboxStatusCommand
 
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Outbox/CancelOutgoingMailCommand.cs
+++ b/src/Cli/Commands/Outbox/CancelOutgoingMailCommand.cs
@@ -41,7 +41,7 @@ internal static class CancelOutgoingMailCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(messageOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Outbox/OutboxListCommand.cs
+++ b/src/Cli/Commands/Outbox/OutboxListCommand.cs
@@ -41,15 +41,8 @@ internal static class OutboxListCommand
             Description = "Report only the sends standing at this stage, by the stage's own name.",
         };
 
-        Option<int?> pageSizeOption = new("--page-size")
-        {
-            Description = "How many messages to read. Defaults to what the deployment serves.",
-        };
-
-        Option<string?> cursorOption = new("--cursor")
-        {
-            Description = "Continue from where a previous page ended, using the cursor it printed.",
-        };
+        var pageSizeOption = CliOptions.PageSize("messages");
+        var cursorOption = CliOptions.Cursor();
 
         Command command = new("list", "Report what this deployment has been asked to send, newest first.")
         {
@@ -67,7 +60,7 @@ internal static class OutboxListCommand
                 result.GetValue(stageOption),
                 result.GetValue(pageSizeOption),
                 result.GetValue(cursorOption)),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Outbox/OutboxStatusCommand.cs
+++ b/src/Cli/Commands/Outbox/OutboxStatusCommand.cs
@@ -44,7 +44,7 @@ internal static class OutboxStatusCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(accountOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Outbox/RequeueOutgoingMailCommand.cs
+++ b/src/Cli/Commands/Outbox/RequeueOutgoingMailCommand.cs
@@ -57,7 +57,7 @@ internal static class RequeueOutgoingMailCommand
             context,
             result.GetValue(messageOption),
             result.GetValue(despiteRefusalOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Outbox/ShowOutgoingMailCommand.cs
+++ b/src/Cli/Commands/Outbox/ShowOutgoingMailCommand.cs
@@ -44,7 +44,7 @@ internal static class ShowOutgoingMailCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(messageOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/RederivationStatusCommand.cs
+++ b/src/Cli/Commands/RederivationStatusCommand.cs
@@ -42,7 +42,7 @@ internal static class RederivationStatusCommand
             context,
             result.GetValue(accountOption) ?? string.Empty,
             result.GetValue(folderOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/RederiveMailboxCommand.cs
+++ b/src/Cli/Commands/RederiveMailboxCommand.cs
@@ -56,7 +56,7 @@ internal static class RederiveMailboxCommand
             context,
             result.GetValue(accountOption) ?? string.Empty,
             result.GetValue(folderOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/RewindMailboxCommand.cs
+++ b/src/Cli/Commands/RewindMailboxCommand.cs
@@ -42,10 +42,7 @@ internal static class RewindMailboxCommand
         var endpointOption = CliOptions.Endpoint();
         var accountOption = CliOptions.MailAccount();
         var folderOption = CliOptions.NarrowedMailFolder();
-        var confirmedOption = new Option<bool>("--yes", "-y")
-        {
-            Description = "Agree to the fetch without being asked, which is what a scripted rewind needs.",
-        };
+        var confirmedOption = CliOptions.Confirmed("fetch");
 
         Command command = new(
             "rewind",
@@ -61,7 +58,7 @@ internal static class RewindMailboxCommand
             context,
             result.GetValue(accountOption) ?? string.Empty,
             result.GetValue(folderOption),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             result.GetValue(confirmedOption),
             cancellationToken));
 
@@ -128,33 +125,16 @@ internal static class RewindMailboxCommand
 
     /// <summary>Reports whether the person running this agreed to the fetch, refusing to guess where nobody can answer.</summary>
     /// <remarks>
-    /// <para>
-    /// A redirected input has nobody to ask, and reading the answer out of whatever was piped in would turn a stray
-    /// line into an agreement to pull somebody's whole mailbox again. Such an invocation is told to pass the flag
-    /// instead, which is an operator stating the agreement in the command rather than a command inferring it.
-    /// </para>
-    /// <para>
     /// A scope the assessment counted no mail in is asked about like any other. The count is what the deployment
     /// stores, which is deliberately not what a run would fetch: mail that arrived since is fetched without ever
     /// having been stored, and a scope whose local copies are all tombstoned counts nothing while its folders still
     /// hold progress a rewind takes away. Both are cases where zero would have waved through the fetch this
     /// confirmation exists for, and the second needs no race to reach. So the figure informs the question rather than
     /// answering it, and <c>--yes</c> stays the one way to state the agreement without being asked.
-    /// </para>
     /// </remarks>
-    private static bool Agreed(CliContext context, bool confirmedUpFront)
-    {
-        if (confirmedUpFront)
-        {
-            return true;
-        }
-
-        if (!context.Console.CanConfirm)
-        {
-            throw new CliFailure(
-                "There is nobody at the terminal to agree to this, and rewinding has the deployment read the scope from the mail server again. Pass --yes to rewind without being asked.");
-        }
-
-        return context.Console.Confirm("Rewind that scope? [y/N] ");
-    }
+    private static bool Agreed(CliContext context, bool confirmedUpFront) => CliConfirmation.Agreed(
+        context,
+        confirmedUpFront,
+        "There is nobody at the terminal to agree to this, and rewinding has the deployment read the scope from the mail server again. Pass --yes to rewind without being asked.",
+        "Rewind that scope? [y/N] ");
 }

--- a/src/Cli/Commands/Rules/ListRulesCommand.cs
+++ b/src/Cli/Commands/Rules/ListRulesCommand.cs
@@ -34,7 +34,7 @@ internal static class ListRulesCommand
 
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Rules/RuleHistoryCommand.cs
+++ b/src/Cli/Commands/Rules/RuleHistoryCommand.cs
@@ -45,15 +45,8 @@ internal static class RuleHistoryCommand
             Description = "Report only what was concluded about this message, named by its local identifier.",
         };
 
-        Option<int?> pageSizeOption = new("--page-size")
-        {
-            Description = "How many executions to read. Defaults to what the deployment serves.",
-        };
-
-        Option<string?> cursorOption = new("--cursor")
-        {
-            Description = "Continue from where a previous page ended, using the cursor it printed.",
-        };
+        var pageSizeOption = CliOptions.PageSize("executions");
+        var cursorOption = CliOptions.Cursor();
 
         Command command = new("history", "Report what the rules concluded about an account's mail, newest first.")
         {
@@ -73,7 +66,7 @@ internal static class RuleHistoryCommand
                 result.GetValue(emailOption),
                 result.GetValue(pageSizeOption),
                 result.GetValue(cursorOption)),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Rules/RuleRunStatusCommand.cs
+++ b/src/Cli/Commands/Rules/RuleRunStatusCommand.cs
@@ -36,7 +36,7 @@ internal static class RuleRunStatusCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(accountOption) ?? string.Empty,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Rules/RunRulesCommand.cs
+++ b/src/Cli/Commands/Rules/RunRulesCommand.cs
@@ -46,7 +46,7 @@ internal static class RunRulesCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(accountOption) ?? string.Empty,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Rules/ShowRuleCommand.cs
+++ b/src/Cli/Commands/Rules/ShowRuleCommand.cs
@@ -49,7 +49,7 @@ internal static class ShowRuleCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(nameArgument) ?? string.Empty,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Spam/ClassificationRunStatusCommand.cs
+++ b/src/Cli/Commands/Spam/ClassificationRunStatusCommand.cs
@@ -37,7 +37,7 @@ internal static class ClassificationRunStatusCommand
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
             result.GetValue(accountOption) ?? string.Empty,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Spam/ClassificationsCommand.cs
+++ b/src/Cli/Commands/Spam/ClassificationsCommand.cs
@@ -46,15 +46,8 @@ internal static class ClassificationsCommand
             Description = "Report only messages carrying this verdict: Spam, NotSpam, or Undetermined.",
         };
 
-        Option<int?> pageSizeOption = new("--page-size")
-        {
-            Description = "How many classifications to read. Defaults to what the deployment serves.",
-        };
-
-        Option<string?> cursorOption = new("--cursor")
-        {
-            Description = "Continue from where a previous page ended, using the cursor it printed.",
-        };
+        var pageSizeOption = CliOptions.PageSize("classifications");
+        var cursorOption = CliOptions.Cursor();
 
         Command command = new(
             "classifications",
@@ -76,7 +69,7 @@ internal static class ClassificationsCommand
                 result.GetValue(verdictOption),
                 result.GetValue(pageSizeOption),
                 result.GetValue(cursorOption)),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/Spam/ClassifyMailCommand.cs
+++ b/src/Cli/Commands/Spam/ClassifyMailCommand.cs
@@ -73,7 +73,7 @@ internal static class ClassifyMailCommand
                 result.GetValue(foldersOption),
                 result.GetValue(applyOption),
                 result.GetValue(rescoreOption)),
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/src/Cli/Commands/StatusCommand.cs
+++ b/src/Cli/Commands/StatusCommand.cs
@@ -42,7 +42,7 @@ internal static class StatusCommand
 
         command.SetAction((result, cancellationToken) => RunAsync(
             context,
-            CliOptions.RequestedDeployment(result.GetValue(endpointOption)),
+            CliOptions.RequestedDeployment(result.GetValue(endpointOption), context.Variable(CliOptions.EndpointVariable)),
             cancellationToken));
 
         return command;

--- a/tests/Cli.UnitTests/AdminQueryStringTests.cs
+++ b/tests/Cli.UnitTests/AdminQueryStringTests.cs
@@ -1,0 +1,100 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Administration;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers how one request's filters reach the administrative endpoint.</summary>
+/// <remarks>
+/// Every narrowed reading the command performs composes its query string here, so an escaping decision taken wrongly is
+/// taken wrongly for all of them at once. That is the trade this type was written for, and it is why the escaping is
+/// asserted against a value an operator can actually write rather than against a bare word.
+/// </remarks>
+public sealed class AdminQueryStringTests
+{
+    /// <summary>A request narrowing nothing asks for the route itself, which is what leaves a listing at the deployment's own defaults.</summary>
+    [Fact]
+    public void ToString_NoFilterNamed_IsAnEmptyString()
+    {
+        // Act, Assert
+        Assert.Equal(string.Empty, new AdminQueryString().ToString());
+    }
+
+    [Fact]
+    public void ToString_SeveralFilters_OpensWithAQuestionMarkAndSeparatesWithAmpersands()
+    {
+        // Act
+        var query = new AdminQueryString()
+            .Add("account", "personal")
+            .Add("pageSize", 25)
+            .ToString();
+
+        // Assert
+        Assert.Equal("?account=personal&pageSize=25", query);
+    }
+
+    /// <summary>
+    /// A rule name may carry a space and a cursor is base64url, so a value written into the query unescaped is a
+    /// request that means something other than what the operator asked for.
+    /// </summary>
+    [Theory]
+    [InlineData("Move newsletters", "rule=Move%20newsletters")]
+    [InlineData("a&b=c", "rule=a%26b%3Dc")]
+    [InlineData("zażółć", "rule=za%C5%BC%C3%B3%C5%82%C4%87")]
+    public void Add_AValueAnOperatorWrote_IsEscapedForTheQueryString(string value, string expected)
+    {
+        // Act
+        var query = new AdminQueryString().Add("rule", value).ToString();
+
+        // Assert
+        Assert.Equal($"?{expected}", query);
+    }
+
+    /// <summary>
+    /// A filter nobody named is left out rather than sent empty, so the deployment reads it as every account it serves
+    /// rather than as one more shape to have an opinion about.
+    /// </summary>
+    [Fact]
+    public void Add_ValuesTheOperatorLeftOut_AreNotInTheQueryString()
+    {
+        // Act
+        var query = new AdminQueryString()
+            .Add("account", (string?)null)
+            .Add("stage", string.Empty)
+            .Add("pageSize", (int?)null)
+            .Add("email", (Guid?)null)
+            .Add("cursor", "b3V0Ym94LTE")
+            .ToString();
+
+        // Assert
+        Assert.Equal("?cursor=b3V0Ym94LTE", query);
+    }
+
+    /// <summary>An identifier reaches every administrative route in the hyphenated form, whatever a machine's own formatting would be.</summary>
+    [Fact]
+    public void Add_AnIdentifier_IsWrittenHyphenatedAndInvariantly()
+    {
+        // Arrange
+        var email = new Guid("8a1d4f2e-6c3b-4a91-9f77-2b5e0d1c4a63");
+
+        // Act
+        var query = new AdminQueryString().Add("email", email).ToString();
+
+        // Assert
+        Assert.Equal("?email=8a1d4f2e-6c3b-4a91-9f77-2b5e0d1c4a63", query);
+    }
+
+    /// <summary>A count is written invariantly, so a machine whose locale groups digits does not send a size the endpoint cannot read.</summary>
+    [Fact]
+    public void Add_ACount_IsWrittenInvariantly()
+    {
+        // Act
+        var query = new AdminQueryString().Add("pageSize", 22_500).ToString();
+
+        // Assert
+        Assert.Equal("?pageSize=22500", query);
+    }
+}

--- a/tests/Cli.UnitTests/CliConfirmationTests.cs
+++ b/tests/Cli.UnitTests/CliConfirmationTests.cs
@@ -1,0 +1,87 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics;
+using MailFathom.Cli.Credentials;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers the one rule every command that does something irreversible asks its question under.</summary>
+/// <remarks>
+/// Asserted here as well as through each command, because this is now the only place the rule is written: a command
+/// asking without the flag, an unattended invocation refused rather than guessed at, and an answered question honoured
+/// either way. What each command still owns is the sentence it refuses with and the question it puts.
+/// </remarks>
+public sealed class CliConfirmationTests
+{
+    private const string UnattendedRefusal =
+        "There is nobody at the terminal to agree to this, and erasing a contact cannot be undone. Pass --yes to erase without being asked.";
+
+    private const string Question = "Erase that contact and everything derived from it? [y/N] ";
+
+    private readonly RecordingCliConsole console = new();
+
+    /// <summary>The flag is an operator stating the agreement in the command, so nothing is asked and nobody is needed.</summary>
+    [Fact]
+    public void Agreed_TheAgreementStatedInTheCommand_AsksNothing()
+    {
+        // Arrange
+        this.console.AnswersQuestions = false;
+
+        // Act
+        var agreed = CliConfirmation.Agreed(this.Context(), confirmedUpFront: true, UnattendedRefusal, Question);
+
+        // Assert
+        Assert.True(agreed);
+        Assert.Empty(this.console.Questions);
+    }
+
+    /// <summary>
+    /// A redirected input has nobody to ask, and reading the answer out of whatever was piped in would turn a stray
+    /// line into an agreement to erase somebody. Such an invocation is told to pass the flag instead.
+    /// </summary>
+    [Fact]
+    public void Agreed_NobodyAtTheTerminalAndNoFlag_RefusesWithTheCommandsOwnSentence()
+    {
+        // Arrange
+        this.console.AnswersQuestions = false;
+        this.console.AnswerToGive = true;
+
+        // Act
+        var failure = Assert.Throws<CliFailure>(
+            () => CliConfirmation.Agreed(this.Context(), confirmedUpFront: false, UnattendedRefusal, Question));
+
+        // Assert
+        Assert.Equal(UnattendedRefusal, failure.Message);
+        Assert.Empty(this.console.Questions);
+    }
+
+    /// <summary>Somebody is at the terminal, so the answer is theirs — including the one that stops the command.</summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Agreed_SomebodyAtTheTerminal_IsWhateverTheyAnswered(bool answer)
+    {
+        // Arrange
+        this.console.AnswerToGive = answer;
+
+        // Act
+        var agreed = CliConfirmation.Agreed(this.Context(), confirmedUpFront: false, UnattendedRefusal, Question);
+
+        // Assert
+        Assert.Equal(answer, agreed);
+        Assert.Equal([Question], this.console.Questions);
+    }
+
+    /// <summary>The terminal is the only thing the rule reaches, and nothing here opens a store, a transport, or a browser.</summary>
+    private CliContext Context() => new(
+        this.console,
+        new CredentialStore("credentials.json", new TokenProtector("credentials.key")),
+        (_, _) => throw new UnreachableException("A confirmation reaches no deployment."),
+        _ => throw new UnreachableException("A confirmation awaits no redirect."),
+        _ => throw new UnreachableException("A confirmation opens no browser."),
+        new FakeTimeProvider(new DateTimeOffset(2026, 8, 20, 12, 0, 0, TimeSpan.Zero)));
+}

--- a/tests/Cli.UnitTests/CliEndpointVariableTests.cs
+++ b/tests/Cli.UnitTests/CliEndpointVariableTests.cs
@@ -1,0 +1,116 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Cli.Credentials;
+using MailFathom.TestSupport;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace MailFathom.Cli.UnitTests;
+
+/// <summary>Covers the order that decides which deployment a command sends its credential to.</summary>
+/// <remarks>
+/// Asserted against a stated value of the variable rather than against the process environment, which every other test
+/// in this assembly shares and any of them could be reading while these run. That is the whole reason the variable
+/// reaches the command through <see cref="CliContext.Variable" />: a developer who exported
+/// <c>MAILFATHOM_ENDPOINT</c> for their own shell would otherwise have these tests resolve a deployment nobody asked
+/// for, and the failure would be theirs alone to reproduce.
+/// </remarks>
+public sealed class CliEndpointVariableTests : IDisposable
+{
+    private const string SignedInProfileName = "production";
+
+    private const string QuietDeployment = """
+        {"synchronizationEnabled": false, "accounts": []}
+        """;
+
+    private static readonly Uri EndpointAddress = new("https://mail.example.test:8443");
+
+    private readonly string storeDirectory =
+        Path.Combine(Path.GetTempPath(), $"mailfathom-endpoint-variable-tests-{Guid.NewGuid():N}");
+
+    private readonly RecordingCliConsole console = new();
+
+    private readonly FakeTimeProvider clock = new(new DateTimeOffset(2026, 8, 20, 12, 0, 0, TimeSpan.Zero));
+
+    /// <summary>A shell that stated the deployment once for a session is what a command with no option acts on.</summary>
+    [Fact]
+    public async Task Command_AShellThatNamedADeployment_ActsOnWhatTheShellWasTold()
+    {
+        // Arrange
+        using var deployment = FakeMailboxDeployment.Answering(QuietDeployment);
+
+        // Act: the name is one the store does not hold, so what the command resolved is in the refusal.
+        var exitCode = await this.RunAsync(deployment, "staging", "mailbox", "status");
+
+        // Assert
+        Assert.Equal(CliExitCode.Failure, exitCode);
+        Assert.Contains(this.console.Errors, line => line.Contains("staging", StringComparison.Ordinal));
+    }
+
+    /// <summary>What an operator typed beats what their shell was told, which is the order every other input here follows.</summary>
+    [Fact]
+    public async Task Command_AnEndpointOnTheCommandLine_BeatsWhatTheShellWasTold()
+    {
+        // Arrange
+        using var deployment = FakeMailboxDeployment.Answering(QuietDeployment);
+
+        // Act
+        var exitCode = await this.RunAsync(
+            deployment,
+            "staging",
+            "mailbox",
+            "status",
+            "--endpoint",
+            SignedInProfileName);
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Empty(this.console.Failures);
+    }
+
+    /// <summary>A shell that said nothing leaves the profile the operator last switched to, which the store settles.</summary>
+    [Fact]
+    public async Task Command_AShellThatNamedNothing_ActsOnTheStoredDefault()
+    {
+        // Arrange
+        using var deployment = FakeMailboxDeployment.Answering(QuietDeployment);
+
+        // Act
+        var exitCode = await this.RunAsync(deployment, endpointVariable: null, "mailbox", "status");
+
+        // Assert
+        Assert.Equal(CliExitCode.Success, exitCode);
+        Assert.Empty(this.console.Failures);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(this.storeDirectory))
+        {
+            Directory.Delete(this.storeDirectory, recursive: true);
+        }
+    }
+
+    private Task<int> RunAsync(FakeHttpMessageHandler deployment, string? endpointVariable, params string[] args)
+    {
+        var store = new CredentialStore(
+            Path.Combine(this.storeDirectory, "credentials.json"),
+            new TokenProtector(Path.Combine(this.storeDirectory, "credentials.key")));
+
+        store.Save(SignedInProfileName, EndpointAddress, "not-a-real-key", "workstation");
+
+        var context = new CliContext(
+            this.console,
+            store,
+            (endpoint, trust) => FakeDeploymentTransport.Over(deployment, endpoint, trust),
+            FakeMailboxRedirect.Silent(),
+            _ => false,
+            this.clock,
+            Log: null,
+            name => name == CliOptions.EndpointVariable ? endpointVariable : null);
+
+        return CliRunner.RunAsync(context, args);
+    }
+}

--- a/tests/Cli.UnitTests/CliOptionsTests.cs
+++ b/tests/Cli.UnitTests/CliOptionsTests.cs
@@ -16,15 +16,25 @@ public sealed class CliOptionsTests
     [Fact]
     public void RequestedDeployment_AValueOnTheCommandLine_IsWhatTheCommandActsOn()
     {
-        // Act, Assert
-        Assert.Equal("production", CliOptions.RequestedDeployment("production"));
+        // Act, Assert: what an operator typed beats what their shell was told.
+        Assert.Equal("production", CliOptions.RequestedDeployment("production", "staging"));
     }
 
     [Fact]
     public void RequestedDeployment_SurroundingWhitespace_IsNotPartOfTheName()
     {
         // Act, Assert: a value pasted from a terminal or a script arrives with whatever was around it.
-        Assert.Equal("production", CliOptions.RequestedDeployment("  production  "));
+        Assert.Equal("production", CliOptions.RequestedDeployment("  production  ", endpointVariable: null));
+    }
+
+    /// <summary>The variable is the shell stating it once for a session, and it beats the stored default.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void RequestedDeployment_NothingOnTheCommandLine_IsWhatTheShellWasTold(string? configuredEndpoint)
+    {
+        // Act, Assert
+        Assert.Equal("staging", CliOptions.RequestedDeployment(configuredEndpoint, "  staging  "));
     }
 
     /// <summary>Nothing named means the profile the operator last switched to, which the store settles rather than this.</summary>
@@ -32,7 +42,7 @@ public sealed class CliOptionsTests
     public void RequestedDeployment_NothingAnywhere_NamesNoDeployment()
     {
         // Act, Assert
-        Assert.Null(CliOptions.RequestedDeployment(configuredEndpoint: null));
+        Assert.Null(CliOptions.RequestedDeployment(configuredEndpoint: null, endpointVariable: null));
     }
 
     [Theory]
@@ -103,5 +113,60 @@ public sealed class CliOptionsTests
         // Assert
         Assert.False(option.Required);
         Assert.False(option.HasDefaultValue);
+    }
+
+    /// <summary>
+    /// An absent size is the deployment's own default rather than a number this tool keeps in step with it, so the
+    /// option carries none of its own — and the listing that omits it asks for whatever the endpoint serves.
+    /// </summary>
+    [Fact]
+    public void PageSize_Always_IsOptionalAndDefaultsToNothing()
+    {
+        // Act
+        var option = CliOptions.PageSize("contacts");
+
+        // Assert
+        Assert.False(option.Required);
+        Assert.False(option.HasDefaultValue);
+    }
+
+    /// <summary>The noun is the whole of what differs between the listings, which is what makes one factory serve all five.</summary>
+    [Fact]
+    public void PageSize_ANounOfTheListing_IsWhatTheDescriptionCounts()
+    {
+        // Act
+        var option = CliOptions.PageSize("classifications");
+
+        // Assert
+        Assert.Equal("How many classifications to read. Defaults to what the deployment serves.", option.Description);
+    }
+
+    /// <summary>A cursor is handed back unread, so nothing is assumed about a walk nobody started.</summary>
+    [Fact]
+    public void Cursor_Always_IsOptionalAndDefaultsToNothing()
+    {
+        // Act
+        var option = CliOptions.Cursor();
+
+        // Assert
+        Assert.False(option.Required);
+        Assert.False(option.HasDefaultValue);
+    }
+
+    /// <summary>
+    /// The prompt is the default and the flag is the exception, so nothing about it is required. The short form is
+    /// part of the contract rather than a convenience: it is what the four commands were each declaring by hand, and
+    /// one copy dropping it would leave <c>-y</c> working on three of them.
+    /// </summary>
+    [Fact]
+    public void Confirmed_Always_IsOptionalAndAcceptsTheShortForm()
+    {
+        // Act
+        var option = CliOptions.Confirmed("erasure");
+
+        // Assert
+        Assert.False(option.Required);
+        Assert.Contains("-y", option.Aliases);
+        Assert.Equal("Agree to the erasure without being asked, which is what a scripted run needs.", option.Description);
     }
 }


### PR DESCRIPTION
Five families of `mfctl` boilerplate, each written again by each concurrent command family rather than added to the place that already existed for it. Four of them are folded here; the fifth — a `CliContext.ConnectAsync` returning a disposable connection — stays out of scope by the issue's own reading, because it is a 33-file edit for one line per command.

## What moved

**`src/Cli/Administration/AdminQueryString.cs`** composes every narrowed administrative request. One `Add` overload per value shape — `string?`, `int?`, `Guid?` — each leaving out a filter the caller named nothing for, and a `ToString()` returning an empty string for no filters and `?a=1&b=2` otherwise. The four query records (`MailRuleHistoryQuery`, `SpamClassificationQuery`, `DeadLetteredJobQuery`, `OutboxQuery`) each become four or five `Add` calls, and `AdminApiClient`'s three hand-written composers — `AccountQuery`, `ScopeQuery`, `ContactPageQuery` — fold in at their call sites. The remark four of the five carried, claiming each was the one place an escaping decision was taken, is now true of the one place that takes it.

The two apparent return shapes turn out to be one. `MailRuleHistoryQuery` and `SpamClassificationQuery` seeded their list with a required `account=` and so returned unconditionally; both now return the empty string when every filter is absent. That is reachable only through `--account ""`, and `MailRuleEndpoints.ResolveAccount` reads an absent and an empty account identically through `string.IsNullOrWhiteSpace`, so the deployment answers `400` either way.

**`CliOptions`** gains `Cursor()`, `PageSize(string noun)` and `Confirmed(string description)` beside the six factories already there. Fourteen inline declarations across five concurrent families — contacts (#905), jobs (#814), outbox (#995), rules (#728), spam (#795) — are replaced. The five `--cursor` and five `--page-size` descriptions come through byte-identical; the four `--yes` descriptions close on `which is what a scripted run needs` instead of naming the act, which is the one string this change alters.

**`src/Cli/CliConfirmation.cs`** holds `Agreed(CliContext, bool confirmedUpFront, string unattendedRefusal, string question)` — the flag states the agreement, an invocation with nobody at the terminal is refused rather than guessed at, everything else is asked. The four private copies of that body are gone. `DeleteContactCommand` and `DeleteCollectedContactsCommand` call it at the site; `ActivateEmbeddingCommand` and `RewindMailboxCommand` keep a private method that is no longer a copy of the rule — the first builds its refusal from the assessment's own cost, the second carries the recorded decision about why a scope counting no mail is asked about like any other.

**`CliOptions.RequestedDeployment`** takes the variable as a second parameter, passed as `context.Variable(CliOptions.EndpointVariable)` from each of the 39 `SetAction` bodies, matching `RecordsInvocation(ParseResult, string?)` directly above it. `CliContext.Variable` exists behind a doc comment saying it is a seam because the process environment is shared by every test in a parallel assembly; it is now the only path to that environment for the endpoint, so a developer who exports `MAILFATHOM_ENDPOINT` no longer has CLI command tests resolve a deployment nobody asked for.

## Tests

`AdminQueryStringTests` covers the composition, the omissions, and the escaping — asserted against a rule name with a space, one with `&` and `=` in it, and one outside ASCII, rather than against a bare word. `CliConfirmationTests` covers the three outcomes of the shared rule directly. `CliEndpointVariableTests` drives a command end to end and proves the seam is the path taken: a shell-stated deployment the store does not hold reaches the refusal, an `--endpoint` on the command line beats it, and a shell that said nothing leaves the stored default. `CliOptionsTests` covers the new factories and the two-parameter precedence.

Golden output is unchanged: 473 tests in `Cli.UnitTests`, 10,222 across the suite.

## Compatibility

No break to the MCP tool contract, the configuration schema, the database schema, or the deployment contract. The only operator-visible drift is the `--yes` help line, and no documentation page states it — every page describing the flag describes its behaviour, which is unchanged.

Closes #1023
