### PR TITLE
[#1026] Renew a token the submission server refuses, and share the MailKit client lifetime

### DIFF
--- a/docs/features/mail-delivery.md
+++ b/docs/features/mail-delivery.md
@@ -241,6 +241,15 @@ command: `AUTH` is the only way to present a credential, so a server advertising
 leaves nothing to fall back to. The attempt ends there with `MailAuthenticationMechanismUnavailableException`, before
 any credential is presented.
 
+**A refused access token is renewed once here too**, exactly as it is on the reading side and for the same reason: a
+cached token can be refused for something no expiry instant predicts, and the cache replaces an entry only when a
+renewal tells it to, so presenting the same value again would fail every send until that entry expired on its own. A
+token the submission server refuses is therefore renewed and presented a second time, and a fresh token it also refuses
+fails the attempt rather than looping. The exchange that renews it is a request to the authorization server, bounded by
+that dependency class rather than by the Authentication stage below — which is why that stage bounds one presentation
+rather than the whole authentication, and why an authorization server that stops answering is never reported as the
+submission server having done so.
+
 ## Five stages, five budgets
 
 Reaching a submission server and using one are five things that fail differently, so each is bounded on its own and
@@ -250,7 +259,7 @@ reported as itself:
 | --- | --- | --- |
 | Connection | 15 s | Opening the transport to the endpoint. |
 | Greeting | 15 s | Encryption, the greeting, and the capability exchange. |
-| Authentication | 20 s | The server answering the account's credential. |
+| Authentication | 20 s | The server answering one presentation of the account's credential. |
 | Command | 30 s | Any one command over the established session. |
 | Transmission | 5 min | Offering the envelope and transmitting the whole message, as one. |
 
@@ -265,7 +274,8 @@ server can therefore never be read as a process shutting down, and a shutdown ne
 
 The first three bound the stages of establishing the session and sit inside the attempt budget of the `EmailDelivery`
 resilience class, which is what a deployment configures. Their defaults total 50 s against that class's 60 s default
-attempt timeout, so a stage can expire on its own before the enclosing budget takes the attempt away from it. The other
+attempt timeout, so a stage can expire on its own before the enclosing budget takes the attempt away from it. A
+renewal is the one path that enters a stage twice, and the enclosing attempt budget is what bounds it there. The other
 two are not part of that total: both bound work over a session that is already established, which is outside the
 establishment attempt. The command budget is set on the client itself; the transmission budget is applied around the
 submission and is enclosed instead by `MailDelivery:AttemptTimeout`, which is the outbox's own bound rather than the

--- a/docs/operations/mailbox-oauth.md
+++ b/docs/operations/mailbox-oauth.md
@@ -264,7 +264,8 @@ endpoint that is not absolute HTTPS, and a `refresh_token` grant with no refresh
   where a server offers both, the registered `OAUTHBEARER` is used.
 - **A rejected token is retried once, with a new one.** A token the mail server refuses despite being unexpired — it
   was revoked, or the mailbox password changed — triggers one renewal and one re-authentication. A fresh token that is
-  also refused fails the attempt rather than looping.
+  also refused fails the attempt rather than looping. This holds on both connections an account opens, the mailbox one
+  and the submission one, since the renewal is also the only thing that replaces the cached entry.
 - **The stored refresh token is preferred over the configured one.** An account whose token has been rotated at least
   once spends what MailFathom stored; one whose token never has is served from its configured reference. Both are
   handled the same way from there.

--- a/src/Infrastructure/Mail/MailKit/Delivery/MailDeliveryTimeouts.cs
+++ b/src/Infrastructure/Mail/MailKit/Delivery/MailDeliveryTimeouts.cs
@@ -7,7 +7,7 @@ namespace MailFathom.Infrastructure.Mail.MailKit.Delivery;
 /// <summary>The budget each stage of reaching a submission server is given before it is abandoned.</summary>
 /// <param name="Connection">How long the transport to the endpoint may take to open.</param>
 /// <param name="Greeting">How long encryption, the greeting, and the capability exchange may take together.</param>
-/// <param name="Authentication">How long the server may take to answer the account's credential.</param>
+/// <param name="Authentication">How long the server may take to answer one presentation of the account's credential.</param>
 /// <param name="Command">How long any command over the established session may take, which the client enforces itself.</param>
 /// <param name="Transmission">How long offering the envelope and transmitting the whole message may take together.</param>
 /// <remarks>
@@ -18,6 +18,12 @@ namespace MailFathom.Infrastructure.Mail.MailKit.Delivery;
 /// <see cref="TimeoutException" /> rather than a cancellation, so a hung server can never be read as a host shutting
 /// down. Their defaults total less than that class's default attempt timeout, which is what keeps a stage able to
 /// expire on its own before the enclosing budget takes the attempt away from it.
+/// </para>
+/// <para>
+/// <see cref="Authentication" /> bounds one round trip rather than the whole authentication, because an account
+/// whose access token the server refuses presents a renewed one over a second round trip. The exchange that renews it
+/// is not inside this budget at all: it is a request to the authorization server, bounded by that dependency class,
+/// and holding it here would report its silence against the submission server.
 /// </para>
 /// <para>
 /// <see cref="Command" /> is not one of them. It is applied to the client as its own timeout and bounds a command over

--- a/src/Infrastructure/Mail/MailKit/Delivery/MailKitSmtpConnection.cs
+++ b/src/Infrastructure/Mail/MailKit/Delivery/MailKitSmtpConnection.cs
@@ -4,9 +4,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
-using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using MailFathom.Application.Mail.Delivery;
 using MailFathom.Application.Mail.Delivery.Transmission;
@@ -249,7 +247,7 @@ internal sealed partial class MailKitSmtpConnection : IAsyncDisposable
 
         if (ownedClient is not null)
         {
-            await DisconnectAndDisposeAsync(ownedClient);
+            await MailKitClientLifetime.DisconnectAndDisposeAsync(ownedClient);
         }
     }
 
@@ -267,7 +265,9 @@ internal sealed partial class MailKitSmtpConnection : IAsyncDisposable
             {
                 attemptClient.Timeout = (int)this.timeouts.Command.TotalMilliseconds;
 
-                TrustConfiguredCertificateAuthority(attemptClient, settings.Material.TrustedCertificateAuthority);
+                MailKitClientLifetime.TrustConfiguredCertificateAuthority(
+                    attemptClient,
+                    settings.Material.TrustedCertificateAuthority);
 
                 var socket = await this.RunPhaseAsync(
                     MailDeliveryPhase.Connection,
@@ -276,10 +276,7 @@ internal sealed partial class MailKitSmtpConnection : IAsyncDisposable
 
                 await this.GreetOverAsync(attemptClient, socket, settings, cancellationToken);
 
-                await this.RunPhaseAsync(
-                    MailDeliveryPhase.Authentication,
-                    phaseToken => this.AuthenticateAsync(attemptClient, settings, phaseToken),
-                    cancellationToken);
+                await this.AuthenticateAsync(attemptClient, settings, cancellationToken);
 
                 // Read before the client is adopted, so a failure here still leaves this connection holding nothing and
                 // the abandonment below is the only thing that closes the client.
@@ -291,7 +288,7 @@ internal sealed partial class MailKitSmtpConnection : IAsyncDisposable
             catch (SmtpCommandException refusal)
             {
                 this.ReportRefusal(refusal);
-                Abandon(attemptClient);
+                MailKitClientLifetime.Abandon(attemptClient);
 
                 throw;
             }
@@ -299,7 +296,7 @@ internal sealed partial class MailKitSmtpConnection : IAsyncDisposable
             {
                 // A half-established connection is unusable by definition, and this cleanup runs inside an attempt the
                 // pipeline may abandon, so it closes the socket rather than waiting on a reply the server owes it.
-                Abandon(attemptClient);
+                MailKitClientLifetime.Abandon(attemptClient);
 
                 throw;
             }
@@ -339,9 +336,21 @@ internal sealed partial class MailKitSmtpConnection : IAsyncDisposable
 
     /// <summary>Narrows the advertised mechanisms to the allow-list and authenticates with whichever credential the survivors need.</summary>
     /// <remarks>
+    /// <para>
     /// The advertised set is narrowed first, because MailKit selects a mechanism from whatever remains in it, and
     /// nothing widens it again. A submission server that offers nothing the account permits ends the attempt here with
     /// the account's own coded failure, since SMTP has no clear-text command to fall back to.
+    /// </para>
+    /// <para>
+    /// The Authentication budget bounds each round trip to the submission server rather than the whole of this method,
+    /// which is what lets a rejected access token be renewed here at all. A renewal is a request to the authorization
+    /// server, whose own class already allows it more than one exchange across its retries, so a stage sized to contain
+    /// a token exchange and two <c>AUTH</c> exchanges would have to be larger than the establishment stages may total
+    /// while staying inside the delivery attempt budget they are deliberately kept under. It would also attribute a
+    /// hung authorization server to the submission server, which is the reading that class's own budget exists to
+    /// prevent. So the exchanges sit between the stages instead of inside one, bounded by the class that owns them,
+    /// and every stage timeout this connection reports still names something the mail server did.
+    /// </para>
     /// </remarks>
     private async Task AuthenticateAsync(
         ISmtpClient attemptClient,
@@ -358,10 +367,15 @@ internal sealed partial class MailKitSmtpConnection : IAsyncDisposable
             this.transportSecurityPolicy.Authentication,
             out var tokenMechanism))
         {
-            var accessToken = await this.accessTokenSource.GetAccessTokenAsync(settings.AccountId, cancellationToken);
-
-            await attemptClient.AuthenticateAsync(
-                MailKitTransportSecurityMapping.ToSaslMechanism(tokenMechanism, settings.UserName, accessToken.Value),
+            await MailKitAccessTokenAuthentication.AuthenticateAsync(
+                this.accessTokenSource,
+                tokenMechanism,
+                settings.AccountId,
+                settings.UserName,
+                (mechanism, credentialToken) => this.RunPhaseAsync(
+                    MailDeliveryPhase.Authentication,
+                    phaseToken => attemptClient.AuthenticateAsync(mechanism, phaseToken),
+                    credentialToken),
                 cancellationToken);
 
             return;
@@ -375,7 +389,10 @@ internal sealed partial class MailKitSmtpConnection : IAsyncDisposable
 
         // MailKit's authentication contract takes a string, so an un-erasable copy of the password is unavoidable
         // here. It is created at the call itself and never stored, logged, or passed on.
-        await attemptClient.AuthenticateAsync(settings.UserName, password.RevealAsString(), cancellationToken);
+        await this.RunPhaseAsync(
+            MailDeliveryPhase.Authentication,
+            phaseToken => attemptClient.AuthenticateAsync(settings.UserName, password.RevealAsString(), phaseToken),
+            cancellationToken);
     }
 
     /// <summary>Runs one stage of reaching the server under a budget of its own.</summary>
@@ -471,79 +488,6 @@ internal sealed partial class MailKitSmtpConnection : IAsyncDisposable
             classification.ReplyCode,
             classification.EnhancedStatusCode?.ToString() ?? "none",
             classification.Disposition.ToString());
-    }
-
-    /// <summary>Points the client at the account's configured authority before the handshake that will consult it.</summary>
-    /// <remarks>
-    /// The anchor lives as long as the connection attempt that resolved it, and so does the callback that closes over
-    /// it: the client is created per attempt and disposed with it, so no callback outlives the certificate it reads.
-    /// An account without a configured authority leaves the client's own validating default untouched.
-    /// </remarks>
-    private static void TrustConfiguredCertificateAuthority(
-        ISmtpClient client,
-        X509Certificate2? trustedCertificateAuthority)
-    {
-        if (trustedCertificateAuthority is null)
-        {
-            return;
-        }
-
-        client.ServerCertificateValidationCallback = (_, certificate, chain, sslPolicyErrors) =>
-            MailServerCertificateValidator.IsServerCertificateTrusted(
-                trustedCertificateAuthority,
-                certificate,
-                chain,
-                sslPolicyErrors);
-    }
-
-    /// <summary>Drops a client this type has already declared unusable, without speaking the protocol again.</summary>
-    /// <remarks>
-    /// A graceful quit is a command, and a command sent to a server that stopped answering waits for a reply that may
-    /// never come, through a cancellation token this cleanup has no way to observe. Closing the socket asks the server
-    /// for nothing. Politeness belongs to <see cref="DisposeAsync" />, where the session is ending in order.
-    /// </remarks>
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "A connection already being abandoned must not have its cleanup failure replace the failure that caused the abandonment.")]
-    [SuppressMessage("Roslynator", "RCS1075:Avoid empty catch clause that catches System.Exception", Justification = "There is no second action to take: the connection is already unusable, and the caller is about to rethrow the failure that made it so.")]
-    private static void Abandon(ISmtpClient client)
-    {
-        try
-        {
-            client.Dispose();
-        }
-        catch (Exception)
-        {
-        }
-    }
-
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Both cleanup operations must be attempted while the first cleanup failure remains observable.")]
-    private static async ValueTask DisconnectAndDisposeAsync(ISmtpClient client)
-    {
-        Exception? firstCleanupException = null;
-        try
-        {
-            if (client.IsConnected)
-            {
-                await client.DisconnectAsync(quit: true, CancellationToken.None);
-            }
-        }
-        catch (Exception exception)
-        {
-            firstCleanupException = exception;
-        }
-
-        try
-        {
-            client.Dispose();
-        }
-        catch (Exception exception)
-        {
-            firstCleanupException ??= exception;
-        }
-
-        if (firstCleanupException is not null)
-        {
-            ExceptionDispatchInfo.Capture(firstCleanupException).Throw();
-        }
     }
 
     [LoggerMessage(

--- a/src/Infrastructure/Mail/MailKit/MailKitAccessTokenAuthentication.cs
+++ b/src/Infrastructure/Mail/MailKit/MailKitAccessTokenAuthentication.cs
@@ -1,0 +1,79 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Domain.Transport;
+using MailFathom.Infrastructure.Mail.OAuth;
+using MailKit.Security;
+
+namespace MailFathom.Infrastructure.Mail.MailKit;
+
+/// <summary>Presents an account's access token to a mail server, renewing it once when the server rejects one.</summary>
+/// <remarks>
+/// Both protocols authenticate the same way and neither may present a refused token twice, so the sequence is written
+/// once here rather than in each adapter. What the two do differ on is how a single presentation is bounded, which is
+/// why the presentation arrives as a delegate: the mailbox adapter authenticates under the establishment attempt
+/// budget alone, while the submission adapter gives every round trip to its server a stage budget of its own.
+/// </remarks>
+internal static class MailKitAccessTokenAuthentication
+{
+    /// <summary>Authenticates with the account's access token, renewing it once when the server refuses one this process believed was valid.</summary>
+    /// <param name="accessTokenSource">Issues the token and replaces a rejected one.</param>
+    /// <param name="tokenMechanism">The mechanism chosen from what the server advertised.</param>
+    /// <param name="accountId">The account whose token is being presented.</param>
+    /// <param name="userName">The mailbox the token acts for.</param>
+    /// <param name="presentCredential">Runs one authentication round trip against the server, under whatever budget the caller bounds it with.</param>
+    /// <param name="cancellationToken">Cancels acquiring the token and presenting it.</param>
+    /// <returns>A task that completes when the server has accepted the account's token.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when a required argument is <see langword="null" />.</exception>
+    /// <exception cref="AuthenticationException">Thrown when the server refuses a token this call has already renewed once.</exception>
+    /// <remarks>
+    /// <para>
+    /// The single retry is what separates an expired token from a rejected credential. A cached token can be refused
+    /// for reasons no expiry instant predicts — it was revoked, the mailbox password changed, an administrator
+    /// withdrew consent — and repeating the same value would spend the caller's budget on an answer that cannot
+    /// change. Renewing once distinguishes the two: a fresh token that is also refused is a decision the authorization
+    /// server and the mail server agree on, and it fails the attempt.
+    /// </para>
+    /// <para>
+    /// Renewal is also the only thing that replaces the cached entry, so without it a rotated token would keep being
+    /// presented until that entry expired on its own — which on a submission path means every send failing in the
+    /// meantime.
+    /// </para>
+    /// <para>
+    /// This is bounded and non-recursive by construction. There is exactly one renewal per call, and the token source
+    /// has its own retry budget under a different dependency class, so no retry layer nests inside another.
+    /// </para>
+    /// </remarks>
+    internal static async Task AuthenticateAsync(
+        IMailAccessTokenSource accessTokenSource,
+        MailAuthenticationMechanism tokenMechanism,
+        string accountId,
+        string userName,
+        Func<SaslMechanism, CancellationToken, Task> presentCredential,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(accessTokenSource);
+        ArgumentNullException.ThrowIfNull(presentCredential);
+
+        var accessToken = await accessTokenSource.GetAccessTokenAsync(accountId, cancellationToken);
+
+        try
+        {
+            await presentCredential(
+                MailKitTransportSecurityMapping.ToSaslMechanism(tokenMechanism, userName, accessToken.Value),
+                cancellationToken);
+        }
+        catch (AuthenticationException)
+        {
+            var renewedToken = await accessTokenSource.RenewAccessTokenAsync(
+                accountId,
+                accessToken,
+                cancellationToken);
+
+            await presentCredential(
+                MailKitTransportSecurityMapping.ToSaslMechanism(tokenMechanism, userName, renewedToken.Value),
+                cancellationToken);
+        }
+    }
+}

--- a/src/Infrastructure/Mail/MailKit/MailKitClientLifetime.cs
+++ b/src/Infrastructure/Mail/MailKit/MailKitClientLifetime.cs
@@ -1,0 +1,121 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
+using System.Security.Cryptography.X509Certificates;
+using MailKit;
+
+namespace MailFathom.Infrastructure.Mail.MailKit;
+
+/// <summary>Arranges the trust of a mail client and ends it, in the one way both protocol adapters end one.</summary>
+/// <remarks>
+/// The members are declared over <see cref="IMailService" />, which is the contract MailKit already publishes for a
+/// message service and which both the mailbox client and the submission client derive from. Nothing here is an
+/// abstraction this repository invented: certificate trust, connectedness, and the disconnect are declared there, so
+/// sharing the three costs no seam and keeps the mail library's types inside the adapter that owns them.
+/// </remarks>
+internal static class MailKitClientLifetime
+{
+    /// <summary>Points the client at the account's configured authority before the handshake that will consult it.</summary>
+    /// <param name="client">The client about to greet its server.</param>
+    /// <param name="trustedCertificateAuthority">The authority the account pins, or <see langword="null" /> to leave the client's own default in place.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="client" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// The anchor lives as long as the connection attempt that resolved it, and so does the callback that closes over
+    /// it: the client is created per attempt and disposed with it, so no callback outlives the certificate it reads.
+    /// An account without a configured authority leaves the client's own validating default untouched.
+    /// </remarks>
+    internal static void TrustConfiguredCertificateAuthority(
+        IMailService client,
+        X509Certificate2? trustedCertificateAuthority)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        if (trustedCertificateAuthority is null)
+        {
+            return;
+        }
+
+        client.ServerCertificateValidationCallback = (_, certificate, chain, sslPolicyErrors) =>
+            MailServerCertificateValidator.IsServerCertificateTrusted(
+                trustedCertificateAuthority,
+                certificate,
+                chain,
+                sslPolicyErrors);
+    }
+
+    /// <summary>Drops a client its owner has already declared unusable, without speaking the protocol again.</summary>
+    /// <param name="client">The client to close without a farewell.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="client" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// A graceful logout or quit is a command, and a command sent to a server that stopped answering waits for a reply
+    /// that may never come — on a client whose only timeout is its own, far beyond the attempt budget, and through a
+    /// cancellation token this cleanup has no way to observe. Closing the socket asks the server for nothing and
+    /// cannot block on it.
+    /// </para>
+    /// <para>
+    /// The waiting is what makes this more than impoliteness. Every caller is inside an attempt the resilience
+    /// pipeline may abandon, so a cleanup that blocked would still be running against a connection object that is not
+    /// safe for concurrent use while the next attempt was already using one. That holds on both protocols: a mailbox
+    /// connection replaces itself after a dropped read, and a submission session is established under a class that
+    /// makes a second attempt of its own.
+    /// </para>
+    /// <para>
+    /// Politeness belongs to the owner's disposal, where the session is ending in order and no attempt is racing it.
+    /// </para>
+    /// </remarks>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "A connection already being replaced or abandoned must not have its cleanup failure replace the failure that made it unusable.")]
+    [SuppressMessage("Roslynator", "RCS1075:Avoid empty catch clause that catches System.Exception", Justification = "There is no second action to take: the connection is already unusable, and the caller is about to rethrow the failure that made it so.")]
+    internal static void Abandon(IMailService client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        try
+        {
+            client.Dispose();
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    /// <summary>Ends a session in order, reporting the first cleanup failure once both cleanups have been attempted.</summary>
+    /// <param name="client">The client whose session is ending.</param>
+    /// <returns>A task that completes when the client has been disconnected and released.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="client" /> is <see langword="null" />.</exception>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Both cleanup operations must be attempted while the first cleanup failure remains observable.")]
+    internal static async ValueTask DisconnectAndDisposeAsync(IMailService client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        Exception? firstCleanupException = null;
+        try
+        {
+            if (client.IsConnected)
+            {
+                await client.DisconnectAsync(quit: true, CancellationToken.None);
+            }
+        }
+        catch (Exception exception)
+        {
+            firstCleanupException = exception;
+        }
+
+        try
+        {
+            client.Dispose();
+        }
+        catch (Exception exception)
+        {
+            firstCleanupException ??= exception;
+        }
+
+        if (firstCleanupException is not null)
+        {
+            ExceptionDispatchInfo.Capture(firstCleanupException).Throw();
+        }
+    }
+}

--- a/src/Infrastructure/Mail/MailKit/MailKitImapConnection.cs
+++ b/src/Infrastructure/Mail/MailKit/MailKitImapConnection.cs
@@ -3,8 +3,6 @@
 // Project repository: https://github.com/Krzysztof318/MailFathom
 
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.ExceptionServices;
-using System.Security.Cryptography.X509Certificates;
 using MailFathom.Application.EmailContent.Storage;
 using MailFathom.Application.Resilience;
 using MailFathom.Application.Synchronization.Sessions;
@@ -473,7 +471,7 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
 
         if (ownedClient is not null)
         {
-            await DisconnectAndDisposeAsync(ownedClient);
+            await MailKitClientLifetime.DisconnectAndDisposeAsync(ownedClient);
         }
     }
 
@@ -514,7 +512,9 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
             var attemptClient = this.clientFactory();
             try
             {
-                TrustConfiguredCertificateAuthority(attemptClient, settings.Material.TrustedCertificateAuthority);
+                MailKitClientLifetime.TrustConfiguredCertificateAuthority(
+                    attemptClient,
+                    settings.Material.TrustedCertificateAuthority);
 
                 await attemptClient.ConnectAsync(
                     settings.Host,
@@ -536,7 +536,7 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
             {
                 // A half-established connection is unusable by definition, and this cleanup runs inside an attempt the
                 // pipeline may abandon, so it closes the socket rather than waiting on a logout the server owes it.
-                Abandon(attemptClient);
+                MailKitClientLifetime.Abandon(attemptClient);
                 throw;
             }
         }
@@ -589,7 +589,13 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
             this.transportSecurityPolicy.Authentication,
             out var tokenMechanism))
         {
-            await this.AuthenticateWithAccessTokenAsync(attemptClient, settings, tokenMechanism, cancellationToken);
+            await MailKitAccessTokenAuthentication.AuthenticateAsync(
+                this.accessTokenSource,
+                tokenMechanism,
+                settings.AccountId,
+                settings.UserName,
+                attemptClient.AuthenticateAsync,
+                cancellationToken);
 
             return;
         }
@@ -603,48 +609,6 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
         // MailKit's authentication contract takes a string, so an un-erasable copy of the password is unavoidable
         // here. It is created at the call itself and never stored, logged, or passed on.
         await attemptClient.AuthenticateAsync(settings.UserName, password.RevealAsString(), cancellationToken);
-    }
-
-    /// <summary>Presents an access token, renewing it once when the server rejects one this process believed was valid.</summary>
-    /// <remarks>
-    /// <para>
-    /// The single retry is what separates an expired token from a rejected credential. A cached token can be refused
-    /// for reasons no expiry instant predicts — it was revoked, the mailbox password changed, an administrator
-    /// withdrew consent — and repeating the same value would spend the establishment budget on an answer that cannot
-    /// change. Renewing once distinguishes the two: a fresh token that is also refused is a decision the authorization
-    /// server and the mail server agree on, and it fails the attempt.
-    /// </para>
-    /// <para>
-    /// This is bounded and non-recursive by construction. There is exactly one renewal per establishment attempt, and
-    /// the token source has its own retry budget under a different dependency class, so no retry layer nests inside
-    /// another.
-    /// </para>
-    /// </remarks>
-    private async Task AuthenticateWithAccessTokenAsync(
-        IImapClient attemptClient,
-        ImapAccountSettings settings,
-        MailAuthenticationMechanism tokenMechanism,
-        CancellationToken cancellationToken)
-    {
-        var accessToken = await this.accessTokenSource.GetAccessTokenAsync(settings.AccountId, cancellationToken);
-
-        try
-        {
-            await attemptClient.AuthenticateAsync(
-                MailKitTransportSecurityMapping.ToSaslMechanism(tokenMechanism, settings.UserName, accessToken.Value),
-                cancellationToken);
-        }
-        catch (global::MailKit.Security.AuthenticationException)
-        {
-            var renewedToken = await this.accessTokenSource.RenewAccessTokenAsync(
-                settings.AccountId,
-                accessToken,
-                cancellationToken);
-
-            await attemptClient.AuthenticateAsync(
-                MailKitTransportSecurityMapping.ToSaslMechanism(tokenMechanism, settings.UserName, renewedToken.Value),
-                cancellationToken);
-        }
     }
 
     /// <summary>Selects the pinned folder with this connection's fixed access, once it is confirmed to be the one the session started on.</summary>
@@ -756,83 +720,7 @@ internal sealed class MailKitImapConnection : IAsyncDisposable
 
         if (discardedClient is not null)
         {
-            Abandon(discardedClient);
-        }
-    }
-
-    /// <summary>Points the client at the account's configured authority before the handshake that will consult it.</summary>
-    /// <remarks>
-    /// The anchor lives as long as the connection attempt that resolved it, and so does the callback that closes over
-    /// it: the client is created per attempt and disposed with it, so no callback outlives the certificate it reads.
-    /// An account without a configured authority leaves the client's own validating default untouched.
-    /// </remarks>
-    private static void TrustConfiguredCertificateAuthority(
-        IImapClient client,
-        X509Certificate2? trustedCertificateAuthority)
-    {
-        if (trustedCertificateAuthority is null)
-        {
-            return;
-        }
-
-        client.ServerCertificateValidationCallback = (_, certificate, chain, sslPolicyErrors) =>
-            MailServerCertificateValidator.IsServerCertificateTrusted(
-                trustedCertificateAuthority,
-                certificate,
-                chain,
-                sslPolicyErrors);
-    }
-
-    /// <summary>Drops a connection this type has already declared unusable, without speaking the protocol again.</summary>
-    /// <remarks>
-    /// A graceful logout is a command, and a command sent to a server that stopped answering waits for a reply that
-    /// may never come — on a client whose only timeout is its own, far beyond the attempt budget, and through a
-    /// cancellation token that this cleanup has no way to observe. The pipeline would abandon the attempt and start
-    /// the next one while this call was still running against a connection object that is not safe for concurrent
-    /// use. Closing the socket asks the server for nothing and cannot block on it. Politeness belongs to
-    /// <see cref="DisposeAsync" />, where the session is ending in order and no attempt is racing it.
-    /// </remarks>
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "A connection already being replaced must not have its cleanup failure replace the failure that is being retried.")]
-    [SuppressMessage("Roslynator", "RCS1075:Avoid empty catch clause that catches System.Exception", Justification = "There is no second action to take: the connection is already unusable, and the caller is about to rethrow the failure that made it so.")]
-    private static void Abandon(IImapClient client)
-    {
-        try
-        {
-            client.Dispose();
-        }
-        catch (Exception)
-        {
-        }
-    }
-
-    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Both cleanup operations must be attempted while the first cleanup failure remains observable.")]
-    private static async ValueTask DisconnectAndDisposeAsync(IImapClient client)
-    {
-        Exception? firstCleanupException = null;
-        try
-        {
-            if (client.IsConnected)
-            {
-                await client.DisconnectAsync(quit: true, CancellationToken.None);
-            }
-        }
-        catch (Exception exception)
-        {
-            firstCleanupException = exception;
-        }
-
-        try
-        {
-            client.Dispose();
-        }
-        catch (Exception exception)
-        {
-            firstCleanupException ??= exception;
-        }
-
-        if (firstCleanupException is not null)
-        {
-            ExceptionDispatchInfo.Capture(firstCleanupException).Throw();
+            MailKitClientLifetime.Abandon(discardedClient);
         }
     }
 }

--- a/tests/Infrastructure.UnitTests/Mail/MailKit/Delivery/MailKitSmtpTokenAuthenticationTests.cs
+++ b/tests/Infrastructure.UnitTests/Mail/MailKit/Delivery/MailKitSmtpTokenAuthenticationTests.cs
@@ -1,0 +1,167 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Application.Mail.Delivery;
+using MailFathom.Infrastructure.Mail.MailKit.Delivery;
+using MailFathom.Infrastructure.UnitTests.TestDoubles;
+using MailKit.Security;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Mail.MailKit.Delivery;
+
+/// <summary>
+/// Covers what a submission does about an access token its server refuses. Without a renewal a rotated token is
+/// presented on every send until the process-wide cache entry expires on its own, so each one fails; with an unbounded
+/// one a permanently refused credential would loop instead of failing the attempt. Where the renewal sits relative to
+/// the stage budgets is asserted here too, because a token exchange inside the Authentication stage would report the
+/// authorization server's silence as the submission server's.
+/// </summary>
+public sealed class MailKitSmtpTokenAuthenticationTests
+{
+    private static readonly DateTimeOffset TokenExpiry = new(2026, 8, 21, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>An accepted token is presented once, and nothing is renewed.</summary>
+    [Fact]
+    public async Task OpenForDeliveryAsync_ServerAcceptingTheCachedToken_PresentsItOnceAndRenewsNothing()
+    {
+        // Arrange
+        using var resilience = SmtpDeliveryTestContext.CreateSingleAttemptResilience();
+        using var client = SmtpDeliveryTestContext.CreateClient("OAUTHBEARER");
+        using var transport = new ScriptedSubmissionTransport();
+        var presentedAccessTokens = SmtpDeliveryTestContext.ScriptTokenAuthentication(client);
+        var accessTokenSource = new RecordingMailAccessTokenSource(TokenExpiry);
+
+        // Act
+        await using var session = await OpenAsync(SmtpDeliveryTestContext.CreateFactory(
+            resilience,
+            client,
+            transport,
+            accessTokenSource: accessTokenSource));
+
+        // Assert
+        Assert.Equal(["access-token-1"], presentedAccessTokens);
+        Assert.Equal(0, accessTokenSource.RenewCount);
+    }
+
+    /// <summary>The case the renewal exists for: a token this process believed was valid, refused by the server.</summary>
+    [Fact]
+    public async Task OpenForDeliveryAsync_ServerRejectsAnUnexpiredToken_RenewsOnceAndPresentsTheReplacement()
+    {
+        // Arrange
+        using var resilience = SmtpDeliveryTestContext.CreateSingleAttemptResilience();
+        using var client = SmtpDeliveryTestContext.CreateClient("OAUTHBEARER");
+        using var transport = new ScriptedSubmissionTransport();
+        var presentedAccessTokens = SmtpDeliveryTestContext.ScriptTokenAuthentication(
+            client,
+            refusedAuthenticationCount: 1);
+        var accessTokenSource = new RecordingMailAccessTokenSource(TokenExpiry);
+
+        // Act
+        await using var session = await OpenAsync(SmtpDeliveryTestContext.CreateFactory(
+            resilience,
+            client,
+            transport,
+            accessTokenSource: accessTokenSource));
+
+        // Assert: the second attempt presented the renewed token rather than repeating the refused one.
+        Assert.Equal(["access-token-1", "access-token-2"], presentedAccessTokens);
+        Assert.Equal(1, accessTokenSource.RenewCount);
+        Assert.Equal(["access-token-1"], accessTokenSource.RejectedTokens);
+    }
+
+    /// <summary>A credential the authorization server and the mail server agree on fails the attempt rather than looping.</summary>
+    [Fact]
+    public async Task OpenForDeliveryAsync_ServerRejectsTheRenewedTokenToo_FailsAfterExactlyOneRenewal()
+    {
+        // Arrange
+        using var resilience = SmtpDeliveryTestContext.CreateSingleAttemptResilience();
+        using var client = SmtpDeliveryTestContext.CreateClient("OAUTHBEARER");
+        using var transport = new ScriptedSubmissionTransport();
+        var presentedAccessTokens = SmtpDeliveryTestContext.ScriptTokenAuthentication(
+            client,
+            refusedAuthenticationCount: int.MaxValue);
+        var accessTokenSource = new RecordingMailAccessTokenSource(TokenExpiry);
+
+        // Act
+        await Assert.ThrowsAsync<AuthenticationException>(() =>
+            OpenAsync(SmtpDeliveryTestContext.CreateFactory(
+            resilience,
+            client,
+            transport,
+            accessTokenSource: accessTokenSource)));
+
+        // Assert
+        Assert.Equal(2, presentedAccessTokens.Count);
+        Assert.Equal(1, accessTokenSource.RenewCount);
+        Assert.Equal(
+            presentedAccessTokens.Count,
+            presentedAccessTokens.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    /// <summary>
+    /// The exchange is bounded by the authorization server's own class, not by the Authentication stage, so an
+    /// exchange slower than that stage's budget still ends in an authenticated session.
+    /// </summary>
+    [Fact]
+    public async Task OpenForDeliveryAsync_TokenExchangeOutlastingTheAuthenticationBudget_StillAuthenticates()
+    {
+        // Arrange
+        using var resilience = SmtpDeliveryTestContext.CreateSingleAttemptResilience();
+        using var client = SmtpDeliveryTestContext.CreateClient("OAUTHBEARER");
+        using var transport = new ScriptedSubmissionTransport();
+        var presentedAccessTokens = SmtpDeliveryTestContext.ScriptTokenAuthentication(client);
+        var accessTokenSource = new RecordingMailAccessTokenSource(TokenExpiry)
+        {
+            WhileExchanging = exchangeToken => Task.Delay(
+                MailDeliveryTimeouts.Default.Authentication + TimeSpan.FromSeconds(5),
+                resilience.TimeProvider,
+                exchangeToken),
+        };
+
+        // Act
+        var opening = OpenAsync(SmtpDeliveryTestContext.CreateFactory(
+            resilience,
+            client,
+            transport,
+            accessTokenSource: accessTokenSource));
+        await using var session = await resilience.CompleteOnVirtualTimeAsync(opening, TimeSpan.FromSeconds(1));
+
+        // Assert
+        Assert.Equal(["access-token-1"], presentedAccessTokens);
+    }
+
+    /// <summary>Every round trip to the submission server still carries the stage budget, and reports it by name.</summary>
+    [Fact]
+    public async Task OpenForDeliveryAsync_ServerNeverAnsweringTheCredential_FailsWithATimeoutNamingTheAuthenticationStage()
+    {
+        // Arrange
+        using var resilience = SmtpDeliveryTestContext.CreateSingleAttemptResilience();
+        using var client = SmtpDeliveryTestContext.CreateClient("OAUTHBEARER");
+        using var transport = new ScriptedSubmissionTransport();
+        client.AuthenticateAsync(Arg.Any<SaslMechanism>(), Arg.Any<CancellationToken>())
+            .Returns(call => Task.Delay(Timeout.Infinite, call.Arg<CancellationToken>()));
+        var accessTokenSource = new RecordingMailAccessTokenSource(TokenExpiry);
+
+        // Act
+        var opening = OpenAsync(SmtpDeliveryTestContext.CreateFactory(
+            resilience,
+            client,
+            transport,
+            accessTokenSource: accessTokenSource));
+
+        var failure = await Assert.ThrowsAsync<TimeoutException>(() =>
+            resilience.CompleteOnVirtualTimeAsync(opening, TimeSpan.FromSeconds(1)));
+
+        // Assert
+        Assert.Contains(nameof(MailDeliveryPhase.Authentication), failure.Message, StringComparison.Ordinal);
+        Assert.Contains(SmtpDeliveryTestContext.Account.Value, failure.Message, StringComparison.Ordinal);
+    }
+
+    private static Task<IMailDeliverySession> OpenAsync(MailKitSmtpDeliverySessionFactory factory) =>
+        factory.OpenForDeliveryAsync(
+            SmtpDeliveryTestContext.Account,
+            SmtpDeliveryTestContext.TlsOnConnectWithOAuthBearerPolicy,
+            CancellationToken.None);
+}

--- a/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitClientLifetimeTests.cs
+++ b/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitClientLifetimeTests.cs
@@ -1,0 +1,134 @@
+// Copyright © 2026 Krzysztof Kasprowicz
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+// Project repository: https://github.com/Krzysztof318/MailFathom
+
+using MailFathom.Infrastructure.Mail.MailKit;
+using MailKit;
+using NSubstitute;
+using Xunit;
+
+namespace MailFathom.Infrastructure.UnitTests.Mail.MailKit;
+
+/// <summary>
+/// Covers how a mail client is ended, which both protocol adapters now reach through one implementation. What matters
+/// is the ordering a failure must not disturb: a client is released whatever the disconnect did, and a cleanup that
+/// fails is either reported once or deliberately swallowed, never allowed to replace the failure that caused it.
+/// </summary>
+public sealed class MailKitClientLifetimeTests
+{
+    [Fact]
+    public async Task DisconnectAndDisposeAsync_ConnectedClient_LogsOutBeforeReleasingIt()
+    {
+        // Arrange
+        var client = Substitute.For<IMailService>();
+        client.IsConnected.Returns(true);
+
+        // Act
+        await MailKitClientLifetime.DisconnectAndDisposeAsync(client);
+
+        // Assert
+        await client.Received(1).DisconnectAsync(quit: true, Arg.Any<CancellationToken>());
+        client.Received(1).Dispose();
+    }
+
+    [Fact]
+    public async Task DisconnectAndDisposeAsync_ClientAlreadyDisconnected_ReleasesItWithoutSpeakingToTheServer()
+    {
+        // Arrange
+        var client = Substitute.For<IMailService>();
+        client.IsConnected.Returns(false);
+
+        // Act
+        await MailKitClientLifetime.DisconnectAndDisposeAsync(client);
+
+        // Assert
+        await client.DidNotReceive().DisconnectAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+        client.Received(1).Dispose();
+    }
+
+    /// <summary>A logout that failed must not cost the release, since the socket would otherwise outlive the session.</summary>
+    [Fact]
+    public async Task DisconnectAndDisposeAsync_DisconnectFailing_StillReleasesTheClientAndReportsThatFailure()
+    {
+        // Arrange
+        var client = Substitute.For<IMailService>();
+        client.IsConnected.Returns(true);
+        client.DisconnectAsync(quit: true, Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new IOException("The server stopped answering.")));
+
+        // Act
+        var failure = await Assert.ThrowsAsync<IOException>(async () =>
+            await MailKitClientLifetime.DisconnectAndDisposeAsync(client));
+
+        // Assert
+        Assert.Equal("The server stopped answering.", failure.Message);
+        client.Received(1).Dispose();
+    }
+
+    /// <summary>With nothing else to report, the release's own failure is the one the caller sees.</summary>
+    [Fact]
+    public async Task DisconnectAndDisposeAsync_ReleaseFailingAfterACleanLogout_ReportsTheReleaseFailure()
+    {
+        // Arrange
+        var client = Substitute.For<IMailService>();
+        client.IsConnected.Returns(true);
+        client.When(released => released.Dispose())
+            .Do(_ => throw new InvalidOperationException("The client could not be released."));
+
+        // Act
+        var failure = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await MailKitClientLifetime.DisconnectAndDisposeAsync(client));
+
+        // Assert
+        Assert.Equal("The client could not be released.", failure.Message);
+    }
+
+    /// <summary>The first failure is the one worth reporting: the second happened to a client the first had already doomed.</summary>
+    [Fact]
+    public async Task DisconnectAndDisposeAsync_BothCleanupsFailing_ReportsTheFirstOne()
+    {
+        // Arrange
+        var client = Substitute.For<IMailService>();
+        client.IsConnected.Returns(true);
+        client.DisconnectAsync(quit: true, Arg.Any<CancellationToken>())
+            .Returns(Task.FromException(new IOException("The server stopped answering.")));
+        client.When(released => released.Dispose())
+            .Do(_ => throw new InvalidOperationException("The client could not be released."));
+
+        // Act, Assert
+        await Assert.ThrowsAsync<IOException>(async () =>
+            await MailKitClientLifetime.DisconnectAndDisposeAsync(client));
+    }
+
+    /// <summary>An abandonment happens while a failure is already on its way to the caller, so it may not raise one of its own.</summary>
+    [Fact]
+    public void Abandon_ReleaseFailing_SwallowsTheCleanupFailure()
+    {
+        // Arrange
+        var client = Substitute.For<IMailService>();
+        client.When(released => released.Dispose())
+            .Do(_ => throw new InvalidOperationException("The client could not be released."));
+
+        // Act
+        MailKitClientLifetime.Abandon(client);
+
+        // Assert
+        client.Received(1).Dispose();
+    }
+
+    /// <summary>Abandoning asks the server for nothing, because a server that stopped answering would never reply.</summary>
+    [Fact]
+    public void Abandon_ConnectedClient_ReleasesItWithoutLoggingOut()
+    {
+        // Arrange
+        var client = Substitute.For<IMailService>();
+        client.IsConnected.Returns(true);
+
+        // Act
+        MailKitClientLifetime.Abandon(client);
+
+        // Assert
+        client.Received(1).Dispose();
+        client.DidNotReceive().Disconnect(Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitClientLifetimeTests.cs
+++ b/tests/Infrastructure.UnitTests/Mail/MailKit/MailKitClientLifetimeTests.cs
@@ -118,7 +118,7 @@ public sealed class MailKitClientLifetimeTests
 
     /// <summary>Abandoning asks the server for nothing, because a server that stopped answering would never reply.</summary>
     [Fact]
-    public void Abandon_ConnectedClient_ReleasesItWithoutLoggingOut()
+    public async Task Abandon_ConnectedClient_ReleasesItWithoutLoggingOut()
     {
         // Arrange
         var client = Substitute.For<IMailService>();
@@ -127,8 +127,9 @@ public sealed class MailKitClientLifetimeTests
         // Act
         MailKitClientLifetime.Abandon(client);
 
-        // Assert
+        // Assert: the asynchronous logout is the one an edit would reach for, so it is the one this has to refuse.
         client.Received(1).Dispose();
+        await client.DidNotReceive().DisconnectAsync(Arg.Any<bool>(), Arg.Any<CancellationToken>());
         client.DidNotReceive().Disconnect(Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Infrastructure.UnitTests/TestDoubles/RecordingMailAccessTokenSource.cs
+++ b/tests/Infrastructure.UnitTests/TestDoubles/RecordingMailAccessTokenSource.cs
@@ -25,19 +25,37 @@ internal sealed class RecordingMailAccessTokenSource : IMailAccessTokenSource
     /// <summary>Gets how many times a renewal was requested.</summary>
     internal int RenewCount => this.RejectedTokens.Count;
 
-    /// <inheritdoc />
-    public Task<MailAccessToken> GetAccessTokenAsync(string accountId, CancellationToken cancellationToken) =>
-        Task.FromResult(this.IssueNext());
+    /// <summary>Gets or sets what happens before an exchange answers, which a test uses to model a slow authorization server.</summary>
+    /// <remarks>Left unset, an exchange answers at once, which is what every test that is not about the exchange's own duration wants.</remarks>
+    internal Func<CancellationToken, Task>? WhileExchanging { get; set; }
 
     /// <inheritdoc />
-    public Task<MailAccessToken> RenewAccessTokenAsync(
+    public async Task<MailAccessToken> GetAccessTokenAsync(string accountId, CancellationToken cancellationToken)
+    {
+        await this.ExchangeAsync(cancellationToken);
+
+        return this.IssueNext();
+    }
+
+    /// <inheritdoc />
+    public async Task<MailAccessToken> RenewAccessTokenAsync(
         string accountId,
         MailAccessToken rejectedToken,
         CancellationToken cancellationToken)
     {
         this.RejectedTokens.Add(rejectedToken.Value);
 
-        return Task.FromResult(this.IssueNext());
+        await this.ExchangeAsync(cancellationToken);
+
+        return this.IssueNext();
+    }
+
+    private async Task ExchangeAsync(CancellationToken cancellationToken)
+    {
+        if (this.WhileExchanging is { } exchange)
+        {
+            await exchange(cancellationToken);
+        }
     }
 
     private MailAccessToken IssueNext()

--- a/tests/Infrastructure.UnitTests/TestDoubles/SmtpDeliveryTestContext.cs
+++ b/tests/Infrastructure.UnitTests/TestDoubles/SmtpDeliveryTestContext.cs
@@ -10,6 +10,7 @@ using MailFathom.Infrastructure.Mail.MailKit.Delivery;
 using MailFathom.Infrastructure.Mail.OAuth;
 using MailFathom.Infrastructure.Observability;
 using MailFathom.Infrastructure.Secrets.Resolution;
+using MailKit.Security;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -57,6 +58,39 @@ internal static class SmtpDeliveryTestContext
         client.AuthenticationMechanisms.Returns([.. advertisedMechanisms]);
 
         return client;
+    }
+
+    /// <summary>Scripts how a submission server answers the access tokens presented to it, and records each one.</summary>
+    /// <param name="client">The scripted server.</param>
+    /// <param name="refusedAuthenticationCount">How many of the first tokens the server refuses, modelling one it no longer accepts.</param>
+    /// <returns>The access token presented by every token authentication attempted, in order.</returns>
+    /// <remarks>
+    /// The presented value is recorded rather than counted, because what the renewal path has to prove is that the
+    /// second attempt carried a different token: a re-authentication repeating the refused one would pass a test that
+    /// only counted the round trips.
+    /// </remarks>
+    internal static IReadOnlyList<string> ScriptTokenAuthentication(
+        ISubmissionClient client,
+        int refusedAuthenticationCount = 0)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+
+        var presentedAccessTokens = new List<string>();
+
+        client.AuthenticateAsync(Arg.Any<SaslMechanism>(), Arg.Any<CancellationToken>()).Returns(call =>
+        {
+            var mechanism = call.Arg<SaslMechanism>()
+                ?? throw new InvalidOperationException("The adapter authenticated with no SASL mechanism.");
+
+            presentedAccessTokens.Add(mechanism.Credentials?.Password ?? string.Empty);
+
+            // Counted against the attempts already recorded, so "refuse the first one" reads as exactly that.
+            return presentedAccessTokens.Count <= refusedAuthenticationCount
+                ? throw new AuthenticationException("The submission server refused the access token.")
+                : Task.CompletedTask;
+        });
+
+        return presentedAccessTokens;
     }
 
     /// <summary>Builds a settings provider that resolves a password for the scripted endpoint on every attempt.</summary>


### PR DESCRIPTION
## What this changes

An SMTP submission presented whatever `MailAccessTokenCache` happened to hold and accepted the server's refusal, while the IMAP path renewed once and re-authenticated. Only `RenewAsync` replaces a rejected cache entry, so a rotated or revoked access token kept being presented on the submission path until that entry expired on its own — and every send in between failed.

Three client-lifetime helpers were also duplicated line for line between the two connection types.

## The decision the issue asked for

**Renewal is taken, and it runs outside `RunPhaseAsync`.**

Sizing the Authentication stage to cover a token exchange plus two `AUTH` round trips is not available: `MailAuthorizationServerInvocation` already allows more than one exchange across its own retries, so a stage that had to contain all three would have to exceed what the three establishment stages may total while staying inside the `EmailDelivery` attempt budget they are deliberately kept under — and raising that budget is exactly what the delivery class refuses, since a repeated submission is visible to the recipient. Holding the exchange inside the stage would also report a hung authorization server as the submission server having stopped answering, which is the reading that class's own budget exists to prevent.

So the phase wrapping moved inward onto each credential presentation. Every `AUTH` round trip — the password one, the first token one, and the one after a renewal — keeps its own `MailDeliveryPhase.Authentication` budget; the token exchanges sit between them, bounded by the class that owns them. The Authentication budget now bounds *one presentation* rather than the whole authentication, and every stage timeout this connection reports still names something the mail server did.

## Shape

- `MailKitAccessTokenAuthentication` (new, `src/Infrastructure/Mail/MailKit/`) carries the get → present → renew → present sequence and is called from both adapters.
- Its signature differs from the one the issue sketched in one parameter: the `IMailService` becomes a `Func<SaslMechanism, CancellationToken, Task>`. That follows directly from the decision above — how one presentation is bounded is the single thing the two protocols disagree on, and passing the client instead would force the submission path to choose between losing its stage budget on the OAuth path and putting the token exchange inside it.
- `MailKitClientLifetime` (new, beside `MailKitTransportSecurityMapping`) carries `TrustConfiguredCertificateAuthority`, `Abandon`, and `DisconnectAndDisposeAsync`, declared over `MailKit.IMailService` — which both `IImapClient` and `ISmtpClient` derive from, and which declares `ServerCertificateValidationCallback`, `IsConnected`, and `DisconnectAsync(Boolean, CancellationToken)`, verified against MailKit 4.17.0's own XML documentation.
- The two `Abandon` remarks are merged rather than picked. The IMAP wording about a retry pipeline racing the cleanup is kept and generalized, because it holds on both protocols: a submission session is established under a class that makes a second attempt of its own, so only `TransmitAsync` runs outside a pipeline.

## Contracts

No break. No configuration key, database column, MCP tool argument, or deployment value moves; the shipped budget defaults are unchanged.

## Tests

- `MailKitSmtpTokenAuthenticationTests` (new, 5): a cached token accepted presents once and renews nothing; a refused token renews once and presents the replacement; a token refused twice fails after exactly one renewal, never repeating the refused value; **a token exchange outlasting the Authentication budget still authenticates**, which is the regression guard for the placement decision and fails against the previous shape; and a server that never answers a credential still fails with a `TimeoutException` naming the Authentication stage.
- `MailKitClientLifetimeTests` (new, 7) covers the shared teardown, including the first-failure-wins branch that existed twice and was tested nowhere.
- `MailKitImapTokenAuthenticationTests` is unchanged and still passes through the extracted helper.

Full gate: 10294 tests, 0 failed; aggregate line coverage 95.54%; 237 workflow contracts passed.

## Documentation

- `docs/features/mail-delivery.md` — the renewal on the submission path and where it sits relative to the stage budgets; the Authentication row now says *one presentation*; the 50 s/60 s paragraph names the renewal as the one path that enters a stage twice.
- `docs/operations/mailbox-oauth.md` — the "rejected token is retried once" bullet now states it holds on both connections an account opens.

Closes #1026
