### PR TITLE
[#1019] Write the keyset cursor codec and the filter fingerprint once

### DIFF
--- a/src/Application/Emails/Mailboxes/EmailTimelineCursor.cs
+++ b/src/Application/Emails/Mailboxes/EmailTimelineCursor.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Text;
-using System.Globalization;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Emails.Mailboxes;
@@ -24,28 +22,14 @@ namespace MailFathom.Application.Emails.Mailboxes;
 /// opacity rather than protection — a client that cannot read a cursor cannot build one, and building one is how a
 /// caller would end up asking for a boundary this system never computed.
 /// </para>
+/// <para>
+/// The encoded form itself is <see cref="KeysetCursorPayload" />'s, which every keyset cursor here shares. This is the
+/// one reading whose rows need not carry an instant — a message no header could date is still on the timeline — so it
+/// is also the one that accepts a decoded position of <see langword="null" /> rather than refusing it.
+/// </para>
 /// </remarks>
 public readonly record struct EmailTimelineCursor
 {
-    /// <summary>The greatest number of characters an encoded cursor may carry before it is refused unread.</summary>
-    /// <remarks>
-    /// Comfortably above every cursor this version issues, and low enough that a caller cannot make the decoder work.
-    /// The bound is applied before decoding, because a decoder is the wrong place to discover that an input is absurd.
-    /// </remarks>
-    public const int MaximumEncodedLength = 512;
-
-    /// <summary>The field the encoded form uses for a message no header could date.</summary>
-    private const string AbsentReceivedTimestamp = "-";
-
-    /// <summary>
-    /// The encoded form's version. It leads the payload so a later change to the fields — another ordering key, a
-    /// different fingerprint — refuses the cursors this version issued instead of misreading them.
-    /// </summary>
-    private const string FormatVersion = "1";
-
-    /// <summary>Separates the encoded fields, chosen because it appears in none of them.</summary>
-    private const char FieldSeparator = '.';
-
     private EmailTimelineCursor(EmailTimelinePosition position, string filterFingerprint)
     {
         this.Position = position;
@@ -90,82 +74,21 @@ public readonly record struct EmailTimelineCursor
     {
         cursor = default;
 
-        if (text is null || text.Length is 0 or > MaximumEncodedLength)
-        {
-            return false;
-        }
-
-        // Validity is checked separately because the decoder's Try form reports only that a destination was too small
-        // and throws on text that is not base64url at all, which is the shape a caller most easily presents.
-        if (!Base64Url.IsValid(text))
-        {
-            return false;
-        }
-
-        Span<byte> decoded = stackalloc byte[Base64Url.GetMaxDecodedLength(MaximumEncodedLength)];
-        if (!Base64Url.TryDecodeFromChars(text, decoded, out var decodedLength))
-        {
-            return false;
-        }
-
-        var fields = Encoding.UTF8.GetString(decoded[..decodedLength]).Split(FieldSeparator);
-
-        if (fields is not [FormatVersion, var receivedField, var identifierField, var fingerprintField]
-            || !TryReadReceivedAt(receivedField, out var receivedAt)
-            || !Guid.TryParseExact(identifierField, "N", out var identifier)
-            || identifier == Guid.Empty
-            || fingerprintField.Length is 0)
+        if (!KeysetCursorPayload.TryDecode(text, out var payload))
         {
             return false;
         }
 
         cursor = new EmailTimelineCursor(
-            new EmailTimelinePosition(receivedAt, StoredEmailId.Create(identifier)),
-            fingerprintField);
+            new EmailTimelinePosition(payload.Position, StoredEmailId.Create(payload.Identity)),
+            payload.FilterFingerprint);
 
         return true;
     }
 
     /// <summary>Writes the cursor as the opaque string a caller presents to continue the walk.</summary>
     /// <returns>The encoded cursor.</returns>
-    /// <remarks>
-    /// The received timestamp is written as its UTC tick count, which is the form the timeline order compares: two
-    /// timestamps that name the same instant in different offsets encode identically, so a boundary cannot depend on the
-    /// offset a mail server happened to write.
-    /// </remarks>
-    public string Encode()
-    {
-        var payload = string.Join(
-            FieldSeparator,
-            FormatVersion,
-            this.Position.ReceivedAt is { } receivedAt
-                ? receivedAt.UtcTicks.ToString(CultureInfo.InvariantCulture)
-                : AbsentReceivedTimestamp,
-            this.Position.StoredEmailId.Value.ToString("N", CultureInfo.InvariantCulture),
-            this.FilterFingerprint);
-
-        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
-    }
-
-    private static bool TryReadReceivedAt(string field, out DateTimeOffset? receivedAt)
-    {
-        receivedAt = null;
-
-        if (string.Equals(field, AbsentReceivedTimestamp, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        // NumberStyles.None refuses a sign, so no negative tick count reaches the range check below.
-        if (!long.TryParse(field, NumberStyles.None, CultureInfo.InvariantCulture, out var utcTicks)
-            || utcTicks < DateTime.MinValue.Ticks
-            || utcTicks > DateTime.MaxValue.Ticks)
-        {
-            return false;
-        }
-
-        receivedAt = new DateTimeOffset(utcTicks, TimeSpan.Zero);
-
-        return true;
-    }
+    public string Encode() => KeysetCursorPayload
+        .At(this.Position.ReceivedAt, this.Position.StoredEmailId.Value, this.FilterFingerprint)
+        .Encode();
 }

--- a/src/Application/Jobs/DeadLetters/DeadLetteredJobCursor.cs
+++ b/src/Application/Jobs/DeadLetters/DeadLetteredJobCursor.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Text;
-using System.Globalization;
-using System.Text;
+using MailFathom.Application.Paging;
 
 namespace MailFathom.Application.Jobs.DeadLetters;
 
@@ -20,22 +18,11 @@ namespace MailFathom.Application.Jobs.DeadLetters;
 /// <para>
 /// It carries no secret and needs no signature: every value in it is one the caller already supplied or already
 /// received. Encoding is about opacity rather than protection — a client that cannot read a cursor does not build one.
+/// The encoded form itself is <see cref="KeysetCursorPayload" />'s, which every keyset cursor here shares.
 /// </para>
 /// </remarks>
 public readonly record struct DeadLetteredJobCursor
 {
-    /// <summary>The greatest number of characters an encoded cursor may carry before it is refused unread.</summary>
-    public const int MaximumEncodedLength = 512;
-
-    /// <summary>
-    /// The encoded form's version. It leads the payload so a later change to the fields refuses the cursors this version
-    /// issued instead of misreading them.
-    /// </summary>
-    private const string FormatVersion = "1";
-
-    /// <summary>Separates the encoded fields, chosen because it appears in none of them.</summary>
-    private const char FieldSeparator = '.';
-
     private DeadLetteredJobCursor(DateTimeOffset deadLetteredAt, JobId jobId, string filterFingerprint)
     {
         this.DeadLetteredAt = deadLetteredAt;
@@ -70,82 +57,32 @@ public readonly record struct DeadLetteredJobCursor
 
     /// <summary>Reads a cursor a caller presented.</summary>
     /// <param name="text">The encoded cursor, as a previous page returned it.</param>
-    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise the struct default.</param>
+    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise <see langword="null" />.</param>
     /// <returns><see langword="true" /> when the text decoded into a usable cursor; otherwise <see langword="false" />.</returns>
     /// <remarks>
-    /// Whether a decoded cursor belongs to the current request is a separate question its
+    /// Every job this reading returns stopped at a known instant, so a payload carrying none names no boundary here and
+    /// is refused. Whether a decoded cursor belongs to the current request is a separate question its
     /// <see cref="FilterFingerprint" /> answers, and one this method deliberately does not ask.
     /// </remarks>
-    public static bool TryDecode(string? text, out DeadLetteredJobCursor cursor)
+    public static bool TryDecode(string? text, out DeadLetteredJobCursor? cursor)
     {
-        cursor = default;
+        cursor = null;
 
-        if (text is null || text.Length is 0 or > MaximumEncodedLength)
+        if (!KeysetCursorPayload.TryDecode(text, out var payload) || payload.Position is not { } deadLetteredAt)
         {
             return false;
         }
 
-        // Validity is checked separately because the decoder's Try form reports only that a destination was too small
-        // and throws on text that is not base64url at all, which is the shape a caller most easily presents.
-        if (!Base64Url.IsValid(text))
-        {
-            return false;
-        }
-
-        Span<byte> decoded = stackalloc byte[Base64Url.GetMaxDecodedLength(MaximumEncodedLength)];
-        if (!Base64Url.TryDecodeFromChars(text, decoded, out var decodedLength))
-        {
-            return false;
-        }
-
-        var fields = Encoding.UTF8.GetString(decoded[..decodedLength]).Split(FieldSeparator);
-
-        if (fields is not [FormatVersion, var stoppedField, var identifierField, var fingerprintField]
-            || !TryReadDeadLetteredAt(stoppedField, out var deadLetteredAt)
-            || !Guid.TryParseExact(identifierField, "N", out var identifier)
-            || identifier == Guid.Empty
-            || fingerprintField.Length is 0)
-        {
-            return false;
-        }
-
-        cursor = new DeadLetteredJobCursor(deadLetteredAt, JobId.Create(identifier), fingerprintField);
+        cursor = new DeadLetteredJobCursor(
+            deadLetteredAt,
+            JobId.Create(payload.Identity),
+            payload.FilterFingerprint);
 
         return true;
     }
 
     /// <summary>Writes the cursor as the opaque string a caller presents to continue the walk.</summary>
     /// <returns>The encoded cursor.</returns>
-    /// <remarks>
-    /// The instant is written as its UTC tick count, which is the form the order compares: two timestamps naming the
-    /// same instant in different offsets encode identically.
-    /// </remarks>
-    public string Encode()
-    {
-        var payload = string.Join(
-            FieldSeparator,
-            FormatVersion,
-            this.DeadLetteredAt.UtcTicks.ToString(CultureInfo.InvariantCulture),
-            this.JobId.Value.ToString("N", CultureInfo.InvariantCulture),
-            this.FilterFingerprint);
-
-        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
-    }
-
-    private static bool TryReadDeadLetteredAt(string field, out DateTimeOffset deadLetteredAt)
-    {
-        deadLetteredAt = default;
-
-        // NumberStyles.None refuses a sign, so no negative tick count reaches the range check below.
-        if (!long.TryParse(field, NumberStyles.None, CultureInfo.InvariantCulture, out var utcTicks)
-            || utcTicks < DateTime.MinValue.Ticks
-            || utcTicks > DateTime.MaxValue.Ticks)
-        {
-            return false;
-        }
-
-        deadLetteredAt = new DateTimeOffset(utcTicks, TimeSpan.Zero);
-
-        return true;
-    }
+    public string Encode() =>
+        KeysetCursorPayload.At(this.DeadLetteredAt, this.JobId.Value, this.FilterFingerprint).Encode();
 }

--- a/src/Application/Jobs/DeadLetters/DeadLetteredJobQuery.cs
+++ b/src/Application/Jobs/DeadLetters/DeadLetteredJobQuery.cs
@@ -2,8 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Security.Cryptography;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Accounts;
 
 namespace MailFathom.Application.Jobs.DeadLetters;
@@ -35,16 +34,6 @@ public sealed record DeadLetteredJobQuery
     /// many rows it names.
     /// </remarks>
     public const int MaximumPageSize = 200;
-
-    /// <summary>Separates the fingerprint's fields, chosen because no filter value can contain it.</summary>
-    private const char FingerprintFieldSeparator = '\u001f';
-
-    /// <summary>How many hexadecimal characters of the filter digest a cursor carries.</summary>
-    /// <remarks>
-    /// Short because it distinguishes one caller's own filter sets rather than resisting a search for a collision: a
-    /// forged fingerprint buys a boundary inside a page that same caller is already entitled to read.
-    /// </remarks>
-    private const int FingerprintLength = 16;
 
     private DeadLetteredJobQuery(
         JobType? jobType,
@@ -115,13 +104,6 @@ public sealed record DeadLetteredJobQuery
     }
 
     /// <summary>Reduces the filters to the short stable text a cursor carries to prove it belongs to this walk.</summary>
-    private static string ComputeFingerprint(JobType? jobType, MailAccountId? accountId)
-    {
-        var material = string.Join(
-            FingerprintFieldSeparator,
-            jobType?.Name ?? string.Empty,
-            accountId?.Value ?? string.Empty);
-
-        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..FingerprintLength];
-    }
+    private static string ComputeFingerprint(JobType? jobType, MailAccountId? accountId) =>
+        PageFilterFingerprint.Of(jobType?.Name, accountId?.Value);
 }

--- a/src/Application/Mail/Delivery/Operations/OutboxCursor.cs
+++ b/src/Application/Mail/Delivery/Operations/OutboxCursor.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Text;
-using System.Globalization;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Delivery;
 
 namespace MailFathom.Application.Mail.Delivery.Operations;
@@ -21,22 +19,11 @@ namespace MailFathom.Application.Mail.Delivery.Operations;
 /// <para>
 /// It carries no secret and needs no signature: every value in it is one the caller already supplied or already
 /// received. Encoding is about opacity rather than protection — a client that cannot read a cursor does not build one.
+/// The encoded form itself is <see cref="KeysetCursorPayload" />'s, which every keyset cursor here shares.
 /// </para>
 /// </remarks>
 public readonly record struct OutboxCursor
 {
-    /// <summary>The greatest number of characters an encoded cursor may carry before it is refused unread.</summary>
-    public const int MaximumEncodedLength = 512;
-
-    /// <summary>
-    /// The encoded form's version. It leads the payload so a later change to the fields refuses the cursors this version
-    /// issued instead of misreading them.
-    /// </summary>
-    private const string FormatVersion = "1";
-
-    /// <summary>Separates the encoded fields, chosen because it appears in none of them.</summary>
-    private const char FieldSeparator = '.';
-
     private OutboxCursor(DateTimeOffset recordedAt, OutgoingEmailId outgoingEmailId, string filterFingerprint)
     {
         this.RecordedAt = recordedAt;
@@ -71,82 +58,32 @@ public readonly record struct OutboxCursor
 
     /// <summary>Reads a cursor a caller presented.</summary>
     /// <param name="text">The encoded cursor, as a previous page returned it.</param>
-    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise the struct default.</param>
+    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise <see langword="null" />.</param>
     /// <returns><see langword="true" /> when the text decoded into a usable cursor; otherwise <see langword="false" />.</returns>
     /// <remarks>
-    /// Whether a decoded cursor belongs to the current request is a separate question its
+    /// Every send this reading returns was written down at a known instant, so a payload carrying none names no
+    /// boundary here and is refused. Whether a decoded cursor belongs to the current request is a separate question its
     /// <see cref="FilterFingerprint" /> answers, and one this method deliberately does not ask.
     /// </remarks>
-    public static bool TryDecode(string? text, out OutboxCursor cursor)
+    public static bool TryDecode(string? text, out OutboxCursor? cursor)
     {
-        cursor = default;
+        cursor = null;
 
-        if (text is null || text.Length is 0 or > MaximumEncodedLength)
+        if (!KeysetCursorPayload.TryDecode(text, out var payload) || payload.Position is not { } recordedAt)
         {
             return false;
         }
 
-        // Validity is checked separately because the decoder's Try form reports only that a destination was too small
-        // and throws on text that is not base64url at all, which is the shape a caller most easily presents.
-        if (!Base64Url.IsValid(text))
-        {
-            return false;
-        }
-
-        Span<byte> decoded = stackalloc byte[Base64Url.GetMaxDecodedLength(MaximumEncodedLength)];
-        if (!Base64Url.TryDecodeFromChars(text, decoded, out var decodedLength))
-        {
-            return false;
-        }
-
-        var fields = Encoding.UTF8.GetString(decoded[..decodedLength]).Split(FieldSeparator);
-
-        if (fields is not [FormatVersion, var recordedField, var identifierField, var fingerprintField]
-            || !TryReadRecordedAt(recordedField, out var recordedAt)
-            || !Guid.TryParseExact(identifierField, "N", out var identifier)
-            || identifier == Guid.Empty
-            || fingerprintField.Length is 0)
-        {
-            return false;
-        }
-
-        cursor = new OutboxCursor(recordedAt, OutgoingEmailId.Create(identifier), fingerprintField);
+        cursor = new OutboxCursor(
+            recordedAt,
+            OutgoingEmailId.Create(payload.Identity),
+            payload.FilterFingerprint);
 
         return true;
     }
 
     /// <summary>Writes the cursor as the opaque string a caller presents to continue the walk.</summary>
     /// <returns>The encoded cursor.</returns>
-    /// <remarks>
-    /// The instant is written as its UTC tick count, which is the form the order compares: two timestamps naming the
-    /// same instant in different offsets encode identically.
-    /// </remarks>
-    public string Encode()
-    {
-        var payload = string.Join(
-            FieldSeparator,
-            FormatVersion,
-            this.RecordedAt.UtcTicks.ToString(CultureInfo.InvariantCulture),
-            this.OutgoingEmailId.Value.ToString("N", CultureInfo.InvariantCulture),
-            this.FilterFingerprint);
-
-        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
-    }
-
-    private static bool TryReadRecordedAt(string field, out DateTimeOffset recordedAt)
-    {
-        recordedAt = default;
-
-        // NumberStyles.None refuses a sign, so no negative tick count reaches the range check below.
-        if (!long.TryParse(field, NumberStyles.None, CultureInfo.InvariantCulture, out var utcTicks)
-            || utcTicks < DateTime.MinValue.Ticks
-            || utcTicks > DateTime.MaxValue.Ticks)
-        {
-            return false;
-        }
-
-        recordedAt = new DateTimeOffset(utcTicks, TimeSpan.Zero);
-
-        return true;
-    }
+    public string Encode() =>
+        KeysetCursorPayload.At(this.RecordedAt, this.OutgoingEmailId.Value, this.FilterFingerprint).Encode();
 }

--- a/src/Application/Mail/Delivery/Operations/OutboxQuery.cs
+++ b/src/Application/Mail/Delivery/Operations/OutboxQuery.cs
@@ -2,8 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Security.Cryptography;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Delivery;
 
@@ -33,16 +32,6 @@ public sealed record OutboxQuery
     /// a coded failure — so this figure bounds what the answer weighs as well as how many rows it names.
     /// </remarks>
     public const int MaximumPageSize = 200;
-
-    /// <summary>Separates the fingerprint's fields, chosen because no filter value can contain it.</summary>
-    private const char FingerprintFieldSeparator = '\u001f';
-
-    /// <summary>How many hexadecimal characters of the filter digest a cursor carries.</summary>
-    /// <remarks>
-    /// Short because it distinguishes one caller's own filter sets rather than resisting a search for a collision: a
-    /// forged fingerprint buys a boundary inside a page that same caller is already entitled to read.
-    /// </remarks>
-    private const int FingerprintLength = 16;
 
     private OutboxQuery(
         MailAccountId? accountId,
@@ -113,15 +102,8 @@ public sealed record OutboxQuery
     }
 
     /// <summary>Reduces the filters to the short stable text a cursor carries to prove it belongs to this walk.</summary>
-    private static string ComputeFingerprint(MailAccountId? accountId, OutgoingEmailStage? stage)
-    {
-        var material = string.Join(
-            FingerprintFieldSeparator,
-            accountId?.Value ?? string.Empty,
-            stage is { } named ? named.ToString() : string.Empty);
-
-        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..FingerprintLength];
-    }
+    private static string ComputeFingerprint(MailAccountId? accountId, OutgoingEmailStage? stage) =>
+        PageFilterFingerprint.Of(accountId?.Value, stage?.ToString());
 
     /// <summary>Names the stages a caller may narrow to, for a refusal that says what to write instead.</summary>
     /// <returns>The declared stage names, separated by commas.</returns>

--- a/src/Application/Mail/Mutations/Audit/MailboxMutationAuditCursor.cs
+++ b/src/Application/Mail/Mutations/Audit/MailboxMutationAuditCursor.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Text;
-using System.Globalization;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Mutations.Audit;
 
 namespace MailFathom.Application.Mail.Mutations.Audit;
@@ -22,23 +20,12 @@ namespace MailFathom.Application.Mail.Mutations.Audit;
 /// <para>
 /// It carries no secret and needs no signature: every value in it is one the caller already supplied or already
 /// received. Encoding is about opacity rather than protection — a client that cannot read a cursor does not build one,
-/// and a built cursor is how a caller would ask for a boundary this system never computed.
+/// and a built cursor is how a caller would ask for a boundary this system never computed. The encoded form itself is
+/// <see cref="KeysetCursorPayload" />'s, which every keyset cursor here shares.
 /// </para>
 /// </remarks>
 public readonly record struct MailboxMutationAuditCursor
 {
-    /// <summary>The greatest number of characters an encoded cursor may carry before it is refused unread.</summary>
-    public const int MaximumEncodedLength = 512;
-
-    /// <summary>
-    /// The encoded form's version. It leads the payload so a later change to the fields refuses the cursors this version
-    /// issued instead of misreading them.
-    /// </summary>
-    private const string FormatVersion = "1";
-
-    /// <summary>Separates the encoded fields, chosen because it appears in none of them.</summary>
-    private const char FieldSeparator = '.';
-
     private MailboxMutationAuditCursor(
         DateTimeOffset completedAt,
         MailboxMutationAuditEntryId entryId,
@@ -94,85 +81,32 @@ public readonly record struct MailboxMutationAuditCursor
 
     /// <summary>Reads a cursor a caller presented.</summary>
     /// <param name="text">The encoded cursor, as a previous page returned it.</param>
-    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise the struct default.</param>
+    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise <see langword="null" />.</param>
     /// <returns><see langword="true" /> when the text decoded into a usable cursor; otherwise <see langword="false" />.</returns>
     /// <remarks>
-    /// Whether a decoded cursor belongs to the current request is a separate question its
+    /// Every entry this trail returns completed at a known instant, so a payload carrying none names no boundary here
+    /// and is refused. Whether a decoded cursor belongs to the current request is a separate question its
     /// <see cref="FilterFingerprint" /> answers, and one this method deliberately does not ask.
     /// </remarks>
-    public static bool TryDecode(string? text, out MailboxMutationAuditCursor cursor)
+    public static bool TryDecode(string? text, out MailboxMutationAuditCursor? cursor)
     {
-        cursor = default;
+        cursor = null;
 
-        if (text is null || text.Length is 0 or > MaximumEncodedLength)
-        {
-            return false;
-        }
-
-        // Validity is checked separately because the decoder's Try form reports only that a destination was too small
-        // and throws on text that is not base64url at all, which is the shape a caller most easily presents.
-        if (!Base64Url.IsValid(text))
-        {
-            return false;
-        }
-
-        Span<byte> decoded = stackalloc byte[Base64Url.GetMaxDecodedLength(MaximumEncodedLength)];
-        if (!Base64Url.TryDecodeFromChars(text, decoded, out var decodedLength))
-        {
-            return false;
-        }
-
-        var fields = Encoding.UTF8.GetString(decoded[..decodedLength]).Split(FieldSeparator);
-
-        if (fields is not [FormatVersion, var completedField, var identifierField, var fingerprintField]
-            || !TryReadCompletedAt(completedField, out var completedAt)
-            || !Guid.TryParseExact(identifierField, "N", out var identifier)
-            || identifier == Guid.Empty
-            || fingerprintField.Length is 0)
+        if (!KeysetCursorPayload.TryDecode(text, out var payload) || payload.Position is not { } completedAt)
         {
             return false;
         }
 
         cursor = new MailboxMutationAuditCursor(
             completedAt,
-            MailboxMutationAuditEntryId.Create(identifier),
-            fingerprintField);
+            MailboxMutationAuditEntryId.Create(payload.Identity),
+            payload.FilterFingerprint);
 
         return true;
     }
 
     /// <summary>Writes the cursor as the opaque string a caller presents to continue the walk.</summary>
     /// <returns>The encoded cursor.</returns>
-    /// <remarks>
-    /// The completion instant is written as its UTC tick count, which is the form the order compares: two timestamps
-    /// naming the same instant in different offsets encode identically.
-    /// </remarks>
-    public string Encode()
-    {
-        var payload = string.Join(
-            FieldSeparator,
-            FormatVersion,
-            this.CompletedAt.UtcTicks.ToString(CultureInfo.InvariantCulture),
-            this.EntryId.Value.ToString("N", CultureInfo.InvariantCulture),
-            this.FilterFingerprint);
-
-        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
-    }
-
-    private static bool TryReadCompletedAt(string field, out DateTimeOffset completedAt)
-    {
-        completedAt = default;
-
-        // NumberStyles.None refuses a sign, so no negative tick count reaches the range check below.
-        if (!long.TryParse(field, NumberStyles.None, CultureInfo.InvariantCulture, out var utcTicks)
-            || utcTicks < DateTime.MinValue.Ticks
-            || utcTicks > DateTime.MaxValue.Ticks)
-        {
-            return false;
-        }
-
-        completedAt = new DateTimeOffset(utcTicks, TimeSpan.Zero);
-
-        return true;
-    }
+    public string Encode() =>
+        KeysetCursorPayload.At(this.CompletedAt, this.EntryId.Value, this.FilterFingerprint).Encode();
 }

--- a/src/Application/Mail/Mutations/Audit/MailboxMutationAuditQuery.cs
+++ b/src/Application/Mail/Mutations/Audit/MailboxMutationAuditQuery.cs
@@ -3,8 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Globalization;
-using System.Security.Cryptography;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Mutations;
 
@@ -30,16 +29,6 @@ public sealed record MailboxMutationAuditQuery
 
     /// <summary>The greatest page size one request may ask for.</summary>
     public const int MaximumPageSize = 200;
-
-    /// <summary>Separates the fingerprint's fields, chosen because no filter value can contain it.</summary>
-    private const char FingerprintFieldSeparator = '\u001f';
-
-    /// <summary>How many hexadecimal characters of the filter digest a cursor carries.</summary>
-    /// <remarks>
-    /// Short because it distinguishes one caller's own filter sets rather than resisting a search for a collision: a
-    /// forged fingerprint buys a boundary inside a page that same caller is already entitled to read.
-    /// </remarks>
-    private const int FingerprintLength = 16;
 
     private MailboxMutationAuditQuery(
         MailAccountId accountId,
@@ -136,15 +125,10 @@ public sealed record MailboxMutationAuditQuery
         MailAccountId accountId,
         MailboxMutation mutation,
         DateTimeOffset? completedFrom,
-        DateTimeOffset? completedBefore)
-    {
-        var material = string.Join(
-            FingerprintFieldSeparator,
+        DateTimeOffset? completedBefore) =>
+        PageFilterFingerprint.Of(
             accountId.Value,
-            mutation.IsSpecified ? mutation.Name : string.Empty,
-            completedFrom?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
-            completedBefore?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
-
-        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..FingerprintLength];
-    }
+            mutation.IsSpecified ? mutation.Name : null,
+            completedFrom?.UtcTicks.ToString(CultureInfo.InvariantCulture),
+            completedBefore?.UtcTicks.ToString(CultureInfo.InvariantCulture));
 }

--- a/src/Application/Paging/KeysetCursorPayload.cs
+++ b/src/Application/Paging/KeysetCursorPayload.cs
@@ -1,0 +1,176 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+
+namespace MailFathom.Application.Paging;
+
+/// <summary>Carries what every keyset cursor here encodes: an ordering position, the row at it, and a filter fingerprint.</summary>
+/// <remarks>
+/// <para>
+/// Each paged reading declares a cursor of its own, because the position it walks and the identity that breaks a tie
+/// are its own domain types and its own words. What none of them owns is the encoding: the field layout, the version
+/// that leads it, the length bound applied before a byte is decoded, and the tick form an instant is written in are one
+/// decision, and a defect in any of them is a page served twice or skipped on every surface at once.
+/// </para>
+/// <para>
+/// The format version is shared as well, which is what writing the codec once costs: a later change to the layout
+/// retires the cursors of all seven families together rather than one family at a time. That is the intended trade — a
+/// cursor is opaque and short-lived, and a version that drifted per family is one nobody could reason about.
+/// </para>
+/// <para>
+/// <see cref="Contacts.ContactCursor" /> is deliberately outside this. It orders by a name's comparison form rather
+/// than by an instant, carries no fingerprint, and lets its last field hold the separator: a different format that
+/// happens to be base64url, not a seventh copy of this one.
+/// </para>
+/// <para>
+/// The payload carries no secret and needs no signature, because every value in it is one the caller already supplied
+/// or already received. Encoding is about opacity rather than protection — a client that cannot read a cursor does not
+/// build one, and a built cursor is how a caller would ask for a boundary this system never computed.
+/// </para>
+/// </remarks>
+public readonly record struct KeysetCursorPayload
+{
+    /// <summary>The greatest number of characters an encoded cursor may carry before it is refused unread.</summary>
+    /// <remarks>
+    /// Comfortably above every cursor this version issues, and low enough that a caller cannot make the decoder work.
+    /// The bound is applied before decoding, because a decoder is the wrong place to discover that an input is absurd.
+    /// </remarks>
+    public const int MaximumEncodedLength = 512;
+
+    /// <summary>The field a row no instant orders is written with, for the one reading that has such rows.</summary>
+    private const string AbsentPosition = "-";
+
+    /// <summary>
+    /// The encoded form's version. It leads the payload so a later change to the fields refuses the cursors this version
+    /// issued instead of misreading them.
+    /// </summary>
+    private const string FormatVersion = "1";
+
+    /// <summary>Separates the encoded fields, chosen because it appears in none of them.</summary>
+    private const char FieldSeparator = '.';
+
+    private KeysetCursorPayload(DateTimeOffset? position, Guid identity, string filterFingerprint)
+    {
+        this.Position = position;
+        this.Identity = identity;
+        this.FilterFingerprint = filterFingerprint;
+    }
+
+    /// <summary>Gets the instant the page ended on, or <see langword="null" /> when no instant orders that row.</summary>
+    public DateTimeOffset? Position { get; }
+
+    /// <summary>Gets the identity of the row at that position, which breaks a tie between two sharing an instant.</summary>
+    public Guid Identity { get; }
+
+    /// <summary>Gets the fingerprint of the filters the cursor was issued for.</summary>
+    public string FilterFingerprint { get; }
+
+    /// <summary>Creates the payload one page boundary encodes to.</summary>
+    /// <param name="position">The instant the page ended on, or <see langword="null" /> when no instant orders that row.</param>
+    /// <param name="identity">The identity of the row at that position.</param>
+    /// <param name="filterFingerprint">The fingerprint of the filters the page was read under.</param>
+    /// <returns>The payload.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="filterFingerprint" /> is blank.</exception>
+    public static KeysetCursorPayload At(DateTimeOffset? position, Guid identity, string filterFingerprint)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filterFingerprint);
+
+        return new KeysetCursorPayload(position, identity, filterFingerprint);
+    }
+
+    /// <summary>Reads the payload out of the text a caller presented.</summary>
+    /// <param name="text">The encoded cursor, as a previous page returned it.</param>
+    /// <param name="payload">The decoded payload when the text is one this version issued; otherwise the struct default.</param>
+    /// <returns><see langword="true" /> when the text decoded into a usable payload; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// Every field is validated before a payload is produced, so a caller cannot reach a query with a boundary that
+    /// decoded only partially. A reading whose every row is ordered by an instant refuses a decoded
+    /// <see cref="Position" /> of <see langword="null" /> itself, because that field means something only where a row
+    /// can lack the instant. Whether a payload belongs to the current request is a separate question its
+    /// <see cref="FilterFingerprint" /> answers, and one this method deliberately does not ask.
+    /// </remarks>
+    public static bool TryDecode(string? text, out KeysetCursorPayload payload)
+    {
+        payload = default;
+
+        if (text is null || text.Length is 0 or > MaximumEncodedLength)
+        {
+            return false;
+        }
+
+        // Validity is checked separately because the decoder's Try form reports only that a destination was too small
+        // and throws on text that is not base64url at all, which is the shape a caller most easily presents.
+        if (!Base64Url.IsValid(text))
+        {
+            return false;
+        }
+
+        Span<byte> decoded = stackalloc byte[Base64Url.GetMaxDecodedLength(MaximumEncodedLength)];
+        if (!Base64Url.TryDecodeFromChars(text, decoded, out var decodedLength))
+        {
+            return false;
+        }
+
+        var fields = Encoding.UTF8.GetString(decoded[..decodedLength]).Split(FieldSeparator);
+
+        if (fields is not [FormatVersion, var positionField, var identityField, var fingerprintField]
+            || !TryReadPosition(positionField, out var position)
+            || !Guid.TryParseExact(identityField, "N", out var identity)
+            || identity == Guid.Empty
+            || fingerprintField.Length is 0)
+        {
+            return false;
+        }
+
+        payload = new KeysetCursorPayload(position, identity, fingerprintField);
+
+        return true;
+    }
+
+    /// <summary>Writes the payload as the opaque string a caller presents to continue the walk.</summary>
+    /// <returns>The encoded cursor.</returns>
+    /// <remarks>
+    /// The position is written as its UTC tick count, which is the form every one of these orderings compares: two
+    /// timestamps naming the same instant in different offsets encode identically, so a boundary cannot depend on the
+    /// offset whoever wrote the row happened to use.
+    /// </remarks>
+    public string Encode()
+    {
+        var payload = string.Join(
+            FieldSeparator,
+            FormatVersion,
+            this.Position is { } position
+                ? position.UtcTicks.ToString(CultureInfo.InvariantCulture)
+                : AbsentPosition,
+            this.Identity.ToString("N", CultureInfo.InvariantCulture),
+            this.FilterFingerprint);
+
+        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
+    }
+
+    private static bool TryReadPosition(string field, out DateTimeOffset? position)
+    {
+        position = null;
+
+        if (string.Equals(field, AbsentPosition, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // NumberStyles.None refuses a sign, so no negative tick count reaches the range check below.
+        if (!long.TryParse(field, NumberStyles.None, CultureInfo.InvariantCulture, out var utcTicks)
+            || utcTicks < DateTime.MinValue.Ticks
+            || utcTicks > DateTime.MaxValue.Ticks)
+        {
+            return false;
+        }
+
+        position = new DateTimeOffset(utcTicks, TimeSpan.Zero);
+
+        return true;
+    }
+}

--- a/src/Application/Paging/PageFilterFingerprint.cs
+++ b/src/Application/Paging/PageFilterFingerprint.cs
@@ -1,0 +1,58 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MailFathom.Application.Paging;
+
+/// <summary>Reduces the filters a page was read under to the short stable text its cursor carries.</summary>
+/// <remarks>
+/// <para>
+/// A keyset position names a page edge only within the filtered set it was computed for, so a cursor carries a digest
+/// of that set and a query refuses one whose digest is not its own. Which fields go into the digest is each reading's
+/// own question and stays in its own <c>ComputeFingerprint</c>; how they are reduced to text is this.
+/// </para>
+/// <para>
+/// The digest is truncated because it distinguishes one caller's own filter sets rather than resisting a search for a
+/// collision: a forged fingerprint buys a boundary inside a page that same caller is already entitled to read. That is
+/// what makes this the weaker of the two schemes in the repository, and deliberately so.
+/// <see cref="Emails.Mailboxes.EmailTimelineFilter" /> hashes a length-prefixed canonical text instead, so no value it
+/// covers can be written to look like the field boundary — a stronger scheme for a surface where a filter is
+/// caller-composed and long-lived. The two are not interchangeable: a cursor encodes the digest it was issued with, so
+/// moving either reading onto the other's scheme invalidates every cursor a client is part-way through.
+/// </para>
+/// <para>
+/// The separator is chosen because a filter value is not expected to contain it. That is an assumption rather than an
+/// invariant — a free-text filter is refused only for being blank — and where it fails, two different filter sets
+/// reduce to one digest and a cursor issued for the first is accepted for the second. The consequence stays inside the
+/// bound above: both sets belong to the same caller, over the same account, and name a boundary that caller may
+/// already read.
+/// </para>
+/// </remarks>
+public static class PageFilterFingerprint
+{
+    /// <summary>Separates the fields, chosen because a filter value is not expected to contain it.</summary>
+    private const char FieldSeparator = '\u001f';
+
+    /// <summary>How many hexadecimal characters of the digest a cursor carries.</summary>
+    private const int FingerprintLength = 16;
+
+    /// <summary>Reduces one reading's filter values to the fingerprint its cursors carry.</summary>
+    /// <param name="fields">The filter values, in a fixed order, with <see langword="null" /> for one nobody named.</param>
+    /// <returns>The fingerprint.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="fields" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Every field is written, absent ones included, so a filter a later build adds cannot produce the text an earlier
+    /// build produced for a caller who named fewer.
+    /// </remarks>
+    public static string Of(params string?[] fields)
+    {
+        ArgumentNullException.ThrowIfNull(fields);
+
+        var material = string.Join(FieldSeparator, fields);
+
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..FingerprintLength];
+    }
+}

--- a/src/Application/Retrieval/AskMail/Audit/MailAnsweringAuditCursor.cs
+++ b/src/Application/Retrieval/AskMail/Audit/MailAnsweringAuditCursor.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Text;
-using System.Globalization;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Answering.Audit;
 
 namespace MailFathom.Application.Retrieval.AskMail.Audit;
@@ -21,23 +19,12 @@ namespace MailFathom.Application.Retrieval.AskMail.Audit;
 /// <para>
 /// It carries no secret and needs no signature: every value in it is one the caller already supplied or already
 /// received. Encoding is about opacity rather than protection — a client that cannot read a cursor does not build one,
-/// and a built cursor is how a caller would ask for a boundary this system never computed.
+/// and a built cursor is how a caller would ask for a boundary this system never computed. The encoded form itself is
+/// <see cref="KeysetCursorPayload" />'s, which every keyset cursor here shares.
 /// </para>
 /// </remarks>
 public readonly record struct MailAnsweringAuditCursor
 {
-    /// <summary>The greatest number of characters an encoded cursor may carry before it is refused unread.</summary>
-    public const int MaximumEncodedLength = 512;
-
-    /// <summary>
-    /// The encoded form's version. It leads the payload so a later change to the fields refuses the cursors this version
-    /// issued instead of misreading them.
-    /// </summary>
-    private const string FormatVersion = "1";
-
-    /// <summary>Separates the encoded fields, chosen because it appears in none of them.</summary>
-    private const char FieldSeparator = '.';
-
     private MailAnsweringAuditCursor(
         DateTimeOffset completedAt,
         MailAnsweringAuditEntryId entryId,
@@ -80,85 +67,32 @@ public readonly record struct MailAnsweringAuditCursor
 
     /// <summary>Reads a cursor a caller presented.</summary>
     /// <param name="text">The encoded cursor, as a previous page returned it.</param>
-    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise the struct default.</param>
+    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise <see langword="null" />.</param>
     /// <returns><see langword="true" /> when the text decoded into a usable cursor; otherwise <see langword="false" />.</returns>
     /// <remarks>
-    /// Whether a decoded cursor belongs to the current request is a separate question its
+    /// Every entry this record returns completed at a known instant, so a payload carrying none names no boundary here
+    /// and is refused. Whether a decoded cursor belongs to the current request is a separate question its
     /// <see cref="FilterFingerprint" /> answers, and one this method deliberately does not ask.
     /// </remarks>
-    public static bool TryDecode(string? text, out MailAnsweringAuditCursor cursor)
+    public static bool TryDecode(string? text, out MailAnsweringAuditCursor? cursor)
     {
-        cursor = default;
+        cursor = null;
 
-        if (text is null || text.Length is 0 or > MaximumEncodedLength)
-        {
-            return false;
-        }
-
-        // Validity is checked separately because the decoder's Try form reports only that a destination was too small
-        // and throws on text that is not base64url at all, which is the shape a caller most easily presents.
-        if (!Base64Url.IsValid(text))
-        {
-            return false;
-        }
-
-        Span<byte> decoded = stackalloc byte[Base64Url.GetMaxDecodedLength(MaximumEncodedLength)];
-        if (!Base64Url.TryDecodeFromChars(text, decoded, out var decodedLength))
-        {
-            return false;
-        }
-
-        var fields = Encoding.UTF8.GetString(decoded[..decodedLength]).Split(FieldSeparator);
-
-        if (fields is not [FormatVersion, var completedField, var identifierField, var fingerprintField]
-            || !TryReadCompletedAt(completedField, out var completedAt)
-            || !Guid.TryParseExact(identifierField, "N", out var identifier)
-            || identifier == Guid.Empty
-            || fingerprintField.Length is 0)
+        if (!KeysetCursorPayload.TryDecode(text, out var payload) || payload.Position is not { } completedAt)
         {
             return false;
         }
 
         cursor = new MailAnsweringAuditCursor(
             completedAt,
-            MailAnsweringAuditEntryId.Create(identifier),
-            fingerprintField);
+            MailAnsweringAuditEntryId.Create(payload.Identity),
+            payload.FilterFingerprint);
 
         return true;
     }
 
     /// <summary>Writes the cursor as the opaque string a caller presents to continue the walk.</summary>
     /// <returns>The encoded cursor.</returns>
-    /// <remarks>
-    /// The completion instant is written as its UTC tick count, which is the form the order compares: two timestamps
-    /// naming the same instant in different offsets encode identically.
-    /// </remarks>
-    public string Encode()
-    {
-        var payload = string.Join(
-            FieldSeparator,
-            FormatVersion,
-            this.CompletedAt.UtcTicks.ToString(CultureInfo.InvariantCulture),
-            this.EntryId.Value.ToString("N", CultureInfo.InvariantCulture),
-            this.FilterFingerprint);
-
-        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
-    }
-
-    private static bool TryReadCompletedAt(string field, out DateTimeOffset completedAt)
-    {
-        completedAt = default;
-
-        // NumberStyles.None refuses a sign, so no negative tick count reaches the range check below.
-        if (!long.TryParse(field, NumberStyles.None, CultureInfo.InvariantCulture, out var utcTicks)
-            || utcTicks < DateTime.MinValue.Ticks
-            || utcTicks > DateTime.MaxValue.Ticks)
-        {
-            return false;
-        }
-
-        completedAt = new DateTimeOffset(utcTicks, TimeSpan.Zero);
-
-        return true;
-    }
+    public string Encode() =>
+        KeysetCursorPayload.At(this.CompletedAt, this.EntryId.Value, this.FilterFingerprint).Encode();
 }

--- a/src/Application/Retrieval/AskMail/Audit/MailAnsweringAuditQuery.cs
+++ b/src/Application/Retrieval/AskMail/Audit/MailAnsweringAuditQuery.cs
@@ -3,8 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Globalization;
-using System.Security.Cryptography;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Accounts;
 
 namespace MailFathom.Application.Retrieval.AskMail.Audit;
@@ -33,16 +32,6 @@ public sealed record MailAnsweringAuditQuery
     /// fixed set of columns. A page is bounded by what it returns rather than only by how many rows it names.
     /// </remarks>
     public const int MaximumPageSize = 100;
-
-    /// <summary>Separates the fingerprint's fields, chosen because no filter value can contain it.</summary>
-    private const char FingerprintFieldSeparator = '\u001f';
-
-    /// <summary>How many hexadecimal characters of the filter digest a cursor carries.</summary>
-    /// <remarks>
-    /// Short because it distinguishes one caller's own filter sets rather than resisting a search for a collision: a
-    /// forged fingerprint buys a boundary inside a page that same caller is already entitled to read.
-    /// </remarks>
-    private const int FingerprintLength = 16;
 
     private MailAnsweringAuditQuery(
         MailAccountId accountId,
@@ -129,14 +118,9 @@ public sealed record MailAnsweringAuditQuery
     private static string ComputeFingerprint(
         MailAccountId accountId,
         DateTimeOffset? completedFrom,
-        DateTimeOffset? completedBefore)
-    {
-        var material = string.Join(
-            FingerprintFieldSeparator,
+        DateTimeOffset? completedBefore) =>
+        PageFilterFingerprint.Of(
             accountId.Value,
-            completedFrom?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
-            completedBefore?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
-
-        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..FingerprintLength];
-    }
+            completedFrom?.UtcTicks.ToString(CultureInfo.InvariantCulture),
+            completedBefore?.UtcTicks.ToString(CultureInfo.InvariantCulture));
 }

--- a/src/Application/Rules/History/MailRuleExecutionCursor.cs
+++ b/src/Application/Rules/History/MailRuleExecutionCursor.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Text;
-using System.Globalization;
-using System.Text;
+using MailFathom.Application.Paging;
 
 namespace MailFathom.Application.Rules.History;
 
@@ -20,22 +18,11 @@ namespace MailFathom.Application.Rules.History;
 /// <para>
 /// It carries no secret and needs no signature: every value in it is one the caller already supplied or already
 /// received. Encoding is about opacity rather than protection — a client that cannot read a cursor does not build one.
+/// The encoded form itself is <see cref="KeysetCursorPayload" />'s, which every keyset cursor here shares.
 /// </para>
 /// </remarks>
 public readonly record struct MailRuleExecutionCursor
 {
-    /// <summary>The greatest number of characters an encoded cursor may carry before it is refused unread.</summary>
-    public const int MaximumEncodedLength = 512;
-
-    /// <summary>
-    /// The encoded form's version. It leads the payload so a later change to the fields refuses the cursors this version
-    /// issued instead of misreading them.
-    /// </summary>
-    private const string FormatVersion = "1";
-
-    /// <summary>Separates the encoded fields, chosen because it appears in none of them.</summary>
-    private const char FieldSeparator = '.';
-
     private MailRuleExecutionCursor(
         DateTimeOffset evaluatedAt,
         MailRuleExecutionId executionId,
@@ -73,85 +60,32 @@ public readonly record struct MailRuleExecutionCursor
 
     /// <summary>Reads a cursor a caller presented.</summary>
     /// <param name="text">The encoded cursor, as a previous page returned it.</param>
-    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise the struct default.</param>
+    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise <see langword="null" />.</param>
     /// <returns><see langword="true" /> when the text decoded into a usable cursor; otherwise <see langword="false" />.</returns>
     /// <remarks>
-    /// Whether a decoded cursor belongs to the current request is a separate question its
+    /// Every execution this history returns was evaluated at a known instant, so a payload carrying none names no
+    /// boundary here and is refused. Whether a decoded cursor belongs to the current request is a separate question its
     /// <see cref="FilterFingerprint" /> answers, and one this method deliberately does not ask.
     /// </remarks>
-    public static bool TryDecode(string? text, out MailRuleExecutionCursor cursor)
+    public static bool TryDecode(string? text, out MailRuleExecutionCursor? cursor)
     {
-        cursor = default;
+        cursor = null;
 
-        if (text is null || text.Length is 0 or > MaximumEncodedLength)
-        {
-            return false;
-        }
-
-        // Validity is checked separately because the decoder's Try form reports only that a destination was too small
-        // and throws on text that is not base64url at all, which is the shape a caller most easily presents.
-        if (!Base64Url.IsValid(text))
-        {
-            return false;
-        }
-
-        Span<byte> decoded = stackalloc byte[Base64Url.GetMaxDecodedLength(MaximumEncodedLength)];
-        if (!Base64Url.TryDecodeFromChars(text, decoded, out var decodedLength))
-        {
-            return false;
-        }
-
-        var fields = Encoding.UTF8.GetString(decoded[..decodedLength]).Split(FieldSeparator);
-
-        if (fields is not [FormatVersion, var evaluatedField, var identifierField, var fingerprintField]
-            || !TryReadEvaluatedAt(evaluatedField, out var evaluatedAt)
-            || !Guid.TryParseExact(identifierField, "N", out var identifier)
-            || identifier == Guid.Empty
-            || fingerprintField.Length is 0)
+        if (!KeysetCursorPayload.TryDecode(text, out var payload) || payload.Position is not { } evaluatedAt)
         {
             return false;
         }
 
         cursor = new MailRuleExecutionCursor(
             evaluatedAt,
-            MailRuleExecutionId.Create(identifier),
-            fingerprintField);
+            MailRuleExecutionId.Create(payload.Identity),
+            payload.FilterFingerprint);
 
         return true;
     }
 
     /// <summary>Writes the cursor as the opaque string a caller presents to continue the walk.</summary>
     /// <returns>The encoded cursor.</returns>
-    /// <remarks>
-    /// The evaluation instant is written as its UTC tick count, which is the form the order compares: two timestamps
-    /// naming the same instant in different offsets encode identically.
-    /// </remarks>
-    public string Encode()
-    {
-        var payload = string.Join(
-            FieldSeparator,
-            FormatVersion,
-            this.EvaluatedAt.UtcTicks.ToString(CultureInfo.InvariantCulture),
-            this.ExecutionId.Value.ToString("N", CultureInfo.InvariantCulture),
-            this.FilterFingerprint);
-
-        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
-    }
-
-    private static bool TryReadEvaluatedAt(string field, out DateTimeOffset evaluatedAt)
-    {
-        evaluatedAt = default;
-
-        // NumberStyles.None refuses a sign, so no negative tick count reaches the range check below.
-        if (!long.TryParse(field, NumberStyles.None, CultureInfo.InvariantCulture, out var utcTicks)
-            || utcTicks < DateTime.MinValue.Ticks
-            || utcTicks > DateTime.MaxValue.Ticks)
-        {
-            return false;
-        }
-
-        evaluatedAt = new DateTimeOffset(utcTicks, TimeSpan.Zero);
-
-        return true;
-    }
+    public string Encode() =>
+        KeysetCursorPayload.At(this.EvaluatedAt, this.ExecutionId.Value, this.FilterFingerprint).Encode();
 }

--- a/src/Application/Rules/History/MailRuleExecutionQuery.cs
+++ b/src/Application/Rules/History/MailRuleExecutionQuery.cs
@@ -3,8 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Globalization;
-using System.Security.Cryptography;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 
@@ -39,16 +38,6 @@ public sealed record MailRuleExecutionQuery
     /// is what keeps this figure meaningful.
     /// </remarks>
     public const int MaximumPageSize = 200;
-
-    /// <summary>Separates the fingerprint's fields, chosen because no filter value can contain it.</summary>
-    private const char FingerprintFieldSeparator = '\u001f';
-
-    /// <summary>How many hexadecimal characters of the filter digest a cursor carries.</summary>
-    /// <remarks>
-    /// Short because it distinguishes one caller's own filter sets rather than resisting a search for a collision: a
-    /// forged fingerprint buys a boundary inside a page that same caller is already entitled to read.
-    /// </remarks>
-    private const int FingerprintLength = 16;
 
     private MailRuleExecutionQuery(
         MailAccountId accountId,
@@ -162,16 +151,11 @@ public sealed record MailRuleExecutionQuery
         string? ruleName,
         StoredEmailId? storedEmailId,
         DateTimeOffset? evaluatedFrom,
-        DateTimeOffset? evaluatedBefore)
-    {
-        var material = string.Join(
-            FingerprintFieldSeparator,
+        DateTimeOffset? evaluatedBefore) =>
+        PageFilterFingerprint.Of(
             accountId.Value,
-            ruleName ?? string.Empty,
-            storedEmailId?.Value.ToString("N", CultureInfo.InvariantCulture) ?? string.Empty,
-            evaluatedFrom?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
-            evaluatedBefore?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
-
-        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..FingerprintLength];
-    }
+            ruleName,
+            storedEmailId?.Value.ToString("N", CultureInfo.InvariantCulture),
+            evaluatedFrom?.UtcTicks.ToString(CultureInfo.InvariantCulture),
+            evaluatedBefore?.UtcTicks.ToString(CultureInfo.InvariantCulture));
 }

--- a/src/Application/Spam/History/SpamClassificationHistoryCursor.cs
+++ b/src/Application/Spam/History/SpamClassificationHistoryCursor.cs
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Text;
-using System.Globalization;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Emails;
 
 namespace MailFathom.Application.Spam.History;
@@ -21,22 +19,11 @@ namespace MailFathom.Application.Spam.History;
 /// <para>
 /// It carries no secret and needs no signature: every value in it is one the caller already supplied or already
 /// received. Encoding is about opacity rather than protection — a client that cannot read a cursor does not build one.
+/// The encoded form itself is <see cref="KeysetCursorPayload" />'s, which every keyset cursor here shares.
 /// </para>
 /// </remarks>
 public readonly record struct SpamClassificationHistoryCursor
 {
-    /// <summary>The greatest number of characters an encoded cursor may carry before it is refused unread.</summary>
-    public const int MaximumEncodedLength = 512;
-
-    /// <summary>
-    /// The encoded form's version. It leads the payload so a later change to the fields refuses the cursors this version
-    /// issued instead of misreading them.
-    /// </summary>
-    private const string FormatVersion = "1";
-
-    /// <summary>Separates the encoded fields, chosen because it appears in none of them.</summary>
-    private const char FieldSeparator = '.';
-
     private SpamClassificationHistoryCursor(
         DateTimeOffset evaluatedAt,
         StoredEmailId emailId,
@@ -74,85 +61,32 @@ public readonly record struct SpamClassificationHistoryCursor
 
     /// <summary>Reads a cursor a caller presented.</summary>
     /// <param name="text">The encoded cursor, as a previous page returned it.</param>
-    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise the struct default.</param>
+    /// <param name="cursor">The decoded cursor when the text is one this version issued; otherwise <see langword="null" />.</param>
     /// <returns><see langword="true" /> when the text decoded into a usable cursor; otherwise <see langword="false" />.</returns>
     /// <remarks>
-    /// Whether a decoded cursor belongs to the current request is a separate question its
+    /// Every classification this reading returns was evaluated at a known instant, so a payload carrying none names no
+    /// boundary here and is refused. Whether a decoded cursor belongs to the current request is a separate question its
     /// <see cref="FilterFingerprint" /> answers, and one this method deliberately does not ask.
     /// </remarks>
-    public static bool TryDecode(string? text, out SpamClassificationHistoryCursor cursor)
+    public static bool TryDecode(string? text, out SpamClassificationHistoryCursor? cursor)
     {
-        cursor = default;
+        cursor = null;
 
-        if (text is null || text.Length is 0 or > MaximumEncodedLength)
-        {
-            return false;
-        }
-
-        // Validity is checked separately because the decoder's Try form reports only that a destination was too small
-        // and throws on text that is not base64url at all, which is the shape a caller most easily presents.
-        if (!Base64Url.IsValid(text))
-        {
-            return false;
-        }
-
-        Span<byte> decoded = stackalloc byte[Base64Url.GetMaxDecodedLength(MaximumEncodedLength)];
-        if (!Base64Url.TryDecodeFromChars(text, decoded, out var decodedLength))
-        {
-            return false;
-        }
-
-        var fields = Encoding.UTF8.GetString(decoded[..decodedLength]).Split(FieldSeparator);
-
-        if (fields is not [FormatVersion, var evaluatedField, var identifierField, var fingerprintField]
-            || !TryReadEvaluatedAt(evaluatedField, out var evaluatedAt)
-            || !Guid.TryParseExact(identifierField, "N", out var identifier)
-            || identifier == Guid.Empty
-            || fingerprintField.Length is 0)
+        if (!KeysetCursorPayload.TryDecode(text, out var payload) || payload.Position is not { } evaluatedAt)
         {
             return false;
         }
 
         cursor = new SpamClassificationHistoryCursor(
             evaluatedAt,
-            StoredEmailId.Create(identifier),
-            fingerprintField);
+            StoredEmailId.Create(payload.Identity),
+            payload.FilterFingerprint);
 
         return true;
     }
 
     /// <summary>Writes the cursor as the opaque string a caller presents to continue the walk.</summary>
     /// <returns>The encoded cursor.</returns>
-    /// <remarks>
-    /// The evaluation instant is written as its UTC tick count, which is the form the order compares: two timestamps
-    /// naming the same instant in different offsets encode identically.
-    /// </remarks>
-    public string Encode()
-    {
-        var payload = string.Join(
-            FieldSeparator,
-            FormatVersion,
-            this.EvaluatedAt.UtcTicks.ToString(CultureInfo.InvariantCulture),
-            this.EmailId.Value.ToString("N", CultureInfo.InvariantCulture),
-            this.FilterFingerprint);
-
-        return Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
-    }
-
-    private static bool TryReadEvaluatedAt(string field, out DateTimeOffset evaluatedAt)
-    {
-        evaluatedAt = default;
-
-        // NumberStyles.None refuses a sign, so no negative tick count reaches the range check below.
-        if (!long.TryParse(field, NumberStyles.None, CultureInfo.InvariantCulture, out var utcTicks)
-            || utcTicks < DateTime.MinValue.Ticks
-            || utcTicks > DateTime.MaxValue.Ticks)
-        {
-            return false;
-        }
-
-        evaluatedAt = new DateTimeOffset(utcTicks, TimeSpan.Zero);
-
-        return true;
-    }
+    public string Encode() =>
+        KeysetCursorPayload.At(this.EvaluatedAt, this.EmailId.Value, this.FilterFingerprint).Encode();
 }

--- a/src/Application/Spam/History/SpamClassificationHistoryQuery.cs
+++ b/src/Application/Spam/History/SpamClassificationHistoryQuery.cs
@@ -3,8 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Globalization;
-using System.Security.Cryptography;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Spam;
@@ -40,16 +39,6 @@ public sealed record SpamClassificationHistoryQuery
     /// bounded per record, which is what keeps this figure meaningful.
     /// </remarks>
     public const int MaximumPageSize = 200;
-
-    /// <summary>Separates the fingerprint's fields, chosen because no filter value can contain it.</summary>
-    private const char FingerprintFieldSeparator = '\u001f';
-
-    /// <summary>How many hexadecimal characters of the filter digest a cursor carries.</summary>
-    /// <remarks>
-    /// Short because it distinguishes one caller's own filter sets rather than resisting a search for a collision: a
-    /// forged fingerprint buys a boundary inside a page that same caller is already entitled to read.
-    /// </remarks>
-    private const int FingerprintLength = 16;
 
     private SpamClassificationHistoryQuery(
         MailAccountId accountId,
@@ -165,16 +154,11 @@ public sealed record SpamClassificationHistoryQuery
         StoredEmailId? storedEmailId,
         SpamVerdict? verdict,
         DateTimeOffset? evaluatedFrom,
-        DateTimeOffset? evaluatedBefore)
-    {
-        var material = string.Join(
-            FingerprintFieldSeparator,
+        DateTimeOffset? evaluatedBefore) =>
+        PageFilterFingerprint.Of(
             accountId.Value,
-            storedEmailId?.Value.ToString("N", CultureInfo.InvariantCulture) ?? string.Empty,
-            verdict?.ToString() ?? string.Empty,
-            evaluatedFrom?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? string.Empty,
-            evaluatedBefore?.UtcTicks.ToString(CultureInfo.InvariantCulture) ?? string.Empty);
-
-        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(material)))[..FingerprintLength];
-    }
+            storedEmailId?.Value.ToString("N", CultureInfo.InvariantCulture),
+            verdict?.ToString(),
+            evaluatedFrom?.UtcTicks.ToString(CultureInfo.InvariantCulture),
+            evaluatedBefore?.UtcTicks.ToString(CultureInfo.InvariantCulture));
 }

--- a/src/Host/Api/JobDeadLetterEndpoints.cs
+++ b/src/Host/Api/JobDeadLetterEndpoints.cs
@@ -120,16 +120,11 @@ internal static class JobDeadLetterEndpoints
 
         DeadLetteredJobCursor? decodedCursor = null;
 
-        if (cursor is not null)
+        if (cursor is not null && !DeadLetteredJobCursor.TryDecode(cursor, out decodedCursor))
         {
-            if (!DeadLetteredJobCursor.TryDecode(cursor, out var presentedCursor))
-            {
-                return TypedResults.Problem(
-                    "The continuation cursor is not one this deployment issued.",
-                    statusCode: StatusCodes.Status400BadRequest);
-            }
-
-            decodedCursor = presentedCursor;
+            return TypedResults.Problem(
+                "The continuation cursor is not one this deployment issued.",
+                statusCode: StatusCodes.Status400BadRequest);
         }
 
         var queryResult = DeadLetteredJobQuery.Create(jobType, accountId, pageSize, decodedCursor);

--- a/src/Host/Api/MailAnsweringAuditEndpoint.cs
+++ b/src/Host/Api/MailAnsweringAuditEndpoint.cs
@@ -83,16 +83,11 @@ internal static class MailAnsweringAuditEndpoint
 
         MailAnsweringAuditCursor? decodedCursor = null;
 
-        if (cursor is not null)
+        if (cursor is not null && !MailAnsweringAuditCursor.TryDecode(cursor, out decodedCursor))
         {
-            if (!MailAnsweringAuditCursor.TryDecode(cursor, out var presentedCursor))
-            {
-                return TypedResults.Problem(
-                    "The continuation cursor is not one this deployment issued.",
-                    statusCode: StatusCodes.Status400BadRequest);
-            }
-
-            decodedCursor = presentedCursor;
+            return TypedResults.Problem(
+                "The continuation cursor is not one this deployment issued.",
+                statusCode: StatusCodes.Status400BadRequest);
         }
 
         var queryResult = MailAnsweringAuditQuery.Create(accountId, from, before, pageSize, decodedCursor);

--- a/src/Host/Api/MailRuleEndpoints.cs
+++ b/src/Host/Api/MailRuleEndpoints.cs
@@ -224,16 +224,11 @@ internal static class MailRuleEndpoints
 
         MailRuleExecutionCursor? decodedCursor = null;
 
-        if (cursor is not null)
+        if (cursor is not null && !MailRuleExecutionCursor.TryDecode(cursor, out decodedCursor))
         {
-            if (!MailRuleExecutionCursor.TryDecode(cursor, out var presentedCursor))
-            {
-                return TypedResults.Problem(
-                    "The continuation cursor is not one this deployment issued.",
-                    statusCode: StatusCodes.Status400BadRequest);
-            }
-
-            decodedCursor = presentedCursor;
+            return TypedResults.Problem(
+                "The continuation cursor is not one this deployment issued.",
+                statusCode: StatusCodes.Status400BadRequest);
         }
 
         var queryResult = MailRuleExecutionQuery.Create(

--- a/src/Host/Api/MailboxMutationAuditEndpoint.cs
+++ b/src/Host/Api/MailboxMutationAuditEndpoint.cs
@@ -98,16 +98,11 @@ internal static class MailboxMutationAuditEndpoint
 
         MailboxMutationAuditCursor? decodedCursor = null;
 
-        if (cursor is not null)
+        if (cursor is not null && !MailboxMutationAuditCursor.TryDecode(cursor, out decodedCursor))
         {
-            if (!MailboxMutationAuditCursor.TryDecode(cursor, out var presentedCursor))
-            {
-                return TypedResults.Problem(
-                    "The continuation cursor is not one this deployment issued.",
-                    statusCode: StatusCodes.Status400BadRequest);
-            }
-
-            decodedCursor = presentedCursor;
+            return TypedResults.Problem(
+                "The continuation cursor is not one this deployment issued.",
+                statusCode: StatusCodes.Status400BadRequest);
         }
 
         var queryResult = MailboxMutationAuditQuery.Create(

--- a/src/Host/Api/OutboxEndpoints.cs
+++ b/src/Host/Api/OutboxEndpoints.cs
@@ -168,16 +168,11 @@ internal static class OutboxEndpoints
 
         OutboxCursor? decodedCursor = null;
 
-        if (cursor is not null)
+        if (cursor is not null && !OutboxCursor.TryDecode(cursor, out decodedCursor))
         {
-            if (!OutboxCursor.TryDecode(cursor, out var presentedCursor))
-            {
-                return TypedResults.Problem(
-                    "The continuation cursor is not one this deployment issued.",
-                    statusCode: StatusCodes.Status400BadRequest);
-            }
-
-            decodedCursor = presentedCursor;
+            return TypedResults.Problem(
+                "The continuation cursor is not one this deployment issued.",
+                statusCode: StatusCodes.Status400BadRequest);
         }
 
         var queryResult = OutboxQuery.Create(accountId, namedStage, pageSize, decodedCursor);

--- a/src/Host/Api/SpamClassificationEndpoints.cs
+++ b/src/Host/Api/SpamClassificationEndpoints.cs
@@ -207,16 +207,11 @@ internal static class SpamClassificationEndpoints
 
         SpamClassificationHistoryCursor? decodedCursor = null;
 
-        if (cursor is not null)
+        if (cursor is not null && !SpamClassificationHistoryCursor.TryDecode(cursor, out decodedCursor))
         {
-            if (!SpamClassificationHistoryCursor.TryDecode(cursor, out var presentedCursor))
-            {
-                return TypedResults.Problem(
-                    "The continuation cursor is not one this deployment issued.",
-                    statusCode: StatusCodes.Status400BadRequest);
-            }
-
-            decodedCursor = presentedCursor;
+            return TypedResults.Problem(
+                "The continuation cursor is not one this deployment issued.",
+                statusCode: StatusCodes.Status400BadRequest);
         }
 
         if (!TryReadVerdict(verdict, out var namedVerdict))

--- a/tests/Application.UnitTests/Emails/Mailboxes/EmailTimelineCursorTests.cs
+++ b/tests/Application.UnitTests/Emails/Mailboxes/EmailTimelineCursorTests.cs
@@ -2,91 +2,78 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Text;
-using System.Text;
 using MailFathom.Application.Emails.Mailboxes;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Emails;
 using Xunit;
 
 namespace MailFathom.Application.UnitTests.Emails.Mailboxes;
 
-/// <summary>Covers the continuation cursor: what it preserves across an encode, and what it refuses to read back.</summary>
+/// <summary>Covers the continuation cursor over its own position type, dated and undated alike.</summary>
+/// <remarks>
+/// The encoding is <see cref="KeysetCursorPayload" />'s and is covered once beside it, refusals included. What is
+/// asserted here is this reading's own half: the recorded text a client may be part-way through, and the fact that this
+/// is the one timeline whose rows need not carry an instant — a message no header could date is still on it.
+/// </remarks>
 public sealed class EmailTimelineCursorTests
 {
     private const string Fingerprint = "AAECAwQFBgcICQoLDA0ODw";
 
-    private static readonly StoredEmailId BoundaryId = StoredEmailId.Create(Guid.CreateVersion7());
+    private const string RecordedDatedCursor =
+        "MS42MzkyMjcyODYwMDAwMDAwMDAuMDE5ODkzZTU2YWQwN2JkMDlmMTE2YzNhMWQ1ZTRiMjYuQUFFQ0F3UUZCZ2NJQ1FvTERBME9Edw";
 
+    private const string RecordedUndatedCursor =
+        "MS4tLjAxOTg5M2U1NmFkMDdiZDA5ZjExNmMzYTFkNWU0YjI2LkFBRUNBd1FGQmdjSUNRb0xEQTBPRHc";
+
+    private static readonly DateTimeOffset ReceivedAt = new(2026, 8, 19, 9, 30, 0, TimeSpan.Zero);
+
+    private static readonly StoredEmailId BoundaryId =
+        StoredEmailId.Create(new Guid("019893e5-6ad0-7bd0-9f11-6c3a1d5e4b26"));
+
+    /// <summary>A client holds this text between two pages, so it is pinned rather than only compared with itself.</summary>
     [Fact]
-    public void Encode_DatedPosition_RoundTripsThePositionAndTheFingerprint()
+    public void Encode_ARecordedDatedPosition_RoundTripsThroughTheTextThisTimelineHasAlwaysIssued()
     {
         // Arrange
-        var position = new EmailTimelinePosition(new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), BoundaryId);
+        var position = new EmailTimelinePosition(ReceivedAt, BoundaryId);
 
         // Act
-        var decoded = Decode(EmailTimelineCursor.After(position, Fingerprint).Encode());
+        var encoded = EmailTimelineCursor.After(position, Fingerprint).Encode();
+        var read = EmailTimelineCursor.TryDecode(RecordedDatedCursor, out var cursor);
 
         // Assert
-        Assert.Equal(position, decoded.Position);
-        Assert.Equal(Fingerprint, decoded.FilterFingerprint);
+        Assert.Equal(RecordedDatedCursor, encoded);
+        Assert.True(read);
+        Assert.Equal(position, cursor.Position);
+        Assert.Equal(Fingerprint, cursor.FilterFingerprint);
     }
 
+    /// <summary>A message no header could date still sits on the timeline, so its boundary encodes and reads back too.</summary>
     [Fact]
-    public void Encode_UndatedPosition_RoundTripsTheAbsentTimestamp()
+    public void Encode_ARecordedUndatedPosition_RoundTripsThroughTheSentinelTextItHasAlwaysIssued()
     {
         // Arrange
         var position = new EmailTimelinePosition(null, BoundaryId);
 
         // Act
-        var decoded = Decode(EmailTimelineCursor.After(position, Fingerprint).Encode());
-
-        // Assert
-        Assert.Null(decoded.Position.ReceivedAt);
-        Assert.Equal(BoundaryId, decoded.Position.StoredEmailId);
-    }
-
-    /// <summary>
-    /// The order compares instants, so a boundary written in another offset must decode to the same one. Encoding the
-    /// offset would otherwise make two cursors for one row, and the page after each of them would differ.
-    /// </summary>
-    [Fact]
-    public void Encode_TimestampsWritingTheSameInstantInDifferentOffsets_ProduceTheSameCursor()
-    {
-        // Arrange
-        var inUtc = new EmailTimelinePosition(new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), BoundaryId);
-        var inLocalOffset = new EmailTimelinePosition(
-            new DateTimeOffset(2026, 7, 24, 10, 0, 0, TimeSpan.FromHours(2)),
-            BoundaryId);
-
-        // Act
-        var fromUtc = EmailTimelineCursor.After(inUtc, Fingerprint).Encode();
-        var fromLocalOffset = EmailTimelineCursor.After(inLocalOffset, Fingerprint).Encode();
-
-        // Assert
-        Assert.Equal(fromUtc, fromLocalOffset);
-    }
-
-    /// <summary>A cursor is opaque, which is also what stops a client from reading a mail timestamp out of it at a glance.</summary>
-    [Fact]
-    public void Encode_AnyPosition_ProducesTextThatCarriesNoReadableField()
-    {
-        // Arrange
-        var position = new EmailTimelinePosition(new DateTimeOffset(2026, 7, 24, 8, 0, 0, TimeSpan.Zero), BoundaryId);
-
-        // Act
         var encoded = EmailTimelineCursor.After(position, Fingerprint).Encode();
+        var read = EmailTimelineCursor.TryDecode(RecordedUndatedCursor, out var cursor);
 
         // Assert
-        Assert.DoesNotContain(BoundaryId.Value.ToString("N"), encoded, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("2026", encoded, StringComparison.Ordinal);
+        Assert.Equal(RecordedUndatedCursor, encoded);
+        Assert.True(read);
+        Assert.Null(cursor.Position.ReceivedAt);
+        Assert.Equal(BoundaryId, cursor.Position.StoredEmailId);
     }
 
     [Fact]
     public void After_PositionWithoutAStoredEmailIdentity_IsRejected()
     {
         // Act, Assert
-        Assert.Throws<ArgumentException>(() =>
+        var failure = Assert.Throws<ArgumentException>(() =>
             EmailTimelineCursor.After(new EmailTimelinePosition(null, default), Fingerprint));
+
+        Assert.Equal("position", failure.ParamName);
     }
 
     [Theory]
@@ -110,48 +97,4 @@ public sealed class EmailTimelineCursorTests
         // Act, Assert
         Assert.Throws<ArgumentNullException>(() => EmailTimelineCursor.After(position, null!));
     }
-
-    [Fact]
-    public void TryDecode_TextLongerThanACursorEverIs_IsRefusedWithoutDecoding()
-    {
-        // Arrange
-        var overlyLongText = new string('A', EmailTimelineCursor.MaximumEncodedLength + 1);
-
-        // Act
-        var decoded = EmailTimelineCursor.TryDecode(overlyLongText, out var cursor);
-
-        // Assert
-        Assert.False(decoded);
-        Assert.Equal(default, cursor);
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    public void TryDecode_NoText_IsRefused(string? text)
-    {
-        // Act, Assert
-        Assert.False(EmailTimelineCursor.TryDecode(text, out _));
-    }
-
-    /// <summary>A tick count no date can hold is refused rather than allowed to fault the position it would build.</summary>
-    [Fact]
-    public void TryDecode_ReceivedTicksBeyondTheCalendar_IsRefused()
-    {
-        // Arrange
-        var beyondTheCalendar = EncodedPayload($"1.{long.MaxValue}.{BoundaryId.Value:N}.{Fingerprint}");
-
-        // Act, Assert
-        Assert.False(EmailTimelineCursor.TryDecode(beyondTheCalendar, out _));
-    }
-
-    private static EmailTimelineCursor Decode(string encoded)
-    {
-        Assert.True(EmailTimelineCursor.TryDecode(encoded, out var cursor));
-
-        return cursor;
-    }
-
-    private static string EncodedPayload(string payload) =>
-        Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
 }

--- a/tests/Application.UnitTests/Jobs/DeadLetters/DeadLetteredJobCursorTests.cs
+++ b/tests/Application.UnitTests/Jobs/DeadLetters/DeadLetteredJobCursorTests.cs
@@ -4,82 +4,67 @@
 
 using MailFathom.Application.Jobs;
 using MailFathom.Application.Jobs.DeadLetters;
+using MailFathom.Application.Paging;
 using Xunit;
 
 namespace MailFathom.Application.UnitTests.Jobs.DeadLetters;
 
-/// <summary>Covers the boundary a continued reading of the dead letters resumes from.</summary>
+/// <summary>Covers the boundary a continued reading of the dead letters resumes from, over its own identity.</summary>
 /// <remarks>
-/// The set moves while it is read — a worker dead-letters another job, an operator retries one from a second terminal —
-/// so what these assert is that the boundary survives a round trip intact and that anything else is refused rather than
-/// read as a position in a reading it does not belong to.
+/// The encoding is <see cref="KeysetCursorPayload" />'s and is covered once beside it, refusals included. What is
+/// asserted here is this reading's own half: the recorded text a client may be part-way through, the job identity it
+/// reads back, and the boundary shape this reading has no row for.
 /// </remarks>
 public sealed class DeadLetteredJobCursorTests
 {
-    private static readonly DateTimeOffset StoppedAt = new(2026, 8, 13, 9, 30, 0, TimeSpan.Zero);
+    private const string Fingerprint = "abcdef0123456789";
 
-    private static readonly JobId Job = JobId.Create(new Guid("2f1c1d6c-6f0b-4a5e-9f3d-0f9b2a5c7e11"));
+    private const string RecordedCursor =
+        "MS42MzkyMjcyODYwMDAwMDAwMDAuMDE5ODkzZTU2YWQwN2JkMDlmMTE2YzNhMWQ1ZTRiMjMuYWJjZGVmMDEyMzQ1Njc4OQ";
 
-    /// <summary>A cursor is only useful if the next request reads back exactly the position the last page ended on.</summary>
+    private static readonly DateTimeOffset StoppedAt = new(2026, 8, 19, 9, 30, 0, TimeSpan.Zero);
+
+    private static readonly JobId Job = JobId.Create(new Guid("019893e5-6ad0-7bd0-9f11-6c3a1d5e4b23"));
+
+    /// <summary>A client holds this text between two pages, so it is pinned rather than only compared with itself.</summary>
     [Fact]
-    public void TryDecode_ACursorThisVersionIssued_ReadsBackTheSamePosition()
+    public void Encode_ARecordedBoundary_RoundTripsThroughTheTextThisReadingHasAlwaysIssued()
     {
-        // Arrange
-        var encoded = DeadLetteredJobCursor.After(StoppedAt, Job, "fingerprint").Encode();
-
         // Act
-        var decoded = DeadLetteredJobCursor.TryDecode(encoded, out var cursor);
+        var encoded = DeadLetteredJobCursor.After(StoppedAt, Job, Fingerprint).Encode();
+        var read = DeadLetteredJobCursor.TryDecode(RecordedCursor, out var cursor);
 
         // Assert
-        Assert.True(decoded);
-        Assert.Equal(StoppedAt, cursor.DeadLetteredAt);
-        Assert.Equal(Job, cursor.JobId);
-        Assert.Equal("fingerprint", cursor.FilterFingerprint);
+        Assert.Equal(RecordedCursor, encoded);
+        Assert.True(read);
+        Assert.NotNull(cursor);
+        Assert.Equal(StoppedAt, cursor.Value.DeadLetteredAt);
+        Assert.Equal(Job, cursor.Value.JobId);
+        Assert.Equal(Fingerprint, cursor.Value.FilterFingerprint);
     }
 
-    /// <summary>
-    /// The instant is written as its UTC tick count, so two timestamps naming the same moment in different offsets are
-    /// one boundary rather than two that compare differently against the order the reading is taken in.
-    /// </summary>
+    /// <summary>Every job this reading returns stopped at a known instant, so a payload with none names nothing here.</summary>
     [Fact]
-    public void Encode_TheSameInstantInAnotherOffset_ProducesTheSameCursor()
+    public void TryDecode_APayloadCarryingNoPosition_IsRefused()
     {
         // Arrange
-        var elsewhere = StoppedAt.ToOffset(TimeSpan.FromHours(2));
+        var withoutPosition = KeysetCursorPayload.At(null, Job.Value, Fingerprint).Encode();
 
         // Act
-        var encoded = DeadLetteredJobCursor.After(elsewhere, Job, "fingerprint").Encode();
+        var read = DeadLetteredJobCursor.TryDecode(withoutPosition, out var cursor);
 
         // Assert
-        Assert.Equal(DeadLetteredJobCursor.After(StoppedAt, Job, "fingerprint").Encode(), encoded);
+        Assert.False(read);
+        Assert.Null(cursor);
     }
 
-    /// <summary>Anything a client built for itself is refused, because a client that cannot read a cursor does not write one.</summary>
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("not a cursor at all")]
-    [InlineData("MS4yLjM")]
-    public void TryDecode_TextThisVersionDidNotIssue_IsRefused(string? text)
-    {
-        // Arrange, Act
-        var decoded = DeadLetteredJobCursor.TryDecode(text, out _);
-
-        // Assert
-        Assert.False(decoded);
-    }
-
-    /// <summary>A cursor longer than the bound is refused unread, so no caller can make the decoder work for it.</summary>
+    /// <summary>A cursor proves which walk it belongs to, so it is refused without the fingerprint that says so.</summary>
     [Fact]
-    public void TryDecode_TextLongerThanTheBound_IsRefusedWithoutBeingDecoded()
+    public void After_ABlankFingerprint_IsRefused()
     {
-        // Arrange
-        var overlong = new string('a', DeadLetteredJobCursor.MaximumEncodedLength + 1);
+        // Act, Assert
+        var failure = Assert.Throws<ArgumentException>(() => DeadLetteredJobCursor.After(StoppedAt, Job, "   "));
 
-        // Act
-        var decoded = DeadLetteredJobCursor.TryDecode(overlong, out _);
-
-        // Assert
-        Assert.False(decoded);
+        Assert.Equal("filterFingerprint", failure.ParamName);
     }
 }

--- a/tests/Application.UnitTests/Mail/Delivery/Operations/OutboxCursorTests.cs
+++ b/tests/Application.UnitTests/Mail/Delivery/Operations/OutboxCursorTests.cs
@@ -3,88 +3,69 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Mail.Delivery.Operations;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Delivery;
 using Xunit;
 
 namespace MailFathom.Application.UnitTests.Mail.Delivery.Operations;
 
-/// <summary>Covers what an outbox cursor carries across an encoding, and what it refuses to be read from.</summary>
+/// <summary>Covers what an outbox cursor carries across an encoding, over its own position and its own identity.</summary>
 /// <remarks>
-/// A cursor is the boundary a page continues from, so anything it loses or misreads is a send served twice or skipped
-/// entirely. What is asserted is the round trip and the refusals: text this version did not issue is refused rather than
-/// read as a position nobody meant.
+/// The encoding is <see cref="KeysetCursorPayload" />'s and is covered once beside it, refusals included. What is
+/// asserted here is this reading's own half: the recorded text a client may be part-way through, the send identity it
+/// reads back, and the boundary shape this reading has no row for.
 /// </remarks>
 public sealed class OutboxCursorTests
 {
+    private const string Fingerprint = "abcdef0123456789";
+
+    private const string RecordedCursor =
+        "MS42MzkyMjcyODYwMDAwMDAwMDAuMDE5ODkzZTU2YWQwN2JkMDlmMTE2YzNhMWQ1ZTRiMjAuYWJjZGVmMDEyMzQ1Njc4OQ";
+
     private static readonly DateTimeOffset RecordedAt = new(2026, 8, 19, 9, 30, 0, TimeSpan.Zero);
 
-    private static readonly OutgoingEmailId Send = OutgoingEmailId.Create(Guid.CreateVersion7(RecordedAt));
+    private static readonly OutgoingEmailId Send =
+        OutgoingEmailId.Create(new Guid("019893e5-6ad0-7bd0-9f11-6c3a1d5e4b20"));
 
+    /// <summary>A client holds this text between two pages, so it is pinned rather than only compared with itself.</summary>
     [Fact]
-    public void TryDecode_ACursorThisVersionEncoded_ReadsBackEveryValueItCarried()
+    public void Encode_ARecordedBoundary_RoundTripsThroughTheTextThisReadingHasAlwaysIssued()
     {
-        // Arrange
-        var encoded = OutboxCursor.After(RecordedAt, Send, "abcdef0123456789").Encode();
-
         // Act
-        var read = OutboxCursor.TryDecode(encoded, out var cursor);
+        var encoded = OutboxCursor.After(RecordedAt, Send, Fingerprint).Encode();
+        var read = OutboxCursor.TryDecode(RecordedCursor, out var cursor);
 
         // Assert
+        Assert.Equal(RecordedCursor, encoded);
         Assert.True(read);
-        Assert.Equal(RecordedAt, cursor.RecordedAt);
-        Assert.Equal(Send, cursor.OutgoingEmailId);
-        Assert.Equal("abcdef0123456789", cursor.FilterFingerprint);
+        Assert.NotNull(cursor);
+        Assert.Equal(RecordedAt, cursor.Value.RecordedAt);
+        Assert.Equal(Send, cursor.Value.OutgoingEmailId);
+        Assert.Equal(Fingerprint, cursor.Value.FilterFingerprint);
     }
 
-    /// <summary>The instant is compared as an instant, so an offset the caller happened to write it in changes nothing.</summary>
+    /// <summary>Every send this reading returns was written down at a known instant, so a payload with none names nothing here.</summary>
     [Fact]
-    public void Encode_TwoTimestampsNamingOneInstant_ProduceTheSameCursor()
+    public void TryDecode_APayloadCarryingNoPosition_IsRefused()
     {
         // Arrange
-        var elsewhere = RecordedAt.ToOffset(TimeSpan.FromHours(2));
+        var withoutPosition = KeysetCursorPayload.At(null, Send.Value, Fingerprint).Encode();
 
         // Act
-        var here = OutboxCursor.After(RecordedAt, Send, "fingerprint").Encode();
-        var there = OutboxCursor.After(elsewhere, Send, "fingerprint").Encode();
-
-        // Assert
-        Assert.Equal(here, there);
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("not base64url at all!!")]
-    [InlineData("YWJj")]
-    public void TryDecode_TextThisVersionDidNotIssue_IsRefusedRatherThanRead(string? text)
-    {
-        // Act
-        var read = OutboxCursor.TryDecode(text, out var cursor);
+        var read = OutboxCursor.TryDecode(withoutPosition, out var cursor);
 
         // Assert
         Assert.False(read);
-        Assert.Equal(default, cursor);
-    }
-
-    /// <summary>A cursor longer than the reading ever issues is refused unread rather than decoded into a buffer sized for it.</summary>
-    [Fact]
-    public void TryDecode_TextLongerThanAnIssuedCursor_IsRefusedUnread()
-    {
-        // Arrange
-        var overlong = new string('A', OutboxCursor.MaximumEncodedLength + 1);
-
-        // Act
-        var read = OutboxCursor.TryDecode(overlong, out _);
-
-        // Assert
-        Assert.False(read);
+        Assert.Null(cursor);
     }
 
     /// <summary>A cursor proves which walk it belongs to, so it is refused without the fingerprint that says so.</summary>
     [Fact]
     public void After_ABlankFingerprint_IsRefused()
     {
-        // Act and assert
-        Assert.Throws<ArgumentException>(() => OutboxCursor.After(RecordedAt, Send, "  "));
+        // Act, Assert
+        var failure = Assert.Throws<ArgumentException>(() => OutboxCursor.After(RecordedAt, Send, "  "));
+
+        Assert.Equal("filterFingerprint", failure.ParamName);
     }
 }

--- a/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditCursorTests.cs
+++ b/tests/Application.UnitTests/Mail/Mutations/Audit/MailboxMutationAuditCursorTests.cs
@@ -3,6 +3,7 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using MailFathom.Application.Mail.Mutations.Audit;
+using MailFathom.Application.Paging;
 using MailFathom.Domain.Accounts;
 using MailFathom.Domain.Emails;
 using MailFathom.Domain.Failures;
@@ -13,80 +14,79 @@ using Xunit;
 
 namespace MailFathom.Application.UnitTests.Mail.Mutations.Audit;
 
-/// <summary>Covers the boundary one page of an audit trail hands to the next.</summary>
+/// <summary>Covers the boundary one page of an audit trail hands to the next, over its own identity.</summary>
+/// <remarks>
+/// The encoding is <see cref="KeysetCursorPayload" />'s and is covered once beside it, refusals included. What is
+/// asserted here is this reading's own half: the recorded text a client may be part-way through, the entry identity it
+/// reads back, and the boundary shape this reading has no row for.
+/// </remarks>
 public sealed class MailboxMutationAuditCursorTests
 {
-    private const string Fingerprint = "0123456789abcdef";
+    private const string Fingerprint = "abcdef0123456789";
 
-    private static readonly DateTimeOffset CompletedAt = new(2026, 8, 7, 12, 0, 0, TimeSpan.Zero);
+    private const string RecordedCursor =
+        "MS42MzkyMjcyODYwMDAwMDAwMDAuMDE5ODkzZTU2YWQwN2JkMDlmMTE2YzNhMWQ1ZTRiMjQuYWJjZGVmMDEyMzQ1Njc4OQ";
 
-    /// <summary>A cursor survives the round trip through the opaque text a caller presents.</summary>
+    private static readonly DateTimeOffset CompletedAt = new(2026, 8, 19, 9, 30, 0, TimeSpan.Zero);
+
+    private static readonly MailboxMutationAuditEntryId EntryId =
+        MailboxMutationAuditEntryId.Create(new Guid("019893e5-6ad0-7bd0-9f11-6c3a1d5e4b24"));
+
+    /// <summary>A client holds this text between two pages, so it is pinned rather than only compared with itself.</summary>
+    /// <remarks>The entry overload is what a page actually advances by, so it is the one the recorded text is issued from.</remarks>
     [Fact]
-    public void TryDecode_TextThisVersionEncoded_RestoresTheBoundary()
+    public void Encode_ARecordedBoundary_RoundTripsThroughTheTextThisTrailHasAlwaysIssued()
     {
-        // Arrange
-        var entry = Entry();
-        var encoded = MailboxMutationAuditCursor.After(entry, Fingerprint).Encode();
-
         // Act
-        var decoded = MailboxMutationAuditCursor.TryDecode(encoded, out var cursor);
+        var encoded = MailboxMutationAuditCursor.After(Entry(), Fingerprint).Encode();
+        var read = MailboxMutationAuditCursor.TryDecode(RecordedCursor, out var cursor);
 
         // Assert
-        Assert.Equal(
-            (true, entry.CompletedAt, entry.Id, Fingerprint),
-            (decoded, cursor.CompletedAt, cursor.EntryId, cursor.FilterFingerprint));
+        Assert.Equal(RecordedCursor, encoded);
+        Assert.True(read);
+        Assert.NotNull(cursor);
+        Assert.Equal(CompletedAt, cursor.Value.CompletedAt);
+        Assert.Equal(EntryId, cursor.Value.EntryId);
+        Assert.Equal(Fingerprint, cursor.Value.FilterFingerprint);
     }
 
-    /// <summary>An instant written in another offset encodes identically, so a boundary never depends on the offset.</summary>
+    /// <summary>Every entry this trail returns completed at a known instant, so a payload with none names nothing here.</summary>
     [Fact]
-    public void Encode_SameInstantInAnotherOffset_ProducesTheSameCursor()
+    public void TryDecode_APayloadCarryingNoPosition_IsRefused()
     {
         // Arrange
-        var entry = Entry();
-        var shifted = entry with { CompletedAt = entry.CompletedAt.ToOffset(TimeSpan.FromHours(2)) };
+        var withoutPosition = KeysetCursorPayload.At(null, EntryId.Value, Fingerprint).Encode();
 
         // Act
-        var encodings = new[]
-        {
-            MailboxMutationAuditCursor.After(entry, Fingerprint).Encode(),
-            MailboxMutationAuditCursor.After(shifted, Fingerprint).Encode(),
-        };
+        var read = MailboxMutationAuditCursor.TryDecode(withoutPosition, out var cursor);
 
         // Assert
-        Assert.Equal(encodings[0], encodings[1]);
+        Assert.False(read);
+        Assert.Null(cursor);
     }
 
-    /// <summary>Text this system never issued names no boundary, and is reported rather than partly decoded.</summary>
-    [Theory]
-    [InlineData("")]
-    [InlineData("not a cursor")]
-    [InlineData("MC5ub3BlLm5vcGUubm9wZQ")]
-    public void TryDecode_TextThisSystemNeverIssued_IsRefused(string text)
-    {
-        // Act
-        var decoded = MailboxMutationAuditCursor.TryDecode(text, out _);
-
-        // Assert
-        Assert.False(decoded);
-    }
-
-    /// <summary>A cursor longer than any this version issues is refused before it is decoded at all.</summary>
+    /// <summary>A cursor proves which walk it belongs to, so it is refused without the fingerprint that says so.</summary>
     [Fact]
-    public void TryDecode_TextLongerThanAnyCursorThisVersionIssues_IsRefusedUnread()
+    public void After_ABlankFingerprint_IsRefused()
     {
-        // Arrange
-        var overlong = new string('A', MailboxMutationAuditCursor.MaximumEncodedLength + 1);
+        // Act, Assert
+        var failure = Assert.Throws<ArgumentException>(
+            () => MailboxMutationAuditCursor.After(CompletedAt, EntryId, "   "));
 
-        // Act
-        var decoded = MailboxMutationAuditCursor.TryDecode(overlong, out _);
+        Assert.Equal("filterFingerprint", failure.ParamName);
+    }
 
-        // Assert
-        Assert.False(decoded);
+    /// <summary>A page advances by the rows it read, so the overload taking one is refused nothing to advance from.</summary>
+    [Fact]
+    public void After_NoEntry_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => MailboxMutationAuditCursor.After(null!, Fingerprint));
     }
 
     private static MailboxMutationAuditEntry Entry() => new()
     {
-        Id = MailboxMutationAuditEntryId.Create(Guid.CreateVersion7(CompletedAt)),
+        Id = EntryId,
         MutationRecordId = MailboxMutationRecordId.Create(Guid.CreateVersion7(CompletedAt)),
         AccountId = MailAccountId.Create("work"),
         StoredEmailId = StoredEmailId.Create(Guid.CreateVersion7(CompletedAt)),

--- a/tests/Application.UnitTests/Paging/KeysetCursorPayloadTests.cs
+++ b/tests/Application.UnitTests/Paging/KeysetCursorPayloadTests.cs
@@ -1,0 +1,177 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Buffers.Text;
+using System.Text;
+using MailFathom.Application.Paging;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Paging;
+
+/// <summary>Covers the encoding every keyset cursor shares: what survives it, and what it refuses to read.</summary>
+/// <remarks>
+/// This is the codec seven cursor families reach through, so a defect here is a page served twice or skipped on all of
+/// them at once. What is asserted is the round trip, the recorded text a client may be part-way through, and the
+/// refusals: text this version did not issue is refused rather than read as a boundary nobody meant.
+/// </remarks>
+public sealed class KeysetCursorPayloadTests
+{
+    private const string Fingerprint = "abcdef0123456789";
+
+    private const string RecordedDatedCursor =
+        "MS42MzkyMjcyODYwMDAwMDAwMDAuMDE5ODkzZTU2YWQwN2JkMDlmMTE2YzNhMWQ1ZTRiMmYuYWJjZGVmMDEyMzQ1Njc4OQ";
+
+    private const string RecordedUndatedCursor = "MS4tLjAxOTg5M2U1NmFkMDdiZDA5ZjExNmMzYTFkNWU0YjJmLmFiY2RlZjAxMjM0NTY3ODk";
+
+    private static readonly DateTimeOffset Position = new(2026, 8, 19, 9, 30, 0, TimeSpan.Zero);
+
+    private static readonly Guid Identity = new("019893e5-6ad0-7bd0-9f11-6c3a1d5e4b2f");
+
+    /// <summary>The encoded text is what a client holds between two pages, so it is pinned rather than only round-tripped.</summary>
+    [Fact]
+    public void Encode_ARecordedPosition_ProducesTheTextThisFormatHasAlwaysIssued()
+    {
+        // Act
+        var encoded = KeysetCursorPayload.At(Position, Identity, Fingerprint).Encode();
+
+        // Assert
+        Assert.Equal(RecordedDatedCursor, encoded);
+    }
+
+    /// <summary>A reading whose rows need not carry an instant writes the sentinel, and that text is pinned too.</summary>
+    [Fact]
+    public void Encode_NoPosition_ProducesTheRecordedSentinelText()
+    {
+        // Act
+        var encoded = KeysetCursorPayload.At(null, Identity, Fingerprint).Encode();
+
+        // Assert
+        Assert.Equal(RecordedUndatedCursor, encoded);
+    }
+
+    [Fact]
+    public void TryDecode_ARecordedCursor_ReadsBackEveryValueItCarried()
+    {
+        // Act
+        var read = KeysetCursorPayload.TryDecode(RecordedDatedCursor, out var payload);
+
+        // Assert
+        Assert.True(read);
+        Assert.Equal(Position, payload.Position);
+        Assert.Equal(Identity, payload.Identity);
+        Assert.Equal(Fingerprint, payload.FilterFingerprint);
+    }
+
+    [Fact]
+    public void TryDecode_ARecordedCursorWithNoPosition_ReadsBackTheAbsence()
+    {
+        // Act
+        var read = KeysetCursorPayload.TryDecode(RecordedUndatedCursor, out var payload);
+
+        // Assert
+        Assert.True(read);
+        Assert.Null(payload.Position);
+        Assert.Equal(Identity, payload.Identity);
+    }
+
+    /// <summary>The orderings compare instants, so the offset whoever wrote the row used must not reach the text.</summary>
+    [Fact]
+    public void Encode_TwoTimestampsNamingOneInstant_ProduceTheSameText()
+    {
+        // Arrange
+        var elsewhere = Position.ToOffset(TimeSpan.FromHours(2));
+
+        // Act
+        var here = KeysetCursorPayload.At(Position, Identity, Fingerprint).Encode();
+        var there = KeysetCursorPayload.At(elsewhere, Identity, Fingerprint).Encode();
+
+        // Assert
+        Assert.Equal(here, there);
+    }
+
+    /// <summary>A cursor is opaque, which is also what stops a client from reading a row's instant out of it at a glance.</summary>
+    [Fact]
+    public void Encode_AnyPosition_ProducesTextThatCarriesNoReadableField()
+    {
+        // Act
+        var encoded = KeysetCursorPayload.At(Position, Identity, Fingerprint).Encode();
+
+        // Assert
+        Assert.DoesNotContain(Identity.ToString("N"), encoded, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("2026", encoded, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not base64url at all!!")]
+    [InlineData("YWJj")]
+    public void TryDecode_TextThisVersionDidNotIssue_IsRefusedRatherThanRead(string? text)
+    {
+        // Act
+        var read = KeysetCursorPayload.TryDecode(text, out var payload);
+
+        // Assert
+        Assert.False(read);
+        Assert.Equal(default, payload);
+    }
+
+    /// <summary>Text longer than a cursor ever is is refused unread rather than decoded into a buffer sized for it.</summary>
+    [Fact]
+    public void TryDecode_TextLongerThanAnIssuedCursor_IsRefusedUnread()
+    {
+        // Arrange
+        var overlong = new string('A', KeysetCursorPayload.MaximumEncodedLength + 1);
+
+        // Act
+        var read = KeysetCursorPayload.TryDecode(overlong, out _);
+
+        // Assert
+        Assert.False(read);
+    }
+
+    /// <summary>The version leads the payload so a cursor an older or newer layout issued is refused, never misread.</summary>
+    [Theory]
+    [InlineData("2.639227286000000000.019893e56ad07bd09f116c3a1d5e4b2f.abcdef0123456789")]
+    [InlineData("1.639227286000000000.019893e56ad07bd09f116c3a1d5e4b2f")]
+    [InlineData("1.639227286000000000.019893e56ad07bd09f116c3a1d5e4b2f.abcdef0123456789.extra")]
+    public void TryDecode_APayloadThisLayoutDidNotWrite_IsRefused(string payload)
+    {
+        // Act, Assert
+        Assert.False(KeysetCursorPayload.TryDecode(Encoded(payload), out _));
+    }
+
+    /// <summary>Every field is validated before a payload is produced, so no boundary decodes only partially.</summary>
+    [Theory]
+    [InlineData("1.not-a-tick-count.019893e56ad07bd09f116c3a1d5e4b2f.abcdef0123456789")]
+    [InlineData("1.-1.019893e56ad07bd09f116c3a1d5e4b2f.abcdef0123456789")]
+    [InlineData("1.9223372036854775807.019893e56ad07bd09f116c3a1d5e4b2f.abcdef0123456789")]
+    [InlineData("1.639227286000000000.not-a-guid.abcdef0123456789")]
+    [InlineData("1.639227286000000000.00000000000000000000000000000000.abcdef0123456789")]
+    [InlineData("1.639227286000000000.019893e56ad07bd09f116c3a1d5e4b2f.")]
+    public void TryDecode_AFieldNoWalkCouldHaveWritten_IsRefused(string payload)
+    {
+        // Act, Assert
+        Assert.False(KeysetCursorPayload.TryDecode(Encoded(payload), out _));
+    }
+
+    /// <summary>A payload proves which walk it belongs to, so it is refused without the fingerprint that says so.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void At_ABlankFingerprint_IsRefused(string fingerprint)
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentException>(() => KeysetCursorPayload.At(Position, Identity, fingerprint));
+    }
+
+    [Fact]
+    public void At_NoFingerprint_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => KeysetCursorPayload.At(Position, Identity, null!));
+    }
+
+    private static string Encoded(string payload) => Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
+}

--- a/tests/Application.UnitTests/Paging/PageFilterFingerprintTests.cs
+++ b/tests/Application.UnitTests/Paging/PageFilterFingerprintTests.cs
@@ -1,0 +1,97 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Paging;
+using Xunit;
+
+namespace MailFathom.Application.UnitTests.Paging;
+
+/// <summary>Covers the digest six administrative readings reduce their filters to before a cursor carries it.</summary>
+/// <remarks>
+/// The digest text travels inside every cursor those readings issue, so it is pinned against a recorded value rather
+/// than only compared with itself: a change that quietly altered it would invalidate every cursor a client holds.
+/// </remarks>
+public sealed class PageFilterFingerprintTests
+{
+    /// <summary>The digest is a published value once a cursor carries it, so the recorded text is what proves it.</summary>
+    [Fact]
+    public void Of_RecordedFilters_ProduceTheDigestThisSchemeHasAlwaysProduced()
+    {
+        // Act
+        var fingerprint = PageFilterFingerprint.Of("account", null, "third");
+
+        // Assert
+        Assert.Equal("e50fb1a79cbfce19", fingerprint);
+    }
+
+    /// <summary>A filter nobody named and one named as empty are the same request, and reduce to the same digest.</summary>
+    [Fact]
+    public void Of_AnUnnamedFilterAndAnEmptyOne_ReduceToOneDigest()
+    {
+        // Act
+        var unnamed = PageFilterFingerprint.Of("account", null, "third");
+        var empty = PageFilterFingerprint.Of("account", string.Empty, "third");
+
+        // Assert
+        Assert.Equal(unnamed, empty);
+    }
+
+    /// <summary>Each field holds its position, so two filter sets that differ only in which value went where differ here.</summary>
+    [Fact]
+    public void Of_TheSameValuesInAnotherOrder_ProduceAnotherDigest()
+    {
+        // Act
+        var asWritten = PageFilterFingerprint.Of("account", null, "third");
+        var reordered = PageFilterFingerprint.Of("third", null, "account");
+
+        // Assert
+        Assert.NotEqual(asWritten, reordered);
+    }
+
+    /// <summary>Every field is written, so a filter a later build adds cannot produce the text an earlier build produced.</summary>
+    [Fact]
+    public void Of_AnAddedUnnamedFilter_ProducesAnotherDigestThanTheShorterSet()
+    {
+        // Act
+        var shorter = PageFilterFingerprint.Of("account");
+        var longer = PageFilterFingerprint.Of("account", null);
+
+        // Assert
+        Assert.NotEqual(shorter, longer);
+    }
+
+    [Fact]
+    public void Of_AnyFilters_ProducesLowercaseHexadecimalOfTheDeclaredLength()
+    {
+        // Act
+        var fingerprint = PageFilterFingerprint.Of("work");
+
+        // Assert
+        Assert.Equal(16, fingerprint.Length);
+        Assert.All(fingerprint, character => Assert.Contains(character, "0123456789abcdef"));
+    }
+
+    /// <summary>
+    /// The separator is an assumption about filter values rather than an invariant over them, and this is where the
+    /// assumption fails: a value carrying it reduces to what two fields split at it reduce to. The consequence is bounded
+    /// — both sets belong to one caller, over one account, and name a boundary that caller may already read.
+    /// </summary>
+    [Fact]
+    public void Of_AValueCarryingTheSeparator_CollidesWithTwoFieldsSplitAtIt()
+    {
+        // Act
+        var oneField = PageFilterFingerprint.Of("a\u001fb");
+        var twoFields = PageFilterFingerprint.Of("a", "b");
+
+        // Assert
+        Assert.Equal(oneField, twoFields);
+    }
+
+    [Fact]
+    public void Of_NoFields_IsRefused()
+    {
+        // Act, Assert
+        Assert.Throws<ArgumentNullException>(() => PageFilterFingerprint.Of((string?[])null!));
+    }
+}

--- a/tests/Application.UnitTests/Retrieval/AskMail/Audit/MailAnsweringAuditCursorTests.cs
+++ b/tests/Application.UnitTests/Retrieval/AskMail/Audit/MailAnsweringAuditCursorTests.cs
@@ -2,85 +2,71 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Paging;
 using MailFathom.Application.Retrieval.AskMail.Audit;
 using MailFathom.Domain.Answering.Audit;
 using Xunit;
 
 namespace MailFathom.Application.UnitTests.Retrieval.AskMail.Audit;
 
-/// <summary>Covers the boundary one page hands to the next, and what a presented one is refused for.</summary>
+/// <summary>Covers the boundary one page of an answering record hands to the next, over its own identity.</summary>
+/// <remarks>
+/// The encoding is <see cref="KeysetCursorPayload" />'s and is covered once beside it, refusals included. What is
+/// asserted here is this reading's own half: the recorded text a client may be part-way through, the entry identity it
+/// reads back, and the boundary shape this reading has no row for.
+/// </remarks>
 public sealed class MailAnsweringAuditCursorTests
 {
-    private static readonly DateTimeOffset Noon = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
+    private const string Fingerprint = "abcdef0123456789";
 
+    private const string RecordedCursor =
+        "MS42MzkyMjcyODYwMDAwMDAwMDAuMDE5ODkzZTU2YWQwN2JkMDlmMTE2YzNhMWQ1ZTRiMjUuYWJjZGVmMDEyMzQ1Njc4OQ";
+
+    private static readonly DateTimeOffset CompletedAt = new(2026, 8, 19, 9, 30, 0, TimeSpan.Zero);
+
+    private static readonly MailAnsweringAuditEntryId Entry =
+        MailAnsweringAuditEntryId.Create(new Guid("019893e5-6ad0-7bd0-9f11-6c3a1d5e4b25"));
+
+    /// <summary>A client holds this text between two pages, so it is pinned rather than only compared with itself.</summary>
     [Fact]
-    public void Encode_ABoundary_RoundTripsThroughTheEncodedForm()
+    public void Encode_ARecordedBoundary_RoundTripsThroughTheTextThisReadingHasAlwaysIssued()
+    {
+        // Act
+        var encoded = MailAnsweringAuditCursor.After(CompletedAt, Entry, Fingerprint).Encode();
+        var read = MailAnsweringAuditCursor.TryDecode(RecordedCursor, out var cursor);
+
+        // Assert
+        Assert.Equal(RecordedCursor, encoded);
+        Assert.True(read);
+        Assert.NotNull(cursor);
+        Assert.Equal(CompletedAt, cursor.Value.CompletedAt);
+        Assert.Equal(Entry, cursor.Value.EntryId);
+        Assert.Equal(Fingerprint, cursor.Value.FilterFingerprint);
+    }
+
+    /// <summary>Every entry this record returns completed at a known instant, so a payload with none names nothing here.</summary>
+    [Fact]
+    public void TryDecode_APayloadCarryingNoPosition_IsRefused()
     {
         // Arrange
-        var entryId = MailAnsweringAuditEntryId.Create(Guid.CreateVersion7(Noon));
-        var cursor = MailAnsweringAuditCursor.After(Noon, entryId, "abcdef0123456789");
+        var withoutPosition = KeysetCursorPayload.At(null, Entry.Value, Fingerprint).Encode();
 
         // Act
-        var decoded = MailAnsweringAuditCursor.TryDecode(cursor.Encode(), out var read);
+        var read = MailAnsweringAuditCursor.TryDecode(withoutPosition, out var cursor);
 
         // Assert
-        Assert.True(decoded);
-        Assert.Equal((Noon, entryId, "abcdef0123456789"), (read.CompletedAt, read.EntryId, read.FilterFingerprint));
+        Assert.False(read);
+        Assert.Null(cursor);
     }
 
-    /// <summary>The instant is compared as its UTC ticks, so two offsets naming one instant continue one walk.</summary>
-    [Fact]
-    public void Encode_TheSameInstantInTwoOffsets_ProducesOneCursor()
-    {
-        // Arrange
-        var entryId = MailAnsweringAuditEntryId.Create(Guid.CreateVersion7(Noon));
-
-        // Act
-        var utc = MailAnsweringAuditCursor.After(Noon, entryId, "abcdef0123456789").Encode();
-        var offset = MailAnsweringAuditCursor
-            .After(Noon.ToOffset(TimeSpan.FromHours(2)), entryId, "abcdef0123456789")
-            .Encode();
-
-        // Assert
-        Assert.Equal(utc, offset);
-    }
-
-    /// <summary>A built cursor is how a caller would ask for a boundary this system never computed.</summary>
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("not base64url!!")]
-    [InlineData("MS4xLjEuMQ")]
-    public void TryDecode_TextThisVersionDidNotIssue_IsRefused(string? text)
-    {
-        // Act
-        var decoded = MailAnsweringAuditCursor.TryDecode(text, out var cursor);
-
-        // Assert
-        Assert.False(decoded);
-        Assert.Equal(default, cursor);
-    }
-
-    /// <summary>A cursor longer than one this system issues is refused before it is read at all.</summary>
-    [Fact]
-    public void TryDecode_TextLongerThanACursor_IsRefusedUnread()
-    {
-        // Act
-        var decoded = MailAnsweringAuditCursor.TryDecode(
-            new string('a', MailAnsweringAuditCursor.MaximumEncodedLength + 1),
-            out _);
-
-        // Assert
-        Assert.False(decoded);
-    }
-
+    /// <summary>A cursor proves which walk it belongs to, so it is refused without the fingerprint that says so.</summary>
     [Fact]
     public void After_ABlankFingerprint_IsRefused()
     {
         // Act, Assert
-        Assert.Throws<ArgumentException>(() => MailAnsweringAuditCursor.After(
-            Noon,
-            MailAnsweringAuditEntryId.Create(Guid.CreateVersion7()),
-            "   "));
+        var failure = Assert.Throws<ArgumentException>(
+            () => MailAnsweringAuditCursor.After(CompletedAt, Entry, "   "));
+
+        Assert.Equal("filterFingerprint", failure.ParamName);
     }
 }

--- a/tests/Application.UnitTests/Rules/History/MailRuleExecutionCursorTests.cs
+++ b/tests/Application.UnitTests/Rules/History/MailRuleExecutionCursorTests.cs
@@ -2,86 +2,70 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
+using MailFathom.Application.Paging;
 using MailFathom.Application.Rules.History;
 using Xunit;
 
 namespace MailFathom.Application.UnitTests.Rules.History;
 
-/// <summary>Covers the boundary one page of the rule history hands to the next, and what a presented one is refused for.</summary>
+/// <summary>Covers the boundary one page of the rule history hands to the next, over its own identity.</summary>
+/// <remarks>
+/// The encoding is <see cref="KeysetCursorPayload" />'s and is covered once beside it, refusals included. What is
+/// asserted here is this reading's own half: the recorded text a client may be part-way through, the execution identity
+/// it reads back, and the boundary shape this reading has no row for.
+/// </remarks>
 public sealed class MailRuleExecutionCursorTests
 {
     private const string Fingerprint = "abcdef0123456789";
 
-    private static readonly DateTimeOffset Noon = new(2026, 8, 8, 12, 0, 0, TimeSpan.Zero);
+    private const string RecordedCursor =
+        "MS42MzkyMjcyODYwMDAwMDAwMDAuMDE5ODkzZTU2YWQwN2JkMDlmMTE2YzNhMWQ1ZTRiMjEuYWJjZGVmMDEyMzQ1Njc4OQ";
 
+    private static readonly DateTimeOffset EvaluatedAt = new(2026, 8, 19, 9, 30, 0, TimeSpan.Zero);
+
+    private static readonly MailRuleExecutionId Execution =
+        MailRuleExecutionId.Create(new Guid("019893e5-6ad0-7bd0-9f11-6c3a1d5e4b21"));
+
+    /// <summary>A client holds this text between two pages, so it is pinned rather than only compared with itself.</summary>
     [Fact]
-    public void Encode_ABoundary_RoundTripsThroughTheEncodedForm()
+    public void Encode_ARecordedBoundary_RoundTripsThroughTheTextThisReadingHasAlwaysIssued()
+    {
+        // Act
+        var encoded = MailRuleExecutionCursor.After(EvaluatedAt, Execution, Fingerprint).Encode();
+        var read = MailRuleExecutionCursor.TryDecode(RecordedCursor, out var cursor);
+
+        // Assert
+        Assert.Equal(RecordedCursor, encoded);
+        Assert.True(read);
+        Assert.NotNull(cursor);
+        Assert.Equal(EvaluatedAt, cursor.Value.EvaluatedAt);
+        Assert.Equal(Execution, cursor.Value.ExecutionId);
+        Assert.Equal(Fingerprint, cursor.Value.FilterFingerprint);
+    }
+
+    /// <summary>Every execution this history returns was evaluated at a known instant, so a payload with none names nothing here.</summary>
+    [Fact]
+    public void TryDecode_APayloadCarryingNoPosition_IsRefused()
     {
         // Arrange
-        var executionId = MailRuleExecutionId.Create(Guid.CreateVersion7(Noon));
-        var cursor = MailRuleExecutionCursor.After(Noon, executionId, Fingerprint);
+        var withoutPosition = KeysetCursorPayload.At(null, Execution.Value, Fingerprint).Encode();
 
         // Act
-        var decoded = MailRuleExecutionCursor.TryDecode(cursor.Encode(), out var read);
+        var read = MailRuleExecutionCursor.TryDecode(withoutPosition, out var cursor);
 
         // Assert
-        Assert.True(decoded);
-        Assert.Equal((Noon, executionId, Fingerprint), (read.EvaluatedAt, read.ExecutionId, read.FilterFingerprint));
+        Assert.False(read);
+        Assert.Null(cursor);
     }
 
-    /// <summary>The instant is compared as its UTC ticks, so two offsets naming one instant continue one walk.</summary>
-    [Fact]
-    public void Encode_TheSameInstantInTwoOffsets_ProducesOneCursor()
-    {
-        // Arrange
-        var executionId = MailRuleExecutionId.Create(Guid.CreateVersion7(Noon));
-
-        // Act
-        var utc = MailRuleExecutionCursor.After(Noon, executionId, Fingerprint).Encode();
-        var offset = MailRuleExecutionCursor
-            .After(Noon.ToOffset(TimeSpan.FromHours(2)), executionId, Fingerprint)
-            .Encode();
-
-        // Assert
-        Assert.Equal(utc, offset);
-    }
-
-    /// <summary>A built cursor is how a caller would ask for a boundary this system never computed.</summary>
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("not base64url!!")]
-    [InlineData("MS4xLjEuMQ")]
-    public void TryDecode_TextThisVersionDidNotIssue_IsRefused(string? text)
-    {
-        // Act
-        var decoded = MailRuleExecutionCursor.TryDecode(text, out var cursor);
-
-        // Assert
-        Assert.False(decoded);
-        Assert.Equal(default, cursor);
-    }
-
-    /// <summary>A cursor longer than one this system issues is refused before it is read at all.</summary>
-    [Fact]
-    public void TryDecode_TextLongerThanACursor_IsRefusedUnread()
-    {
-        // Act
-        var decoded = MailRuleExecutionCursor.TryDecode(
-            new string('a', MailRuleExecutionCursor.MaximumEncodedLength + 1),
-            out _);
-
-        // Assert
-        Assert.False(decoded);
-    }
-
+    /// <summary>A cursor proves which walk it belongs to, so it is refused without the fingerprint that says so.</summary>
     [Fact]
     public void After_ABlankFingerprint_IsRefused()
     {
         // Act, Assert
-        Assert.Throws<ArgumentException>(() => MailRuleExecutionCursor.After(
-            Noon,
-            MailRuleExecutionId.New(),
-            "   "));
+        var failure = Assert.Throws<ArgumentException>(
+            () => MailRuleExecutionCursor.After(EvaluatedAt, Execution, "   "));
+
+        Assert.Equal("filterFingerprint", failure.ParamName);
     }
 }

--- a/tests/Application.UnitTests/Spam/History/SpamClassificationHistoryCursorTests.cs
+++ b/tests/Application.UnitTests/Spam/History/SpamClassificationHistoryCursorTests.cs
@@ -2,103 +2,71 @@
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
-using System.Buffers.Text;
-using System.Text;
+using MailFathom.Application.Paging;
 using MailFathom.Application.Spam.History;
 using MailFathom.Domain.Emails;
 using Xunit;
 
 namespace MailFathom.Application.UnitTests.Spam.History;
 
-/// <summary>Covers the round trip, and everything a presented cursor is refused for before it is read.</summary>
+/// <summary>Covers the boundary one page of an account's classifications hands to the next, over its own identity.</summary>
+/// <remarks>
+/// The encoding is <see cref="KeysetCursorPayload" />'s and is covered once beside it, refusals included. What is
+/// asserted here is this reading's own half: the recorded text a client may be part-way through, the occurrence identity
+/// it reads back, and the boundary shape this reading has no row for.
+/// </remarks>
 public sealed class SpamClassificationHistoryCursorTests
 {
-    private const string Fingerprint = "0123456789abcdef";
+    private const string Fingerprint = "abcdef0123456789";
+
+    private const string RecordedCursor =
+        "MS42MzkyMjcyODYwMDAwMDAwMDAuMDE5ODkzZTU2YWQwN2JkMDlmMTE2YzNhMWQ1ZTRiMjIuYWJjZGVmMDEyMzQ1Njc4OQ";
+
+    private static readonly DateTimeOffset EvaluatedAt = new(2026, 8, 19, 9, 30, 0, TimeSpan.Zero);
 
     private static readonly StoredEmailId Email =
-        StoredEmailId.Create(Guid.Parse("0199a0c0-0000-7000-8000-0000000090a0"));
+        StoredEmailId.Create(new Guid("019893e5-6ad0-7bd0-9f11-6c3a1d5e4b22"));
 
-    private static readonly DateTimeOffset EvaluatedAt = new(2026, 8, 12, 9, 0, 0, TimeSpan.Zero);
-
+    /// <summary>A client holds this text between two pages, so it is pinned rather than only compared with itself.</summary>
     [Fact]
-    public void TryDecode_ACursorThisTypeIssued_ReadsBackWhatItCarried()
+    public void Encode_ARecordedBoundary_RoundTripsThroughTheTextThisReadingHasAlwaysIssued()
     {
-        // Arrange
-        var issued = SpamClassificationHistoryCursor.After(EvaluatedAt, Email, Fingerprint);
-
         // Act
-        var decoded = SpamClassificationHistoryCursor.TryDecode(issued.Encode(), out var cursor);
+        var encoded = SpamClassificationHistoryCursor.After(EvaluatedAt, Email, Fingerprint).Encode();
+        var read = SpamClassificationHistoryCursor.TryDecode(RecordedCursor, out var cursor);
 
         // Assert
-        Assert.True(decoded);
-        Assert.Equal(EvaluatedAt, cursor.EvaluatedAt);
-        Assert.Equal(Email, cursor.EmailId);
-        Assert.Equal(Fingerprint, cursor.FilterFingerprint);
+        Assert.Equal(RecordedCursor, encoded);
+        Assert.True(read);
+        Assert.NotNull(cursor);
+        Assert.Equal(EvaluatedAt, cursor.Value.EvaluatedAt);
+        Assert.Equal(Email, cursor.Value.EmailId);
+        Assert.Equal(Fingerprint, cursor.Value.FilterFingerprint);
     }
 
-    /// <summary>The instant is compared as ticks, so the same moment written at another offset encodes identically.</summary>
+    /// <summary>Every classification this reading returns was evaluated at a known instant, so a payload with none names nothing here.</summary>
     [Fact]
-    public void Encode_TheSameInstantAtAnotherOffset_ProducesTheSameCursor()
+    public void TryDecode_APayloadCarryingNoPosition_IsRefused()
     {
         // Arrange
-        var here = SpamClassificationHistoryCursor.After(EvaluatedAt, Email, Fingerprint);
-        var elsewhere = SpamClassificationHistoryCursor.After(
-            new DateTimeOffset(2026, 8, 12, 11, 0, 0, TimeSpan.FromHours(2)),
-            Email,
-            Fingerprint);
+        var withoutPosition = KeysetCursorPayload.At(null, Email.Value, Fingerprint).Encode();
 
-        // Act, Assert
-        Assert.Equal(here.Encode(), elsewhere.Encode());
+        // Act
+        var read = SpamClassificationHistoryCursor.TryDecode(withoutPosition, out var cursor);
+
+        // Assert
+        Assert.False(read);
+        Assert.Null(cursor);
     }
 
+    /// <summary>A cursor proves which walk it belongs to, so it is refused without the fingerprint that says so.</summary>
     [Fact]
     public void After_ABlankFingerprint_IsRefused()
     {
-        // Arrange, Act, Assert
+        // Act, Assert
         var failure = Assert.Throws<ArgumentException>(
             () => SpamClassificationHistoryCursor.After(EvaluatedAt, Email, "   "));
 
         Assert.Equal("filterFingerprint", failure.ParamName);
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("not base64url!!")]
-    public void TryDecode_TextNoPageIssued_IsRefused(string? text)
-    {
-        // Arrange, Act
-        var decoded = SpamClassificationHistoryCursor.TryDecode(text, out var cursor);
-
-        // Assert
-        Assert.False(decoded);
-        Assert.Equal(default, cursor);
-    }
-
-    [Fact]
-    public void TryDecode_TextLongerThanTheBound_IsRefusedUnread()
-    {
-        // Arrange
-        var overlong = new string('a', SpamClassificationHistoryCursor.MaximumEncodedLength + 1);
-
-        // Act, Assert
-        Assert.False(SpamClassificationHistoryCursor.TryDecode(overlong, out _));
-    }
-
-    [Theory]
-    [InlineData("2.638000000000000000.0199a0c000007000800000000000abcd.0123456789abcdef")]
-    [InlineData("1.not-a-number.0199a0c000007000800000000000abcd.0123456789abcdef")]
-    [InlineData("1.-638000000000000000.0199a0c000007000800000000000abcd.0123456789abcdef")]
-    [InlineData("1.638000000000000000.not-a-guid.0123456789abcdef")]
-    [InlineData("1.638000000000000000.00000000000000000000000000000000.0123456789abcdef")]
-    [InlineData("1.638000000000000000.0199a0c000007000800000000000abcd.")]
-    [InlineData("1.638000000000000000.0199a0c000007000800000000000abcd")]
-    public void TryDecode_APayloadThisVersionDidNotIssue_IsRefused(string payload)
-    {
-        // Arrange
-        var encoded = Base64Url.EncodeToString(Encoding.UTF8.GetBytes(payload));
-
-        // Act, Assert
-        Assert.False(SpamClassificationHistoryCursor.TryDecode(encoded, out _));
     }
 }

--- a/tests/Host.UnitTests/Api/MailRuleEndpointsTests.cs
+++ b/tests/Host.UnitTests/Api/MailRuleEndpointsTests.cs
@@ -402,7 +402,8 @@ public sealed class MailRuleEndpointsTests
         // Assert
         var page = Assert.IsType<Ok<MailRuleHistoryPageResponse>>(result.Result).Value!;
         Assert.True(MailRuleExecutionCursor.TryDecode(page.NextCursor, out var cursor));
-        Assert.Equal(executionId, cursor.ExecutionId);
+        Assert.NotNull(cursor);
+        Assert.Equal(executionId, cursor.Value.ExecutionId);
     }
 
     /// <summary>A cursor this deployment did not issue is refused before anything is read with it.</summary>


### PR DESCRIPTION
Closes #1019

## What moved

`src/Application/Paging/` is new and holds two concrete types and no interface.

**`KeysetCursorPayload`** — a `readonly record struct` of position, identity and filter fingerprint — owns the encoded form seven cursor families were each writing out: the `"1"` format version that leads the payload, the `'.'` separator, the 512-character bound applied before a byte is decoded, the UTC tick formatting, the calendar range check, and the `"-"` sentinel for a row no instant orders. Six of the seven copies were token-for-token identical, comments included; the seventh differed only by that sentinel.

**`PageFilterFingerprint.Of(params string?[])`** owns the U+001F separator, the SHA-256 digest and the 16-character truncation, together with the reasoning that stood in six files.

Each cursor keeps its own file, its own domain-typed identifier, its own `After` factory and its own XML documentation. Each query keeps its own `ComputeFingerprint` naming its own fields.

## The encoded text is unchanged

Both the cursor text and the digest text are byte-identical to what this deployment already issued, so a client part-way through a page keeps resolving. That is asserted rather than asserted-about: each of the seven cursors has a test pinning its encoding against a recorded literal, `KeysetCursorPayloadTests` pins the dated and the undated form, and `PageFilterFingerprintTests` pins a recorded digest. Every one of those literals was computed independently of this branch's code — from the format as `main` implements it — so the tests would fail if the codec had drifted, rather than agree with whatever it now does.

## Behaviour that is genuinely new

The six readings whose every row carries an instant refuse a payload that carries none. Before, `-` failed to parse as a tick count and the cursor was refused; now the codec reads it as an absent position and each of the six refuses it explicitly. Same answer, and it is the one thing separating them from `EmailTimelineCursor`, where a message no header could date is still on the timeline. Each of the six has a test for it.

## Host

The six administrative cursors now declare a nullable `out`, so their endpoints decode in the two statements `ContactEndpoints` already used — twelve lines become four in each of `MailAnsweringAuditEndpoint`, `MailboxMutationAuditEndpoint`, `MailRuleEndpoints`, `SpamClassificationEndpoints`, `OutboxEndpoints` and `JobDeadLetterEndpoints`. `EmailTimelineCursor` keeps its signature.

## Two things settled while here

**The page-size bound.** Five administrative queries cap at 50/200 and `MailAnsweringAuditQuery` at 50/100. The difference is already documented where it is declared — an answering entry carries the list of emails one run read rather than a fixed set of columns — so it stays as it is rather than being flattened into a number that would widen a bound for no reason. The acceptance criterion offered either, and this is the half that changes no contract.

**The separator assumption.** The hex scheme assumes no filter value contains U+001F, and `MailRuleExecutionQuery`'s free-text rule name is validated only for being blank, so the assumption is unproven there. Folding the scheme's failure mode out would change the digest text and invalidate every cursor in flight, which this change is explicitly not allowed to do, so it is recorded instead: `PageFilterFingerprint`'s remarks state it as an assumption rather than an invariant, and `Of_AValueCarryingTheSeparator_CollidesWithTwoFieldsSplitAtIt` makes it a verifiable fact rather than prose. The consequence stays inside the bound the truncation already accepts — both filter sets belong to one caller, over one account, and name a boundary that caller may already read.

## Scope held to

`ContactCursor` is untouched: three fields, no fingerprint, a heap buffer sized to the input, and a last field allowed to hold the separator. `EmailTimelineFilter.ComputeFingerprint` is untouched too — its length-prefixed canonical text over base64url is the stronger of the two schemes, and `PageFilterFingerprint`'s remarks now say so and say why the two cannot be swapped. No `PagedQueryResult<,>`, no `QueryRefusal.Declared<>`, no generic cursor predicate in the stores, and nothing under `src/Application/Abstractions/`, which means ports here rather than a place to keep a byte codec.

## Contract surfaces

None break. The MCP tool contract, the configuration schema, the database schema and the deployment contract are all untouched; so are the administrative HTTP responses, their refusal messages and their page sizes. `MaximumEncodedLength` moves from seven cursors to `KeysetCursorPayload`, which no production code outside those cursors ever read.

## Verification

`scripts/verify-full.sh` passed over exactly this tree; 10253 unit tests, 0 failed. `$check-docs-licenses` returned `n/a` on all three verdicts — no observable behaviour moved, so no page went stale, and no dependency was added, raised or removed.
