### PR TITLE
[#1024] Fold the Domain value objects two branches wrote twice, and guard the requester identity that was left unguarded

### DIFF
--- a/src/Application/Digests/CanonicalDigest.cs
+++ b/src/Application/Digests/CanonicalDigest.cs
@@ -1,0 +1,62 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MailFathom.Application.Digests;
+
+/// <summary>Writes the one-to-one encoding every value object in this system hashes over, and reads a digest back.</summary>
+/// <remarks>
+/// <para>
+/// Three value objects derive an identity from configuration or content, and each of them depends on the same property:
+/// that two different sets of values cannot produce one byte sequence. Length-prefixing every text field and writing
+/// every number big-endian is what buys it — without the prefix, a pair of fields could be re-cut into a different pair
+/// writing the same bytes, and without a fixed byte order the digest would depend on the machine that computed it.
+/// </para>
+/// <para>
+/// What stays with each value object is everything that decides what its digest <em>means</em>: its own hash domain, its
+/// own field order, its own <c>IncrementalHash</c>, and its own refusal message. This holds only how a field is written,
+/// so the three cannot drift apart on the encoding while remaining free to disagree on the contents.
+/// </para>
+/// </remarks>
+internal static class CanonicalDigest
+{
+    /// <summary>Answers whether stored text is a digest of the expected length in the form this system writes.</summary>
+    /// <param name="value">The text a stored row carries.</param>
+    /// <param name="length">The number of characters the digest occupies.</param>
+    /// <returns><see langword="true" /> when the value is exactly that many lowercase hexadecimal characters.</returns>
+    /// <remarks>
+    /// Upper case is refused rather than accepted and lowered, because a digest read back is compared against one
+    /// computed here and the computation writes lower case. Accepting both forms would let one value be stored under two
+    /// spellings that a unique index reads as two rows.
+    /// </remarks>
+    public static bool IsHexadecimalDigest(string value, int length) =>
+        value.Length == length && value.All(IsLowercaseHexadecimal);
+
+    /// <summary>Writes a number into the digest in a byte order that does not depend on the machine.</summary>
+    /// <param name="digest">The digest being accumulated.</param>
+    /// <param name="value">The number to write.</param>
+    public static void AppendNumber(IncrementalHash digest, int value)
+    {
+        Span<byte> encoded = stackalloc byte[sizeof(int)];
+        BinaryPrimitives.WriteInt32BigEndian(encoded, value);
+        digest.AppendData(encoded);
+    }
+
+    /// <summary>Writes text into the digest, preceded by the length that makes the encoding one-to-one.</summary>
+    /// <param name="digest">The digest being accumulated.</param>
+    /// <param name="value">The text to write.</param>
+    public static void AppendText(IncrementalHash digest, string value)
+    {
+        var encoded = Encoding.UTF8.GetBytes(value);
+
+        AppendNumber(digest, encoded.Length);
+        digest.AppendData(encoded);
+    }
+
+    private static bool IsLowercaseHexadecimal(char character) =>
+        character is >= '0' and <= '9' or >= 'a' and <= 'f';
+}

--- a/src/Application/Emails/Chunking/EmailChunkContentHash.cs
+++ b/src/Application/Emails/Chunking/EmailChunkContentHash.cs
@@ -2,9 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Binary;
 using System.Security.Cryptography;
-using System.Text;
+using MailFathom.Application.Digests;
 
 namespace MailFathom.Application.Emails.Chunking;
 
@@ -60,21 +59,21 @@ public readonly record struct EmailChunkContentHash
 
         using var digest = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
 
-        AppendText(digest, HashDomain);
-        AppendNumber(digest, rules.RuleSetVersion);
-        AppendNumber(digest, rules.TargetCharacterCount);
-        AppendNumber(digest, rules.MinimumCharacterCount);
-        AppendNumber(digest, rules.OverlapCharacterCount);
-        AppendNumber(digest, (int)rules.SourceForm);
-        AppendNumber(digest, isDerivedFromLossyHtml ? 1 : 0);
-        AppendNumber(digest, rules.BoundarySeparators.Count);
+        CanonicalDigest.AppendText(digest, HashDomain);
+        CanonicalDigest.AppendNumber(digest, rules.RuleSetVersion);
+        CanonicalDigest.AppendNumber(digest, rules.TargetCharacterCount);
+        CanonicalDigest.AppendNumber(digest, rules.MinimumCharacterCount);
+        CanonicalDigest.AppendNumber(digest, rules.OverlapCharacterCount);
+        CanonicalDigest.AppendNumber(digest, (int)rules.SourceForm);
+        CanonicalDigest.AppendNumber(digest, isDerivedFromLossyHtml ? 1 : 0);
+        CanonicalDigest.AppendNumber(digest, rules.BoundarySeparators.Count);
 
         foreach (var separator in rules.BoundarySeparators)
         {
-            AppendText(digest, separator);
+            CanonicalDigest.AppendText(digest, separator);
         }
 
-        AppendText(digest, text);
+        CanonicalDigest.AppendText(digest, text);
 
         return new EmailChunkContentHash(Convert.ToHexStringLower(digest.GetHashAndReset()));
     }
@@ -88,7 +87,7 @@ public readonly record struct EmailChunkContentHash
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        if (value.Length != Length || !value.All(IsLowercaseHexadecimal))
+        if (!CanonicalDigest.IsHexadecimalDigest(value, Length))
         {
             throw new ArgumentException(
                 $"A chunk content hash is {Length} lowercase hexadecimal characters.",
@@ -100,22 +99,4 @@ public readonly record struct EmailChunkContentHash
 
     /// <inheritdoc />
     public override string ToString() => this.Value;
-
-    private static bool IsLowercaseHexadecimal(char character) =>
-        character is >= '0' and <= '9' or >= 'a' and <= 'f';
-
-    private static void AppendNumber(IncrementalHash digest, int value)
-    {
-        Span<byte> encoded = stackalloc byte[sizeof(int)];
-        BinaryPrimitives.WriteInt32BigEndian(encoded, value);
-        digest.AppendData(encoded);
-    }
-
-    private static void AppendText(IncrementalHash digest, string value)
-    {
-        var encoded = Encoding.UTF8.GetBytes(value);
-
-        AppendNumber(digest, encoded.Length);
-        digest.AppendData(encoded);
-    }
 }

--- a/src/Application/Emails/Embeddings/EmbeddingProfileFingerprint.cs
+++ b/src/Application/Emails/Embeddings/EmbeddingProfileFingerprint.cs
@@ -2,9 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Binary;
 using System.Security.Cryptography;
-using System.Text;
+using MailFathom.Application.Digests;
 
 namespace MailFathom.Application.Emails.Embeddings;
 
@@ -56,15 +55,15 @@ public readonly record struct EmbeddingProfileFingerprint
 
         using var digest = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
 
-        AppendText(digest, HashDomain);
-        AppendText(digest, identity.Provider);
-        AppendText(digest, identity.ModelIdentifier);
+        CanonicalDigest.AppendText(digest, HashDomain);
+        CanonicalDigest.AppendText(digest, identity.Provider);
+        CanonicalDigest.AppendText(digest, identity.ModelIdentifier);
         AppendOptionalText(digest, identity.ModelVersion);
-        AppendNumber(digest, identity.Dimension);
-        AppendNumber(digest, (int)identity.DistanceMetric);
-        AppendNumber(digest, preparation.InputCharacterLimit);
+        CanonicalDigest.AppendNumber(digest, identity.Dimension);
+        CanonicalDigest.AppendNumber(digest, (int)identity.DistanceMetric);
+        CanonicalDigest.AppendNumber(digest, preparation.InputCharacterLimit);
         AppendOptionalText(digest, preparation.PassageInstruction);
-        AppendNumber(digest, preparation.NormalizesVector ? 1 : 0);
+        CanonicalDigest.AppendNumber(digest, preparation.NormalizesVector ? 1 : 0);
 
         return new EmbeddingProfileFingerprint(Convert.ToHexStringLower(digest.GetHashAndReset()));
     }
@@ -78,7 +77,7 @@ public readonly record struct EmbeddingProfileFingerprint
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        if (value.Length != Length || !value.All(IsLowercaseHexadecimal))
+        if (!CanonicalDigest.IsHexadecimalDigest(value, Length))
         {
             throw new ArgumentException(
                 $"An embedding profile fingerprint is {Length} lowercase hexadecimal characters.",
@@ -91,31 +90,14 @@ public readonly record struct EmbeddingProfileFingerprint
     /// <inheritdoc />
     public override string ToString() => this.Value;
 
-    private static bool IsLowercaseHexadecimal(char character) =>
-        character is >= '0' and <= '9' or >= 'a' and <= 'f';
-
-    private static void AppendNumber(IncrementalHash digest, int value)
-    {
-        Span<byte> encoded = stackalloc byte[sizeof(int)];
-        BinaryPrimitives.WriteInt32BigEndian(encoded, value);
-        digest.AppendData(encoded);
-    }
-
-    private static void AppendText(IncrementalHash digest, string value)
-    {
-        var encoded = Encoding.UTF8.GetBytes(value);
-
-        AppendNumber(digest, encoded.Length);
-        digest.AppendData(encoded);
-    }
-
+    /// <summary>Writes an optional field as a presence marker followed by the value, so absence is not a shorter value.</summary>
     private static void AppendOptionalText(IncrementalHash digest, string? value)
     {
-        AppendNumber(digest, value is null ? 0 : 1);
+        CanonicalDigest.AppendNumber(digest, value is null ? 0 : 1);
 
         if (value is not null)
         {
-            AppendText(digest, value);
+            CanonicalDigest.AppendText(digest, value);
         }
     }
 }

--- a/src/Application/Mail/Delivery/Filing/OutgoingMailFiler.cs
+++ b/src/Application/Mail/Delivery/Filing/OutgoingMailFiler.cs
@@ -366,7 +366,7 @@ public sealed class OutgoingMailFiler
         var resolution = await this.ResolveDestinationAsync(record, standing.Filing, cancellationToken);
 
         if (resolution.Destination is not { } destination
-            || !string.Equals(destination.Path.Value, standing.FolderPath.Value, StringComparison.Ordinal))
+            || !destination.Path.NamesSameFolderAs(standing.FolderPath))
         {
             return;
         }

--- a/src/Application/SensitiveContent/Derivation/SensitiveContentDerivationStamp.cs
+++ b/src/Application/SensitiveContent/Derivation/SensitiveContentDerivationStamp.cs
@@ -2,9 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Binary;
 using System.Security.Cryptography;
-using System.Text;
+using MailFathom.Application.Digests;
 using MailFathom.Application.SensitiveContent.Detection;
 
 namespace MailFathom.Application.SensitiveContent.Derivation;
@@ -69,18 +68,18 @@ public readonly record struct SensitiveContentDerivationStamp
 
         using var digest = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
 
-        AppendText(digest, HashDomain);
-        AppendNumber(digest, plan.Bounds.MaximumAnalyzedCharacters);
-        AppendNumber(digest, plan.Scanners.Count);
+        CanonicalDigest.AppendText(digest, HashDomain);
+        CanonicalDigest.AppendNumber(digest, plan.Bounds.MaximumAnalyzedCharacters);
+        CanonicalDigest.AppendNumber(digest, plan.Scanners.Count);
 
         foreach (var scannerPlan in plan.Scanners)
         {
             var detector = registered.FirstOrDefault(candidate => candidate.Scanner == scannerPlan.Scanner)?.Detector
                 ?? throw SensitiveContentScannerUnavailableException.NotRegistered(scannerPlan.Scanner);
 
-            AppendNumber(digest, (int)scannerPlan.Scanner);
-            AppendText(digest, detector.Name);
-            AppendText(digest, detector.Revision);
+            CanonicalDigest.AppendNumber(digest, (int)scannerPlan.Scanner);
+            CanonicalDigest.AppendText(digest, detector.Name);
+            CanonicalDigest.AppendText(digest, detector.Revision);
             AppendNames(digest, [.. scannerPlan.Categories.Select(category => category.Name)]);
             AppendNames(digest, [.. scannerPlan.SuppressedRules.Select(rule => rule.ToString())]);
         }
@@ -97,7 +96,7 @@ public readonly record struct SensitiveContentDerivationStamp
     {
         ArgumentNullException.ThrowIfNull(value);
 
-        if (value.Length != Length || !value.All(IsLowercaseHexadecimal))
+        if (!CanonicalDigest.IsHexadecimalDigest(value, Length))
         {
             throw new ArgumentException(
                 $"A sensitive-content derivation stamp is {Length} lowercase hexadecimal characters.",
@@ -110,31 +109,14 @@ public readonly record struct SensitiveContentDerivationStamp
     /// <inheritdoc />
     public override string ToString() => this.Value;
 
-    private static bool IsLowercaseHexadecimal(char character) =>
-        character is >= '0' and <= '9' or >= 'a' and <= 'f';
-
+    /// <summary>Writes a set of names in a fixed order, so two deployments that listed them differently write one stamp.</summary>
     private static void AppendNames(IncrementalHash digest, string[] names)
     {
-        AppendNumber(digest, names.Length);
+        CanonicalDigest.AppendNumber(digest, names.Length);
 
         foreach (var name in names.Order(StringComparer.Ordinal))
         {
-            AppendText(digest, name);
+            CanonicalDigest.AppendText(digest, name);
         }
-    }
-
-    private static void AppendNumber(IncrementalHash digest, int value)
-    {
-        Span<byte> encoded = stackalloc byte[sizeof(int)];
-        BinaryPrimitives.WriteInt32BigEndian(encoded, value);
-        digest.AppendData(encoded);
-    }
-
-    private static void AppendText(IncrementalHash digest, string value)
-    {
-        var encoded = Encoding.UTF8.GetBytes(value);
-
-        AppendNumber(digest, encoded.Length);
-        digest.AppendData(encoded);
     }
 }

--- a/src/Domain/Contacts/Collection/AutomatedMailboxName.cs
+++ b/src/Domain/Contacts/Collection/AutomatedMailboxName.cs
@@ -98,11 +98,7 @@ public static class AutomatedMailboxName
     }
 
     /// <summary>Reads the comparison form of what precedes the address's last at-sign.</summary>
-    /// <remarks>The last one, because a quoted local part may contain an at-sign of its own and every split of an address in this system is made there.</remarks>
-    private static string LocalPartOf(EmailAddress address)
-    {
-        var separatorIndex = address.NormalizedAddress.LastIndexOf('@');
-
-        return separatorIndex <= 0 ? string.Empty : address.NormalizedAddress[..separatorIndex];
-    }
+    /// <remarks>The domain half is not read at all here, because what a name says about a mailbox is said by its local part.</remarks>
+    private static string LocalPartOf(EmailAddress address) =>
+        address.TrySplit(out var localPart, out _) ? localPart : string.Empty;
 }

--- a/src/Domain/Delivery/Drafts/MailDraftServerCopy.cs
+++ b/src/Domain/Delivery/Drafts/MailDraftServerCopy.cs
@@ -85,5 +85,5 @@ public sealed record MailDraftServerCopy
     /// somebody else's mail.
     /// </remarks>
     public bool NamesFolder(RemoteFolderPath resolvedFolderPath) =>
-        string.Equals(this.FolderPath.Value, resolvedFolderPath.Value, StringComparison.Ordinal);
+        this.FolderPath.NamesSameFolderAs(resolvedFolderPath);
 }

--- a/src/Domain/Delivery/Filing/OutgoingMailFilingRecord.cs
+++ b/src/Domain/Delivery/Filing/OutgoingMailFilingRecord.cs
@@ -133,5 +133,5 @@ public sealed record OutgoingMailFilingRecord
     private bool IsJoinable => this.Stage == OutgoingMailFilingStage.Confirmed && this.ObservedAt is null;
 
     private bool NamesFolder(RemoteFolderPath discoveredFolderPath) =>
-        string.Equals(this.FolderPath.Value, discoveredFolderPath.Value, StringComparison.Ordinal);
+        this.FolderPath.NamesSameFolderAs(discoveredFolderPath);
 }

--- a/src/Domain/Delivery/Governance/OutgoingRecipientRule.cs
+++ b/src/Domain/Delivery/Governance/OutgoingRecipientRule.cs
@@ -76,7 +76,8 @@ public sealed record OutgoingRecipientRule
         rule = null;
 
         if (!EmailAddress.TryCreate(displayName: null, address, out var mailbox)
-            || !TrySplitMailbox(mailbox, out var localPart, out var domain))
+            || !mailbox.TrySplit(out var localPart, out var domainText)
+            || !SenderDomain.TryCreate(domainText.ToString(), out var domain))
         {
             return false;
         }
@@ -95,7 +96,8 @@ public sealed record OutgoingRecipientRule
     /// </remarks>
     public bool Matches(EmailAddress recipient)
     {
-        if (!TrySplitMailbox(recipient, out var localPart, out var domain))
+        if (!recipient.TrySplit(out var localPart, out var domainText)
+            || !SenderDomain.TryCreate(domainText.ToString(), out var domain))
         {
             return false;
         }
@@ -106,27 +108,5 @@ public sealed record OutgoingRecipientRule
         }
 
         return domain == this.Domain || domain.IsSubdomainOf(this.Domain);
-    }
-
-    /// <summary>Splits a mailbox into the two halves that are compared separately.</summary>
-    /// <remarks>
-    /// The local part takes the address's own comparison form and the domain takes the domain type's, because only the
-    /// domain has an encoding to settle.
-    /// </remarks>
-    private static bool TrySplitMailbox(EmailAddress mailbox, out string localPart, out SenderDomain domain)
-    {
-        localPart = string.Empty;
-        domain = default;
-
-        var separatorIndex = mailbox.Address.LastIndexOf('@');
-
-        if (separatorIndex <= 0 || !SenderDomain.TryCreate(mailbox.Address[(separatorIndex + 1)..], out domain))
-        {
-            return false;
-        }
-
-        localPart = mailbox.Address[..separatorIndex].ToUpperInvariant();
-
-        return true;
     }
 }

--- a/src/Domain/Emails/Authentication/SenderDomain.cs
+++ b/src/Domain/Emails/Authentication/SenderDomain.cs
@@ -87,14 +87,17 @@ public readonly record struct SenderDomain
     /// <remarks>
     /// RFC 8601 writes the SPF identity as <c>smtp.mailfrom</c>, whose value is a mailbox for an ordinary message and a
     /// bare domain for one whose envelope sender is empty. Both forms are accepted here, and the domain is what follows
-    /// the last at-sign because a quoted local part is allowed to contain one.
+    /// the last at-sign because a quoted local part is allowed to contain one. Text carrying an at-sign but no local
+    /// part is neither form, and it is refused rather than read as the domain that follows it: a mailbox missing a half
+    /// says the identity was written wrongly, which the not-established verdict already has a value for.
     /// </remarks>
     public static bool TryCreateFromMailbox(string? mailbox, out SenderDomain domain)
     {
         var trimmed = mailbox?.Trim() ?? string.Empty;
-        var separatorIndex = trimmed.LastIndexOf('@');
 
-        return TryCreate(separatorIndex < 0 ? trimmed : trimmed[(separatorIndex + 1)..], out domain);
+        return EmailAddress.TrySplit(trimmed, out _, out var domainText)
+            ? TryCreate(domainText.ToString(), out domain)
+            : TryCreate(trimmed, out domain);
     }
 
     /// <summary>Answers whether this domain lies beneath another one in the naming tree.</summary>

--- a/src/Domain/Emails/Authentication/TrustedSenderEntry.cs
+++ b/src/Domain/Emails/Authentication/TrustedSenderEntry.cs
@@ -77,7 +77,8 @@ public sealed record TrustedSenderEntry
         entry = null;
 
         if (!EmailAddress.TryCreate(displayName: null, address, out var mailbox)
-            || !TrySplitMailbox(mailbox, out var localPart, out var domain))
+            || !mailbox.TrySplit(out var localPart, out var domainText)
+            || !SenderDomain.TryCreate(domainText.ToString(), out var domain))
         {
             return false;
         }
@@ -117,7 +118,8 @@ public sealed record TrustedSenderEntry
 
         return authorDomain == this.Domain
             && displayedSender is { } sender
-            && TrySplitMailbox(sender, out var displayedLocalPart, out var displayedDomain)
+            && sender.TrySplit(out var displayedLocalPart, out var displayedDomainText)
+            && SenderDomain.TryCreate(displayedDomainText.ToString(), out var displayedDomain)
             && displayedDomain == this.Domain
             && string.Equals(displayedLocalPart, localPart, StringComparison.Ordinal);
     }
@@ -132,26 +134,4 @@ public sealed record TrustedSenderEntry
     public string ToPolicyStatement() => this.NormalizedLocalPart is { } localPart
         ? $"mailbox:{localPart}@{this.Domain.NormalizedValue}"
         : $"domain{(this.IncludesSubdomains ? "+sub" : string.Empty)}:{this.Domain.NormalizedValue}";
-
-    /// <summary>Splits a mailbox into the two halves that are compared separately.</summary>
-    /// <remarks>
-    /// The local part takes the address's own comparison form, and the domain takes the domain type's, because the two
-    /// halves normalize differently: only the domain has an encoding to settle.
-    /// </remarks>
-    private static bool TrySplitMailbox(EmailAddress mailbox, out string localPart, out SenderDomain domain)
-    {
-        localPart = string.Empty;
-        domain = default;
-
-        var separatorIndex = mailbox.Address.LastIndexOf('@');
-
-        if (separatorIndex <= 0 || !SenderDomain.TryCreate(mailbox.Address[(separatorIndex + 1)..], out domain))
-        {
-            return false;
-        }
-
-        localPart = mailbox.Address[..separatorIndex].ToUpperInvariant();
-
-        return true;
-    }
 }

--- a/src/Domain/Emails/EmailAddress.cs
+++ b/src/Domain/Emails/EmailAddress.cs
@@ -63,6 +63,62 @@ public readonly record struct EmailAddress
         return true;
     }
 
+    /// <summary>Splits an addr-spec into its two halves at the at-sign every split in this system is made at.</summary>
+    /// <param name="address">The addr-spec text to read, which may be anything a header carried.</param>
+    /// <param name="localPartText">What precedes the last at-sign, when the text names a mailbox.</param>
+    /// <param name="domainText">What follows it.</param>
+    /// <returns><see langword="true" /> when the text has both halves; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// The last at-sign, because a quoted local part is allowed to contain one. Both halves must be non-empty for the
+    /// text to name a mailbox at all, so text that is only a domain, only a local part, or a bare at-sign is refused
+    /// rather than handed back with an empty half every caller would have to check for. Neither half is validated here:
+    /// what a usable local part and a usable domain are belongs to the types that own those questions.
+    /// </remarks>
+    public static bool TrySplit(
+        ReadOnlySpan<char> address,
+        out ReadOnlySpan<char> localPartText,
+        out ReadOnlySpan<char> domainText)
+    {
+        var separatorIndex = address.LastIndexOf('@');
+
+        if (separatorIndex <= 0 || separatorIndex == address.Length - 1)
+        {
+            localPartText = default;
+            domainText = default;
+
+            return false;
+        }
+
+        localPartText = address[..separatorIndex];
+        domainText = address[(separatorIndex + 1)..];
+
+        return true;
+    }
+
+    /// <summary>Splits this address into the comparison form of its local part and the text of its domain.</summary>
+    /// <param name="normalizedLocalPart">The local part in the form <see cref="NormalizedAddress" /> is written in.</param>
+    /// <param name="domainText">The domain exactly as the message wrote it, which is the form a domain type normalizes from.</param>
+    /// <returns><see langword="true" /> when the address has both halves; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// The two halves are handed back in different forms because they normalize differently: the local part is compared
+    /// as text and takes this type's comparison form, while the domain has an encoding to settle and is left to the type
+    /// that settles it. Reading the domain from <see cref="Address" /> rather than from the comparison form is what
+    /// keeps a domain type's own record of what its source wrote intact.
+    /// </remarks>
+    public bool TrySplit(out string normalizedLocalPart, out ReadOnlySpan<char> domainText)
+    {
+        if (!TrySplit(this.Address, out var localPartText, out domainText))
+        {
+            normalizedLocalPart = string.Empty;
+
+            return false;
+        }
+
+        normalizedLocalPart = this.NormalizedAddress[..localPartText.Length];
+
+        return true;
+    }
+
     /// <summary>Compares two addresses by the form they were normalized to.</summary>
     /// <param name="other">The address to compare with.</param>
     /// <returns><see langword="true" /> when both name the same mailbox.</returns>
@@ -104,20 +160,16 @@ public readonly record struct EmailAddress
             return false;
         }
 
-        var domainSeparatorIndex = address.LastIndexOf('@');
-        if (domainSeparatorIndex <= 0 || domainSeparatorIndex == address.Length - 1)
+        if (!TrySplit(address, out var localPartText, out var domainText))
         {
             return false;
         }
 
-        var localPart = address[..domainSeparatorIndex];
-        var domain = address[(domainSeparatorIndex + 1)..];
-
-        return !domain.Any(char.IsWhiteSpace) && IsUsableLocalPart(localPart);
+        return !ContainsWhiteSpace(domainText) && IsUsableLocalPart(localPartText);
     }
 
     /// <summary>Accepts a local part that is either an ordinary token or a quoted string.</summary>
-    private static bool IsUsableLocalPart(string localPart)
+    private static bool IsUsableLocalPart(ReadOnlySpan<char> localPart)
     {
         var isQuoted = localPart.Length > 1
             && localPart[0] == '"'
@@ -125,7 +177,25 @@ public readonly record struct EmailAddress
 
         return isQuoted
             ? localPart.Length > 2
-            : !localPart.Any(char.IsWhiteSpace) && !localPart.Contains('@', StringComparison.Ordinal);
+            : !ContainsWhiteSpace(localPart) && !localPart.Contains('@');
+    }
+
+    /// <summary>Reports whether a half of an address carries whitespace, which neither unquoted half may.</summary>
+    /// <remarks>
+    /// Written as a walk rather than as a query, because the halves are spans cut out of the address and materializing
+    /// either of them to ask this question would allocate a string on the path every parsed address takes.
+    /// </remarks>
+    private static bool ContainsWhiteSpace(ReadOnlySpan<char> text)
+    {
+        foreach (var character in text)
+        {
+            if (char.IsWhiteSpace(character))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>Keeps a display name readable and refuses to let one span lines it never spanned.</summary>

--- a/src/Domain/Emails/EmailAddress.cs
+++ b/src/Domain/Emails/EmailAddress.cs
@@ -100,21 +100,31 @@ public readonly record struct EmailAddress
     /// <param name="domainText">The domain exactly as the message wrote it, which is the form a domain type normalizes from.</param>
     /// <returns><see langword="true" /> when the address has both halves; otherwise <see langword="false" />.</returns>
     /// <remarks>
+    /// <para>
     /// The two halves are handed back in different forms because they normalize differently: the local part is compared
     /// as text and takes this type's comparison form, while the domain has an encoding to settle and is left to the type
     /// that settles it. Reading the domain from <see cref="Address" /> rather than from the comparison form is what
     /// keeps a domain type's own record of what its source wrote intact.
+    /// </para>
+    /// <para>
+    /// Each form is cut at its own at-sign rather than at an offset carried from the other. A case mapping is not
+    /// obliged to produce one character per character, so an offset taken from the written address would cut the
+    /// comparison form of a local part that expanded — handing back a truncated prefix that a shorter, unrelated
+    /// mailbox could also produce, in a value sender trust and recipient governance then compare on.
+    /// </para>
     /// </remarks>
     public bool TrySplit(out string normalizedLocalPart, out ReadOnlySpan<char> domainText)
     {
-        if (!TrySplit(this.Address, out var localPartText, out domainText))
+        if (!TrySplit(this.Address, out _, out domainText)
+            || !TrySplit(this.NormalizedAddress, out var normalizedLocalPartText, out _))
         {
             normalizedLocalPart = string.Empty;
+            domainText = default;
 
             return false;
         }
 
-        normalizedLocalPart = this.NormalizedAddress[..localPartText.Length];
+        normalizedLocalPart = normalizedLocalPartText.ToString();
 
         return true;
     }

--- a/src/Domain/Folders/RemoteFolderPath.cs
+++ b/src/Domain/Folders/RemoteFolderPath.cs
@@ -90,6 +90,20 @@ public readonly record struct RemoteFolderPath
         }
     }
 
+    /// <summary>Answers whether two paths name the same folder on the server.</summary>
+    /// <param name="other">The path to compare with.</param>
+    /// <returns><see langword="true" /> when both name one folder.</returns>
+    /// <remarks>
+    /// The comparison is the advertised text alone, which is not what this type's own equality answers: a value also
+    /// carries the hierarchy delimiter the server reported, and two records of one folder can disagree about it when one
+    /// was written before the server reported a delimiter and the other after. That disagreement is a real distinction
+    /// where a resolution is being rebound, which is why equality keeps it, and no distinction at all where the question
+    /// is whether a discovered message landed in the folder a record names. This is the second question, asked in one
+    /// place instead of at every call site that would otherwise reach past the type into <see cref="Value" />.
+    /// </remarks>
+    public bool NamesSameFolderAs(RemoteFolderPath other) =>
+        string.Equals(this.Value, other.Value, StringComparison.Ordinal);
+
     /// <summary>Splits the path into its hierarchy levels.</summary>
     /// <returns>Every level in order, or the whole path as a single level when the server reported no delimiter.</returns>
     public IReadOnlyList<string> ToHierarchyLevels() =>

--- a/src/Domain/Mutations/MailboxMutationRecord.cs
+++ b/src/Domain/Mutations/MailboxMutationRecord.cs
@@ -193,7 +193,7 @@ public sealed record MailboxMutationRecord
         && this.PlacementObservedAt is null
         && this.Stage == MailboxMutationStage.Completed
         && this.Request.DestinationPath is { } destinationPath
-        && string.Equals(destinationPath.Value, discoveredFolderPath.Value, StringComparison.Ordinal)
+        && destinationPath.NamesSameFolderAs(discoveredFolderPath)
         && this.Placement is { UidValidity: { } placedUidValidity, Uid: { } placedUid }
         && placedUidValidity == discoveredUidValidity
         && placedUid == discoveredUid;

--- a/src/Domain/Mutations/MailboxMutationRequester.cs
+++ b/src/Domain/Mutations/MailboxMutationRequester.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using System.Buffers;
 using System.Globalization;
 
 namespace MailFathom.Domain.Mutations;
@@ -26,6 +27,14 @@ public sealed record MailboxMutationRequester
     /// <summary>The greatest length an identity may have, which bounds the column it is stored in and the index over it.</summary>
     public const int MaximumIdentityLength = 128;
 
+    /// <summary>The character a composed identity is written with, and which therefore cannot appear inside its parts.</summary>
+    /// <remarks>
+    /// One character rather than the two an outgoing email's identity is composed with, because a mutation's identity is
+    /// composed of two parts rather than three. It is held as a set so that composing a third part later refuses the
+    /// character that separates it in the same place as this one.
+    /// </remarks>
+    private static readonly SearchValues<char> ComposedIdentitySeparators = SearchValues.Create(['@']);
+
     private MailboxMutationRequester(MailboxMutationOrigin origin, string identity)
     {
         this.Origin = origin;
@@ -42,7 +51,7 @@ public sealed record MailboxMutationRequester
     /// <param name="ruleName">The operator's own name for the rule.</param>
     /// <param name="revision">The identity of the rule set revision the request was produced from.</param>
     /// <returns>A requester naming that revision of that rule.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="ruleName" /> or <paramref name="revision" /> is blank, carries a control character, or is long enough that the composed identity exceeds <see cref="MaximumIdentityLength" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="ruleName" /> or <paramref name="revision" /> is blank, carries a control character, carries the <c>@</c> character the identity is composed with, or is long enough that the composed identity exceeds <see cref="MaximumIdentityLength" />.</exception>
     /// <remarks>
     /// The revision is part of the identity rather than a column beside it, because the comparison that matters is
     /// equality of the whole thing: an edited rule is a different requester and asks again, while an unchanged one
@@ -54,7 +63,10 @@ public sealed record MailboxMutationRequester
         ArgumentException.ThrowIfNullOrWhiteSpace(ruleName);
         ArgumentException.ThrowIfNullOrWhiteSpace(revision);
 
-        var identity = string.Create(CultureInfo.InvariantCulture, $"{ruleName.Trim()}@{revision.Trim()}");
+        var trimmedRuleName = ValidComposedPart(ruleName, nameof(ruleName));
+        var trimmedRevision = ValidComposedPart(revision, nameof(revision));
+
+        var identity = string.Create(CultureInfo.InvariantCulture, $"{trimmedRuleName}@{trimmedRevision}");
 
         // Reported against the rule name rather than against the composed identity, because that is the part the caller
         // supplied and the only part they can shorten.
@@ -65,7 +77,7 @@ public sealed record MailboxMutationRequester
     /// <param name="decidedUnder">What the deciding stage ran under — a scanner's rule corpus, or the stage's own name where it has none.</param>
     /// <param name="actingThreshold">The score MailFathom itself requires before it touches mail, or <see langword="null" /> when the operator configured none.</param>
     /// <returns>A requester naming that profile.</returns>
-    /// <exception cref="ArgumentException">Thrown when <paramref name="decidedUnder" /> is blank, carries a control character, or is long enough that the composed identity exceeds <see cref="MaximumIdentityLength" />.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="decidedUnder" /> is blank, carries a control character, carries the <c>@</c> character the identity is composed with, or is long enough that the composed identity exceeds <see cref="MaximumIdentityLength" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="actingThreshold" /> is not a finite number.</exception>
     /// <remarks>
     /// <para>
@@ -96,7 +108,7 @@ public sealed record MailboxMutationRequester
 
         var identity = string.Create(
             CultureInfo.InvariantCulture,
-            $"{decidedUnder.Trim()}@{DescribeThreshold(actingThreshold)}");
+            $"{ValidComposedPart(decidedUnder, nameof(decidedUnder))}@{DescribeThreshold(actingThreshold)}");
 
         // Reported against the corpus rather than against the composed identity, for the reason the rule factory gives:
         // it is the part the caller supplied and the only part they can shorten.
@@ -141,6 +153,28 @@ public sealed record MailboxMutationRequester
     private static string DescribeThreshold(double? actingThreshold) => actingThreshold is { } threshold
         ? threshold.ToString(CultureInfo.InvariantCulture)
         : "none";
+
+    /// <summary>Validates one part of a composed identity, including that it cannot be mistaken for another split of it.</summary>
+    /// <remarks>
+    /// The separator is refused rather than escaped, because what a composed identity has to guarantee is that two
+    /// distinct pairs cannot write the same string: a rule named <c>a</c> at revision <c>b@c</c> and a rule named
+    /// <c>a@b</c> at revision <c>c</c> would otherwise compose one identity, and the unique index would read the second
+    /// rule's genuine request as a repeat of the first one's and perform nothing. Neither a rule name an operator wrote
+    /// nor a scanner corpus name carries an at-sign, so refusing it costs nothing a caller can legitimately want.
+    /// </remarks>
+    private static string ValidComposedPart(string identityPart, string parameterName)
+    {
+        var trimmedPart = identityPart.Trim();
+
+        if (trimmedPart.AsSpan().ContainsAny(ComposedIdentitySeparators))
+        {
+            throw new ArgumentException(
+                "A part of a composed mutation requester identity cannot contain the character it is composed with.",
+                parameterName);
+        }
+
+        return trimmedPart;
+    }
 
     /// <summary>Validates an identity and reports a refusal against the parameter the caller actually supplied.</summary>
     /// <remarks>

--- a/src/Infrastructure/Mail/MailKit/Writes/MailKitRemoteFolderCreator.cs
+++ b/src/Infrastructure/Mail/MailKit/Writes/MailKitRemoteFolderCreator.cs
@@ -234,7 +234,7 @@ internal sealed partial class MailKitRemoteFolderCreator(
             folder.FullName,
             NormalizeHierarchyDelimiter(folder.DirectorySeparator),
             out var advertisedPath)
-            || !string.Equals(advertisedPath.Value, configuredPath.Value, StringComparison.Ordinal))
+            || !advertisedPath.NamesSameFolderAs(configuredPath))
         {
             throw new RemoteFolderCreationRefusedException(accountId, alias);
         }

--- a/tests/Application.UnitTests/Emails/Embeddings/EmbeddingProfileFingerprintTests.cs
+++ b/tests/Application.UnitTests/Emails/Embeddings/EmbeddingProfileFingerprintTests.cs
@@ -86,6 +86,25 @@ public sealed class EmbeddingProfileFingerprintTests
             "A digest is written in lowercase hexadecimal only."));
     }
 
+    /// <summary>
+    /// The profile table is unique on this value, so the encoding is pinned rather than merely self-consistent: a
+    /// deployment upgraded to a build whose digest writer moved must resolve its registered profile rather than write a
+    /// second row and re-embed a whole mailbox against it. Only a digest written down outside the code can say so, which
+    /// is why this expectation is a literal and not a second computation.
+    /// </summary>
+    [Fact]
+    public void Compute_TheReferenceGeometry_ProducesTheDigestAlreadyRegisteredRowsCarry()
+    {
+        // Arrange
+        const string registeredDigest = "dcf17af40c4cd8b674567539820590850813269ddd23b43009c3189e8f931238";
+
+        // Act
+        var fingerprint = EmbeddingProfileFingerprint.Compute(Identity());
+
+        // Assert
+        Assert.Equal(registeredDigest, fingerprint.Value);
+    }
+
     /// <summary>A fingerprint read back from a registered profile is the one that was written.</summary>
     [Fact]
     public void Create_ADigestThatWasComputed_ReadsBackAsTheSameValue()

--- a/tests/Domain.UnitTests/Emails/Authentication/SenderDomainTests.cs
+++ b/tests/Domain.UnitTests/Emails/Authentication/SenderDomainTests.cs
@@ -182,9 +182,10 @@ public sealed class SenderDomainTests
         Assert.Equal(expected, domain.NormalizedValue);
     }
 
-    /// <summary>A mailbox with nothing after the at-sign names no domain, so nothing is read from it.</summary>
+    /// <summary>A mailbox with a half missing names no domain, so nothing is read from it.</summary>
     [Theory]
     [InlineData("bounce@")]
+    [InlineData("@relay.test")]
     [InlineData("bounce@rel ay.test")]
     [InlineData(null)]
     public void TryCreateFromMailbox_NoUsableDomain_IsRefused(string? mailbox)

--- a/tests/Domain.UnitTests/Emails/EmailAddressTests.cs
+++ b/tests/Domain.UnitTests/Emails/EmailAddressTests.cs
@@ -160,6 +160,31 @@ public sealed class EmailAddressTests
         Assert.Equal(expectedDomain, domainText.ToString());
     }
 
+    /// <summary>
+    /// The local part is taken from the comparison form's own at-sign rather than from an offset into it. A case
+    /// mapping is not obliged to produce one character per character, and an offset carried over from the written
+    /// address would hand back a truncated prefix — one a shorter, unrelated mailbox could also produce, in the value
+    /// sender trust and recipient governance compare on.
+    /// </summary>
+    [Theory]
+    [InlineData("straße@example.test")]
+    [InlineData("ﬁle@example.test")]
+    [InlineData("ǅungla@example.test")]
+    public void TrySplit_ALocalPartWhoseCaseMappingMayResize_TakesTheWholeComparisonFormOfIt(string writtenAddress)
+    {
+        // Arrange
+        EmailAddress.TryCreate(displayName: null, writtenAddress, out var address);
+        var expectedLocalPart = address.NormalizedAddress[..address.NormalizedAddress.LastIndexOf('@')];
+
+        // Act
+        var split = address.TrySplit(out var normalizedLocalPart, out var domainText);
+
+        // Assert
+        Assert.True(split);
+        Assert.Equal(expectedLocalPart, normalizedLocalPart);
+        Assert.Equal("example.test", domainText.ToString());
+    }
+
     /// <summary>A default address carries no text at all, and a caller reading its halves is given the refusal rather than an empty pair.</summary>
     [Fact]
     public void TrySplit_AnAddressThatWasNeverCreated_IsRefused()

--- a/tests/Domain.UnitTests/Emails/EmailAddressTests.cs
+++ b/tests/Domain.UnitTests/Emails/EmailAddressTests.cs
@@ -138,6 +138,61 @@ public sealed class EmailAddressTests
         Assert.Equal(default, address);
     }
 
+    /// <summary>The split is made at the last at-sign, because a quoted local part is allowed to carry one of its own.</summary>
+    [Theory]
+    [InlineData("anna.kowalska@example.test", "ANNA.KOWALSKA", "example.test")]
+    [InlineData("\"a@b\"@example.test", "\"A@B\"", "example.test")]
+    [InlineData("Anna@Example.Test", "ANNA", "Example.Test")]
+    public void TrySplit_AUsableAddress_HandsBackTheComparisonFormAndTheWrittenDomain(
+        string writtenAddress,
+        string expectedLocalPart,
+        string expectedDomain)
+    {
+        // Arrange
+        EmailAddress.TryCreate(displayName: null, writtenAddress, out var address);
+
+        // Act
+        var split = address.TrySplit(out var normalizedLocalPart, out var domainText);
+
+        // Assert
+        Assert.True(split);
+        Assert.Equal(expectedLocalPart, normalizedLocalPart);
+        Assert.Equal(expectedDomain, domainText.ToString());
+    }
+
+    /// <summary>A default address carries no text at all, and a caller reading its halves is given the refusal rather than an empty pair.</summary>
+    [Fact]
+    public void TrySplit_AnAddressThatWasNeverCreated_IsRefused()
+    {
+        // Arrange
+        var address = default(EmailAddress);
+
+        // Act
+        var split = address.TrySplit(out var normalizedLocalPart, out _);
+
+        // Assert
+        Assert.False(split);
+        Assert.Equal(string.Empty, normalizedLocalPart);
+    }
+
+    /// <summary>Text with a half missing names no mailbox, so it is refused rather than handed back with an empty side.</summary>
+    [Theory]
+    [InlineData("@example.test")]
+    [InlineData("anna@")]
+    [InlineData("@")]
+    [InlineData("example.test")]
+    [InlineData("")]
+    public void TrySplit_TextWithoutBothHalves_IsRefused(string candidate)
+    {
+        // Act
+        var split = EmailAddress.TrySplit(candidate, out var localPartText, out var domainText);
+
+        // Assert
+        Assert.False(split);
+        Assert.True(localPartText.IsEmpty);
+        Assert.True(domainText.IsEmpty);
+    }
+
     /// <summary>The role is what makes an address answerable: "wrote this" and "was copied on this" are different questions about one person.</summary>
     [Fact]
     public void EmailParticipant_SameAddressInTwoHeaders_StaysTwoParticipants()

--- a/tests/Domain.UnitTests/Folders/MailFolderTests.cs
+++ b/tests/Domain.UnitTests/Folders/MailFolderTests.cs
@@ -96,6 +96,39 @@ public sealed class MailFolderTests
         Assert.Equal(["Archief", "2026", "Q3"], levels);
     }
 
+    /// <summary>
+    /// A record written before the server reported a delimiter and a resolution made after it are two values of one
+    /// folder. Naming the same folder is therefore the advertised text alone, while equality keeps the delimiter because
+    /// a rebinding is decided on both halves.
+    /// </summary>
+    [Fact]
+    public void NamesSameFolderAs_OnePathWithADelimiterAndOneWithout_NamesOneFolder()
+    {
+        // Arrange
+        var advertised = RemoteFolderPath.Create("Archief/2026", '/');
+        var recorded = RemoteFolderPath.Create("Archief/2026");
+
+        // Act
+        var namesSameFolder = advertised.NamesSameFolderAs(recorded);
+
+        // Assert
+        Assert.True(namesSameFolder);
+        Assert.NotEqual(advertised, recorded);
+    }
+
+    [Fact]
+    public void NamesSameFolderAs_PathsDifferingInCase_NamesTwoFolders()
+    {
+        // Arrange
+        var archive = RemoteFolderPath.Create("Archief", '/');
+
+        // Act
+        var namesSameFolder = archive.NamesSameFolderAs(RemoteFolderPath.Create("archief", '/'));
+
+        // Assert
+        Assert.False(namesSameFolder);
+    }
+
     [Fact]
     public void ToHierarchyLevels_ServerReportedNoDelimiter_KeepsThePathAsOneLevel()
     {

--- a/tests/Domain.UnitTests/Mutations/MailboxMutationRequesterTests.cs
+++ b/tests/Domain.UnitTests/Mutations/MailboxMutationRequesterTests.cs
@@ -134,6 +134,52 @@ public sealed class MailboxMutationRequesterTests
         Assert.Equal("revision", refusal.ParamName);
     }
 
+    /// <summary>
+    /// Two distinct rules must never compose one identity. A rule named <c>a</c> at revision <c>b@c</c> and one named
+    /// <c>a@b</c> at revision <c>c</c> would otherwise write the same key, and the constraint the record is keyed by
+    /// would read the second rule's genuine request as a repeat of the first one's and perform nothing.
+    /// </summary>
+    [Theory]
+    [InlineData("file@newsletters", "3", "ruleName")]
+    [InlineData("file-newsletters", "3@4", "revision")]
+    public void Rule_PartCarryingTheCharacterTheIdentityIsComposedWith_IsRefused(
+        string ruleName,
+        string revision,
+        string expectedParameter)
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentException>(() => MailboxMutationRequester.Rule(ruleName, revision));
+
+        // Assert
+        Assert.Equal(expectedParameter, refusal.ParamName);
+    }
+
+    /// <summary>A corpus name carrying the separator would write the identity another corpus at another threshold writes.</summary>
+    [Fact]
+    public void Classification_CorpusNameCarryingTheCharacterTheIdentityIsComposedWith_IsRefused()
+    {
+        // Act
+        var refusal = Assert.Throws<ArgumentException>(
+            () => MailboxMutationRequester.Classification("spamassassin@4.0.2", actingThreshold: 8));
+
+        // Assert
+        Assert.Equal("decidedUnder", refusal.ParamName);
+    }
+
+    /// <summary>A stored identity carries the separator, so restoring one is not held to the rule its parts are held to.</summary>
+    [Fact]
+    public void Create_ARuleIdentityReadBackFromARecord_IsRestoredUnchanged()
+    {
+        // Arrange
+        var recorded = MailboxMutationRequester.Rule("file-newsletters", "3");
+
+        // Act
+        var restored = MailboxMutationRequester.Create(MailboxMutationOrigin.Rule, recorded.Identity);
+
+        // Assert
+        Assert.Equal(recorded, restored);
+    }
+
     /// <summary>A record hands back what it stored, so restoring has to produce the requester that was written.</summary>
     [Fact]
     public void Create_FromTheStoredOriginAndIdentity_RestoresTheRequesterThatWasWritten()


### PR DESCRIPTION
## What this changes

Four folds under `src/Domain/` and `src/Application/`, each of which two branches had written
independently, and one of them a hardening gap rather than only duplication.

**The requester identity that was left unguarded.** `MailboxMutationRequester.Rule` and
`.Classification` compose their identity from parts a caller supplies and refused nothing, while the
value object written twice beside them — `OutgoingEmailRequester` — refused exactly the characters it
composes with. Both now hold a `SearchValues<char>` guard and a `ValidComposedPart` that reports the
refusal against the parameter the caller actually wrote. The set holds one character rather than two,
because a mutation identity is composed of two parts rather than three.

No live defect is being fixed and none is being introduced. `MailRuleActionRecorder` is the one
production caller of `Rule`, and a rule name is already held to
`^[A-Za-z0-9][A-Za-z0-9 ._-]*$` by `MailRuleOptions` before it reaches the domain, so no configuration
that starts today stops starting. The right-hand part is a `MailRuleSetRevision`, which is twelve
lowercase hexadecimal characters. `Classification`'s corpus revision is bounded and control-character
free by the same path that already made a control character a refusal here.

**One length-prefixed digest writer instead of three.** `internal static class CanonicalDigest` holds
`IsHexadecimalDigest`, `AppendNumber` and `AppendText`. `EmailChunkContentHash`,
`EmbeddingProfileFingerprint` and `SensitiveContentDerivationStamp` each keep their own
`IncrementalHash`, hash domain, field order and `Create` message; only how a field is written is now
stated once.

The encoding is unchanged and this is checked rather than asserted: a new test pins the fingerprint of
the reference geometry to a literal digest, and that literal was computed outside this repository from
the encoding the three writers used before the fold. A build whose writer drifted would resolve a
different profile row and re-embed a whole mailbox against it, which is what the pin now catches.

**One place an address is cut at its last at-sign.** `EmailAddress.TrySplit` has two forms — a static
one over the raw text a header carried, and an instance one handing back the comparison form of the
local part beside the domain exactly as the message wrote it — and the five sites that cut their own
now go through it, each still building its own result type. Two of them were byte-identical private
helpers.

**One place two folder paths are compared.** `RemoteFolderPath.NamesSameFolderAs` replaces the five
call sites that reached past the type into `Value`. Its own equality is untouched, because both halves
of a value are a real distinction where a resolution is being rebound.

## Behaviour that changes

One, and it is a break in a domain read rather than in a published surface:

- `SenderDomain.TryCreateFromMailbox("@relay.test")` now reads no domain, where it previously returned
  `RELAY.TEST`. Text carrying an at-sign but no local part is neither of the two forms RFC 8601 writes
  a `smtp.mailfrom` identity in, and refusing it removes an asymmetry that was already there —
  `bounce@` was refused and `@relay.test` was not. The not-established verdict already has a value for
  an identity written wrongly. Covered by a new `InlineData` row on the existing refusal theory.

No configuration key, database column, MCP tool argument, or deployment contract moves, so this
change breaks none of the four public surfaces ADR 0004 governs.

## Tests

- The separator refusal on `Rule` (both parameters) and on `Classification`, plus the restore path
  that is deliberately not held to the parts' rule.
- `TrySplit` over a quoted local part carrying its own at-sign, over a default address, and over text
  with a half missing.
- `NamesSameFolderAs` across a delimiter disagreement and across case.
- The pinned embedding fingerprint described above.
- Every existing Domain and Application test passes unchanged.

Closes #1024
